### PR TITLE
Make ShaderManager an interface

### DIFF
--- a/engine-tests/src/test/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/TerasologyTestingEnvironment.java
@@ -53,6 +53,7 @@ import org.terasology.persistence.internal.StorageManagerInternal;
 import org.terasology.physics.CollisionGroupManager;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.ShaderManager;
+import org.terasology.rendering.ShaderManagerLwjgl;
 import org.terasology.rendering.assets.animation.MeshAnimation;
 import org.terasology.rendering.assets.animation.MeshAnimationData;
 import org.terasology.rendering.assets.animation.MeshAnimationImpl;
@@ -198,7 +199,7 @@ public abstract class TerasologyTestingEnvironment {
                 }
             });
 
-            CoreRegistry.put(ShaderManager.class, new ShaderManager()).initShaders();
+            CoreRegistry.put(ShaderManager.class, new ShaderManagerLwjgl()).initShaders();
 
             DefaultBlockFamilyFactoryRegistry blockFamilyFactoryRegistry = new DefaultBlockFamilyFactoryRegistry();
             blockFamilyFactoryRegistry.setBlockFamilyFactory("horizontal", new HorizontalBlockFamilyFactory());

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -18,6 +18,7 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+
 import org.lwjgl.LWJGLException;
 import org.lwjgl.LWJGLUtil;
 import org.lwjgl.input.Keyboard;
@@ -72,6 +73,7 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.physics.CollisionGroupManager;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.ShaderManager;
+import org.terasology.rendering.ShaderManagerLwjgl;
 import org.terasology.rendering.VertexBufferObjectManager;
 import org.terasology.rendering.assets.animation.MeshAnimation;
 import org.terasology.rendering.assets.animation.MeshAnimationData;
@@ -111,9 +113,11 @@ import org.terasology.world.block.shapes.BlockShapeData;
 import org.terasology.world.block.shapes.BlockShapeImpl;
 import org.terasology.world.generator.internal.WorldGeneratorManager;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
+
 import sun.reflect.annotation.AnnotationParser;
 
 import javax.swing.*;
+
 import java.awt.*;
 import java.io.FilePermission;
 import java.io.IOException;
@@ -468,7 +472,7 @@ public class TerasologyEngine implements GameEngine {
         });
         assetManager.addResolver(AssetType.SUBTEXTURE, new SubtextureFromAtlasResolver());
         assetManager.addResolver(AssetType.TEXTURE, new ColorTextureAssetResolver());
-        CoreRegistry.putPermanently(ShaderManager.class, new ShaderManager());
+        CoreRegistry.putPermanently(ShaderManager.class, new ShaderManagerLwjgl());
         CoreRegistry.get(ShaderManager.class).initShaders();
         VertexBufferObjectManager.getInstance();
 

