### PR TITLE
Ignore test classes for reflection cache in modules

### DIFF
--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -219,7 +219,7 @@ task createSkeleton() {
 
 task cacheReflections {
     description = 'Caches reflection output to make regular startup faster. May go stale and need cleanup at times.'
-    inputs.files project.classes.outputs.files
+    inputs.files sourceSets.main.output
     outputs.file file(sourceSets.main.output.classesDir.toString() + "/reflections.cache")
     dependsOn classes
     doFirst {

--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -219,14 +219,16 @@ task createSkeleton() {
 
 task cacheReflections {
     description = 'Caches reflection output to make regular startup faster. May go stale and need cleanup at times.'
-    inputs.files sourceSets.main.output
+    // TODO: The extra "org" qualifier excludes test classes otherwise sucked up in Jenkins, causing issues. Redo later
+    File dirToReflect = new File(sourceSets.main.output.classesDir, "org")
+    inputs.files dirToReflect
     outputs.file file(sourceSets.main.output.classesDir.toString() + "/reflections.cache")
     dependsOn classes
     doFirst {
         // Without the .mkdirs() we might hit a scenario where the classes dir doesn't exist yet
-        file(sourceSets.main.output.classesDir.toString()).mkdirs()
+        dirToReflect.mkdirs()
         Reflections reflections = new ConfigurationBuilder()
-                .addUrls(sourceSets.main.output.classesDir.toURI().toURL())
+                .addUrls(dirToReflect.toURI().toURL())
                 .setScanners(new TypeAnnotationsScanner(), new SubTypesScanner())
                 .build()
         reflections.save(sourceSets.main.output.classesDir.toString() + "/reflections.cache")


### PR DESCRIPTION
This is one way to fix #1558 although it is a bit of a goofy way (bases the origin dir to scan on `<classes>/org` which avoids `<classes>/test/org`). Better to tidy up the organization of tests / dependency order but that's a bigger change.

I've tested it with Pathfinding: the reflection cache file is smaller with the Nanoware fork's Core build.gradle (http://jenkins.terasology.org/view/Nanoware/job/NanoPathfinding/lastSuccessfulBuild/artifact/build/libs/Pathfinding-0.1.0-SNAPSHOT.jar) vs the regular Pathfinding. No more crashing with the new jar.

@immortius any concerns?