### PR TITLE
Extracted ChunkMath from TeraMath

### DIFF
--- a/engine-tests/src/test/java/org/terasology/math/ChunkMathTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/ChunkMathTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.math;
+
+import org.junit.Test;
+import org.terasology.config.Config;
+import org.terasology.registry.CoreRegistry;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChunkMathTest {
+
+    @Test
+    public void getEdgeRegion() {
+        Region3i region = Region3i.createFromMinAndSize(new Vector3i(16, 0, 16), new Vector3i(16, 128, 16));
+        assertEquals(Region3i.createFromMinMax(new Vector3i(16, 0, 16), new Vector3i(16, 127, 31)), ChunkMath.getEdgeRegion(region, Side.LEFT));
+    }
+
+    @Test
+    public void regionPositions() {
+        CoreRegistry.put(Config.class, new Config());
+
+        assertEquals(1, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0))).length);
+        assertEquals(1, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(31, 63, 31))).length);
+        assertEquals(2, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 63, 31))).length);
+        assertEquals(4, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 63, 32))).length);
+        assertEquals(8, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 64, 32))).length);
+        assertEquals(12, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(-1, 0, 0), new Vector3i(32, 64, 32))).length);
+
+        Vector3i[] chunks = ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 63, 31)));
+        assertEquals(new Vector3i(0, 0, 0), chunks[0]);
+        assertEquals(new Vector3i(1, 0, 0), chunks[1]);
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/math/TeraMathTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/TeraMathTest.java
@@ -16,8 +16,6 @@
 package org.terasology.math;
 
 import org.junit.Test;
