### PR TITLE
Tooltip Widgets

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
@@ -18,7 +18,9 @@ package org.terasology.rendering.nui;
 import com.google.common.collect.Lists;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
+import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 import org.terasology.rendering.nui.skin.UISkin;
+import org.terasology.rendering.nui.widgets.UILabel;
 
 import java.util.Collection;
 import java.util.List;
@@ -41,7 +43,7 @@ public abstract class AbstractWidget implements UIWidget {
     private Binding<Boolean> visible = new DefaultBinding<>(true);
 
     @LayoutConfig
-    private Binding<String> tooltip = new DefaultBinding<>("");
+    private Binding<UIWidget> tooltip = new DefaultBinding<>();
 
     @LayoutConfig
     private float tooltipDelay = 0.5f;
@@ -174,18 +176,32 @@ public abstract class AbstractWidget implements UIWidget {
     }
 
     @Override
-    public void bindTooltip(Binding<String> binding) {
+    public void bindTooltip(Binding<UIWidget> binding) {
         tooltip = binding;
     }
 
     @Override
-    public String getTooltip() {
+    public UIWidget getTooltip() {
         return tooltip.get();
     }
 
     @Override
-    public void setTooltip(String val) {
+    public void setTooltip(UIWidget val) {
         tooltip.set(val);
+    }
+
+    @Override
+    public void bindTooltipString(Binding<String> bind) {
+        bindTooltip(new TooltipLabelBinding(bind));
+    }
+
+    @Override
+    public void setTooltip(String value) {
+        if (value != null && !value.isEmpty()) {
+            setTooltip(new UILabel(value));
+        } else {
+            tooltip = new DefaultBinding<>(null);
+        }
     }
 
     @Override
@@ -195,5 +211,22 @@ public abstract class AbstractWidget implements UIWidget {
 
     public final void setTooltipDelay(float value) {
         this.tooltipDelay = value;
+    }
+
+    private static class TooltipLabelBinding extends ReadOnlyBinding<UIWidget> {
+
+        private UILabel tooltipLabel = new UILabel();
+
+        public TooltipLabelBinding(Binding<String> stringBind) {
+            tooltipLabel.bindText(stringBind);
+        }
+
+        @Override
+        public UIWidget get() {
+            if (tooltipLabel.getText().isEmpty()) {
+                return null;
+            }
+            return tooltipLabel;
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
@@ -454,6 +454,24 @@ public interface Canvas {
      * @param listener
      * @param tooltip
      */
+    void addInteractionRegion(InteractionListener listener, UIWidget tooltip);
+
+    /**
+     * Adds an interaction region filling the desired region.
+     *
+     * @param listener
+     * @param tooltip
+     * @param region
+     */
+    void addInteractionRegion(InteractionListener listener, UIWidget tooltip, Rect2i region);
+
+    /**
+     * Adds an interaction region filling the region used to draw the current widget. The widget's margin is used to expand the interaction region to fill the
+     * full area of the widget.
+     *
+     * @param listener
+     * @param tooltip
+     */
     void addInteractionRegion(InteractionListener listener, String tooltip);
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/UIWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/UIWidget.java
@@ -91,11 +91,15 @@ public interface UIWidget extends Iterable<UIWidget> {
 
     boolean canBeFocus();
 
-    void bindTooltip(Binding<String> bind);
+    void bindTooltip(Binding<UIWidget> bind);
+
+    void setTooltip(UIWidget value);
+
+    UIWidget getTooltip();
+
+    void bindTooltipString(Binding<String> bind);
 
     void setTooltip(String value);
-
-    String getTooltip();
 
     float getTooltipDelay();
 

--- a/engine/src/main/java/org/terasology/rendering/nui/asset/UILoader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/asset/UILoader.java
@@ -78,6 +78,7 @@ import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.UILayout;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.skin.UISkin;
+import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.utilities.ReflectionUtil;
 import org.terasology.utilities.gson.CaseInsensitiveEnumTypeAdapterFactory;
 import org.terasology.world.block.Block;
@@ -186,6 +187,10 @@ public class UILoader implements AssetLoader<UIData> {
 
         @Override
         public UIWidget deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            if (json.isJsonPrimitive() && json.getAsJsonPrimitive().isString()) {
+                return new UILabel(json.getAsString());
+            }
+
             JsonObject jsonObject = json.getAsJsonObject();
 
             String type = jsonObject.get("type").getAsString();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryCell.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryCell.java
@@ -35,9 +35,11 @@ import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
 import org.terasology.rendering.nui.InteractionListener;
 import org.terasology.rendering.nui.LayoutConfig;
+import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.world.block.items.BlockItemComponent;
 
 /**
@@ -86,7 +88,7 @@ public class InventoryCell extends CoreWidget {
     };
 
     public InventoryCell() {
-        icon.bindTooltip(new ReadOnlyBinding<String>() {
+        icon.bindTooltipString(new ReadOnlyBinding<String>() {
             @Override
             public String get() {
                 DisplayNameComponent displayNameComponent = getTargetItem().getComponent(DisplayNameComponent.class);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemIcon.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemIcon.java
@@ -60,7 +60,7 @@ public class ItemIcon extends CoreWidget {
         if (getQuantity() > 1) {
             canvas.drawText(Integer.toString(getQuantity()));
         }
-        if (!getTooltip().isEmpty()) {
+        if (getTooltip() != null) {
             canvas.addInteractionRegion(listener);
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/AddServerPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/AddServerPopup.java
@@ -41,6 +41,7 @@ public class AddServerPopup extends CoreScreenLayer {
                 UIText name = find("name", UIText.class);
                 UIText address = find("address", UIText.class);
                 if (name != null && address != null) {
+                    // TODO: Validate name and address are present
                     ServerInfo result = new ServerInfo(name.getText(), address.getText());
                     config.getNetwork().add(result);
                 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/CursorAttachment.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/CursorAttachment.java
@@ -95,6 +95,6 @@ public class CursorAttachment extends CoreWidget {
 
     @Override
     public boolean isVisible() {
-        return super.isVisible() && Mouse.isVisible();
+        return super.isVisible() && Mouse.isVisible() && getAttachment() != null && getAttachment().isVisible();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITooltip.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITooltip.java
@@ -15,37 +15,9 @@
  */
 package org.terasology.rendering.nui.widgets;
 
-import org.terasology.rendering.nui.Canvas;
-import org.terasology.rendering.nui.databinding.Binding;
-
 /**
  * @author Immortius
  */
 public class UITooltip extends CursorAttachment {
 
-    private UILabel label;
-
-    public UITooltip() {
-        label = new UILabel();
-        setAttachment(label);
-    }
-
-    @Override
-    public void onDraw(Canvas canvas) {
-        if (!getText().isEmpty()) {
-            super.onDraw(canvas);
-        }
-    }
-
-    public void bindBinding(Binding<String> binding) {
-        label.bindText(binding);
-    }
-
-    public String getText() {
-        return label.getText();
-    }
-
-    public void setText(String val) {
-        label.setText(val);
-    }
 }

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -41,98 +41,62 @@
                     "horizontalSpacing": 8,
                     "family": "option-grid",
                     "contents": [
-                        {
-                            "type": "UILabel",
-                            "text": "Graphics Quality:"
-                        },
+                        "Graphics Quality:",
                         {
                             "type": "UIDropdown",
                             "id": "quality"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Environment Effects:"
-                        },
+                        "Environment Effects:",
                         {
                             "type": "UIDropdown",
                             "id": "environmentEffects"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Viewing Distance:"
-                        },
+                        "Viewing Distance:",
                         {
                             "type": "UIDropdown",
                             "id": "viewDistance"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Reflections:"
-                        },
+                        "Reflections:",
                         {
                             "type": "UIDropdown",
                             "id": "reflections"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "FOV:"
-                        },
+                        "FOV:",
                         {
                             "type": "UISlider",
                             "id": "fov"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Blur Intensity:"
-                        },
+                        "Blur Intensity:",
                         {
                             "type": "UIDropdown",
                             "id": "blur"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Bobbing:"
-                        },
+                        "Bobbing:",
                         {
                             "type": "UICheckbox",
                             "id": "bobbing"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Fullscreen:"
-                        },
+                        "Fullscreen:",
                         {
                             "type": "UICheckbox",
                             "id": "fullscreen"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Dynamic Shadows:"
-                        },
+                        "Dynamic Shadows:",
                         {
                             "type": "UIDropdown",
                             "id": "shadows"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Outline:"
-                        },
+                        "Outline:",
                         {
                             "type": "UICheckbox",
                             "id": "outline"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "VSync:"
-                        },
+                        "VSync:",
                         {
                             "type": "UICheckbox",
                             "id": "vsync"
                         },
-                        {
-                            "type": "UILabel",
-                            "text": "Camera:"
-                        },
+                        "Camera:",
                         {
                             "type": "UIDropdown",
                             "id": "camera"


### PR DESCRIPTION
Adds support for generic tooltips as widgets. These can be declared in ui files, or constructed at runtime. I believe this also allows for extension, by wrapping in a layout and decorating with further widgets.

Additionally, .ui files now support a simplified declaration of UILabels as simple strings - anywhere a widget can be declared a string can be used instead and that will be interpreted as a UILabel. Obviously allows for the tooltip declaration, but can also be used anywhere else a label may be desired. See the videoMenuScreen.ui for an example.
