### PR TITLE
Remove Slick2D dependencies

### DIFF
--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -19,7 +19,8 @@ package org.terasology;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.newdawn.slick.util.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetFactory;
 import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetType;
@@ -78,6 +79,8 @@ import static org.mockito.Mockito.mock;
  * @author Martin Steiger
  */
 public class HeadlessEnvironment extends Environment {
+
+    private static final Logger logger = LoggerFactory.getLogger(HeadlessEnvironment.class);
 
     /**
      * Setup a headless ( = no graphics ) environment
@@ -199,9 +202,9 @@ public class HeadlessEnvironment extends Environment {
 
         if (result.isSuccess()) {
             ModuleEnvironment modEnv = moduleManager.loadEnvironment(result.getModules(), true);
-            Log.debug("Loaded modules: " + modEnv.getModuleIdsOrderedByDependencies());
+            logger.debug("Loaded modules: " + modEnv.getModuleIdsOrderedByDependencies());
         } else {
-            Log.error("Could not resolve module dependencies for " + moduleNames);
+            logger.error("Could not resolve module dependencies for " + moduleNames);
         }
 
         CoreRegistry.put(ModuleManager.class, moduleManager);

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     compile group: 'java3d', name: 'vecmath', version: '1.3.1' // Note: Downgraded to this release until TeraMath ready
     compile group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.1'
     compile group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
-    compile group: 'org.newdawn.slick', name: 'slick', version: '237'
+    compile group: 'de.matthiasmann.twl', name: 'PNGDecoder', version: '1111'
 
     // Logging and audio
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.9'

--- a/engine/src/main/java/org/terasology/rendering/assets/texture/PNGTextureLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/PNGTextureLoader.java
@@ -19,7 +19,9 @@ package org.terasology.rendering.assets.texture;
 import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.newdawn.slick.opengl.PNGDecoder;
+
+import de.matthiasmann.twl.utils.PNGDecoder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetLoader;
@@ -66,7 +68,7 @@ public class PNGTextureLoader implements AssetLoader<TextureData> {
             PNGDecoder decoder = new PNGDecoder(pngStream);
 
             ByteBuffer buf = ByteBuffer.allocateDirect(4 * decoder.getWidth() * decoder.getHeight());
-            decoder.decode(buf, decoder.getWidth() * 4, PNGDecoder.RGBA);
+            decoder.decode(buf, decoder.getWidth() * 4, PNGDecoder.Format.RGBA);
             buf.flip();
 
             ByteBuffer data = buf;

--- a/engine/src/main/java/org/terasology/world/block/DefaultColorSource.java
+++ b/engine/src/main/java/org/terasology/world/block/DefaultColorSource.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.world.block;
 
-import org.newdawn.slick.util.ResourceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.geom.Vector4f;
@@ -73,8 +72,8 @@ public enum DefaultColorSource implements BlockColorSource {
     static {
         try {
             // TODO: Read these from asset manager
-            colorLut = ImageIO.read(ResourceLoader.getResource("assets/textures/grasscolor.png").openStream());
-            foliageLut = ImageIO.read(ResourceLoader.getResource("assets/textures/foliagecolor.png").openStream());
+            colorLut = ImageIO.read(DefaultColorSource.class.getResource("/assets/textures/grasscolor.png"));
+            foliageLut = ImageIO.read(DefaultColorSource.class.getResource("/assets/textures/foliagecolor.png"));
         } catch (IOException e) {
             logger.error("Failed to load LUTs", e);
         }

--- a/engine/src/main/java/org/terasology/world/block/loader/WorldAtlasImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/WorldAtlasImpl.java
@@ -23,7 +23,7 @@ import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
 import gnu.trove.procedure.TObjectIntProcedure;
 
-import org.newdawn.slick.opengl.PNGDecoder;
+import de.matthiasmann.twl.utils.PNGDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetManager;
@@ -254,7 +254,7 @@ public class WorldAtlasImpl implements WorldAtlas {
                 ImageIO.write(image, "png", bos);
                 PNGDecoder decoder = new PNGDecoder(new ByteArrayInputStream(bos.toByteArray()));
                 ByteBuffer buf = ByteBuffer.allocateDirect(4 * decoder.getWidth() * decoder.getHeight());
-                decoder.decode(buf, decoder.getWidth() * 4, PNGDecoder.RGBA);
+                decoder.decode(buf, decoder.getWidth() * 4, PNGDecoder.Format.RGBA);
                 buf.flip();
                 data[i] = buf;
             } catch (IOException e) {


### PR DESCRIPTION
I stumbled over this when I noticed a stray import on Slick's logging system in engine-tests.

Slick2D is no longer maintained and only the PNGDecoder is used. Interestingly, Slick just integrated an older version of TWL's one-class-file JAR `PNGDecoder` (X11 license).

This PR removes the dependency to Slick2D altogether and relies on the latest version of `PNGDecoder` directly. I uploaded it including source to Artifactory.