### PR TITLE
Fix resource classpath in gradle runs

### DIFF
--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -74,9 +74,11 @@ task runPC(type:JavaExec) {
     workingDir = rootDir
     String[] runArgs = ["-homedir"]
     args runArgs
+    jvmArgs "-splash:${sourceSets.main.output.resourcesDir}/splash.jpg"
 
     // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
     classpath sourceSets.main.output.classesDir
+    classpath sourceSets.main.output.resourcesDir
     classpath project(':engine').sourceSets.main.output.classesDir
     classpath project(':engine').configurations.runtime
 }
@@ -155,6 +157,7 @@ task startServer(type:JavaExec) {
 
     // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
     classpath sourceSets.main.output.classesDir
+    classpath sourceSets.main.output.resourcesDir
     classpath project(':engine').sourceSets.main.output.classesDir
     classpath project(':engine').configurations.runtime
 }


### PR DESCRIPTION
Currently, running Terasology through the gradle command line with `runPC` or `startServer` does not include the PC facade's resource folder, which contains the logback config file.

As a consequence, logback uses its own default values. This includes the default log level that is at DEBUG causing major log spills.

This PR fixes that by adding the resources folder to the classpath. 
As a byproduct, it also enables the splash screen for `runPC`.