### PR TITLE
Make eclipse use its own classes folder (for modules)

### DIFF
--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -291,13 +291,6 @@ idea {
     }
 }
 
-// For Eclipse just make sure the classpath is right
-eclipse {
-    classpath {
-        defaultOutputDir = file('build/classes')
-    }
-}
-
 // Utility task to update the module (except Core) via Git - not tested with local changes present, may cause trouble
 task (updateModule, type: GitPull)  {
     description = 'Updates source for the module from its home (most likely GitHub)'


### PR DESCRIPTION
Using the same folder for gradle's class files and eclipse causes some inconsistencies, in particular when using different versions of Java.
