### PR TITLE
PC Facade Improvements: Javadoc, launch args and usage requests.

### DIFF
--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.engine;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.modes.StateLoading;
@@ -44,39 +45,69 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Main method for launching Terasology
+ * Class providing the main() method for launching Terasology.
+ *
+ * Through the following launch arguments default locations to store logs and
+ * game saves can be overridden, by using the current directory or a specified
+ * one as the home directory. Furthermore, Terasology can be launched headless,
+ * to save resources while acting as a server or to run in an environment with
+ * no graphics, audio or input support. Additional arguments are available to
+ * reload the latest game on startup and to disable crash reporting.
+ *
+ * Available launch arguments:
+ *
+ * <table>
+ *  <tbody>
+ *      <tr><td>-homedir</td><td>Use the current directory as the home directory.</td></tr>
+ *      <tr><td>-homedir=path</td><td>Use the specified path as the home directory.</td></tr>
+ *      <tr><td>-headless</td><td>Start headless.</td></tr>
+ *      <tr><td>-loadlastgame</td><td>Load the latest game on startup.</td></tr>
+ *      <tr><td>-noCrashReport</td><td>Disable crash reporting</td></tr>
+ *  </tbody>
+ * </table>
+ *
+ * When used via command line an usage help and some examples can be obtained via:
+ *
+ *      terasology -help    or    terasology /?
+ *
+ * In case of crashes Terasology logs available information in <logpath>/Terasology.log
  *
  * @author Benjamin Glatzel <benjamin.glatzel@me.com>
  * @author Kireev   Anton   <adeon.k87@gmail.com>
  */
+
 public final class Terasology {
 
-    private static final String LOAD_LAST_GAME_ARG = "-loadlastgame";
-    private static final String HOME_ARG = "-homedir=";
-    private static final String LOCAL_ARG = "-homedir";
-    private static final String HEADLESS_ARG = "-headless";
-    private static final String NO_CRASH_REPORT_ARG = "-noCrashReport";
+    private static final String[] PRINT_USAGE_FLAGS = {"--help", "-help", "/help", "-h", "/h", "/?"};
+    private static final String USE_CURRENT_DIR_AS_HOME = "-homedir";
+    private static final String USE_SPECIFIED_DIR_AS_HOME = "-homedir=";
+    private static final String START_HEADLESS = "-headless";
+    private static final String LOAD_LAST_GAME = "-loadlastgame";
+    private static final String NO_CRASH_REPORT = "-noCrashReport";
 
     private Terasology() {
     }
 
     public static void main(String[] args) {
+
+        handlePrintUsageRequest(args);
+
         boolean crashReportEnabled = true;
         boolean loadLastGame = false;
         try {
             boolean isHeadless = false;
             Path homePath = null;
             for (String arg : args) {
-                if (arg.startsWith(HOME_ARG)) {
-                    homePath = Paths.get(arg.substring(HOME_ARG.length()));
-                } else if (arg.equals(LOCAL_ARG)) {
+                if (arg.startsWith(USE_SPECIFIED_DIR_AS_HOME)) {
+                    homePath = Paths.get(arg.substring(USE_SPECIFIED_DIR_AS_HOME.length()));
+                } else if (arg.equals(USE_CURRENT_DIR_AS_HOME)) {
                     homePath = Paths.get("");
-                } else if (arg.equals(HEADLESS_ARG)) {
+                } else if (arg.equals(START_HEADLESS)) {
                     isHeadless = true;
                     crashReportEnabled = false;
-                } else if (arg.equals(NO_CRASH_REPORT_ARG)) {
+                } else if (arg.equals(NO_CRASH_REPORT)) {
                     crashReportEnabled = false;
-                } else if (arg.equals(LOAD_LAST_GAME_ARG)) {
+                } else if (arg.equals(LOAD_LAST_GAME)) {
                     loadLastGame = true;
                 }
             }
@@ -137,6 +168,60 @@ public final class Terasology {
                 }
             }
         }
+    }
+
+    private static void handlePrintUsageRequest(String[] args) {
+        for (String arg : args) {
+            for (String usageArg : PRINT_USAGE_FLAGS) {
+                if (usageArg.equals(arg.toLowerCase())) {
+                    printUsageAndExit();
+                }
+            }
+        }
+    }
+
+    private static void printUsageAndExit() {
+
+        String printUsageFlags = Joiner.on("|").join(PRINT_USAGE_FLAGS);
+
+        System.out.println("Usage:");
+        System.out.println();
+        System.out.println("    terasology [" + printUsageFlags + "] [" + USE_CURRENT_DIR_AS_HOME + "|" + USE_SPECIFIED_DIR_AS_HOME + "<path>] [" + START_HEADLESS + "]");
+        System.out.println();
+        System.out.println("By default Terasology saves data such as game saves and logs into subfolders of a platform-specific \"home directory\".");
+        System.out.println("Optionally, the user can override the default by using one of the following launch arguments:");
+        System.out.println();
+        System.out.println("    " + USE_CURRENT_DIR_AS_HOME + "           Use the current directory as the home directory.");
+        System.out.println("    " + USE_SPECIFIED_DIR_AS_HOME + "<path> Use the specified directory as the home directory.");
+        System.out.println();
+        System.out.println("It is also possible to start Terasology in headless mode (no graphics), i.e. to act as a server.");
+        System.out.println("For this purpose use the " + START_HEADLESS + " launch argument.");
+        System.out.println();
+        System.out.println("To automatically load the latest game on startup,");
+        System.out.println("use the " + LOAD_LAST_GAME + " launch argument.");
+        System.out.println();
+        System.out.println("By default Crash Reporting is enabled.");
+        System.out.println("To disable this feature use the " + NO_CRASH_REPORT + " launch argument.");
+        System.out.println();
+        System.out.println("Examples:");
+        System.out.println();
+        System.out.println("    Use the current directory as the home directory:");
+        System.out.println("    terasology " + USE_CURRENT_DIR_AS_HOME);
+        System.out.println();
+        System.out.println("    Use \"myPath\" as the home directory:");
+        System.out.println("    terasology " + USE_SPECIFIED_DIR_AS_HOME + "myPath");
+        System.out.println();
+        System.out.println("    Start terasology in headless mode (no graphics):");
+        System.out.println("    terasology " + START_HEADLESS);
+        System.out.println();
+        System.out.println("    Load the latest game on startup and disable crash reporting");
+        System.out.println("    terasology " + LOAD_LAST_GAME + " " + NO_CRASH_REPORT);
+        System.out.println();
+        System.out.println("    Don't start Terasology, just print this help:");
+        System.out.println("    terasology " + PRINT_USAGE_FLAGS[1]);
+        System.out.println();
+
+        System.exit(0);
     }
 
     private static GameManifest getLatestGameManifest() {


### PR DESCRIPTION
- Increased class-level javadoc
- Renamed launch argument variables for readability and consistency.
- Now handling command-line usage requests (i.e. --help flag)

These changes were originally part of now obsolete PR #1108 and have been updated to reflect and integrate the current code. Further changes to the PC Facade had been suggested in PR #1108 but I will leave them for a separate PR.
