### PR TITLE
Keep the client infos even if the players leave.

### DIFF
--- a/engine/src/main/java/org/terasology/network/ClientInfoComponent.java
+++ b/engine/src/main/java/org/terasology/network/ClientInfoComponent.java
@@ -24,5 +24,14 @@ import org.terasology.entitySystem.Component;
  */
 @Replicate
 public final class ClientInfoComponent implements Component {
-    // just a marker
+
+    /**
+     * When a client connects, the game searches a client info component for the client id ({@link Client#getId()}).
+     * If it finds one it is gets reused, otherwise a new one will be created.
+     *
+     * The field does not get replicated as there is no need to tell the clients the player ids.
+     *
+     */
+    @NoReplicate
+    public String playerId;
 }

--- a/engine/src/main/resources/assets/prefabs/player/clientInfo.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/clientInfo.prefab
@@ -1,6 +1,5 @@
 {
-    // TODO: This should be persisted, but the Network component is removed while the client is disconnected
-    "persisted" : false,
+    "persisted" : true,
     "DisplayName" : {
         "name" : "Unknown",
         "description" : "A player"


### PR DESCRIPTION
Reasoning: This makes it possible in future to manage offline players.
e.g. adding rights to them or renaming them to free a name once we
introduce unique player names.

This commit makes players also keep their name/color settings accross
sessions. In the future it propably makes sense to add a commands/UI
for changing player names and colors. The current player settings UI 
can now (tempoarly?) only be used to set the initial player color and name.