### PR TITLE
Autosave fix and cleanup

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
@@ -254,9 +254,6 @@ public class SaveTransaction extends AbstractTask {
         deltaToSave.getEntityDeltas().forEachEntry(new TLongObjectProcedure<EntityDelta>() {
             @Override
             public boolean execute(long entityId, EntityDelta delta) {
-                if (entityId >= privateEntityManager.getNextId()) {
-                    privateEntityManager.setNextId(entityId + 1);
-                }
                 if (privateEntityManager.isActiveEntity(entityId)) {
                     EntityRef entity = privateEntityManager.getEntity(entityId);
                     for (Component changedComponent: delta.getChangedComponents().values()) {
@@ -267,7 +264,7 @@ public class SaveTransaction extends AbstractTask {
                         entity.removeComponent(c);
                     }
                 } else {
-                    EntityRef created = privateEntityManager.createEntityWithId(entityId, delta.getChangedComponents().values());
+                    privateEntityManager.createEntityWithId(entityId, delta.getChangedComponents().values());
                 }
 
                 return true;

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
@@ -242,6 +242,15 @@ public class SaveTransaction extends AbstractTask {
                 return true;
             }
         });
+        deltaToSave.getDestroyedEntities().forEach(new TLongProcedure() {
+            @Override
+            public boolean execute(long entityId) {
+                if (entityId >= privateEntityManager.getNextId()) {
+                    privateEntityManager.setNextId(entityId + 1);
+                }
+                return true;
+            }
+        });
         deltaToSave.getEntityDeltas().forEachEntry(new TLongObjectProcedure<EntityDelta>() {
             @Override
             public boolean execute(long entityId, EntityDelta delta) {


### PR DESCRIPTION
The first patch fixes  a small autosave issue::

When a entity got created and detroyed between two autosaves,
then the entity manager private to the saving thread needs still to
recreate the creation of that entity to ensure that entity referenes 
to it get properly invalidated. The recrecation however failed,
sometimes, because the nextId value of the entity manager
did not get incremented properly.

Steps to reproduce: Throw a torch from a stack and recollect it. 
This causes an entity to be created and destroyed.
Without this patch you get an error message at the next
autosave(In this case it makes no diference otherwise, as the recollected torch
does not got referenced by any entity)..

The second patch ist just a cleanup in the same code area.