### PR TITLE
Convert collada unit scale into 1-meter units

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/ColladaMeshLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/ColladaMeshLoader.java
@@ -60,8 +60,14 @@ public class ColladaMeshLoader extends ColladaLoader implements AssetLoader<Mesh
         TFloatList normalsMesh = data.getNormals();
         TIntList indicesMesh = data.getIndices();
 
+        // Scale vertices coordinates by unitsPerMeter
+        for (int i = 0; i < this.vertices.size(); i++) {
+            float originalVertexValue = this.vertices.get(i);
+            float adjustedVertexValue = (float) (originalVertexValue * unitsPerMeter);
+            verticesMesh.add(adjustedVertexValue);
+        }
+
         colorsMesh.addAll(this.colors);
-        verticesMesh.addAll(this.vertices);
         texCoord0Mesh.addAll(this.texCoord0);
         normalsMesh.addAll(this.normals);
         indicesMesh.addAll(this.indices);

--- a/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
@@ -75,6 +75,7 @@ public class ColladaLoader {
     protected TFloatList normals;
     protected TFloatList colors;
     protected TIntList indices;
+    protected double unitsPerMeter;
 
     protected SkeletalMeshDataBuilder skeletonBuilder;
 
@@ -451,7 +452,7 @@ public class ColladaLoader {
             md5Joint.orientation = jointMatrix[0];
         } else if (1 < matrixSet.size()) {
             throw new ColladaParseException("Found " + matrixSet.size() + " joint matrix sets for element " + jointNodeElement.id());
-        // } else {
+            // } else {
             // TODO: Might be translation, rotation pairs instead of a matrix
             // Or might be an unused joint node
             //            throw new ColladaParseException("Found " + matrixSet.size() + " joint matrix sets for element " + jointNodeElement.id());
@@ -517,6 +518,16 @@ public class ColladaLoader {
         }
         Element upAxisElement = upAxisSet.first();
         String upAxis = upAxisElement.text();
+
+        ElementSet unitSet = rootElement.find("asset", "unit");
+        if (1 != unitSet.size()) {
+            throw new ColladaParseException("Found multiple unit asset values");
+        }
+        Element unitElement = unitSet.first();
+        String unitsPerMeterString = unitElement.attr("meter");
+        if (null != unitsPerMeterString) {
+            unitsPerMeter = Double.parseDouble(unitsPerMeterString);
+        }
 
         boolean yUp = "Y_UP".equals(upAxis);
         boolean zUp = "Z_UP".equals(upAxis);


### PR DESCRIPTION
Convert from the current collada unit scale (if provided) into 1-meter units for static meshes.
