### PR TITLE
Don't expose internal data in Facet interfaces

### DIFF
--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BaseBooleanFieldFacet3D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BaseBooleanFieldFacet3D.java
@@ -53,7 +53,6 @@ public abstract class BaseBooleanFieldFacet3D extends BaseFacet3D implements Boo
         return getWorld(pos.x, pos.y, pos.z);
     }
 
-    @Override
     public boolean[] getInternal() {
         return data;
     }
@@ -78,7 +77,6 @@ public abstract class BaseBooleanFieldFacet3D extends BaseFacet3D implements Boo
         setWorld(pos.x, pos.y, pos.z, value);
     }
 
-    @Override
     public void set(boolean[] newData) {
         Preconditions.checkArgument(newData.length == data.length);
         System.arraycopy(newData, 0, data, 0, newData.length);

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BaseFieldFacet2D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BaseFieldFacet2D.java
@@ -53,7 +53,6 @@ public abstract class BaseFieldFacet2D extends BaseFacet2D implements FieldFacet
         return getWorld(pos.x, pos.y);
     }
 
-    @Override
     public float[] getInternal() {
         return data;
     }
@@ -78,7 +77,6 @@ public abstract class BaseFieldFacet2D extends BaseFacet2D implements FieldFacet
         setWorld(pos.x, pos.y, value);
     }
 
-    @Override
     public void set(float[] newData) {
         Preconditions.checkArgument(newData.length == data.length, "New data must have same length as existing");
         System.arraycopy(newData, 0, data, 0, newData.length);

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BaseFieldFacet3D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BaseFieldFacet3D.java
@@ -53,7 +53,6 @@ public abstract class BaseFieldFacet3D extends BaseFacet3D implements FieldFacet
         return getWorld(pos.x, pos.y, pos.z);
     }
 
-    @Override
     public float[] getInternal() {
         return data;
     }
@@ -78,7 +77,6 @@ public abstract class BaseFieldFacet3D extends BaseFacet3D implements FieldFacet
         setWorld(pos.x, pos.y, pos.z, value);
     }
 
-    @Override
     public void set(float[] newData) {
         Preconditions.checkArgument(newData.length == data.length);
         System.arraycopy(newData, 0, data, 0, newData.length);

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BaseObjectFacet2D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BaseObjectFacet2D.java
@@ -55,7 +55,6 @@ public abstract class BaseObjectFacet2D<T> extends BaseFacet2D implements Object
         return getWorld(pos.x, pos.y);
     }
 
-    @Override
     public T[] getInternal() {
         return data;
     }
@@ -80,7 +79,6 @@ public abstract class BaseObjectFacet2D<T> extends BaseFacet2D implements Object
         setWorld(pos.x, pos.y, value);
     }
 
-    @Override
     public void set(T[] newData) {
         Preconditions.checkArgument(newData.length == data.length);
         System.arraycopy(newData, 0, data, 0, newData.length);

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BaseObjectFacet3D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BaseObjectFacet3D.java
@@ -55,7 +55,6 @@ public abstract class BaseObjectFacet3D<T> extends BaseFacet3D implements Object
         return getWorld(pos.x, pos.y, pos.z);
     }
 
-    @Override
     public T[] getInternal() {
         return data;
     }
@@ -80,7 +79,6 @@ public abstract class BaseObjectFacet3D<T> extends BaseFacet3D implements Object
         setWorld(pos.x, pos.y, pos.z, value);
     }
 
-    @Override
     public void set(T[] newData) {
         Preconditions.checkArgument(newData.length == data.length);
         System.arraycopy(newData, 0, data, 0, newData.length);

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BooleanFieldFacet3D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BooleanFieldFacet3D.java
@@ -31,8 +31,6 @@ public interface BooleanFieldFacet3D extends WorldFacet3D {
 
     boolean getWorld(Vector3i pos);
 
-    boolean[] getInternal();
-
     void set(int x, int y, int z, boolean value);
 
     void set(Vector3i pos, boolean value);
@@ -40,6 +38,4 @@ public interface BooleanFieldFacet3D extends WorldFacet3D {
     void setWorld(int x, int y, int z, boolean value);
 
     void setWorld(Vector3i pos, boolean value);
-
-    void set(boolean[] newData);
 }

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/FieldFacet2D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/FieldFacet2D.java
@@ -31,8 +31,6 @@ public interface FieldFacet2D extends WorldFacet2D {
 
     float getWorld(Vector2i pos);
 
-    float[] getInternal();
-
     void set(int x, int y, float value);
 
     void set(Vector2i pos, float value);
@@ -40,6 +38,4 @@ public interface FieldFacet2D extends WorldFacet2D {
     void setWorld(int x, int y, float value);
 
     void setWorld(Vector2i pos, float value);
-
-    void set(float[] data);
 }

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/FieldFacet3D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/FieldFacet3D.java
@@ -31,8 +31,6 @@ public interface FieldFacet3D extends WorldFacet3D {
 
     float getWorld(Vector3i pos);
 
-    float[] getInternal();
-
     void set(int x, int y, int z, float value);
 
     void set(Vector3i pos, float value);
@@ -40,6 +38,4 @@ public interface FieldFacet3D extends WorldFacet3D {
     void setWorld(int x, int y, int z, float value);
 
     void setWorld(Vector3i pos, float value);
-
-    void set(float[] newData);
 }

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/ObjectFacet2D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/ObjectFacet2D.java
@@ -31,8 +31,6 @@ public interface ObjectFacet2D<T> extends WorldFacet2D {
 
     T getWorld(Vector2i pos);
 
-    T[] getInternal();
-
     void set(int x, int y, T value);
 
     void set(Vector2i pos, T value);
@@ -40,6 +38,4 @@ public interface ObjectFacet2D<T> extends WorldFacet2D {
     void setWorld(int x, int y, T value);
 
     void setWorld(Vector2i pos, T value);
-
-    void set(T[] data);
 }

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/ObjectFacet3D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/ObjectFacet3D.java
@@ -31,8 +31,6 @@ public interface ObjectFacet3D<T> extends WorldFacet3D {
 
     T getWorld(Vector3i pos);
 
-    T[] getInternal();
-
     void set(int x, int y, int z, T value);
 
     void set(Vector3i pos, T value);
@@ -40,6 +38,4 @@ public interface ObjectFacet3D<T> extends WorldFacet3D {
     void setWorld(int x, int y, int z, T value);
 
     void setWorld(Vector3i pos, T value);
-
-    void set(T[] data);
 }


### PR DESCRIPTION
I started working on a sparse implementation of 3D facet data, because in some cases only very litte data in the 3D volume is needed.

This posed the challenge to implement `getInternal()` and `set(array)` which doesn't work too well (without allocating a new array).

I therefore propose to remove the two low-level methods from the root interfaces. This is easy to realize and makes it easier to provide alternative implementations. The methods are still present in the base implementations so that the existing classes remain as they are now. 
