### PR TITLE
Updated lwjgl, slf4j, miglayout, netty, groovy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext {
     // Lib dir for use in manifest entries etc (like in :engine). A separate "libsDir" exists, auto-created by Gradle
     subDirLibs = 'libs'
 
-    LwjglVersion = '2.9.1'
+    LwjglVersion = '2.9.2'
 }
 
 // Declare remote repositories we're interested in - library files will be fetched from here

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'
     compile group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
-    compile group: 'io.netty', name: 'netty', version: '3.9.5.Final'
+    compile group: 'io.netty', name: 'netty', version: '3.10.0.Final'
 
     // Java magic
     compile group: 'net.java.dev.jna', name: 'jna', version: '3.5.2'
@@ -108,11 +108,11 @@ dependencies {
     compile group: 'org.lwjgl.lwjgl', name: 'lwjgl_util', version: LwjglVersion
     compile group: 'java3d', name: 'vecmath', version: '1.3.1' // Note: Downgraded to this release until TeraMath ready
     compile group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.1'
-    compile group: 'com.miglayout', name: 'miglayout-core', version: '4.2'
+    compile group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
     compile group: 'org.newdawn.slick', name: 'slick', version: '237'
 
     // Logging and audio
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.9'
     compile group: 'com.projectdarkstar.ext.jorbis', name: 'jorbis', version: '0.0.17'
 
     // Small-time 3rd party libs we've stored in our Artifactory for access
@@ -128,10 +128,10 @@ dependencies {
 
     // TODO: These could be moved into facade
     compile group: 'org.terasology', name: 'CrashReporter', version: '+', changing: true
-    runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.7'
+    runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.9'
     runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
     // And here is Groovy just to read the config file
-    runtime group: 'org.codehaus.groovy', name: 'groovy', version: '2.3.7'
+    runtime group: 'org.codehaus.groovy', name: 'groovy', version: '2.3.9'
 
     // In addition to all the above the dev source set also needs to depend on what gets compiled in main
     devCompile sourceSets.main.output

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/miglayout/MigComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/miglayout/MigComponent.java
@@ -193,13 +193,18 @@ public class MigComponent implements ComponentWrapper {
     }
 
     @Override
-    public void paintDebugOutline() {
+    public void paintDebugOutline(boolean showVisualPadding) {
 
     }
 
     @Override
-    public int getComponetType(boolean disregardScrollPane) {
+    public int getComponentType(boolean disregardScrollPane) {
         return TYPE_UNKNOWN;
+    }
+
+    @Override
+    public int getContentBias() {
+        return -1;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/miglayout/MigLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/miglayout/MigLayout.java
@@ -392,12 +392,17 @@ public class MigLayout extends CoreLayout<MigLayout.CCHint> implements Container
     }
 
     @Override
-    public void paintDebugOutline() {
+    public void paintDebugOutline(boolean showVisualPadding) {
     }
 
     @Override
-    public int getComponetType(boolean disregardScrollPane) {
+    public int getComponentType(boolean disregardScrollPane) {
         return 0;
+    }
+
+    @Override
+    public int getContentBias() {
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
Closes #1464 

@immortius I wasn't able to upgrade gestalt-module (from 2.1.0 to 2.2.2) and/or reflections (from 0.9.9-RC1 to 0.9.9). 

`APIScanner.scan()` crashes on the inner class `PlaySoundNode$PlaySoundTask`. It is enumerated by `getTypesAnnotatedWith(API.class)` but calling `getAnnotation(API.class)` returns null.