### PR TITLE
Inventory drag/drop update.

### DIFF
--- a/src/main/java/org/terasology/components/PlayerComponent.java
+++ b/src/main/java/org/terasology/components/PlayerComponent.java
@@ -27,5 +27,5 @@ import javax.vecmath.Vector3f;
  */
 public final class PlayerComponent implements Component {
     public Vector3f spawnPosition = new Vector3f();
-    public EntityRef movementSlot = EntityRef.NULL;
+    public EntityRef transferSlot = EntityRef.NULL;
 }

--- a/src/main/java/org/terasology/rendering/gui/components/UIItemContainer.java
+++ b/src/main/java/org/terasology/rendering/gui/components/UIItemContainer.java
@@ -4,14 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.vecmath.Vector2f;
 import org.terasology.components.InventoryComponent;
-import org.terasology.components.PlayerComponent;
 import org.terasology.entitySystem.EntityRef;
 import org.terasology.entitySystem.EventHandlerSystem;
 import org.terasology.entitySystem.EventSystem;
 import org.terasology.entitySystem.ReceiveEvent;
 import org.terasology.entitySystem.event.ChangedComponentEvent;
 import org.terasology.game.CoreRegistry;
-import org.terasology.logic.LocalPlayer;
 import org.terasology.rendering.gui.framework.UIDisplayContainer;
 
 /**
@@ -21,19 +19,22 @@ import org.terasology.rendering.gui.framework.UIDisplayContainer;
  */
 public class UIItemContainer extends UIDisplayContainer implements EventHandlerSystem {
 
-    private EntityRef entity = null;
-    InventoryComponent entityInventory = null;
+    private EntityRef entity = EntityRef.NULL;
+    private InventoryComponent entityInventory;
     private List<UIItemCell> cells = new ArrayList<UIItemCell>();
     
+    private EntityRef connectedEntity = EntityRef.NULL;
+    
     private Vector2f cellMargin = new Vector2f(2, 2);
-	private Vector2f cellSize = new Vector2f(48, 48);
+    private Vector2f cellSize = new Vector2f(48, 48);
     
     private int cols;
-    private int rows;
 
-    public UIItemContainer(int cols, int rows) {
+    private int slotStart = -1;
+    private int slotEnd = -1;
+
+    public UIItemContainer(int cols) {
         this.cols = cols;
-        this.rows = rows;
         
         CoreRegistry.get(EventSystem.class).registerEventHandler(this);
     }
@@ -41,91 +42,140 @@ public class UIItemContainer extends UIDisplayContainer implements EventHandlerS
     private void fillInventoryCells() {
         if (entityInventory != null)
         {
-        	//remove old cells
-        	for (UIItemCell cell : cells) {
-				removeDisplayElement(cell);
-			}
-        	cells.clear();
-        	
-        	//add new cells
+            //remove old cells
+            for (UIItemCell cell : cells) {
+                removeDisplayElement(cell);
+            }
+            cells.clear();
+            
+            //add new cells
             setVisible(true);
-	    	setSize(new Vector2f(cols * (cellSize.x + cellMargin.x), rows * (cellSize.y + cellMargin.y)));
+            setSize(new Vector2f(cols * (cellSize.x + cellMargin.x), (entityInventory.itemSlots.size() / cols) * (cellSize.y + cellMargin.y)));
 
-	    	int size = Math.min(entityInventory.itemSlots.size(), cols * rows);
-	        for (int i = 0; i < size; ++i)
-	        {
-	            UIItemCell cell = new UIItemCell(entity, cellSize);
-	            cell.setItem(entityInventory.itemSlots.get(i), i);
-	            cell.setSize(cellSize);
-	            cell.setPosition(new Vector2f((i % cols) * (cellSize.x + cellMargin.x), (i / cols) * (cellSize.y + cellMargin.y)));
-	            cell.setVisible(true);
-	            
-	            cells.add(cell);
-	            addDisplayElement(cell);
-	        }
+            int start = 0;
+            int end = entityInventory.itemSlots.size();
+                    
+            if (slotStart != -1) {
+                start = slotStart;
+            }
+            
+            if (slotEnd != -1) {
+                end = slotEnd;
+            }
+            
+            for (int i = start; i < end; ++i)
+            {
+                UIItemCell cell = new UIItemCell(entity, cellSize);
+                cell.setItem(entityInventory.itemSlots.get(i), i);
+                cell.setSize(cellSize);
+                cell.setConnected(connectedEntity);
+                cell.setPosition(new Vector2f(((i - start) % cols) * (cellSize.x + cellMargin.x), ((i - start) / cols) * (cellSize.y + cellMargin.y)));
+                cell.setVisible(true);
+                
+                cells.add(cell);
+                addDisplayElement(cell);
+            }
         }
-	}
+    }
     
     public void updateInventoryCells() {
-    	if (entityInventory != null) {
-	    	for (int i = 0; i < cells.size(); ++i)
-	        {
-	    		cells.get(i).setItem(entityInventory.itemSlots.get(i), i);
-	        }
-    	}
+        if (entityInventory != null) {
+            int start = Math.max(slotStart, 0);
+            for (int i = 0; i < cells.size(); ++i)
+            {
+                cells.get(i).setItem(entityInventory.itemSlots.get(start), start);
+                start++;
+            }
+        }
+    }
+    
+    /**
+     * Get the entity which is connected to this container for supporting fast transfer.
+     * @return
+     */
+    public EntityRef getConnected() {
+        return connectedEntity;
+    }
+
+    /**
+     * Set the connected entity which is connected to this container.
+     * Therefore fast transfer will be enabled to this entities inventory.
+     * Fast transfer means pressing an button and clicking on an item will automatically transfer the item to this entities inventory.
+     * @param entity The entity to connect to this container.
+     */
+    public void setConnected(EntityRef entity) {
+        this.connectedEntity = entity;
+        
+        for (UIItemCell cell : cells) {
+            cell.setConnected(connectedEntity);
+        }
     }
     
     public List<UIItemCell> getCells() {
-		return cells;
-	}
+        return cells;
+    }
     
