### PR TITLE
Load Component Map data types as a LinkedHashMap

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
@@ -37,11 +37,16 @@ import org.terasology.entitySystem.prefab.internal.PojoPrefab;
 import org.terasology.entitySystem.prefab.internal.PojoPrefabManager;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
+import org.terasology.entitySystem.stubs.OrderedMapTestComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -92,6 +97,26 @@ public class PrefabTest {
     public void prefabHasDefinedComponents() {
         Prefab prefab = prefabManager.getPrefab("unittest:withComponent");
         assertTrue(prefab.hasComponent(StringComponent.class));
+    }
+
+    @Test
+    public void prefabHasDefinedComponentsWithOrderedMap() {
+        Prefab prefab = prefabManager.getPrefab("unittest:withComponentContainingOrderedMap");
+        assertTrue(prefab.hasComponent(OrderedMapTestComponent.class));
+        OrderedMapTestComponent component = prefab.getComponent(OrderedMapTestComponent.class);
+        assertNotNull(component);
+        Map<String, Long> orderedMap = component.orderedMap;
+        Set<String> keySet = orderedMap.keySet();
+        List<String> keyList = new ArrayList<String>(keySet);
+        assertEquals(4, keyList.size());
+        assertEquals("one", keyList.get(0));
+        assertEquals("two", keyList.get(1));
+        assertEquals("three", keyList.get(2));
+        assertEquals("four", keyList.get(3));
+        assertEquals(Long.valueOf(1), orderedMap.get("one"));
+        assertEquals(Long.valueOf(2), orderedMap.get("two"));
+        assertEquals(Long.valueOf(3), orderedMap.get("three"));
+        assertEquals(Long.valueOf(4), orderedMap.get("four"));
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/stubs/OrderedMapTestComponent.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/stubs/OrderedMapTestComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.stubs;
+
+import java.util.Map;
+
+import org.terasology.entitySystem.Component;
+
+public final class OrderedMapTestComponent implements Component {
+    public Map<String,Long> orderedMap;
+}

--- a/engine-tests/src/test/resources/assets/prefabs/withComponentContainingOrderedMap.prefab
+++ b/engine-tests/src/test/resources/assets/prefabs/withComponentContainingOrderedMap.prefab
@@ -1,0 +1,10 @@
+{
+    "OrderedMapTest" = {
+	    "orderedMap" = {
+	    	 "one" : 1,
+	    	 "two" : 2,
+	    	 "three" : 3,
+	    	 "four" : 4
+	    }
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeSerialization/typeHandlers/core/StringMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeSerialization/typeHandlers/core/StringMapTypeHandler.java
@@ -49,7 +49,7 @@ public class StringMapTypeHandler<T> extends SimpleTypeHandler<Map<String, T>> {
 
     @Override
     public Map<String, T> deserialize(EntityData.Value value) {
-        Map<String, T> result = Maps.newHashMap();
+        Map<String, T> result = Maps.newLinkedHashMap();
         for (EntityData.NameValue entry : value.getNameValueList()) {
             result.put(entry.getName(), contentsHandler.deserialize(entry.getValue()));
         }


### PR DESCRIPTION
(07:33:15 PM) Immortius: mkienenb, if we change the StringMapTypeHandler to produce a LinkedHashMap, order will be preserved
(07:33:21 PM) Immortius: probably a good idea in general

Plus tests proving order was preserved.   Also makes a good example to point people at if they need to use a Map in a prefab.
