### PR TITLE
Fixes several issues: #630, #631, #632

### DIFF
--- a/src/main/java/org/terasology/config/Config.java
+++ b/src/main/java/org/terasology/config/Config.java
@@ -31,10 +31,12 @@ import com.google.gson.JsonSerializer;
 import org.lwjgl.opengl.PixelFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.game.types.GameTypeUri;
 import org.terasology.input.Input;
 import org.terasology.game.paths.PathManager;
 import org.terasology.utilities.gson.InputHandler;
 import org.terasology.utilities.gson.MultimapHandler;
+import org.terasology.world.generator.MapGeneratorUri;
 
 import java.io.File;
 import java.io.FileReader;
@@ -134,6 +136,8 @@ public final class Config {
                     .registerTypeAdapter(Input.class, new InputHandler())
                     .registerTypeAdapter(AdvancedConfig.class, new AdvancedConfig.Handler())
                     .registerTypeAdapter(PixelFormat.class, new PixelFormatHandler())
+                    .registerTypeAdapter(MapGeneratorUri.class, new MapGeneratorUri.GsonAdapter())
+                    .registerTypeAdapter(GameTypeUri.class, new GameTypeUri.GsonAdapter())
                     .setPrettyPrinting().create().toJson(config, writer);
         } finally {
             // JAVA7: better closing support
@@ -156,6 +160,8 @@ public final class Config {
                     .registerTypeAdapter(Input.class, new InputHandler())
                     .registerTypeAdapter(AdvancedConfig.class, new AdvancedConfig.Handler())
                     .registerTypeAdapter(PixelFormat.class, new PixelFormatHandler())
+                    .registerTypeAdapter(MapGeneratorUri.class, new MapGeneratorUri.GsonAdapter())
+                    .registerTypeAdapter(GameTypeUri.class, new GameTypeUri.GsonAdapter())
                     .create();
             JsonElement baseConfig = gson.toJsonTree(new Config());
             JsonParser parser = new JsonParser();

--- a/src/main/java/org/terasology/config/WorldGenerationConfig.java
+++ b/src/main/java/org/terasology/config/WorldGenerationConfig.java
@@ -1,6 +1,7 @@
 package org.terasology.config;
 
 
+import org.terasology.game.types.GameTypeUri;
 import org.terasology.world.generator.MapGeneratorUri;
 
 /**
@@ -24,7 +25,8 @@ public class WorldGenerationConfig {
     private float  plateauAreaFACTOR = 50.0f;
     private float  caveDensityFACTOR = 50.0f;
 
-    private MapGeneratorUri defaultMapGenerator = new MapGeneratorUri("core:perlin-setup");
+    private MapGeneratorUri defaultMapGenerator = new MapGeneratorUri("core:perlin");
+    private GameTypeUri defaultGameType = new GameTypeUri("core:survival");
 
     public String getWorldTitle() {
         return worldTitle;
@@ -150,5 +152,13 @@ public class WorldGenerationConfig {
 
     public void setDefaultMapGenerator(MapGeneratorUri defaultMapGenerator) {
         this.defaultMapGenerator = defaultMapGenerator;
+    }
+
+    public GameTypeUri getDefaultGameType() {
+        return defaultGameType;
+    }
+
+    public void setDefaultGameType(GameTypeUri defaultGameType) {
+        this.defaultGameType = defaultGameType;
     }
 }

--- a/src/main/java/org/terasology/rendering/gui/dialogs/UIDialogCreateNewWorld.java
+++ b/src/main/java/org/terasology/rendering/gui/dialogs/UIDialogCreateNewWorld.java
@@ -24,6 +24,7 @@ import org.terasology.game.modes.StateLoading;
 import org.terasology.game.types.GameType;
 import org.terasology.game.types.GameTypeManager;
 import org.terasology.game.paths.PathManager;
+import org.terasology.game.types.GameTypeUri;
 import org.terasology.rendering.gui.framework.UIDisplayContainer;
 import org.terasology.rendering.gui.framework.UIDisplayElement;
 import org.terasology.rendering.gui.framework.events.ClickListener;
@@ -144,16 +145,22 @@ public class UIDialogCreateNewWorld extends UIDialog {
 
         typeOfGame = new UIComboBox(new Vector2f(COMPONENT_WIDTH, COMPONENT_HEIGHT), new Vector2f(COMPONENT_WIDTH, 2*COMPONENT_HEIGHT));
         gameTypes = CoreRegistry.get(GameTypeManager.class).listItems();
+        GameTypeUri defaultGameType = CoreRegistry.get(Config.class).getWorldGeneration().getDefaultGameType();
+
         int index = 0;
         int defaultIndex = 0;
         for (GameType gameType : gameTypes) {
+            if( gameType.uri().equals(defaultGameType) ) {
+                defaultIndex = index;
+            }
             UIListItem item = new UIListItem(gameType.name(), index);
             item.setTextColor(Color.black);
             item.setPadding(new Vector4f(5f, 5f, 5f, 5f));
             typeOfGame.addItem(item);
+
+            index ++;
         }
 
-        typeOfGame.select(defaultIndex);
         typeOfGame.setVisible(true);
         typeOfGame.addSelectionListener(new SelectionListener() {
             @Override
@@ -163,6 +170,13 @@ public class UIDialogCreateNewWorld extends UIDialog {
                 if( gameTypeModConfig!=null ) {
                     modConfig.copy(gameTypeModConfig);
                     modConfig.addMod(CoreRegistry.get(GameTypeManager.class).getMod(getSelectedGameType().uri()));
+                    if( modButton!=null ) {
+                        modButton.setVisible(false);
+                    }
+                } else {
+                    if( modButton!=null ) {
+                        modButton.setVisible(true);
+                    }
                 }
 
                 MapGeneratorUri mapGeneratorUri = getSelectedGameType().defaultMapGenerator();
@@ -178,6 +192,7 @@ public class UIDialogCreateNewWorld extends UIDialog {
                 }
             }
         });
+        typeOfGame.select(defaultIndex);
     }
 
     private void createChunkGeneratorInput() {
@@ -206,7 +221,6 @@ public class UIDialogCreateNewWorld extends UIDialog {
         int index = 0;
         int defaultIndex = 0;
         for (MapGenerator mapGenerator : mapGenerators) {
-
             if( mapGenerator.uri().equals(defaultMapGenerator) ) {
                 defaultIndex = index;
             }

--- a/src/main/java/org/terasology/world/WorldInfo.java
+++ b/src/main/java/org/terasology/world/WorldInfo.java
@@ -16,6 +16,7 @@
 
 package org.terasology.world;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.GsonBuilder;
@@ -49,6 +50,11 @@ public class WorldInfo {
     private MapGeneratorUri mapGeneratorUri = new MapGeneratorUri("core:perlin");
     private GameTypeUri gameTypeUri = null;
     private ModConfig modConfiguration = new ModConfig();
+
+    @Deprecated
+    private String[] chunkGenerators;
+    @Deprecated
+    private String gameType = null;
 
     public WorldInfo() {
     }
@@ -128,6 +134,15 @@ public class WorldInfo {
     }
 
     public GameTypeUri getGameType() {
+        if( gameType!=null ) {
+            if( gameType.endsWith("FreeStyleType") ) {
+                gameTypeUri = new GameTypeUri("core:free-style");
+            } else if( gameType.endsWith("SurvivalType") ) {
+                gameTypeUri = new GameTypeUri("core:survival");
+            } else {
+                throw new IllegalStateException("Unknown game type (old style): "+gameType );
+            }
+        }
         return gameTypeUri;
     }
 
@@ -140,6 +155,32 @@ public class WorldInfo {
     }
 
     public MapGeneratorUri getMapGeneratorUri() {
+        if( chunkGenerators!=null ) {
+            for (String chunkGenerator : chunkGenerators) {
+                if( chunkGenerator.endsWith("PerlinTerrainGenerator") ) {
+                    mapGeneratorUri = new MapGeneratorUri("core:perlin");
+                    break;
+                } else if( chunkGenerator.endsWith("PerlinTerrainGeneratorWithSetup") ) {
+                    mapGeneratorUri = new MapGeneratorUri("core:perlin-setup");
+                    break;
+                } else if( chunkGenerator.endsWith("FlatTerrainGenerator") ) {
+                    mapGeneratorUri = new MapGeneratorUri("core:flat");
+                    break;
+                } else if( chunkGenerator.endsWith("MultiTerrainGenerator") ) {
+                    mapGeneratorUri = new MapGeneratorUri("core:multi");
+                    break;
+                } else if( chunkGenerator.endsWith("BasicHMTerrainGenerator") ) {
+                    mapGeneratorUri = new MapGeneratorUri("core:heightmap");
+                    break;
+                } else if( chunkGenerator.endsWith("PathfinderTestGenerator") ) {
+                    mapGeneratorUri = new MapGeneratorUri("pathfinding:testgen");
+                    break;
+                }
+            }
+            if( mapGeneratorUri==null ) {
+                throw new IllegalStateException("Unknown chunk generators: "+ chunkGenerators );
+            }
+        }
         return mapGeneratorUri;
     }
 


### PR DESCRIPTION
Old worlds are converted on the fly. The deprecated fields in WorldInfo should be removed sometime. 

Mod select button is disabled, when a gametype with custom mod config is selected. This will force the mod config supplied by the gametype.
