### PR TITLE
Provide public method to register a screen by uri

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
@@ -59,6 +59,8 @@ public interface NUIManager extends ComponentSystem, FocusManager {
 
     void pushScreen(CoreScreenLayer screen);
 
+    void pushScreen(CoreScreenLayer screen, AssetUri uri);
+
     void popScreen();
 
     UIScreenLayer setScreen(AssetUri screenUri);


### PR DESCRIPTION
Not sure if this PR is worth doing just yet as it didn't provide a nice solution, but since I have it open, and I wanted to throw out some code for a discussion, might as well take advantage of it.

Code in comments is how things would work in an ideal world.
Code not in comments is how they work right now with this PR.

Problems with this PR are that closing/popping a screen with toggle (maybe we have too many names for the same thing?) unregisters it, meaning you have to re-push it with the url again.

```
    private String EMPTY_NON_MODAL_SCREEN_ID = "mouseReleasingScreen";
    private AssetUri EMPTY_NON_MODAL_SCREEN_ASSET_URI = new AssetUri(AssetType.UI_ELEMENT, EMPTY_NON_MODAL_SCREEN_ID);

    // Would be nice if we didn't need this after registering it for the first time
    private EmptyNonModalScreenLayer EMPTY_NON_MODAL_SCREEN = new EmptyNonModalScreenLayer();

    @Override

    public void postBegin() {
        // nuiManager.registerScreen(new EmptyNonModalScreenLayer(), EMPTY_NON_MODAL_SCREEN_ASSET_URI);
    }

    // Higher priority than critical because NUI grabs all input when mouse is released
    @ReceiveEvent(components = ClientComponent.class, priority=250)
    public void onToggleMouseGrabber(ToggleMouseGrabberButton event, EntityRef entity) {
        if (event.isDown()) {

            // Cannot toggle from closed/unregistered back to registered
            // This may just be the price you have to pay for a programmically-created Screen

            // nuiManager.toggleScreen(EMPTY_NON_MODAL_SCREEN_ASSET_URI);

            if (nuiManager.isOpen(EMPTY_NON_MODAL_SCREEN_ASSET_URI)) {
                nuiManager.closeScreen(EMPTY_NON_MODAL_SCREEN_ASSET_URI);
            } else {
                nuiManager.pushScreen(EMPTY_NON_MODAL_SCREEN, EMPTY_NON_MODAL_SCREEN_ASSET_URI);
            }

```
