### PR TITLE
Remove duplicate image converter util

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -72,6 +72,7 @@ import org.terasology.rendering.assets.texture.ColorTextureAssetResolver;
 import org.terasology.rendering.assets.texture.NoiseTextureAssetResolver;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
+import org.terasology.rendering.assets.texture.TextureUtil;
 import org.terasology.rendering.assets.texture.subtexture.Subtexture;
 import org.terasology.rendering.assets.texture.subtexture.SubtextureData;
 import org.terasology.rendering.assets.texture.subtexture.SubtextureFromAtlasResolver;
@@ -154,10 +155,10 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                 BufferedImage icon128 = ImageIO.read(classLoader.getResourceAsStream(root + "gooey_sweet_128.png"));
 
                 Display.setIcon(new ByteBuffer[]{
-                        imageToByteBuffer(icon16),
-                        imageToByteBuffer(icon32),
-                        imageToByteBuffer(icon64),
-                        imageToByteBuffer(icon128)
+                        TextureUtil.convertToByteBuffer(icon16),
+                        TextureUtil.convertToByteBuffer(icon32),
+                        TextureUtil.convertToByteBuffer(icon64),
+                        TextureUtil.convertToByteBuffer(icon128)
                 });
 
             } catch (IOException | IllegalArgumentException e) {
@@ -183,18 +184,6 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         } catch (LWJGLException e) {
             throw new RuntimeException("Can not initialize graphics device.", e);
         }
-    }
-
-    public ByteBuffer imageToByteBuffer(BufferedImage image) {
-        int width = image.getWidth();
-        int height = image.getHeight();
-
-        int[] data = image.getRGB(0, 0, width, height, null, 0, width);
-        ByteBuffer imageBuffer = ByteBuffer.allocateDirect(data.length * 4);
-        imageBuffer.order(ByteOrder.nativeOrder());
-        imageBuffer.asIntBuffer().put(data);
-
-        return imageBuffer;
     }
 
     private void initOpenGL() {

--- a/engine/src/main/java/org/terasology/rendering/assets/texture/TextureDataFactory.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/TextureDataFactory.java
@@ -47,14 +47,14 @@ public final class TextureDataFactory {
      */
     public static TextureData newInstance(Color color) {
 
-        byte red = UnsignedBytes.checkedCast(color.r());
-        byte green = UnsignedBytes.checkedCast(color.g());
-        byte blue = UnsignedBytes.checkedCast(color.b());
-        byte alpha = UnsignedBytes.checkedCast(color.a());
+        byte red = (byte) color.r();
+        byte green = (byte) color.g();
+        byte blue = (byte) color.b();
+        byte alpha = (byte) color.a();
 
         ByteBuffer data = ByteBuffer.allocateDirect(4 * TEXTURE_WIDTH * TEXTURE_HEIGHT);
-        for (int width = 0; width < TEXTURE_WIDTH; width++) {
-            for (int height = 0; height < TEXTURE_HEIGHT; height++) {
+        for (int height = 0; height < TEXTURE_HEIGHT; height++) {
+            for (int width = 0; width < TEXTURE_WIDTH; width++) {
                 data.put(red).put(green).put(blue).put(alpha);
             }
         }

--- a/engine/src/main/java/org/terasology/rendering/assets/texture/TextureUtil.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/TextureUtil.java
@@ -149,6 +149,12 @@ public final class TextureUtil {
         return image;
     }
 
+    /**
+     * Converts a BufferedImage into a ByteBuffer based on 32-bit values
+     * in RGBA byte order
+     * @param image any type of BufferedImage
+     * @return a ByteBuffer that contains the data in RGBA byte order
+     */
     public static ByteBuffer convertToByteBuffer(BufferedImage image) {
         int width = image.getWidth();
         int height = image.getHeight();


### PR DESCRIPTION
Moved `imageToByteBuffer` from `LwjglGraphics` to `TextureUtil`.

Also added a tiny fix in `TextureDataFactory` about creating single-color textures.