### PR TITLE
More cleanup

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -269,7 +269,13 @@ public class TerasologyEngine implements GameEngine {
 
             cleanup();
         } catch (RuntimeException e) {
-            logger.error("Uncaught exception", e);
+            logger.error("Uncaught exception, attempting clean game shutdown", e);
+            try {
+                cleanup();
+            } catch (RuntimeException innerE) {
+                logger.error("Clean game shutdown after an uncaught exception failed", innerE);
+                logger.error("Rethrowing original exception");
+            }
             throw e;
         }
     }

--- a/modules/Core/assets/prefabs/chest.prefab
+++ b/modules/Core/assets/prefabs/chest.prefab
@@ -1,47 +1,47 @@
 {
-  "Inventory": {
-    "privateToOwner" : false,
-    "itemSlots": [
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  "RetainBlockInventory": {},
-  "PlaySoundAction" : {
-    sounds = "engine:click"
-  },
-  "InteractionTarget": {},
-  "InteractionScreen": {
-    "screen": "engine:containerScreen"
-  },
-  "Network" : {
-  }
+    "Inventory": {
+        "privateToOwner": false,
+        "itemSlots": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    "RetainBlockInventory": {},
+    "PlaySoundAction": {
+        "sounds": "engine:click"
+    },
+    "InteractionTarget": {},
+    "InteractionScreen": {
+        "screen": "engine:containerScreen"
+    },
+    "Network": {
+    }
 }

--- a/modules/Core/assets/prefabs/miniaturizer.prefab
+++ b/modules/Core/assets/prefabs/miniaturizer.prefab
@@ -5,10 +5,10 @@
     },
     "Item" : {
         "icon" : "engine:items.scissors",
-		"usage" : "ON_BLOCK"
+        "usage" : "ON_BLOCK"
     },
-  	"PlaySoundAction" : {
-    	sounds = "engine:click"
-  	},
+    "PlaySoundAction": {
+        "sounds" : "engine:click"
+    },
     "Miniaturizer" : {}
 }


### PR DESCRIPTION
Inspired by #1288 (cleans up better on initialization crashes) I tried to add cleanup() to another spot in the engine to catch crashes during normal runtime. It _looks_ like it fixes another big piece of #1266 and games close correctly. CrashReporter still reports the correct thing, even if a crash happens during cleanup itself.

I'm not super confident in doing changes this fundamental, feels like I must be missing something! Or is it really this simple?

One quirk: If a crash happens during cleanup the error may get reported twice (as cleanup is attempted again after the crash mid-cleanup ...). CR still gets the right message so oh well. Game may still not dispose correctly depending on where the crash happens during cleanup (a simulated crash before stopThreads() for instance still leaves a broken process. CR still triggers correctly even then

Also noticed that the CrashGameBlock in Sample will actually crash the server even if triggered by a client (which then actually gets disconnected instead). CR pops up on the server if enabled, heh. Not sure how to make the client crash without taking down the server.

Thanks for the inspiration @msteiger :D

(also reformatted a couple prefabs as the red squiggly kept nagging me)
