### PR TITLE
Drain input queues when changing state

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -520,6 +520,10 @@ public class TerasologyEngine implements GameEngine {
         for (StateChangeSubscriber subscriber : stateChangeSubscribers) {
             subscriber.onStateChange();
         }
+        // drain input queues
+        InputSystem inputSystem = CoreRegistry.get(InputSystem.class);
+        inputSystem.getMouseDevice().getInputQueue();
+        inputSystem.getKeyboard().getInputQueue();
     }
 
     public boolean isFullscreen() {


### PR DESCRIPTION
I can't say for sure that this happens with LWJGL, but with the AWT input systems, it is possible to receive left-over mouse events in-game because of double-clicking on the game to load.

It seems like a good idea in general to drain any pending input events if we are switching game states.

If you think this makes more sense as a inputSystem.drainInputQueues() method, I can do that instead.
