### PR TITLE
Use block hints to specify water surface height

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
@@ -260,7 +260,11 @@ public final class ChunkTessellator {
         // TODO: Needs review - too much hardcoded special cases and corner cases resulting from this.
         ChunkVertexFlag vertexFlag = ChunkVertexFlag.NORMAL;
         if (block.isWater()) {
-            vertexFlag = ChunkVertexFlag.WATER;
+            if (view.getBlock(x, y + 1, z).isWater()) {
+                vertexFlag = ChunkVertexFlag.WATER;
+            } else {
+                vertexFlag = ChunkVertexFlag.WATER_SURFACE;
+            }
         } else if (block.isLava()) {
             vertexFlag = ChunkVertexFlag.LAVA;
         } else if (block.isWaving() && block.isDoubleSided()) {

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkVertexFlag.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkVertexFlag.java
@@ -21,10 +21,11 @@ package org.terasology.rendering.primitives;
 public enum ChunkVertexFlag {
     NORMAL(0, "BLOCK_HINT_NORMAL"),
     WATER(1, "BLOCK_HINT_WATER"),
-    LAVA(2, "BLOCK_HINT_LAVA"),
-    COLOR_MASK(3, "BLOCK_HINT_GRASS"),
-    WAVING(4, "BLOCK_HINT_WAVING"),
-    WAVING_BLOCK(5, "BLOCK_HINT_WAVING_BLOCK");
+    WATER_SURFACE(2, "BLOCK_HINT_WATER_SURFACE"),
+    LAVA(3, "BLOCK_HINT_LAVA"),
+    COLOR_MASK(4, "BLOCK_HINT_GRASS"),
+    WAVING(5, "BLOCK_HINT_WAVING"),
+    WAVING_BLOCK(6, "BLOCK_HINT_WAVING_BLOCK");
 
     private int value;
     private String defineName;

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -135,23 +135,20 @@ void main() {
     bool isWater = false;
     bool isOceanWater = false;
 
-    if (checkFlag(BLOCK_HINT_WATER, blockHint)) {
-        if (vertexWorldPos.y < 32.5 && vertexWorldPos.y > 31.5 && isUpside > 0.99) {
-            vec2 scaledVertexWorldPos = vertexWorldPos.xz / 32.0;
+    if (checkFlag(BLOCK_HINT_WATER_SURFACE, blockHint) && isUpside > 0.99) {
+        vec2 scaledVertexWorldPos = vertexWorldPos.xz / 32.0f;
 
-            vec2 waterOffset = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.0075), scaledVertexWorldPos.y + timeToTick(time, 0.0075));
-            vec2 waterOffset2 = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.005), scaledVertexWorldPos.y - timeToTick(time, 0.005));
+        vec2 waterOffset = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.0075), scaledVertexWorldPos.y + timeToTick(time, 0.0075));
+        vec2 waterOffset2 = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.005), scaledVertexWorldPos.y - timeToTick(time, 0.005));
 
-            normalWaterOffset = (texture2D(textureWaterNormal, waterOffset).xyz * 2.0 - 1.0).xy;
-            normalWaterOffset += (texture2D(textureWaterNormalAlt, waterOffset2).xyz * 2.0 - 1.0).xy;
-            normalWaterOffset *= 0.5 * (1.0 / vertexViewPos.z * waterNormalBias);
+        normalWaterOffset = (texture2D(textureWaterNormal, waterOffset).xyz * 2.0 - 1.0).xy;
+        normalWaterOffset += (texture2D(textureWaterNormalAlt, waterOffset2).xyz * 2.0 - 1.0).xy;
+        normalWaterOffset *= 0.5 * (1.0 / vertexViewPos.z * waterNormalBias);
 
-            normalWater.xy += normalWaterOffset;
-            normalWater = normalize(normalWater);
+        normalWater.xy += normalWaterOffset;
+        normalWater = normalize(normalWater);
 
-            isOceanWater = true;
-        }
-
+        isOceanWater = true;
         isWater = true;
     }
 #endif

--- a/engine/src/main/resources/assets/shaders/chunk_vert.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_vert.glsl
@@ -155,14 +155,11 @@ void main()
 
 #if defined (FEATURE_REFRACTIVE_PASS)
 #if defined (ANIMATED_WATER)
-    if (checkFlag(BLOCK_HINT_WATER, blockHint)) {
-       // Only animate blocks on sea level
-       if (vertexWorldPos.y < 32.5 && vertexWorldPos.y > 31.5) {
-            vec4 normalAndOffset = calcWaterNormalAndOffset(vertexWorldPos.xz);
+    if (checkFlag(BLOCK_HINT_WATER_SURFACE, blockHint) && isUpside > 0.99) {
+        vec4 normalAndOffset = calcWaterNormalAndOffset(vertexWorldPos.xz);
 
-            waterNormalViewSpace = gl_NormalMatrix * normalAndOffset.xyz;
-            vertexViewPos.y += normalAndOffset.w + waterOffsetY;
-       }
+        waterNormalViewSpace = gl_NormalMatrix * normalAndOffset.xyz;
+        vertexViewPos.y += normalAndOffset.w + waterOffsetY;
     }
 #else
     waterNormalViewSpace = gl_NormalMatrix * vec3(0.0, 1.0, 0.0);


### PR DESCRIPTION
This supersedes #1465 by simply using a block hint to specify the water level. I'm surprised that is was to easy to fix.

A screenshot from PolyWorld illustrates the improvement:
![image](https://cloud.githubusercontent.com/assets/1820007/5587023/e891c1a4-90df-11e4-8e8b-96f0c0fdb379.png)

Kudos go to @MarcinSc for the idea of using block hints.

Closes #1371
Closes #1466