### PR TITLE
Added purgeWorld event notification

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/event/PurgeWorldEvent.java
+++ b/engine/src/main/java/org/terasology/world/chunks/event/PurgeWorldEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.world.chunks.event;
+
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * This {@link Event} is fired when the chunk provider purges
+ * all chunks. This can be triggered using the "purgeWorld" world command. 
+ * @author Martin Steiger
+ */
+public class PurgeWorldEvent implements Event {
+    // empty
+}

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -20,11 +20,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
+
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.TShortObjectMap;
 import gnu.trove.map.hash.TShortObjectHashMap;
 import gnu.trove.procedure.TShortObjectProcedure;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.CoreRegistry;
@@ -52,6 +54,7 @@ import org.terasology.world.chunks.ChunkRegionListener;
 import org.terasology.world.chunks.event.BeforeChunkUnload;
 import org.terasology.world.chunks.event.OnChunkGenerated;
 import org.terasology.world.chunks.event.OnChunkLoaded;
+import org.terasology.world.chunks.event.PurgeWorldEvent;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.chunks.internal.ChunkRelevanceRegion;
 import org.terasology.world.chunks.internal.GeneratingChunkProvider;
@@ -506,6 +509,8 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
         }
         nearCache.clear();
         storageManager.purgeChunks();
+        
+        worldEntity.send(new PurgeWorldEvent());
 
         this.pipeline = new ChunkGenerationPipeline(this, generator, new ChunkTaskRelevanceComparator());
         this.unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 8);


### PR DESCRIPTION
Whenever I run "purgeWorld", I need to clear a few caches to be able to see the changes I've made in the code in the game.

This is why I added a PurgeWorldEvent for WorldComponent, which is sent by LocalChunkProvider.
