### PR TITLE
Differentiate local player by item block selection

### DIFF
--- a/engine/src/main/java/org/terasology/logic/selection/LocalPlayerBlockSelectionByItemSystem.java
+++ b/engine/src/main/java/org/terasology/logic/selection/LocalPlayerBlockSelectionByItemSystem.java
@@ -46,7 +46,7 @@ public class LocalPlayerBlockSelectionByItemSystem implements ComponentSystem {
 
     private EntityRef blockSelectionComponentEntity;
 
-    @ReceiveEvent(components = {BlockSelectionComponent.class})
+    @ReceiveEvent(components = {OnItemActivateSelectionComponent.class})
     public void onPlaced(ActivateEvent event, EntityRef itemEntity) {
         if (event.getTargetLocation() == null) {
             return;

--- a/engine/src/main/java/org/terasology/logic/selection/OnItemActivateSelectionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/selection/OnItemActivateSelectionComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.selection;
+
+import org.terasology.entitySystem.Component;
+
+public final class OnItemActivateSelectionComponent implements Component {
+
+}


### PR DESCRIPTION
Currently the block selection tool system intercepts all BlockSelections and messes with them.
This patch adds a new OnItemActivateSelectionComponent.java to identify just item selection tools.
A patch to maze is next to update that module to use it.
