### PR TITLE
Synchronize NULL field values to clients as well

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/serializers/NetworkEntitySerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/NetworkEntitySerializer.java
@@ -190,12 +190,10 @@ public class NetworkEntitySerializer {
         for (ReplicatedFieldMetadata field : componentMetadata.getFields()) {
             if (fieldCheck.shouldSerializeField(field, component, componentInitial)) {
                 PersistedData fieldValue = serializer.serialize(field, component, serializationContext);
-                if (!fieldValue.isNull()) {
-                    entityFieldIds.write(field.getId());
+                entityFieldIds.write(field.getId());
 
-                    entityData.addFieldValue(((ProtobufPersistedData) fieldValue).getValue());
-                    fieldCount++;
-                }
+                entityData.addFieldValue(((ProtobufPersistedData) fieldValue).getValue());
+                fieldCount++;
             }
         }
 


### PR DESCRIPTION
Do not skipp null field values when serializing components. Otherwise, server-side changes to fields that set them to null values (i.e. EntityRef.NULL) will NOT be synced to clients.

There is one other case where isNull() is checked before writing the field value. It's in serializing the component delta. I do not know where that is used though.

Should fix #1255.
