### PR TITLE
Fine granular permissions

### DIFF
--- a/engine/src/main/java/org/terasology/audio/system/AudioSystem.java
+++ b/engine/src/main/java/org/terasology/audio/system/AudioSystem.java
@@ -29,6 +29,7 @@ import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
@@ -48,7 +49,7 @@ public class AudioSystem extends BaseComponentSystem implements UpdateSubscriber
     @In
     private AudioManager audioManager;
 
-    @Command(shortDescription = "Toggle muting all sound")
+    @Command(shortDescription = "Toggle muting all sound", requiredPermission = PermissionManager.NO_PERMISSION)
     public String mute(@Sender EntityRef sender) {
         audioManager.setMute(!audioManager.isMute());
         return "All sound is now " + ((audioManager.isMute()) ? "muted." : "unmuted.");

--- a/engine/src/main/java/org/terasology/input/internal/BindCommands.java
+++ b/engine/src/main/java/org/terasology/input/internal/BindCommands.java
@@ -23,6 +23,7 @@ import org.terasology.input.InputSystem;
 import org.terasology.input.Keyboard;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.registry.In;
 
 /**
@@ -34,7 +35,7 @@ public class BindCommands extends BaseComponentSystem {
     @In
     private InputSystem inputSystem;
 
-    @Command(shortDescription = "Maps a key to a function")
+    @Command(shortDescription = "Maps a key to a function", requiredPermission = PermissionManager.NO_PERMISSION)
     public String bindKey(@CommandParam("key") String key, @CommandParam("function") String bind) {
         Input keyInput = Keyboard.Key.find(key);
         if (keyInput != null) {
@@ -47,7 +48,8 @@ public class BindCommands extends BaseComponentSystem {
         throw new IllegalArgumentException("Unknown key: " + key);
     }
 
-    @Command(shortDescription = "Switches to typical key binds for AZERTY")
+    @Command(shortDescription = "Switches to typical key binds for AZERTY",
+            requiredPermission = PermissionManager.NO_PERMISSION)
     public String azerty() {
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.Z, new SimpleUri("engine:forwards"));
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.S, new SimpleUri("engine:backwards"));
@@ -56,7 +58,8 @@ public class BindCommands extends BaseComponentSystem {
         return "Changed key bindings to AZERTY keyboard layout.";
     }
 
-    @Command(shortDescription = "Switches to typical keybinds for DVORAK")
+    @Command(shortDescription = "Switches to typical keybinds for DVORAK",
+            requiredPermission = PermissionManager.NO_PERMISSION)
     public String dvorak() {
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.COMMA, new SimpleUri("engine:forwards"));
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.A, new SimpleUri("engine:right"));
@@ -68,7 +71,8 @@ public class BindCommands extends BaseComponentSystem {
         return "Changed key bindings to DVORAK keyboard layout.";
     }
 
-    @Command(shortDescription = "Switches to typical key binds for NEO 2 keyboard layout")
+    @Command(shortDescription = "Switches to typical key binds for NEO 2 keyboard layout",
+            requiredPermission = PermissionManager.NO_PERMISSION)
     public String neo() {
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.V, new SimpleUri("engine:forwards"));
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.I, new SimpleUri("engine:backwards"));

--- a/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
+++ b/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
@@ -38,6 +38,7 @@ import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.console.suggesters.UsernameSuggester;
 import org.terasology.logic.console.ui.MiniChatOverlay;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.FontColor;
@@ -94,7 +95,9 @@ public class ChatSystem extends BaseComponentSystem {
         }
     }
 
-    @Command(runOnServer = true, shortDescription = "Sends a message to all other players")
+    @Command(runOnServer = true,
+            requiredPermission = PermissionManager.CHAT_PERMISSION,
+            shortDescription = "Sends a message to all other players")
     public String say(
             @Sender EntityRef sender,
             @CommandParam(value = "message") String message
@@ -108,7 +111,9 @@ public class ChatSystem extends BaseComponentSystem {
         return "Message sent.";
     }
 
-    @Command(runOnServer = true, shortDescription = "Sends a private message to a specified user")
+    @Command(runOnServer = true,
+            requiredPermission = PermissionManager.CHAT_PERMISSION,
+            shortDescription = "Sends a private message to a specified user")
     public String whisper(
             @Sender EntityRef sender,
             @CommandParam(value = "user", suggester = UsernameSuggester.class) String username,

--- a/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
+++ b/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
@@ -36,7 +36,7 @@ import org.terasology.logic.console.MessageEvent;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
-import org.terasology.logic.console.suggesters.UsernameSuggester;
+import org.terasology.logic.console.suggesters.OnlineUsernameSuggester;
 import org.terasology.logic.console.ui.MiniChatOverlay;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
@@ -116,7 +116,7 @@ public class ChatSystem extends BaseComponentSystem {
             shortDescription = "Sends a private message to a specified user")
     public String whisper(
             @Sender EntityRef sender,
-            @CommandParam(value = "user", suggester = UsernameSuggester.class) String username,
+            @CommandParam(value = "user", suggester = OnlineUsernameSuggester.class) String username,
             @CommandParam("message") String message
     ) {
         Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -241,7 +241,7 @@ public class ConsoleImpl implements Console {
                 Throwable cause = e.getCause();
                 String causeMessage = cause.getLocalizedMessage();
 
-                logger.trace("An error occurred while executing a command: ", e);
+                logger.error("An error occurred while executing a command: ", e);
 
                 if (Strings.isNullOrEmpty(causeMessage)) {
                     causeMessage = cause.toString();

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -267,7 +267,7 @@ public class ConsoleImpl implements Console {
             ClientComponent clientComponent = callingClient.getComponent(ClientComponent.class);
             EntityRef character = clientComponent.character;
 
-            if (permissionManager.hasPermission(character, requiredPermission)) {
+            if (permissionManager.hasPermission(clientComponent.clientInfo, requiredPermission)) {
                 hasPermission = true;
             }
         }

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -262,10 +262,10 @@ public class ConsoleImpl implements Console {
         PermissionManager permissionManager = CoreRegistry.get(PermissionManager.class);
         boolean hasPermission = true;
 
-        if (permissionManager != null && requiredPermission != null && !requiredPermission.isEmpty()) {
+        if (permissionManager != null && requiredPermission != null
+                && !requiredPermission.equals(PermissionManager.NO_PERMISSION)) {
             hasPermission = false;
             ClientComponent clientComponent = callingClient.getComponent(ClientComponent.class);
-            EntityRef character = clientComponent.character;
 
             if (permissionManager.hasPermission(clientComponent.clientInfo, requiredPermission)) {
                 hasPermission = true;

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/AbstractCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/AbstractCommand.java
@@ -67,7 +67,7 @@ public abstract class AbstractCommand implements ConsoleCommand {
         Preconditions.checkNotNull(helpText);
 
         this.name = name;
-        this.requiredPermission = requiredPermission != null ? requiredPermission : PermissionManager.OPERATOR_PERMISSION;
+        this.requiredPermission = requiredPermission != null ? requiredPermission : PermissionManager.DEBUG_PERMISSION;
         this.runOnServer = runOnServer;
         this.description = description;
         this.helpText = helpText;

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/annotations/Command.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/annotations/Command.java
@@ -78,5 +78,5 @@ public @interface Command {
     /**
      * @return The permission required to run the command
      */
-    String requiredPermission() default PermissionManager.OPERATOR_PERMISSION;
+    String requiredPermission() default PermissionManager.DEBUG_PERMISSION;
 }

