### PR TITLE
Update dependency versions

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     compile group: 'org.terasology', name: 'gestalt-module', version: '1.2.2'
     compile group: 'org.eaxy', name: 'eaxy', version: '0.1'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
-    compile group: 'com.google.guava', name: 'guava', version: '15.0'
+    compile group: 'com.google.guava', name: 'guava', version: '17.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '2.5.0'
     compile group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'


### PR DESCRIPTION
This PR updates groovy, guava and reflectasm versions so that they are up to date again.
- Groovy: afaics it is used only for logback log-file parsing. Updating should not cause any problems
- ReflectAsm: Used in ModuleManager, EventSystem and ByteCodeReflectFactory. I did some testing and everything appears to work fine.
- Guava: mostly additions, TS compiles and runs fine with version 17.

We have to keep in mind that it also affects dependent modules.
