### PR TITLE
TerasologyEngine, some refactoring

### DIFF
--- a/engine/src/main/java/org/terasology/editor/TeraEd.java
+++ b/engine/src/main/java/org/terasology/editor/TeraEd.java
@@ -80,7 +80,6 @@ public final class TeraEd extends JWindow {
 
             engine.setHibernationAllowed(false);
             engine.subscribeToStateChange(mainWindow);
-            engine.init();
 
             engine.run(new StateMainMenu());
             engine.close();

--- a/engine/src/main/java/org/terasology/engine/GameEngine.java
+++ b/engine/src/main/java/org/terasology/engine/GameEngine.java
@@ -27,11 +27,6 @@ import org.terasology.engine.modes.GameState;
 public interface GameEngine extends AutoCloseable {
 
     /**
-     * Initialises the engine
-     */
-    void init();
-
-    /**
      * Runs the engine, which will block the thread.
      * Invalid for a disposed engine
      */
@@ -47,6 +42,16 @@ public interface GameEngine extends AutoCloseable {
      * This method should not throw exceptions.
      */
     void close();
+
+    /**
+     * @return Whether the engine has been uninitialized
+     */
+    boolean isUninitialized();
+
+    /**
+     * @return Whether the engine has been initialized
+     */
+    boolean isInitialized();
 
     /**
      * @return Whether the engine is running

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -27,6 +27,7 @@ import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
 import org.terasology.engine.bootstrap.ApplyModulesUtil;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.module.ModuleManager;
@@ -86,93 +87,190 @@ public class TerasologyEngine implements GameEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(TerasologyEngine.class);
 
-    private GameState currentState;
-    private boolean initialised;
-    private boolean running;
-    private boolean disposed;
-    private GameState pendingState;
-
     private Config config;
-
+    private RenderingConfig renderingConfig;
     private EngineTime time;
+
+    private GameState currentState;
+    private GameState pendingState;
+    private Set<StateChangeSubscriber> stateChangeSubscribers = Sets.newLinkedHashSet();
+
+    private enum EngineState { UNINITIALIZED, INITIALIZED, RUNNING, DISPOSED }
+    private EngineState engineState = EngineState.UNINITIALIZED;
+
     private final TaskMaster<Task> commonThreadPool = TaskMaster.createFIFOTaskMaster("common", 16);
 
     private boolean hibernationAllowed;
     private boolean gameFocused = true;
-    private Set<StateChangeSubscriber> stateChangeSubscribers = Sets.newLinkedHashSet();
+    private final int ONE_MEBIBYTE = 1024 * 1024;
 
     private Deque<EngineSubsystem> subsystems;
-
-    public TerasologyEngine(Collection<EngineSubsystem> subsystems) {
-        this.subsystems = Queues.newArrayDeque(subsystems);
-    }
-
     public Iterable<EngineSubsystem> getSubsystems() {
         return subsystems;
     }
 
-    @Override
-    public void init() {
-        if (initialised) {
-            return;
-        }
+    public TerasologyEngine(Collection<EngineSubsystem> subsystems) {
 
-        Stopwatch sw = Stopwatch.createStarted();
+        Stopwatch totalInitTime = Stopwatch.createStarted();
+
+        this.subsystems = Queues.newArrayDeque(subsystems);
 
         try {
             logger.info("Initializing Terasology...");
-            logger.info(TerasologyVersion.getInstance().toString());
-            logger.info("Home path: {}", PathManager.getInstance().getHomePath());
-            logger.info("Install path: {}", PathManager.getInstance().getInstallPath());
-            logger.info("Java: {} in {}", System.getProperty("java.version"), System.getProperty("java.home"));
-            logger.info("Java VM: {}, version: {}", System.getProperty("java.vm.name"), System.getProperty("java.vm.version"));
-            logger.info("OS: {}, arch: {}, version: {}", System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"));
-            logger.info("Max. Memory: {} MB", Runtime.getRuntime().maxMemory() / (1024 * 1024));
-            logger.info("Processors: {}", Runtime.getRuntime().availableProcessors());
+            logEnvironmentInfo();
 
             initConfig();
 
-            for (EngineSubsystem subsystem : getSubsystems()) {
-                subsystem.preInitialise();
-            }
+            preInitSubsystems();
 
-            // Verify required systems are available
+            // time must be set here as it is required by some of the managers.
+            verifyRequiredSystemIsRegistered(Time.class);
             time = (EngineTime) CoreRegistry.get(Time.class);
-            if (time == null) {
-                throw new IllegalStateException("Time not registered as a core system.");
-            }
+
+            GameThread.setToCurrentThread();
 
             initManagers();
 
-            for (EngineSubsystem subsystem : getSubsystems()) {
-                subsystem.postInitialise(config);
-            }
+            postInitSubsystems();
 
-            // Verify required systems are available
-            if (CoreRegistry.get(DisplayDevice.class) == null) {
-                throw new IllegalStateException("DisplayDevice not registered as a core system.");
-            }
-            if (CoreRegistry.get(RenderingSubsystemFactory.class) == null) {
-                throw new IllegalStateException("EngineSubsystemFactory not registered as a core system.");
-            }
-            if (CoreRegistry.get(InputSystem.class) == null) {
-                throw new IllegalStateException("InputSystem not registered as a core system.");
-            }
+            verifyRequiredSystemIsRegistered(DisplayDevice.class);
+            verifyRequiredSystemIsRegistered(RenderingSubsystemFactory.class);
+            verifyRequiredSystemIsRegistered(InputSystem.class);
 
             initAssets();
 
-            if (config.getSystem().isMonitoringEnabled()) {
-                new AdvancedMonitor().setVisible(true);
-            }
-            initialised = true;
+            // TODO: Review - The advanced monitor shouldn't be hooked-in this way (see issue #692)
+            initAdvancedMonitor();
+
+            engineState = EngineState.INITIALIZED;
+
         } catch (RuntimeException e) {
             logger.error("Failed to initialise Terasology", e);
             cleanup();
             throw e;
         }
 
-        double secs = 0.001 * sw.elapsed(TimeUnit.MILLISECONDS);
-        logger.info("Initialization completed in {}sec.", String.format("%.2f", secs));
+        double seconds = 0.001 * totalInitTime.elapsed(TimeUnit.MILLISECONDS);
+        logger.info("Initialization completed in {}sec.", String.format("%.2f", seconds));
+    }
+
+    /**
+     * Logs software, environment and hardware information.
+     */
+    private void logEnvironmentInfo() {
+        logger.info(TerasologyVersion.getInstance().toString());
+        logger.info("Home path: {}", PathManager.getInstance().getHomePath());
+        logger.info("Install path: {}", PathManager.getInstance().getInstallPath());
+        logger.info("Java: {} in {}", System.getProperty("java.version"), System.getProperty("java.home"));
+        logger.info("Java VM: {}, version: {}", System.getProperty("java.vm.name"), System.getProperty("java.vm.version"));
+        logger.info("OS: {}, arch: {}, version: {}", System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"));
+        logger.info("Max. Memory: {} MB", Runtime.getRuntime().maxMemory() / ONE_MEBIBYTE);
+        logger.info("Processors: {}", Runtime.getRuntime().availableProcessors());
+    }
+
+    private void initConfig() {
+        if (Files.isRegularFile(Config.getConfigFile())) {
+            try {
+                config = Config.load(Config.getConfigFile());
+            } catch (IOException e) {
+                logger.error("Failed to load config", e);
+                config = new Config();
+            }
+        } else {
+            config = new Config();
+        }
+        if (!config.getDefaultModSelection().hasModule(TerasologyConstants.CORE_MODULE)) {
+            config.getDefaultModSelection().addModule(TerasologyConstants.CORE_MODULE);
+        }
+
+        if (!validateServerIdentity()) {
+            CertificateGenerator generator = new CertificateGenerator();
+            CertificatePair serverIdentity = generator.generateSelfSigned();
+            config.getSecurity().setServerCredentials(serverIdentity.getPublicCert(), serverIdentity.getPrivateCert());
+            config.save();
+        }
+
+        renderingConfig = config.getRendering();
+        logger.info("Video Settings: " + renderingConfig.toString());
+        CoreRegistry.putPermanently(Config.class, config);
+    }
+
+    private boolean validateServerIdentity() {
+        PrivateIdentityCertificate privateCert = config.getSecurity().getServerPrivateCertificate();
+        PublicIdentityCertificate publicCert = config.getSecurity().getServerPublicCertificate();
+
+        if (privateCert == null || publicCert == null) {
+            return false;
+        }
+
+        // Validate the signature
+        if (!publicCert.verifySelfSigned()) {
+            logger.error("Server signature is not self signed! Generating new server identity.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Gives a chance to subsystems to do something BEFORE managers and Time are initialized.
+     */
+    private void preInitSubsystems() {
+        for (EngineSubsystem subsystem : getSubsystems()) {
+            subsystem.preInitialise();
+        }
+    }
+
+    /**
+     * Gives a chance to subsystems to do something AFTER managers and Time are initialized.
+     */
+    private void postInitSubsystems() {
+        for (EngineSubsystem subsystem : getSubsystems()) {
+            subsystem.postInitialise(config);
+        }
+    }
+
+    /**
+     * Verifies that a required class is available through the core registry.
+     *
+     * @param clazz The required type, i.e. Time.class
+     * @throws IllegalStateException Details the required system that has not been registered.
+     */
+    private void verifyRequiredSystemIsRegistered(Class clazz) {
+        if (CoreRegistry.get(clazz) == null) {
+            throw new IllegalStateException(clazz.getSimpleName() + " not registered as a core system.");
+        }
+    }
+
+    private void initManagers() {
+        ModuleManager moduleManager = CoreRegistry.putPermanently(ModuleManager.class, new ModuleManager());
+
+        ReflectFactory reflectFactory = CoreRegistry.putPermanently(ReflectFactory.class, new ReflectionReflectFactory());
+        CopyStrategyLibrary copyStrategyLibrary = CoreRegistry.putPermanently(CopyStrategyLibrary.class, new CopyStrategyLibrary(reflectFactory));
+
+        CoreRegistry.putPermanently(TypeSerializationLibrary.class, new TypeSerializationLibrary(reflectFactory, copyStrategyLibrary));
+
+        AssetManager assetManager = CoreRegistry.putPermanently(AssetManager.class, new AssetManager(moduleManager.getEnvironment()));
+        assetManager.setEnvironment(moduleManager.getEnvironment());
+        CoreRegistry.putPermanently(CollisionGroupManager.class, new CollisionGroupManager());
+        CoreRegistry.putPermanently(WorldGeneratorManager.class, new WorldGeneratorManager());
+        CoreRegistry.putPermanently(ComponentSystemManager.class, new ComponentSystemManager());
+        CoreRegistry.putPermanently(NetworkSystem.class, new NetworkSystemImpl(time));
+        CoreRegistry.putPermanently(Game.class, new Game(this, time));
+        assetManager.setEnvironment(moduleManager.getEnvironment());
+
+        AssetType.registerAssetTypes(assetManager);
+        ApplyModulesUtil.applyModules();
+    }
+
+    /**
+     * The Advanced Monitor is a display opening in a separate window
+     * allowing for monitoring of Threads, Chunks and Performance.
+     */
+    private void initAdvancedMonitor() {
+        if (config.getSystem().isMonitoringEnabled()) {
+            new AdvancedMonitor().setVisible(true);
+        }
     }
 
     private void initAssets() {
@@ -212,62 +310,17 @@ public class TerasologyEngine implements GameEngine {
 
     }
 
-    private void initConfig() {
-        if (Files.isRegularFile(Config.getConfigFile())) {
-            try {
-                config = Config.load(Config.getConfigFile());
-            } catch (IOException e) {
-                logger.error("Failed to load config", e);
-                config = new Config();
-            }
-        } else {
-            config = new Config();
-        }
-        if (!config.getDefaultModSelection().hasModule(TerasologyConstants.CORE_MODULE)) {
-            config.getDefaultModSelection().addModule(TerasologyConstants.CORE_MODULE);
-        }
-
-        if (!validateServerIdentity()) {
-            CertificateGenerator generator = new CertificateGenerator();
-            CertificatePair serverIdentity = generator.generateSelfSigned();
-            config.getSecurity().setServerCredentials(serverIdentity.getPublicCert(), serverIdentity.getPrivateCert());
-            config.save();
-        }
-        logger.info("Video Settings: " + config.getRendering().toString());
-        CoreRegistry.putPermanently(Config.class, config);
-    }
-
-    private boolean validateServerIdentity() {
-        PrivateIdentityCertificate privateCert = config.getSecurity().getServerPrivateCertificate();
-        PublicIdentityCertificate publicCert = config.getSecurity().getServerPublicCertificate();
-
-        if (privateCert == null || publicCert == null) {
-            return false;
-        }
-
-        // Validate the signature
-        if (!publicCert.verifySelfSigned()) {
-            logger.error("Server signature is not self signed! Generating new server identity.");
-            return false;
-        }
-
-        return true;
-    }
-
     @Override
     public void run(GameState initialState) {
         try {
             CoreRegistry.putPermanently(GameEngine.class, this);
-            if (!initialised) {
-                init();
-            }
             changeState(initialState);
-            running = true;
+            engineState = EngineState.RUNNING;
             Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
 
-            mainLoop();
-
+            mainLoop(); // -THE- MAIN LOOP. Most of the application time and resources are spent here.
             cleanup();
+
         } catch (RuntimeException e) {
             logger.error("Uncaught exception, attempting clean game shutdown", e);
             try {
@@ -282,19 +335,18 @@ public class TerasologyEngine implements GameEngine {
 
     @Override
     public void shutdown() {
-        running = false;
+        engineState = EngineState.INITIALIZED;
     }
 
     @Override
     public void close() {
 
         /*
-         * The engine is shutdown even when running is true for so that terasology gets also properly disposed in
+         * The engine is shutdown even when in RUNNING state, for so that terasology gets also properly disposed in
          * case of a crash: The mouse must be made visible again for the crash reporter and the main window needs to
          * be closed.
          */
-        disposed = true;
-        initialised = false;
+        engineState = EngineState.DISPOSED;
         Iterator<EngineSubsystem> iter = subsystems.descendingIterator();
         while (iter.hasNext()) {
             EngineSubsystem subsystem = iter.next();
@@ -308,13 +360,23 @@ public class TerasologyEngine implements GameEngine {
     }
 
     @Override
+    public boolean isUninitialized() {
+        return engineState == EngineState.UNINITIALIZED;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return engineState == EngineState.INITIALIZED;
+    }
+
+    @Override
     public boolean isRunning() {
-        return running;
+        return engineState == EngineState.RUNNING ;
     }
 
     @Override
     public boolean isDisposed() {
-        return disposed;
+        return engineState == EngineState.DISPOSED;
     }
 
     @Override
@@ -365,28 +427,6 @@ public class TerasologyEngine implements GameEngine {
         }
     }
 
-    private void initManagers() {
-        GameThread.setToCurrentThread();
-        ModuleManager moduleManager = CoreRegistry.putPermanently(ModuleManager.class, new ModuleManager());
-
-        ReflectFactory reflectFactory = CoreRegistry.putPermanently(ReflectFactory.class, new ReflectionReflectFactory());
-        CopyStrategyLibrary copyStrategyLibrary = CoreRegistry.putPermanently(CopyStrategyLibrary.class, new CopyStrategyLibrary(reflectFactory));
-
-        CoreRegistry.putPermanently(TypeSerializationLibrary.class, new TypeSerializationLibrary(reflectFactory, copyStrategyLibrary));
-
-        AssetManager assetManager = CoreRegistry.putPermanently(AssetManager.class, new AssetManager(moduleManager.getEnvironment()));
-        assetManager.setEnvironment(moduleManager.getEnvironment());
-        CoreRegistry.putPermanently(CollisionGroupManager.class, new CollisionGroupManager());
-        CoreRegistry.putPermanently(WorldGeneratorManager.class, new WorldGeneratorManager());
-        CoreRegistry.putPermanently(ComponentSystemManager.class, new ComponentSystemManager());
-        CoreRegistry.putPermanently(NetworkSystem.class, new NetworkSystemImpl(time));
-        CoreRegistry.putPermanently(Game.class, new Game(this, time));
-        assetManager.setEnvironment(moduleManager.getEnvironment());
-
-        AssetType.registerAssetTypes(assetManager);
-        ApplyModulesUtil.applyModules();
-    }
-
     private void cleanup() {
         logger.info("Shutting down Terasology...");
 
@@ -407,7 +447,6 @@ public class TerasologyEngine implements GameEngine {
             // the thread pool has to be shut down
             stopThreads();
         }
-
     }
 
     public void stopThreads() {
@@ -425,7 +464,7 @@ public class TerasologyEngine implements GameEngine {
 
         PerformanceMonitor.startActivity("Other");
         // MAIN GAME LOOP
-        while (running && !display.isCloseRequested()) {
+        while (engineState == EngineState.RUNNING && !display.isCloseRequested()) {
 
             // Only process rendering and updating once a second
             if (!display.isActive() && isHibernationAllowed()) {
@@ -487,7 +526,11 @@ public class TerasologyEngine implements GameEngine {
             PerformanceMonitor.startActivity("Other");
         }
         PerformanceMonitor.endActivity();
-        running = false;
+
+        // This becomes important only if display.isCloseRequested() is true.
+        // In all other circumstances the EngineState is already set to
+        // INITIALIZED by the time the flow gets here.
+        engineState = EngineState.INITIALIZED;
     }
 
     private void processStateChanges() {
@@ -518,12 +561,12 @@ public class TerasologyEngine implements GameEngine {
     }
 
     public boolean isFullscreen() {
-        return config.getRendering().isFullscreen();
+        return renderingConfig.isFullscreen();
     }
 
     public void setFullscreen(boolean state) {
-        if (config.getRendering().isFullscreen() != state) {
-            config.getRendering().setFullscreen(state);
+        if (renderingConfig.isFullscreen() != state) {
+            renderingConfig.setFullscreen(state);
             DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
             display.setFullscreen(state);
         }

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -98,7 +98,6 @@ public final class Terasology {
         handleLaunchArguments(args);
 
         try (final TerasologyEngine engine = new TerasologyEngine(createSubsystemList())) {
-            engine.init();
             if (isHeadless) {
                 engine.subscribeToStateChange(new HeadlessStateChangeListener());
                 engine.run(new StateHeadlessSetup());


### PR DESCRIPTION
Some refactoring in TerasologyEngine class, everything else is a consequence.
- reordered initial variables in related clusters where possible
- three engine state boolean variables made into one EngineState enum and added corresponding accessor methods, updated GameEngine interface accordingly
- renderingConfig is now its own variable initialized once instead of calling config.getRendering() multiple times in the class
- moved init() method's code to the constructor, refactored it adding support methods, updated GameEngine interface accordingly
- edited TeraEd and PC Facade to remove calls to no longer existing engine.init()
- reordered constructor-supporting methods: they are now in order of appearance and the have all been placed immediately after the constructor.
- renamed stopwatch variable from "sw" to "totalInitTime" for readability
- added an issue-pointing TODO regarding the Advanced Monitor

Many changes to TerasologyEngine, including most of these ones, had been previously discussed in PR #1108. I included in this PR only the least controversial (I think!). I will include some other changes from #1108 (i.e. javadocs) in a different PR.
