### PR TITLE
Small tweaks for water in Core

### DIFF
--- a/modules/Core/assets/blocks/liquid/Water.block
+++ b/modules/Core/assets/blocks/liquid/Water.block
@@ -30,6 +30,6 @@
     "replacementAllowed" : true,
     "tint" : [0.1, 0.2, 0.2],
     "entity" : {
-        "prefab" : "water"
+        "prefab" : "core:water"
     }
 }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/GroundRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/GroundRasterizer.java
@@ -23,6 +23,8 @@ import org.terasology.world.chunks.CoreChunk;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.WorldRasterizer;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.liquid.LiquidData;
+import org.terasology.world.liquid.LiquidType;
 
 /**
  * @author Immortius
@@ -41,6 +43,7 @@ public class GroundRasterizer implements WorldRasterizer {
 
     @Override
     public void generateChunk(CoreChunk chunk, Region chunkRegion) {
+        LiquidData waterLiquid = new LiquidData(LiquidType.WATER, LiquidData.MAX_LIQUID_DEPTH);
         SurfaceHeightFacet surfaceHeightData = chunkRegion.getFacet(SurfaceHeightFacet.class);
         Vector3i chunkOffset = chunk.getChunkWorldOffset();
         for (int x = 0; x < chunk.getChunkSizeX(); ++x) {
@@ -52,6 +55,7 @@ public class GroundRasterizer implements WorldRasterizer {
                 }
                 for (; y < chunk.getChunkSizeY() && y + chunkOffset.y <= 32; ++y) {
                     chunk.setBlock(x, y, z, water);
+                    chunk.setLiquid(x, y, z, waterLiquid);
                 }
             }
         }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -29,6 +29,8 @@ import org.terasology.world.generation.Region;
 import org.terasology.world.generation.WorldRasterizer;
 import org.terasology.world.generation.facets.DensityFacet;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.liquid.LiquidData;
+import org.terasology.world.liquid.LiquidType;
 
 /**
  * @author Immortius
@@ -57,6 +59,7 @@ public class SolidRasterizer implements WorldRasterizer {
 
     @Override
     public void generateChunk(CoreChunk chunk, Region chunkRegion) {
+        LiquidData waterLiquid = new LiquidData(LiquidType.WATER, LiquidData.MAX_LIQUID_DEPTH);
         DensityFacet solidityFacet = chunkRegion.getFacet(DensityFacet.class);
         SurfaceHeightFacet surfaceFacet = chunkRegion.getFacet(SurfaceHeightFacet.class);
         BiomeFacet biomeFacet = chunkRegion.getFacet(BiomeFacet.class);
@@ -80,6 +83,7 @@ public class SolidRasterizer implements WorldRasterizer {
                     chunk.setBlock(pos, ice);
                 } else if (posY <= 32) {
                     chunk.setBlock(pos, water);
+                    chunk.setLiquid(pos, waterLiquid);
                 }
             }
         }


### PR DESCRIPTION
- Add liquid data for water placement in the default rasterizers.
- Explicitly set the water block's prefab with a module name to avoid conflicts with other modules.
