### PR TITLE
Corrected the usage string for vararg/array parameters.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameter.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameter.java
@@ -219,21 +219,15 @@ public final class CommandParameter<T> implements Parameter {
             usage.append(' ').append(getName());
         }
 
-        if (required) {
+        if (isArray()) {
+            usage.insert(0, '(');
+            usage.append("...)");
+        } else if (isRequired()) {
             usage.insert(0, '<');
             usage.append('>');
         } else {
             usage.insert(0, '(');
             usage.append(')');
-        }
-
-        if (isArray()) {
-            usage.append(" (")
-                    .append(simpleTypeName)
-                    .append(' ')
-                    .append(getName())
-                    .append(")...");
-
         }
 
         return usage.toString();


### PR DESCRIPTION
As per the comments in the previous PR for command parameters, corrects the usage string to correctly indicate that varargs are optional. Also moves the ... into the bracket and removes one repetition.