### PR TITLE
Added regex-based command completion in console

### DIFF
--- a/engine-tests/src/test/java/org/terasology/utilities/CamelCaseMatcherTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/CamelCaseMatcherTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2012-2014 Martin Steiger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.terasology.utilities;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.terasology.rendering.gui.windows.CamelCaseMatcher;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Tests {@link CamelCaseMatcher}
+ * @author Martin Steiger
+ */
+public class CamelCaseMatcherTest
+{
+	@Test
+	public void testDefault() {
+		List<String> commands = ImmutableList.of("MyPossibleResultString");
+		List<String> queries = ImmutableList.of("MyPossibleResultString", "MPRS", 
+				"MPRString", "MyPosResStr" , "M", "MyP*RString", "*PosResString", "My*String");
+		
+		for (String query : queries) {
+			List<String> matches = CamelCaseMatcher.getMatches(query, commands);
+			assertTrue("The query did not match the command",  matches.size() == 1);
+		}
+	}
+	
+	@Test
+	public void testTeraCommands() {
+		List<String> commands = ImmutableList.of("azerty", "bindKey", "clearChunkCache", "countAI", 
+				"damage", "debugTarget", "destroyAI", "destroyEntitiesUsingPrefab", "dumpEntities", 
+				"exit", "fullscreen", "generateNameList", "generateNameList", "ghost", "giveBlock", 
+				"giveBlock", "giveItem", "health", "help", "hjump", "hspeed", "initNameGenerator", 
+				"kill", "listBlocks", "listBlocksByCategory", "listFreeShapeBlocks", "listItems", 
+				"listShapes", "mute", "neo", "nextName", "placeBlock", "playTestSound", "purgeWorld", 
+				"restoreSpeed", "say", "setGroundFriction", "setJumpSpeed", "setMaxGhostSpeed", 
+				"setMaxGroundSpeed", "setMaxHealth", "setRegenRaterate", "showHealth", "showMovement", 
+				"sleigh", "spawnBlock", "spawnPrefab", "stepHeight", "teleport");
+
+		List<String> noHitQueries = ImmutableList.of("asdfd", "AvDS", "MPRString");
+
+		for (String query : noHitQueries) {
+			List<String> matches = CamelCaseMatcher.getMatches(query, commands);
+			assertTrue("The query '" + query + "' should not match any command",  matches.size() == 0);
+		}
+
+		List<String> oneHitQueries = ImmutableList.of("liFSB", "puW", "liI");
+		
+		for (String query : oneHitQueries) {
+			List<String> matches = CamelCaseMatcher.getMatches(query, commands);
+			assertTrue("The query '" + query + "' should match exactly 1 command, not " + matches.size(), matches.size() == 1);
+		}
+
+		List<String> multiHitQueries = ImmutableList.of("liB", "spa", "seMaGSpe");
+		
+		for (String query : multiHitQueries) {
+			List<String> matches = CamelCaseMatcher.getMatches(query, commands);
+			assertTrue("The query '" + query + "' should match multiple commands, not " + matches.size(),  matches.size() > 1);
+		}
+	}
+	
+}

