### PR TITLE
Added opengl 2.1 check.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -259,6 +259,8 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                 GLContext.getCapabilities().OpenGL14,
                 GLContext.getCapabilities().OpenGL15,
                 GLContext.getCapabilities().OpenGL20,
+                GLContext.getCapabilities().OpenGL21,   // needed as we use GLSL 1.20
+
                 GLContext.getCapabilities().GL_ARB_framebuffer_object,  // Extensions eventually included in
                 GLContext.getCapabilities().GL_ARB_texture_float,       // OpenGl 3.0 according to
                 GLContext.getCapabilities().GL_ARB_half_float_pixel};   // http://en.wikipedia.org/wiki/OpenGL#OpenGL_3.0
@@ -267,6 +269,7 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                                     "OpenGL14",
                                     "OpenGL15",
                                     "OpenGL20",
+                                    "OpenGL21",
                                     "GL_ARB_framebuffer_object",
                                     "GL_ARB_texture_float",
                                     "GL_ARB_half_float_pixel"};


### PR DESCRIPTION
Class LwjglGraphics now checks for driver's compatibility with OpenGL 2.1. 

OpenGL 2.1 is necessary as it requires the implementation to support GLSL 1.20, which is the GLSL version used by Terasology's shaders. 

GLSL 1.20 is enforced by the GLSLShader class prepending a "#version 120" statement in each shader. No change has been made to that class.