### PR TITLE
Moved all opengl commands from WorldRendererLwjgl to DefaultRenderingProcess

### DIFF
--- a/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
+++ b/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
@@ -19,9 +19,7 @@ import com.google.common.collect.Lists;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.backdrop.BackdropRenderer;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
-import org.terasology.rendering.backdrop.Skysphere;
-import org.terasology.rendering.world.WorldRenderer;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 import java.util.List;
 
@@ -40,7 +38,7 @@ public class SceneProperties implements PropertyProvider {
         if (backdropRenderer != null) {
             result.addAll(new ReflectionProvider(backdropRenderer).getProperties());
         }
-        DefaultRenderingProcess postRenderer = DefaultRenderingProcess.getInstance();
+        LwjglRenderingProcess postRenderer = LwjglRenderingProcess.getInstance();
         if (postRenderer != null) {
             result.addAll(new ReflectionProvider(postRenderer).getProperties());
         }

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.TeraOVR;
 import org.terasology.asset.AssetManager;
+import org.terasology.audio.AudioManager;
 import org.terasology.config.Config;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
@@ -125,6 +126,8 @@ public class StateIngame implements GameState {
         eventSystem.process();
         GameThread.processWaitingProcesses();
         nuiManager.clear();
+
+        CoreRegistry.get(AudioManager.class).stopAllSounds();
 
         if (worldRenderer != null) {
             worldRenderer.dispose();

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
@@ -78,7 +78,7 @@ public class HeadlessGraphics implements EngineSubsystem {
 
         CoreRegistry.putPermanently(NUIManager.class, new NUIManagerInternal(new HeadlessCanvasRenderer()));
 
-        //        CoreRegistry.putPermanently(DefaultRenderingProcess.class, new HeadlessRenderingProcess());
+        //        CoreRegistry.putPermanently(LwjglRenderingProcess.class, new HeadlessRenderingProcess());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglRenderingSubsystemFactory.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglRenderingSubsystemFactory.java
@@ -20,7 +20,7 @@ import org.terasology.logic.players.LocalPlayerSystem;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.world.WorldRenderer;
-import org.terasology.rendering.world.WorldRendererLwjgl;
+import org.terasology.rendering.world.WorldRendererImpl;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
 
@@ -35,6 +35,6 @@ public class LwjglRenderingSubsystemFactory implements RenderingSubsystemFactory
     @Override
     public WorldRenderer createWorldRenderer(BackdropProvider backdropProvider, BackdropRenderer backdropRenderer,
                                              WorldProvider worldProvider, ChunkProvider chunkProvider, LocalPlayerSystem localPlayerSystem) {
-        return new WorldRendererLwjgl(backdropProvider, backdropRenderer, worldProvider, chunkProvider, localPlayerSystem, bufferPool);
+        return new WorldRendererImpl(backdropProvider, backdropRenderer, worldProvider, chunkProvider, localPlayerSystem, bufferPool);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -39,7 +39,7 @@ import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.asset.UIData;
 import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.layers.ingame.inventory.TransferItemCursor;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 /**
  * @author Immortius
@@ -78,7 +78,7 @@ public class MenuControlSystem extends BaseComponentSystem {
     public void onKeyDown(KeyDownEvent event, EntityRef entity) {
         switch (event.getKey().getId()) {
             case Keyboard.KeyId.F12:
-                DefaultRenderingProcess.getInstance().takeScreenshot();
+                LwjglRenderingProcess.getInstance().takeScreenshot();
                 CoreRegistry.get(AudioManager.class).playSound(Assets.getSound("engine:camera"));
                 break;
             default:

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
@@ -24,7 +24,7 @@ import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
 
@@ -108,10 +108,10 @@ public class ShaderParametersChunk extends ShaderParametersBase {
         glBindTexture(GL11.GL_TEXTURE_2D, effects.getId());
         program.setInt("textureEffects", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        DefaultRenderingProcess.getInstance().bindFboTexture("sceneReflected");
+        LwjglRenderingProcess.getInstance().bindFboTexture("sceneReflected");
         program.setInt("textureWaterReflection", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        DefaultRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+        LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
         program.setInt("texSceneOpaque", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -22,7 +22,7 @@ import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 /**
@@ -49,7 +49,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         int texId = 0;
 
-        DefaultRenderingProcess.FBO sceneOpaque = DefaultRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess.FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -69,7 +69,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
             program.setInt("texSceneOpaqueLightBuffer", texId++, true);
         }
 
-        DefaultRenderingProcess.FBO sceneReflectiveRefractive = DefaultRenderingProcess.getInstance().getFBO("sceneReflectiveRefractive");
+        LwjglRenderingProcess.FBO sceneReflectiveRefractive = LwjglRenderingProcess.getInstance().getFBO("sceneReflectiveRefractive");
 
         if (sceneReflectiveRefractive != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -93,13 +93,13 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isSsao()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
+            LwjglRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
             program.setInt("texSsao", texId++, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isOutline()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().bindFboTexture("sobel");
+            LwjglRenderingProcess.getInstance().bindFboTexture("sobel");
             program.setInt("texEdges", texId++, true);
 
             program.setFloat("outlineDepthThreshold", outlineDepthThreshold, true);
@@ -108,7 +108,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isInscattering()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
+            LwjglRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
             program.setInt("texSceneSkyBand", texId++, true);
 
             Vector4f skyInscatteringSettingsFrag = new Vector4f();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
@@ -20,7 +20,7 @@ import org.terasology.config.Config;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 /**
@@ -40,48 +40,48 @@ public class ShaderParametersDebug extends ShaderParametersBase {
         switch (config.getRendering().getDebug().getStage()) {
             case SHADOW_MAP:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
+                LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_NORMALS:
             case OPAQUE_SUNLIGHT:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboNormalsTexture("sceneOpaque");
+                LwjglRenderingProcess.getInstance().bindFboNormalsTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_DEPTH:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
+                LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_LIGHT_BUFFER:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboLightBufferTexture("sceneOpaque");
+                LwjglRenderingProcess.getInstance().bindFboLightBufferTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case TRANSPARENT_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sceneReflectiveRefractive");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sceneReflectiveRefractive");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SSAO:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
+                LwjglRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SOBEL:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sobel");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sobel");
                 program.setInt("texDebug", texId++, true);
                 break;
             case BAKED_OCCLUSION:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case RECONSTRUCTED_POSITION:
@@ -91,27 +91,27 @@ public class ShaderParametersDebug extends ShaderParametersBase {
                 }
 
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
+                LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case BLOOM:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
                 program.setInt("texDebug", texId++, true);
                 break;
             case HIGH_PASS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sceneHighPass");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sceneHighPass");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SKY_BAND:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
+                LwjglRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
                 program.setInt("texDebug", texId++, true);
                 break;
             case LIGHT_SHAFTS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                DefaultRenderingProcess.getInstance().bindFboTexture("lightShafts");
+                LwjglRenderingProcess.getInstance().bindFboTexture("lightShafts");
                 program.setInt("texDebug", texId++, true);
                 break;
             default:

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -18,7 +18,7 @@ package org.terasology.rendering.shader;
 import org.lwjgl.opengl.GL13;
 import org.terasology.editor.EditorRange;
 import org.terasology.rendering.assets.material.Material;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 /**
  * Shader parameters for the Post-processing shader program.
@@ -36,10 +36,10 @@ public class ShaderParametersHdr extends ShaderParametersBase {
         super.applyParameters(program);
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
-        DefaultRenderingProcess.getInstance().bindFboTexture("scenePrePost");
+        LwjglRenderingProcess.getInstance().bindFboTexture("scenePrePost");
 
         program.setInt("texScene", 0, true);
-        program.setFloat("exposure", DefaultRenderingProcess.getInstance().getExposure() * exposureBias, true);
+        program.setFloat("exposure", LwjglRenderingProcess.getInstance().getExposure() * exposureBias, true);
         program.setFloat("whitePoint", whitePoint, true);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -24,7 +24,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
@@ -40,7 +40,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        DefaultRenderingProcess.FBO sceneOpaque = DefaultRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess.FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         int texId = 0;
         if (sceneOpaque != null) {
@@ -59,7 +59,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isDynamicShadows()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
+            LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
             program.setInt("texSceneShadowMap", texId++, true);
 
             Camera lightCamera = CoreRegistry.get(WorldRenderer.class).getLightCamera();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -23,7 +23,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 /**
@@ -46,7 +46,7 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        DefaultRenderingProcess.FBO scene = DefaultRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess.FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
@@ -17,7 +17,7 @@ package org.terasology.rendering.shader;
 
 import org.lwjgl.opengl.GL13;
 import org.terasology.rendering.assets.material.Material;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 /**
  * Shader parameters for the Combine shader program.
@@ -32,7 +32,7 @@ public class ShaderParametersOcDistortion extends ShaderParametersBase {
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        DefaultRenderingProcess.getInstance().bindFboTexture("sceneFinal");
+        LwjglRenderingProcess.getInstance().bindFboTexture("sceneFinal");
         program.setInt("texSceneFinal", texId++, true);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -26,7 +26,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -53,12 +53,12 @@ public class ShaderParametersPost extends ShaderParametersBase {
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        DefaultRenderingProcess.getInstance().bindFboTexture("sceneToneMapped");
+        LwjglRenderingProcess.getInstance().bindFboTexture("sceneToneMapped");
         program.setInt("texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().getBlurIntensity() != 0) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().getFBO("sceneBlur1").bindTexture();
+            LwjglRenderingProcess.getInstance().getFBO("sceneBlur1").bindTexture();
             program.setInt("texBlur", texId++, true);
 
             if (cameraTargetSystem != null) {
@@ -74,7 +74,7 @@ public class ShaderParametersPost extends ShaderParametersBase {
             program.setInt("texColorGradingLut", texId++, true);
         }
 
-        DefaultRenderingProcess.FBO sceneCombined = DefaultRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess.FBO sceneCombined = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         if (sceneCombined != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
@@ -24,7 +24,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
@@ -53,12 +53,12 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        DefaultRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+        LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
         program.setInt("texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isBloom()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
+            LwjglRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
             program.setInt("texBloom", texId++, true);
 
             program.setFloat("bloomFactor", bloomFactor, true);
@@ -68,7 +68,7 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isLightShafts()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            DefaultRenderingProcess.getInstance().bindFboTexture("lightShafts");
+            LwjglRenderingProcess.getInstance().bindFboTexture("lightShafts");
             program.setInt("texLightShafts", texId++, true);
         }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -30,7 +30,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -91,7 +91,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        DefaultRenderingProcess.FBO scene = DefaultRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess.FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -18,7 +18,7 @@ package org.terasology.rendering.shader;
 import org.lwjgl.opengl.GL13;
 import org.terasology.editor.EditorRange;
 import org.terasology.rendering.assets.material.Material;
-import org.terasology.rendering.opengl.DefaultRenderingProcess;
+import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 /**
  * Shader parameters for the Post-processing shader program.
@@ -36,7 +36,7 @@ public class ShaderParametersSobel extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        DefaultRenderingProcess.FBO scene = DefaultRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess.FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);


### PR DESCRIPTION
Note: WorldRendererLwjgl has been renamed to WorldRendererImpl and DefaultRenderingProcess has been renamed to LwjglRenderingProcess, as the former is now more generic and the latter has always been
lwjgl-dependent. 

Most changes, i.e. in Shader*.java classes, are due to this renaming. The files to focus on are therefore WorldRendererImpl, LwjglRenderingProcess and StateIngame.

Also moved stopping of all sounds from WorldRenderer.dispose() to StateInGame.dispose().