### PR TITLE
Changes to WorldRendererLwjgl update() method, addressed part of issue #1536

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
@@ -34,7 +34,8 @@ public interface RenderableWorld {
     boolean updateChunksInProximity(Region3i renderableRegion);
     boolean updateChunksInProximity(ViewDistance viewDistance);
 
-    int updateAndQueueVisibleChunks(boolean isFirstRenderingStageForCurrentFrame);
+    void generateVBOs();
+    int queueVisibleChunks(boolean isFirstRenderingStageForCurrentFrame);
 
     void dispose();
 

--- a/engine/src/main/java/org/terasology/world/chunks/ChunkConstants.java
+++ b/engine/src/main/java/org/terasology/world/chunks/ChunkConstants.java
@@ -31,13 +31,15 @@ public final class ChunkConstants {
     public static final int SIZE_X = 32;
     public static final int SIZE_Y = 64;
     public static final int SIZE_Z = 32;
+
     public static final int INNER_CHUNK_POS_FILTER_X = TeraMath.ceilPowerOfTwo(SIZE_X) - 1;
     public static final int INNER_CHUNK_POS_FILTER_Y = TeraMath.ceilPowerOfTwo(SIZE_Y) - 1;
     public static final int INNER_CHUNK_POS_FILTER_Z = TeraMath.ceilPowerOfTwo(SIZE_Z) - 1;
+
     public static final int POWER_X = TeraMath.sizeOfPower(SIZE_X);
     public static final int POWER_Y = TeraMath.sizeOfPower(SIZE_Y);
     public static final int POWER_Z = TeraMath.sizeOfPower(SIZE_Z);
-    public static final int VERTICAL_SEGMENTS = CoreRegistry.get(Config.class).getSystem().getVerticalChunkMeshSegments();
+
     public static final byte MAX_LIGHT = 0x0f;
     public static final byte MAX_SUNLIGHT = 0x0f;
     public static final byte MAX_SUNLIGHT_REGEN = 63;

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.config.Config;
 import org.terasology.math.AABB;
 import org.terasology.math.Region3i;
 import org.terasology.math.Vector3i;
@@ -64,6 +65,9 @@ public class ChunkImpl implements Chunk {
     private static final DecimalFormat PERCENT_FORMAT = new DecimalFormat("0.##");
     private static final DecimalFormat SIZE_FORMAT = new DecimalFormat("#,###");
 
+    private final int verticalChunkMeshSegments = CoreRegistry.get(Config.class).getSystem().getVerticalChunkMeshSegments();
+    private final int chunkHalfHeight = ChunkConstants.SIZE_Y / verticalChunkMeshSegments / 2;
+
     private final Vector3i chunkPos = new Vector3i();
 
     private BlockManager blockManager;
@@ -72,7 +76,6 @@ public class ChunkImpl implements Chunk {
     private TeraArray sunlightData;
     private TeraArray sunlightRegenData;
     private TeraArray lightData;
-
 
     private TeraArray blockData;
     private volatile TeraArray blockDataSnapshot;
@@ -510,13 +513,11 @@ public class ChunkImpl implements Chunk {
     @Override
     public AABB getSubMeshAABB(int subMesh) {
         if (subMeshAABB == null) {
-            subMeshAABB = new AABB[ChunkConstants.VERTICAL_SEGMENTS];
-
-            int heightHalf = ChunkConstants.SIZE_Y / ChunkConstants.VERTICAL_SEGMENTS / 2;
+            subMeshAABB = new AABB[verticalChunkMeshSegments];
 
             for (int i = 0; i < subMeshAABB.length; i++) {
-                Vector3f dimensions = new Vector3f(8, heightHalf, 8);
-                Vector3f position = new Vector3f(getChunkWorldOffsetX() - 0.5f, (i * heightHalf * 2) - 0.5f, getChunkWorldOffsetZ() - 0.5f);
+                Vector3f dimensions = new Vector3f(8, chunkHalfHeight, 8);
+                Vector3f position = new Vector3f(getChunkWorldOffsetX() - 0.5f, (i * chunkHalfHeight * 2) - 0.5f, getChunkWorldOffsetZ() - 0.5f);
                 position.add(dimensions);
                 subMeshAABB[i] = AABB.createCenterExtent(position, dimensions);
             }


### PR DESCRIPTION
Renderer changes: 
* moved some of the WorldRendererLwjgl.update() functionality in a codeblock that is executed only once per frame, in preRenderUpdate()
* split RenderableWorldImpl.updateAndQueueVisibleChunks() method in generateVBOs() and queueVisibleChunks() methods
* eliminated RenderableWorldImpl.processChunk() method: its code is now in queueVisibleChunks()
* removed WorldRendererLwjgl.getTime() method: no usages and it's best to get the time from the Time class, I reasoned
* removed WorldRendererLwjgl.updateTick(): its code is now in update()

Also addressed *part* of issue #1536, regarding the ChunkConstant class. Modified ChunkImpl class accordingly. 

See comments for some additional notes on specific lines.