### PR TITLE
Updated checkstyle header for 2014+

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,12 +22,12 @@
     <!-- See http://checkstyle.sourceforge.net/config_header.html --> 
     <!-- ***************** --> 
     <!-- Checks that a source file begins with a specified header. --> 
-    <module name="Header"> 
-        <property name="severity" value="warning"/> 
-        <property name="header" value="/*\n * Copyright 2013 MovingBlocks\n *\n"/> 
-        <property name="fileExtensions" value="java"/> 
-    </module>
-
+	<module name="RegexpHeader">
+		<property name="severity" value="warning"/>
+		<property name="header" value="/*\n * Copyright 20\d\d MovingBlocks\n *\n * Licensed under the Apache License, Version 2.0"/>
+		<property name="fileExtensions" value="java"/>
+	</module>
+  
     <module name="TreeWalker">
         <!-- Checks for Naming Conventions -->
         <!-- See http://checkstyle.sourceforge.net/config_naming.html -->

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -506,6 +506,7 @@ public class TerasologyEngine implements GameEngine {
         ModuleManager moduleManager = CoreRegistry.putPermanently(ModuleManager.class, new ModuleManagerImpl(moduleSecurityManager));
         moduleSecurityManager.addAPIPackage("java.lang");
         moduleSecurityManager.addAPIPackage("java.lang.ref");
+        moduleSecurityManager.addAPIPackage("java.math");
         moduleSecurityManager.addAPIPackage("java.util");
         moduleSecurityManager.addAPIPackage("java.util.concurrent");
         moduleSecurityManager.addAPIPackage("java.util.concurrent.atomic");

--- a/engine/src/main/java/org/terasology/world/WorldCommands.java
+++ b/engine/src/main/java/org/terasology/world/WorldCommands.java
@@ -40,7 +40,7 @@ public class WorldCommands implements ComponentSystem {
 
     }
 
-    @Command
+    @Command(shortDescription = "Purges all generated chunks which triggers re-generation")
     public void purgeWorld() {
         chunkProvider.purgeChunks();
     }


### PR DESCRIPTION
Using reg-exp makes it possible to use any year in the range [2000..2099] in the copyright header.

Also added "java.math" for modules and a description for "purgeWorld"
