### PR TITLE
Shadow Map FBO Initialization Bug

### DIFF
--- a/src/main/java/org/terasology/logic/manager/DefaultRenderingProcess.java
+++ b/src/main/java/org/terasology/logic/manager/DefaultRenderingProcess.java
@@ -375,7 +375,9 @@ public class DefaultRenderingProcess implements IPropertyProvider {
         }
         bufferIds.flip();
         if (bufferIds.limit() == 0) {
-            GL11.glReadBuffer(GL11.GL_NONE);
+            if (depth && type == FBOType.FBOT_NO_COLOR) {
+                GL11.glReadBuffer(GL11.GL_NONE);
+            }
             GL20.glDrawBuffers(GL11.GL_NONE);
         } else {
             GL20.glDrawBuffers(bufferIds);


### PR DESCRIPTION
I fixed the FBO initialization code when a depth only FBO is created. On my MacBook Pro this lead to the error "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT". 
