### PR TITLE
Adding permissions to Terasology.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
+++ b/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
@@ -91,7 +91,7 @@ public class ChatSystem extends BaseComponentSystem {
         }
     }
     
-    @Command(shortDescription = "Sends a message to all other players", runOnServer = true)
+    @Command(shortDescription = "Sends a message to all other players", runOnServer = true, requiredPermission = "")
     public void say(@CommandParam("message") String message, EntityRef speaker) {
         logger.debug("Received chat message from {} : '{}'", speaker, message);
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {

--- a/engine/src/main/java/org/terasology/logic/console/Command.java
+++ b/engine/src/main/java/org/terasology/logic/console/Command.java
@@ -16,6 +16,8 @@
 
 package org.terasology.logic.console;
 
+import org.terasology.logic.permission.PermissionManager;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -46,4 +48,6 @@ public @interface Command {
      * @return Whether this command should be sent to and run on the server.
      */
     boolean runOnServer() default false;
+
+    String requiredPermission() default PermissionManager.OPERATOR_PERMISSION;
 }

--- a/engine/src/main/java/org/terasology/logic/console/internal/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/internal/ConsoleImpl.java
@@ -37,6 +37,7 @@ import org.terasology.logic.console.ConsoleSubscriber;
 import org.terasology.logic.console.CoreMessageType;
 import org.terasology.logic.console.Message;
 import org.terasology.logic.console.MessageType;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.CoreRegistry;
@@ -287,7 +288,7 @@ public class ConsoleImpl implements Console {
                 }
 
                 return true;
-            } catch (IllegalArgumentException e) {
+            } catch (InvalidCommandCallException e) {
                 String msgText = e.getLocalizedMessage();
                 if (msgText != null && !msgText.isEmpty()) {
                     if (callingClient.exists()) {
@@ -296,12 +297,6 @@ public class ConsoleImpl implements Console {
                         addErrorMessage(e.getLocalizedMessage());
                     }
                 }
-                return false;
-
-            } catch (Exception e) {
-                addErrorMessage("Error executing command '" + commandName + "': " + e.getLocalizedMessage());
-
-                logger.error("Failed to execute command", e);
                 return false;
             }
         }

--- a/engine/src/main/java/org/terasology/logic/console/internal/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/internal/CoreCommands.java
@@ -294,7 +294,8 @@ public class CoreCommands extends BaseComponentSystem {
         }
     }
 
