### PR TITLE
Fixed common thread pool shutdown on initilization crashes

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -19,6 +19,7 @@ package org.terasology.engine;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetFactory;
@@ -166,6 +167,7 @@ public class TerasologyEngine implements GameEngine {
             initialised = true;
         } catch (RuntimeException e) {
             logger.error("Failed to initialise Terasology", e);
+            cleanup();
             throw e;
         }
 
@@ -511,14 +513,17 @@ public class TerasologyEngine implements GameEngine {
         }
     }
 
+    @Override
     public boolean isHibernationAllowed() {
         return hibernationAllowed && currentState.isHibernationAllowed();
     }
 
+    @Override
     public void setHibernationAllowed(boolean allowed) {
         this.hibernationAllowed = allowed;
     }
 
+    @Override
     public boolean hasFocus() {
         DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
         return gameFocused && display.isActive();
@@ -529,6 +534,7 @@ public class TerasologyEngine implements GameEngine {
         return gameFocused;
     }
 
+    @Override
     public void setFocus(boolean focused) {
         gameFocused = focused;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -138,11 +138,11 @@ public class StateIngame implements GameState {
         CoreRegistry.clear();
         BlockManager.getAir().setEntity(EntityRef.NULL);
         GameThread.clearWaitingProcesses();
-		/*
-		 * Clear the binding as otherwise the complete ingame state would be
-		 * referenced.
-		 */
-		nuiManager.getHUD().clearVisibleBinding();
+        /*
+         * Clear the binding as otherwise the complete ingame state would be
+         * referenced.
+         */
+        nuiManager.getHUD().clearVisibleBinding();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglAudio.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglAudio.java
@@ -32,7 +32,7 @@ import org.terasology.registry.CoreRegistry;
 public class LwjglAudio extends BaseLwjglSubsystem {
 
     private static final Logger logger = LoggerFactory.getLogger(LwjglAudio.class);
-    
+
     private AudioManager audioManager;
 
     @Override
@@ -60,7 +60,9 @@ public class LwjglAudio extends BaseLwjglSubsystem {
 
     @Override
     public void dispose() {
-        audioManager.dispose();
+        if (audioManager != null) {
+            audioManager.dispose();
+        }
     }
 
     private void initOpenAL(Config config) {

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -124,7 +124,7 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
 
     @Override
     public void shutdown(Config config) {
-        if (!Display.isFullscreen() && Display.isVisible()) {
+        if (Display.isCreated() && !Display.isFullscreen() && Display.isVisible()) {
             config.getRendering().setWindowPosX(Display.getX());
             config.getRendering().setWindowPosY(Display.getY());
         }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -21,7 +21,6 @@ import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.events.ActivationPredicted;
 import org.terasology.logic.characters.events.ActivationRequest;
-import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.Direction;
 import org.terasology.math.TeraMath;
@@ -31,7 +30,6 @@ import org.terasology.physics.HitResult;
 import org.terasology.physics.Physics;
 import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.registry.CoreRegistry;
-import sun.rmi.server.Activation;
 
 import javax.vecmath.Quat4f;
 import javax.vecmath.Vector3f;
@@ -42,7 +40,7 @@ import javax.vecmath.Vector3f;
 public class LocalPlayer {
 
     private EntityRef clientEntity = EntityRef.NULL;
-    private int nextActivationId = 0;
+    private int nextActivationId;
 
     // TODO use same as CharacterSystem?
     private CollisionGroup[] filter = {StandardCollisionGroup.DEFAULT, StandardCollisionGroup.WORLD};

--- a/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
@@ -133,6 +133,7 @@ public abstract class AbstractWidget implements UIWidget {
         }
     }
 
+    @Override
     public boolean isVisible() {
         return visible.get();
     }
@@ -145,9 +146,9 @@ public abstract class AbstractWidget implements UIWidget {
         this.visible = bind;
     }
 
-	public void clearVisibleBinding() {
-		this.visible = new DefaultBinding<>(true);
-	}
+    public void clearVisibleBinding() {
+        this.visible = new DefaultBinding<>(true);
+    }
 
     @Override
     public void onGainFocus() {


### PR DESCRIPTION
The most important change is the `cleanup()` in the initialization catch block.

This PR also fixes all remaining CheckStyle errors (and most  warnings in the files I touched)
