### PR TITLE
Fixed tiny bug with huge performance impact on world rendering.

### DIFF
--- a/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -513,7 +513,7 @@ public final class WorldRenderer {
                     c.setPendingMesh(null);
                 }
 
-                if ((c.isDirty() || mesh == null) && isChunkValidForRender(c)) {
+                if ((c.isDirty() || c.getMesh() == null) && isChunkValidForRender(c)) {
                     statDirtyChunks++;
                     chunkUpdateManager.queueChunkUpdate(c, ChunkUpdateManager.UPDATE_TYPE.DEFAULT);
                 }


### PR DESCRIPTION
Hi

I have found a tiny bug on a single line in the class WorldRenderer, which caused every single chunk to be tessellated and transmitted TWICE to the graphics card instead of only once!

This has a severe performance impact on my slow laptop, and i think, it should be noticable on faster machines, too.

Panserbjoern