-    // TODO: Fix this up for multiplayer (cannot at the moment due to the use of the camera)
+    // TODO: Fix this up for multiplayer (cannot at the moment due to the use of the camera), also applied required
+    // TODO: permission
     @Command(shortDescription = "Spawns a block in front of the player", helpText = "Spawns the specified block as a " +
             "item in front of the player. You can simply pick it up.")
     public String spawnBlock(@CommandParam("blockName") String blockName) {

--- a/engine/src/main/java/org/terasology/logic/console/internal/InvalidCommandCallException.java
+++ b/engine/src/main/java/org/terasology/logic/console/internal/InvalidCommandCallException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.console.internal;
+
+public class InvalidCommandCallException extends Exception {
+    public InvalidCommandCallException(String message) {
+        super(message);
+    }
+
+    public InvalidCommandCallException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.permission;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.common.DisplayNameComponent;
+import org.terasology.logic.console.Command;
+import org.terasology.logic.console.CommandParam;
+import org.terasology.network.ClientComponent;
+import org.terasology.registry.In;
+
+@RegisterSystem
+public class PermissionCommands extends BaseComponentSystem {
+    @In
+    private PermissionManager permissionManager;
+    @In
+    private EntityManager entityManager;
+
+    @Command(shortDescription = "Gives specified permission to player",
+            helpText = "Gives specified permission to player",
+            runOnServer = true)
+    public String givePermission(
+            @CommandParam("player") String player,
+            @CommandParam("permission") String permission, EntityRef speaker) {
+        boolean permissionGiven = false;
+
+        for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
+            ClientComponent clientComponent = client.getComponent(ClientComponent.class);
+            if (clientHasName(clientComponent, player)) {
+                permissionManager.addPermission(clientComponent.character, permission);
+                permissionGiven = true;
+            }
+        }
+
+        if (permissionGiven) {
+            return "Permission " + permission + " added to player " + player;
+        } else {
+            return "Unable to find player " + player;
+        }
+    }
+
+    @Command(shortDescription = "Removes specified permission from player",
+            helpText = "Removes specified permission from player",
+            runOnServer = true)
+    public String removePermission(
+            @CommandParam("player") String player,
+            @CommandParam("permission") String permission, EntityRef speaker) {
+        boolean permissionGiven = false;
+
+        for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
+            ClientComponent clientComponent = client.getComponent(ClientComponent.class);
+            if (clientHasName(clientComponent, player)) {
+                permissionManager.removePermission(clientComponent.character, permission);
+                permissionGiven = true;
+            }
+        }
+
+        if (permissionGiven) {
+            return "Permission " + permission + " removed to player " + player;
+        } else {
+            return "Unable to find player " + player;
+        }
+    }
+
+    private boolean clientHasName(ClientComponent client, String playerName) {
+        EntityRef clientInfo = client.clientInfo;
+        if (clientInfo != null) {
+            String name = clientInfo.getComponent(DisplayNameComponent.class).name;
+            return playerName.equals(name);
+        }
+        return false;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.permission;
+
+import com.google.common.base.Predicate;
+import org.terasology.entitySystem.entity.EntityRef;
+
+public interface PermissionManager {
+    public static final String OPERATOR_PERMISSION = "op";
+
+    /**
+     * Adds specified permission to the player (character).
+     * @param player Player (character) to add permission to.
+     * @param permission Permission to add.
+     */
+    void addPermission(EntityRef player, String permission);
+
+    /**
+     * Checks if the specified player (character) has said permission.
+     * Note: Local player is considered to have all the permissions in all situations.
+     * @param player Player (character) to check.
+     * @param permission Permission to check.
+     * @return If player (character) has permission.
+     */
+    boolean hasPermission(EntityRef player, String permission);
+
+    /**
+     * Checks if the specified player (character) has permission that is accepted by the specified predicate.
+     * Note: Local player is considered to have all the permissions in all situations.
+     * @param player Player (character) to check.
+     * @param permissionPredicate Permission predicate to check against.
+     * @return If player (character) has permission matching the predicate.
+     */
+    boolean hasPermission(EntityRef player, Predicate<String> permissionPredicate);
+
+    /**
+     * Removes specified permission from the player (character).
+     * @param player Player (character) to remove permission from.
+     * @param permission Permission to remove.
+     */
+    void removePermission(EntityRef player, String permission);
+}

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionSetComponent.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionSetComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.permission;
+
+import org.terasology.entitySystem.Component;
+
+import java.util.Set;
+
+public class PermissionSetComponent implements Component {
+    public Set<String> permissions;
+}

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionSystem.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.permission;
+
+import com.google.common.base.Predicate;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.registry.In;
+import org.terasology.registry.Share;
+
+import java.util.Set;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+@Share(PermissionManager.class)
+public class PermissionSystem extends BaseComponentSystem implements PermissionManager {
+    @In
+    private LocalPlayer localPlayer;
+
+    @Override
+    public void addPermission(EntityRef player, String permission) {
+        PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
+        if (permissionSet != null) {
+            permissionSet.permissions.add(permission.toLowerCase());
+            player.saveComponent(permissionSet);
+        }
+    }
+
+    @Override
+    public boolean hasPermission(EntityRef player, String permission) {
+        // Local player has all permissions in every situation
+        if (isLocal(player)) {
+            return true;
+        }
+
+        PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
+        return permissionSet != null && permissionSet.permissions.contains(permission.toLowerCase());
+    }
+
+    @Override
+    public boolean hasPermission(EntityRef player, Predicate<String> permissionPredicate) {
+        // Local player has all permission in every situation
+        if (isLocal(player)) {
+            return true;
+        }
+
+        PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
+        return permissionSet != null && predicateMatches(permissionPredicate, permissionSet.permissions);
+    }
+
+    private boolean predicateMatches(Predicate<String> permissionPredicate, Set<String> permissions) {
+        for (String permission : permissions) {
+            if (permissionPredicate.apply(permission)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void removePermission(EntityRef player, String permission) {
+        PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
+        if (permissionSet != null) {
+            permissionSet.permissions.remove(permission.toLowerCase());
+            player.saveComponent(permissionSet);
+        }
+    }
+
+    private boolean isLocal(EntityRef player) {
+        return localPlayer != null && localPlayer.getCharacterEntity() == player;
+    }
+}

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -87,7 +87,7 @@ public class BlockCommands extends BaseComponentSystem {
         blockItemFactory = new BlockItemFactory(entityManager);
     }
 
-    // TODO: Fix this up for multiplayer (cannot at the moment due to the use of camera)
+    // TODO: Fix this up for multiplayer (cannot at the moment due to the use of camera), also apply required permission
     @Command(shortDescription = "Places a block in front of the player", helpText = "Places the specified block in front of the player. " +
             "The block is set directly into the world and might override existing blocks. After placement the block can be destroyed like any regular placed block.")
     public String placeBlock(@CommandParam("blockName") String blockName) {

--- a/engine/src/main/resources/assets/prefabs/player/player.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/player.prefab
@@ -60,5 +60,8 @@
               0,0,0,0,0,0,0,0,0,0
             ]
     },
-    "Breather" : {}
+    "Breather" : {},
+    "PermissionSet": {
+        "permissions": []
+    }
 }


### PR DESCRIPTION
This adds concept of permissions to players. Each player may have many different permissions, identified by name of the permission (case-insensitive).

The local player is considered to always have all permissions.

At the moment, the only use for this is in @Command that allows specifying which permission is required to be able to invoke this. Keep in mind, that this works only for commands run on server. In the future other systems might use permissions with PermissionManager interface.

I've added two new commands "givePermission [playerName] [permissionName]" and "removePermission [playerName] [permissionName]". Both of those commands, as well as many other commands already existing in Core/Engine now require "op" permission to run them (unless you are local player).
