### PR TITLE
Bugfix for file logging

### DIFF
--- a/src/main/java/org/terasology/game/TerasologyEngine.java
+++ b/src/main/java/org/terasology/game/TerasologyEngine.java
@@ -217,7 +217,7 @@ public class TerasologyEngine implements GameEngine {
                         } catch (Exception ex) {
                         }
                     }
-                    return String.format("[%s] (%s)\t%s - %s\n%s", record.getLevel().getLocalizedName(), dateFormat.format(new Date(record.getMillis())), record.getLoggerName(), record.getSourceMethodName(), formatMessage(record), thrownMessage);
+                    return String.format("[%s] (%s)\t%s:%s() - %s\n%s", record.getLevel().getLocalizedName(), dateFormat.format(new Date(record.getMillis())), record.getLoggerName(), record.getSourceMethodName(), formatMessage(record), thrownMessage);
                 }
             });
             java.util.logging.Logger.getLogger("").addHandler(fh);


### PR DESCRIPTION
The format method has six parameters but only 5 "%s".
I added the missing SourceMethodName ":%s()".
Alternitiv: remove "record.getSourceMethodName(),"
