### PR TITLE
A bux fix for issue #340

### DIFF
--- a/src/main/java/org/terasology/physics/character/BulletCharacterMovementSystem.java
+++ b/src/main/java/org/terasology/physics/character/BulletCharacterMovementSystem.java
@@ -322,7 +322,7 @@ public final class BulletCharacterMovementSystem implements UpdateSubscriberSyst
         moveDelta.scale(delta);
 
         // Note: No stepping underwater, no issue with slopes
-        MoveResult moveResult = move(location.getWorldPosition(), moveDelta, 0, 1, movementComp.collider);
+        MoveResult moveResult = move(location.getWorldPosition(), moveDelta, 0, 0.1f, movementComp.collider);
         Vector3f distanceMoved = new Vector3f(moveResult.finalPosition);
         distanceMoved.sub(location.getWorldPosition());
 


### PR DESCRIPTION
There was a bug where if a character runs into a corner underwater, they get launched into the sky (I believe the underwater stairs was an example of this). The bug is fixed by a one liner. I think it was merely a typo.

Let me know if you guys need me to change anything for this pull request.
