### PR TITLE
Skip rendering block particles with a null location.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
@@ -236,6 +236,11 @@ public class BlockParticleEmitterSystem implements UpdateSubscriberSystem, Rende
 
         for (EntityRef entity : particleEntities) {
             LocationComponent location = entity.getComponent(LocationComponent.class);
+
+            if (null == location) {
+                continue;
+            }
+
             Vector3f worldPos = location.getWorldPosition();
 
             if (!worldProvider.isBlockRelevant(worldPos)) {


### PR DESCRIPTION
Fixes #784.  While it probably needs final review by @Immortius, skipping the rendering of a block particle with no location during rendering is probably a sufficient fix.