-import org.terasology.config.Config;
-import org.terasology.registry.CoreRegistry;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,13 +25,6 @@ import static org.junit.Assert.fail;
 public class TeraMathTest {
 
     private static final double MAX_DOUBLE_ERROR = 0.00001;
-
-
-    @Test
-    public void getEdgeRegion() {
-        Region3i region = Region3i.createFromMinAndSize(new Vector3i(16, 0, 16), new Vector3i(16, 128, 16));
-        assertEquals(Region3i.createFromMinMax(new Vector3i(16, 0, 16), new Vector3i(16, 127, 31)), TeraMath.getEdgeRegion(region, Side.LEFT));
-    }
 
     // This function mimicks a power function using ints only
     private long longPow(int base, int exp) {
@@ -71,9 +62,9 @@ public class TeraMathTest {
                 }
 
                 try {
-                    int result = TeraMath.pow(base, exp);
+                    long result = TeraMath.pow(base, exp);
                     assertFalse("(int)" + base + "^" + exp + " did not throw an exception as expected", exception);
-                    assertEquals(base + "^" + exp, javaMathResult, (long) result);
+                    assertEquals(base + "^" + exp, javaMathResult, result);
                 } catch (ArithmeticException e) {
                     assertTrue("(int)" + base + "^" + exp + " threw an unexpected exception", exception);
                 }
@@ -108,21 +99,5 @@ public class TeraMathTest {
         if (ratio >= error) {
             fail(msg);
         }
-    }
-
-    @Test
-    public void regionPositions() {
-        CoreRegistry.put(Config.class, new Config());
-
-        assertEquals(1, TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0))).length);
-        assertEquals(1, TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(31, 63, 31))).length);
-        assertEquals(2, TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 63, 31))).length);
-        assertEquals(4, TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 63, 32))).length);
-        assertEquals(8, TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 64, 32))).length);
-        assertEquals(12, TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(-1, 0, 0), new Vector3i(32, 64, 32))).length);
-
-        Vector3i[] chunks = TeraMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(32, 63, 31)));
-        assertEquals(new Vector3i(0, 0, 0), chunks[0]);
-        assertEquals(new Vector3i(1, 0, 0), chunks[1]);
     }
 }

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.math;
+
+import org.terasology.math.geom.Vector3f;
+import org.terasology.world.chunks.ChunkConstants;
+
+/**
+ * Collection of math functions.
+ *
+ * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ */
+public final class ChunkMath {
+
+    private ChunkMath() {
+    }
+
+    /**
+     * Returns the chunk position of a given coordinate.
+     *
+     * @param x The X-coordinate of the block
+     * @return The X-coordinate of the chunk
+     */
+    public static int calcChunkPosX(int x, int chunkPowerX) {
+        return (x >> chunkPowerX);
+    }
+
+    /**
+     * Returns the chunk position of a given coordinate.
+     *
+     * @param y The Y-coordinate of the block
+     * @return The Y-coordinate of the chunk
+     */
+    public static int calcChunkPosY(int y, int chunkPowerY) {
+        return (y >> chunkPowerY);
+    }
+
+    /**
+     * Returns the chunk position of a given coordinate.
+     *
+     * @param z The Z-coordinate of the block
+     * @return The Z-coordinate of the chunk
+     */
+    public static int calcChunkPosZ(int z, int chunkPowerZ) {
+        return (z >> chunkPowerZ);
+    }
+
+    public static Vector3i calcChunkPos(Vector3i pos, Vector3i chunkPower) {
+        return calcChunkPos(pos.x, pos.y, pos.z, chunkPower);
+    }
+
+    public static Vector3i calcChunkPos(Vector3f pos) {
+        return calcChunkPos(new Vector3i(pos, 0.5f));
+    }
+
+    public static Vector3i calcChunkPos(Vector3i pos) {
+        return calcChunkPos(pos.x, pos.y, pos.z);
+    }
+
+    public static Vector3i calcChunkPos(int x, int y, int z) {
+        return calcChunkPos(x, y, z, ChunkConstants.CHUNK_POWER);
+    }
+
+    public static Vector3i[] calcChunkPos(Region3i region) {
+        return calcChunkPos(region, ChunkConstants.CHUNK_POWER);
+    }
+
+    public static Vector3i calcChunkPos(int x, int y, int z, Vector3i chunkPower) {
+        return new Vector3i(calcChunkPosX(x, chunkPower.x), calcChunkPosY(y, chunkPower.y), calcChunkPosZ(z, chunkPower.z));
+    }
+
+    public static Vector3i[] calcChunkPos(Region3i region, Vector3i chunkPower) {
+        int minX = calcChunkPosX(region.minX(), chunkPower.x);
+        int minY = calcChunkPosY(region.minY(), chunkPower.y);
+        int minZ = calcChunkPosZ(region.minZ(), chunkPower.z);
+
+        int maxX = calcChunkPosX(region.maxX(), chunkPower.x);
+        int maxY = calcChunkPosY(region.maxY(), chunkPower.y);
+        int maxZ = calcChunkPosZ(region.maxZ(), chunkPower.z);
+
+        int size = (maxX - minX + 1) * (maxY - minY + 1) * (maxZ - minZ + 1);
+
+        Vector3i[] result = new Vector3i[size];
+        int index = 0;
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    result[index++] = new Vector3i(x, y, z);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the internal position of a block within a chunk.
+     *
+     * @param blockX The X-coordinate of the block in the world
+     * @return The X-coordinate of the block within the chunk
+     */
+    public static int calcBlockPosX(int blockX, int chunkPosFilterX) {
+        return blockX & chunkPosFilterX;
+    }
+
+    public static int calcBlockPosY(int blockY, int chunkPosFilterY) {
+        return blockY & chunkPosFilterY;
+    }
+
+    /**
+     * Returns the internal position of a block within a chunk.
+     *
+     * @param blockZ The Z-coordinate of the block in the world
+     * @return The Z-coordinate of the block within the chunk
+     */
+    public static int calcBlockPosZ(int blockZ, int chunkPosFilterZ) {
+        return blockZ & chunkPosFilterZ;
+    }
+
+    public static Vector3i calcBlockPos(Vector3i worldPos) {
+        return calcBlockPos(worldPos.x, worldPos.y, worldPos.z, ChunkConstants.INNER_CHUNK_POS_FILTER);
+    }
+
+    public static Vector3i calcBlockPos(int x, int y, int z) {
+        return calcBlockPos(x, y, z, ChunkConstants.INNER_CHUNK_POS_FILTER);
+    }
+
+    public static Vector3i calcBlockPos(int x, int y, int z, Vector3i chunkFilterSize) {
+        return new Vector3i(calcBlockPosX(x, chunkFilterSize.x), calcBlockPosY(y, chunkFilterSize.y), calcBlockPosZ(z, chunkFilterSize.z));
+    }
+
+    public static Region3i getChunkRegionAroundWorldPos(Vector3i pos, int extent) {
+        Vector3i minPos = new Vector3i(-extent, -extent, -extent);
+        minPos.add(pos);
+        Vector3i maxPos = new Vector3i(extent, extent, extent);
+        maxPos.add(pos);
+
+        Vector3i minChunk = calcChunkPos(minPos);
+        Vector3i maxChunk = calcChunkPos(maxPos);
+
+        return Region3i.createFromMinMax(minChunk, maxChunk);
+    }
+
+    // TODO: This doesn't belong in this class, move it.
+    public static Side getSecondaryPlacementDirection(Vector3f direction, Vector3f normal) {
+        Side surfaceDir = Side.inDirection(normal);
+        Vector3f attachDir = surfaceDir.reverse().getVector3i().toVector3f();
+        Vector3f rawDirection = new Vector3f(direction);
+        float dot = (float) rawDirection.dot(attachDir);
+        rawDirection.sub(new Vector3f(dot * attachDir.x, dot * attachDir.y, dot * attachDir.z));
+        return Side.inDirection(rawDirection.x, rawDirection.y, rawDirection.z).reverse();
+    }
+
+    /**
+     * Produces a region containing the region touching the side of the given region, both in and outside the region.
+     *
+     * @param region
+     * @param side
+     * @return
+     */
+    public static Region3i getEdgeRegion(Region3i region, Side side) {
+        Vector3i sideDir = side.getVector3i();
+        Vector3i min = region.min();
+        Vector3i max = region.max();
+        Vector3i edgeMin = new Vector3i(min);
+        Vector3i edgeMax = new Vector3i(max);
+        if (sideDir.x < 0) {
+            edgeMin.x = min.x;
+            edgeMax.x = min.x;
+        } else if (sideDir.x > 0) {
+            edgeMin.x = max.x;
+            edgeMax.x = max.x;
+        } else if (sideDir.y < 0) {
+            edgeMin.y = min.y;
+            edgeMax.y = min.y;
+        } else if (sideDir.y > 0) {
+            edgeMin.y = max.y;
+            edgeMax.y = max.y;
+        } else if (sideDir.z < 0) {
+            edgeMin.z = min.z;
+            edgeMax.z = min.z;
+        } else if (sideDir.z > 0) {
+            edgeMin.z = max.z;
+            edgeMax.z = max.z;
+        }
+        return Region3i.createFromMinMax(edgeMin, edgeMax);
+    }
+
+    /**
+     * Populates a target array with the minimum value adjacent to each location, including the location itself.
+     * TODO: this is too specific for a general class like this. Move to a new class AbstractBatchPropagator
+     * @param source
+     * @param target
+     * @param populateMargins Whether to populate the edges of the target array
+     */
+    public static void populateMinAdjacent2D(int[] source, int[] target, int dimX, int dimY, boolean populateMargins) {
+        System.arraycopy(source, 0, target, 0, target.length);
+
+        // 0 < x < dimX - 1; 0 < y < dimY - 1
+        for (int y = 1; y < dimY - 1; ++y) {
+            for (int x = 1; x < dimX - 1; ++x) {
+                target[x + y * dimX] = Math.min(Math.min(source[x + (y - 1) * dimX], source[x + (y + 1) * dimX]),
+                        Math.min(source[x + 1 + y * dimX], source[x - 1 + y * dimX]));
+            }
+        }
+
+        if (populateMargins) {
+            // x == 0, y == 0
+            target[0] = Math.min(source[1], source[dimX]);
+
+            // 0 < x < dimX - 1, y == 0
+            for (int x = 1; x < dimX - 1; ++x) {
+                target[x] = Math.min(source[x - 1], Math.min(source[x + 1], source[x + dimX]));
+            }
+
+            // x == dimX - 1, y == 0
+            target[dimX - 1] = Math.min(source[2 * dimX - 1], source[dimX - 2]);
+
+            // 0 < y < dimY - 1
+            for (int y = 1; y < dimY - 1; ++y) {
+                // x == 0
+                target[y * dimX] = Math.min(source[dimX * (y - 1)], Math.min(source[dimX * (y + 1)], source[1 + dimX * y]));
+                // x == dimX - 1
+                target[dimX - 1 + y * dimX] = Math.min(source[dimX - 1 + dimX * (y - 1)], Math.min(source[dimX - 1 + dimX * (y + 1)], source[dimX - 2 + dimX * y]));
+            }
+            // x == 0, y == dimY - 1
+            target[dimX * (dimY - 1)] = Math.min(source[1 + dimX * (dimY - 1)], source[dimX * (dimY - 2)]);
+
+            // 0 < x < dimX - 1; y == dimY - 1
+            for (int x = 1; x < dimX - 1; ++x) {
+                target[x + dimX * (dimY - 1)] = Math.min(source[x - 1 + dimX * (dimY - 1)], Math.min(source[x + 1 + dimX * (dimY - 1)], source[x + dimX * (dimY - 2)]));
+            }
+
+            // x == dimX - 1; y == dimY - 1
+            target[dimX - 1 + dimX * (dimY - 1)] = Math.min(source[dimX - 2 + dimX * (dimY - 1)], source[dimX - 1 + dimX * (dimY - 2)]);
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/math/TeraMath.java
+++ b/engine/src/main/java/org/terasology/math/TeraMath.java
@@ -494,7 +494,9 @@ public final class TeraMath {
      *
      * @param x The X-coordinate of the block
      * @return The X-coordinate of the chunk
+     * @deprecated use ChunkMath instead
      */
+    @Deprecated
     public static int calcChunkPosX(int x, int chunkPowerX) {
         return (x >> chunkPowerX);
     }
@@ -504,7 +506,9 @@ public final class TeraMath {
      *
      * @param y The Y-coordinate of the block
      * @return The Y-coordinate of the chunk
+     * @deprecated use ChunkMath instead
      */
+    @Deprecated
     public static int calcChunkPosY(int y, int chunkPowerY) {
         return (y >> chunkPowerY);
     }
@@ -514,35 +518,65 @@ public final class TeraMath {
      *
      * @param z The Z-coordinate of the block
      * @return The Z-coordinate of the chunk
+     * @deprecated use ChunkMath instead
      */
+    @Deprecated
     public static int calcChunkPosZ(int z, int chunkPowerZ) {
         return (z >> chunkPowerZ);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcChunkPos(Vector3i pos, Vector3i chunkPower) {
         return calcChunkPos(pos.x, pos.y, pos.z, chunkPower);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcChunkPos(Vector3f pos) {
         return calcChunkPos(new Vector3i(pos, 0.5f));
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcChunkPos(Vector3i pos) {
         return calcChunkPos(pos.x, pos.y, pos.z);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcChunkPos(int x, int y, int z) {
         return calcChunkPos(x, y, z, ChunkConstants.CHUNK_POWER);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i[] calcChunkPos(Region3i region) {
         return calcChunkPos(region, ChunkConstants.CHUNK_POWER);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcChunkPos(int x, int y, int z, Vector3i chunkPower) {
         return new Vector3i(calcChunkPosX(x, chunkPower.x), calcChunkPosY(y, chunkPower.y), calcChunkPosZ(z, chunkPower.z));
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i[] calcChunkPos(Region3i region, Vector3i chunkPower) {
         int minX = calcChunkPosX(region.minX(), chunkPower.x);
         int minY = calcChunkPosY(region.minY(), chunkPower.y);
@@ -571,11 +605,17 @@ public final class TeraMath {
      *
      * @param blockX The X-coordinate of the block in the world
      * @return The X-coordinate of the block within the chunk
+     * @deprecated use ChunkMath instead
      */
+    @Deprecated
     public static int calcBlockPosX(int blockX, int chunkPosFilterX) {
         return blockX & chunkPosFilterX;
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static int calcBlockPosY(int blockY, int chunkPosFilterY) {
         return blockY & chunkPosFilterY;
     }
@@ -585,23 +625,41 @@ public final class TeraMath {
      *
      * @param blockZ The Z-coordinate of the block in the world
      * @return The Z-coordinate of the block within the chunk
+     * @deprecated use ChunkMath instead
      */
+    @Deprecated
     public static int calcBlockPosZ(int blockZ, int chunkPosFilterZ) {
         return blockZ & chunkPosFilterZ;
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcBlockPos(Vector3i worldPos) {
         return calcBlockPos(worldPos.x, worldPos.y, worldPos.z, ChunkConstants.INNER_CHUNK_POS_FILTER);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcBlockPos(int x, int y, int z) {
         return calcBlockPos(x, y, z, ChunkConstants.INNER_CHUNK_POS_FILTER);
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Vector3i calcBlockPos(int x, int y, int z, Vector3i chunkFilterSize) {
         return new Vector3i(calcBlockPosX(x, chunkFilterSize.x), calcBlockPosY(y, chunkFilterSize.y), calcBlockPosZ(z, chunkFilterSize.z));
     }
 
+    /**
+     * @deprecated use ChunkMath instead
+     */
+    @Deprecated
     public static Region3i getChunkRegionAroundWorldPos(Vector3i pos, int extent) {
         Vector3i minPos = new Vector3i(-extent, -extent, -extent);
         minPos.add(pos);
@@ -648,7 +706,9 @@ public final class TeraMath {
     /**
      * @param value
      * @return The size of a power of two - that is, the exponent.
+     * @deprecated use ChunkMath instead
      */
+    @Deprecated
     public static int sizeOfPower(int value) {
         int power = 0;
         int val = value;
@@ -707,6 +767,10 @@ public final class TeraMath {
     }
 
     // TODO: This doesn't belong in this class, move it.
+    /**
+     * @deprecated use {@link ChunkMath#getSecondaryPlacementDirection(Vector3f, Vector3f)} instead
+     */
+    @Deprecated
     public static Side getSecondaryPlacementDirection(Vector3f direction, Vector3f normal) {
         Side surfaceDir = Side.inDirection(normal);
         Vector3f attachDir = surfaceDir.reverse().getVector3i().toVector3f();
@@ -722,7 +786,9 @@ public final class TeraMath {
      * @param region
      * @param side
      * @return
+     * @deprecated use {@link ChunkMath#getEdgeRegion(Region3i, Side)}
      */
+    @Deprecated
     public static Region3i getEdgeRegion(Region3i region, Side side) {
         Vector3i sideDir = side.getVector3i();
         Vector3i min = region.min();
@@ -765,7 +831,9 @@ public final class TeraMath {
      * @param source
      * @param target
      * @param populateMargins Whether to populate the edges of the target array
+     * @deprecated move to a new class AbstractBatchPropagator
      */
+    @Deprecated
     public static void populateMinAdjacent2D(int[] source, int[] target, int dimX, int dimY, boolean populateMargins) {
         System.arraycopy(source, 0, target, 0, target.length);
 

--- a/engine/src/main/java/org/terasology/monitoring/gui/ChunkMonitorDisplay.java
+++ b/engine/src/main/java/org/terasology/monitoring/gui/ChunkMonitorDisplay.java
@@ -20,9 +20,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.monitoring.chunk.ChunkMonitor;
@@ -34,6 +36,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.world.chunks.Chunk;
 
 import javax.swing.*;
+
 import java.awt.*;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
@@ -155,7 +158,7 @@ public class ChunkMonitorDisplay extends JPanel {
     private Vector3i calcPlayerChunkPos() {
         final LocalPlayer p = CoreRegistry.get(LocalPlayer.class);
         if (p != null) {
-            return TeraMath.calcChunkPos(new Vector3i(p.getPosition()));
+            return ChunkMath.calcChunkPos(new Vector3i(p.getPosition()));
         }
         return null;
     }

--- a/engine/src/main/java/org/terasology/network/internal/NetClient.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetClient.java
@@ -23,9 +23,11 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+
 import gnu.trove.iterator.TIntIterator;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
+
 import org.jboss.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,7 @@ import org.terasology.identity.PublicIdentityCertificate;
 import org.terasology.logic.characters.PredictionSystem;
 import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.network.Client;
@@ -253,7 +256,7 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
                 Vector3i center = new Vector3i();
                 LocationComponent loc = getEntity().getComponent(ClientComponent.class).character.getComponent(LocationComponent.class);
                 if (loc != null) {
-                    center.set(TeraMath.calcChunkPos(new Vector3i(loc.getWorldPosition(), 0.5f)));
+                    center.set(ChunkMath.calcChunkPos(new Vector3i(loc.getWorldPosition(), 0.5f)));
                 }
                 Vector3i pos = null;
                 int distance = Integer.MAX_VALUE;
@@ -342,7 +345,7 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
         try {
             BlockComponent blockComp = target.getComponent(BlockComponent.class);
             if (blockComp != null) {
-                if (relevantChunks.contains(TeraMath.calcChunkPos(blockComp.getPosition()))) {
+                if (relevantChunks.contains(ChunkMath.calcChunkPos(blockComp.getPosition()))) {
                     queuedOutgoingEvents.add(NetData.EventMessage.newBuilder()
                             .setTargetBlockPos(NetMessageUtil.convert(blockComp.getPosition()))
                             .setEvent(eventSerializer.serialize(event)).build());
@@ -393,7 +396,7 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
 
     @Override
     public void onBlockChanged(Vector3i pos, Block newBlock, Block originalBlock) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(pos);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(pos);
         if (relevantChunks.contains(chunkPos)) {
             queuedOutgoingBlockChanges.add(NetData.BlockChangeMessage.newBuilder()
                     .setPos(NetMessageUtil.convert(pos))
@@ -404,7 +407,7 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
 
     @Override
     public void onBiomeChanged(Vector3i pos, Biome newBiome, Biome originalBiome) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(pos);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(pos);
         if (relevantChunks.contains(chunkPos)) {
             queuedOutgoingBiomeChanges.add(NetData.BiomeChangeMessage.newBuilder()
                     .setPos(NetMessageUtil.convert(pos))

--- a/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
@@ -23,9 +23,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.SetMultimap;
+
 import gnu.trove.iterator.TIntIterator;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
+
 import org.jboss.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +37,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.network.NetMetricSource;
@@ -297,7 +300,7 @@ public class ServerImpl implements Server {
             if (worldProvider.isBlockRelevant(pos)) {
                 worldProvider.setBlock(pos, newBlock);
             } else {
-                awaitingChunkReadyBlockUpdates.put(TeraMath.calcChunkPos(pos), blockChange);
+                awaitingChunkReadyBlockUpdates.put(ChunkMath.calcChunkPos(pos), blockChange);
             }
         }
     }
@@ -312,7 +315,7 @@ public class ServerImpl implements Server {
                 Biome newBiome = biomeManager.getBiomeByShortId((short) biomeChange.getNewBiome());
                 worldProvider.setBiome(pos, newBiome);
             } else {
-                awaitingChunkReadyBiomeUpdates.put(TeraMath.calcChunkPos(pos), biomeChange);
+                awaitingChunkReadyBiomeUpdates.put(ChunkMath.calcChunkPos(pos), biomeChange);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
@@ -18,8 +18,10 @@ package org.terasology.persistence.internal;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import gnu.trove.procedure.TLongObjectProcedure;
 import gnu.trove.procedure.TLongProcedure;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.Component;
@@ -27,6 +29,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.game.GameManifest;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
@@ -218,7 +221,7 @@ public class SaveTransaction extends AbstractTask {
                 LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
                 if (locationComponent != null) {
                     Vector3f loc = locationComponent.getWorldPosition();
-                    Vector3i chunkPos = TeraMath.calcChunkPos((int) loc.x, (int) loc.y, (int) loc.z);
+                    Vector3i chunkPos = ChunkMath.calcChunkPos((int) loc.x, (int) loc.y, (int) loc.z);
                     Collection<EntityRef> collection = chunkPosToEntitiesMap.get(chunkPos);
                     if (collection == null) {
                         collection = Lists.newArrayList();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
@@ -117,7 +118,7 @@ public class DebugOverlay extends CoreScreenLayer {
                     Vector3f pos = localPlayer.getPosition();
                     CharacterComponent character = localPlayer.getCharacterEntity().getComponent(CharacterComponent.class);
                     float yaw = (character != null) ? character.yaw : 0;
-                    Vector3i chunkPos = TeraMath.calcChunkPos((int) pos.x, (int) pos.y, (int) pos.z);
+                    Vector3i chunkPos = ChunkMath.calcChunkPos((int) pos.x, (int) pos.y, (int) pos.z);
                     return String.format(Locale.US, "Pos (%.2f, %.2f, %.2f), Chunk (%d, %d, %d), Yaw %.2f", pos.x, pos.y, pos.z, chunkPos.x, chunkPos.y, chunkPos.z, yaw);
                 }
             });

--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
@@ -101,7 +102,7 @@ public final class ChunkMeshUpdateManager {
      * immediately.
      */
     public void setCameraPosition(Vector3f cameraPosition) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(cameraPosition);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(cameraPosition);
         cameraChunkPosX = chunkPos.x;
         cameraChunkPosY = chunkPos.y;
         cameraChunkPosZ = chunkPos.z;

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -27,7 +27,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.math.Side;
-import org.terasology.math.TeraMath;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Vector3i;
 import org.terasology.network.NetworkSystem;
 import org.terasology.physics.Physics;
@@ -70,7 +70,7 @@ public class BlockItemSystem extends BaseComponentSystem {
         BlockItemComponent blockItem = item.getComponent(BlockItemComponent.class);
         BlockFamily type = blockItem.blockFamily;
         Side surfaceSide = Side.inDirection(event.getHitNormal());
-        Side secondaryDirection = TeraMath.getSecondaryPlacementDirection(event.getDirection(), event.getHitNormal());
+        Side secondaryDirection = ChunkMath.getSecondaryPlacementDirection(event.getDirection(), event.getHitNormal());
 
         BlockComponent blockComponent = event.getTarget().getComponent(BlockComponent.class);
         if (blockComponent == null) {

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
@@ -18,10 +18,11 @@ package org.terasology.world.chunks.internal;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
+
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
-import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkRegionListener;
@@ -51,7 +52,7 @@ public class ChunkRelevanceRegion {
         if (loc == null) {
             dirty = false;
         } else {
-            center.set(TeraMath.calcChunkPos(loc.getWorldPosition()));
+            center.set(ChunkMath.calcChunkPos(loc.getWorldPosition()));
             currentRegion = calculateRegion();
             dirty = true;
         }
@@ -122,7 +123,7 @@ public class ChunkRelevanceRegion {
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         if (loc != null) {
             Vector3i extents = new Vector3i(relevanceDistance.x / 2, relevanceDistance.y / 2, relevanceDistance.z / 2);
-            return Region3i.createFromCenterExtents(TeraMath.calcChunkPos(loc.getWorldPosition()), extents);
+            return Region3i.createFromCenterExtents(ChunkMath.calcChunkPos(loc.getWorldPosition()), extents);
         }
         return Region3i.EMPTY;
     }
@@ -130,7 +131,7 @@ public class ChunkRelevanceRegion {
     private Vector3i calculateCenter() {
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         if (loc != null) {
-            return TeraMath.calcChunkPos(loc.getWorldPosition());
+            return ChunkMath.calcChunkPos(loc.getWorldPosition());
         }
         return new Vector3i();
     }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -20,15 +20,18 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
+
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.TShortObjectMap;
 import gnu.trove.map.hash.TShortObjectHashMap;
 import gnu.trove.procedure.TShortObjectProcedure;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.TeraMath;
@@ -138,7 +141,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
 
     @Override
     public ChunkViewCore getSubviewAroundBlock(Vector3i blockPos, int extent) {
-        Region3i region = TeraMath.getChunkRegionAroundWorldPos(blockPos, extent);
+        Region3i region = ChunkMath.getChunkRegionAroundWorldPos(blockPos, extent);
         return createWorldView(region, new Vector3i(-region.min().x, -region.min().y, -region.min().z));
     }
 

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.TeraMath;
@@ -209,7 +210,7 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
 
     @Override
     public ChunkViewCore getSubviewAroundBlock(Vector3i blockPos, int extent) {
-        Region3i region = TeraMath.getChunkRegionAroundWorldPos(blockPos, extent);
+        Region3i region = ChunkMath.getChunkRegionAroundWorldPos(blockPos, extent);
         return createWorldView(region, new Vector3i(-region.min().x, -region.min().y, -region.min().z));
     }
 
@@ -321,7 +322,7 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
         }
 
         private int score(Vector3i chunk) {
-            Vector3i playerChunk = TeraMath.calcChunkPos(new Vector3i(localPlayer.getPosition(), 0.5f));
+            Vector3i playerChunk = ChunkMath.calcChunkPos(new Vector3i(localPlayer.getPosition(), 0.5f));
             return playerChunk.distanceSquared(chunk);
         }
     }

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -18,6 +18,7 @@ package org.terasology.world.internal;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
@@ -83,7 +84,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         }
 
         int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getBlock(TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
+        return chunks[chunkIndex].getBlock(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
     }
 
     @Override
@@ -103,7 +104,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         }
 
         int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        Vector3i blockPos = TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize);
+        Vector3i blockPos = ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize);
         return chunks[chunkIndex].getBiome(blockPos.x, blockPos.y, blockPos.z);
     }
 
@@ -134,7 +135,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         }
 
         int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getSunlight(TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
+        return chunks[chunkIndex].getSunlight(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
     }
 
     @Override
@@ -144,7 +145,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         }
 
         int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getLight(TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
+        return chunks[chunkIndex].getLight(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
     }
 
     @Override
@@ -158,7 +159,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
             throw new IllegalStateException("Attempted to modify block though an unlocked view");
         } else if (blockRegion.encompasses(blockX, blockY, blockZ)) {
             int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setBlock(TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), type);
+            chunks[chunkIndex].setBlock(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), type);
         } else {
             logger.warn("Attempt to modify block outside of the view");
         }
@@ -175,7 +176,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
             throw new IllegalStateException("Attempted to modify biome though an unlocked view");
         } else if (blockRegion.encompasses(blockX, blockY, blockZ)) {
             int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            Vector3i pos = TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize);
+            Vector3i pos = ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize);
             chunks[chunkIndex].setBiome(pos.x, pos.y, pos.z, biome);
         } else {
             logger.warn("Attempt to modify biome outside of the view");
@@ -194,7 +195,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         }
 
         int chunkIndex = relChunkIndex(x, y, z);
-        return chunks[chunkIndex].getLiquid(TeraMath.calcBlockPos(x, y, z, chunkFilterSize));
+        return chunks[chunkIndex].getLiquid(ChunkMath.calcBlockPos(x, y, z, chunkFilterSize));
     }
 
     @Override
@@ -206,7 +207,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     public void setLiquid(int x, int y, int z, LiquidData newState) {
         if (locked.get() && blockRegion.encompasses(x, y, z)) {
             int chunkIndex = relChunkIndex(x, y, z);
-            chunks[chunkIndex].setLiquid(TeraMath.calcBlockPos(x, y, z, chunkFilterSize), newState);
+            chunks[chunkIndex].setLiquid(ChunkMath.calcBlockPos(x, y, z, chunkFilterSize), newState);
         } else {
             throw new IllegalStateException("Attempted to modify liquid data though an unlocked view");
         }
@@ -221,7 +222,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     public void setLight(int blockX, int blockY, int blockZ, byte light) {
         if (locked.get() && blockRegion.encompasses(blockX, blockY, blockZ)) {
             int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setLight(TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), light);
+            chunks[chunkIndex].setLight(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), light);
         } else if (!locked.get()) {
             throw new IllegalStateException("Attempted to modify light though an unlocked view");
         } else {
@@ -238,7 +239,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     public void setSunlight(int blockX, int blockY, int blockZ, byte light) {
         if (locked.get() && blockRegion.encompasses(blockX, blockY, blockZ)) {
             int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setSunlight(TeraMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), light);
+            chunks[chunkIndex].setSunlight(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), light);
         } else {
             throw new IllegalStateException("Attempted to modify sunlight though an unlocked view");
         }
@@ -246,7 +247,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
 
     @Override
     public void setDirtyAround(Vector3i blockPos) {
-        for (Vector3i pos : TeraMath.getChunkRegionAroundWorldPos(blockPos, 1)) {
+        for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(blockPos, 1)) {
             chunks[pos.x + offset.x + chunkRegion.size().x * (pos.z + offset.z)].setDirty(true);
         }
     }
@@ -258,8 +259,8 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         Vector3i maxPos = new Vector3i(region.max());
         maxPos.add(1, 1, 1);
 
-        Vector3i minChunk = TeraMath.calcChunkPos(minPos, chunkPower);
-        Vector3i maxChunk = TeraMath.calcChunkPos(maxPos, chunkPower);
+        Vector3i minChunk = ChunkMath.calcChunkPos(minPos, chunkPower);
+        Vector3i maxChunk = ChunkMath.calcChunkPos(maxPos, chunkPower);
 
         for (Vector3i pos : Region3i.createFromMinMax(minChunk, maxChunk)) {
             chunks[pos.x + offset.x + chunkRegion.size().x * (pos.z + offset.z)].setDirty(true);
@@ -302,9 +303,9 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     }
 
     protected int relChunkIndex(int x, int y, int z) {
-        return TeraMath.calculate3DArrayIndex(TeraMath.calcChunkPosX(x, chunkPower.x) + offset.x,
-                TeraMath.calcChunkPosY(y, chunkPower.y) + offset.y,
-                TeraMath.calcChunkPosZ(z, chunkPower.z) + offset.z, chunkRegion.size());
+        return TeraMath.calculate3DArrayIndex(ChunkMath.calcChunkPosX(x, chunkPower.x) + offset.x,
+                ChunkMath.calcChunkPosY(y, chunkPower.y) + offset.y,
+                ChunkMath.calcChunkPosZ(z, chunkPower.z) + offset.z, chunkRegion.size());
     }
 
     public void setChunkSize(Vector3i chunkSize) {

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -21,11 +21,13 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
@@ -164,12 +166,12 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public boolean isBlockRelevant(int x, int y, int z) {
-        return chunkProvider.isChunkReady(TeraMath.calcChunkPos(x, y, z));
+        return chunkProvider.isChunkReady(ChunkMath.calcChunkPos(x, y, z));
     }
 
     @Override
     public boolean isRegionRelevant(Region3i region) {
-        for (Vector3i chunkPos : TeraMath.calcChunkPos(region)) {
+        for (Vector3i chunkPos : ChunkMath.calcChunkPos(region)) {
             if (!chunkProvider.isChunkReady(chunkPos)) {
                 return false;
             }
@@ -179,10 +181,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public Block setBlock(Vector3i worldPos, Block type) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(worldPos);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(worldPos);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(worldPos);
+            Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
             chunk.lock();
             Block oldBlockType = chunk.setBlock(blockPos, type);
             chunk.unlock();
@@ -193,7 +195,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 } else {
                     oldChange.setTo(type);
                 }
-                for (Vector3i pos : TeraMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
+                for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
                     RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
                     if (dirtiedChunk != null) {
                         dirtiedChunk.setDirty(true);
@@ -229,12 +231,12 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public boolean setLiquid(int x, int y, int z, LiquidData newState, LiquidData oldState) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(x, y, z);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             chunk.lock();
             try {
-                Vector3i blockPos = TeraMath.calcBlockPos(x, y, z);
+                Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
                 LiquidData liquidState = chunk.getLiquid(blockPos);
                 if (liquidState.equals(oldState)) {
                     chunk.setLiquid(blockPos, newState);
@@ -249,10 +251,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public LiquidData getLiquid(int x, int y, int z) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(x, y, z);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(x, y, z);
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getLiquid(blockPos);
         }
         logger.warn("Attempted to access unavailable chunk via liquid data at {}, {}, {}", x, y, z);
@@ -261,10 +263,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public Block getBlock(int x, int y, int z) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(x, y, z);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(x, y, z);
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getBlock(blockPos);
         }
         logger.warn("Attempted to access unavailable chunk via block at {}, {}, {}", x, y, z);
@@ -273,10 +275,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public Biome getBiome(Vector3i pos) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(pos);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(pos);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(pos);
+            Vector3i blockPos = ChunkMath.calcBlockPos(pos);
             return chunk.getBiome(blockPos.x, blockPos.y, blockPos.z);
         }
         logger.warn("Attempted to access unavailable chunk via block at {}, {}, {}", pos.x, pos.y, pos.z);
@@ -285,10 +287,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public Biome setBiome(Vector3i worldPos, Biome biome) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(worldPos);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(worldPos);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(worldPos);
+            Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
             chunk.lock();
             Biome oldBiomeType = chunk.setBiome(blockPos.x, blockPos.y, blockPos.z, biome);
             chunk.unlock();
@@ -299,7 +301,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 } else {
                     oldChange.setTo(biome);
                 }
-                for (Vector3i pos : TeraMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
+                for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
                     RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
                     if (dirtiedChunk != null) {
                         dirtiedChunk.setDirty(true);
@@ -315,10 +317,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public byte getLight(int x, int y, int z) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(x, y, z);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         LitChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(x, y, z);
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getLight(blockPos);
         }
         logger.warn("Attempted to access unavailable chunk via light at {}, {}, {}", x, y, z);
@@ -327,10 +329,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public byte getSunlight(int x, int y, int z) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(x, y, z);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         LitChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(x, y, z);
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getSunlight(blockPos);
         }
         logger.warn("Attempted to access unavailable chunk via sunlight at {}, {}, {}", x, y, z);
@@ -339,10 +341,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public byte getTotalLight(int x, int y, int z) {
-        Vector3i chunkPos = TeraMath.calcChunkPos(x, y, z);
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         LitChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            Vector3i blockPos = TeraMath.calcBlockPos(x, y, z);
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return (byte) Math.max(chunk.getSunlight(blockPos), chunk.getLight(blockPos));
         }
         logger.warn("Attempted to access unavailable chunk via total light at {}, {}, {}", x, y, z);

--- a/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.propagation;
 
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.world.block.Block;
@@ -38,14 +39,14 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
 
     private Chunk getChunk(Vector3i pos) {
 
-        return chunkProvider.getChunk(TeraMath.calcChunkPos(pos));
+        return chunkProvider.getChunk(ChunkMath.calcChunkPos(pos));
     }
 
     @Override
     public byte getValueAt(Vector3i pos) {
         LitChunk chunk = getChunk(pos);
         if (chunk != null) {
-            return getValueAt(chunk, TeraMath.calcBlockPos(pos.x, pos.y, pos.z));
+            return getValueAt(chunk, ChunkMath.calcBlockPos(pos.x, pos.y, pos.z));
         }
         return UNAVAILABLE;
     }
@@ -61,8 +62,8 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
 
     @Override
     public void setValueAt(Vector3i pos, byte value) {
-        setValueAt(getChunk(pos), TeraMath.calcBlockPos(pos.x, pos.y, pos.z), value);
-        for (Vector3i affectedChunkPos : TeraMath.getChunkRegionAroundWorldPos(pos, 1)) {
+        setValueAt(getChunk(pos), ChunkMath.calcBlockPos(pos.x, pos.y, pos.z), value);
+        for (Vector3i affectedChunkPos : ChunkMath.getChunkRegionAroundWorldPos(pos, 1)) {
             Chunk dirtiedChunk = chunkProvider.getChunk(affectedChunkPos);
             if (dirtiedChunk != null) {
                 dirtiedChunk.setDirty(true);
@@ -81,9 +82,9 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
 
     @Override
     public Block getBlockAt(Vector3i pos) {
-        CoreChunk chunk = chunkProvider.getChunk(TeraMath.calcChunkPos(pos));
+        CoreChunk chunk = chunkProvider.getChunk(ChunkMath.calcChunkPos(pos));
         if (chunk != null) {
-            return chunk.getBlock(TeraMath.calcBlockPos(pos));
+            return chunk.getBlock(ChunkMath.calcBlockPos(pos));
         }
         return null;
     }

--- a/engine/src/main/java/org/terasology/world/propagation/LocalChunkView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/LocalChunkView.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.propagation;
 
+import org.terasology.math.ChunkMath;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.world.block.Block;
@@ -38,16 +39,16 @@ public class LocalChunkView implements PropagatorWorldView {
     }
 
     private int chunkIndexOf(Vector3i blockPos) {
-        return TeraMath.calcChunkPosX(blockPos.x, ChunkConstants.POWER_X) - topLeft.x
-                + 3 * (TeraMath.calcChunkPosY(blockPos.y, ChunkConstants.POWER_Y) - topLeft.y
-                + 3 * (TeraMath.calcChunkPosZ(blockPos.z, ChunkConstants.POWER_Z) - topLeft.z));
+        return ChunkMath.calcChunkPosX(blockPos.x, ChunkConstants.POWER_X) - topLeft.x
+                + 3 * (ChunkMath.calcChunkPosY(blockPos.y, ChunkConstants.POWER_Y) - topLeft.y
+                + 3 * (ChunkMath.calcChunkPosZ(blockPos.z, ChunkConstants.POWER_Z) - topLeft.z));
     }
 
     @Override
     public byte getValueAt(Vector3i pos) {
         Chunk chunk = chunks[chunkIndexOf(pos)];
         if (chunk != null) {
-            return rules.getValue(chunk, TeraMath.calcBlockPos(pos));
+            return rules.getValue(chunk, ChunkMath.calcBlockPos(pos));
         }
         return UNAVAILABLE;
     }
@@ -56,7 +57,7 @@ public class LocalChunkView implements PropagatorWorldView {
     public void setValueAt(Vector3i pos, byte value) {
         Chunk chunk = chunks[chunkIndexOf(pos)];
         if (chunk != null) {
-            rules.setValue(chunk, TeraMath.calcBlockPos(pos), value);
+            rules.setValue(chunk, ChunkMath.calcBlockPos(pos), value);
         }
     }
 
@@ -65,7 +66,7 @@ public class LocalChunkView implements PropagatorWorldView {
         int index = chunkIndexOf(pos);
         Chunk chunk = chunks[index];
         if (chunk != null) {
-            return chunk.getBlock(TeraMath.calcBlockPos(pos));
+            return chunk.getBlock(ChunkMath.calcBlockPos(pos));
         }
         return null;
     }

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -17,9 +17,10 @@ package org.terasology.world.propagation;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
-import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.ChunkConstants;
@@ -240,7 +241,7 @@ public class StandardBatchPropagator implements BatchPropagator {
     public void propagateBetween(LitChunk chunk, LitChunk adjChunk, Side side, boolean propagateExternal) {
         IndexProvider indexProvider = createIndexProvider(side);
 
-        Region3i edgeRegion = TeraMath.getEdgeRegion(Region3i.createFromMinAndSize(Vector3i.zero(), ChunkConstants.CHUNK_SIZE), side);
+        Region3i edgeRegion = ChunkMath.getEdgeRegion(Region3i.createFromMinAndSize(Vector3i.zero(), ChunkConstants.CHUNK_SIZE), side);
 
         int edgeSize = edgeRegion.size().x * edgeRegion.size().y * edgeRegion.size().z;
         int[] depth = new int[edgeSize];
@@ -255,7 +256,7 @@ public class StandardBatchPropagator implements BatchPropagator {
         int[] adjDepth = new int[depths.length];
         int dimA = (side == Side.LEFT || side == Side.RIGHT) ? ChunkConstants.SIZE_Y : ChunkConstants.SIZE_X;
         int dimB = (side == Side.FRONT || side == Side.BACK) ? ChunkConstants.SIZE_Y : ChunkConstants.SIZE_Z;
-        TeraMath.populateMinAdjacent2D(depths, adjDepth, dimA, dimB, !propagateExternal);
+        ChunkMath.populateMinAdjacent2D(depths, adjDepth, dimA, dimB, !propagateExternal);
 
         if (propagateExternal) {
             for (int y = 0; y < dimB; ++y) {

--- a/engine/src/main/java/org/terasology/world/propagation/SunlightRegenBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/SunlightRegenBatchPropagator.java
@@ -16,8 +16,9 @@
 package org.terasology.world.propagation;
 
 import com.google.common.collect.Sets;
+
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Side;
-import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.ChunkConstants;
@@ -196,7 +197,7 @@ public class SunlightRegenBatchPropagator implements BatchPropagator {
             propagateSweep(chunk, adjChunk, depth, startingRegen);
 
             int[] adjDepths = new int[depth.length];
-            TeraMath.populateMinAdjacent2D(depth, adjDepths, ChunkConstants.SIZE_X, ChunkConstants.SIZE_Z, !propagateExternal);
+            ChunkMath.populateMinAdjacent2D(depth, adjDepths, ChunkConstants.SIZE_X, ChunkConstants.SIZE_Z, !propagateExternal);
             if (propagateExternal) {
                 for (int z = 0; z < ChunkConstants.SIZE_Z; ++z) {
                     adjDepths[z * ChunkConstants.SIZE_X] = 0;
@@ -209,7 +210,7 @@ public class SunlightRegenBatchPropagator implements BatchPropagator {
             }
 
             int[] adjStartingRegen = new int[depth.length];
-            TeraMath.populateMinAdjacent2D(startingRegen, adjStartingRegen, ChunkConstants.SIZE_X, ChunkConstants.SIZE_Z, true);
+            ChunkMath.populateMinAdjacent2D(startingRegen, adjStartingRegen, ChunkConstants.SIZE_X, ChunkConstants.SIZE_Z, true);
 
             markForPropagation(adjChunk, depth, startingRegen, adjDepths, adjStartingRegen);
         }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/HeightMapSurfaceHeightProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/HeightMapSurfaceHeightProvider.java
@@ -16,9 +16,11 @@
 package org.terasology.core.world.generator.facetProviders;
 
 import com.google.common.collect.Sets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.Assets;
+import org.terasology.math.ChunkMath;
 import org.terasology.math.Rect2i;
 import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
@@ -76,7 +78,7 @@ public class HeightMapSurfaceHeightProvider implements FacetProvider {
 
         Set<Vector3i> chunkCoordinates = Sets.newHashSet();
         for (Vector3i pos : border.expandTo3D(region.getRegion())) {
-            chunkCoordinates.add(TeraMath.calcChunkPos(pos));
+            chunkCoordinates.add(ChunkMath.calcChunkPos(pos));
         }
 
         for (Vector3i chunkCoordinate : chunkCoordinates) {
@@ -101,7 +103,7 @@ public class HeightMapSurfaceHeightProvider implements FacetProvider {
                     chunkWorldRegion.sizeZ());
 
             for (Vector2i pos : worldRegion) {
-                Vector3i localPos = TeraMath.calcBlockPos(new Vector3i(pos.x, 0, pos.y));
+                Vector3i localPos = ChunkMath.calcBlockPos(new Vector3i(pos.x, 0, pos.y));
                 int x = localPos.x;
                 int z = localPos.z;
                 //calculate avg height


### PR DESCRIPTION
The goal of this PR is to prepare moving the TeraMath class to the project TeraMath, where it is needed. In the next iteration, `Vector3i`, `Region3i`, etc. can be moved there also.

I therefore split the class into *general* math code that stays (can be moved transparently to TeraMath later) and *chunk/block-related* code, which shouldn't be in a generic math library. This is now in `ChunkMath`.

I guess that ChunkMath is not ideal for all methods. Some should be somewhere else, but the focus here is on the TeraMath refactoring.

This PR already fixes all uses in engine and Core and supports a transition phase for modules through the `@Deprecate` annotation.