### PR TITLE
Don't use the float suffix f in post_frag.glsl.

### DIFF
--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -136,7 +136,7 @@ void main() {
     bool isOceanWater = false;
 
     if (checkFlag(BLOCK_HINT_WATER_SURFACE, blockHint) && isUpside > 0.99) {
-        vec2 scaledVertexWorldPos = vertexWorldPos.xz / 32.0f;
+        vec2 scaledVertexWorldPos = vertexWorldPos.xz / 32.0;
 
         vec2 waterOffset = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.0075), scaledVertexWorldPos.y + timeToTick(time, 0.0075));
         vec2 waterOffset2 = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.005), scaledVertexWorldPos.y - timeToTick(time, 0.005));

--- a/engine/src/main/resources/assets/shaders/post_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/post_frag.glsl
@@ -111,7 +111,7 @@ void main() {
 
 #ifdef FILM_GRAIN
     vec3 noise = texture2D(texNoise, renderTargetSize * (gl_TexCoord[0].xy + noiseOffset) / noiseSize).xyz * 2.0 - 1.0;
-    finalColor.rgb += clamp(noise.xxx * grainIntensity, 0.0f, 1.0f);
+    finalColor.rgb += clamp(noise.xxx * grainIntensity, 0.0, 1.0);
 #endif
 
     // In the case the color is > 1.0 or < 0.0 despite tonemapping


### PR DESCRIPTION
Reasoning:

This should fix the following error message generated by a buggy graphic
driver(See #1215 & http://forum.terasology.org/threads/black-window-nothing.1204/):

"Only GLSL version > 110 allows postfix "F" or "f" for float
WARNING: 0:475: Only GLSL version > 110 allows postfix "F" or "f" for float"

In GLSL shader version 1.10 it is not allowed to use the suffix,
but we explictly state via #version that version 1.20 should be used.
So it is a bug if a graphic driver complains about it.