### PR TITLE
BackdropProvider, BackdropRenderer

### DIFF
--- a/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
+++ b/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
@@ -18,6 +18,7 @@ package org.terasology.editor.properties;
 import com.google.common.collect.Lists;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.opengl.DefaultRenderingProcess;
 import org.terasology.rendering.backdrop.Skysphere;
 import org.terasology.rendering.world.WorldRenderer;
@@ -34,6 +35,10 @@ public class SceneProperties implements PropertyProvider {
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
         if (backdropProvider != null) {
             result.addAll(new ReflectionProvider(backdropProvider).getProperties());
+        }
+        BackdropRenderer backdropRenderer = CoreRegistry.get(BackdropRenderer.class);
+        if (backdropRenderer != null) {
+            result.addAll(new ReflectionProvider(backdropRenderer).getProperties());
         }
         DefaultRenderingProcess postRenderer = DefaultRenderingProcess.getInstance();
         if (postRenderer != null) {

--- a/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
+++ b/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
@@ -17,8 +17,9 @@ package org.terasology.editor.properties;
 
 import com.google.common.collect.Lists;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.opengl.DefaultRenderingProcess;
-import org.terasology.rendering.world.Skysphere;
+import org.terasology.rendering.backdrop.Skysphere;
 import org.terasology.rendering.world.WorldRenderer;
 
 import java.util.List;
@@ -30,9 +31,9 @@ public class SceneProperties implements PropertyProvider {
     @Override
     public List<Property<?>> getProperties() {
         List<Property<?>> result = Lists.newArrayList();
-        Skysphere skysphere = CoreRegistry.get(WorldRenderer.class).getSkysphere();
-        if (skysphere != null) {
-            result.addAll(new ReflectionProvider(skysphere).getProperties());
+        BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
+        if (backdropProvider != null) {
+            result.addAll(new ReflectionProvider(backdropProvider).getProperties());
         }
         DefaultRenderingProcess postRenderer = DefaultRenderingProcess.getInstance();
         if (postRenderer != null) {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -24,6 +24,9 @@ import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.LocalPlayerSystem;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.backdrop.BackdropRenderer;
+import org.terasology.rendering.backdrop.Skysphere;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.BlockEntityRegistry;
@@ -71,8 +74,15 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         CoreRegistry.get(ComponentSystemManager.class).register(celestialSystem);
 
         // Init. a new world
+        Skysphere skysphere = new Skysphere();
+        BackdropProvider backdropProvider = skysphere;
+        BackdropRenderer backdropRenderer = skysphere;
+        CoreRegistry.put(BackdropProvider.class, backdropProvider);
+        CoreRegistry.put(BackdropRenderer.class, backdropRenderer);
+
         RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);
-        WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
+        WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(backdropProvider, backdropRenderer,
+                                                                                 worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
         float reflectionHeight = CoreRegistry.get(NetworkSystem.class).getServer().getInfo().getReflectionHeight();
         worldRenderer.getActiveCamera().setReflectionHeight(reflectionHeight);
         CoreRegistry.put(WorldRenderer.class, worldRenderer);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -38,11 +38,12 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.internal.ReadOnlyStorageManager;
 import org.terasology.persistence.internal.ReadWriteStorageManager;
-import org.terasology.physics.Physics;
-import org.terasology.physics.engine.PhysicsEngine;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.backdrop.BackdropRenderer;
+import org.terasology.rendering.backdrop.Skysphere;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
@@ -139,8 +140,15 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         CoreRegistry.put(CelestialSystem.class, celestialSystem);
         CoreRegistry.get(ComponentSystemManager.class).register(celestialSystem);
 
+        Skysphere skysphere = new Skysphere();
+        BackdropProvider backdropProvider = skysphere;
+        BackdropRenderer backdropRenderer = skysphere;
+        CoreRegistry.put(BackdropProvider.class, backdropProvider);
+        CoreRegistry.put(BackdropRenderer.class, backdropRenderer);
+
         RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);
-        WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
+        WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(backdropProvider, backdropRenderer,
+                                                                                 worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
         CoreRegistry.put(WorldRenderer.class, worldRenderer);
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer

--- a/engine/src/main/java/org/terasology/engine/subsystem/RenderingSubsystemFactory.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/RenderingSubsystemFactory.java
@@ -16,12 +16,15 @@
 package org.terasology.engine.subsystem;
 
 import org.terasology.logic.players.LocalPlayerSystem;
+import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
 
 public interface RenderingSubsystemFactory {
 
-    WorldRenderer createWorldRenderer(WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem);
+    WorldRenderer createWorldRenderer(BackdropProvider backdropProvider, BackdropRenderer backdropRenderer,
+                                      WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem);
 
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessRenderingSubsystemFactory.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessRenderingSubsystemFactory.java
@@ -17,6 +17,8 @@ package org.terasology.engine.subsystem.headless.renderer;
 
 import org.terasology.engine.subsystem.RenderingSubsystemFactory;
 import org.terasology.logic.players.LocalPlayerSystem;
+import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
@@ -24,7 +26,8 @@ import org.terasology.world.chunks.ChunkProvider;
 public class HeadlessRenderingSubsystemFactory implements RenderingSubsystemFactory {
 
     @Override
-    public WorldRenderer createWorldRenderer(WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem) {
+    public WorldRenderer createWorldRenderer(BackdropProvider backdropProvider, BackdropRenderer backdropRenderer,
+                                             WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem) {
         return new HeadlessWorldRenderer(worldProvider, chunkProvider, localPlayerSystem);
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -20,17 +20,13 @@ import com.google.common.collect.Lists;
 import org.terasology.config.Config;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.LocalPlayerSystem;
-import org.terasology.math.AABB;
 import org.terasology.math.Region3i;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.monitoring.PerformanceMonitor;
-import org.terasology.physics.bullet.BulletPhysics;
-import org.terasology.physics.engine.PhysicsEngine;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.opengl.DefaultRenderingProcess.StereoRenderState;
-import org.terasology.rendering.world.Skysphere;
 import org.terasology.rendering.world.ViewDistance;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -144,12 +140,6 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     }
 
     @Override
-    public float getDaylight() {
-        // TODO Auto-generated method stub
-        return 0;
-    }
-
-    @Override
     public float getSunlightValue() {
         // TODO Auto-generated method stub
         return 0;
@@ -201,12 +191,6 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     public float getTick() {
         // TODO Auto-generated method stub
         return 0;
-    }
-
-    @Override
-    public Skysphere getSkysphere() {
-        // TODO Auto-generated method stub
-        return null;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglRenderingSubsystemFactory.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglRenderingSubsystemFactory.java
@@ -17,6 +17,8 @@ package org.terasology.engine.subsystem.lwjgl;
 
 import org.terasology.engine.subsystem.RenderingSubsystemFactory;
 import org.terasology.logic.players.LocalPlayerSystem;
+import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.rendering.world.WorldRendererLwjgl;
 import org.terasology.world.WorldProvider;
@@ -31,7 +33,8 @@ public class LwjglRenderingSubsystemFactory implements RenderingSubsystemFactory
     }
 
     @Override
-    public WorldRenderer createWorldRenderer(WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem) {
-        return new WorldRendererLwjgl(worldProvider, chunkProvider, localPlayerSystem, bufferPool);
+    public WorldRenderer createWorldRenderer(BackdropProvider backdropProvider, BackdropRenderer backdropRenderer,
+                                             WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem) {
+        return new WorldRendererLwjgl(backdropProvider, backdropRenderer, worldProvider, chunkProvider, localPlayerSystem, bufferPool);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/backdrop/BackdropProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/BackdropProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.backdrop;
+
+import org.terasology.math.geom.Vector3f;
+
+/**
+ * Implementations of this interface provide read and/or write access to the backdrop,
+ * the visual layer that is rendered beyond the 3d scene rendered by the WorldRenderer
+ *
+ * This is generally intended to be the sky, but the theatrical term "backdrop" is used to include
+ * anything in the background. On the other hand, the term "background" itself was avoided as it is
+ * used in the context of background/foreground processes and threads.
+ *
+ * Created by manu on 13.01.2015.
+ */
+public interface BackdropProvider {
+
+    // Note: I intentionally leave this interface undocumented (which is how I found it
+    // in the skysphere implementation) as I plan to radically change it. -- emanuele3d
+
+    float getDaylight();
+
+    float getTurbidity();
+
+    float getColorExp();
+
+    float getSunPositionAngle();
+
+    Vector3f getQuantizedSunDirection(float stepSize);
+
+    Vector3f getSunDirection(boolean moonlightFlip);
+
+}

--- a/engine/src/main/java/org/terasology/rendering/backdrop/BackdropRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/BackdropRenderer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.backdrop;
+
+import org.terasology.rendering.cameras.Camera;
+
+/**
+ * Implementations of this interface are responsible for rendering the backdrop of terasology's world,
+ * that is anything that is visually beyond the 3d scene renderered by the WorldRenderer.
+ *
+ * This is generally intended to be the sky, but the theatrical term "backdrop" is used to include
+ * anything in the background. On the other hand, the term "background" itself was avoided as it is
+ * used in the context of background/foreground processes and threads.
+ *
+ * Created by manu on 13.01.2015.
+ */
+public interface BackdropRenderer {
+
+    /**
+     * Renders the backdrop from the point of view provided by the camera, straight into the currently bound buffer.
+     *
+     * @param camera The camera providing the point of view to render the backdrop from.
+     */
+    void render(Camera camera);
+}

--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.world;
+package org.terasology.rendering.backdrop;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Sphere;
@@ -41,7 +41,7 @@ import static org.lwjgl.opengl.GL11.glNewList;
  * @author Anthony Kireev <adeon.k87@gmail.com>
  * @author Benjamin Glatzel <benjamin.glatzel@me.com>
  */
-public class Skysphere {
+public class Skysphere implements BackdropProvider, BackdropRenderer{
 
     private static int displayListSphere = -1;
 
@@ -97,12 +97,12 @@ public class Skysphere {
         glCallList(displayListSphere);
     }
 
-    public float getSunPosAngle() {
+    public float getSunPositionAngle() {
         return celSystem.getSunPosAngle();
     }
 
     public float getDaylight() {
-        float angle = (float) Math.toDegrees(TeraMath.clamp(Math.cos(getSunPosAngle())));
+        float angle = (float) Math.toDegrees(TeraMath.clamp(Math.cos(getSunPositionAngle())));
         float daylight = 1.0f;
 
         if (angle < 24.0f) {
@@ -121,7 +121,7 @@ public class Skysphere {
     }
 
     public Vector3f getQuantizedSunDirection(float stepSize) {
-        float sunAngle = (float) Math.floor(getSunPosAngle() * stepSize) / stepSize + 0.0001f;
+        float sunAngle = (float) Math.floor(getSunPositionAngle() * stepSize) / stepSize + 0.0001f;
         Vector3f sunDirection = new Vector3f(0.0f, (float) Math.cos(sunAngle), (float) Math.sin(sunAngle));
 
         // Moonlight flip
@@ -133,7 +133,7 @@ public class Skysphere {
     }
 
     public Vector3f getSunDirection(boolean moonlightFlip) {
-        float sunAngle = getSunPosAngle() + 0.0001f;
+        float sunAngle = getSunPositionAngle() + 0.0001f;
         Vector3f sunDirection = new Vector3f(0.0f, (float) Math.cos(sunAngle), (float) Math.sin(sunAngle));
 
         // Moonlight flip

--- a/engine/src/main/java/org/terasology/rendering/opengl/DefaultRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/DefaultRenderingProcess.java
@@ -38,6 +38,7 @@ import org.terasology.engine.GameEngine;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.math.TeraMath;
 import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.oculusVr.OculusVrHelper;
 import org.terasology.rendering.world.WorldRenderer;
 
@@ -595,7 +596,7 @@ public class DefaultRenderingProcess {
 
             float maxExposure = hdrMaxExposure;
 
-            if (CoreRegistry.get(WorldRenderer.class).getSkysphere().getDaylight() == 0.0) {
+            if (CoreRegistry.get(BackdropProvider.class).getDaylight() == 0.0) {
                 maxExposure = hdrMaxExposureNight;
             }
 
@@ -608,7 +609,7 @@ public class DefaultRenderingProcess {
             currentExposure = (float) TeraMath.lerp(currentExposure, targetExposure, hdrExposureAdjustmentSpeed);
 
         } else {
-            if (CoreRegistry.get(WorldRenderer.class).getSkysphere().getDaylight() == 0.0) {
+            if (CoreRegistry.get(BackdropProvider.class).getDaylight() == 0.0) {
                 currentExposure = hdrMaxExposureNight;
             } else {
                 currentExposure = hdrExposureDefault;

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
@@ -19,6 +19,8 @@ import org.terasology.config.Config;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.backdrop.BackdropProvider;
+import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
 
@@ -43,27 +45,29 @@ public class ShaderParametersBase implements ShaderParameters {
         program.setFloat("viewingDistance", CoreRegistry.get(Config.class).getRendering().getViewDistance().getChunkDistance().x * 8.0f);
 
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
-        WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
+        BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
 
-        if (worldRenderer != null) {
-            program.setFloat("daylight", worldRenderer.getDaylight(), true);
+        if (worldRenderer != null && backdropProvider != null) {
+            program.setFloat("daylight", backdropProvider.getDaylight(), true);
             program.setFloat("swimming", worldRenderer.isHeadUnderWater() ? 1.0f : 0.0f, true);
             program.setFloat("tick", worldRenderer.getTick(), true);
             program.setFloat("sunlightValueAtPlayerPos", worldRenderer.getSmoothedPlayerSunlightValue(), true);
 
-            if (worldRenderer.getActiveCamera() != null) {
-                final Vector3f cameraDir = worldRenderer.getActiveCamera().getViewingDirection();
-                final Vector3f cameraPosition = worldRenderer.getActiveCamera().getPosition();
+            Camera activeCamera = worldRenderer.getActiveCamera();
+            if (activeCamera != null) {
+                final Vector3f cameraDir = activeCamera.getViewingDirection();
+                final Vector3f cameraPosition = activeCamera.getPosition();
 
                 program.setFloat3("cameraPosition", cameraPosition.x, cameraPosition.y, cameraPosition.z, true);
                 program.setFloat3("cameraDirection", cameraDir.x, cameraDir.y, cameraDir.z, true);
-                program.setFloat3("cameraParameters", worldRenderer.getActiveCamera().getzNear(), worldRenderer.getActiveCamera().getzFar(), 0.0f, true);
+                program.setFloat3("cameraParameters", activeCamera.getzNear(), activeCamera.getzFar(), 0.0f, true);
             }
 
-            Vector3f sunDirection = worldRenderer.getSkysphere().getSunDirection(false);
+            Vector3f sunDirection = backdropProvider.getSunDirection(false);
             program.setFloat3("sunVec", sunDirection.x, sunDirection.y, sunDirection.z, true);
         }
 
+        WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
         if (worldProvider != null) {
             program.setFloat("time", worldProvider.getTime().getDays());
         }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -21,6 +21,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.opengl.DefaultRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
@@ -64,10 +65,12 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
         program.setFloat("decay", decay, true);
 
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
-        if (worldRenderer != null) {
-            Vector3f sunDirection = worldRenderer.getSkysphere().getSunDirection(true);
+        BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
 
-            Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
+        if (worldRenderer != null) {
+            Vector3f sunDirection = backdropProvider.getSunDirection(true);
+
+            Camera activeCamera = worldRenderer.getActiveCamera();
 
             Vector4f sunPositionWorldSpace4 = new Vector4f(sunDirection.x * 10000.0f, sunDirection.y * 10000.0f, sunDirection.z * 10000.0f, 1.0f);
             Vector4f sunPositionScreenSpace = new Vector4f(sunPositionWorldSpace4);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
@@ -24,7 +24,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
-import org.terasology.rendering.world.WorldRenderer;
+import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.world.WorldProvider;
 
 /**
@@ -76,17 +76,17 @@ public class ShaderParametersSky extends ShaderParametersBase {
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, Assets.getTexture("engine:sky180").getId());
         program.setInt("texSky180", texId++, true);
 
-        WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
+        BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
 
-        if (worldProvider != null && worldRenderer != null) {
-            program.setFloat("colorExp", worldRenderer.getSkysphere().getColorExp(), true);
+        if (worldProvider != null && backdropProvider != null) {
+            program.setFloat("colorExp", backdropProvider.getColorExp(), true);
 
-            Vector3f sunDirection = worldRenderer.getSkysphere().getSunDirection(false);
-            Vector3d zenithColor = getAllWeatherZenith(sunDirection.y, worldRenderer.getSkysphere().getTurbidity());
+            Vector3f sunDirection = backdropProvider.getSunDirection(false);
+            Vector3d zenithColor = getAllWeatherZenith(sunDirection.y, backdropProvider.getTurbidity());
 
-            program.setFloat("sunAngle", worldRenderer.getSkysphere().getSunPosAngle(), true);
-            program.setFloat("turbidity", (Float) worldRenderer.getSkysphere().getTurbidity(), true);
+            program.setFloat("sunAngle", backdropProvider.getSunPositionAngle(), true);
+            program.setFloat("turbidity", backdropProvider.getTurbidity(), true);
             program.setFloat3("zenith", (float) zenithColor.x, (float) zenithColor.y, (float) zenithColor.z, true);
         }
 

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -16,10 +16,8 @@
 package org.terasology.rendering.world;
 
 import org.terasology.logic.players.LocalPlayer;
-import org.terasology.math.AABB;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.physics.engine.PhysicsEngine;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.opengl.DefaultRenderingProcess.StereoRenderState;
 import org.terasology.world.WorldProvider;
@@ -60,8 +58,6 @@ public interface WorldRenderer {
 
     void changeViewDistance(ViewDistance viewDistance);
 
-    float getDaylight();
-
     float getSunlightValue();
 
     float getBlockLightValue();
@@ -79,8 +75,6 @@ public interface WorldRenderer {
     Vector3f getTint();
 
     float getTick();
-
-    Skysphere getSkysphere();
 
     WorldRenderingStage getCurrentRenderStage();
 


### PR DESCRIPTION
In this PR the current skysphere is mantained as an implementation of two new interfaces: **BackdropProvider** and **BackdropRenderer**, both available through the CoreRegistry. Almost every other change is a consequence. 

The few unrelated changes are some easy optimizations I stumbled upon, some renaming to remove abbreviations and some unused imports removals.