### PR TITLE
Fix for #1085 - modules not fully disabled at end off game session

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -19,14 +19,12 @@ package org.terasology.engine;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetFactory;
 import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
-import org.terasology.asset.sources.ClasspathSource;
 import org.terasology.config.Config;
 import org.terasology.engine.bootstrap.ApplyModulesUtil;
 import org.terasology.engine.modes.GameState;
@@ -121,7 +119,7 @@ public class TerasologyEngine implements GameEngine {
         if (initialised) {
             return;
         }
-        
+
         Stopwatch sw = Stopwatch.createStarted();
 
         try {
@@ -171,7 +169,7 @@ public class TerasologyEngine implements GameEngine {
             logger.error("Failed to initialise Terasology", t);
             throw new RuntimeException("Failed to initialise Terasology", t);
         }
-        
+
         logger.info("Initialization completed in {}sec.", 0.01 * (sw.elapsed(TimeUnit.MILLISECONDS) / 10)); // round to 2 digits
     }
 
@@ -354,10 +352,7 @@ public class TerasologyEngine implements GameEngine {
         CoreRegistry.putPermanently(Game.class, new Game(this, time));
 
         AssetType.registerAssetTypes(assetManager);
-        ClasspathSource source = new ClasspathSource(TerasologyConstants.ENGINE_MODULE,
-                getClass().getProtectionDomain().getCodeSource(), TerasologyConstants.ASSETS_SUBDIRECTORY, TerasologyConstants.OVERRIDES_SUBDIRECTORY, TerasologyConstants.DELTAS_SUBDIRECTORY);
-        assetManager.addAssetSource(source);
-
+        assetManager.addAssetSource(moduleManager.getActiveModule(TerasologyConstants.ENGINE_MODULE).getModuleSource());
         ApplyModulesUtil.applyModules();
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -23,6 +23,7 @@ import org.terasology.config.Config;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.GameThread;
+import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -128,6 +129,7 @@ public class StateIngame implements GameState {
         CoreRegistry.get(PhysicsEngine.class).dispose();
 
         entityManager.clear();
+        CoreRegistry.get(ModuleManager.class).disableAllModules();
         CoreRegistry.get(AssetManager.class).refresh();
         CoreRegistry.get(Console.class).dispose();
         CoreRegistry.clear();

--- a/engine/src/main/java/org/terasology/engine/module/EngineModule.java
+++ b/engine/src/main/java/org/terasology/engine/module/EngineModule.java
@@ -16,6 +16,8 @@
 package org.terasology.engine.module;
 
 import org.reflections.Reflections;
+import org.terasology.asset.AssetSource;
+import org.terasology.asset.sources.ClasspathSource;
 import org.terasology.engine.TerasologyConstants;
 
 import java.io.IOException;
@@ -30,11 +32,19 @@ public class EngineModule implements Module {
     private ModuleInfo info;
     private String id = TerasologyConstants.ENGINE_MODULE;
     private Version version;
+    private AssetSource source;
 
     public EngineModule(Reflections reflections, ModuleInfo moduleInfo) {
         this.reflections = reflections;
         this.info = moduleInfo;
         this.version = Version.create(moduleInfo.getVersion());
+        this.source = new ClasspathSource(id, getClass().getProtectionDomain().getCodeSource(),
+                TerasologyConstants.ASSETS_SUBDIRECTORY, TerasologyConstants.OVERRIDES_SUBDIRECTORY, TerasologyConstants.DELTAS_SUBDIRECTORY);
+    }
+
+    @Override
+    public AssetSource getModuleSource() {
+        return source;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/module/ExtensionModule.java
+++ b/engine/src/main/java/org/terasology/engine/module/ExtensionModule.java
@@ -21,9 +21,7 @@ import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ConfigurationBuilder;
-import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetSource;
-import org.terasology.registry.CoreRegistry;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -57,12 +55,9 @@ public class ExtensionModule implements Module {
         this.version = version;
     }
 
-    void enable() {
-        CoreRegistry.get(AssetManager.class).addAssetSource(moduleSource);
-    }
-
-    void disable() {
-        CoreRegistry.get(AssetManager.class).removeAssetSource(moduleSource);
+    @Override
+    public AssetSource getModuleSource() {
+        return moduleSource;
     }
 
     URL getModuleClasspathUrl() {

--- a/engine/src/main/java/org/terasology/engine/module/Module.java
+++ b/engine/src/main/java/org/terasology/engine/module/Module.java
@@ -16,6 +16,7 @@
 package org.terasology.engine.module;
 
 import org.reflections.Reflections;
+import org.terasology.asset.AssetSource;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +25,8 @@ import java.io.InputStream;
  * @author Immortius
  */
 public interface Module {
+
+    AssetSource getModuleSource();
 
     String getId();
 

--- a/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
@@ -29,11 +29,13 @@ import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetSource;
 import org.terasology.asset.sources.ArchiveSource;
 import org.terasology.asset.sources.DirectorySource;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.paths.PathManager;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.FilesUtil;
 import org.terasology.utilities.gson.VersionTypeAdapter;
 import org.terasology.version.TerasologyVersion;
@@ -166,6 +168,11 @@ public class ModuleManagerImpl implements ModuleManager {
 
     @Override
     public void disableAllModules() {
+        for (Module module : activeModules.values()) {
+            if (module instanceof ExtensionModule) {
+                CoreRegistry.get(AssetManager.class).removeAssetSource(module.getModuleSource());
+            }
+        }
         activeModules.clear();
         activeModules.put(engineModule.getId(), engineModule);
     }
@@ -175,10 +182,10 @@ public class ModuleManagerImpl implements ModuleManager {
         Module oldModule = activeModules.put(module.getId(), module);
         if (!module.equals(oldModule)) {
             if (oldModule != null && oldModule instanceof ExtensionModule) {
-                ((ExtensionModule) oldModule).disable();
+                CoreRegistry.get(AssetManager.class).removeAssetSource(module.getModuleSource());
             }
             if (module instanceof ExtensionModule) {
-                ((ExtensionModule) module).enable();
+                CoreRegistry.get(AssetManager.class).addAssetSource(module.getModuleSource());
             }
         }
     }
@@ -193,10 +200,10 @@ public class ModuleManagerImpl implements ModuleManager {
         Module oldModule = activeModules.put(module.getId(), module);
         if (!module.equals(oldModule)) {
             if (oldModule != null && oldModule instanceof ExtensionModule) {
-                ((ExtensionModule) oldModule).disable();
+                CoreRegistry.get(AssetManager.class).removeAssetSource(module.getModuleSource());
             }
             if (module instanceof ExtensionModule) {
-                ((ExtensionModule) module).enable();
+                CoreRegistry.get(AssetManager.class).addAssetSource(module.getModuleSource());
             }
         }
     }
@@ -205,7 +212,7 @@ public class ModuleManagerImpl implements ModuleManager {
     public void disableModule(Module module) {
         Module removedModule = activeModules.remove(module.getId());
         if (removedModule != null && removedModule instanceof ExtensionModule) {
-            ((ExtensionModule) module).disable();
+            CoreRegistry.get(AssetManager.class).removeAssetSource(module.getModuleSource());
         }
     }
 

--- a/facades/PC/src/main/java/org/terasology/engine/CrashReporter.java
+++ b/facades/PC/src/main/java/org/terasology/engine/CrashReporter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.terasology.utilities;
+package org.terasology.engine;
 
 import java.awt.Component;
 import java.awt.Cursor;

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -32,7 +32,6 @@ import org.terasology.engine.subsystem.lwjgl.LwjglAudio;
 import org.terasology.engine.subsystem.lwjgl.LwjglGraphics;
 import org.terasology.engine.subsystem.lwjgl.LwjglInput;
 import org.terasology.engine.subsystem.lwjgl.LwjglTimer;
-import org.terasology.utilities.CrashReporter;
 
 import com.google.common.collect.Lists;
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ import groovy.io.FileType
 
 rootProject.name = 'Terasology'
 
-include 'engine', 'engine-tests', 'facades', 'libs', 'modules'
+include 'engine', 'engine-tests', 'facades', 'meta', 'libs', 'modules'
 
 // Handy little snippet found online that'll "fake" having nested settings.gradle files under /modules, /libs, etc
 rootDir.eachDir { possibleSubprojectDir ->


### PR DESCRIPTION
Fix for #1085 - modules not correctly being disabled at the end of a game session.

Moved CrashReporter to the PC facade.
Added missing 'meta' subproject to settings.gradle