-	public EntityRef getEntity() {
-		return entity;
-	}
+    public EntityRef getEntity() {
+        return entity;
+    }
 
-	public void setEntity(EntityRef entity) {
+    public void setEntity(EntityRef entity) {
         this.entity = entity;
         this.entityInventory = entity.getComponent(InventoryComponent.class);
+        
+        this.slotStart = -1;
+        this.slotEnd = -1;
+        
+        fillInventoryCells();
+    }
+    
+    public void setEntity(EntityRef entity, int slotStart) {        
+        this.entity = entity;
+        this.entityInventory = entity.getComponent(InventoryComponent.class);
+        
+        this.slotStart = slotStart;
+        this.slotEnd = -1;
+        
+        fillInventoryCells();
+    }
+    
+    public void setEntity(EntityRef entity, int slotStart, int slotEnd) {        
+        this.entity = entity;
+        this.entityInventory = entity.getComponent(InventoryComponent.class);
+        
+        this.slotStart = slotStart;
+        this.slotEnd = slotEnd + 1;
         
         fillInventoryCells();
     }
 
     public Vector2f getCellMargin() {
-		return cellMargin;
-	}
+        return cellMargin;
+    }
 
-	public void setCellMargin(Vector2f cellMargin) {
-		this.cellMargin = cellMargin;
-		fillInventoryCells();
-	}
+    public void setCellMargin(Vector2f cellMargin) {
+        this.cellMargin = cellMargin;
+        fillInventoryCells();
+    }
 
-	public Vector2f getCellSize() {
-		return cellSize;
-	}
+    public Vector2f getCellSize() {
+        return cellSize;
+    }
 
-	public void setCellSize(Vector2f cellSize) {
-		this.cellSize = cellSize;
-		fillInventoryCells();
-	}
+    public void setCellSize(Vector2f cellSize) {
+        this.cellSize = cellSize;
+        fillInventoryCells();
+    }
 
-	public int getCols() {
-		return cols;
-	}
+    public int getCols() {
+        return cols;
+    }
 
