### PR TITLE
Mostly test fixes; It adjusts also EntityManager#create

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/EntitySerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/EntitySerializerTest.java
@@ -227,7 +227,7 @@ public class EntitySerializerTest {
         EntityRef newEntity = entitySerializer.deserialize(entityData);
         assertTrue(newEntity.hasComponent(EntityInfoComponent.class));
         EntityInfoComponent comp = newEntity.getComponent(EntityInfoComponent.class);
-        assertEquals(prefab.getName(), comp.parentPrefab);
+        assertEquals(prefab, comp.parentPrefab);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -119,6 +119,9 @@ public class StorageManagerTest {
         entityManager = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem,
                 new ReflectionReflectFactory());
 
+        esm = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), entityManager, false);
+        CoreRegistry.put(StorageManager.class, esm);
+
         this.character = entityManager.create();
         Client client = createClientMock(PLAYER_ID, character);
 
@@ -132,8 +135,7 @@ public class StorageManagerTest {
         testBlock2.setId((short) 2);
         blockManager.addBlockFamily(new SymmetricFamily(new BlockUri("test:testblock2"), testBlock2), true);
 
-        esm = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), entityManager, false);
-        CoreRegistry.put(StorageManager.class, esm);
+
 
         ComponentSystemManager componentSystemManager = new ComponentSystemManager();
         CoreRegistry.put(ComponentSystemManager.class, componentSystemManager);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -141,7 +141,13 @@ public class PojoEntityManager implements LowLevelEntityManager, EngineEntityMan
 
     @Override
     public EntityRef create() {
-        return createEntityRef(createEntity());
+        EntityRef entityRef = createEntityRef(createEntity());
+        /*
+         * The entity change listener are also used to detect new entities. By adding one component we inform those
+         * listeners about the new entity.
+         */
+        entityRef.addComponent(new EntityInfoComponent());
+        return entityRef;
     }
 
     private long createEntity() {


### PR DESCRIPTION
While this pull request contains mostly test fixes for #1517, it also changes the argument less create method of the EntityManager to ensure that the storage manager notices the creation of a otherwise component less entity.

@immortius Maybe we should make it possible to listen for create events anyway?

Otherwise we must adjust the other create methods to ensure that they add at least 1 component and not for example an empty list.