### PR TITLE
Add settings for the core module to prevent giving start items

### DIFF
--- a/modules/Core/assets/prefabs/CoreSettings.prefab
+++ b/modules/Core/assets/prefabs/CoreSettings.prefab
@@ -1,0 +1,5 @@
+{
+    "CoreSettings" : {
+        "useStartingInventory" : true
+    }
+}

--- a/modules/Core/src/main/java/org/terasology/core/CoreSettingsComponent.java
+++ b/modules/Core/src/main/java/org/terasology/core/CoreSettingsComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.core;
+
+import org.terasology.entitySystem.Component;
+
+public class CoreSettingsComponent implements Component {
+    public boolean useStartingInventory;
+}

--- a/modules/Core/src/main/java/org/terasology/core/logic/PlayerStartingInventorySystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/PlayerStartingInventorySystem.java
@@ -15,9 +15,12 @@
  */
 package org.terasology.core.logic;
 
+import org.terasology.asset.Assets;
+import org.terasology.core.CoreSettingsComponent;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.inventory.InventoryComponent;
@@ -40,6 +43,11 @@ public class PlayerStartingInventorySystem extends BaseComponentSystem {
 
     @ReceiveEvent(components = InventoryComponent.class)
     public void onPlayerSpawnedEvent(OnPlayerSpawnedEvent event, EntityRef player) {
+        Prefab settingsPrefab = Assets.getPrefab("Core:CoreSettings");
+        if (!settingsPrefab.getComponent(CoreSettingsComponent.class).useStartingInventory) {
+            return;
+        }
+
         BlockItemFactory blockFactory = new BlockItemFactory(entityManager);
         // Goodie chest
         EntityRef chest = blockFactory.newInstance(blockManager.getBlockFamily("core:chest"));


### PR DESCRIPTION
Could I get a code review for this?  It is a pattern to accomodate module level settings.  I dont know if it is the right pattern.  It enables dependent modules to override certain functionality without messing with Java.  Thoughts?

Also, is the root folder a good location to put the CoreSettingsComponent?  It seemed like it should be at a module global level,  but I am open to suggestions.
