### PR TITLE
Fix the headless server unable to find a world generator and other things

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyConstants.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyConstants.java
@@ -33,7 +33,7 @@ public final class TerasologyConstants {
     public static final String MAIN_WORLD = "main";
     public static final Charset CHARSET = Charsets.UTF_8;
     public static final Name ENGINE_MODULE = new Name("engine");
-    public static final Name CORE_MODULE = new Name("core");
+    public static final Name CORE_GAMEPLAY_MODULE = new Name("coresamplegameplay");
     public static final String ASSETS_SUBDIRECTORY = "assets";
     public static final String OVERRIDES_SUBDIRECTORY = "overrides";
     public static final String DELTAS_SUBDIRECTORY = "deltas";

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -19,7 +19,6 @@ package org.terasology.engine;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetFactory;
@@ -216,8 +215,8 @@ public class TerasologyEngine implements GameEngine {
         } else {
             config = new Config();
         }
-        if (!config.getDefaultModSelection().hasModule(TerasologyConstants.CORE_MODULE)) {
-            config.getDefaultModSelection().addModule(TerasologyConstants.CORE_MODULE);
+        if (!config.getDefaultModSelection().hasModule(TerasologyConstants.CORE_GAMEPLAY_MODULE)) {
+            config.getDefaultModSelection().addModule(TerasologyConstants.CORE_GAMEPLAY_MODULE);
         }
 
         if (!validateServerIdentity()) {

--- a/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
@@ -16,9 +16,9 @@
 package org.terasology.engine.module;
 
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.SimpleUri;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.module.ClasspathModule;
@@ -52,8 +52,8 @@ import java.util.Set;
 public class ModuleManager {
 
     public static final String SERVER_SIDE_ONLY_EXT = "serverSideOnly";
-    public static final String IS_GAMEPLAY_EXT = "isGameplay";
-    public static final String DEFAULT_WORLD_GENERATOR_EXT = "defaultWorldGenerator";
+    private static final String IS_GAMEPLAY_EXT = "isGameplay";
+    private static final String DEFAULT_WORLD_GENERATOR_EXT = "defaultWorldGenerator";
 
     private ModuleSecurityManager moduleSecurityManager;
 
@@ -198,5 +198,9 @@ public class ModuleManager {
     public boolean isGameplayModule(Module module) {
         Boolean isGameplay = module.getMetadata().getExtension(IS_GAMEPLAY_EXT, Boolean.class);
         return isGameplay != null && isGameplay;
+    }
+
+    public SimpleUri getDefaultWorldGenerator(Module module) {
+        return new SimpleUri(module.getMetadata().getExtension(ModuleManager.DEFAULT_WORLD_GENERATOR_EXT, String.class));
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -83,8 +83,8 @@ public class StateHeadlessSetup extends StateSetup {
             for (Name moduleName : config.getDefaultModSelection().listModules()) {
                 Module module = moduleManager.getRegistry().getLatestModuleVersion(moduleName);
                 if (moduleManager.isGameplayModule(module)) {
-                    String defaultWorldGenerator = module.getMetadata().getExtension(ModuleManager.DEFAULT_WORLD_GENERATOR_EXT, String.class);
-                    worldGenConfig.setDefaultGenerator(new SimpleUri(defaultWorldGenerator));
+                    SimpleUri defaultWorldGenerator = moduleManager.getDefaultWorldGenerator(module);
+                    worldGenConfig.setDefaultGenerator(defaultWorldGenerator);
                     break;
                 }
             }


### PR DESCRIPTION
- Fix blank gameplay template drop down when first going to the create game menu.  Resolves #1610
- New behavior after selecting a gameplay template: 
 - clear all selected modules (resolves #1535)
 - find all available world generators by recursing through the module dependencies
 - always set the default world generator as per the gameplay module
- Encapsulate the module metadata extension for getting the gameplay default world generator.