### PR TITLE
Fix two null pointer crashes caused by configured but missing modules.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfigWorldGenScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfigWorldGenScreen.java
@@ -76,9 +76,11 @@ public class ConfigWorldGenScreen extends CoreScreenLayer {
         Set<Module> selectedModules = Sets.newHashSet();
         for (Name moduleName : config.getDefaultModSelection().listModules()) {
             Module module = moduleManager.getRegistry().getLatestModuleVersion(moduleName);
-            selectedModules.add(module);
-            for (DependencyInfo dependencyInfo : module.getMetadata().getDependencies()) {
-                selectedModules.add(moduleManager.getRegistry().getLatestModuleVersion(dependencyInfo.getId()));
+            if (module != null) {
+	            selectedModules.add(module);
+	            for (DependencyInfo dependencyInfo : module.getMetadata().getDependencies()) {
+	                selectedModules.add(moduleManager.getRegistry().getLatestModuleVersion(dependencyInfo.getId()));
+	            }
             }
         }
         ModuleEnvironment environment = moduleManager.loadEnvironment(selectedModules, false);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -321,9 +321,13 @@ public class CreateGameScreen extends CoreScreenLayer {
         Set<Name> enabledModules = Sets.newHashSet();
         for (Name moduleName : config.getDefaultModSelection().listModules()) {
             Module module = moduleManager.getRegistry().getLatestModuleVersion(moduleName);
-            enabledModules.add(moduleName);
-            for (DependencyInfo dependencyInfo : module.getMetadata().getDependencies()) {
-                enabledModules.add(dependencyInfo.getId());
+            if (module != null) {
+                enabledModules.add(moduleName);
+	            if (module != null) {
+					for (DependencyInfo dependencyInfo : module.getMetadata().getDependencies()) {
+		                enabledModules.add(dependencyInfo.getId());
+		            }
+	            }
             }
         }
 


### PR DESCRIPTION
Fix two null pointer crashes caused by configured but missing modules.

Crashes occured after:
- Creating a new game
- Configuring a new game
