### PR TITLE
Automatically register all defined asset types

### DIFF
--- a/src/main/java/org/terasology/asset/AssetType.java
+++ b/src/main/java/org/terasology/asset/AssetType.java
@@ -17,20 +17,30 @@
 package org.terasology.asset;
 
 import com.google.common.collect.Maps;
+import org.terasology.asset.loaders.*;
+import org.terasology.logic.manager.AssetManager;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+
 
 /**
+ * An AssetType defines a type of resource accessible through the AssetManager.
+ *
  * @author Immortius
+ * @author Lucas Jenss <public@x3ro.de>
  */
 public enum AssetType {
-    PREFAB("prefab", "prefabs"),
-    SOUND("sound", "sounds"),
-    MUSIC("music", "music"),
-    SHAPE("shape", "shapes"),
-    MESH("mesh", "mesh"),
-    TEXTURE("texture", "textures"),
-    SHADER("shader", "shaders") {
+    PREFAB("prefab", "prefabs", null, null),
+    SOUND("sound", "sounds", "ogg", OggSoundLoader.class),
+    MUSIC("music", "music", "ogg", OggStreamingSoundLoader.class),
+    SHAPE("shape", "shapes", null, null),
+    MESH("mesh", "mesh", "obj", ObjMeshLoader.class),
+    TEXTURE("texture", "textures", "png", PNGTextureLoader.class),
+    SHADER("shader", "shaders", "glsl", GLSLShaderLoader.class) {
         @Override
         public AssetUri getUri(String sourceId, String item) {
             int index = item.lastIndexOf("_frag.glsl");
@@ -46,13 +56,40 @@ public enum AssetType {
             return null;
         }
     },
-    MATERIAL("material", "materials");
+    MATERIAL("material", "materials", "mat", MaterialLoader.class);
+
+
+
+    /* ============
+     * Class fields
+     * ============ */
 
     private String typeId;
+
+    /**
+     * The sub-directory from which assets of this type can be loaded from.
+     */
     private String subDir;
+
+    /**
+     * The file extension for assets of this type.
+     */
+    private String fileExtension;
 
     private static Map<String, AssetType> typeIdLookup;
     private static Map<String, AssetType> subDirLookup;
+
+    /**
+     * The AssetLoader class able to load assets of this type.
+     */
+    private Class<? extends AssetLoader> assetLoaderClass;
+
+    /**
+     * An instance of the asset loader for the current asset type.
+     */
+    private AssetLoader assetLoaderInstance;
+
+    private Logger logger = Logger.getLogger(getClass().getName());
 
     static {
         typeIdLookup = Maps.newHashMap();
@@ -64,9 +101,17 @@ public enum AssetType {
 
     }
 
-    private AssetType(String typeId, String subDir) {
+
+
+    /* ==========
+     * Public API
+     * ========== */
+
+    private AssetType(String typeId, String subDir, String fileExtension, Class<? extends AssetLoader> assetLoaderClass) {
         this.typeId = typeId;
         this.subDir = subDir;
+        this.fileExtension = fileExtension;
+        this.assetLoaderClass = assetLoaderClass;
     }
 
     public String getTypeId() {
@@ -77,12 +122,45 @@ public enum AssetType {
         return subDir;
     }
 
-    public static AssetType getTypeForId(String id) {
-        return typeIdLookup.get(id);
+    public String getFileExtension() {
+        return fileExtension;
     }
 
-    public static AssetType getTypeForSubDir(String dir) {
-        return subDirLookup.get(dir);
+    public Class<? extends AssetLoader> getAssetLoaderClass() {
+        return assetLoaderClass;
+    }
+
+    /**
+     * Returns an instance of the asset loader class assigned to this asset type.
+     */
+    public AssetLoader getAssetLoaderInstance() {
+        // Use cached instance if already created
+        if(assetLoaderInstance != null) {
+            return assetLoaderInstance;
+        }
+
+        // Bail out if no asset loader class was assigned to the asset type
+        if(assetLoaderClass == null) {
+            return null;
+        }
+
+        try {
+            assetLoaderInstance = assetLoaderClass.getConstructor().newInstance();
+        } catch(NoSuchMethodException e) {
+            // Error logging in "finally" block
+        } catch(InstantiationException e) {
+            // Error logging in "finally" block
+        } catch (IllegalAccessException e) {
+            // Error logging in "finally" block
+        } catch (InvocationTargetException e) {
+            // Error logging in "finally" block
+        } finally {
+            if(assetLoaderInstance == null) {
+                logger.log(Level.SEVERE, String.format("Error creating asset loader from class '%s'.", assetLoaderClass));
+            }
+        }
+
+        return assetLoaderInstance;
     }
 
     public AssetUri getUri(String sourceId, String item) {
@@ -92,4 +170,34 @@ public enum AssetType {
         return null;
     }
 
+
+
+    /* ==========
+     * Static API
+     * ========== */
+
+    public static AssetType getTypeForId(String id) {
+        return typeIdLookup.get(id);
+    }
+
+    public static AssetType getTypeForSubDir(String dir) {
+        return subDirLookup.get(dir);
+    }
+
+    /**
+     * Registers all asset types with the AssetManager if they have an AssetLoader
+     * class associated with them.
+     */
+    public static void registerAssetTypes() {
+        for(AssetType type : AssetType.values()) {
+            AssetLoader loader = type.getAssetLoaderInstance();
+            if(loader == null) continue; // No loader has been assigned to this AssetType
+
+            AssetManager.getInstance().register(
+                    type,
+                    type.getFileExtension(),
+                    type.getAssetLoaderInstance()
+            );
+        }
+    }
 }

--- a/src/main/java/org/terasology/game/TerasologyEngine.java
+++ b/src/main/java/org/terasology/game/TerasologyEngine.java
@@ -25,7 +25,6 @@ import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GLContext;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
-import org.terasology.asset.loaders.*;
 import org.terasology.asset.sources.ClasspathSource;
 import org.terasology.game.modes.GameState;
 import org.terasology.logic.manager.*;
@@ -333,12 +332,8 @@ public class TerasologyEngine implements GameEngine {
 
     private void initManagers() {
         CoreRegistry.put(GroovyManager.class, new GroovyManager());
-        AssetManager.getInstance().register(AssetType.MESH, "obj", new ObjMeshLoader());
-        AssetManager.getInstance().register(AssetType.MUSIC, "ogg", new OggStreamingSoundLoader());
-        AssetManager.getInstance().register(AssetType.SOUND, "ogg", new OggSoundLoader());
-        AssetManager.getInstance().register(AssetType.TEXTURE, "png", new PNGTextureLoader());
-        AssetManager.getInstance().register(AssetType.SHADER, "glsl", new GLSLShaderLoader());
-        AssetManager.getInstance().register(AssetType.MATERIAL, "mat", new MaterialLoader());
+
+        AssetType.registerAssetTypes();
         AssetManager.getInstance().addAssetSource(new ClasspathSource("engine", getClass().getProtectionDomain().getCodeSource(), "org/terasology/data"));
         // TODO: Shouldn't be setting up the block/block shape managers here (do on transition to StateSinglePlayer)
         BlockShapeManager.getInstance().reload();


### PR DESCRIPTION
Instead of having to register every `AssetType` by hand, a mechanism is added that registers all defined asset types (provided they have an `AssetLoader` associated). This functionality is implemented in the static `AssetType.registerAssetTypes` method.
