### PR TITLE
Added an item for inspecting entities powered by an external reference.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/common/InspectionToolComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/InspectionToolComponent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.common;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.network.Replicate;
+
+/**
+ * Component of the inspection tool which can be used to view the json data of
+ * entities. This component can also be used to test external references.
+ * 
+ * @author Florian <florian@fkoeberle.de>
+ */
+public class InspectionToolComponent implements Component {
+    @Replicate
+    public EntityRef inspectedEntity = EntityRef.NULL;
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/InspectionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/InspectionScreen.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.ingame;
+
+import org.lwjgl.input.Mouse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.common.InspectionToolComponent;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.nui.BaseInteractionScreen;
+import org.terasology.rendering.nui.UIWidget;
+import org.terasology.rendering.nui.layouts.ScrollableArea;
+import org.terasology.rendering.nui.widgets.ActivateEventListener;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UILabel;
+import org.terasology.rendering.nui.widgets.UILoadBar;
+import org.terasology.rendering.nui.widgets.UIText;
+
+/**
+ * @author Florian <florian@fkoeberle.de>
+ */
+public class InspectionScreen extends BaseInteractionScreen {
+    private UIText fullDescriptionLabel;
+    private UIText entityIdField;
+    private UIButton setEntityIdButton;
+
+
+    @Override
+    public void initialise() {
+        fullDescriptionLabel = find("fullDescriptionLabel", UIText.class);
+        entityIdField = find("entityIdField", UIText.class);
+        setEntityIdButton = find("setEntityIdButton", UIButton.class);
+        setEntityIdButton.subscribe(new ActivateEventListener() {
+
+            @Override
+            public void onActivated(UIWidget widget) {
+                String text = entityIdField.getText();
+                EntityRef interactionTarget = getInteractionTarget();
+                InspectionToolComponent inspectorComponent = interactionTarget.getComponent(InspectionToolComponent.class);
+                if (text.equals("this")) {
+                    inspectorComponent.inspectedEntity = interactionTarget;
+                } else {
+                    try {
+                        int id = Integer.parseInt(text);
+                        inspectorComponent.inspectedEntity = CoreRegistry.get(EntityManager.class).getEntity(id);
+                    } catch (NumberFormatException e) {
+                        fullDescriptionLabel.setText("Please specify a valid number");
+                    }
+                }
+                updateFields(interactionTarget);
+            }
+        });
+
+    }
+
+    @Override
+    protected void initializeWithInteractionTarget(EntityRef interactionTarget) {
+        updateFields(interactionTarget);
+    }
+
+    private void updateFields(EntityRef interactionTarget) {
+        InspectionToolComponent inspectorComponent = interactionTarget.getComponent(InspectionToolComponent.class);
+        EntityRef inspectedEntity = inspectorComponent.inspectedEntity;
+        entityIdField.setText(Integer.toString(inspectedEntity.getId()));
+        if (inspectedEntity.exists()) {
+            if (inspectedEntity.isActive()) {
+                fullDescriptionLabel.setText(inspectedEntity.toFullDescription());
+            } else {
+                fullDescriptionLabel.setText("not active: " + inspectedEntity.toFullDescription());
+            }
+        } else {
+            fullDescriptionLabel.setText("Non existing entity with id " + inspectedEntity.getId());
+        }
+    }
+
+}

--- a/engine/src/main/resources/assets/ui/ingame/inspectionScreen.ui
+++ b/engine/src/main/resources/assets/ui/ingame/inspectionScreen.ui
@@ -1,0 +1,61 @@
+{
+    "type" : "InspectionScreen",
+    "contents" : {
+        "type": "RelativeLayout",
+        "contents": [
+            {
+                "type": "ScrollableArea",
+                "id": "scrollArea",
+                "content": {
+                    "type": "UIText",
+                    "readOnly": true,
+                    "multiline": true,
+                    "id": "fullDescriptionLabel"
+                },
+                "layoutInfo": {
+                    "height" : 300,
+                    "width" : 500,
+                    "position-horizontal-center" : {},
+                    "position-vertical-center": {}
+                }
+            },
+             {
+                "type" : "RowLayout",
+                "contents" : [
+                    {
+                        "type" : "UILabel",
+                        "text" : "Entity Id: ",
+                        "layoutInfo" : {
+                            "useContentWidth":true
+                        }
+                    },
+                    {
+                        "type": "UIText",
+                        "multiline": false,
+                        "id": "entityIdField"
+                    },
+                    {
+                        "type" : "UIButton",
+                        "text" : "Set",
+                        "id" : "setEntityIdButton",
+                        "layoutInfo" : {
+                            "relativeWidth":0.1
+                        }
+                    }
+                ],
+                "layoutInfo" : {
+                    "use-content-height" : true,
+                    "use-content-height" : true,
+                    "width" : 500,
+                    "position-horizontal-center" : {},
+                    "position-vertical-top" : {},
+                    "position-bottom": {
+                            "widget": "scrollArea",
+                            "target": "TOP"
+                    }
+                }
+            },
+
+        ]
+    }
+}

--- a/modules/Core/assets/prefabs/inspectionTool.prefab
+++ b/modules/Core/assets/prefabs/inspectionTool.prefab
@@ -1,0 +1,14 @@
+{
+    "parent" : "engine:iconItem",
+    "DisplayName" : {
+        "name" : "Inspection Tool"
+    },
+    "Item" : {
+        "icon" : "engine:items.whiteRecipe"
+    },
+    "InspectionTool" : {},
+    "InteractionTarget": {},
+    "InteractionScreen": {
+        "screen": "engine:inspectionScreen"
+    }
+}


### PR DESCRIPTION
The item can currently only be obtained via /giveItem inspectionTool

The item has two purposes:
- You can link it to an entity and then use that item to view the current
  json representation of the selected entity. To get started use the item
  and enter "this". This will make the inspection tool show it's own
  entity data in json format. Via the owener attribute you can then
  determine the ids of the other items in your inventory.
- It is powered by a component that has an reference to the selected
  entity. That makes it possible to construct external entity references
  accross chunk borders. Thus the item can be used to debug/test external
  entity references too.
