### PR TITLE
Improved /placeBlock command to use BlockFamily.

### DIFF
--- a/src/main/java/org/terasology/logic/commands/Commands.java
+++ b/src/main/java/org/terasology/logic/commands/Commands.java
@@ -478,13 +478,30 @@ public class Commands implements CommandProvider {
         offset.scale(3);
         spawnPos.add(offset);
 
-        Block block = BlockManager.getInstance().getBlock(blockName);
-        if (block == null) return;
+        BlockFamily blockFamily;
+
+        List<BlockUri> matchingUris = resolveBlockUri(blockName);
+        if (matchingUris.size() == 1) {
+            blockFamily = BlockManager.getInstance().getBlockFamily(matchingUris.get(0));
+
+            //return;
+        } else if (matchingUris.isEmpty()) {
+            MessageManager.getInstance().addMessage("No block found for '" + blockName + "'", EMessageScope.PRIVATE);
+
+            return;
+        } else {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Non-unique block name, possible matches: ");
+            Joiner.on(", ").appendTo(builder, matchingUris);
+            MessageManager.getInstance().addMessage(builder.toString(), EMessageScope.PRIVATE);
+
+            return;
+        }
 
         WorldProvider provider = CoreRegistry.get(WorldProvider.class);
         if (provider != null) {
-            Block oldBlock = provider.getBlock(spawnPos);
-            provider.setBlock((int) spawnPos.x, (int) spawnPos.y, (int) spawnPos.z, block, oldBlock);
+            Block oldBlock = provider.getBlock((int) spawnPos.x, (int) spawnPos.y, (int) spawnPos.z);
+            provider.setBlock((int) spawnPos.x, (int) spawnPos.y, (int) spawnPos.z, blockFamily.getArchetypeBlock(), oldBlock);
         }
     }
 


### PR DESCRIPTION
- Using BlockFamily to determine the block to place (like in /giveItem commands)
- Improved fetching old block

Question to the architects: Why do I need to determine the old block a placement position? I think it has something to do with the lighting propagation, but shouldn't there be a variant without that check and forcing the recalculation of light.
