### PR TITLE
Reset the visibility binding properly when the in game state is left.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -103,7 +103,6 @@ public class StateIngame implements GameState {
                 return !CoreRegistry.get(Config.class).getRendering().getDebug().isHudHidden();
             }
         });
-
     }
 
     @Override
@@ -139,7 +138,11 @@ public class StateIngame implements GameState {
         CoreRegistry.clear();
         BlockManager.getAir().setEntity(EntityRef.NULL);
         GameThread.clearWaitingProcesses();
-
+		/*
+		 * Clear the binding as otherwise the complete ingame state would be
+		 * referenced.
+		 */
+		nuiManager.getHUD().clearVisibleBinding();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
@@ -145,6 +145,10 @@ public abstract class AbstractWidget implements UIWidget {
         this.visible = bind;
     }
 
+	public void clearVisibleBinding() {
+		this.visible = new DefaultBinding<>(true);
+	}
+
     @Override
     public void onGainFocus() {
         focused = true;


### PR DESCRIPTION
This also fix an uncritical memory leak: The StateIngame reference could
not be garbage collected properly before, because the HUDScreenLayer
was referencing it implictly through the anonymous binding class.
