### PR TITLE
Increase world timer tick frequency

### DIFF
--- a/engine/src/main/java/org/terasology/world/time/WorldTime.java
+++ b/engine/src/main/java/org/terasology/world/time/WorldTime.java
@@ -31,7 +31,7 @@ public interface WorldTime extends ComponentSystem {
      * The number of timer tick events per day.
      * This must be a divisor of {@link #DAY_LENGTH} to avoid rounding issues.
      */
-    long TICK_EVENTS_PER_DAY = 100;
+    long TICK_EVENTS_PER_DAY = 1000;
 
     long TICK_EVENT_RATE = DAY_LENGTH / TICK_EVENTS_PER_DAY;
 


### PR DESCRIPTION
From currently 18 secs. / tick to 1.8 secs / tick.

This change enables MusicDirector to check music triggers more often (but not too often)
