### PR TITLE
Use headless env. for testing

### DIFF
--- a/engine-tests/src/test/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/TerasologyTestingEnvironment.java
@@ -65,7 +65,7 @@ public abstract class TerasologyTestingEnvironment {
     private static ModuleManager moduleManager;
     private static AssetManager assetManager;
 
-    private static DisplayEnvironment env;
+    private static HeadlessEnvironment env;
 
     private EngineEntityManager engineEntityManager;
     private ComponentSystemManager componentSystemManager;
@@ -80,7 +80,7 @@ public abstract class TerasologyTestingEnvironment {
         if (!setup) {
             setup = true;
 
-            env = new DisplayEnvironment();
+            env = new HeadlessEnvironment();
             assetManager = CoreRegistry.get(AssetManager.class);
             blockManager = CoreRegistry.get(BlockManager.class);
             config = CoreRegistry.get(Config.class);


### PR DESCRIPTION
Afaict, the unit tests that currently fail seem to fail due to the missing graphics environment on the Jenkins server. To my surprise, they seem to work fine in a headless environment. 

This small fix changes the env. It was tested locally in eclipse and on the Jenkins server:

http://jenkins.terasology.org/job/TerasologyTemp/2/

This fixes 18 unit tests.
