### PR TITLE
Defer reading sea level until after world gen init.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -184,7 +184,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new PreBeginSystems());
         loadProcesses.add(new InitialiseBlockTypeEntities());
         loadProcesses.add(new CreateWorldEntity());
-        loadProcesses.add(new InitialiseWorldGenerator(gameManifest));
+        loadProcesses.add(new InitialiseWorldGenerator());
         if (netMode.isServer()) {
             boolean dedicated;
             if (netMode == NetworkMode.DEDICATED_SERVER) {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -141,7 +141,6 @@ public class InitialiseWorld extends SingleStepLoadProcess {
 
         RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);
         WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
-        worldRenderer.getActiveCamera().setReflectionHeight(worldGenerator.getWorld().getSeaLevel());
         CoreRegistry.put(WorldRenderer.class, worldRenderer);
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
@@ -16,28 +16,22 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.terasology.game.GameManifest;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.generator.WorldGenerator;
 
 /**
+ * Initialize the world generator.
+ * <br/><br/>
+ * This is done after the world entity has been created/loaded so that
+ * world generation config. is available at the time of initialization.
  * @author Martin Steiger
  */
 public class InitialiseWorldGenerator extends SingleStepLoadProcess {
 
-    private static final Logger logger = LoggerFactory.getLogger(InitialiseWorldGenerator.class);
-
-    private GameManifest gameManifest;
-
-    public InitialiseWorldGenerator(GameManifest gameManifest) {
-        this.gameManifest = gameManifest;
-    }
-
     @Override
     public String getMessage() {
-        return "Generating world ...";
+        return "Initialize world generator ...";
     }
 
     @Override
@@ -45,6 +39,9 @@ public class InitialiseWorldGenerator extends SingleStepLoadProcess {
 
         WorldGenerator worldGenerator = CoreRegistry.get(WorldGenerator.class);
         worldGenerator.initialize();
+
+        WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
+        worldRenderer.getActiveCamera().setReflectionHeight(worldGenerator.getWorld().getSeaLevel());
 
         return true;
     }


### PR DESCRIPTION
The TtA world gen creates the world later than the others (which is fine but this is why I hadn't noticed earlier). So this PR defers reading out the sea level until after world gen. initialization has completed.

Tested with TtA, Cities, Perlin and PolyWorld.

Fixes #1483