### PR TITLE
Disable storing chunks on reload

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
@@ -224,7 +224,7 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         }
 
         @Override
-        public boolean purgeChunk(Vector3i pos) {
+        public boolean reloadChunk(Vector3i pos) {
             return false;
         }
 

--- a/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
@@ -153,8 +153,12 @@ public class ServerCommands extends BaseComponentSystem {
     }
 
     @Command(shortDescription = "Deletes the specified chunk and re-generate it", runOnServer = true)
-    public void purgeChunk(@CommandParam("x") int x, @CommandParam("y") int y, @CommandParam("z") int z) {
-        chunkProvider.purgeChunk(new Vector3i(x, y, z));
+    public String purgeChunk(@CommandParam("x") int x, @CommandParam("y") int y, @CommandParam("z") int z) {
+        boolean success = chunkProvider.purgeChunk(new Vector3i(x, y, z));
+
+        return success
+            ? "Cleared chunk from cache and triggered reload"
+            : "Chunk did not exist in the cache";
     }
 
     @Command(shortDescription = "Deletes the current world and generated new chunks", runOnServer = true)

--- a/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
@@ -152,13 +152,13 @@ public class ServerCommands extends BaseComponentSystem {
         storageManager.requestSaving();
     }
 
-    @Command(shortDescription = "Deletes the specified chunk and re-generate it", runOnServer = true)
-    public String purgeChunk(@CommandParam("x") int x, @CommandParam("y") int y, @CommandParam("z") int z) {
-        boolean success = chunkProvider.purgeChunk(new Vector3i(x, y, z));
-
+    @Command(shortDescription = "Invalidates the specified chunk and reload/recreate it", runOnServer = true)
+    public String reloadChunk(@CommandParam("x") int x, @CommandParam("y") int y, @CommandParam("z") int z) {
+        Vector3i pos = new Vector3i(x, y, z);
+        boolean success = chunkProvider.reloadChunk(pos);
         return success
-            ? "Cleared chunk from cache and triggered reload"
-            : "Chunk did not exist in the cache";
+            ? "Cleared chunk " + pos + " from cache and triggered reload"
+            : "Chunk " + pos + " did not exist in the cache";
     }
 
     @Command(shortDescription = "Deletes the current world and generated new chunks", runOnServer = true)

--- a/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
@@ -17,6 +17,7 @@ package org.terasology.logic.console.commands;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.config.Config;
 import org.terasology.engine.GameEngine;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -152,9 +153,12 @@ public class ServerCommands extends BaseComponentSystem {
         storageManager.requestSaving();
     }
 
-    @Command(shortDescription = "Invalidates the specified chunk and reload/recreate it", runOnServer = true)
+    @Command(shortDescription = "Invalidates the specified chunk and recreates it (requires storage manager disabled)", runOnServer = true)
     public String reloadChunk(@CommandParam("x") int x, @CommandParam("y") int y, @CommandParam("z") int z) {
         Vector3i pos = new Vector3i(x, y, z);
+        if (CoreRegistry.get(Config.class).getTransients().isWriteSaveGamesEnabled()) {
+            return "Writing save games is enabled! Invalidating chunk has no effect";
+        }
         boolean success = chunkProvider.reloadChunk(pos);
         return success
             ? "Cleared chunk " + pos + " from cache and triggered reload"

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadOnlyStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadOnlyStorageManager.java
@@ -18,10 +18,13 @@ package org.terasology.persistence.internal;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.Client;
+import org.terasology.network.ClientComponent;
 import org.terasology.world.chunks.Chunk;
 
 /**
@@ -55,7 +58,11 @@ public final class ReadOnlyStorageManager extends AbstractStorageManager {
 
     @Override
     public void deactivateChunk(Chunk chunk) {
-        // don't care
+        Collection<EntityRef> entitiesOfChunk = getEntitiesOfChunk(chunk);
+
+        for (EntityRef entity : entitiesOfChunk) {
+            deactivateOrDestroyEntityRecursive(entity);
+        }
     }
 
     @Override
@@ -79,6 +86,7 @@ public final class ReadOnlyStorageManager extends AbstractStorageManager {
 
     @Override
     public void deactivatePlayer(Client client) {
-        // don't care
+        EntityRef character = client.getEntity().getComponent(ClientComponent.class).character;
+        deactivateOrDestroyEntityRecursive(character);
     }
 }

--- a/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
@@ -101,7 +101,7 @@ public interface ChunkProvider {
      * @param pos the chunk coordinates
      * @return whether this chunk was purged successfully or not
      */
-    boolean purgeChunk(Vector3i pos);
+    boolean reloadChunk(Vector3i pos);
 
     /**
      * Purges all chunks that are currently loaded and force their re-generation.

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -363,7 +363,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             if (!keep) {
                 // TODO: need some way to not dispose chunks being edited or processed (or do so safely)
                 // Note: Above won't matter if all changes are on the main thread
-                if (unloadChunkInternal(pos, true)) {
+                if (unloadChunkInternal(pos)) {
                     iterator.remove();
                     if (++unloaded >= UNLOAD_PER_FRAME) {
                         break;
@@ -374,7 +374,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
         PerformanceMonitor.endActivity();
     }
 
-    private boolean unloadChunkInternal(Vector3i pos, boolean storeChunk) {
+    private boolean unloadChunkInternal(Vector3i pos) {
         Chunk chunk = nearCache.get(pos);
         if (chunk.isLocked()) {
             return false;
@@ -398,9 +398,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             for (ChunkRelevanceRegion region : regions.values()) {
                 region.chunkUnloaded(pos);
             }
-            if (storeChunk) {
-                storageManager.deactivateChunk(chunk);
-            }
+            storageManager.deactivateChunk(chunk);
             chunk.dispose();
             updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
 
@@ -568,9 +566,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             return false;
         }
 
-        if (unloadChunkInternal(coords, false)) {
-            // TODO: destroy all entities in this chunk similar to the storage manager
-
+        if (unloadChunkInternal(coords)) {
             nearCache.remove(coords);
             createOrLoadChunk(coords);
             return true;

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -363,7 +363,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             if (!keep) {
                 // TODO: need some way to not dispose chunks being edited or processed (or do so safely)
                 // Note: Above won't matter if all changes are on the main thread
-                if (unloadChunkInternal(pos)) {
+                if (unloadChunkInternal(pos, true)) {
                     iterator.remove();
                     if (++unloaded >= UNLOAD_PER_FRAME) {
                         break;
@@ -374,7 +374,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
         PerformanceMonitor.endActivity();
     }
 
-    private boolean unloadChunkInternal(Vector3i pos) {
+    private boolean unloadChunkInternal(Vector3i pos, boolean storeChunk) {
         Chunk chunk = nearCache.get(pos);
         if (chunk.isLocked()) {
             return false;
@@ -398,7 +398,9 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             for (ChunkRelevanceRegion region : regions.values()) {
                 region.chunkUnloaded(pos);
             }
-            storageManager.deactivateChunk(chunk);
+            if (storeChunk) {
+                storageManager.deactivateChunk(chunk);
+            }
             chunk.dispose();
             updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
 
@@ -566,7 +568,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             return false;
         }
 
-        if (unloadChunkInternal(coords)) {
+        if (unloadChunkInternal(coords, false)) {
             nearCache.remove(coords);
             createOrLoadChunk(coords);
             return true;

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -563,12 +563,14 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
     }
 
     @Override
-    public boolean purgeChunk(Vector3i coords) {
+    public boolean reloadChunk(Vector3i coords) {
         if (!nearCache.containsKey(coords)) {
             return false;
         }
 
         if (unloadChunkInternal(coords, false)) {
+            // TODO: destroy all entities in this chunk similar to the storage manager
+
             nearCache.remove(coords);
             createOrLoadChunk(coords);
             return true;

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -175,7 +175,7 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
     }
 
     @Override
-    public boolean purgeChunk(Vector3i pos) {
+    public boolean reloadChunk(Vector3i pos) {
         return false;
     }
 


### PR DESCRIPTION
This is a follow-up PR for #1526 based on the suggestions that were made there.

* The command was renamed to `reloadChunk` as it better reflects what it does.
* The command returns a human-readable message whether the command was successful or not.
* Storing to disk is explicitly disabled. It will reload the previously saved status or trigger regeneration.
* The read-only storage manager now also destroys entities in unloaded chunks correctly.

Entities from chunks that are reloaded will survive unharmed.
