### PR TITLE
Develop

### DIFF
--- a/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -1034,16 +1034,16 @@ public final class WorldRenderer {
         // If the screen is windowed, fallback to the DesktopDisplayMode value,
         // Finally fallback to 32bpp default value.
         DisplayMode dm = Display.getDisplayMode();
-        int test_bpp = 0;
-        if ( (test_bpp = dm.getBitsPerPixel()) == 0 && !dm.isFullscreenCapable())
+        int bpp = 0;
+        if ( (bpp = dm.getBitsPerPixel()) == 0 && !dm.isFullscreenCapable())
         {
         	dm = Display.getDesktopDisplayMode();
-        	test_bpp = dm.getBitsPerPixel();
+        	bpp = dm.getBitsPerPixel();
         }
-        final int bpp = test_bpp == 0 ? 32 : test_bpp;
+        final int bytePP = ( bpp == 0 ? 32 : bpp ) / 8;
         
-        final ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * bpp / 8);
-        GL11.glReadPixels(0, 0, width, height, bpp == 24 ? GL11.GL_RGB : GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
+        final ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * bytePP );
+        GL11.glReadPixels(0, 0, width, height, bytePP == 3 ? GL11.GL_RGB : GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
         Runnable r = new Runnable() {
             @Override
             public void run() {
@@ -1055,7 +1055,7 @@ public final class WorldRenderer {
 
                 for (int x = 0; x < width; x++)
                     for (int y = 0; y < height; y++) {
-                        int i = (x + width * y) * bpp/8;
+                        int i = (x + width * y) * bytePP;
                         int r = buffer.get(i) & 0xFF;
                         int g = buffer.get(i + 1) & 0xFF;
                         int b = buffer.get(i + 2) & 0xFF;


### PR DESCRIPTION
Fixed bpp lookup for screenshot, which in turn fixes a 'dead code' warning eclipse was giving me about a hard-coded value used in a ternary.
