### PR TITLE
Don't track changes of non persistent entities for autosave

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -343,9 +343,4 @@ public class StorageManagerTest {
 
         assertTrue(character.isActive());
     }
-
-    @Test
-    public void ignoresDestroyOfUnreferencedEntity() {
-        esm.onEntityDestroyed(3);
-    }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -73,13 +73,6 @@ public abstract class EntityRef implements MutableComponentContainer {
     public abstract boolean isPersistent();
 
     /**
-     * Sets whether this entity should be saved
-     *
-     * @param persistent
-     */
-    public abstract void setPersistent(boolean persistent);
-
-    /**
      * @return Whether this entity should remain active even when the part of the world/owner of the entity is not
      *         relevant
      */

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -45,17 +45,6 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public void setPersistent(boolean persistent) {
-        if (exists()) {
-            EntityInfoComponent info = getEntityInfo();
-            if (info.persisted != persistent) {
-                info.persisted = persistent;
-                saveComponent(info);
-            }
-        }
-    }
-
-    @Override
     public boolean isAlwaysRelevant() {
         return isActive() && getEntityInfo().alwaysRelevant;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityDestroySubscriber.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityDestroySubscriber.java
@@ -15,11 +15,22 @@
  */
 package org.terasology.entitySystem.entity.internal;
 
+import org.terasology.entitySystem.entity.EntityRef;
+
 /**
+ * See {@link EngineEntityManager#subscribeForDestruction(EntityDestroySubscriber)}.
+ *
  * @author Immortius
+ * @author Florian <florian@fkoeberle.de>
  */
 public interface EntityDestroySubscriber {
 
-    void onEntityDestroyed(long entityId);
+    /**
+     * At the point this method gets called the entity has still it's components, it should however not be modified
+     * anymore.
+     *
+     * @param entity that is about to be destroyed.
+     */
+    void onEntityDestroyed(EntityRef entity);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
@@ -20,6 +20,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.internal.NullPrefab;
 import org.terasology.network.Replicate;
+import org.terasology.persistence.StorageManager;
 
 /**
  * Component for storing entity system information on an entity
@@ -28,6 +29,10 @@ import org.terasology.network.Replicate;
  */
 public class EntityInfoComponent implements Component {
     public Prefab parentPrefab = new NullPrefab();
+    /**
+     * To simplify things for the {@link StorageManager} the persistent property of entities must not be changed
+     * after creation.
+     */
     public boolean persisted = true;
 
     @Replicate

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
@@ -99,11 +99,7 @@ public final class NullEntityRef extends EntityRef {
     public boolean isPersistent() {
         return false;
     }
-
-    @Override
-    public void setPersistent(boolean persistent) {
-    }
-
+    
     @Override
     public boolean isAlwaysRelevant() {
         return false;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -548,10 +548,10 @@ public class PojoEntityManager implements LowLevelEntityManager, EngineEntityMan
         for (Component comp : store.iterateComponents(entityId)) {
             notifyComponentRemoved(ref, comp.getClass());
         }
-        destroy(ref);
         for (EntityDestroySubscriber destroySubscriber : destroySubscribers) {
-            destroySubscriber.onEntityDestroyed(entityId);
+            destroySubscriber.onEntityDestroyed(ref);
         }
+        destroy(ref);
     }
 
     private void destroy(EntityRef ref) {

--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
@@ -89,11 +89,6 @@ public class DelayedEntityRef extends EntityRef {
     }
 
     @Override
-    public void setPersistent(boolean persistent) {
-        getEntityRef().setPersistent(persistent);
-    }
-
-    @Override
     public boolean isAlwaysRelevant() {
         return getEntityRef().isAlwaysRelevant();
     }

--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRefCopyStrategy.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRefCopyStrategy.java
@@ -19,7 +19,8 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.reflection.copy.CopyStrategy;
 
 /**
- * This copy strategy return {@link DelayedEntityRef}s. See that class for more info.
+ * This copy strategy return {@link DelayedEntityRef}s for persistent entities that exists.
+ * For non persistent entities or entities that do no longer exist it returns {@link EntityRef#NULL}.
  *
  * @author Florian <florian@fkoeberle.de>
  */
@@ -34,7 +35,11 @@ class DelayedEntityRefCopyStrategy implements CopyStrategy<EntityRef> {
     @Override
     public EntityRef copy(EntityRef value) {
         if (value != null) {
-            return delayedEntityRefFactory.createDelayedEntityRef(value.getId());
+            if (value.exists() && value.isPersistent()) {
+                return delayedEntityRefFactory.createDelayedEntityRef(value.getId());
+            } else {
+                return EntityRef.NULL;
+            }
         } else {
             return null;
         }

--- a/engine/src/main/java/org/terasology/persistence/internal/EntitySetDeltaRecorder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/EntitySetDeltaRecorder.java
@@ -58,19 +58,25 @@ class EntitySetDeltaRecorder {
     }
 
     public void onEntityComponentAdded(EntityRef entity, Class<? extends Component> componentClass) {
-        onEntityComponentChange(entity, componentClass);
+        if (entity.isPersistent()) {
+            onEntityComponentChange(entity, componentClass);
+        }
     }
 
     public void onEntityComponentChange(EntityRef entity, Class<? extends Component> componentClass) {
-        EntityDelta entityDelta = getOrCreateEntityDeltaFor(entity);
-        Component component = entity.getComponent(componentClass);
-        Component componentSnapshot = componentLibrary.copy(component);
-        entityDelta.setChangedComponent(componentSnapshot);
+        if (entity.isPersistent()) {
+            EntityDelta entityDelta = getOrCreateEntityDeltaFor(entity);
+            Component component = entity.getComponent(componentClass);
+            Component componentSnapshot = componentLibrary.copy(component);
+            entityDelta.setChangedComponent(componentSnapshot);
+        }
     }
 
     public void onEntityComponentRemoved(EntityRef entity, Class<? extends Component> component){
-        EntityDelta entityDelta = getOrCreateEntityDeltaFor(entity);
-        entityDelta.removeComponent(component);
+        if (entity.isPersistent()) {
+            EntityDelta entityDelta = getOrCreateEntityDeltaFor(entity);
+            entityDelta.removeComponent(component);
+        }
     }
 
     private EntityDelta getOrCreateEntityDeltaFor(EntityRef entity) {
@@ -84,8 +90,10 @@ class EntitySetDeltaRecorder {
     }
 
     public void onEntityDestroyed(EntityRef entity) {
-        entityDeltas.remove(entity.getId());
-        destroyedEntities.add(entity.getId());
+        if (entity.isPersistent()) {
+            entityDeltas.remove(entity.getId());
+            destroyedEntities.add(entity.getId());
+        }
     }
 
     public TLongObjectMap<EntityDelta> getEntityDeltas() {
@@ -101,15 +109,19 @@ class EntitySetDeltaRecorder {
     }
 
     public void onReactivation(EntityRef entity, Collection<Component> components) {
-        EntityDelta entityDelta = getOrCreateEntityDeltaFor(entity);
-        for (Component component : components) {
-            Component componentSnapshot = componentLibrary.copy(component);
-            entityDelta.setChangedComponent(componentSnapshot);
+        if (entity.isPersistent()) {
+            EntityDelta entityDelta = getOrCreateEntityDeltaFor(entity);
+            for (Component component : components) {
+                Component componentSnapshot = componentLibrary.copy(component);
+                entityDelta.setChangedComponent(componentSnapshot);
+            }
         }
     }
 
     public void onBeforeDeactivation(EntityRef entity, Collection<Component> components) {
-        deactivatedEntities.add(entity.getId());
+        if (entity.isPersistent()) {
+            deactivatedEntities.add(entity.getId());
+        }
     }
 
     public void registerDelayedEntityRef(DelayedEntityRef delayedEntity) {

--- a/engine/src/main/java/org/terasology/persistence/internal/EntitySetDeltaRecorder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/EntitySetDeltaRecorder.java
@@ -83,9 +83,9 @@ class EntitySetDeltaRecorder {
         return entityDelta;
     }
 
-    public void onEntityDestroyed(long entityId) {
-        entityDeltas.remove(entityId);
-        destroyedEntities.add(entityId);
+    public void onEntityDestroyed(EntityRef entity) {
+        entityDeltas.remove(entity.getId());
+        destroyedEntities.add(entity.getId());
     }
 
     public TLongObjectMap<EntityDelta> getEntityDeltas() {

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
@@ -27,14 +27,12 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.entity.internal.EntityChangeSubscriber;
 import org.terasology.entitySystem.entity.internal.EntityDestroySubscriber;
-import org.terasology.entitySystem.entity.internal.OwnershipHelper;
 import org.terasology.entitySystem.entity.internal.PojoEntityManager;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.systems.ComponentSystem;
 import org.terasology.game.Game;
 import org.terasology.game.GameManifest;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.AABB;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.module.Module;
@@ -346,8 +344,8 @@ public final class ReadWriteStorageManager extends AbstractStorageManager implem
     }
 
     @Override
-    public void onEntityDestroyed(long entityId) {
-        entitySetDeltaRecorder.onEntityDestroyed(entityId);
+    public void onEntityDestroyed(EntityRef entity) {
+        entitySetDeltaRecorder.onEntityDestroyed(entity);
     }
 
     private void addGameManifestToSaveTransaction(SaveTransactionBuilder saveTransactionBuilder) {

--- a/engine/src/main/resources/assets/prefabs/player/player.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/player.prefab
@@ -1,5 +1,5 @@
 {
-    "persisted" : false,
+    "persisted" : true,
     "Location" : {
         "replicateChanges" : false
     },


### PR DESCRIPTION
While it is a performance optimization that isn't based on any profiling I think it is reasonable to do it: This change basically halves the memory usage for non persistent entities.

See comments of commits for further details.