### PR TITLE
Remove client entity from relevance region when removed

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -174,6 +174,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         if (character.exists()) {
             event.getPlayerStore().setCharacter(character);
         }
+        worldRenderer.getChunkProvider().removeRelevanceEntity(entity);
     }
 
     @ReceiveEvent(components = {ClientComponent.class})


### PR DESCRIPTION
This fixes the second issue that was mentioned in #1049: after joining a game a second(or third) time, the player sometimes finds himself floating in empty space.

It took a while to track this down, but the reason is simple: if the joining client has the same entity id as before, the server does not recognize the difference and does not send chunk updates. This because it is not notified on disconnection.