-	public void setCols(int cols) {
-		this.cols = cols;
-		fillInventoryCells();
-	}
-
-	public int getRows() {
-		return rows;
-	}
-
-	public void setRows(int rows) {
-		this.rows = rows;
-		fillInventoryCells();
-	}
-	
+    public void setCols(int cols) {
+        this.cols = cols;
+        fillInventoryCells();
+    }
+    
     @Override
     public void initialise() {
 
@@ -137,24 +187,6 @@ public class UIItemContainer extends UIDisplayContainer implements EventHandlerS
     
     @ReceiveEvent(components = InventoryComponent.class)
     public void onReceiveItem(ChangedComponentEvent event, EntityRef entity) {
-	    updateInventoryCells();
+        updateInventoryCells();
     }
-    
-    /*
-    @Override
-    public void setVisible(boolean visible) {
-    	super.setVisible(visible);
-    	
-    	//this is ugly. need to find a way to clean the movement slot as the container gets closed.
-    	EntityRef player = CoreRegistry.get(LocalPlayer.class).getEntity();
-    	
-    	if (player == null)
-    		return;
-    	
-    	PlayerComponent playerComponent = player.getComponent(PlayerComponent.class);
-    	
-    	if (playerComponent == null)
-    		return;
-    }
-    */
 }

--- a/src/main/java/org/terasology/rendering/gui/components/UIToolbar.java
+++ b/src/main/java/org/terasology/rendering/gui/components/UIToolbar.java
@@ -31,14 +31,14 @@ import javax.vecmath.Vector2f;
  * @author Marcel Lehwald <marcel.lehwald@googlemail.com>
  */
 public class UIToolbar extends UIDisplayContainer {
-	
+    
     private final UIItemContainer tools;
     private int previousSelected = 0;
     
     public UIToolbar() {
         setSize(new Vector2f(364f, 44f));
         
-        tools = new UIItemContainer(9, 1);
+        tools = new UIItemContainer(9);
         tools.setEntity(CoreRegistry.get(LocalPlayer.class).getEntity());
         tools.setVisible(true);
 
@@ -47,34 +47,34 @@ public class UIToolbar extends UIDisplayContainer {
         layout();
     }
 
-	@Override
+    @Override
     public void layout() {
-    	super.layout();
-    			
+        super.layout();
+                
         centerHorizontally();
         getPosition().y = Display.getHeight() - getSize().y;
     }
-	
-	@Override
-	public void update() {
-		super.update();
-		//TODO solve this with events
+    
+    @Override
+    public void update() {
+        super.update();
+        //TODO solve this with events
 
-		//this is a work around to set the entity when its there. constructor will execute before..
-		if (tools != null && CoreRegistry.get(LocalPlayer.class).getEntity() != EntityRef.NULL) {
-			if (tools.getEntity() == EntityRef.NULL) {
-				tools.setEntity(CoreRegistry.get(LocalPlayer.class).getEntity());
-			}
-		}
+        //this is a work around to set the entity when its there. constructor will execute before..
+        if (tools != null && CoreRegistry.get(LocalPlayer.class).getEntity() != EntityRef.NULL) {
+            if (tools.getEntity() == EntityRef.NULL) {
+                tools.setEntity(CoreRegistry.get(LocalPlayer.class).getEntity(), 0, 8);
+            }
+        }
 
-		//set the selection rectangle
-		if (tools.getCells().size() > 0) {
-			LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
-			LocalPlayerComponent localPlayerComp = localPlayer.getEntity().getComponent(LocalPlayerComponent.class);
-			
-			tools.getCells().get(previousSelected).setSelectionRectangleEnable(false);
-			tools.getCells().get(localPlayerComp.selectedTool).setSelectionRectangleEnable(true);
-			previousSelected = localPlayerComp.selectedTool;
-		}
-	}
+        //set the selection rectangle
+        if (tools.getCells().size() > 0) {
+            LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
+            LocalPlayerComponent localPlayerComp = localPlayer.getEntity().getComponent(LocalPlayerComponent.class);
+            
+            tools.getCells().get(previousSelected).setSelectionRectangleEnable(false);
+            tools.getCells().get(localPlayerComp.selectedTool).setSelectionRectangleEnable(true);
+            previousSelected = localPlayerComp.selectedTool;
+        }
+    }
 }

--- a/src/main/java/org/terasology/rendering/gui/framework/UIDisplayContainer.java
+++ b/src/main/java/org/terasology/rendering/gui/framework/UIDisplayContainer.java
@@ -113,6 +113,20 @@ public abstract class UIDisplayContainer extends UIDisplayElement {
             _displayElements.get(i).layout();
         }
     }
