### PR TITLE
Fixed unit test display creation on my linux pc.

### DIFF
--- a/engine-tests/src/test/java/org/terasology/DisplayEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/DisplayEnvironment.java
@@ -85,7 +85,7 @@ public class DisplayEnvironment extends HeadlessEnvironment {
         LWJGLHelper.initNativeLibs();
 
         try {
-            Display.setDisplayMode(new DisplayMode(0, 0));
+            Display.setDisplayMode(new DisplayMode(1, 1));
             Display.create(CoreRegistry.get(Config.class).getRendering().getPixelFormat());
         } catch (LWJGLException e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
On my linux machine I couldn't run the StorageManagerTest test. I got the following exception durtion the display creation:

Caused by: org.lwjgl.LWJGLException: X Error - disp: 0x7f6df8a39040 serial: 28 error: BadValue (integer parameter out of range for operation) request_code: 1 minor_code: 0

Making the window 1 pixel large, fixed the issue.
