### PR TITLE
Fixed sound issues, when Alt+Tabbed

### DIFF
--- a/src/main/java/org/terasology/audio/openAL/OpenALStreamingSound.java
+++ b/src/main/java/org/terasology/audio/openAL/OpenALStreamingSound.java
@@ -27,7 +27,7 @@ import org.terasology.audio.Sound;
 import org.terasology.audio.openAL.OpenALException;
 
 public abstract class OpenALStreamingSound implements Sound {
-    private final static int BUFFER_POOL_SIZE = 3;
+    private final static int BUFFER_POOL_SIZE = 8;
 
     private final AssetUri uri;
     protected final URL audioSource;


### PR DESCRIPTION
When Alt+Tabbed the streaming sound will start to lag. This is because the main-loop speed is reduced, so there are not enough OpenAL soundbuffers available to fill on update().

I just set the number of buffers to 8. Maybe a better solution is, to move the openal code to a thread running at fixed speed? Or allocate buffers dynamically?

However, this will fix the stuttering sound for now. 
