### PR TITLE
#1024 - Splits ToggleViewDistance buttons

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
@@ -80,8 +80,24 @@ public class DebugControlSystem extends BaseComponentSystem {
     }
 
     @ReceiveEvent(components = ClientComponent.class)
-    public void onToggleViewDistance(ToggleViewDistanceButton button, EntityRef entity) {
-        config.getRendering().setViewDistance(ViewDistance.forIndex((config.getRendering().getViewDistance().getIndex() + 1) % ViewDistance.values().length));
+    public void onIncreaseViewDistance(IncreaseViewDistanceButton button, EntityRef entity) {
+        int viewDistance = config.getRendering().getViewDistance().getIndex();
+        int maxViewDistance = ViewDistance.values().length - 1;
+
+        if (viewDistance != maxViewDistance) {
+            config.getRendering().setViewDistance(ViewDistance.forIndex((config.getRendering().getViewDistance().getIndex() + 1)));
+        }
+        button.consume();
+    }
+
+    @ReceiveEvent(components = ClientComponent.class)
+    public void onDecreaseViewDistance(DecreaseViewDistanceButton button, EntityRef entity) {
+        int viewDistance = config.getRendering().getViewDistance().getIndex();
+        int minViewDistance = 0;
+
+        if (viewDistance != minViewDistance) {
+            config.getRendering().setViewDistance(ViewDistance.forIndex((config.getRendering().getViewDistance().getIndex() - 1)));
+        }
         button.consume();
     }
 

--- a/engine/src/main/java/org/terasology/logic/players/DecreaseViewDistanceButton.java
+++ b/engine/src/main/java/org/terasology/logic/players/DecreaseViewDistanceButton.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players;
+
+import org.terasology.input.ActivateMode;
+import org.terasology.input.BindButtonEvent;
+import org.terasology.input.DefaultBinding;
+import org.terasology.input.InputType;
+import org.terasology.input.Keyboard;
+import org.terasology.input.RegisterBindButton;
+
+/**
+ * @author Immortius
+ */
+@RegisterBindButton(id = "decreaseViewDistance", description = "Decrease View Distance", mode = ActivateMode.PRESS, category = "general")
+@DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.END)
+public class DecreaseViewDistanceButton extends BindButtonEvent {
+}

--- a/engine/src/main/java/org/terasology/logic/players/IncreaseViewDistanceButton.java
+++ b/engine/src/main/java/org/terasology/logic/players/IncreaseViewDistanceButton.java
@@ -25,7 +25,7 @@ import org.terasology.input.RegisterBindButton;
 /**
  * @author Immortius
  */
-@RegisterBindButton(id = "toggleViewDistance", description = "Toggle View Distance", mode = ActivateMode.PRESS, category = "general")
+@RegisterBindButton(id = "increaseViewDistance", description = "Increase View Distance", mode = ActivateMode.PRESS, category = "general")
 @DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.HOME)
-public class ToggleViewDistanceButton extends BindButtonEvent {
+public class IncreaseViewDistanceButton extends BindButtonEvent {
 }


### PR DESCRIPTION
Addresses issue #1024 - splits the ToggleViewDistance button to the HOME and END keys and adds them to the options menu for configuration and remapping.
