### PR TITLE
Support different camera reflection heights

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -73,6 +73,8 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         // Init. a new world
         RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);
         WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
+        float reflectionHeight = CoreRegistry.get(NetworkSystem.class).getServer().getInfo().getReflectionHeight();
+        worldRenderer.getActiveCamera().setReflectionHeight(reflectionHeight);
         CoreRegistry.put(WorldRenderer.class, worldRenderer);
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer
         CoreRegistry.put(Camera.class, worldRenderer.getActiveCamera());

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -141,6 +141,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
 
         RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);
         WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
+        worldRenderer.getActiveCamera().setReflectionHeight(worldGenerator.getWorld().getSeaLevel());
         CoreRegistry.put(WorldRenderer.class, worldRenderer);
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer

--- a/engine/src/main/java/org/terasology/network/ServerInfoMessage.java
+++ b/engine/src/main/java/org/terasology/network/ServerInfoMessage.java
@@ -58,4 +58,9 @@ public interface ServerInfoMessage {
      */
     List<NameVersion> getModuleList();
 
+    /**
+     * @return the block height that is used to compute (water) reflections
+     */
+    float getReflectionHeight();
+
 }

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -24,10 +24,12 @@ import com.google.common.collect.Queues;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
+
 import gnu.trove.map.TIntIntMap;
 import gnu.trove.map.TIntLongMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TIntLongHashMap;
+
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
@@ -83,6 +85,7 @@ import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.chunks.remoteChunkProvider.RemoteChunkProvider;
+import org.terasology.world.generator.WorldGenerator;
 
 import java.net.BindException;
 import java.net.InetSocketAddress;