--- a/engine/src/main/java/org/terasology/rendering/ShaderManager.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManager.java
@@ -1,164 +1,30 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.terasology.rendering;
 
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL13;
-import org.lwjgl.opengl.GL20;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.terasology.asset.AssetManager;
-import org.terasology.asset.AssetType;
-import org.terasology.asset.AssetUri;
-import org.terasology.asset.Assets;
-import org.terasology.registry.CoreRegistry;
-import org.terasology.rendering.assets.material.MaterialData;
-import org.terasology.rendering.assets.shader.Shader;
+import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
-import org.terasology.rendering.opengl.GLSLMaterial;
-import org.terasology.rendering.shader.ShaderParameters;
-import org.terasology.rendering.shader.ShaderParametersBlock;
-import org.terasology.rendering.shader.ShaderParametersChunk;
-import org.terasology.rendering.shader.ShaderParametersCombine;
-import org.terasology.rendering.shader.ShaderParametersDebug;
-import org.terasology.rendering.shader.ShaderParametersDefault;
-import org.terasology.rendering.shader.ShaderParametersGelCube;
-import org.terasology.rendering.shader.ShaderParametersHdr;
-import org.terasology.rendering.shader.ShaderParametersLightBufferPass;
-import org.terasology.rendering.shader.ShaderParametersLightGeometryPass;
-import org.terasology.rendering.shader.ShaderParametersLightShaft;
-import org.terasology.rendering.shader.ShaderParametersOcDistortion;
-import org.terasology.rendering.shader.ShaderParametersParticle;
-import org.terasology.rendering.shader.ShaderParametersPost;
-import org.terasology.rendering.shader.ShaderParametersPrePost;
-import org.terasology.rendering.shader.ShaderParametersSSAO;
-import org.terasology.rendering.shader.ShaderParametersShadowMap;
-import org.terasology.rendering.shader.ShaderParametersSky;
-import org.terasology.rendering.shader.ShaderParametersSobel;
-import org.terasology.rendering.shader.ShaderParametersVolumetricLightingRayMarching;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+public interface ShaderManager {
 
-/**
- * Provides support for loading and applying shaders.
- *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- */
-public class ShaderManager {
+    public void initShaders();
 
-    private static final Logger logger = LoggerFactory.getLogger(ShaderManager.class);
+    public void setActiveMaterial(Material material);
 
-    private GLSLMaterial activeMaterial;
-    private GLSLMaterial defaultShaderProgram;
-    private GLSLMaterial defaultTexturedShaderProgram;
+    public void bindTexture(int slot, Texture texture);
 
-    public ShaderManager() {
-        logger.info("Loading Terasology shader manager...");
-        logger.info("GL_VERSION: {}", GL11.glGetString(GL11.GL_VERSION));
-        logger.info("SHADING_LANGUAGE VERSION: {}", GL11.glGetString(GL20.GL_SHADING_LANGUAGE_VERSION));
-        logger.info("EXTENSIONS: {}", GL11.glGetString(GL11.GL_EXTENSIONS));
-    }
+    public Material getActiveMaterial();
 
-    public void initShaders() {
-        defaultShaderProgram = prepareAndStoreShaderProgramInstance("default", new ShaderParametersDefault());
-        defaultTexturedShaderProgram = prepareAndStoreShaderProgramInstance("defaultTextured", new ShaderParametersDefault());
-
-        // TODO: Find a better way to do this
-        prepareAndStoreShaderProgramInstance("post", new ShaderParametersPost());
-        prepareAndStoreShaderProgramInstance("ssao", new ShaderParametersSSAO());
-        prepareAndStoreShaderProgramInstance("lightshaft", new ShaderParametersLightShaft());
-        prepareAndStoreShaderProgramInstance("sobel", new ShaderParametersSobel());
-        prepareAndStoreShaderProgramInstance("prePost", new ShaderParametersPrePost());
-        prepareAndStoreShaderProgramInstance("combine", new ShaderParametersCombine());
-        prepareAndStoreShaderProgramInstance("highp", new ShaderParametersDefault());
-        prepareAndStoreShaderProgramInstance("blur", new ShaderParametersDefault());
-        prepareAndStoreShaderProgramInstance("down", new ShaderParametersDefault());
-        prepareAndStoreShaderProgramInstance("hdr", new ShaderParametersHdr());
-        prepareAndStoreShaderProgramInstance("sky", new ShaderParametersSky());
-        prepareAndStoreShaderProgramInstance("chunk", new ShaderParametersChunk());
-        prepareAndStoreShaderProgramInstance("particle", new ShaderParametersParticle());
-        prepareAndStoreShaderProgramInstance("block", new ShaderParametersBlock());
-        prepareAndStoreShaderProgramInstance("gelatinousCube", new ShaderParametersGelCube());
-        prepareAndStoreShaderProgramInstance("animateOpacity", new ShaderParametersDefault());
-        prepareAndStoreShaderProgramInstance("shadowMap", new ShaderParametersShadowMap());
-        prepareAndStoreShaderProgramInstance("debug", new ShaderParametersDebug());
-        prepareAndStoreShaderProgramInstance("ocDistortion", new ShaderParametersOcDistortion());
-        prepareAndStoreShaderProgramInstance("lightBufferPass", new ShaderParametersLightBufferPass());
-        prepareAndStoreShaderProgramInstance("lightGeometryPass", new ShaderParametersLightGeometryPass());
-        prepareAndStoreShaderProgramInstance("simple", new ShaderParametersDefault());
-        prepareAndStoreShaderProgramInstance("ssaoBlur", new ShaderParametersDefault());
-        prepareAndStoreShaderProgramInstance("volLightingRayMarching", new ShaderParametersVolumetricLightingRayMarching());
-    }
-
-    public void setActiveMaterial(GLSLMaterial material) {
-        if (!material.equals(activeMaterial)) {
-            activeMaterial = material;
-        }
-    }
-
-    public void bindTexture(int slot, Texture texture) {
-        if (activeMaterial != null && !activeMaterial.isDisposed()) {
-            GL13.glActiveTexture(GL13.GL_TEXTURE0 + slot);
-            // TODO: Need to be cubemap aware, only need to clear bind when switching from cubemap to 2D and vice versa,
-            // TODO: Don't bind if already bound to the same
-            GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture.getId());
-            GL13.glActiveTexture(GL13.GL_TEXTURE0);
-        }
-    }
-
-    public GLSLMaterial getActiveMaterial() {
-        return activeMaterial;
-    }
-
-    public void recompileAllShaders() {
-        for (Shader shader : CoreRegistry.get(AssetManager.class).listLoadedAssets(AssetType.SHADER, Shader.class)) {
-            shader.recompile();
-        }
-
-        activeMaterial = null;
-    }
-
-    private GLSLMaterial prepareAndStoreShaderProgramInstance(String title, ShaderParameters params) {
-        String uri = "engine:" + title;
-        Shader shader = Assets.getShader(uri);
-        checkNotNull(shader, "Failed to resolve %s", uri);
-        shader.recompile();
-        GLSLMaterial material = Assets.generateAsset(new AssetUri(AssetType.MATERIAL, uri), new MaterialData(shader), GLSLMaterial.class);
-        material.setShaderParameters(params);
-
-        return material;
-    }
+    public void recompileAllShaders();
 
     /**
      * Enables the default shader program.
      */
-    public void enableDefault() {
-        defaultShaderProgram.enable();
-    }
+    public void enableDefault();
 
     /**
      * Enables the default shader program.
      */
-    public void enableDefaultTextured() {
-        defaultTexturedShaderProgram.enable();
-    }
+    public void enableDefaultTextured();
 
-    public void disableShader() {
-        GL20.glUseProgram(0);
-        activeMaterial = null;
-    }
+    public void disableShader();
 
 }

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerHeadless.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerHeadless.java
@@ -1,0 +1,50 @@
+
+package org.terasology.rendering;
+
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.assets.texture.Texture;
+
+public class ShaderManagerHeadless implements ShaderManager {
+
+    private Material activeMaterial;
+
+    @Override
+    public void initShaders() {
+    }
+
+    @Override
+    public void setActiveMaterial(Material material) {
+        activeMaterial = material;
+    }
+
+    @Override
+    public void bindTexture(int slot, Texture texture) {
+        // Do nothing
+    }
+
+    @Override
+    public Material getActiveMaterial() {
+        return activeMaterial;
+    }
+
+    @Override
+    public void recompileAllShaders() {
+        // Do nothing
+    }
+
+    @Override
+    public void enableDefault() {
+        // Do nothing
+    }
+
+    @Override
+    public void enableDefaultTextured() {
+        // Do nothing
+    }
+
+    @Override
+    public void disableShader() {
+        // Do nothing
+    }
+
+}

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL20;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.asset.AssetManager;
+import org.terasology.asset.AssetType;
+import org.terasology.asset.AssetUri;
+import org.terasology.asset.Assets;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.assets.material.MaterialData;
+import org.terasology.rendering.assets.shader.Shader;
+import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.opengl.GLSLMaterial;
+import org.terasology.rendering.shader.ShaderParameters;
+import org.terasology.rendering.shader.ShaderParametersBlock;
+import org.terasology.rendering.shader.ShaderParametersChunk;
+import org.terasology.rendering.shader.ShaderParametersCombine;
+import org.terasology.rendering.shader.ShaderParametersDebug;
+import org.terasology.rendering.shader.ShaderParametersDefault;
+import org.terasology.rendering.shader.ShaderParametersGelCube;
+import org.terasology.rendering.shader.ShaderParametersHdr;
+import org.terasology.rendering.shader.ShaderParametersLightBufferPass;
+import org.terasology.rendering.shader.ShaderParametersLightGeometryPass;
+import org.terasology.rendering.shader.ShaderParametersLightShaft;
+import org.terasology.rendering.shader.ShaderParametersOcDistortion;
+import org.terasology.rendering.shader.ShaderParametersParticle;
+import org.terasology.rendering.shader.ShaderParametersPost;
+import org.terasology.rendering.shader.ShaderParametersPrePost;
+import org.terasology.rendering.shader.ShaderParametersSSAO;
+import org.terasology.rendering.shader.ShaderParametersShadowMap;
+import org.terasology.rendering.shader.ShaderParametersSky;
+import org.terasology.rendering.shader.ShaderParametersSobel;
+import org.terasology.rendering.shader.ShaderParametersVolumetricLightingRayMarching;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Provides support for loading and applying shaders.
+ *
+ * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ */
+public class ShaderManagerLwjgl implements ShaderManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShaderManagerLwjgl.class);
+
+    private GLSLMaterial activeMaterial;
+    private GLSLMaterial defaultShaderProgram;
+    private GLSLMaterial defaultTexturedShaderProgram;
+
+    public ShaderManagerLwjgl() {
+        logger.info("Loading Terasology shader manager...");
+        logger.info("GL_VERSION: {}", GL11.glGetString(GL11.GL_VERSION));
+        logger.info("SHADING_LANGUAGE VERSION: {}", GL11.glGetString(GL20.GL_SHADING_LANGUAGE_VERSION));
+        logger.info("EXTENSIONS: {}", GL11.glGetString(GL11.GL_EXTENSIONS));
+    }
+
+    @Override
+    public void initShaders() {
+        defaultShaderProgram = prepareAndStoreShaderProgramInstance("default", new ShaderParametersDefault());
+        defaultTexturedShaderProgram = prepareAndStoreShaderProgramInstance("defaultTextured", new ShaderParametersDefault());
+
+        // TODO: Find a better way to do this
+        prepareAndStoreShaderProgramInstance("post", new ShaderParametersPost());
+        prepareAndStoreShaderProgramInstance("ssao", new ShaderParametersSSAO());
+        prepareAndStoreShaderProgramInstance("lightshaft", new ShaderParametersLightShaft());
+        prepareAndStoreShaderProgramInstance("sobel", new ShaderParametersSobel());
+        prepareAndStoreShaderProgramInstance("prePost", new ShaderParametersPrePost());
+        prepareAndStoreShaderProgramInstance("combine", new ShaderParametersCombine());
+        prepareAndStoreShaderProgramInstance("highp", new ShaderParametersDefault());
+        prepareAndStoreShaderProgramInstance("blur", new ShaderParametersDefault());
+        prepareAndStoreShaderProgramInstance("down", new ShaderParametersDefault());
+        prepareAndStoreShaderProgramInstance("hdr", new ShaderParametersHdr());
+        prepareAndStoreShaderProgramInstance("sky", new ShaderParametersSky());
+        prepareAndStoreShaderProgramInstance("chunk", new ShaderParametersChunk());
+        prepareAndStoreShaderProgramInstance("particle", new ShaderParametersParticle());
+        prepareAndStoreShaderProgramInstance("block", new ShaderParametersBlock());
+        prepareAndStoreShaderProgramInstance("gelatinousCube", new ShaderParametersGelCube());
+        prepareAndStoreShaderProgramInstance("animateOpacity", new ShaderParametersDefault());
+        prepareAndStoreShaderProgramInstance("shadowMap", new ShaderParametersShadowMap());
+        prepareAndStoreShaderProgramInstance("debug", new ShaderParametersDebug());
+        prepareAndStoreShaderProgramInstance("ocDistortion", new ShaderParametersOcDistortion());
+        prepareAndStoreShaderProgramInstance("lightBufferPass", new ShaderParametersLightBufferPass());
+        prepareAndStoreShaderProgramInstance("lightGeometryPass", new ShaderParametersLightGeometryPass());
+        prepareAndStoreShaderProgramInstance("simple", new ShaderParametersDefault());
+        prepareAndStoreShaderProgramInstance("ssaoBlur", new ShaderParametersDefault());
+        prepareAndStoreShaderProgramInstance("volLightingRayMarching", new ShaderParametersVolumetricLightingRayMarching());
+    }
+
+    @Override
+    public void setActiveMaterial(Material material) {
+        // TODO: is this the best way to convert the material to the lwjgl version?  Do we need more checks?
+        GLSLMaterial glslMaterial = (GLSLMaterial)material;
+        if (!glslMaterial.equals(activeMaterial)) {
+            activeMaterial = glslMaterial;
+        }
+    }
+
+    @Override
+    public void bindTexture(int slot, Texture texture) {
+        if (activeMaterial != null && !activeMaterial.isDisposed()) {
+            GL13.glActiveTexture(GL13.GL_TEXTURE0 + slot);
+            // TODO: Need to be cubemap aware, only need to clear bind when switching from cubemap to 2D and vice versa,
+            // TODO: Don't bind if already bound to the same
+            GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture.getId());
+            GL13.glActiveTexture(GL13.GL_TEXTURE0);
+        }
+    }
+
+    @Override
+    public Material getActiveMaterial() {
+        return activeMaterial;
+    }
+
+    @Override
+    public void recompileAllShaders() {
+        for (Shader shader : CoreRegistry.get(AssetManager.class).listLoadedAssets(AssetType.SHADER, Shader.class)) {
+            shader.recompile();
+        }
+
+        activeMaterial = null;
+    }
+
+    private GLSLMaterial prepareAndStoreShaderProgramInstance(String title, ShaderParameters params) {
+        String uri = "engine:" + title;
+        Shader shader = Assets.getShader(uri);
+        checkNotNull(shader, "Failed to resolve %s", uri);
+        shader.recompile();
+        GLSLMaterial material = Assets.generateAsset(new AssetUri(AssetType.MATERIAL, uri), new MaterialData(shader), GLSLMaterial.class);
+        material.setShaderParameters(params);
+
+        return material;
+    }
+
+    /**
+     * Enables the default shader program.
+     */
+    @Override
+    public void enableDefault() {
+        defaultShaderProgram.enable();
+    }
+
+    /**
+     * Enables the default shader program.
+     */
+    @Override
+    public void enableDefaultTextured() {
+        defaultTexturedShaderProgram.enable();
+    }
+
+    @Override
+    public void disableShader() {
+        GL20.glUseProgram(0);
+        activeMaterial = null;
+    }
+
+}


### PR DESCRIPTION
Add Headless ShaderManager by making ShaderManager an interface.

One concern here is that the lwjgl version explicitly casts to the lwjgl GLSLMaterial.  I'm guessing this should be ok.
-    public void setActiveMaterial(Material material) {
-        // TODO: is this the best way to convert the material to the lwjgl version?  Do we need more checks?
-        GLSLMaterial glslMaterial = (GLSLMaterial)material;
