### PR TITLE
Updated logging libs

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -83,7 +83,7 @@ configurations.all {
 dependencies {
     // Main library files fetched online
     compile group: 'org.eaxy', name: 'eaxy', version: '0.1'
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.5'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
     compile group: 'com.google.guava', name: 'guava', version: '15.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '2.5.0'
@@ -109,8 +109,8 @@ dependencies {
 
 	// TODO: These could be moved into facade
 	compile group: 'org.terasology', name: 'CrashReporter', version: '1.1+', changing: true
-	runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.13'
-	runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.5'
+	runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
+	runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.7'
     // And here is Groovy to read the config file
     runtime group: 'org.codehaus.groovy', name: 'groovy', version: '2.1.7'
 


### PR DESCRIPTION
This updates slf4j from 1.7.5 to 1.7.7 and Logback from 1.0.13 to 1.1.2 (both released in April 2014)

Changelogs
http://www.slf4j.org/news.html
http://logback.qos.ch/news.html