@@ -766,12 +769,16 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     NetData.ServerInfoMessage getServerInfoMessage() {
         NetData.ServerInfoMessage.Builder serverInfoMessageBuilder = NetData.ServerInfoMessage.newBuilder();
         serverInfoMessageBuilder.setTime(time.getGameTimeInMs());
-        WorldProvider world = CoreRegistry.get(WorldProvider.class);
-        if (world != null) {
+        WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
+        if (worldProvider != null) {
             NetData.WorldInfo.Builder worldInfoBuilder = NetData.WorldInfo.newBuilder();
-            worldInfoBuilder.setTime(world.getTime().getMilliseconds());
-            worldInfoBuilder.setTitle(world.getTitle());
+            worldInfoBuilder.setTime(worldProvider.getTime().getMilliseconds());
+            worldInfoBuilder.setTitle(worldProvider.getTitle());
             serverInfoMessageBuilder.addWorldInfo(worldInfoBuilder);
+        }
+        WorldGenerator worldGen = CoreRegistry.get(WorldGenerator.class);
+        if (worldGen != null) {
+            serverInfoMessageBuilder.setReflectionHeight(worldGen.getWorld().getSeaLevel());
         }
         for (Module module : CoreRegistry.get(ModuleManager.class).getEnvironment()) {
             Boolean serverSideOnly = module.getMetadata().getExtension(ModuleManager.SERVER_SIDE_ONLY_EXT, Boolean.class);

--- a/engine/src/main/java/org/terasology/network/internal/ServerInfoMessageImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerInfoMessageImpl.java
@@ -78,6 +78,11 @@ class ServerInfoMessageImpl implements ServerInfoMessage {
     }
 
     @Override
+    public float getReflectionHeight() {
+        return info.getReflectionHeight();
+    }
+
+    @Override
     public List<NameVersion> getModuleList() {
         List<NameVersion> result = Lists.newArrayList();
 

--- a/engine/src/main/java/org/terasology/protobuf/NetData.java
+++ b/engine/src/main/java/org/terasology/protobuf/NetData.java
@@ -14859,6 +14859,15 @@ public final class NetData {
      * <code>optional int64 time = 17;</code>
      */
     long getTime();
+
+    /**
+     * <code>optional float reflectionHeight = 18;</code>
+     */
+    boolean hasReflectionHeight();
+    /**
+     * <code>optional float reflectionHeight = 18;</code>
+     */
+    float getReflectionHeight();
   }
   /**
    * Protobuf type {@code ServerInfoMessage}
@@ -15059,6 +15068,11 @@ public final class NetData {
             case 136: {
               bitField0_ |= 0x00000004;
               time_ = input.readInt64();
+              break;
+            }
+            case 149: {
+              bitField0_ |= 0x00000008;
+              reflectionHeight_ = input.readFloat();
               break;
             }
           }
@@ -15558,6 +15572,21 @@ public final class NetData {
       return time_;
     }
 
+    public static final int REFLECTIONHEIGHT_FIELD_NUMBER = 18;
+    private float reflectionHeight_;
+    /**
+     * <code>optional float reflectionHeight = 18;</code>
+     */
+    public boolean hasReflectionHeight() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional float reflectionHeight = 18;</code>
+     */
+    public float getReflectionHeight() {
+      return reflectionHeight_;
+    }
+
     private void initFields() {
       module_ = java.util.Collections.emptyList();
       blockId_ = java.util.Collections.emptyList();
@@ -15573,6 +15602,7 @@ public final class NetData {
       version_ = "";
       gameName_ = "";
       time_ = 0L;
+      reflectionHeight_ = 0F;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -15671,6 +15701,9 @@ public final class NetData {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeInt64(17, time_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeFloat(18, reflectionHeight_);
       }
       extensionWriter.writeUntil(536870912, output);
       getUnknownFields().writeTo(output);
@@ -15787,6 +15820,10 @@ public final class NetData {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(17, time_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeFloatSize(18, reflectionHeight_);
       }
       size += extensionsSerializedSize();
       size += getUnknownFields().getSerializedSize();
@@ -15955,6 +15992,8 @@ public final class NetData {
         bitField0_ = (bitField0_ & ~0x00001000);
         time_ = 0L;
         bitField0_ = (bitField0_ & ~0x00002000);
+        reflectionHeight_ = 0F;
+        bitField0_ = (bitField0_ & ~0x00004000);
         return this;
       }
 
@@ -16066,6 +16105,10 @@ public final class NetData {
           to_bitField0_ |= 0x00000004;
         }
         result.time_ = time_;
+        if (((from_bitField0_ & 0x00004000) == 0x00004000)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.reflectionHeight_ = reflectionHeight_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -16268,6 +16311,9 @@ public final class NetData {
         }
         if (other.hasTime()) {
           setTime(other.getTime());
+        }
+        if (other.hasReflectionHeight()) {
+          setReflectionHeight(other.getReflectionHeight());
         }
         this.mergeExtensionFields(other);
         this.mergeUnknownFields(other.getUnknownFields());
@@ -18035,6 +18081,38 @@ public final class NetData {
       public Builder clearTime() {
         bitField0_ = (bitField0_ & ~0x00002000);
         time_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private float reflectionHeight_ ;
+      /**
+       * <code>optional float reflectionHeight = 18;</code>
+       */
+      public boolean hasReflectionHeight() {
+        return ((bitField0_ & 0x00004000) == 0x00004000);
+      }
+      /**
+       * <code>optional float reflectionHeight = 18;</code>
+       */
+      public float getReflectionHeight() {
+        return reflectionHeight_;
+      }
+      /**
+       * <code>optional float reflectionHeight = 18;</code>
+       */
+      public Builder setReflectionHeight(float value) {
+        bitField0_ |= 0x00004000;
+        reflectionHeight_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional float reflectionHeight = 18;</code>
+       */
+      public Builder clearReflectionHeight() {
+        bitField0_ = (bitField0_ & ~0x00004000);
+        reflectionHeight_ = 0F;
         onChanged();
         return this;
       }
@@ -25151,7 +25229,7 @@ public final class NetData {
       "\022\031\n\021viewDistanceLevel\030\003 \001(\021\022\025\n\005color\030\004 \001" +
       "(\0132\006.Color*\t\010\210\'\020\200\200\200\200\002\"\025\n\005Color\022\014\n\004rgba\030\001" +
       " \001(\r\"2\n\023JoinCompleteMessage\022\020\n\010clientId\030" +
-      "\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"\354\002\n\021ServerInfoMessage\022\033",
+      "\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"\206\003\n\021ServerInfoMessage\022\033",
       "\n\006module\030\001 \003(\0132\013.ModuleInfo\022\023\n\007blockId\030\002" +
       " \003(\021B\002\020\001\022\021\n\tblockName\030\003 \003(\t\022%\n\tcomponent" +
       "\030\004 \003(\0132\022.SerializationInfo\022!\n\005event\030\005 \003(" +
@@ -25160,27 +25238,28 @@ public final class NetData {
       "ily\030\010 \003(\t\022\035\n\tworldInfo\030\t \003(\0132\n.WorldInfo" +
       "\022\030\n\014biomeShortId\030\n \003(\021B\002\020\001\022\017\n\007biomeId\030\013 " +
       "\003(\t\022\017\n\007version\030\017 \001(\t\022\020\n\010gameName\030\020 \001(\t\022\014" +
-      "\n\004time\030\021 \001(\003*\t\010\210\'\020\200\200\200\200\002\"3\n\tWorldInfo\022\r\n\005" +
-      "title\030\001 \001(\t\022\014\n\004time\030\002 \001(\003*\t\010\210\'\020\200\200\200\200\002\"]\n\021",
-      "SerializationInfo\022\014\n\004name\030\001 \001(\t\022\n\n\002id\030\002 " +
-      "\001(\005\022\021\n\tfieldName\030\003 \003(\t\022\020\n\010fieldIds\030\004 \001(\014" +
-      "*\t\010\210\'\020\200\200\200\200\002\"@\n\nModuleInfo\022\020\n\010moduleId\030\001 " +
-      "\001(\t\022\025\n\rmoduleVersion\030\002 \001(\t*\t\010\210\'\020\200\200\200\200\002\",\n" +
-      "\rModuleRequest\022\020\n\010moduleId\030\001 \001(\t*\t\010\210\'\020\200\200" +
-      "\200\200\002\"W\n\020ModuleDataHeader\022\n\n\002id\030\001 \001(\t\022\017\n\007v" +
-      "ersion\030\002 \001(\t\022\014\n\004size\030\003 \001(\003\022\r\n\005error\030\017 \001(" +
-      "\t*\t\010\210\'\020\200\200\200\200\002\"\'\n\nModuleData\022\016\n\006module\030\001 \001" +
-      "(\014*\t\010\210\'\020\200\200\200\200\002\"-\n\017ModuleSendError\022\017\n\007mess" +
-      "age\030\001 \001(\t*\t\010\210\'\020\200\200\200\200\002\"`\n\023CreateEntityMess",
-      "age\022\035\n\006entity\030\001 \001(\0132\r.PackedEntity\022\037\n\010bl" +
-      "ockPos\030\002 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002\"N" +
-      "\n\023UpdateEntityMessage\022\035\n\006entity\030\001 \001(\0132\r." +
-      "PackedEntity\022\r\n\005netId\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/" +
-      "\n\023RemoveEntityMessage\022\r\n\005netId\030\001 \001(\005*\t\010\210" +
-      "\'\020\200\200\200\200\002\"i\n\014EventMessage\022\020\n\010targetId\030\001 \001(" +
-      "\005\022\025\n\005event\030\002 \001(\0132\006.Event\022%\n\016targetBlockP" +
-      "os\030\003 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002B$\n\027or" +
-      "g.terasology.protobufB\007NetDataH\001"
+      "\n\004time\030\021 \001(\003\022\030\n\020reflectionHeight\030\022 \001(\002*\t" +
+      "\010\210\'\020\200\200\200\200\002\"3\n\tWorldInfo\022\r\n\005title\030\001 \001(\t\022\014\n",
+      "\004time\030\002 \001(\003*\t\010\210\'\020\200\200\200\200\002\"]\n\021SerializationI" +
+      "nfo\022\014\n\004name\030\001 \001(\t\022\n\n\002id\030\002 \001(\005\022\021\n\tfieldNa" +
+      "me\030\003 \003(\t\022\020\n\010fieldIds\030\004 \001(\014*\t\010\210\'\020\200\200\200\200\002\"@\n" +
+      "\nModuleInfo\022\020\n\010moduleId\030\001 \001(\t\022\025\n\rmoduleV" +
+      "ersion\030\002 \001(\t*\t\010\210\'\020\200\200\200\200\002\",\n\rModuleRequest" +
+      "\022\020\n\010moduleId\030\001 \001(\t*\t\010\210\'\020\200\200\200\200\002\"W\n\020ModuleD" +
+      "ataHeader\022\n\n\002id\030\001 \001(\t\022\017\n\007version\030\002 \001(\t\022\014" +
+      "\n\004size\030\003 \001(\003\022\r\n\005error\030\017 \001(\t*\t\010\210\'\020\200\200\200\200\002\"\'" +
+      "\n\nModuleData\022\016\n\006module\030\001 \001(\014*\t\010\210\'\020\200\200\200\200\002\"" +
+      "-\n\017ModuleSendError\022\017\n\007message\030\001 \001(\t*\t\010\210\'",
+      "\020\200\200\200\200\002\"`\n\023CreateEntityMessage\022\035\n\006entity\030" +
+      "\001 \001(\0132\r.PackedEntity\022\037\n\010blockPos\030\002 \001(\0132\r" +
+      ".Vector3iData*\t\010\210\'\020\200\200\200\200\002\"N\n\023UpdateEntity" +
+      "Message\022\035\n\006entity\030\001 \001(\0132\r.PackedEntity\022\r" +
+      "\n\005netId\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/\n\023RemoveEntity" +
+      "Message\022\r\n\005netId\030\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"i\n\014Eve" +
+      "ntMessage\022\020\n\010targetId\030\001 \001(\005\022\025\n\005event\030\002 \001" +
+      "(\0132\006.Event\022%\n\016targetBlockPos\030\003 \001(\0132\r.Vec" +
+      "tor3iData*\t\010\210\'\020\200\200\200\200\002B$\n\027org.terasology.p" +
+      "rotobufB\007NetDataH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -25296,7 +25375,7 @@ public final class NetData {
     internal_static_ServerInfoMessage_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ServerInfoMessage_descriptor,
-        new java.lang.String[] { "Module", "BlockId", "BlockName", "Component", "Event", "AssetId", "AssetUri", "RegisterBlockFamily", "WorldInfo", "BiomeShortId", "BiomeId", "Version", "GameName", "Time", });
+        new java.lang.String[] { "Module", "BlockId", "BlockName", "Component", "Event", "AssetId", "AssetUri", "RegisterBlockFamily", "WorldInfo", "BiomeShortId", "BiomeId", "Version", "GameName", "Time", "ReflectionHeight", });
     internal_static_WorldInfo_descriptor =
       getDescriptor().getMessageTypes().get(17);
     internal_static_WorldInfo_fieldAccessorTable = new

--- a/engine/src/main/java/org/terasology/rendering/cameras/Camera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/Camera.java
@@ -70,9 +70,11 @@ public abstract class Camera {
     protected float cachedFov;
     protected float cachedZNear;
     protected float cachedZFar;
+    protected float cachedReflectionHeight;
 
-    /* ETC */
+    /* (Water) Reflection */
     private boolean reflected;
+    private float reflectionHeight = 32;
 
     /**
      * Applies the projection and modelview matrix.
@@ -142,12 +144,22 @@ public abstract class Camera {
         this.reflected = reflected;
     }
 
+    public float getReflectionHeight() {
+        return reflectionHeight;
+    }
+
+    public void setReflectionHeight(float reflectionHeight) {
+        this.reflectionHeight = reflectionHeight;
+    }
+
     public void updatePrevViewProjectionMatrix() {
         prevViewProjectionMatrix.set(viewProjectionMatrix);
     }
 
     public float getClipHeight() {
-        return 31.5f;
+        // msteiger: I believe the offset results from the
+        // slightly lowered water surface height.
+        return reflectionHeight - 0.5f;
     }
 
     public Matrix4f getViewMatrix() {

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -124,7 +124,8 @@ public class PerspectiveCamera extends Camera {
         if (cachedPosition.equals(getPosition()) && cachedViewigDirection.equals(getViewingDirection())
                 && cachedBobbingRotationOffsetFactor == bobbingRotationOffsetFactor && cachedBobbingVerticalOffsetFactor == bobbingVerticalOffsetFactor
                 && cachedFov == fov
-                && cachedZFar == getzFar() && cachedZNear == getzNear()) {
+                && cachedZFar == getzFar() && cachedZNear == getzNear()
+                && cachedReflectionHeight == getReflectionHeight()) {
             return;
         }
 
@@ -140,7 +141,7 @@ public class PerspectiveCamera extends Camera {
                 up.x + tempRightVector.x, up.y + tempRightVector.y, up.z + tempRightVector.z);
 
         reflectionMatrix.setRow(0, 1.0f, 0.0f, 0.0f, 0.0f);
-        reflectionMatrix.setRow(1, 0.0f, -1.0f, 0.0f, 2f * (-position.y + 32f));
+        reflectionMatrix.setRow(1, 0.0f, -1.0f, 0.0f, 2f * (-position.y + getReflectionHeight()));
         reflectionMatrix.setRow(2, 0.0f, 0.0f, 1.0f, 0.0f);
         reflectionMatrix.setRow(3, 0.0f, 0.0f, 0.0f, 1.0f);
         viewMatrixReflected.mul(viewMatrix, reflectionMatrix);
@@ -161,6 +162,7 @@ public class PerspectiveCamera extends Camera {
         cachedFov = fov;
         cachedZNear = getzNear();
         cachedZFar = getzFar();
+        cachedReflectionHeight = getReflectionHeight();
 
         updateFrustum();
     }

--- a/engine/src/main/java/org/terasology/world/generation/World.java
+++ b/engine/src/main/java/org/terasology/world/generation/World.java
@@ -28,6 +28,11 @@ public interface World {
 
     Region getWorldData(Region3i region);
 
+    /**
+     * @return the sea level, measured in blocks
+     */
+    int getSeaLevel();
+
     void rasterizeChunk(CoreChunk chunk);
 
     /**

--- a/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.Component;
@@ -38,10 +39,11 @@ public class WorldBuilder {
 
     private static final Logger logger = LoggerFactory.getLogger(WorldBuilder.class);
 
-    private long seed;
-    private List<FacetProvider> providersList = Lists.newArrayList();
-    private Set<Class<? extends WorldFacet>> facetCalculationInProgress = Sets.newHashSet();
-    private List<WorldRasterizer> rasterizers = Lists.newArrayList();
+    private final long seed;
+    private final List<FacetProvider> providersList = Lists.newArrayList();
+    private final Set<Class<? extends WorldFacet>> facetCalculationInProgress = Sets.newHashSet();
+    private final List<WorldRasterizer> rasterizers = Lists.newArrayList();
+    private int seaLevel = 32;
 
     public WorldBuilder(long seed) {
         this.seed = seed;
@@ -71,11 +73,20 @@ public class WorldBuilder {
         return this;
     }
 
+    /**
+     * @param level the sea level, measured in blocks
+     * @return this
+     */
+    public WorldBuilder setSeaLevel(int level) {
+        this.seaLevel = level;
+        return this;
+    }
+
     public World build() {
         // TODO: ensure the required providers are present
 
         ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains = determineProviderChains();
-        return new WorldImpl(providerChains, rasterizers, determineBorders(providerChains));
+        return new WorldImpl(providerChains, rasterizers, determineBorders(providerChains), seaLevel);
     }
 
     private Map<Class<? extends WorldFacet>, Border3D> determineBorders(ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains) {

--- a/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
@@ -30,21 +30,29 @@ import com.google.common.collect.Sets;
  * @author Immortius
  */
 public class WorldImpl implements World {
-    private ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains;
-    private List<WorldRasterizer> worldRasterizers;
-    private Map<Class<? extends WorldFacet>, Border3D> borders;
+    private final ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains;
+    private final List<WorldRasterizer> worldRasterizers;
+    private final Map<Class<? extends WorldFacet>, Border3D> borders;
+    private final int seaLevel;
 
-    public WorldImpl(ListMultimap<Class<? extends WorldFacet>,
-        FacetProvider> facetProviderChains,
-                     List<WorldRasterizer> worldRasterizers, Map<Class<? extends WorldFacet>, Border3D> borders) {
+    public WorldImpl(ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains,
+                     List<WorldRasterizer> worldRasterizers,
+                     Map<Class<? extends WorldFacet>, Border3D> borders,
+                     int seaLevel) {
         this.facetProviderChains = facetProviderChains;
         this.worldRasterizers = worldRasterizers;
         this.borders = borders;
+        this.seaLevel = seaLevel;
     }
 
     @Override
     public Region getWorldData(Region3i region) {
         return new RegionImpl(region, facetProviderChains, borders);
+    }
+
+    @Override
+    public int getSeaLevel() {
+        return seaLevel;
     }
 
     @Override

--- a/engine/src/main/protobuf/NetMessage.proto
+++ b/engine/src/main/protobuf/NetMessage.proto
@@ -154,6 +154,7 @@ message ServerInfoMessage {
     optional string version = 15;
     optional string gameName = 16;
     optional int64 time = 17;
+    optional float reflectionHeight = 18;
 
     extensions 5000 to max;
 }


### PR DESCRIPTION
Currently a fixed height of 32 blocks is used to compute surface reflections. This PR makes this value flexible through a getter/setter in `Camera` and also uses a newly introduced sea level parameter to find meaningful values for this.

Every reflection level requires a rendering pass which is why only one reflection level is supported.

As the world generator defines this value, it must also be communicated to remote clients. This is done through the `ServerInfoMessage` class.

