### PR TITLE
Fix various command-related issues

### DIFF
--- a/engine-tests/src/test/java/org/terasology/logic/location/LocationComponentTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/location/LocationComponentTest.java
@@ -55,11 +55,11 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
     }
 
     private EntityRef createFakeEntityWith(LocationComponent locationComponent) {
-        EntityRef entity = mock(EntityRef.class);
-        when(entity.getComponent(LocationComponent.class)).thenReturn(locationComponent);
-        when(entity.exists()).thenReturn(true);
-        when(entity.getId()).thenReturn(nextFakeEntityId++);
-        return entity;
+        EntityRef entRef = mock(EntityRef.class);
+        when(entRef.getComponent(LocationComponent.class)).thenReturn(locationComponent);
+        when(entRef.exists()).thenReturn(true);
+        when(entRef.getId()).thenReturn(nextFakeEntityId++);
+        return entRef;
     }
 
     @Test

--- a/engine/src/main/java/org/terasology/logic/console/Console.java
+++ b/engine/src/main/java/org/terasology/logic/console/Console.java
@@ -26,11 +26,11 @@ import java.util.List;
  * @author Immortius
  */
 public interface Console {
-	/**
-	 * Registers a {@link org.terasology.logic.console.commandSystem.ConsoleCommand}.
-	 *
-	 * @param command
-	 */
+    /**
+     * Registers a {@link org.terasology.logic.console.commandSystem.ConsoleCommand}.
+     *
+     * @param command
+     */
     void registerCommand(ConsoleCommand command);
 
     void dispose();
@@ -61,7 +61,7 @@ public interface Console {
      * @return An iterator over all messages in the console
      */
     Iterable<Message> getMessages();
-    
+
     /**
      * @param types a set of allowed message types
      * @return All messages in the console, filtered by message type (OR)
@@ -94,7 +94,7 @@ public interface Console {
 
     /**
      * Execute a command
-     * 
+     *
      * @param commandName the command name
      * @param params a list of parameters (no quotes!)
      * @param callingClient the resonsible client entity

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -74,7 +74,7 @@ public class ConsoleImpl implements Console {
         if (commandRegistry.containsKey(commandName)) {
             logger.warn("Command with name '{}' already registered by class '{}', skipping '{}'",
                     commandName, commandRegistry.get(commandName).getSource().getClass().getCanonicalName(),
-                    command.getClass().getCanonicalName());
+                    command.getSource().getClass().getCanonicalName());
         } else {
             commandRegistry.put(commandName, command);
             logger.debug("Command '{}' successfully registered for class '{}'.", commandName,

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -179,15 +179,6 @@ public class CoreCommands extends BaseComponentSystem {
 
     }
 
-    @Command(shortDescription = "Reduce the player's health to zero", runOnServer = true)
-    public void kill(EntityRef client) {
-        ClientComponent clientComp = client.getComponent(ClientComponent.class);
-        HealthComponent health = clientComp.character.getComponent(HealthComponent.class);
-        if (health != null) {
-            clientComp.character.send(new DestroyEvent(clientComp.character, EntityRef.NULL, EngineDamageTypes.DIRECT.get()));
-        }
-    }
-
     @Command(shortDescription = "Removes all entities of the given prefab", runOnServer = true)
     public void destroyEntitiesUsingPrefab(@CommandParam("prefabName") String prefabName) {
         Prefab prefab = entityManager.getPrefabManager().getPrefab(prefabName);
@@ -197,17 +188,6 @@ public class CoreCommands extends BaseComponentSystem {
                     entity.destroy();
                 }
             }
-        }
-    }
-
-    @Command(shortDescription = "Teleports you to a location", runOnServer = true,
-            requiredPermission = PermissionManager.CHEAT_PERMISSION)
-    public void teleport(@CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z, EntityRef client) {
-        ClientComponent clientComp = client.getComponent(ClientComponent.class);
-        LocationComponent location = clientComp.character.getComponent(LocationComponent.class);
-        if (location != null) {
-            location.setWorldPosition(new Vector3f(x, y, z));
-            clientComp.character.saveComponent(location);
         }
     }
 
@@ -261,12 +241,6 @@ public class CoreCommands extends BaseComponentSystem {
         } else {
             return "Not connected";
         }
-    }
-
-    @Command(shortDescription = "Displays debug information on the target entity")
-    public String debugTarget() {
-        EntityRef cameraTarget = cameraTargetSystem.getTarget();
-        return cameraTarget.toFullDescription();
     }
 
     @Command(shortDescription = "Writes out information on all entities to a text file for debugging",
@@ -327,14 +301,6 @@ public class CoreCommands extends BaseComponentSystem {
 
         pickupBuilder.createPickupFor(blockItem, spawnPos, 60);
         return "Spawned block.";
-    }
-
-    @Command(shortDescription = "Sets the current world time in days")
-    public String setWorldTime(@CommandParam("day") float day) {
-        WorldProvider world = CoreRegistry.get(WorldProvider.class);
-        world.getTime().setDays(day);
-
-        return "World time changed";
     }
 
     @Command(shortDescription = "Prints out short descriptions for all available commands, or a longer help text if a command is provided.",

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -127,14 +127,23 @@ public class CoreCommands extends BaseComponentSystem {
         return "Automatic reloading of screens enabled: Check console for hints where they get loaded from";
     }
 
-    @Command(shortDescription = "Reloads a ui and clears the HUD. Use at your own risk")
-    public String reloadUI(@CommandParam("ui") String ui) {
-        CoreRegistry.get(NUIManager.class).clear();
+    @Command(shortDescription = "Reloads a ui screen")
+    public String reloadScreen(@CommandParam("ui") String ui) {
 
         AssetUri uri = new AssetUri(AssetType.UI_ELEMENT, ui);
         UIData uiData = CoreRegistry.get(AssetManager.class).loadAssetData(uri, UIData.class);
         if (uiData != null) {
+            NUIManager nuiManager = CoreRegistry.get(NUIManager.class);
+            boolean wasOpen = nuiManager.isOpen(uri);
+            if (wasOpen) {
+                nuiManager.closeScreen(uri);
+            }
+
             CoreRegistry.get(AssetManager.class).generateAsset(uri, uiData);
+
+            if (wasOpen) {
+                nuiManager.pushScreen(uri);
+            }
             return "Success";
         } else {
             return "Unable to resolve ui '" + ui + "'";

--- a/engine/src/main/java/org/terasology/logic/health/HealthSystem.java
+++ b/engine/src/main/java/org/terasology/logic/health/HealthSystem.java
@@ -214,7 +214,7 @@ public class HealthSystem extends BaseComponentSystem implements UpdateSubscribe
 
     @Command(shortDescription = "Restores your health to max", runOnServer = true,
             requiredPermission = PermissionManager.CHEAT_PERMISSION)
-    public String health(@Sender EntityRef clientEntity) {
+    public String healthMax(@Sender EntityRef clientEntity) {
         ClientComponent clientComp = clientEntity.getComponent(ClientComponent.class);
         clientComp.character.send(new DoHealEvent(100000, clientComp.character));
         return "Health restored";

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotFormatBinding.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotFormatBinding.java
@@ -28,11 +28,12 @@ public class ScreenshotFormatBinding implements Binding<ScreenshotFormat> {
 
     @Override
     public ScreenshotFormat get() {
-        if(config.getScreenshotFormat() == "png") {
+        switch (config.getScreenshotFormat()) {
+        case "png":
             return ScreenshotFormat.PNG;
-        } else if(config.getScreenshotFormat() == "jpeg") {
+        case "jpeg":
             return ScreenshotFormat.JPEG;
-        } else {
+        default:
             return ScreenshotFormat.PNG;
         }
     }


### PR DESCRIPTION
This PR 
* removes the four duplicate commands methods
* renames one method to avoid name conflicts: `health(int amount)` vs. `health()` -> `healthMax()`
* fixes logging of duplicate method warning
* fixes the `teleport` method (resets ghosting mode though)
* nothing about `kill` - it worked fine for me already
* fixes all (4) CheckStyle errors (Tabs and string comparison)
* fixes the `reloadScreen` command

Fixes #1602
Fixes #1552