### PR TITLE
Split InitialiseWorld to enable access WorldEntity during world gen

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -18,6 +18,7 @@ package org.terasology.engine.modes;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
+
 import org.lwjgl.Sys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import org.terasology.engine.modes.loadProcesses.InitialiseGraphics;
 import org.terasology.engine.modes.loadProcesses.InitialiseRemoteWorld;
 import org.terasology.engine.modes.loadProcesses.InitialiseSystems;
 import org.terasology.engine.modes.loadProcesses.InitialiseWorld;
+import org.terasology.engine.modes.loadProcesses.InitialiseWorldGenerator;
 import org.terasology.engine.modes.loadProcesses.JoinServer;
 import org.terasology.engine.modes.loadProcesses.LoadEntities;
 import org.terasology.engine.modes.loadProcesses.LoadPrefabs;
@@ -171,6 +173,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new LoadEntities());
         loadProcesses.add(new InitialiseBlockTypeEntities());
         loadProcesses.add(new CreateWorldEntity());
+        loadProcesses.add(new InitialiseWorldGenerator(gameManifest));
         if (netMode == NetworkMode.SERVER) {
             loadProcesses.add(new StartServer());
         }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -89,8 +89,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         WorldGenerator worldGenerator;
         try {
             worldGenerator = CoreRegistry.get(WorldGeneratorManager.class).createGenerator(worldInfo.getWorldGenerator());
-            worldGenerator.initialize();
-            worldGenerator.setWorldSeed(worldInfo.getSeed());
+            CoreRegistry.put(WorldGenerator.class, worldGenerator);
         } catch (UnresolvedWorldGeneratorException e) {
             logger.error("Unable to load world generator", e);
             CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu("Failed to resolve world generator."));

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.engine.modes.loadProcesses;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.TerasologyConstants;
+import org.terasology.game.GameManifest;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.world.generator.WorldGenerator;
+import org.terasology.world.internal.WorldInfo;
+
+/**
+ * @author Martin Steiger
+ */
+public class InitialiseWorldGenerator extends SingleStepLoadProcess {
+
+    private static final Logger logger = LoggerFactory.getLogger(InitialiseWorldGenerator.class);
+
+    private GameManifest gameManifest;
+
+    public InitialiseWorldGenerator(GameManifest gameManifest) {
+        this.gameManifest = gameManifest;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Generating world ...";
+    }
+
+    @Override
+    public boolean step() {
+
+        WorldGenerator worldGenerator;
+        WorldInfo worldInfo = gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD);
+        worldGenerator = CoreRegistry.get(WorldGenerator.class);
+        worldGenerator.initialize();
+        worldGenerator.setWorldSeed(worldInfo.getSeed());
+
+        return true;
+    }
+
+    @Override
+    public int getExpectedCost() {
+        return 5;
+    }
+}


### PR DESCRIPTION
I had to put WorldGenerator into CoreRegistry to be able to access it later on - works as expected.
