### PR TITLE
Disable splashscreen in headless mode

### DIFF
--- a/engine/src/main/java/org/terasology/engine/splash/SplashScreen.java
+++ b/engine/src/main/java/org/terasology/engine/splash/SplashScreen.java
@@ -22,7 +22,8 @@ package org.terasology.engine.splash;
  */
 public final class SplashScreen {
 
-    private static final SplashScreenCore INSTANCE = (java.awt.SplashScreen.getSplashScreen() != null)
+    private static final SplashScreenCore INSTANCE =
+            (!java.awt.GraphicsEnvironment.isHeadless() && java.awt.SplashScreen.getSplashScreen() != null)
             ? new SplashScreenImpl()
             : new SplashScreenStub();
 


### PR DESCRIPTION
This PR fixes the headless server that can be run by Jenkins:

Before:
http://jenkins.movingblocks.net/job/TerasologyHeadlessServer/1/console

After:
http://jenkins.movingblocks.net/job/TerasologyHeadlessServer/2/console