### PR TITLE
Added Resolution Scaling for the Game Scene

### DIFF
--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -69,6 +69,7 @@ public class RenderingConfig {
     private boolean inscattering = true;
     private boolean localReflections;
     private boolean vSync;
+    private int fboScale = 100;
     private PerspectiveCameraSettings cameraSettings = new PerspectiveCameraSettings(CameraSetting.NORMAL);
 
     private RenderingDebugConfig debug = new RenderingDebugConfig();
@@ -409,6 +410,14 @@ public class RenderingConfig {
 
     public void setFrameLimit(int frameLimit) {
         this.frameLimit = frameLimit;
+    }
+
+    public int getFboScale() {
+        return fboScale;
+    }
+
+    public void setFboScale(int fboScale) {
+        this.fboScale = fboScale;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -155,6 +155,31 @@ public class VideoSettingsScreen extends CoreScreenLayer {
             });
         }
 
+        final UISlider fboScaleSlider = find("fboScale", UISlider.class);
+        if (fboScaleSlider != null) {
+            fboScaleSlider.setIncrement(5.0f);
+            fboScaleSlider.setPrecision(0);
+            fboScaleSlider.setMinimum(25);
+            fboScaleSlider.setRange(200);
+            fboScaleSlider.setLabelFunction(new Function<Float, String>() {
+                @Override
+                public String apply(Float input) {
+                return String.valueOf(input.intValue()) + "%";
+                }
+            });
+            fboScaleSlider.bindValue(new Binding<Float>() {
+                @Override
+                public Float get() {
+                    return (float) config.getRendering().getFboScale();
+                }
+
+                @Override
+                public void set(Float value) {
+                    config.getRendering().setFboScale(value.intValue());
+                }
+            });
+        }
+
         UIDropdown<CameraSetting> cameraSetting = find("camera", UIDropdown.class);
         if (cameraSetting != null) {
             cameraSetting.setOptions(Arrays.asList(CameraSetting.values()));

--- a/engine/src/main/java/org/terasology/rendering/opengl/DefaultRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/DefaultRenderingProcess.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.Assets;
 import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
 import org.terasology.editor.EditorRange;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.CoreRegistry;
@@ -263,7 +264,12 @@ public class DefaultRenderingProcess {
             rtFullHeight = org.lwjgl.opengl.Display.getHeight();
         }
 
-        if (CoreRegistry.get(Config.class).getRendering().isOculusVrSupport()) {
+        RenderingConfig renderingConfig = CoreRegistry.get(Config.class).getRendering();
+
+        rtFullWidth *= renderingConfig.getFboScale() / 100f;
+        rtFullHeight *= renderingConfig.getFboScale() / 100f;
+
+        if (renderingConfig.isOculusVrSupport()) {
             if (overwriteRtWidth == 0) {
                 rtFullWidth *= OculusVrHelper.getScaleFactor();
             }

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -213,12 +213,12 @@
                                 "id": "frameLimit"
                             },
                             {
-                                "type": "UISpace",
-                                "size": [1, 13]
+                                "type": "UILabel",
+                                "text": "Render Quality: "
                             },
                             {
-                                "type": "UISpace",
-                                "size": [1, 13]
+                                "type": "UISlider",
+                                "id": "fboScale"
                             },
                             {
                                 "type": "UISpace",


### PR DESCRIPTION
Added a rendering setting to scale the FBOs to effectively reduce (or increase) the resolution of the game scene without affecting the resolution of the UI. I (arbitrarily) set the range from 25% to 200%. Increasing the size should essentially be like supersampling. Also added a slider to the video settings dialog to control this.

This should fix #1172 
