### PR TITLE
Fix NPE in getDefaultWorldGenerator()

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
@@ -201,6 +201,7 @@ public class ModuleManager {
     }
 
     public SimpleUri getDefaultWorldGenerator(Module module) {
-        return new SimpleUri(module.getMetadata().getExtension(ModuleManager.DEFAULT_WORLD_GENERATOR_EXT, String.class));
+        String ext = module.getMetadata().getExtension(ModuleManager.DEFAULT_WORLD_GENERATOR_EXT, String.class);
+        return ext != null ? new SimpleUri(ext) : null;
     }
 }


### PR DESCRIPTION
Tiny check for `null` that was necessary for my setup. Most probably related to #1611.