### PR TITLE
Log non RuntimeExceptions too.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -381,6 +381,9 @@ public class TerasologyEngine implements GameEngine {
                 logger.error("Rethrowing original exception");
             }
             throw e;
+        } catch (Throwable t) {
+            logger.error("Uncaught throwable", t);
+            throw t;
         }
     }
 


### PR DESCRIPTION
Reasoning: Previously NoClassDefFoundError resulted in a silent crash,
if you started the game without crash reporter.