### PR TITLE
Make the game quit for real when the main thread ends.

### DIFF
--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -122,7 +122,7 @@ public final class Terasology {
                     e.printStackTrace();
                 }
             }
-        } catch (RuntimeException | IOException e) {
+        } catch (Throwable t) {
 
             if (!GraphicsEnvironment.isHeadless()) {
                 Path logPath = Paths.get(".");
@@ -138,10 +138,13 @@ public final class Terasology {
                 if (crashReportEnabled) {
                     Path logFile = logPath.resolve("Terasology.log");
 
-                    CrashReporter.report(e, logFile);
+                    CrashReporter.report(t, logFile);
                 }
             }
+            // Quits ths VM, to prevent invisible crashed games in the background to sum up and eat resources:
+            System.exit(1);
         }
+        System.exit(0);
     }
 
     private static GameManifest getLatestGameManifest() {


### PR DESCRIPTION
Through bugs or an unclean shutdown it can happen that there are still
running threads when the main thread comes to an end. If we don't
explictly shutdown the VM, it may happen that the VM keeps
running invisible in the background consuming resources.

To prevent this, this thread forces the VM to quit when the
main thread coems to an end.

Note: The crash reporter call blocks till the crash reporter is done.
So the VM won't be force quitted before the user quits the crash reporter.

This patch should fix all scenarios of #1266 as the VM quits now even if there was no clean shutdown.