--- a/engine/src/main/java/org/terasology/rendering/gui/windows/CamelCaseMatcher.java
+++ b/engine/src/main/java/org/terasology/rendering/gui/windows/CamelCaseMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.gui.windows;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Inspired by
+ * <p>
+ * http://stackoverflow.com/questions/745415/regex-to-match-from-partial-or-camel-case-string
+ * </p>
+ * @author Martin Steiger
+ */
+public final class CamelCaseMatcher {
+
+    private CamelCaseMatcher() {
+        // avoid instantiation
+    }
+
+    /**
+     * @param commandName
+     * @param commands
+     * @return
+     */
+    public static List<String> getMatches(String queryStr, Collection<String> commands) {
+        List<String> matches = Lists.newArrayList();
+
+        String query = queryStr.replaceAll("\\*", ".*?");
+        query = query.replaceFirst("\\b([a-z]+)", "$1[a-z]*");
+        String re = "\\b(" + query.replaceAll("([A-Z][^A-Z]*)", "$1[^A-Z]*") + ".*?)\\b";
+
+        Pattern regex = Pattern.compile(re);
+
+        for (String cmd : commands) {
+            Matcher m = regex.matcher(cmd);
+
+            if (m.find()) {
+                matches.add(m.group());
+            } 
+        }
+        
+        return matches;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/gui/windows/UIScreenConsole.java
+++ b/engine/src/main/java/org/terasology/rendering/gui/windows/UIScreenConsole.java
@@ -16,7 +16,12 @@
 
 package org.terasology.rendering.gui.windows;
 
-import com.google.common.collect.Lists;
+import java.util.Collection;
+import java.util.List;
+
+import javax.vecmath.Vector2f;
+import javax.vecmath.Vector4f;
+
 import org.lwjgl.input.Keyboard;
 import org.newdawn.slick.Color;
 import org.terasology.engine.CoreRegistry;
@@ -34,9 +39,8 @@ import org.terasology.rendering.gui.widgets.UIListItem;
 import org.terasology.rendering.gui.widgets.UIText;
 import org.terasology.rendering.gui.widgets.UIWindow;
 
-import javax.vecmath.Vector2f;
-import javax.vecmath.Vector4f;
-import java.util.List;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
 
 /**
  * The in-game chat.
@@ -104,33 +108,35 @@ public class UIScreenConsole extends UIWindow implements ConsoleSubscriber {
                         }
                     } else if (event.getKey() == Keyboard.KEY_TAB && !inputBox.getText().trim().isEmpty()) {
                         //guess command
-                        String message = inputBox.getText().trim();
+                        String cmdQuery = inputBox.getText().trim();
 
-                        String commandName = message.substring(1);
                         List<CommandInfo> commands = console.getCommandList();
-                        List<CommandInfo> matches = Lists.newArrayList();
+                        
+                        // Explicitly create a map String->CommandInfo if the CommandInfo is required later
+                        Collection<String> commandNames = Collections2.transform(commands, new Function<CommandInfo, String>() {
 
-                        //check for matching commands
-                        for (CommandInfo cmd : commands) {
-                            if (cmd.getName().regionMatches(0, commandName, 0, commandName.length())) {
-                                matches.add(cmd);
+                            @Override
+                            public String apply(CommandInfo input) {
+                                return input.getName();
                             }
-                        }
+                        });
+                        
+                        List<String> matches = CamelCaseMatcher.getMatches(cmdQuery, commandNames);
 
                         //one match found
                         if (matches.size() == 1) {
-                            inputBox.setText(matches.get(0).getName());
+                            inputBox.setText(matches.get(0));
                             inputBox.setCursorEnd();
                         } else if (matches.size() > 1) {
                             //multiple matches found
                             //add list of available commands
                             String commandMatches = "";
-                            for (CommandInfo cmd : matches) {
+                            for (String cmd : matches) {
                                 if (!commandMatches.isEmpty()) {
                                     commandMatches += " ";
                                 }
 
-                                commandMatches += cmd.getName();
+                                commandMatches += cmd;
                             }
                             console.addMessage(commandMatches);
 


### PR DESCRIPTION
This one is actually quite funny: I don't know under which circumstances the previous console command auto-completion worked. It should check for exact matches, but imho the offset of 1 character breaks everything.

Anyway, I threw it out and added camel-case auto-completion instead (just like in eclipse's "Open Type" dialog). For example:

gh -> ghost
liB -> listBlocks
pW -> purgeWorld
seMaGSpe-> setMaxGroundSpeed setMaxGhostSpeed

Using the asterisk wildcard "*" also works. See the tests in `CamelCaseMatcherTest` for more examples.
