### PR TITLE
Climbing improvements

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterStateEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterStateEvent.java
@@ -16,6 +16,7 @@
 
 package org.terasology.logic.characters;
 
+import org.terasology.math.Side;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
@@ -42,6 +43,7 @@ public class CharacterStateEvent extends NetworkEvent {
     private float yaw;
     private float pitch;
     private float footstepDelta;
+    private Side climbDirection;
 
     protected CharacterStateEvent() {
     }
@@ -57,6 +59,7 @@ public class CharacterStateEvent extends NetworkEvent {
         this.pitch = previous.pitch;
         this.yaw = previous.yaw;
         this.footstepDelta = previous.footstepDelta;
+        this.climbDirection = previous.climbDirection;
     }
 
     public CharacterStateEvent(
@@ -124,6 +127,13 @@ public class CharacterStateEvent extends NetworkEvent {
         this.sequenceNumber = sequenceNumber;
     }
 
+    public void setClimbDirection(Side climbDirection) {
+        this.climbDirection = climbDirection;
+    }
+
+    public Side getClimbDirection() {
+        return climbDirection;
+    }
     /**
      * Retrieve the pitch in degrees.
      *
@@ -255,4 +265,5 @@ public class CharacterStateEvent extends NetworkEvent {
         CharacterCollider collider = physics.getCharacterCollider(entity);
         collider.setLocation(newPos);
     }
+
 }

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -26,6 +26,7 @@ import org.terasology.logic.characters.events.OnEnterBlockEvent;
 import org.terasology.logic.characters.events.SwimStrokeEvent;
 import org.terasology.logic.characters.events.VerticalCollisionEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.Side;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3fUtil;
 import org.terasology.math.Vector3i;
@@ -37,6 +38,7 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 
 import javax.vecmath.AxisAngle4f;
+import javax.vecmath.Quat4f;
 import javax.vecmath.Vector3f;
 
 /**
@@ -194,9 +196,20 @@ public class KinematicCharacterMover implements CharacterMover {
             sides[3].z -= factor * movementComp.radius;
             sides[4].y -= movementComp.height;
             for (Vector3f side : sides) {
-                if (worldProvider.getBlock(side).isClimbable()) {
-                    //If any of our sides are near a climbable block, climb!
-                    newClimbing = true;
+                Block block = worldProvider.getBlock(side);
+                if (block.isClimbable()) {
+                    //If any of our sides are near a climbable block, check if we are near to the side and climb!
+
+                    Vector3i climbBlockPos = new Vector3i(side, 0.5f);
+                    Vector3i dir = block.getDirection().getVector3i();
+
+                    if (dir.x != 0 && Math.abs(state.getPosition().x - (float) climbBlockPos.x + (float) dir.x * .5f) < movementComp.radius + 0.1f) {
+                        newClimbing = true;
+                        state.setClimbDirection(block.getDirection());
+                    } else if (dir.z != 0 && Math.abs(state.getPosition().z - (float) climbBlockPos.z + (float) dir.z * .5f) < movementComp.radius + 0.1f) {
+                        newClimbing = true;
+                        state.setClimbDirection(block.getDirection());
+                    }
                     break;
                 }
             }
@@ -517,6 +530,7 @@ public class KinematicCharacterMover implements CharacterMover {
     private void walk(final CharacterMovementComponent movementComp, final CharacterStateEvent state,
                       CharacterMoveInputEvent input, EntityRef entity) {
         Vector3f desiredVelocity = new Vector3f(input.getMovementDirection());
+
         float lengthSquared = desiredVelocity.lengthSquared();
 
         // If the length of desired movement is > 1, normalise it to prevent movement being faster than allowed.
@@ -541,6 +555,11 @@ public class KinematicCharacterMover implements CharacterMover {
             }
         }
         desiredVelocity.scale(maxSpeed);
+
+        if (movementComp.mode == MovementMode.CLIMBING) {
+            climb(state, input, desiredVelocity);
+        }
+
         // Modify velocity towards desired, up to the maximum rate determined by friction
         Vector3f velocityDiff = new Vector3f(desiredVelocity);
         velocityDiff.sub(state.getVelocity());
@@ -559,7 +578,8 @@ public class KinematicCharacterMover implements CharacterMover {
         Vector3f moveDelta = new Vector3f(endVelocity);
         moveDelta.scale(input.getDelta());
         CharacterCollider collider = movementComp.mode.useCollision ? physics.getCharacterCollider(entity) : null;
-        MoveResult moveResult = move(state.getPosition(), moveDelta, (state.isGrounded() && movementComp.mode.canBeGrounded) ? movementComp.stepHeight : 0,
+        MoveResult moveResult = move(state.getPosition(), moveDelta,
+                (state.getMode() != MovementMode.CLIMBING && state.isGrounded() && movementComp.mode.canBeGrounded) ? movementComp.stepHeight : 0,
                 movementComp.slopeFactor, collider);
         Vector3f distanceMoved = new Vector3f(moveResult.getFinalPosition());
         distanceMoved.sub(state.getPosition());
@@ -613,6 +633,60 @@ public class KinematicCharacterMover implements CharacterMover {
                             break;
                     }
                 }
+            }
+        }
+    }
+
+    private void climb(final CharacterStateEvent state, CharacterMoveInputEvent input, Vector3f desiredVelocity) {
+        if (state.getClimbDirection() == null) {
+            return;
+        }
+        Quat4f rotation = new Quat4f();
+        Vector3f tmp;
+
+        Side climbSide = state.getClimbDirection();
+        Vector3i climbDir3i = climbSide.getVector3i();
+        Vector3f climbDir3f = climbDir3i.toVector3f();
+
+        QuaternionUtil.setEuler(rotation, TeraMath.DEG_TO_RAD * state.getYaw(), 0, 0);
+        tmp = new Vector3f(0.0f, 0.0f, -1.0f);
+        QuaternionUtil.quatRotate(rotation, tmp, tmp);
+        float angleToClimbDirection = tmp.angle(climbDir3f);
+
+        boolean clearMovementToDirection = !state.isGrounded();
+
+        // facing the ladder or looking down or up
+        if (angleToClimbDirection < Math.PI / 4.0 || Math.abs(input.getPitch()) > 60f) {
+            float pitchAmount = state.isGrounded() ? 45f : 90f;
+            float pitch = input.getPitch() > 30f ? pitchAmount : -pitchAmount;
+            QuaternionUtil.setEuler(rotation, TeraMath.DEG_TO_RAD * state.getYaw(), TeraMath.DEG_TO_RAD * pitch, 0);
+            QuaternionUtil.quatRotate(rotation, desiredVelocity, desiredVelocity);
+
+        // looking sidewards from ladder
+        } else if (angleToClimbDirection < Math.PI * 3.0 / 4.0) {
+            tmp = new Vector3f();
+            QuaternionUtil.quatRotate(rotation, climbDir3f, tmp);
+            float leftOrRight = tmp.x;
+            float plusOrMinus = (leftOrRight < 0f ? -1.0f : 1.0f) * (climbDir3i.x != 0 ? -1.0f : 1.0f);
+            QuaternionUtil.setEuler(rotation, TeraMath.DEG_TO_RAD * input.getYaw(), 0f,
+                TeraMath.DEG_TO_RAD * 90f * plusOrMinus
+            );
+            QuaternionUtil.quatRotate(rotation, desiredVelocity, desiredVelocity);
+
+        // facing away from ladder
+        } else {
+            QuaternionUtil.setEuler(rotation, TeraMath.DEG_TO_RAD * state.getYaw(), 0, 0);
+            QuaternionUtil.quatRotate(rotation, desiredVelocity, desiredVelocity);
+            clearMovementToDirection = false;
+        }
+
+        // clear out movement towards or away from the ladder
+        if (clearMovementToDirection) {
+            if (climbDir3i.x != 0) {
+                desiredVelocity.x = 0f;
+            }
+            if (climbDir3i.z != 0) {
+                desiredVelocity.z = 0f;
             }
         }
     }

--- a/engine/src/main/java/org/terasology/logic/characters/MovementMode.java
+++ b/engine/src/main/java/org/terasology/logic/characters/MovementMode.java
@@ -21,7 +21,7 @@ package org.terasology.logic.characters;
  */
 public enum MovementMode {
     WALKING(1f, 8f, true, true, true, 3f, false),
-    CLIMBING(0f, 8f, true, false, true, 3f, true),
+    CLIMBING(0f, 8f, true, true, true, 3f, false),
     SWIMMING(0.05f, 2f, true, false, true, 2f, true),
     GHOSTING(0f, 4f, false, false, false, 5f, true),
     FLYING(0f, 4f, true, false, false, 3f, true),

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -148,10 +148,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
                 QuaternionUtil.quatRotate(viewRot, relMove, relMove);
                 break;
             case CLIMBING:
-                float pitch = characterComponent.pitch > 0 ? 60f : -60f;
-                QuaternionUtil.setEuler(viewRot, TeraMath.DEG_TO_RAD * characterComponent.yaw, TeraMath.DEG_TO_RAD * pitch, 0);
-                QuaternionUtil.quatRotate(viewRot, relMove, relMove);
-                relMove.y += relativeMovement.y;
+                // Rotation is applied in KinematicCharacterMover
                 break;
             default:
                 QuaternionUtil.setEuler(viewRot, TeraMath.DEG_TO_RAD * characterComponent.yaw, TeraMath.DEG_TO_RAD * characterComponent.pitch, 0);


### PR DESCRIPTION
#478 I tried to fix the climbing as good as I could, however my math skills are not good enough for a really elegant solution. While I guess this could be solved a lot smarter for someone with the skills, it's still a major improvement over the current climbing behavior.

Basically the following changes were made:
- Climbing initiates only when touching the ladder. Previously climbing was also initiated when you were a good step away from the ladder, which felt weird.
- While Climbing, Movement is always restricted to 2 axes, depending on how you are facing the ladder (see the 3 modes below). Previously, when you hit the back-key while facing the ladder, you moved down the ladder AND backwards, which eventually detached you from the ladder.
- Climbing Mode 1. facing the ladder or having a pitch > 60 Degrees : forward/back will move up/down,  strafe left/right will strafe left/right (similar to the way it worked before)
- Climbing Mode 2. Looking sidewards relative to the ladder: forward/back will move forward/backward, strafe left/right will climb up/down
- Climbing Mode 3. looking away from the ladder: forward/back will move forward/back, strafe left/right will move left/right (this mode doesn't allow you to climb, but  allows to detach yourself from the ladder by just moving in the opposite direction from the ladder, which is not possible in the other modes)
