### PR TITLE
Allow retrieval of UIWidget assets from code

### DIFF
--- a/engine/src/main/java/org/terasology/asset/Assets.java
+++ b/engine/src/main/java/org/terasology/asset/Assets.java
@@ -30,6 +30,7 @@ import org.terasology.rendering.assets.skeletalmesh.SkeletalMesh;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.assets.texture.subtexture.Subtexture;
+import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.skin.UISkin;
 
@@ -299,6 +300,10 @@ public final class Assets {
 
     public static UIElement getUIElement(String uri) {
         return get(AssetType.UI_ELEMENT, uri, UIElement.class);
+    }
+
+    public static UIWidget getUIWidget(String uri) {
+        return getUIElement(uri).getRootWidget();
     }
 
     public static <T extends Asset<U>, U extends AssetData> T generateAsset(AssetUri uri, U data, Class<T> assetClass) {


### PR DESCRIPTION
Likely this is not the best way to do this.  Exposing UIElement (and its friends) to the modding API also did not seem like a good idea.  There could also be concerns regarding disposing and reloading the underlying UIElement.

This would be useful when using a common window and inserting json defined UI parts based on external input.

In my case, I have a block that brings up a default window when activated. The window has the character's inventory and the block's inventory.  I want to add a component on the block that can specify another .ui asset to insert on to a specific spot on the window.  This would allow the same window to provide base UI elements and entity hookup for multiple blocks that have the same general functionality. 
