### PR TITLE
Set sourceCompatibility  to Java 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ task extractNatives {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 
 // Add additional "source set" beyond the default (src/main/ + src/test/), in this case src/dev/ (utility)
 sourceSets {


### PR DESCRIPTION
Not necessary, but if we want to switch to Java 7 and use new features, we need it.
