### PR TITLE
Improved support for copying entities

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -112,7 +112,7 @@ public interface EntityManager {
      * @param other
      * @return A new entity with a copy of each of the other entity's components
      */
-    // TODO: Remove? A little dangerous due to ownership
+    @Deprecated
     EntityRef copy(EntityRef other);
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -35,6 +35,14 @@ public abstract class EntityRef implements MutableComponentContainer {
     public static final EntityRef NULL = NullEntityRef.getInstance();
 
     /**
+     * Copies this entity, creating a new entity with identical components.
+     * Note: You will need to be careful when copying entities, particularly around ownership - this method does nothing to prevent you ending up
+     * with multiple entities owning the same entities.
+     * @return A copy of this entity.
+     */
+    public abstract EntityRef copy();
+
+    /**
      * @return Does this entity exist - that is, is not deleted.
      */
     public abstract boolean exists();

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -31,7 +31,7 @@ import java.util.Collections;
  */
 public abstract class BaseEntityRef extends EntityRef {
 
-    private LowLevelEntityManager entityManager;
+    protected LowLevelEntityManager entityManager;
 
     public BaseEntityRef(LowLevelEntityManager entityManager) {
         this.entityManager = entityManager;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
@@ -39,6 +39,11 @@ public final class NullEntityRef extends EntityRef {
     }
 
     @Override
+    public EntityRef copy() {
+        return this;
+    }
+
+    @Override
     public boolean exists() {
         return false;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityRef.java
@@ -17,6 +17,7 @@ package org.terasology.entitySystem.entity.internal;
 
 import com.google.common.base.Objects;
 import org.terasology.asset.AssetUri;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.network.NetworkComponent;
 
@@ -35,6 +36,14 @@ public class PojoEntityRef extends BaseEntityRef {
     @Override
     public int getId() {
         return id;
+    }
+
+    @Override
+    public EntityRef copy() {
+        if (exists) {
+            entityManager.create(entityManager.copyComponents(this).values());
+        }
+        return NULL;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/network/internal/NetEntityRef.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetEntityRef.java
@@ -16,9 +16,14 @@
 
 package org.terasology.network.internal;
 
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.network.NetworkComponent;
+import org.terasology.protobuf.EntityData;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -52,6 +57,23 @@ public class NetEntityRef extends BaseEntityRef {
     @Override
     public int hashCode() {
         return Objects.hashCode(networkId);
+    }
+
+    @Override
+    public EntityRef copy() {
+        if (!isActive()) {
+            return NULL;
+        }
+        Map<Class<? extends Component>, Component> classComponentMap = entityManager.copyComponents(this);
+        if (networkSystem.getMode().isAuthority()) {
+            NetworkComponent netComp = (NetworkComponent) classComponentMap.get(NetworkComponent.class);
+            if (netComp != null) {
+                netComp.setNetworkId(0);
+            }
+        } else {
+            classComponentMap.remove(NetworkComponent.class);
+        }
+        return entityManager.create(classComponentMap.values());
     }
 
     @Override


### PR DESCRIPTION
Deprecated EntityManager.copy(EntityRef).
Added EntityRef.copy()
NetEntityRef.copy() has special handling for the NetworkComponent.
