### PR TITLE
Handle null EntityRefs in DelayedEntityRefCopyStrategy.

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRefCopyStrategy.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRefCopyStrategy.java
@@ -33,6 +33,10 @@ class DelayedEntityRefCopyStrategy implements CopyStrategy<EntityRef> {
 
     @Override
     public EntityRef copy(EntityRef value) {
-        return delayedEntityRefFactory.createDelayedEntityRef(value.getId());
+        if (value != null) {
+            return delayedEntityRefFactory.createDelayedEntityRef(value.getId());
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Reasoning: Not all modules do properly apply the null object pattern for EntityRefs.

This fixes #1531