### PR TITLE
Video Settings UI Improvements and A New Lighting Setting

### DIFF
--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -69,6 +69,7 @@ public class RenderingConfig {
     private boolean inscattering = true;
     private boolean localReflections;
     private boolean vSync;
+    private boolean clampLighting;
     private int fboScale = 100;
     private PerspectiveCameraSettings cameraSettings = new PerspectiveCameraSettings(CameraSetting.NORMAL);
 
@@ -418,6 +419,14 @@ public class RenderingConfig {
 
     public void setFboScale(int fboScale) {
         this.fboScale = fboScale;
+    }
+
+    public boolean isClampLighting() {
+        return clampLighting;
+    }
+
+    public void setClampLighting(boolean clampLighting) {
+        this.clampLighting = clampLighting;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/DebugCallback.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/DebugCallback.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.subsystem.lwjgl;
+
+import org.lwjgl.opengl.KHRDebugCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.lwjgl.opengl.GL43.*;
+
+/**
+ * Callback used by the OpenGL driver to output additional debug information about our use of the API.
+ */
+class DebugCallback implements KHRDebugCallback.Handler {
+
+    private static final Logger logger = LoggerFactory.getLogger("OpenGL");
+
+    @Override
+    public void handleMessage(int source, int type, int id, int severity, String message) {
+        String logFormat = "[{}] [{}] {}";
+        Object[] args = new Object[] { getSourceString(source), getTypeString(type), message };
+
+        switch (severity) {
+            case GL_DEBUG_SEVERITY_HIGH:
+                logger.error(logFormat, args);
+                break;
+            case GL_DEBUG_SEVERITY_MEDIUM:
+                logger.warn(logFormat, args);
+                break;
+            case GL_DEBUG_SEVERITY_LOW:
+                logger.debug(logFormat, args);
+                break;
+            default:
+            case GL_DEBUG_SEVERITY_NOTIFICATION:
+                logger.info(logFormat, args);
+                break;
+        }
+    }
+
+    private static String getSourceString(int source) {
+        switch (source) {
+            case GL_DEBUG_SOURCE_API:
+                return "api";
+            case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
+                return "window system";
+            case GL_DEBUG_SOURCE_SHADER_COMPILER:
+                return "shader compiler";
+            case GL_DEBUG_SOURCE_THIRD_PARTY:
+                return "third party";
+            case GL_DEBUG_SOURCE_APPLICATION:
+                return "app";
+            default:
+            case GL_DEBUG_SOURCE_OTHER:
+                return "other";
+        }
+    }
+
+    private static String getTypeString(int type) {
+        switch (type) {
+            case GL_DEBUG_TYPE_ERROR:
+                return "error";
+            case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
+                return "deprecated";
+            case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
+                return "undefined behaviour";
+            case GL_DEBUG_TYPE_PORTABILITY:
+                return "portability";
+            case GL_DEBUG_TYPE_PERFORMANCE:
+                return "performance";
+            case GL_DEBUG_TYPE_MARKER:
+                return "marker";
+            case GL_DEBUG_TYPE_PUSH_GROUP:
+                return "pushGroup";
+            case GL_DEBUG_TYPE_POP_GROUP:
+                return "popGroup";
+            default:
+            case GL_DEBUG_TYPE_OTHER:
+                return "other";
+        }
+    }
+
+}

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -16,8 +16,7 @@
 package org.terasology.engine.subsystem.lwjgl;
 
 import org.lwjgl.LWJGLException;
-import org.lwjgl.opengl.Display;
-import org.lwjgl.opengl.GLContext;
+import org.lwjgl.opengl.*;
 import org.newdawn.slick.opengl.ImageIOImageData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,7 +161,22 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
             } catch (IOException | IllegalArgumentException e) {
                 logger.warn("Could not set icon", e);
             }
-            Display.create(rc.getPixelFormat());
+
+            if (config.getRendering().getDebug().isEnabled()) {
+                try {
+                    ContextAttribs ctxAttribs = new ContextAttribs().withDebug(true);
+                    Display.create(config.getRendering().getPixelFormat(), ctxAttribs);
+
+                    GL43.glDebugMessageCallback(new KHRDebugCallback(new DebugCallback()));
+                } catch (LWJGLException e) {
+                    logger.warn("Unable to create an OpenGL debug context. Maybe your graphics card does not support it.", e);
+                    Display.create(rc.getPixelFormat()); // Create a normal context instead
+                }
+
+            } else {
+                Display.create(rc.getPixelFormat());
+            }
+
             Display.setVSyncEnabled(rc.isVSync());
         } catch (LWJGLException e) {
             throw new RuntimeException("Can not initialize graphics device.", e);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -195,6 +195,12 @@ public class VideoSettingsScreen extends CoreScreenLayer {
         WidgetUtil.tryBindCheckbox(this, "vsync", BindHelper.bindBeanProperty("vSync", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "eyeAdaptation", BindHelper.bindBeanProperty("eyeAdaptation", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "fullscreen", BindHelper.bindBeanProperty("fullscreen", engine, Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "ssao", BindHelper.bindBeanProperty("ssao", config.getRendering(), Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "clampLighting", BindHelper.bindBeanProperty("clampLighting", config.getRendering(), Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "bloom", BindHelper.bindBeanProperty("bloom", config.getRendering(), Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "lightShafts", BindHelper.bindBeanProperty("lightShafts", config.getRendering(), Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "vignette", BindHelper.bindBeanProperty("vignette", config.getRendering(), Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "flickeringLight", BindHelper.bindBeanProperty("flickeringLight", config.getRendering(), Boolean.TYPE));
 
         WidgetUtil.trySubscribe(this, "fovReset", new ActivateEventListener() {
             @Override

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -245,6 +245,10 @@ public class GLSLShader extends AbstractAsset<ShaderData> implements Shader {
         if (config.getRendering().isInscattering()) {
             builder.append("#define INSCATTERING \n");
         }
+        // TODO A 3D wizard should take a look at this. Configurable for the moment to make better comparisons possible.
+        if (config.getRendering().isClampLighting()) {
+            builder.append("#define CLAMP_LIGHTING \n");
+        }
 
         for (RenderingDebugConfig.DebugRenderingStage stage : RenderingDebugConfig.DebugRenderingStage.values()) {
             builder.append("#define ").append(stage.getDefineName()).append(" int(").append(stage.getIndex()).append(") \n");

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererLwjgl.java
@@ -17,6 +17,8 @@ package org.terasology.rendering.world;
 
 import com.google.common.collect.Lists;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.KHRDebug;
+import org.lwjgl.opengl.KHRDebugCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.Assets;

--- a/engine/src/main/resources/assets/shaders/lightGeometryPass_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/lightGeometryPass_frag.glsl
@@ -148,5 +148,10 @@ void main() {
     color *= attenuation;
 #endif
 
+// TODO A 3D wizard should take a look at this. Configurable for the moment to make better comparisons possible.
+#if defined (CLAMP_LIGHTING)
+    gl_FragData[0].rgba = clamp(vec4(color.r, color.g, color.b, specular), 0.0, 1.05);
+#else
     gl_FragData[0].rgba = vec4(color.r, color.g, color.b, specular);
+#endif
 }

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -317,18 +317,52 @@
                                 "id": "oculusVrSupport"
                             },
                             {
-                                "type": "UISpace",
-                                "size": [1, 13]
+                                "type": "UILabel",
+                                "text": "SSAO: "
                             },
                             {
-                                "type": "UISpace",
-                                "size": [1, 13]
+                                "type": "UICheckbox",
+                                "id": "ssao"
                             },
                             {
-                                "type": "UIButton",
-                                "text": "Advanced Settings",
-                                "id": "advancedVideo",
-                                "enabled" : false
+                                "type": "UILabel",
+                                "text": "Clamp Lighting: "
+                            },
+                            {
+                                "type": "UICheckbox",
+                                "id": "clampLighting"
+                            },
+                            {
+                                "type": "UILabel",
+                                "text": "Bloom: "
+                            },
+                            {
+                                "type": "UICheckbox",
+                                "id": "bloom"
+                            },
+                            {
+                                "type": "UILabel",
+                                "text": "Light Shafts: "
+                            },
+                            {
+                                "type": "UICheckbox",
+                                "id": "lightShafts"
+                            },
+                            {
+                               "type": "UILabel",
+                               "text": "Vignette: "
+                            },
+                            {
+                               "type": "UICheckbox",
+                               "id": "vignette"
+                            },
+                            {
+                              "type": "UILabel",
+                              "text": "Flickering Lights: "
+                            },
+                            {
+                              "type": "UICheckbox",
+                              "id": "flickeringLight"
                             }
                         ],
                         "layoutInfo": {


### PR DESCRIPTION
Added an option that allows light contribution to be clamped to (1,1,1),... effectively reducing oversaturation.

Added a lot more video options (currently all under experimental/high end since impact is unknown).
When debugging is enabled for rendering, an OpenGL debug context is created and a debug hook is registered. This logs a lot of info from the graphics driver in the log.

For video settings see issue #962
