### PR TITLE
Make EntityRef.NULL accessible to Modules

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -19,7 +19,6 @@ import org.terasology.asset.AssetUri;
 import org.terasology.engine.CoreRegistry;
 import org.terasology.entitySystem.MutableComponentContainer;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
-import org.terasology.entitySystem.entity.internal.NullEntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/NullEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/NullEntityRef.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.entitySystem.entity.internal;
+package org.terasology.entitySystem.entity;
 
 import org.terasology.asset.AssetUri;
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.PojoEntityManager;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.utilities.collection.NullIterator;


### PR DESCRIPTION
This change makes Make EntityRef.NULL accessible to Modules.  Currently NULL points to NullEntityRef in the restricted internal package.   Don't see any reason why it shouldn't be moved out of internal.
