### PR TITLE
Move lwjgl native loading from graphics to timer

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -25,14 +25,12 @@ import static org.lwjgl.opengl.GL11.glViewport;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.ByteBuffer;
 
 import javax.imageio.ImageIO;
 import javax.swing.JOptionPane;
 
 import org.lwjgl.LWJGLException;
-import org.lwjgl.LWJGLUtil;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GLContext;
 import org.newdawn.slick.opengl.ImageIOImageData;
@@ -84,7 +82,6 @@ import org.terasology.rendering.opengl.OpenGLFont;
 import org.terasology.rendering.opengl.OpenGLMesh;
 import org.terasology.rendering.opengl.OpenGLSkeletalMesh;
 import org.terasology.rendering.opengl.OpenGLTexture;
-import org.terasology.utilities.LWJGLHelper;
 
 public class LwjglGraphics implements EngineSubsystem {
 
@@ -92,8 +89,6 @@ public class LwjglGraphics implements EngineSubsystem {
 
     @Override
     public void preInitialise() {
-        initLogger();
-        LWJGLHelper.initNativeLibs();
     }
 
     @Override
@@ -135,28 +130,6 @@ public class LwjglGraphics implements EngineSubsystem {
     @Override
     public void dispose() {
         Display.destroy();
-    }
-
-    private void initLogger() {
-        if (LWJGLUtil.DEBUG) {
-            // Pipes System.out and err to log, because that's where lwjgl writes it to.
-            System.setOut(new PrintStream(System.out) {
-                private Logger logger = LoggerFactory.getLogger("org.lwjgl");
-
-                @Override
-                public void print(final String message) {
-                    logger.info(message);
-                }
-            });
-            System.setErr(new PrintStream(System.err) {
-                private Logger logger = LoggerFactory.getLogger("org.lwjgl");
-
-                @Override
-                public void print(final String message) {
-                    logger.error(message);
-                }
-            });
-        }
     }
 
     private void initDisplay(Config config, LwjglDisplayDevice lwjglDisplay) {

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglTimer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglTimer.java
@@ -15,6 +15,11 @@
  */
 package org.terasology.engine.subsystem.lwjgl;
 
+import java.io.PrintStream;
+
+import org.lwjgl.LWJGLUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
@@ -22,11 +27,14 @@ import org.terasology.engine.internal.TimeLwjgl;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.utilities.LWJGLHelper;
 
 public class LwjglTimer implements EngineSubsystem {
 
     @Override
     public void preInitialise() {
+        initLogger();
+        LWJGLHelper.initNativeLibs();
         initTimer(); // Dependent on LWJGL
     }
 
@@ -48,6 +56,28 @@ public class LwjglTimer implements EngineSubsystem {
 
     @Override
     public void dispose() {
+    }
+
+    private void initLogger() {
+        if (LWJGLUtil.DEBUG) {
+            // Pipes System.out and err to log, because that's where lwjgl writes it to.
+            System.setOut(new PrintStream(System.out) {
+                private Logger logger = LoggerFactory.getLogger("org.lwjgl");
+
+                @Override
+                public void print(final String message) {
+                    logger.info(message);
+                }
+            });
+            System.setErr(new PrintStream(System.err) {
+                private Logger logger = LoggerFactory.getLogger("org.lwjgl");
+
+                @Override
+                public void print(final String message) {
+                    logger.error(message);
+                }
+            });
+        }
     }
 
     private void initTimer() {


### PR DESCRIPTION
This should allow TimerLwjgl to be used by Headless or another non-lwjgl configuration instead of TimerSystem
