### PR TITLE
Add getDisplaySize() to UIDisplayElement to remove lwjgl dependency

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/gui/framework/UIDisplayElement.java
+++ b/engine/src/main/java/org/terasology/rendering/gui/framework/UIDisplayElement.java
@@ -24,6 +24,7 @@ import org.terasology.engine.CoreRegistry;
 import org.terasology.input.BindButtonEvent;
 import org.terasology.input.events.KeyEvent;
 import org.terasology.logic.manager.GUIManager;
+import org.terasology.math.Vector2i;
 import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.gui.animation.Animation;
 import org.terasology.rendering.gui.framework.events.AnimationListener;
@@ -568,6 +569,10 @@ public abstract class UIDisplayElement {
      */
     public EUnitType getUnitPositionY() {
         return unitPositionY;
+    }
+
+    public Vector2i getDisplaySize() {
+        return new Vector2i(Display.getWidth(), Display.getHeight());
     }
 
     /**


### PR DESCRIPTION
Oops.  Original version of this was on UIWindow which was not sufficient.  Not sure how that change got pushed and not this one.  Looks like github automatically closed the bad one when I deleted the branch.

Needed because module UI elements want to resize to a specific place on the window based on window width/height.

Put in UIDisplayElement because it seems the most accessible and I didn't want to create a static util class for it.
