### PR TITLE
Added a headless IDEA run configuration

### DIFF
--- a/config/gradle/ide.gradle
+++ b/config/gradle/ide.gradle
@@ -179,7 +179,7 @@ ext {
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
               <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
-              <option name="PROGRAM_PARAMETERS" value="-headless -homedir -noCrashReport"/>
+              <option name="PROGRAM_PARAMETERS" value="-headless -homedir=terasology-server"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
               <option name="ALTERNATIVE_JRE_PATH" value=""/>


### PR DESCRIPTION
This just adds a secondary run-config to the IPR file that allows Terasology to be started in headless mode.
