### PR TITLE
Fix issues with too much vegetation being generated

### DIFF
--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/DefaultTreeProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/DefaultTreeProvider.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.core.world.generator.facetProviders;
 
-import java.util.List;
-
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
 import org.terasology.core.world.CoreBiome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
 import org.terasology.core.world.generator.facets.TreeFacet;
@@ -38,8 +38,7 @@ import org.terasology.world.generation.Requires;
 import org.terasology.world.generation.facets.SeaLevelFacet;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
+import java.util.List;
 
 /**
  * Determines where trees can be placed.  Will put trees one block above the surface.
@@ -90,7 +89,7 @@ public class DefaultTreeProvider extends SurfaceObjectProvider<Biome, TreeGenera
         List<Predicate<Vector3i>> filters = Lists.newArrayList();
 
         filters.add(PositionFilters.minHeight(seaLevel.getSeaLevel()));
-        filters.add(PositionFilters.probability(densityNoiseGen, configuration.density * 0.1f));
+        filters.add(PositionFilters.probability(densityNoiseGen, configuration.density * 0.05f));
         filters.add(PositionFilters.flatness(surface, 1, 0));
 
         // these value are derived from the maximum tree extents as

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/PositionFilters.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/PositionFilters.java
@@ -16,13 +16,12 @@
 
 package org.terasology.core.world.generator.facetProviders;
 
+import com.google.common.base.Predicate;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
 import org.terasology.utilities.procedural.Noise;
 import org.terasology.world.generation.facets.DensityFacet;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
-
-import com.google.common.base.Predicate;
 
 /**
  * A collection of filters that restrict the placement of objects
@@ -137,7 +136,7 @@ public final class PositionFilters {
 
             @Override
             public boolean apply(Vector3i input) {
-                return noiseGen.noise(input.getX(), input.getY(), input.getZ()) < density;
+                return Math.abs(noiseGen.noise(input.getX(), input.getY(), input.getZ())) < density;
             }
         };
     }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SurfaceObjectProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SurfaceObjectProvider.java
@@ -16,9 +16,10 @@
 
 package org.terasology.core.world.generator.facetProviders;
 
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3i;
@@ -31,10 +32,8 @@ import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generation.facets.base.ObjectFacet2D;
 import org.terasology.world.generation.facets.base.ObjectFacet3D;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Places objects on the surface based on population densities
@@ -132,7 +131,7 @@ public abstract class SurfaceObjectProvider<B, T> implements FacetProvider {
      * @return a random pick from the map or <code>null</code>
      */
     protected T getType(int x, int z, Map<T, Float> objs) {
-        float random = typeNoiseGen.noise(x, z);
+        float random = Math.abs(typeNoiseGen.noise(x, z));
 
         for (T generator : objs.keySet()) {
             Float threshold = objs.get(generator);


### PR DESCRIPTION
- Fix some issues with [-1,1] noise being treated as [0,1] with vegetation probability.
- Half the amount of trees.

Desert
![terasology-150212154449-1152x720](https://cloud.githubusercontent.com/assets/5922109/6179697/67373cfc-b2d0-11e4-94cf-1a64e2e9a817.png)

Mountains
![terasology-150212154636-1152x720](https://cloud.githubusercontent.com/assets/5922109/6179702/71c6aaea-b2d0-11e4-8ed7-e0e3b14322e0.png)

Forest
![terasology-150212154832-1152x720](https://cloud.githubusercontent.com/assets/5922109/6179706/80b286b4-b2d0-11e4-8bdc-03762f80f457.png)

Plains (see the red tree!)
![terasology-150212155123-1152x720](https://cloud.githubusercontent.com/assets/5922109/6179707/895723ec-b2d0-11e4-9ed4-9406e956612c.png)

