### PR TITLE
Upgrade logback to 1.0.13 to fix UnknownHostException on OS X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ dependencies {
 
     // Needed as "compile" for logback.groovy in IntelliJ - otherwise it could be left as a runtime only dependency
     //TODO: Find way to avoid compiling logback.groovy to the resource dir
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.9'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.13'
 
     // These dependencies are only needed for running tests
     testCompile group: 'junit', name: 'junit', version: '4.10'


### PR DESCRIPTION
![](http://cdn.memegenerator.net/instances/250x250/22023809.jpg)

See http://jira.qos.ch/browse/LOGBACK-749 for details
