### PR TITLE
Added an option to change the server port via a command line argument (updated)

### DIFF
--- a/engine/src/main/java/org/terasology/config/Config.java
+++ b/engine/src/main/java/org/terasology/config/Config.java
@@ -80,7 +80,7 @@ public final class Config {
     /**
      * Transient fields are not persisted in GSON's serialization process.
      */
-    private transient TransientConfig transients = new TransientConfig();
+    private transient TransientConfig transients = new TransientConfig(this);
 
     /**
      * Create a new, empty config

--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -30,8 +30,7 @@ public class NetworkConfig implements Iterable<ServerInfo> {
     private List<ServerInfo> servers = Lists.newArrayList();
     // Available upstream bandwidth in kilobits per second
     private int upstreamBandwidth = 1024;
-    
-    // the port that is used for hosting
+    //The port that is used for hosting
     private int serverPort = TerasologyConstants.DEFAULT_PORT;
 
     public void clear() {
@@ -45,7 +44,7 @@ public class NetworkConfig implements Iterable<ServerInfo> {
     public void setUpstreamBandwidth(int upstreamBandwidth) {
         this.upstreamBandwidth = upstreamBandwidth;
     }
-    
+
     public int getServerPort() {
         return serverPort;
     }

--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -30,7 +30,8 @@ public class NetworkConfig implements Iterable<ServerInfo> {
     private List<ServerInfo> servers = Lists.newArrayList();
     // Available upstream bandwidth in kilobits per second
     private int upstreamBandwidth = 1024;
-    //The port that is used for hosting
+
+    // the port that is used for hosting
     private int serverPort = TerasologyConstants.DEFAULT_PORT;
 
     public void clear() {

--- a/engine/src/main/java/org/terasology/config/TransientConfig.java
+++ b/engine/src/main/java/org/terasology/config/TransientConfig.java
@@ -24,6 +24,14 @@ package org.terasology.config;
 public class TransientConfig {
 
     private boolean writeSaveGamesEnabled = true;
+    //The port that is used for hosting
+    private int serverPort = -1;
+
+    private Config config;
+
+    public TransientConfig(Config config) {
+        this.config = config;
+    }
 
     /**
      * Enables/disables write access for the storage manager.
@@ -34,9 +42,21 @@ public class TransientConfig {
     }
 
     /**
-     * @param storeSaveGames if save games should be (periodically) stored on the file system
+     * @param writeSaveGamesEnabled if save games should be (periodically) stored on the file system
      */
     public void setWriteSaveGamesEnabled(boolean writeSaveGamesEnabled) {
         this.writeSaveGamesEnabled = writeSaveGamesEnabled;
+    }
+
+    public int getServerPort() {
+        if (serverPort == -1) {
+            return config.getNetwork().getServerPort();
+        } else {
+            return serverPort;
+        }
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
     }
 }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/StartServer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/StartServer.java
@@ -46,7 +46,7 @@ public class StartServer extends SingleStepLoadProcess {
     public boolean step() {
         try {
             Config config = CoreRegistry.get(Config.class);
-            int port = config.getNetwork().getServerPort();
+            int port = config.getTransients().getServerPort();
             CoreRegistry.get(NetworkSystem.class).host(port, dedicated);
         } catch (HostingFailedException e) {
             CoreRegistry.get(NUIManager.class).pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Failed to Host",


### PR DESCRIPTION
This is an update of PR #1604 by @unpause.

It adds a command line argument: "-serverPort=xxxxx"

Fixed #1603 

Sidenote: using an invalid port is one situation where `TerasologyEngine` does not get disposed properly. This is due to the fact that dispose() does not clean up.