+    
+    @Override
+    public boolean processBindButton(String id, boolean pressed) {
+        if (!isVisible())
+            return false;
+    	
+        boolean ret = super.processBindButton(id, pressed);
+        // Pass the bind key to all display elements
+        for (int i = 0; i < _displayElements.size(); i++) {
+        	ret |= _displayElements.get(i).processBindButton(id, pressed);
+        }
+        
+        return ret;
+    }
 
     @Override
     public void processKeyboardInput(int key) {

--- a/src/main/java/org/terasology/rendering/gui/framework/UIDisplayWindow.java
+++ b/src/main/java/org/terasology/rendering/gui/framework/UIDisplayWindow.java
@@ -17,18 +17,22 @@ package org.terasology.rendering.gui.framework;
 
 import org.lwjgl.opengl.Display;
 import org.terasology.logic.manager.GUIManager;
+import org.terasology.rendering.gui.framework.events.WindowListener;
 
 import javax.vecmath.Vector2f;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.lwjgl.opengl.GL11.*;
 
 public class UIDisplayWindow extends UIScrollableDisplayContainer {
 
+    private enum eWindowEvent {OPEN, CLOSE};
+    private final ArrayList<WindowListener> _windowListeners = new ArrayList<WindowListener>();
+    private final HashMap<String, UIDisplayElement> _displayElementsById = new HashMap<String, UIDisplayElement>();
     private boolean _maximized = false;
     private boolean _modal = false;
-    private HashMap<String, UIDisplayElement> _displayElementsById = new HashMap<String, UIDisplayElement>();
-
 
     protected void drag(Vector2f value) {
         getPosition().x -= value.x;
@@ -77,6 +81,30 @@ public class UIDisplayWindow extends UIScrollableDisplayContainer {
         glEnd();
         glPopMatrix();
     }
+    
+    private void notifyWindowListeners(eWindowEvent event) {
+        //we copy the list so the listener can remove itself within the close/open method call (see UIItemCell). Otherwise ConcurrentModificationException.
+        //TODO other solution?
+        ArrayList<WindowListener> listeners = (ArrayList<WindowListener>) _windowListeners.clone();
+        
+        if (event == eWindowEvent.OPEN) {
+            for (WindowListener listener : listeners) {
+                listener.open(this);
+            }
+        } else if (event == eWindowEvent.CLOSE) {
+            for (WindowListener listener : listeners) {
+                listener.close(this);
+            }
+        }
+    }
+    
+    public void addWindowListener(WindowListener listener) {
+        _windowListeners.add(listener);
+    }
+
+    public void removeWindowListener(WindowListener listener) {
+        _windowListeners.remove(listener);
+    }
 
     public void maximize() {
         setSize(new Vector2f(Display.getWidth(), Display.getHeight()));
@@ -111,8 +139,19 @@ public class UIDisplayWindow extends UIScrollableDisplayContainer {
     
     @Override
     public void setSize(Vector2f scale) {
-    	super.setSize(scale);
-    	
-    	layout();
+        super.setSize(scale);
+        
+        layout();
+    }
+    
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+        
+        if (visible) {
+            notifyWindowListeners(eWindowEvent.OPEN);
+        } else {
+            notifyWindowListeners(eWindowEvent.CLOSE);
+        }
     }
 }

--- a/src/main/java/org/terasology/rendering/gui/framework/events/WindowListener.java
+++ b/src/main/java/org/terasology/rendering/gui/framework/events/WindowListener.java
@@ -1,0 +1,8 @@
+package org.terasology.rendering.gui.framework.events;
+
+import org.terasology.rendering.gui.framework.UIDisplayElement;
+
+public interface WindowListener {
+	public void open(UIDisplayElement element);
+	public void close(UIDisplayElement element);
+}

--- a/src/main/java/org/terasology/rendering/gui/windows/UIScreenContainer.java
+++ b/src/main/java/org/terasology/rendering/gui/windows/UIScreenContainer.java
@@ -48,10 +48,10 @@ public class UIScreenContainer extends UIDisplayWindow {
         background.getTextureOrigin().set(new Vector2f(0.0f, 0.0f));
         background.setVisible(true);
         
-        playerInventory = new UIItemContainer(4, 9);
+        playerInventory = new UIItemContainer(4);
         playerInventory.setVisible(true);
 
-        containerInventory = new UIItemContainer(4, 9);
+        containerInventory = new UIItemContainer(4);
         containerInventory.setVisible(true);
         
         addDisplayElement(background);
@@ -66,6 +66,9 @@ public class UIScreenContainer extends UIDisplayWindow {
         this.creature = creature;
         playerInventory.setEntity(creature);
         containerInventory.setEntity(container);
+        
+        playerInventory.setConnected(container);
+        containerInventory.setConnected(creature);
     }
 
     @Override

--- a/src/main/java/org/terasology/rendering/gui/windows/UIScreenInventory.java
+++ b/src/main/java/org/terasology/rendering/gui/windows/UIScreenInventory.java
@@ -32,13 +32,18 @@ import org.terasology.rendering.gui.framework.UIGraphicsElement;
  */
 public class UIScreenInventory extends UIDisplayWindow {
 
+    private final UIItemContainer toolbar;
     private final UIItemContainer inventory;
-	private UIGraphicsElement background;
+    private UIGraphicsElement background;
 
     public UIScreenInventory() {
         setSize(new Vector2f(192.0f * 2.5f, 180.0f * 2.5f));
         
-        inventory = new UIItemContainer(9, 4);
+        toolbar = new UIItemContainer(9);
+        toolbar.setVisible(true);
+        toolbar.setCellMargin(new Vector2f(1, 1));
+        
+        inventory = new UIItemContainer(9);
         inventory.setVisible(true);
         inventory.setCellMargin(new Vector2f(1, 1));
 
@@ -48,6 +53,7 @@ public class UIScreenInventory extends UIDisplayWindow {
         background.setVisible(true);
         
         addDisplayElement(background);
+        addDisplayElement(toolbar);
         addDisplayElement(inventory);
 
         layout();
@@ -56,10 +62,13 @@ public class UIScreenInventory extends UIDisplayWindow {
     
     @Override
     public void setVisible(boolean visible) {
-    	super.setVisible(visible);
-    	
-    	if (visible)
-            inventory.setEntity(CoreRegistry.get(LocalPlayer.class).getEntity());
+        super.setVisible(visible);
+        
+        if (visible) {
+            toolbar.setEntity(CoreRegistry.get(LocalPlayer.class).getEntity(), 0, 8);
+            inventory.setEntity(CoreRegistry.get(LocalPlayer.class).getEntity(), 9);
+            //TODO connect toolbar <-> inventory somehow to allow fast transfer.
+        }
     }
 
     @Override
@@ -67,16 +76,11 @@ public class UIScreenInventory extends UIDisplayWindow {
         super.layout();
         
         if (inventory != null) {
-        	background.center();
-        	inventory.center();
-        	inventory.getPosition().y += 48;
-        	
-        	if (inventory.getCells().size() >= 9) {
-        		float toolbarPos = calcAbsolutePosition().y + 208;
-	        	for (int i = 0; i < 9; i++) {
-	        		inventory.getCells().get(i).getPosition().y = toolbarPos;		
-				}
-        	}
+            background.center();
+            toolbar.center();
+            toolbar.getPosition().y += 254;
+            inventory.center();
+            inventory.getPosition().y += 98;
         }
     }
     


### PR DESCRIPTION
Fixed:
- As the user leaves the screen when he still moves an item, the item will be dropped back to his inventory.
- Some other item loss fixes :D

Featues:
- It is now possible to connect 2 Entities inventories (through UIItemContainer), which allows a fast transfer between them. By pressing the run button (default shift) and clicking on an item, this item will automatically be moved to the other entities inventory.
- Right click with an item stack in hand will transfer just 1 item.
- Item gets dropped if inventory is full (but thats not 100% working yet)
