### PR TITLE
Fix NetworkOwnershipTest unit tests

### DIFF
--- a/engine-tests/src/test/java/org/terasology/network/internal/NetworkOwnershipTest.java
+++ b/engine-tests/src/test/java/org/terasology/network/internal/NetworkOwnershipTest.java
@@ -70,6 +70,7 @@ public class NetworkOwnershipTest extends TerasologyTestingEnvironment {
         clientNetComp.replicateMode = NetworkComponent.ReplicateMode.OWNER;
         clientEntity = entityManager.create(clientNetComp);
         when(client.getEntity()).thenReturn(clientEntity);
+        when(client.getId()).thenReturn("dummyID");
         networkSystem.mockHost();
         networkSystem.connectToEntitySystem(entityManager, CoreRegistry.get(EntitySystemLibrary.class), mock(BlockEntityRegistry.class));
         networkSystem.registerNetworkEntity(clientEntity);


### PR DESCRIPTION
This PR fixes all NetworkOwnershipTest unit tests with a single line of code :+1: 
Guava's ConcurrentMap throws a NPE if the key is `null`. Using a dummy client ID instead fixes the problem.
