### PR TITLE
Allow small inventory grids to shrink further

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -87,7 +87,7 @@ public class InventoryGrid extends CoreWidget {
         int numSlots = Math.min(InventoryUtils.getSlotCount(getTargetEntity()) - getCellOffset(), getMaxCellCount());
         if (numSlots != 0 && !cells.isEmpty()) {
             Vector2i cellSize = canvas.calculatePreferredSize(cells.get(0));
-            int horizontalCells = Math.min(maxHorizontalCells, sizeHint.getX() / cellSize.getX());
+            int horizontalCells = Math.min(Math.min(maxHorizontalCells, numSlots), sizeHint.getX() / cellSize.getX());
             int verticalCells = ((numSlots - 1) / horizontalCells) + 1;
             return new Vector2i(horizontalCells * cellSize.x, verticalCells * cellSize.y);
         }


### PR DESCRIPTION
When inventory grids do not have cell counts up to the maximum horizontal cells, it still uses the maxHorizontalCells to calculate the content width.  This can cause more dynamic layouts to expand much wider than expected and run out of space.
