### PR TITLE
Make player system facet agnostic

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -143,11 +143,10 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
 	                    }
 	                }
 	            }
-            }else{
-            	Vector3i pos =new Vector3i(spawnPos.x,spawnPos.y,spawnPos.z);
-                if (findOpenVerticalPosition(pos)) {
-                    return pos;
-                }
+            }
+            Vector3i pos =new Vector3i(spawnPos.x,spawnPos.y,spawnPos.z);
+            if (findOpenVerticalPosition(pos)) {
+                return pos;
             }
         }
         return spawnPos;


### PR DESCRIPTION
update to allow generate worlds whitout default facets.
I looked trough comments to last pr of same name. and fixed what could
be. This if is necesary because not all world generators use default
facets.
