### PR TITLE
Fix dropped items being invisible #1131

### DIFF
--- a/engine/src/main/resources/assets/materials/droppedItem.mat
+++ b/engine/src/main/resources/assets/materials/droppedItem.mat
@@ -1,5 +1,5 @@
 {
-    "shader" : "engine:prog.block",
+    "shader" : "engine:block",
     "params" : {
         "colorOffset" : [1.0, 1.0, 1.0],
         "textured" : false


### PR DESCRIPTION
The shader's material is called "engine:prog.block"  but the shader itself is still "engine:block".
Fixes #1131 
