### PR TITLE
Fix crash on remote clien by initializing the CelestialSystem on remote clients too.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -32,6 +32,9 @@ import org.terasology.world.chunks.remoteChunkProvider.RemoteChunkProvider;
 import org.terasology.world.internal.EntityAwareWorldProvider;
 import org.terasology.world.internal.WorldProviderCoreImpl;
 import org.terasology.world.internal.WorldProviderWrapper;
+import org.terasology.world.sun.BasicCelestialModel;
+import org.terasology.world.sun.CelestialSystem;
+import org.terasology.world.sun.DefaultCelestialSystem;
 
 /**
  * @author Immortius
@@ -62,6 +65,10 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         CoreRegistry.put(WorldProvider.class, worldProvider);
         CoreRegistry.put(BlockEntityRegistry.class, entityWorldProvider);
         CoreRegistry.get(ComponentSystemManager.class).register(entityWorldProvider, "engine:BlockEntityRegistry");
+
+        DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel());
+        CoreRegistry.put(CelestialSystem.class, celestialSystem);
+        CoreRegistry.get(ComponentSystemManager.class).register(celestialSystem);
 
         // Init. a new world
         RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);


### PR DESCRIPTION
The crash happend in getSunPosAngle in Skysphere.

@msteiger: This is just a quick fix from me. I am not sure if you intended the client to have it's own celestial system.
