### PR TITLE
Fix Rect2i.encompasses()

### DIFF
--- a/engine-tests/src/test/java/org/terasology/utilities/Rect2iTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/Rect2iTest.java
@@ -64,6 +64,18 @@ public class Rect2iTest {
     }
 
     @Test
+    public void testEncompass() {
+        // encompass self
+        assertTrue(Rect2i.createFromMinAndSize(5, 5, 47, 57).encompasses(Rect2i.createFromMinAndSize(5, 5, 47, 57)));
+
+        assertTrue(Rect2i.createFromMinAndSize(5, 5, 47, 57).encompasses(Rect2i.createFromMinAndSize(45, 35, 5, 20)));
+        assertTrue(Rect2i.createFromMinAndSize(5, 5, 47, 57).encompasses(Rect2i.createFromMinAndSize(50, 60, 2, 2)));
+
+        assertFalse(Rect2i.createFromMinAndSize(5, 5, 47, 57).encompasses(Rect2i.createFromMinAndSize(50, 60, 3, 2)));
+        assertFalse(Rect2i.createFromMinAndSize(5, 5, 47, 57).encompasses(Rect2i.createFromMinAndSize(50, 60, 2, 3)));
+    }
+
+    @Test
     public void testContains() {
         Rect2i a = Rect2i.createFromMinAndMax(0, 0, 0, 0);
         assertTrue(a.contains(0, 0));

--- a/engine/src/main/java/org/terasology/math/Rect2i.java
+++ b/engine/src/main/java/org/terasology/math/Rect2i.java
@@ -157,7 +157,7 @@ public final class Rect2i implements Iterable<Vector2i> {
     }
 
     public boolean encompasses(Rect2i other) {
-        return !isEmpty() && other.posX >= posX && other.posY >= posY && other.posX + other.w <= posX + w && other.posY + w <= posY + w;
+        return !isEmpty() && other.posX >= posX && other.posY >= posY && other.posX + other.w <= posX + w && other.posY + other.h <= posY + h;
     }
 
     public boolean overlaps(Rect2i other) {


### PR DESCRIPTION
The method is used mainly in `LwjglCanvasRenderer.drawTexture` to update the texture`s crop region. This fix does not seem to harm that operation (maybe even improve it?).
