### PR TITLE
Prevent reads during the merge of the prepared world changes.

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
@@ -31,6 +31,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Task that writes a previously created memory snapshot of the game to the disk.
@@ -44,6 +45,7 @@ public class SaveTransaction extends AbstractTask {
 
     private static final ImmutableMap<String, String> CREATE_ZIP_OPTIONS = ImmutableMap.of("create", "true", "encoding", "UTF-8");
     private final GameManifest gameManifest;
+    private final Lock worldDirectoryWriteLock;
     private volatile SaveTransactionResult result;
 
     // Unprocessed data to save:
@@ -61,7 +63,8 @@ public class SaveTransaction extends AbstractTask {
 
     public SaveTransaction(Map<String, EntityData.PlayerStore> playerStores, EntityData.GlobalStore globalStore,
                            Map<Vector3i, CompressedChunkBuilder> compressedChunkBuilder, GameManifest gameManifest,
-                           boolean storeChunksInZips, StoragePathProvider storagePathProvider) {
+                           boolean storeChunksInZips, StoragePathProvider storagePathProvider,
+                           Lock worldDirectoryWriteLock) {
         this.playerStores = playerStores;
         this.compressedChunkBuilders = compressedChunkBuilder;
         this.globalStore = globalStore;
@@ -69,6 +72,7 @@ public class SaveTransaction extends AbstractTask {
         this.storeChunksInZips = storeChunksInZips;
         this.storagePathProvider = storagePathProvider;
         this.saveTransactionHelper = new SaveTransactionHelper(storagePathProvider);
+        this.worldDirectoryWriteLock = worldDirectoryWriteLock;
     }
 
 
@@ -90,7 +94,7 @@ public class SaveTransaction extends AbstractTask {
             writeChunkStores();
             saveGameManifest();
             perpareChangesForMerge();
-            saveTransactionHelper.mergeChanges();
+            mergeChanges();
             result = SaveTransactionResult.createSuccessResult();
             logger.info("Save game finished");
         } catch (Throwable t) {
@@ -98,6 +102,8 @@ public class SaveTransaction extends AbstractTask {
             result = SaveTransactionResult.createFailureResult(t);
         }
     }
+
+
 
     private void createSaveTransactionDirectory() throws IOException {
         Path directory = storagePathProvider.getUnfinishedSaveTransactionPath();
@@ -225,6 +231,15 @@ public class SaveTransaction extends AbstractTask {
             GameManifest.save(path, gameManifest);
         } catch (IOException e) {
             logger.error("Failed to save world manifest", e);
+        }
+    }
+
+    private void mergeChanges() throws IOException {
+        worldDirectoryWriteLock.lock();
+        try {
+            saveTransactionHelper.mergeChanges();
+        } finally {
+            worldDirectoryWriteLock.unlock();
         }
     }
 

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionBuilder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionBuilder.java
@@ -21,12 +21,14 @@ import org.terasology.math.Vector3i;
 import org.terasology.protobuf.EntityData;
 
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Utility class for creating {@link SaveTransaction} instances.
  * @author Florian <florian@fkoeberle.de>
  */
 class SaveTransactionBuilder {
+    private final Lock worldDirectoryWriteLock;
     private Map<String, EntityData.PlayerStore> playerStores = Maps.newHashMap();
     private Map<Vector3i, CompressedChunkBuilder> compressedChunkBuilders = Maps.newHashMap();
     private EntityData.GlobalStore globalStore;
@@ -34,9 +36,11 @@ class SaveTransactionBuilder {
     private final StoragePathProvider storagePathProvider;
     private GameManifest gameManifest;
 
-    SaveTransactionBuilder(boolean storeChunksInZips, StoragePathProvider storagePathProvider) {
+    SaveTransactionBuilder(boolean storeChunksInZips, StoragePathProvider storagePathProvider,
+                           Lock worldDirectoryWriteLock) {
         this.storeChunksInZips = storeChunksInZips;
         this.storagePathProvider = storagePathProvider;
+        this.worldDirectoryWriteLock = worldDirectoryWriteLock;
     }
 
     public void addPlayerStore(String id, EntityData.PlayerStore playerStore) {
@@ -53,7 +57,7 @@ class SaveTransactionBuilder {
 
     public SaveTransaction build() {
         return new SaveTransaction(playerStores, globalStore, compressedChunkBuilders, gameManifest, storeChunksInZips,
-                storagePathProvider);
+                storagePathProvider, worldDirectoryWriteLock);
     }
 
     public void setGameManifest(GameManifest gameManifest) {

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionHelper.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionHelper.java
@@ -58,6 +58,8 @@ public class SaveTransactionHelper {
     /**
      * Merges all outstanding changes into the save game. If this operation gets interrupted it can be started again
      * without any file corruption when the file system supports atomic moves.
+     *
+     * The write lock for the save directory should be acquired before this method gets called.
      */
     public void mergeChanges() throws IOException {
         final Path sourceDirectory = storagePathProvider.getUnmergedChangesPath();


### PR DESCRIPTION
This prevents issues when a chunk/player gets loaded while the file they
are reading from gets replaced.

For example this race condition could lead to this crash:
https://gist.github.com/Cervator/0f959ed839c5d1463f0f#file-random-failure-to-load-a-chunk

For details have a look at the javadoc of:

STorageManagerInternal#worldDirectoryLock
