### PR TITLE
Ignore eclipse files in eclipse sub-projects

### DIFF
--- a/facades/PC/.gitignore
+++ b/facades/PC/.gitignore
@@ -1,0 +1,11 @@
+# Boo eclipse! - every eclipse project needs its own .gitignore file
+
+# Ignore Eclipse
+/.checkstyle
+/.project
+/.classpath
+/.settings/
+/bin/
+
+# Ignore gradle
+/build/

--- a/modules/Core/.gitignore
+++ b/modules/Core/.gitignore
@@ -1,0 +1,11 @@
+# Boo eclipse! - every eclipse project needs its own .gitignore file
+
+# Ignore Eclipse
+/.checkstyle
+/.project
+/.classpath
+/.settings/
+/bin/
+
+# Ignore gradle
+/build/


### PR DESCRIPTION
The docs for eclipse Indigo still explicitly state that eclipse does not look outside project folders for `.gitignore` files. 

This sentence is missing in eclipse Luna's doc (egit v3.4.1) and it seems to work for engine and engine-test.
It does not work for modules/Core and facades/PC which makes me guess it checks one level above the project root.

Can other eclipse users confirm this? Ping @mkienenb !
