### PR TITLE
Fix bugs related to rendering items in a slot that have bad data

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityRef.java
@@ -41,7 +41,7 @@ public class PojoEntityRef extends BaseEntityRef {
     @Override
     public EntityRef copy() {
         if (exists) {
-            entityManager.create(entityManager.copyComponents(this).values());
+            return entityManager.create(entityManager.copyComponents(this).values());
         }
         return NULL;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -53,6 +53,12 @@ public class InventoryGrid extends CoreWidget {
         super.update(delta);
 
         int numSlots = InventoryUtils.getSlotCount(getTargetEntity()) - getCellOffset();
+
+        // allow the UI to shrink the cell count if the inventory shrinks
+        if (numSlots < cells.size()) {
+            cells.clear();
+        }
+
         if (numSlots > cells.size() && cells.size() < getMaxCellCount()) {
             for (int i = cells.size(); i < numSlots && i < getMaxCellCount(); ++i) {
                 InventoryCell cell = new InventoryCell();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemCell.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemCell.java
@@ -67,7 +67,7 @@ public abstract class ItemCell extends CoreWidget {
                         return itemComp.icon;
                     }
                     BlockItemComponent blockItemComp = getTargetItem().getComponent(BlockItemComponent.class);
-                    if (blockItemComp == null) {
+                    if (blockItemComp == null || blockItemComp.blockFamily == null) {
                         return Assets.getTextureRegion("engine:items.questionMark");
                     }
                 }
@@ -78,7 +78,7 @@ public abstract class ItemCell extends CoreWidget {
             @Override
             public Mesh get() {
                 BlockItemComponent blockItemComp = getTargetItem().getComponent(BlockItemComponent.class);
-                if (blockItemComp != null) {
+                if (blockItemComp != null && blockItemComp.blockFamily != null) {
                     return blockItemComp.blockFamily.getArchetypeBlock().getMesh();
                 }
                 return null;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/TransferItemCursor.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/TransferItemCursor.java
@@ -58,7 +58,7 @@ public class TransferItemCursor extends CursorAttachment implements ControlWidge
                             return itemComp.icon;
                         }
                         BlockItemComponent blockItemComp = getItem().getComponent(BlockItemComponent.class);
-                        if (blockItemComp == null) {
+                        if (blockItemComp == null || blockItemComp.blockFamily == null) {
                             return Assets.getTextureRegion("engine:items.questionMark");
                         }
                     }
@@ -69,7 +69,7 @@ public class TransferItemCursor extends CursorAttachment implements ControlWidge
                 @Override
                 public Mesh get() {
                     BlockItemComponent blockItemComp = getItem().getComponent(BlockItemComponent.class);
-                    if (blockItemComp != null) {
+                    if (blockItemComp != null && blockItemComp.blockFamily != null) {
                         return blockItemComp.blockFamily.getArchetypeBlock().getMesh();
                     }
                     return null;


### PR DESCRIPTION
- This accommodates what was in the legacy block picker for items that cause exceptions when putting them into an inventory slot.  
- EntityRef.copy() did not ever return the copy it just created.
- The InventoryGrid now resizes back down when the inventory shrinks from previous.
