### PR TITLE
Promote entity builder usage

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
@@ -23,6 +23,7 @@ import org.terasology.asset.AssetType;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.prefab.Prefab;
@@ -74,8 +75,10 @@ public class WorldSerializerTest {
 
     @Test
     public void testNotPersistedIfFlagedOtherwise() throws Exception {
-        EntityRef entity = entityManager.create();
-        entity.setPersistent(false);
+        EntityBuilder entityBuilder = entityManager.newBuilder();
+        entityBuilder.setPersistent(false);
+        @SuppressWarnings("unused") // just used to express that an entity got created
+        EntityRef entity = entityBuilder.build();
 
         EntityData.GlobalStore worldData = worldSerializer.serializeWorld(false);
         assertEquals(0, worldData.getEntityCount());

--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorNodeFactory.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorNodeFactory.java
@@ -25,6 +25,7 @@ import org.terasology.asset.AssetUri;
 import org.terasology.engine.ComponentFieldUri;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
@@ -177,8 +178,9 @@ public class BehaviorNodeFactory extends BaseComponentSystem {
     private void refreshPrefabs() {
         Collection<Prefab> prefabs = prefabManager.listPrefabs(BehaviorNodeComponent.class);
         for (Prefab prefab : prefabs) {
-            EntityRef entityRef = entityManager.create(prefab);
-            entityRef.setPersistent(false);
+            EntityBuilder entityBuilder = entityManager.newBuilder(prefab);
+            entityBuilder.setPersistent(false);
+            EntityRef entityRef =entityBuilder.build();
             BehaviorNodeComponent component = entityRef.getComponent(BehaviorNodeComponent.class);
             ClassMetadata<? extends Node, ?> classMetadata = nodesClassLibrary.resolve(component.type);
             if (classMetadata != null) {

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
@@ -40,11 +40,13 @@ public class BlockItemFactory {
         return newInstance(blockFamily, 1);
     }
 
-    public EntityRef newInstance(BlockFamily blockFamily, int quantity) {
-        if (blockFamily == null) {
-            return EntityRef.NULL;
-        }
-
+    /**
+     * Use this method instead of {@link #newInstance(BlockFamily)} to modify entity properties like the persistence
+     * flag before it gets created.
+     *
+     * @param blockFamily must not be null
+     */
+    public EntityBuilder newBuilder(BlockFamily blockFamily, int quantity) {
         EntityBuilder builder = entityManager.newBuilder("engine:blockItemBase");
         if (blockFamily.getArchetypeBlock().getLuminance() > 0) {
             builder.addComponent(new LightComponent());
@@ -72,6 +74,14 @@ public class BlockItemFactory {
         BlockItemComponent blockItem = builder.getComponent(BlockItemComponent.class);
         blockItem.blockFamily = blockFamily;
 
+        return builder;
+    }
+
+    public EntityRef newInstance(BlockFamily blockFamily, int quantity) {
+        if (blockFamily == null) {
+            return EntityRef.NULL;
+        }
+        EntityBuilder builder = newBuilder(blockFamily, quantity);
         return builder.build();
     }
 


### PR DESCRIPTION
Promote entity builder usage: It is just not more correct in terms of life cycle events but it is also needed for a future improvment of the autosaving.

The plan is to get rid of EntityRef#setPersistent so that it is simpler to just record the changes of non persistent entities.