### PR TITLE
Use swing thread for error message dialog display

### DIFF
--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -32,6 +32,8 @@ import org.terasology.engine.subsystem.lwjgl.LwjglTimer;
 
 import javax.swing.*;
 
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -76,7 +78,7 @@ public final class Terasology {
             } else {
                 subsystemList = Lists.<EngineSubsystem>newArrayList(new LwjglGraphics(), new LwjglTimer(), new LwjglAudio(), new LwjglInput());
             }
-
+            
             TerasologyEngine engine = new TerasologyEngine(subsystemList);
             engine.init();
             if (isHeadless) {
@@ -86,10 +88,28 @@ public final class Terasology {
             }
             engine.dispose();
         } catch (Throwable t) {
-            String text = getNestedMessageText(t);
-            JOptionPane.showMessageDialog(null, text, "Fatal Error", JOptionPane.ERROR_MESSAGE);
+            
+            if (!GraphicsEnvironment.isHeadless()) {
+                String text = getNestedMessageText(t);
+                showModalDialog(text);
+            }
         }
         System.exit(0);
+    }
+
+    private static void showModalDialog(final String text) {
+        // Swing element methods must be called in the swing thread
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                
+                @Override
+                public void run() {
+                    JOptionPane.showMessageDialog(null, text, "Fatal Error", JOptionPane.ERROR_MESSAGE);
+                }
+            });
+        } catch (InvocationTargetException | InterruptedException e) {
+            e.printStackTrace(System.err);
+        }
     }
 
     private static String getNestedMessageText(Throwable t) {


### PR DESCRIPTION
I never thought that calling a message dialog could ever cause problems, but the error message dialog got caught in a weird deadlock in showMessageDialog() today. 

Not sure if this is because it was called from a different thread than the Swing GUI thread, but according to the specs. this is obligatory and it's also the only thing I can think of.

It now also shows only if a graphics environment is available (e.g. Jenkins probably doesn't have one)
