### PR TITLE
Added whitelist candidate

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -377,6 +377,7 @@ public class TerasologyEngine implements GameEngine {
         moduleSecurityManager.addAPIPackage("java.awt");
         moduleSecurityManager.addAPIPackage("java.awt.geom");
         moduleSecurityManager.addAPIPackage("java.awt.image");
+        moduleSecurityManager.addAPIPackage("java.text");
         moduleSecurityManager.addAPIPackage("com.google.common.annotations");
         moduleSecurityManager.addAPIPackage("com.google.common.cache");
         moduleSecurityManager.addAPIPackage("com.google.common.collect");


### PR DESCRIPTION
@immortius - would the java.text package be a suitable addition to our module whitelist ? @Josharias had used DecimalFormat over in TerraTech, but it wasn't whitelisted. Fixed differently for now, but the whole package looks pretty peaceful. Or does the Annotation class there perhaps cause any trouble?

http://docs.oracle.com/javase/7/docs/api/java/text/package-summary.html
