### PR TITLE
Prevent an index out of bounds exception due to negative noise.

### DIFF
--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/FloraRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/FloraRasterizer.java
@@ -78,7 +78,7 @@ public class FloraRasterizer implements WorldRasterizer {
 
                 FloraType type = entries.get(pos);
                 List<Block> list = flora.get(type);
-                int blockIdx = noise.intNoise(pos.x, pos.y, pos.z) % list.size();
+                int blockIdx = Math.abs(noise.intNoise(pos.x, pos.y, pos.z)) % list.size();
                 Block block = list.get(blockIdx);
                 chunk.setBlock(pos, block);
             }


### PR DESCRIPTION
@msteiger  please review. I am not sure if it is intended that intNoise returns negative numbers. Also there is no javadoc on the intNoise method. Could you add some please? I would find it interesting to know what the expected return values are. e.g. if they are supposed to be negative or not.