### PR TITLE
Properly close terasology and free the mouse for the crash reporter when a crash occurs.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -280,15 +280,19 @@ public class TerasologyEngine implements GameEngine {
     @Override
     public void dispose() {
         try {
-            if (!running) {
-                disposed = true;
-                initialised = false;
-                Iterator<EngineSubsystem> iter = subsystems.descendingIterator();
-                while (iter.hasNext()) {
-                    EngineSubsystem subsystem = iter.next();
-                    subsystem.dispose();
-                }
+            /*
+             * The engine is shutdown even when running is true for so that terasology gets also properly disposed in
+             * case of a crash: The mouse must be made visible again for the crash reporter and the main window needs to
+             * be closed.
+             */
+            disposed = true;
+            initialised = false;
+            Iterator<EngineSubsystem> iter = subsystems.descendingIterator();
+            while (iter.hasNext()) {
+                EngineSubsystem subsystem = iter.next();
+                subsystem.dispose();
             }
+
         } catch (RuntimeException e) {
             logger.error("Uncaught exception", e);
             throw e;


### PR DESCRIPTION
When there was a crash it could happen that I ended up without a mouse because it was still grabbed by the game which was also still visible besides the crash reporter. Closing the crash reporter left the game still open in a broken state.

With this change terasology will try to shutdown the subsystems even in the case of a crash.

I am not totally sure why the "if (!running)" check was added in the first place. @immortius Do you know if there is still a good reason for not disposing the sub systems if runnings == true?
