### PR TITLE
Adding module context while loading block definitions to avoid problems,...

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/loader/BlockLoader.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockLoader.java
@@ -140,8 +140,6 @@ public class BlockLoader implements BlockBuilderHelper {
                         }
                     }
                 }
-            } catch (JsonParseException | NullPointerException e) {
-                logger.error("Failed to load block '{}'", blockDefUri, e);
             } catch (Exception e) {
                 logger.error("Error loading block {}", blockDefUri, e);
             }


### PR DESCRIPTION
... if block does not specify module name for their tiles and there are multiple files with the same name in different mods.
