### PR TITLE
Reimplement the purgeWorld command on top of the new auto save system.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/server/ServerCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/server/ServerCommands.java
@@ -36,6 +36,7 @@ import org.terasology.persistence.StorageManager;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.FontColor;
+import org.terasology.world.chunks.ChunkProvider;
 
 /**
  * Commands to administer a remote server
@@ -51,6 +52,9 @@ public class ServerCommands extends BaseComponentSystem {
 
     @In
     private StorageManager storageManager;
+
+    @In
+    private ChunkProvider chunkProvider;
 
     @Command(shortDescription = "Shutdown the server", runOnServer = true)
     public String shutdownServer(EntityRef sender) {
@@ -143,6 +147,11 @@ public class ServerCommands extends BaseComponentSystem {
     @Command(shortDescription = "Triggers the creation of a save game", runOnServer = true)
     public void save() {
         storageManager.requestSaving();
+    }
+
+    @Command(shortDescription = "Deletes the current world and generated new chunks", runOnServer = true)
+    public void purgeWorld() {
+        chunkProvider.purgeWorld();
     }
 }
 

--- a/engine/src/main/java/org/terasology/persistence/StorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/StorageManager.java
@@ -73,4 +73,6 @@ public interface StorageManager {
     boolean isSaving();
 
     void checkAndRepairSaveIfNecessary() throws IOException;
+
+    void deleteWorld();
 }

--- a/engine/src/main/java/org/terasology/persistence/internal/StorageManagerInternal.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/StorageManagerInternal.java
@@ -51,6 +51,7 @@ import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.serializers.PrefabSerializer;
 import org.terasology.protobuf.EntityData;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.utilities.FilesUtil;
 import org.terasology.utilities.concurrency.ShutdownTask;
 import org.terasology.utilities.concurrency.Task;
 import org.terasology.utilities.concurrency.TaskMaster;
@@ -669,6 +670,22 @@ public final class StorageManagerInternal implements StorageManager, EntityDestr
         saveTransactionHelper.cleanupSaveTransactionDirectory();
         if (Files.exists(storagePathProvider.getUnmergedChangesPath())) {
             saveTransactionHelper.mergeChanges();
+        }
+    }
+
+
+    @Override
+    public void deleteWorld() {
+        waitForCompletionOfPreviousSave();
+        unloadedAndUnsavedChunkMap.clear();
+        unloadedAndSavingChunkMap.clear();
+        unloadedAndUnsavedPlayerMap.clear();
+        unloadedAndSavingPlayerMap.clear();
+
+        try {
+            FilesUtil.recursiveDelete(storagePathProvider.getWorldPath());
+        } catch (IOException e) {
+            logger.error("Failed to purge chunks", e);
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
@@ -98,6 +98,8 @@ public interface ChunkProvider {
      */
     void beginUpdate();
 
+    void purgeWorld();
+
     /**
      * @param pos
      * @return Whether this chunk is available and ready for use

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -167,6 +167,10 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
     }
 
     @Override
+    public void purgeWorld() {
+    }
+
+    @Override
     public void shutdown() {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
The auto-save branch removed the purgeWorld command as it needed to be reimplemented and it seemed unused.

@msteiger told me today that he would like to have the command back.

This patch reintroduces the purgeWorld command. 

It's purging purging now also half loaded chunks.