--- a/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
@@ -21,6 +21,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
@@ -39,7 +40,8 @@ public class ClientCommands extends BaseComponentSystem {
         return cameraTarget.toFullDescription();
     }
 
-    @Command(shortDescription = "Sets the current world time in days")
+    @Command(shortDescription = "Sets the current world time of the in days for the local player",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setWorldTime(@CommandParam("day") float day) {
         WorldProvider world = CoreRegistry.get(WorldProvider.class);
         world.getTime().setDays(day);

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -46,6 +46,7 @@ import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.health.HealthComponent;
 import org.terasology.logic.inventory.PickupBuilder;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.math.Direction;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
@@ -164,7 +165,7 @@ public class CoreCommands extends BaseComponentSystem {
         }
     }
 
-    @Command(shortDescription = "Toggles Fullscreen Mode")
+    @Command(shortDescription = "Toggles Fullscreen Mode", requiredPermission = PermissionManager.NO_PERMISSION)
     public String fullscreen() {
         TerasologyEngine te = (TerasologyEngine) CoreRegistry.get(GameEngine.class);
 
@@ -209,12 +210,12 @@ public class CoreCommands extends BaseComponentSystem {
         }
     }
 
-    @Command(shortDescription = "Exits the game")
+    @Command(shortDescription = "Exits the game", requiredPermission = PermissionManager.NO_PERMISSION)
     public void exit() {
         CoreRegistry.get(GameEngine.class).shutdown();
     }
 
-    @Command(shortDescription = "Join a game")
+    @Command(shortDescription = "Join a game", requiredPermission = PermissionManager.NO_PERMISSION)
     public void join(@CommandParam("address") final String address, @CommandParam(value = "port", required = false) Integer portParam) {
         final int port = portParam != null ? portParam : TerasologyConstants.DEFAULT_PORT;
 
@@ -249,7 +250,8 @@ public class CoreCommands extends BaseComponentSystem {
         popup.startOperation(operation, true);
     }
 
-    @Command(shortDescription = "Leaves the current game and returns to main menu")
+    @Command(shortDescription = "Leaves the current game and returns to main menu",
+            requiredPermission = PermissionManager.NO_PERMISSION)
     public String leave() {
         NetworkSystem networkSystem = CoreRegistry.get(NetworkSystem.class);
         if (networkSystem.getMode() != NetworkMode.NONE) {
@@ -334,7 +336,8 @@ public class CoreCommands extends BaseComponentSystem {
         return "World time changed";
     }
 
-    @Command(shortDescription = "Prints out short descriptions for all available commands, or a longer help text if a command is provided.")
+    @Command(shortDescription = "Prints out short descriptions for all available commands, or a longer help text if a command is provided.",
+            requiredPermission = PermissionManager.NO_PERMISSION)
     public String help(@CommandParam(value = "command", required = false, suggester = CommandNameSuggester.class) Name commandName) {
         if (commandName == null) {
             StringBuilder msg = new StringBuilder();

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -200,7 +200,8 @@ public class CoreCommands extends BaseComponentSystem {
         }
     }
 
-    @Command(shortDescription = "Teleports you to a location", runOnServer = true)
+    @Command(shortDescription = "Teleports you to a location", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public void teleport(@CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z, EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         LocationComponent location = clientComp.character.getComponent(LocationComponent.class);

--- a/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
@@ -61,7 +61,8 @@ public class ServerCommands extends BaseComponentSystem {
     @In
     private ChunkProvider chunkProvider;
 
-    @Command(shortDescription = "Shutdown the server", runOnServer = true)
+    @Command(shortDescription = "Shutdown the server", runOnServer = true,
+            requiredPermission = PermissionManager.SERVER_MANAGEMENT_PERMISSION)
     public String shutdownServer(@Sender EntityRef sender) {
 
         // TODO: verify permissions of sender
@@ -150,7 +151,8 @@ public class ServerCommands extends BaseComponentSystem {
         return "Request declined";
     }
 
-    @Command(shortDescription = "Triggers the creation of a save game", runOnServer = true)
+    @Command(shortDescription = "Triggers the creation of a save game", runOnServer = true,
+            requiredPermission = PermissionManager.SERVER_MANAGEMENT_PERMISSION)
     public void save() {
         storageManager.requestSaving();
     }

--- a/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ServerCommands.java
@@ -28,6 +28,7 @@ import org.terasology.logic.console.Message;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.math.Vector3i;
 import org.terasology.network.Client;
 import org.terasology.network.ClientComponent;
@@ -75,10 +76,9 @@ public class ServerCommands extends BaseComponentSystem {
         return "Server shutdown triggered";
     }
 
-    @Command(shortDescription = "Kick user by name", runOnServer = true)
+    @Command(shortDescription = "Kick user by name", runOnServer = true,
+            requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String kickUser(@CommandParam("username") String username) {
-
-        // TODO: verify permissions of sender
 
         for (EntityRef clientEntity : entityManager.getEntitiesWith(ClientComponent.class)) {
             EntityRef clientInfo = clientEntity.getComponent(ClientComponent.class).clientInfo;
@@ -93,7 +93,8 @@ public class ServerCommands extends BaseComponentSystem {
         throw new IllegalArgumentException("No such user '" + username + "'");
     }
 
-    @Command(shortDescription = "Kick user by ID", runOnServer = true)
+    @Command(shortDescription = "Kick user by ID", runOnServer = true,
+            requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String kickUserByID(@CommandParam("userId") int userId) {
 
         // TODO: verify permissions of sender
@@ -110,7 +111,8 @@ public class ServerCommands extends BaseComponentSystem {
         throw new IllegalArgumentException("No such user with ID " + userId);
     }
 
-    @Command(shortDescription = "List users")
+    @Command(shortDescription = "List users",
+            requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String listUsers() {
 
         StringBuilder stringBuilder = new StringBuilder();

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/OnlineUsernameSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/OnlineUsernameSuggester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MovingBlocks
+ * Copyright 2014 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,25 +20,28 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
-import org.terasology.network.ClientInfoComponent;
+import org.terasology.network.ClientComponent;
 import org.terasology.registry.CoreRegistry;
 
 import java.util.Set;
 
 /**
- * Suggests user names of all users even if they aren't online.
+ *
+ * Suggests user names of all online users
  *
  * @author Limeth
- * @author Florian <florian@fkoeberle.de>
  */
-public class UsernameSuggester implements CommandParameterSuggester<String> {
+public class OnlineUsernameSuggester implements CommandParameterSuggester<String> {
     @Override
     public Set<String> suggest(EntityRef sender, Object... resolvedParameters) {
         EntityManager entityManager = CoreRegistry.get(EntityManager.class);
-
+        Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
         Set<String> clientNames = Sets.newHashSet();
-        for (EntityRef clientInfo : entityManager.getEntitiesWith(ClientInfoComponent.class)) {
-            DisplayNameComponent displayNameComponent = clientInfo.getComponent(DisplayNameComponent.class);
+
+        for (EntityRef client : clients) {
+            ClientComponent clientComponent = client.getComponent(ClientComponent.class);
+            DisplayNameComponent displayNameComponent = clientComponent.clientInfo.getComponent(DisplayNameComponent.class);
+
             clientNames.add(displayNameComponent.name);
         }
 

--- a/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
+++ b/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
@@ -29,6 +29,7 @@ import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.health.HealthComponent;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
 
 /**
@@ -37,7 +38,8 @@ import org.terasology.network.ClientComponent;
 @RegisterSystem
 public class MovementDebugCommands extends BaseComponentSystem {
 
-    @Command(shortDescription = "Grants flight and movement through walls", runOnServer = true)
+    @Command(shortDescription = "Grants flight and movement through walls", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String ghost(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         clientComp.character.send(new SetMovementModeEvent(MovementMode.GHOSTING));
@@ -45,7 +47,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "Ghost mode toggled";
     }
 
-    @Command(shortDescription = "Grants flight", runOnServer = true)
+    @Command(shortDescription = "Grants flight", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String flight(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         clientComp.character.send(new SetMovementModeEvent(MovementMode.FLYING));
@@ -54,7 +57,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
     }
 
 
-    @Command(shortDescription = "Set speed multiplier", helpText = "Set speedMultiplier", runOnServer = true)
+    @Command(shortDescription = "Set speed multiplier", helpText = "Set speedMultiplier", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setSpeedMultiplier(@Sender EntityRef client, @CommandParam("amount") float amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);
@@ -69,7 +73,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "";
     }
 
-    @Command(shortDescription = "Set jump speed", runOnServer = true)
+    @Command(shortDescription = "Set jump speed", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setJumpSpeed(@Sender EntityRef client, @CommandParam("amount") float amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);
@@ -84,7 +89,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "";
     }
 
-    @Command(shortDescription = "Show your Movement stats")
+    @Command(shortDescription = "Show your Movement stats",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String showMovement(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);
@@ -96,7 +102,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "You're dead I guess.";
     }
 
-    @Command(shortDescription = "Go really fast", runOnServer = true)
+    @Command(shortDescription = "Go really fast", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String hspeed(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);
@@ -111,7 +118,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "";
     }
 
-    @Command(shortDescription = "Jump really high", runOnServer = true)
+    @Command(shortDescription = "Jump really high", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String hjump(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);
@@ -129,7 +137,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "";
     }
 
-    @Command(shortDescription = "Restore normal speed values", runOnServer = true)
+    @Command(shortDescription = "Restore normal speed values", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String restoreSpeed(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
 
@@ -158,7 +167,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "Normal speed values restored";
     }
 
-    @Command(shortDescription = "Toggles the maximum slope the player can walk up", runOnServer = true)
+    @Command(shortDescription = "Toggles the maximum slope the player can walk up", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String sleigh(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);
@@ -175,7 +185,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
         return "";
     }
 
-    @Command(shortDescription = "Sets the height the player can step up", runOnServer = true)
+    @Command(shortDescription = "Sets the height the player can step up", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String stepHeight(@Sender EntityRef client, @CommandParam("height") float amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         CharacterMovementComponent move = clientComp.character.getComponent(CharacterMovementComponent.class);

--- a/engine/src/main/java/org/terasology/logic/health/HealthSystem.java
+++ b/engine/src/main/java/org/terasology/logic/health/HealthSystem.java
@@ -33,6 +33,7 @@ import org.terasology.logic.characters.events.VerticalCollisionEvent;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
@@ -211,20 +212,23 @@ public class HealthSystem extends BaseComponentSystem implements UpdateSubscribe
         return "Inflicted damage of " + amount;
     }
 
-    @Command(shortDescription = "Restores your health to max", runOnServer = true)
+    @Command(shortDescription = "Restores your health to max", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String health(@Sender EntityRef clientEntity) {
         ClientComponent clientComp = clientEntity.getComponent(ClientComponent.class);
         clientComp.character.send(new DoHealEvent(100000, clientComp.character));
         return "Health restored";
     }
 
-    @Command(shortDescription = "Restores your health by an amount", runOnServer = true)
+    @Command(shortDescription = "Restores your health by an amount", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public void health(@Sender EntityRef client, @CommandParam("amount") int amount) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         clientComp.character.send(new DoHealEvent(amount, clientComp.character));
     }
 
-    @Command(shortDescription = "Set max health", runOnServer = true)
+    @Command(shortDescription = "Set max health", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setMaxHealth(@Sender EntityRef client, @CommandParam("max") int max) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         HealthComponent health = clientComp.character.getComponent(HealthComponent.class);
@@ -234,7 +238,8 @@ public class HealthSystem extends BaseComponentSystem implements UpdateSubscribe
         return "Max health set to " + max;
     }
 
-    @Command(shortDescription = "Set health regen rate", runOnServer = true)
+    @Command(shortDescription = "Set health regen rate", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setRegenRate(@Sender EntityRef client, @CommandParam("rate") float rate) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         HealthComponent health = clientComp.character.getComponent(HealthComponent.class);

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -25,6 +25,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.world.block.entity.BlockCommands;
@@ -47,7 +48,8 @@ public class ItemCommands extends BaseComponentSystem {
     @In
     private EntityManager entityManager;
 
-    @Command(shortDescription = "Adds an item to your inventory", runOnServer = true)
+    @Command(shortDescription = "Adds an item to your inventory", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String giveItem(
             @Sender EntityRef client,
             @CommandParam("prefabId or blockName") String itemPrefabName,

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -47,8 +47,12 @@ public class PermissionCommands extends BaseComponentSystem {
     @In
     private Console console;
 
-    @Command(shortDescription = "Use an one time key to get all permissions",
-            helpText = "The config file contains a one time key which can be used to get all permissions.",
+    @In
+    private Config config;
+
+    @Command(shortDescription = "Use an one time key to get all* permissions",
+            helpText = "The config file contains a one time key which can be used to get all* permissions."
+                    + "Please note that the debug permission will only be granted if the debug setting is on.",
             runOnServer = true, requiredPermission = PermissionManager.NO_PERMISSION)
     public String usePermissionKey(@CommandParam("key") String key, @Sender EntityRef client) {
         PermissionConfig permissionConfig = CoreRegistry.get(Config.class).getPermission();
@@ -59,7 +63,13 @@ public class PermissionCommands extends BaseComponentSystem {
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
             EntityRef clientInfo = clientComponent.clientInfo;
             for (String permission: findAllPermissions()) {
-                permissionManager.addPermission(clientInfo, permission);
+                boolean add = true;
+                if (permission.equals(PermissionManager.DEBUG_PERMISSION)) {
+                    add = config.getSystem().isDebugEnabled();
+                }
+                if (add) {
+                    permissionManager.addPermission(clientInfo, permission);
+                }
             }
             PermissionSetComponent permissionSetComp = clientInfo.getComponent(PermissionSetComponent.class);
             return "Permission key used: You have now the following permissions: " + permissionSetComp.permissions;

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -94,8 +94,15 @@ public class PermissionCommands extends BaseComponentSystem {
             runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String givePermission(
             @CommandParam("player") String player,
-            @CommandParam("permission") String permission) {
+            @CommandParam("permission") String permission,
+            @Sender EntityRef requester) {
         boolean permissionGiven = false;
+
+        ClientComponent requesterClientComponent = requester.getComponent(ClientComponent.class);
+        EntityRef requesterClientInfo = requesterClientComponent.clientInfo;
+        if (!permissionManager.hasPermission(requesterClientInfo, permission)) {
+            return String.format("You can't give the permission %s because you don't have it yourself", permission);
+        }
 
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
@@ -132,8 +139,15 @@ public class PermissionCommands extends BaseComponentSystem {
             runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String removePermission(
             @CommandParam("player") String player,
-            @CommandParam("permission") String permission) {
+            @CommandParam("permission") String permission,
+            @Sender EntityRef requester) {
         boolean permissionGiven = false;
+
+        ClientComponent requesterClientComponent = requester.getComponent(ClientComponent.class);
+        EntityRef requesterClientInfo = requesterClientComponent.clientInfo;
+        if (!permissionManager.hasPermission(requesterClientInfo, permission)) {
+            return String.format("You can't remove the permission %s because you don't have it yourself", permission);
+        }
 
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
@@ -144,7 +158,7 @@ public class PermissionCommands extends BaseComponentSystem {
         }
 
         if (permissionGiven) {
-            return "Permission " + permission + " removed to player " + player;
+            return "Permission " + permission + " removed from player " + player;
         } else {
             return "Unable to find player " + player;
         }

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -93,7 +93,7 @@ public class PermissionCommands extends BaseComponentSystem {
             helpText = "Gives specified permission to player",
             runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String givePermission(
-            @CommandParam("player") String player,
+            @CommandParam(value = "player", suggester = UsernameSuggester.class) String player,
             @CommandParam("permission") String permission,
             @Sender EntityRef requester) {
         boolean permissionGiven = false;
@@ -138,7 +138,7 @@ public class PermissionCommands extends BaseComponentSystem {
             helpText = "Removes specified permission from player",
             runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String removePermission(
-            @CommandParam("player") String player,
+            @CommandParam(value = "player", suggester = UsernameSuggester.class) String player,
             @CommandParam("permission") String permission,
             @Sender EntityRef requester) {
         boolean permissionGiven = false;

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -58,7 +58,7 @@ public class PermissionCommands extends BaseComponentSystem {
 
     @Command(shortDescription = "Gives specified permission to player",
             helpText = "Gives specified permission to player",
-            runOnServer = true)
+            runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String givePermission(
             @CommandParam("player") String player,
             @CommandParam("permission") String permission) {
@@ -81,7 +81,7 @@ public class PermissionCommands extends BaseComponentSystem {
 
     @Command(shortDescription = "Lists all permission the specified player has",
             helpText = "Lists all permission the specified player has",
-            runOnServer = true)
+            runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String listPermissions(@CommandParam(value = "player", suggester = UsernameSuggester.class) String player) {
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
@@ -96,7 +96,7 @@ public class PermissionCommands extends BaseComponentSystem {
 
     @Command(shortDescription = "Removes specified permission from player",
             helpText = "Removes specified permission from player",
-            runOnServer = true)
+            runOnServer = true, requiredPermission = PermissionManager.USER_MANAGEMENT_PERMISSION)
     public String removePermission(
             @CommandParam("player") String player,
             @CommandParam("permission") String permission) {

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -41,7 +41,7 @@ public class PermissionCommands extends BaseComponentSystem {
 
     @Command(shortDescription = "Use an one time key to get op permission",
             helpText = "The config file contains a one time key which can be used to get op permission",
-            runOnServer = true, requiredPermission = "")
+            runOnServer = true, requiredPermission = PermissionManager.NO_PERMISSION)
     public String usePermissionKey(@CommandParam("key") String key, @Sender EntityRef client) {
         PermissionConfig permissionConfig = CoreRegistry.get(Config.class).getPermission();
         String expectedKey = permissionConfig.getOneTimeAuthorizationKey();

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -46,7 +46,7 @@ public class PermissionCommands extends BaseComponentSystem {
         if (expectedKey != null && !expectedKey.equals("") && key.equals(expectedKey)) {
             permissionConfig.setOneTimeAuthorizationKey("");
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
-            permissionManager.addPermission(clientComponent.character, PermissionManager.OPERATOR_PERMISSION);
+            permissionManager.addPermission(clientComponent.clientInfo, PermissionManager.OPERATOR_PERMISSION);
             return "Permission key used: You have now \"op\" rights";
         } else {
             return "Key invalid or used";
@@ -64,7 +64,7 @@ public class PermissionCommands extends BaseComponentSystem {
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
             if (clientHasName(clientComponent, player)) {
-                permissionManager.addPermission(clientComponent.character, permission);
+                permissionManager.addPermission(clientComponent.clientInfo, permission);
                 permissionGiven = true;
             }
         }
@@ -87,7 +87,7 @@ public class PermissionCommands extends BaseComponentSystem {
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
             ClientComponent clientComponent = client.getComponent(ClientComponent.class);
             if (clientHasName(clientComponent, player)) {
-                permissionManager.removePermission(clientComponent.character, permission);
+                permissionManager.removePermission(clientComponent.clientInfo, permission);
                 permissionGiven = true;
             }
         }

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -25,9 +25,12 @@ import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
+import org.terasology.logic.console.suggesters.UsernameSuggester;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
+
+import java.util.Objects;
 
 @RegisterSystem
 public class PermissionCommands extends BaseComponentSystem {
@@ -74,6 +77,21 @@ public class PermissionCommands extends BaseComponentSystem {
         } else {
             return "Unable to find player " + player;
         }
+    }
+
+    @Command(shortDescription = "Lists all permission the specified player has",
+            helpText = "Lists all permission the specified player has",
+            runOnServer = true)
+    public String listPermissions(@CommandParam(value = "player", suggester = UsernameSuggester.class) String player) {
+        for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
+            ClientComponent clientComponent = client.getComponent(ClientComponent.class);
+            if (clientHasName(clientComponent, player)) {
+                EntityRef clientInfo = clientComponent.clientInfo;
+                PermissionSetComponent permissionSetComp = clientInfo.getComponent(PermissionSetComponent.class);
+                return Objects.toString(permissionSetComp.permissions);
+            }
+        }
+        return "Player not found";
     }
 
     @Command(shortDescription = "Removes specified permission from player",

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -21,6 +21,16 @@ import org.terasology.entitySystem.entity.EntityRef;
 public interface PermissionManager {
     static final String OPERATOR_PERMISSION = "op";
     static final String CHAT_PERMISSION = "chat";
+    /**
+     * Allows the player to use cheats that
+     * <ul>
+     *     <li>1. have no global impact.</li>
+     *     <li>2. don't endanger the stability of the game</li>
+     * </ul>
+     * The intention is that the permission can be given to all players on a server where players focus on building and
+     * not mining.
+     */
+    static final String CHEAT_PERMISSION = "cheat";
     static final String NO_PERMISSION = "";
 
     /**

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -34,6 +34,13 @@ public interface PermissionManager {
     static final String NO_PERMISSION = "";
 
     /**
+     * Allows the player to edit settings of other users.
+     *
+     * e.g. adding permissions, renaming them etc.
+     */
+    static final String USER_MANAGEMENT_PERMISSION = "userManagement";
+
+    /**
      * Adds specified permission to the player (client info entity).
      *
      * @param player     Player (client info entity) to add permission to.

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -22,37 +22,37 @@ public interface PermissionManager {
     String OPERATOR_PERMISSION = "op";
 
     /**
-     * Adds specified permission to the player (character).
+     * Adds specified permission to the player (client info entity).
      *
-     * @param player     Player (character) to add permission to.
+     * @param player     Player (client info entity) to add permission to.
      * @param permission Permission to add.
      */
     void addPermission(EntityRef player, String permission);
 
     /**
-     * Checks if the specified player (character) has said permission.
+     * Checks if the specified player (client info entity) has said permission.
      * Note: Local player is considered to have all the permissions in all situations.
      *
-     * @param player     Player (character) to check.
+     * @param player     Player (client info entity) to check.
      * @param permission Permission to check.
-     * @return If player (character) has permission.
+     * @return If player (client info entity) has permission.
      */
     boolean hasPermission(EntityRef player, String permission);
 
     /**
-     * Checks if the specified player (character) has permission that is accepted by the specified predicate.
+     * Checks if the specified player (client info entity) has permission that is accepted by the specified predicate.
      * Note: Local player is considered to have all the permissions in all situations.
      *
-     * @param player              Player (character) to check.
+     * @param player              Player (client info entity) to check.
      * @param permissionPredicate Permission predicate to check against.
-     * @return If player (character) has permission matching the predicate.
+     * @return If player (client info entity) has permission matching the predicate.
      */
     boolean hasPermission(EntityRef player, Predicate<String> permissionPredicate);
 
     /**
-     * Removes specified permission from the player (character).
+     * Removes specified permission from the player (client info entity).
      *
-     * @param player     Player (character) to remove permission from.
+     * @param player     Player (client info entity) to remove permission from.
      * @param permission Permission to remove.
      */
     void removePermission(EntityRef player, String permission);

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -19,7 +19,8 @@ import com.google.common.base.Predicate;
 import org.terasology.entitySystem.entity.EntityRef;
 
 public interface PermissionManager {
-    String OPERATOR_PERMISSION = "op";
+    static final String OPERATOR_PERMISSION = "op";
+    static final String CHAT_PERMISSION = "chat";
 
     /**
      * Adds specified permission to the player (client info entity).

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -19,7 +19,6 @@ import com.google.common.base.Predicate;
 import org.terasology.entitySystem.entity.EntityRef;
 
 public interface PermissionManager {
-    static final String OPERATOR_PERMISSION = "op";
     static final String CHAT_PERMISSION = "chat";
     /**
      * Allows the player to use cheats that
@@ -39,6 +38,16 @@ public interface PermissionManager {
      * e.g. adding permissions, renaming them etc.
      */
     static final String USER_MANAGEMENT_PERMISSION = "userManagement";
+
+    /**
+     * Allows the player to perform server maintenance tasks like stopping the server.
+     */
+    static final String SERVER_MANAGEMENT_PERMISSION = "serverManagement";
+
+    /**
+     * Allows the player to use debug commands which are not intended to be used on a real server.
+     */
+    static final String DEBUG_PERMISSION = "debug";
 
     /**
      * Adds specified permission to the player (client info entity).

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -19,7 +19,11 @@ import com.google.common.base.Predicate;
 import org.terasology.entitySystem.entity.EntityRef;
 
 public interface PermissionManager {
+    /**
+     * Allows the player to use chat commands.
+     */
     static final String CHAT_PERMISSION = "chat";
+    
     /**
      * Allows the player to use cheats that
      * <ul>
@@ -30,6 +34,10 @@ public interface PermissionManager {
      * not mining.
      */
     static final String CHEAT_PERMISSION = "cheat";
+
+    /**
+     * Used to indicate that something requires no permission.
+     */
     static final String NO_PERMISSION = "";
 
     /**

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -21,6 +21,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 public interface PermissionManager {
     static final String OPERATOR_PERMISSION = "op";
     static final String CHAT_PERMISSION = "chat";
+    static final String NO_PERMISSION = "";
 
     /**
      * Adds specified permission to the player (client info entity).

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionSystem.java
@@ -36,7 +36,7 @@ public class PermissionSystem extends BaseComponentSystem implements PermissionM
     public void addPermission(EntityRef player, String permission) {
         PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
         if (permissionSet != null) {
-            permissionSet.permissions.add(permission.toLowerCase());
+            permissionSet.permissions.add(permission);
             player.saveComponent(permissionSet);
         }
     }
@@ -49,7 +49,7 @@ public class PermissionSystem extends BaseComponentSystem implements PermissionM
         }
 
         PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
-        return permissionSet != null && permissionSet.permissions.contains(permission.toLowerCase());
+        return permissionSet != null && permissionSet.permissions.contains(permission);
     }
 
     @Override
@@ -76,7 +76,7 @@ public class PermissionSystem extends BaseComponentSystem implements PermissionM
     public void removePermission(EntityRef player, String permission) {
         PermissionSetComponent permissionSet = player.getComponent(PermissionSetComponent.class);
         if (permissionSet != null) {
-            permissionSet.permissions.remove(permission.toLowerCase());
+            permissionSet.permissions.remove(permission);
             player.saveComponent(permissionSet);
         }
     }

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionSystem.java
@@ -81,7 +81,13 @@ public class PermissionSystem extends BaseComponentSystem implements PermissionM
         }
     }
 
+    /**
+     *
+     * @param player client info entity of the player
+     *
+     * @return true if it is the local player
+     */
     private boolean isLocal(EntityRef player) {
-        return localPlayer != null && localPlayer.getCharacterEntity() == player;
+        return localPlayer != null && localPlayer.getClientInfoEntity().equals(player);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -76,6 +76,14 @@ public class LocalPlayer {
         return EntityRef.NULL;
     }
 
+    public EntityRef getClientInfoEntity() {
+        ClientComponent client = clientEntity.getComponent(ClientComponent.class);
+        if (client != null) {
+            return client.clientInfo;
+        }
+        return EntityRef.NULL;
+    }
+
     public boolean isValid() {
         EntityRef characterEntity = getCharacterEntity();
         return characterEntity.exists() && characterEntity.hasComponent(LocationComponent.class) && characterEntity.hasComponent(CharacterComponent.class)

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -34,6 +34,7 @@ import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.health.HealthComponent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.logic.players.event.RespawnRequestEvent;
 import org.terasology.math.Region3i;
@@ -281,7 +282,8 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         }
     }
 
-    @Command(value = "kill", shortDescription = "Reduce the player's health to zero", runOnServer = true)
+    @Command(value = "kill", shortDescription = "Reduce the player's health to zero", runOnServer = true,
+            requiredPermission = PermissionManager.NO_PERMISSION)
     public void killCommand(@Sender EntityRef client) {
         ClientComponent clientComp = client.getComponent(ClientComponent.class);
         HealthComponent health = clientComp.character.getComponent(HealthComponent.class);

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -292,7 +292,8 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         }
     }
 
-    @Command(value = "teleport", shortDescription = "Teleports you to a location", runOnServer = true)
+    @Command(value = "teleport", shortDescription = "Teleports you to a location", runOnServer = true,
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String teleportCommand(@Sender EntityRef sender, @CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z) {
         ClientComponent clientComp = sender.getComponent(ClientComponent.class);
         LocationComponent location = clientComp.character.getComponent(LocationComponent.class);

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -32,6 +32,7 @@ import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.inventory.InventoryManager;
+import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.Vector3i;
 import org.terasology.math.geom.Vector3f;
@@ -123,7 +124,8 @@ public class BlockCommands extends BaseComponentSystem {
         throw new IllegalArgumentException("Sorry, something went wrong!");
     }
 
-    @Command(shortDescription = "Lists all available items (prefabs)")
+    @Command(shortDescription = "Lists all available items (prefabs)",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String listItems() {
 
         List<String> stringItems = Lists.newArrayList();
@@ -145,7 +147,7 @@ public class BlockCommands extends BaseComponentSystem {
         return items.toString();
     }
 
-    @Command(shortDescription = "List all available blocks")
+    @Command(shortDescription = "List all available blocks", requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String listBlocks() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("Used Blocks");
@@ -172,7 +174,7 @@ public class BlockCommands extends BaseComponentSystem {
         return stringBuilder.toString();
     }
 
-    @Command(shortDescription = "Lists all blocks by category")
+    @Command(shortDescription = "Lists all blocks by category", requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String listBlocksByCategory() {
         StringBuilder stringBuilder = new StringBuilder();
         for (String category : blockManager.getBlockCategories()) {
@@ -190,7 +192,8 @@ public class BlockCommands extends BaseComponentSystem {
         return stringBuilder.toString();
     }
 
-    @Command(shortDescription = "Lists all available shapes")
+    @Command(shortDescription = "Lists all available shapes",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String listShapes() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("Shapes");
@@ -206,7 +209,9 @@ public class BlockCommands extends BaseComponentSystem {
         return stringBuilder.toString();
     }
 
-    @Command(shortDescription = "Lists available free shape blocks", helpText = "Lists all the available free shape blocks. These blocks can be created with any shape.")
+    @Command(shortDescription = "Lists available free shape blocks",
+            helpText = "Lists all the available free shape blocks. These blocks can be created with any shape.",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String listFreeShapeBlocks() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("Free Shape Blocks");
@@ -224,7 +229,7 @@ public class BlockCommands extends BaseComponentSystem {
 
     @Command(shortDescription = "Adds a block to your inventory",
             helpText = "Puts a desired number of the given block with the give shape into your inventory",
-            runOnServer = true)
+            runOnServer = true, requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String giveBlock(
             @Sender EntityRef sender,
             @CommandParam("blockName") String uri,

--- a/engine/src/main/resources/assets/prefabs/player/clientInfo.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/clientInfo.prefab
@@ -6,5 +6,8 @@
     },
     "Network" : {
         "replicateMode" : "ALWAYS"
+    },
+    "PermissionSet": {
+        "permissions": []
     }
 }

--- a/engine/src/main/resources/assets/prefabs/player/clientInfo.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/clientInfo.prefab
@@ -8,6 +8,6 @@
         "replicateMode" : "ALWAYS"
     },
     "PermissionSet": {
-        "permissions": []
+        "permissions": ["chat"]
     }
 }

--- a/engine/src/main/resources/assets/prefabs/player/player.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/player.prefab
@@ -60,8 +60,5 @@
               0,0,0,0,0,0,0,0,0,0
             ]
     },
-    "Breather" : {},
-    "PermissionSet": {
-        "permissions": []
-    }
+    "Breather" : {}
 }


### PR DESCRIPTION
This patch series introduces more granular permissions

* There is now a "chat" permission which every player has per default. So new players that join a server can chat.
* There is now a "userManagment" permission which allows the player to perform user management tasks like giving permissions.
* Even with the permission "userManagment"  you can now only give or remove permissions which you already own.
* There is now a "cheat" permission which allows the user to use non global, non debug cheats.
* Commands default now to a new  "debug" permission. On a typical server no one should have this permission.
* Commands that do someting you can also archive with the UI no longer require any permissions
* The op permission has been removed, as it no longer has any use.
* The usePermissionKey command gives now the user all permissions with one exception: The debug permission is only granted if the debugEnabled setting is true.
* The server shutdown requires now a new "serverManagement" permission. Typically only the server owner will have this permission, while he might have other people helping him out with user management that don't have that permission.
* There is now a new "listPermissions" command that lists the permissions of a player with the given name
* The permission commands use a new UsernameSuggestor that lists also offline players. The old UsernameSuggestor is now called OnlineUsernameSuggestor

Once the patch series is through we propably can close #1577 and #1607