### PR TITLE
Important issue with LocalChunkProvider

### DIFF
--- a/src/main/java/org/terasology/world/chunks/LocalChunkProvider.java
+++ b/src/main/java/org/terasology/world/chunks/LocalChunkProvider.java
@@ -75,8 +75,8 @@ public class LocalChunkProvider implements ChunkProvider {
     private Set<CacheRegion> regions = Sets.newHashSet();
 
     private ConcurrentMap<Vector3i, Chunk> nearCache = Maps.newConcurrentMap();
-    private final ConcurrentMap<Vector3i, Boolean> genCache = Maps.newConcurrentMap();
-
+    private final Set<Vector3i> preparingChunks = Sets.newSetFromMap(Maps.<Vector3i, Boolean>newConcurrentMap());
+    
     private EntityRef worldEntity = EntityRef.NULL;
 
     private ReadWriteLock regionLock = new ReentrantReadWriteLock();
@@ -281,21 +281,22 @@ public class LocalChunkProvider implements ChunkProvider {
         Chunk chunk = getChunk(chunkPos);
         if (chunk == null) {
             PerformanceMonitor.startActivity("Check chunk in cache");
-            if (genCache.putIfAbsent(chunkPos, true) == null) {
+            if (preparingChunks.add(chunkPos)) {
                 if (farStore.contains(chunkPos)) {
                     chunkTasksQueue.offer(new AbstractChunkTask(chunkPos, this) {
                         @Override
                         public void enact() {
                             Chunk chunk = farStore.get(getPosition());
-                            if (nearCache.putIfAbsent(getPosition(), chunk) == null) {
-                                genCache.remove(getPosition());
-                                if (chunk.getChunkState() == Chunk.State.COMPLETE) {
-                                    for (Vector3i adjPos : Region3i.createFromCenterExtents(getPosition(), LOCAL_REGION_EXTENTS)) {
-                                        checkChunkReady(adjPos);
-                                    }
-                                }
-                                reviewChunkQueue.offer(new ChunkRequest(ChunkRequest.RequestType.REVIEW, Region3i.createFromCenterExtents(getPosition(), LOCAL_REGION_EXTENTS)));
+                            if (nearCache.putIfAbsent(getPosition(), chunk) != null) {
+                                logger.warn("Chunk {} is already in the near cache", getPosition());
                             }
+                            preparingChunks.remove(getPosition());
+                            if (chunk.getChunkState() == Chunk.State.COMPLETE) {
+                                for (Vector3i adjPos : Region3i.createFromCenterExtents(getPosition(), LOCAL_REGION_EXTENTS)) {
+                                    checkChunkReady(adjPos);
+                                }
+                            }
+                            reviewChunkQueue.offer(new ChunkRequest(ChunkRequest.RequestType.REVIEW, Region3i.createFromCenterExtents(getPosition(), LOCAL_REGION_EXTENTS)));
                         }
                     });
                 } else {
@@ -303,10 +304,11 @@ public class LocalChunkProvider implements ChunkProvider {
                         @Override
                         public void enact() {
                             Chunk chunk = generator.generateChunk(getPosition());
-                            if (null == nearCache.putIfAbsent(getPosition(), chunk)) {
-                                genCache.remove(getPosition());
-                                reviewChunkQueue.offer(new ChunkRequest(ChunkRequest.RequestType.REVIEW, Region3i.createFromCenterExtents(getPosition(), LOCAL_REGION_EXTENTS)));
+                            if (nearCache.putIfAbsent(getPosition(), chunk) != null) {
+                                logger.warn("Chunk {} is already in the near cache", getPosition());
                             }
+                            preparingChunks.remove(getPosition());
+                            reviewChunkQueue.offer(new ChunkRequest(ChunkRequest.RequestType.REVIEW, Region3i.createFromCenterExtents(getPosition(), LOCAL_REGION_EXTENTS)));
                         }
                     });
                 }


### PR DESCRIPTION
Hi

I have identified a severe issue with LocalChunkProvider. The LocalChunkProvider systematically generates multiple chunks for every chunk position. It actually generates twice as much chunks than necessary and sometimes it keeps generating the same chunk over and over again. And when you move around and new chunks are generated, it generates some chunks more than two times, sometimes 3, 4, 5 times. All the redundant chunks are just thrown away and garbage collected.

This is a very simple fix for that issue.

I notice a signifficant improvement on my old and slow notebook when i create a new world and when i move around. The world is generated much faster and it feels more responsive when i move around and new chunks are generated.

It's difficult to measure the improvement. In my branch stackable-chunks i have implemented a chunk monitor where i can watch the chunks being generated. I can clearly see the difference there.

On my machine, the generation of the world feels up to twice as fast as before!
