### PR TITLE
Remove unnecessary usage of Serializable to fix a permission issue.

### DIFF
--- a/engine/src/main/java/org/terasology/math/Matrix4i.java
+++ b/engine/src/main/java/org/terasology/math/Matrix4i.java
@@ -16,15 +16,12 @@
 
 package org.terasology.math;
 
-import java.io.Serializable;
 import java.util.Arrays;
 
 /**
  * @author Tobias 'skaldarnar' Nett Date: 17.11.12
  */
-public class Matrix4i implements Serializable {
-
-    private static final long serialVersionUID = 7818313294943678102L;
+public class Matrix4i {
 
     private static final int M00 = 0;
     private static final int M01 = 1;

--- a/engine/src/main/java/org/terasology/math/Vector3i.java
+++ b/engine/src/main/java/org/terasology/math/Vector3i.java
@@ -18,16 +18,13 @@ package org.terasology.math;
 import javax.vecmath.Tuple3i;
 import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;
-import java.io.Serializable;
 
 /**
  * Vector3i - integer vector class in the style of VecMath.
  *
  * @author Immortius <immortius@gmail.com>
  */
-public class Vector3i extends javax.vecmath.Tuple3i implements Serializable {
-    private static final long serialVersionUID = -1965792038041767639L;
-
+public class Vector3i extends javax.vecmath.Tuple3i  {
     /**
      * Constructor instantiates a new <code>Vector3i</code> with default
      * values of (0,0,0).


### PR DESCRIPTION
This are the only 2 places where we use Serializable and a headless server log file contained exactly 2 permission violations about Serializable.

See post from @Cervator  in this forum thread: forum.terasology.org/threads/terasology-server-crash-issue-with-log-file.1166/

The other permission issues from that thread get addressed in:
- https://github.com/Terasology/WoodAndStone/pull/29
