### PR TITLE
Let remote clients properly shutdown the pipline and lightMerger.

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -165,6 +165,8 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
     @Override
     public void dispose() {
         ChunkMonitor.fireChunkProviderDisposed(this);
+        pipeline.shutdown();
+        lightMerger.shutdown();
     }
 
     @Override


### PR DESCRIPTION
The pipeline and the light merger have both a thread pool which needs
to be manually disposed. If they don't get disposed the game won't
exit properly.
