### PR TITLE
Remove Reflections.cache after jar build

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -153,6 +153,7 @@ task cacheReflections {
     inputs.files project.classes.outputs.files
     outputs.file file(sourceSets.main.output.classesDir.toString() + "/reflections.cache")
     dependsOn classes
+    
     doFirst {
         // Without the .mkdirs() we might hit a scenario where the classes dir doesn't exist yet
         file(sourceSets.main.output.classesDir.toString()).mkdirs()
@@ -223,6 +224,7 @@ task createVersionInfoFile {
 
 jar.dependsOn createVersionInfoFile
 jar.dependsOn cacheReflections
+jar.finalizedBy cleanReflections
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // General IDE customization                                                                                         //
@@ -237,5 +239,6 @@ idea {
         inheritOutputDirs = false
         outputDir = file('build/classes')
         testOutputDir = file('build/testClasses')
+        downloadSources = true
     }
 }

--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -271,6 +271,8 @@ jar {
     }
 }
 
+jar.finalizedBy cleanReflections
+
 // Prep an IntelliJ module for the Terasology module - yes, might want to read that twice :D
 idea {
     module {
@@ -278,6 +280,7 @@ idea {
         inheritOutputDirs = false
         outputDir = file('build/classes')
         testOutputDir = file('build/testClasses')
+        downloadSources = true
     }
 }
 


### PR DESCRIPTION
This should help prevent the situation when a a developer ends up with a reflections.cache that doesn't reflect their current compile state.