### PR TITLE
WorldRendererLwjgl.render() method refactoring

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
@@ -34,8 +34,7 @@ public interface RenderableWorld {
     boolean updateChunksInProximity(Region3i renderableRegion);
     boolean updateChunksInProximity(ViewDistance viewDistance);
 
-    void updateAndQueueVisibleChunks();
-    int updateAndQueueVisibleChunks(boolean fillShadowRenderQueue, boolean processChunkUpdates);
+    int updateAndQueueVisibleChunks(boolean isFirstRenderingStageForCurrentFrame);
 
     void dispose();
 

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -256,17 +256,12 @@ public class RenderableWorldImpl implements RenderableWorld {
      * Updates the currently visible chunks (in sight of the player).
      */
     @Override
-    public void updateAndQueueVisibleChunks() {
-        updateAndQueueVisibleChunks(true, true);
-    }
-
-    @Override
-    public int updateAndQueueVisibleChunks(boolean fillShadowRenderQueue, boolean processChunkUpdates) {
+    public int updateAndQueueVisibleChunks(boolean isFirstRenderingStageForCurrentFrame) {
         statDirtyChunks = 0;
         statVisibleChunks = 0;
         statIgnoredPhases = 0;
 
-        if (processChunkUpdates) {
+        if (isFirstRenderingStageForCurrentFrame) {
             PerformanceMonitor.startActivity("Building Mesh VBOs");
             chunkMeshUpdateManager.setCameraPosition(playerCamera.getPosition());
             for (RenderableChunk chunk : chunkMeshUpdateManager.availableChunksForUpdate()) {
@@ -305,7 +300,7 @@ public class RenderableWorldImpl implements RenderableWorld {
             if (isChunkValidForRender(chunk)) {
                 mesh = chunk.getMesh();
 
-                if (isDynamicShadows && fillShadowRenderQueue && chunkCounter < maxChunksForShadows && isChunkVisibleLight(chunk)) {
+                if (isDynamicShadows && isFirstRenderingStageForCurrentFrame && chunkCounter < maxChunksForShadows && isChunkVisibleLight(chunk)) {
                     if (triangleCount(mesh, ChunkMesh.RenderPhase.OPAQUE) > 0) {
                         renderQueues.chunksOpaqueShadow.add(chunk);
                     } else {
@@ -346,7 +341,7 @@ public class RenderableWorldImpl implements RenderableWorld {
                 }
 
                 // Process all chunks in the area, not only the visible ones
-                if (processChunkUpdates && processChunkUpdate(chunk)) {
+                if (isFirstRenderingStageForCurrentFrame && processChunkUpdate(chunk)) {
                     processedChunks++;
                 }
             }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererLwjgl.java
@@ -302,8 +302,8 @@ public final class WorldRendererLwjgl implements WorldRenderer {
             DefaultRenderingProcess.getInstance().endRenderSceneOpaque();
 
             PerformanceMonitor.startActivity("Render Light Geometry");
-            renderLightGeometryStencil();
-            //renderLightGeometry();
+            //renderLightGeometryStencil();
+            renderLightGeometry();
             PerformanceMonitor.endActivity();
 
             renderChunksRefractiveReflective();
@@ -447,7 +447,7 @@ public final class WorldRendererLwjgl implements WorldRenderer {
     private void renderLightGeometryStencil() {
 
         DefaultRenderingProcess.getInstance().beginRenderLightGeometryStencilPass();
-        /*
+
         Material program = Assets.getMaterial("engine:prog.simple");
         program.enable();
         program.setCamera(playerCamera);
@@ -457,19 +457,17 @@ public final class WorldRendererLwjgl implements WorldRenderer {
             LightComponent lightComponent = entity.getComponent(LightComponent.class);
 
             final Vector3f worldPosition = locationComponent.getWorldPosition();
-            //renderLightComponent(lightComponent, worldPosition, program, true);
+            renderLightComponent(lightComponent, worldPosition, program, true);
         }
-        */
+
         DefaultRenderingProcess.getInstance().endRenderLightGeometryStencilPass();
 
-    //}
+    }
 
-    //private void renderLightGeometry() {
+    private void renderLightGeometry() {
 
         DefaultRenderingProcess.getInstance().beginRenderLightGeometry();
-        Material program = Assets.getMaterial("engine:prog.lightGeometryPass"); // TODO: should this be enabled, its camera set, as above? Verify. --emanuele3d
-        //program.enable();
-        //program.setCamera(playerCamera);
+        Material program = Assets.getMaterial("engine:prog.lightGeometryPass");
         EntityManager entityManager = CoreRegistry.get(EntityManager.class);
         for (EntityRef entity : entityManager.getEntitiesWith(LightComponent.class, LocationComponent.class)) {
             LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
@@ -479,9 +477,10 @@ public final class WorldRendererLwjgl implements WorldRenderer {
             renderLightComponent(lightComponent, worldPosition, program, false);
         }
         DefaultRenderingProcess.getInstance().endRenderLightGeometry();
-        DefaultRenderingProcess.getInstance().beginRenderDirectionalLights();
 
         // Sunlight
+        DefaultRenderingProcess.getInstance().beginRenderDirectionalLights();
+
         Vector3f sunlightWorldPosition = new Vector3f(skysphere.getSunDirection(true));
         sunlightWorldPosition.scale(50000f);
         sunlightWorldPosition.add(playerCamera.getPosition());

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererLwjgl.java
@@ -34,6 +34,7 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Matrix4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.monitoring.Activity;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.AABBRenderer;
@@ -98,6 +99,7 @@ public final class WorldRendererLwjgl implements WorldRenderer {
 
     private final RenderQueuesHelper renderQueues;
     private WorldRenderingStage currentRenderingStage = WorldRenderingStage.DEFAULT;
+    private boolean isFirstRenderingStageForCurrentFrame;
 
     private final Time time = CoreRegistry.get(Time.class);
     private float tick;
@@ -131,9 +133,13 @@ public final class WorldRendererLwjgl implements WorldRenderer {
         }
         localPlayerSystem.setPlayerCamera(playerCamera);
 
+        initMainDirectionalLight();
+
         renderableWorld = new RenderableWorldImpl(worldProvider, chunkProvider, bufferPool, playerCamera, shadowMapCamera);
         renderQueues = renderableWorld.getRenderQueues();
+    }
 
+    private void initMainDirectionalLight() {
         mainDirectionalLight.lightType = LightComponent.LightType.DIRECTIONAL;
         mainDirectionalLight.lightColorAmbient = new Vector3f(1.0f, 1.0f, 1.0f);
         mainDirectionalLight.lightColorDiffuse = new Vector3f(1.0f, 1.0f, 1.0f);
@@ -181,62 +187,51 @@ public final class WorldRendererLwjgl implements WorldRenderer {
         tick += deltaInSeconds * 1000;
     }
 
+    public void positionShadowMapCamera() {
+        // Shadows are rendered around the player so...
+        Vector3f lightPosition = new Vector3f(playerCamera.getPosition().x, 0.0f, playerCamera.getPosition().z);
+
+        // Project the shadowMapCamera position to light space and make sure it is only moved in texel steps (avoids flickering when moving the shadowMapCamera)
+        float texelSize = 1.0f / renderingConfig.getShadowMapResolution();
+        texelSize *= 2.0f;
+
+        shadowMapCamera.getViewProjectionMatrix().transformPoint(lightPosition);
+        lightPosition.set(TeraMath.fastFloor(lightPosition.x / texelSize) * texelSize, 0.0f, TeraMath.fastFloor(lightPosition.z / texelSize) * texelSize);
+        shadowMapCamera.getInverseViewProjectionMatrix().transformPoint(lightPosition);
+
+        // ... we position our new shadowMapCamera at the position of the player and move it
+        // quite a bit into the direction of the sun (our main light).
+
+        // Make sure the sun does not move too often since it causes massive shadow flickering (from hell to the max)!
+        float stepSize = 50f;
+        Vector3f sunDirection = skysphere.getQuantizedSunDirection(stepSize);
+
+        Vector3f sunPosition = new Vector3f(sunDirection);
+        sunPosition.scale(256.0f + 64.0f);
+        lightPosition.add(sunPosition);
+
+        shadowMapCamera.getPosition().set(lightPosition);
+
+        // and adjust it to look from the sun direction into the direction of our player
+        Vector3f negSunDirection = new Vector3f(sunDirection);
+        negSunDirection.scale(-1.0f);
+
+        shadowMapCamera.getViewingDirection().set(negSunDirection);
+    }
+
     private void resetStats() {
         statChunkMeshEmpty = 0;
         statChunkNotReady = 0;
         statRenderedTriangles = 0;
     }
 
-    /**
-     * Renders the world.
-     */
-    @Override
-    public void render(DefaultRenderingProcess.StereoRenderState stereoRenderState) {
-        resetStats();
-
-        switch (stereoRenderState) {
-            case MONO:
-                currentRenderingStage = WorldRenderingStage.DEFAULT;
-                break;
-            case OCULUS_LEFT_EYE:
-                currentRenderingStage = WorldRenderingStage.OCULUS_LEFT_EYE;
-                playerCamera.updateFrustum();
-                break;
-            case OCULUS_RIGHT_EYE:
-                currentRenderingStage = WorldRenderingStage.OCULUS_RIGHT_EYE;
-                playerCamera.updateFrustum();
-                break;
-        }
-
-        if (stereoRenderState == DefaultRenderingProcess.StereoRenderState.MONO || stereoRenderState == DefaultRenderingProcess.StereoRenderState.OCULUS_LEFT_EYE) {
-            renderableWorld.updateAndQueueVisibleChunks();
-        } else {
-            renderableWorld.updateAndQueueVisibleChunks(false, false);
-        }
-
-        if (renderingConfig.isDynamicShadows()
-                && (stereoRenderState == DefaultRenderingProcess.StereoRenderState.MONO || stereoRenderState == DefaultRenderingProcess.StereoRenderState.OCULUS_LEFT_EYE)) {
-            DefaultRenderingProcess.getInstance().beginRenderSceneShadowMap();
-            renderShadowMap();
-            DefaultRenderingProcess.getInstance().endRenderSceneShadowMap();
-        }
-
-        DefaultRenderingProcess.getInstance().beginRenderReflectedScene();
-        glCullFace(GL11.GL_FRONT);
-        playerCamera.setReflected(true);
-        renderWorldReflection();
-        playerCamera.setReflected(false);
-        glCullFace(GL11.GL_BACK);
-        DefaultRenderingProcess.getInstance().endRenderReflectedScene();
-
-        renderWorld();
-
-        /* COMBINE REFRACTIVE/REFLECTIVE WITH THE OPAQUE SCENE */
+    private void combineRefractiveReflectiveAndOpaquePasses() {
         PerformanceMonitor.startActivity("Render Combined Scene");
         DefaultRenderingProcess.getInstance().renderPreCombinedScene();
         PerformanceMonitor.endActivity();
+    }
 
-        /* RENDER SIMPLE BLEND MATERIALS INTO THE COMBINED SCENE */
+    private void renderSimpleBlendMaterialsIntoCombinedPass() {
         PerformanceMonitor.startActivity("Render Objects (Transparent)");
         DefaultRenderingProcess.getInstance().beginRenderSceneOpaque();
 
@@ -253,45 +248,115 @@ public final class WorldRendererLwjgl implements WorldRenderer {
 
         DefaultRenderingProcess.getInstance().endRenderSceneOpaque();
         PerformanceMonitor.endActivity();
+    }
 
-        /* RENDER THE FINAL POST-PROCESSED SCENE */
+    private void renderFinalPostProcessedScene(DefaultRenderingProcess.StereoRenderState stereoRenderState) {
         PerformanceMonitor.startActivity("Render Post-Processing");
         DefaultRenderingProcess.getInstance().renderPost(stereoRenderState);
         PerformanceMonitor.endActivity();
+    }
+
+    /**
+     * Renders the world.
+     */
+    @Override
+    public void render(DefaultRenderingProcess.StereoRenderState stereoRenderState) {
+        resetStats();
+
+        switch (stereoRenderState) {
+            case MONO:
+                currentRenderingStage = WorldRenderingStage.DEFAULT;
+                isFirstRenderingStageForCurrentFrame = true;
+                break;
+            case OCULUS_LEFT_EYE:
+                currentRenderingStage = WorldRenderingStage.OCULUS_LEFT_EYE;
+                playerCamera.updateFrustum();
+                isFirstRenderingStageForCurrentFrame = true;
+                break;
+            case OCULUS_RIGHT_EYE:
+                currentRenderingStage = WorldRenderingStage.OCULUS_RIGHT_EYE;
+                playerCamera.updateFrustum();
+                isFirstRenderingStageForCurrentFrame = false;
+                break;
+        }
+
+        renderableWorld.updateAndQueueVisibleChunks(isFirstRenderingStageForCurrentFrame);
+
+        renderShadowMap();
+        renderWorldReflection();
+
+        toggleWireFrameON(); // if wireframe is enabled
+
+        DefaultRenderingProcess.getInstance().clear();
+        DefaultRenderingProcess.getInstance().beginRenderSceneOpaque();
+
+        renderSky();
+
+        try (Activity ignored = PerformanceMonitor.startActivity("Render World")) {
+            renderObjectsOpaque();
+            renderChunksOpaque();
+            renderChunksAlphaReject();
+            renderOverlays();
+            renderFirstPersonView();
+
+            DefaultRenderingProcess.getInstance().endRenderSceneOpaque();
+
+            PerformanceMonitor.startActivity("Render Light Geometry");
+            renderLightGeometryStencil();
+            //renderLightGeometry();
+            PerformanceMonitor.endActivity();
+
+            renderChunksRefractiveReflective();
+        }
+
+        toggleWireFrameOFF(); // if wireframe is enabled
+
+        combineRefractiveReflectiveAndOpaquePasses();
+        renderSimpleBlendMaterialsIntoCombinedPass();
+
+        renderFinalPostProcessedScene(stereoRenderState);
 
         playerCamera.updatePrevViewProjectionMatrix();
-
     }
 
     private void renderShadowMap() {
-        PerformanceMonitor.startActivity("Render World (Shadow Map)");
+        if (renderingConfig.isDynamicShadows() && isFirstRenderingStageForCurrentFrame) {
+            PerformanceMonitor.startActivity("Render World (Shadow Map)");
 
-        glDisable(GL_CULL_FACE);
+            DefaultRenderingProcess.getInstance().beginRenderSceneShadowMap();
+            glDisable(GL_CULL_FACE);
 
-        shadowMapCamera.lookThrough();
+            shadowMapCamera.lookThrough();
 
-        while (renderQueues.chunksOpaqueShadow.size() > 0) {
-            renderChunk(renderQueues.chunksOpaqueShadow.poll(), ChunkMesh.RenderPhase.OPAQUE, shadowMapCamera, ChunkRenderMode.SHADOW_MAP);
+            while (renderQueues.chunksOpaqueShadow.size() > 0) {
+                renderChunk(renderQueues.chunksOpaqueShadow.poll(), ChunkMesh.RenderPhase.OPAQUE, shadowMapCamera, ChunkRenderMode.SHADOW_MAP);
+            }
+
+            for (RenderSystem renderer : systemManager.iterateRenderSubscribers()) {
+                renderer.renderShadows();
+            }
+
+            glEnable(GL_CULL_FACE);
+            DefaultRenderingProcess.getInstance().endRenderSceneShadowMap();
+
+            PerformanceMonitor.endActivity();
         }
-
-        for (RenderSystem renderer : systemManager.iterateRenderSubscribers()) {
-            renderer.renderShadows();
-        }
-
-        glEnable(GL_CULL_FACE);
-
-        PerformanceMonitor.endActivity();
     }
 
     public void renderWorldReflection() {
         PerformanceMonitor.startActivity("Render World (Reflection)");
+
+        DefaultRenderingProcess.getInstance().beginRenderReflectedScene();
+        glCullFace(GL11.GL_FRONT);
+        playerCamera.setReflected(true);
+
         playerCamera.lookThroughNormalized();
         skysphere.render(playerCamera);
 
         Material chunkShader = Assets.getMaterial("engine:prog.chunk");
         chunkShader.activateFeature(ShaderProgramFeature.FEATURE_USE_FORWARD_LIGHTING);
 
-        if (renderingConfig.isReflectiveWater()) {
+        if (renderingConfig.isReflectiveWater()) {     // TODO: move this check out of the method?  --emanuele3d
             playerCamera.lookThrough();
 
             glEnable(GL_LIGHT0);
@@ -302,71 +367,57 @@ public final class WorldRendererLwjgl implements WorldRenderer {
         }
 
         chunkShader.deactivateFeature(ShaderProgramFeature.FEATURE_USE_FORWARD_LIGHTING);
+
+        playerCamera.setReflected(false);
+        glCullFace(GL11.GL_BACK);
+        DefaultRenderingProcess.getInstance().endRenderReflectedScene();
+
         PerformanceMonitor.endActivity();
     }
 
-    public void renderWorld() {
-        if (renderingDebugConfig.isWireframe()) {
-            glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-        }
-
-        DefaultRenderingProcess.getInstance().clear();
-        DefaultRenderingProcess.getInstance().beginRenderSceneOpaque();
-
-        /*
-         * SKYSPHERE
-         */
-        playerCamera.lookThroughNormalized();
-
+    private void renderSky() {
         PerformanceMonitor.startActivity("Render Sky");
+        playerCamera.lookThroughNormalized();
         DefaultRenderingProcess.getInstance().beginRenderSceneSky();
         skysphere.render(playerCamera);
         DefaultRenderingProcess.getInstance().endRenderSceneSky();
-        PerformanceMonitor.endActivity();
-
-        /* WORLD RENDERING */
-        PerformanceMonitor.startActivity("Render World");
-
         playerCamera.lookThrough();
-        PerformanceMonitor.startActivity("Render Objects (Opaque)");
+        PerformanceMonitor.endActivity();
+    }
 
+    private void renderObjectsOpaque() {
+        PerformanceMonitor.startActivity("Render Objects (Opaque)");
         for (RenderSystem renderer : systemManager.iterateRenderSubscribers()) {
             renderer.renderOpaque();
         }
         PerformanceMonitor.endActivity();
+    }
 
-        /*
-         * FIRST CHUNK PASS: OPAQUE
-         */
+    private void renderChunksOpaque() {
         PerformanceMonitor.startActivity("Render Chunks (Opaque)");
         while (renderQueues.chunksOpaque.size() > 0) {
             renderChunk(renderQueues.chunksOpaque.poll(), ChunkMesh.RenderPhase.OPAQUE, playerCamera, ChunkRenderMode.DEFAULT);
         }
         PerformanceMonitor.endActivity();
+    }
 
-        /*
-         * SECOND RENDER PASS: ALPHA REJECT
-         */
+    private void renderChunksAlphaReject() {
         PerformanceMonitor.startActivity("Render Chunks (Alpha Reject)");
         while (renderQueues.chunksAlphaReject.size() > 0) {
             renderChunk(renderQueues.chunksAlphaReject.poll(), ChunkMesh.RenderPhase.ALPHA_REJECT, playerCamera, ChunkRenderMode.DEFAULT);
         }
         PerformanceMonitor.endActivity();
+    }
 
-        /*
-         * OVERLAYS
-         */
+    private void renderOverlays() {
         PerformanceMonitor.startActivity("Render Overlays");
-
         for (RenderSystem renderer : systemManager.iterateRenderSubscribers()) {
             renderer.renderOverlay();
         }
-
         PerformanceMonitor.endActivity();
+    }
 
-        /*
-         * FIRST PERSON VIEW
-         */
+    private void renderFirstPersonView() {
         if (!renderingDebugConfig.isFirstPersonElementsHidden()) {
             PerformanceMonitor.startActivity("Render First Person");
 
@@ -391,16 +442,12 @@ public final class WorldRendererLwjgl implements WorldRenderer {
 
             PerformanceMonitor.endActivity();
         }
+    }
 
-
-        DefaultRenderingProcess.getInstance().endRenderSceneOpaque();
-
-        /*
-         * LIGHT GEOMETRY (STENCIL) PASS
-         */
-        PerformanceMonitor.startActivity("Render Light Geometry");
+    private void renderLightGeometryStencil() {
 
         DefaultRenderingProcess.getInstance().beginRenderLightGeometryStencilPass();
+        /*
         Material program = Assets.getMaterial("engine:prog.simple");
         program.enable();
         program.setCamera(playerCamera);
@@ -410,15 +457,20 @@ public final class WorldRendererLwjgl implements WorldRenderer {
             LightComponent lightComponent = entity.getComponent(LightComponent.class);
 
             final Vector3f worldPosition = locationComponent.getWorldPosition();
-            renderLightComponent(lightComponent, worldPosition, program, true);
+            //renderLightComponent(lightComponent, worldPosition, program, true);
         }
+        */
         DefaultRenderingProcess.getInstance().endRenderLightGeometryStencilPass();
 
-        /*
-         * LIGHT GEOMETRY PASS
-         */
+    //}
+
+    //private void renderLightGeometry() {
+
         DefaultRenderingProcess.getInstance().beginRenderLightGeometry();
-        program = Assets.getMaterial("engine:prog.lightGeometryPass");
+        Material program = Assets.getMaterial("engine:prog.lightGeometryPass"); // TODO: should this be enabled, its camera set, as above? Verify. --emanuele3d
+        //program.enable();
+        //program.setCamera(playerCamera);
+        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
         for (EntityRef entity : entityManager.getEntitiesWith(LightComponent.class, LocationComponent.class)) {
             LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
             LightComponent lightComponent = entity.getComponent(LightComponent.class);
@@ -433,36 +485,9 @@ public final class WorldRendererLwjgl implements WorldRenderer {
         Vector3f sunlightWorldPosition = new Vector3f(skysphere.getSunDirection(true));
         sunlightWorldPosition.scale(50000f);
         sunlightWorldPosition.add(playerCamera.getPosition());
-
         renderLightComponent(mainDirectionalLight, sunlightWorldPosition, program, false);
 
         DefaultRenderingProcess.getInstance().endRenderDirectionalLights();
-
-        PerformanceMonitor.endActivity();
-
-        /*
-        * THIRD CHUNK PASS: REFRACTIVE CHUNKS
-        */
-        PerformanceMonitor.startActivity("Render Chunks (Refractive/Reflective)");
-        DefaultRenderingProcess.getInstance().beginRenderSceneReflectiveRefractive();
-        // Make sure the water surface is rendered if the player is swimming
-        boolean isHeadUnderWater = isHeadUnderWater();
-        if (isHeadUnderWater) {
-            glDisable(GL11.GL_CULL_FACE);
-        }
-        while (renderQueues.chunksAlphaBlend.size() > 0) {
-            renderChunk(renderQueues.chunksAlphaBlend.poll(), ChunkMesh.RenderPhase.REFRACTIVE, playerCamera, ChunkRenderMode.DEFAULT);
-        }
-        PerformanceMonitor.endActivity();
-        if (isHeadUnderWater) {
-            glEnable(GL11.GL_CULL_FACE);
-        }
-        PerformanceMonitor.endActivity();
-        DefaultRenderingProcess.getInstance().endRenderSceneReflectiveRefractive();
-
-        if (renderingDebugConfig.isWireframe()) {
-            glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-        }
     }
 
     private boolean renderLightComponent(LightComponent lightComponent, Vector3f lightWorldPosition, Material program, boolean geometryOnly) {
@@ -531,6 +556,37 @@ public final class WorldRendererLwjgl implements WorldRenderer {
         }
 
         return true;
+    }
+
+    private void renderChunksRefractiveReflective() {
+        PerformanceMonitor.startActivity("Render Chunks (Refractive/Reflective)");
+        DefaultRenderingProcess.getInstance().beginRenderSceneReflectiveRefractive();
+        // Make sure the water surface is rendered if the player is swimming
+        boolean isHeadUnderWater = isHeadUnderWater();
+        if (isHeadUnderWater) {
+            glDisable(GL11.GL_CULL_FACE);
+        }
+        while (renderQueues.chunksAlphaBlend.size() > 0) {
+            renderChunk(renderQueues.chunksAlphaBlend.poll(), ChunkMesh.RenderPhase.REFRACTIVE, playerCamera, ChunkRenderMode.DEFAULT);
+        }
+        PerformanceMonitor.endActivity();
+        if (isHeadUnderWater) {
+            glEnable(GL11.GL_CULL_FACE);
+        }
+        PerformanceMonitor.endActivity();
+        DefaultRenderingProcess.getInstance().endRenderSceneReflectiveRefractive();
+    }
+
+    private void toggleWireFrameON() {
+        if (renderingDebugConfig.isWireframe()) {
+            glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+        }
+    }
+
+    private void toggleWireFrameOFF() {
+        if (renderingDebugConfig.isWireframe()) {
+            glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+        }
     }
 
     private void renderChunk(RenderableChunk chunk, ChunkMesh.RenderPhase phase, Camera camera, ChunkRenderMode mode) {
@@ -606,38 +662,6 @@ public final class WorldRendererLwjgl implements WorldRenderer {
         } else {
             statChunkNotReady++;
         }
-    }
-
-    public void positionShadowMapCamera() {
-        // Shadows are rendered around the player so...
-        Vector3f lightPosition = new Vector3f(playerCamera.getPosition().x, 0.0f, playerCamera.getPosition().z);
-
-        // Project the shadowMapCamera position to light space and make sure it is only moved in texel steps (avoids flickering when moving the shadowMapCamera)
-        float texelSize = 1.0f / renderingConfig.getShadowMapResolution();
-        texelSize *= 2.0f;
-
-        shadowMapCamera.getViewProjectionMatrix().transformPoint(lightPosition);
-        lightPosition.set(TeraMath.fastFloor(lightPosition.x / texelSize) * texelSize, 0.0f, TeraMath.fastFloor(lightPosition.z / texelSize) * texelSize);
-        shadowMapCamera.getInverseViewProjectionMatrix().transformPoint(lightPosition);   
-
-        // ... we position our new shadowMapCamera at the position of the player and move it
-        // quite a bit into the direction of the sun (our main light).
-
-        // Make sure the sun does not move too often since it causes massive shadow flickering (from hell to the max)!
-        float stepSize = 50f;
-        Vector3f sunDirection = skysphere.getQuantizedSunDirection(stepSize);
-
-        Vector3f sunPosition = new Vector3f(sunDirection);
-        sunPosition.scale(256.0f + 64.0f);
-        lightPosition.add(sunPosition);
-
-        shadowMapCamera.getPosition().set(lightPosition);
-
-        // and adjust it to look from the sun direction into the direction of our player
-        Vector3f negSunDirection = new Vector3f(sunDirection);
-        negSunDirection.scale(-1.0f);
-
-        shadowMapCamera.getViewingDirection().set(negSunDirection);
     }
 
     /**


### PR DESCRIPTION
This PR *mostly* just moves things around:
* it moves the content of the WorldRendererLwjgl's methods render() and renderWorld() into individual methods called only by render().
* it removes the renderWorld() method altogether 
* it moves a few methods so that they are closer to where they are called

However, it also does a few additional things:
* it changes the signature of RenderableWorld.updateAndQueueVisibleChunks() and the method's implementation in RenderableWorldImpl.
* it wraps mainDirectionaLight initialization in its own method, to remove some clutter from the constructor
* **it disable the light geometry stencil pass** as it currently doesn't seem to do much and it prevents a torch in hand to light up the environment nearby.
