### PR TITLE
Use DisplayDevice isHeadless for registering systems

### DIFF
--- a/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
@@ -17,9 +17,11 @@ package org.terasology.engine;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.systems.ComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -64,6 +66,9 @@ public class ComponentSystemManager {
     }
 
     public void loadSystems(String moduleName, Reflections reflections, NetworkMode netMode) {
+        DisplayDevice displayDevice = CoreRegistry.get(DisplayDevice.class);
+        boolean isHeadless = displayDevice.isHeadless();
+
         Set<Class<?>> systems = reflections.getTypesAnnotatedWith(RegisterSystem.class);
         for (Class<?> system : systems) {
             if (!ComponentSystem.class.isAssignableFrom(system)) {
@@ -72,7 +77,7 @@ public class ComponentSystemManager {
             }
 
             RegisterSystem registerInfo = system.getAnnotation(RegisterSystem.class);
-            if (registerInfo.value().isValidFor(netMode, false)) {
+            if (registerInfo.value().isValidFor(netMode, isHeadless)) {
                 String id = moduleName + ":" + system.getSimpleName();
                 logger.debug("Registering system {}", id);
                 try {

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -33,7 +33,7 @@ import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.module.ModuleManagerImpl;
 import org.terasology.engine.module.ModuleSecurityManager;
 import org.terasology.engine.paths.PathManager;
-import org.terasology.engine.subsystem.Display;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
@@ -138,7 +138,9 @@ public class TerasologyEngine implements GameEngine {
                 subsystem.postInitialise(config);
             }
 
-            // Display is required to be initialized by an EngineSubsystem and registered as a Core system at this point.
+            if (CoreRegistry.get(DisplayDevice.class) == null) {
+                throw new IllegalStateException("DisplayDevice not registered as a core system.");
+            }
 
             initAssets();
 
@@ -453,7 +455,7 @@ public class TerasologyEngine implements GameEngine {
     private void mainLoop() {
         NetworkSystem networkSystem = CoreRegistry.get(NetworkSystem.class);
 
-        Display display = CoreRegistry.get(Display.class);
+        DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
 
         PerformanceMonitor.startActivity("Other");
         // MAIN GAME LOOP
@@ -547,9 +549,8 @@ public class TerasologyEngine implements GameEngine {
     public void setFullscreen(boolean state) {
         if (config.getRendering().isFullscreen() != state) {
             config.getRendering().setFullscreen(state);
-            Display display = CoreRegistry.get(Display.class);
+            DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
             display.setFullscreen(state);
-            display.resizeViewport();
             CoreRegistry.get(GUIManager.class).update(true);
         }
     }
@@ -563,7 +564,7 @@ public class TerasologyEngine implements GameEngine {
     }
 
     public boolean hasFocus() {
-        Display display = CoreRegistry.get(Display.class);
+        DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
         return gameFocused && display.isActive();
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -22,6 +22,7 @@ import org.terasology.config.Config;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.GameThread;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
@@ -43,11 +44,6 @@ import org.terasology.rendering.oculusVr.OculusVrHelper;
 import org.terasology.rendering.opengl.DefaultRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.block.BlockManager;
-
-import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.glClear;
-import static org.lwjgl.opengl.GL11.glLoadIdentity;
 
 /**
  * Play mode.
@@ -170,8 +166,8 @@ public class StateIngame implements GameState {
     }
 
     public void render() {
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        glLoadIdentity();
+        DisplayDevice displayDevice = CoreRegistry.get(DisplayDevice.class);
+        displayDevice.prepareToRender();
 
         if (worldRenderer != null) {
             if (!CoreRegistry.get(Config.class).getRendering().isOculusVrSupport()) {

--- a/engine/src/main/java/org/terasology/engine/subsystem/DisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/DisplayDevice.java
@@ -15,16 +15,12 @@
  */
 package org.terasology.engine.subsystem;
 
-public interface Display {
+public interface DisplayDevice {
     boolean isActive();
 
     boolean isCloseRequested();
 
     void setFullscreen(boolean state);
-
-    void resizeViewport();
-
-    boolean wasResized();
 
     // TODO: this breaks the nice API we have so far.
     // From the lwjgl docs:
@@ -33,5 +29,10 @@ public interface Display {
     //   This method is called from update(), so it is not necessary to call this method
     //   if update() is called periodically.
     void processMessages();
+
+    boolean isHeadless();
+
+    // TODO: another method that possibly doesn't need to exist, but I need to check with Immortius on this
+    void prepareToRender();
 
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -15,6 +15,10 @@
  */
 package org.terasology.engine.subsystem.lwjgl;
 
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glLoadIdentity;
 import static org.lwjgl.opengl.GL11.glViewport;
 
 import org.lwjgl.LWJGLException;
@@ -22,13 +26,14 @@ import org.lwjgl.opengl.Display;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.registry.CoreRegistry;
 
-public class LwjglDisplay implements org.terasology.engine.subsystem.Display {
+public class LwjglDisplayDevice implements DisplayDevice {
 
-    private static final Logger logger = LoggerFactory.getLogger(LwjglDisplay.class);
+    private static final Logger logger = LoggerFactory.getLogger(LwjglDisplayDevice.class);
 
-    public LwjglDisplay() {
+    public LwjglDisplayDevice() {
     }
 
     @Override
@@ -43,6 +48,10 @@ public class LwjglDisplay implements org.terasology.engine.subsystem.Display {
 
     @Override
     public void setFullscreen(boolean state) {
+        setFullscreen(state, true);
+    }
+
+    void setFullscreen(boolean state, boolean resize) {
         try {
             if (state) {
                 Display.setDisplayMode(Display.getDesktopDisplayMode());
@@ -56,20 +65,24 @@ public class LwjglDisplay implements org.terasology.engine.subsystem.Display {
             logger.error("Can not initialize graphics device.", e);
             System.exit(1);
         }
-    }
-
-    @Override
-    public void resizeViewport() {
-        glViewport(0, 0, Display.getWidth(), Display.getHeight());
-    }
-
-    @Override
-    public boolean wasResized() {
-        return Display.wasResized();
+        if (resize) {
+            glViewport(0, 0, Display.getWidth(), Display.getHeight());
+        }
     }
 
     @Override
     public void processMessages() {
         Display.processMessages();
+    }
+
+    @Override
+    public boolean isHeadless() {
+        return false;
+    }
+
+    @Override
+    public void prepareToRender() {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        glLoadIdentity();
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -21,6 +21,7 @@ import static org.lwjgl.opengl.GL11.GL_LEQUAL;
 import static org.lwjgl.opengl.GL11.GL_NORMALIZE;
 import static org.lwjgl.opengl.GL11.glDepthFunc;
 import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glViewport;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -45,6 +46,7 @@ import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.modes.GameState;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.logic.manager.GUIManager;
 import org.terasology.logic.manager.GUIManagerLwjgl;
@@ -96,8 +98,8 @@ public class LwjglGraphics implements EngineSubsystem {
 
     @Override
     public void postInitialise(Config config) {
-        LwjglDisplay lwjglDisplay = new LwjglDisplay();
-        CoreRegistry.putPermanently(org.terasology.engine.subsystem.Display.class, lwjglDisplay);
+        LwjglDisplayDevice lwjglDisplay = new LwjglDisplayDevice();
+        CoreRegistry.putPermanently(DisplayDevice.class, lwjglDisplay);
 
         initDisplay(config, lwjglDisplay);
         initOpenGL(lwjglDisplay);
@@ -117,9 +119,8 @@ public class LwjglGraphics implements EngineSubsystem {
         Display.sync(60);
         currentState.render();
 
-        org.terasology.engine.subsystem.Display display = CoreRegistry.get(org.terasology.engine.subsystem.Display.class);
-        if (display.wasResized()) {
-            display.resizeViewport();
+        if (Display.wasResized()) {
+            glViewport(0, 0, Display.getWidth(), Display.getHeight());
         }
     }
 
@@ -158,9 +159,9 @@ public class LwjglGraphics implements EngineSubsystem {
         }
     }
 
-    private void initDisplay(Config config, LwjglDisplay lwjglDisplay) {
+    private void initDisplay(Config config, LwjglDisplayDevice lwjglDisplay) {
         try {
-            lwjglDisplay.setFullscreen(config.getRendering().isFullscreen());
+            lwjglDisplay.setFullscreen(config.getRendering().isFullscreen(), false);
 
             RenderingConfig rc = config.getRendering();
             Display.setLocation(rc.getWindowPosX(), rc.getWindowPosY());
@@ -192,9 +193,9 @@ public class LwjglGraphics implements EngineSubsystem {
         }
     }
 
-    private void initOpenGL(LwjglDisplay lwjglDisplay) {
+    private void initOpenGL(LwjglDisplayDevice lwjglDisplay) {
         checkOpenGL();
-        lwjglDisplay.resizeViewport();
+        glViewport(0, 0, Display.getWidth(), Display.getHeight());
         initOpenGLParams();
         AssetManager assetManager = CoreRegistry.get(AssetManager.class);
         assetManager.setAssetFactory(AssetType.TEXTURE, new AssetFactory<TextureData, Texture>() {


### PR DESCRIPTION
Use DisplayDevice isHeadless for registering systems

Rename Display to DisplayDevice

Move opengl from StateInGame to DisplayDevice

Remove resizeViewport() and wasResized() and fold them into calling lwjgl classes

Verify DisplayDevice is registered

This one will cause conflicts just because the same areas of TerasologyEngine and LwjglGraphics had additional code added to them.   Both sections of code should be included in each case.
