### PR TITLE
Fix privileges for ogg streaming sounds

### DIFF
--- a/engine/src/main/java/org/terasology/asset/AssetManager.java
+++ b/engine/src/main/java/org/terasology/asset/AssetManager.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.sources.ArchiveSource;
@@ -42,7 +43,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -623,20 +623,6 @@ public class AssetManager {
             } else {
                 next = null;
             }
-        }
-    }
-
-    private static final class PrivilegedOpenStream implements PrivilegedExceptionAction<InputStream> {
-
-        private URL url;
-
-        private PrivilegedOpenStream(URL url) {
-            this.url = url;
-        }
-
-        @Override
-        public InputStream run() throws Exception {
-            return url.openStream();
         }
     }
 }

--- a/engine/src/main/java/org/terasology/asset/PrivilegedOpenStream.java
+++ b/engine/src/main/java/org/terasology/asset/PrivilegedOpenStream.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.asset;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * Opens an URL stream in a privileged action
+ * @author Immortius
+ */
+public final class PrivilegedOpenStream implements PrivilegedExceptionAction<InputStream> {
+
+    private final URL url;
+
+    public PrivilegedOpenStream(URL url) {
+        this.url = url;
+    }
+
+    @Override
+    public InputStream run() throws Exception {
+        return url.openStream();
+    }
+}


### PR DESCRIPTION
This fixes the permission settings for ogg streaming files. 

After cleaning and recompiling a few times, bug #1326 did not appear again. Nonetheless, somebody please verify that this works.
