### PR TITLE
Call initializeWithInteractionTarget each time when a BaseInteractionScreen opens.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/BaseInteractionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/BaseInteractionScreen.java
@@ -29,24 +29,17 @@ public abstract class BaseInteractionScreen extends CoreScreenLayer {
     @In
     private LocalPlayer localPlayer;
 
-    private EntityRef previousInteractionTarget;
-
     protected EntityRef getInteractionTarget() {
         EntityRef characterEntity = localPlayer.getCharacterEntity();
         CharacterComponent characterComponent = characterEntity.getComponent(CharacterComponent.class);
 
-        if (previousInteractionTarget != characterComponent.predictedInteractionTarget && characterComponent.predictedInteractionTarget != null) {
-            previousInteractionTarget = characterComponent.predictedInteractionTarget;
-            initializeWithInteractionTarget(previousInteractionTarget);
-        }
-
-        return previousInteractionTarget;
+        return characterComponent.predictedInteractionTarget;
     }
 
     @Override
     public void onOpened() {
         super.onOpened();
-        getInteractionTarget();
+        initializeWithInteractionTarget(getInteractionTarget());
     }
 
     protected abstract void initializeWithInteractionTarget(EntityRef interactionTarget);


### PR DESCRIPTION
The entity can have changed when a screen opens the next time. Thus the UI should be always updated when it gets opend and not just only when it is a differnt entity.
