### PR TITLE
Added a command for automatically reloading screens when their ui file changed.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/internal/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/internal/CoreCommands.java
@@ -70,6 +70,10 @@ import javax.vecmath.Quat4f;
 import javax.vecmath.Vector3f;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -110,6 +114,12 @@ public class CoreCommands extends BaseComponentSystem {
         } else {
             return "Unable to resolve skin '" + skin + "'";
         }
+    }
+
+    @Command(shortDescription = "Enables the automatic reloading of screens when their file changes")
+    public String enableAutoScreenReloading() {
+        CoreRegistry.get(NUIManager.class).enableAutoReload();
+        return "Automatic reloading of screens enabled: Check console for hints where they get loaded from";
     }
 
     @Command(shortDescription = "Reloads a ui and clears the HUD. Use at your own risk")

--- a/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
@@ -99,4 +99,6 @@ public interface NUIManager extends ComponentSystem, FocusManager {
     boolean isForceReleasingMouse();
 
     void setForceReleasingMouse(boolean value);
+
+    void enableAutoReload();
 }


### PR DESCRIPTION
The command is called enableAutoScreenReloading.

Note that in the current intelij project setup lets terasology load screens from engine/build/classes/assets/ui/.

To perform a live editing of the container screen you need to edit engine/build/classes/assets/ui/ingame/containerScreen.ui

@immortius  is it purpose that the files get copied to the target directory?

It would be cool if terasology could use the source files directly instead of copying them to a classes directory first.
