### PR TITLE
Use loading screen background image

### DIFF
--- a/engine/src/main/resources/assets/skins/loadingScreen.skin
+++ b/engine/src/main/resources/assets/skins/loadingScreen.skin
@@ -1,0 +1,8 @@
+{
+    "inherit": "mainmenu",
+    "elements": {
+        "UIScreenLayer": {
+            "background": "loadingBackground"
+        }
+    }
+}

--- a/engine/src/main/resources/assets/ui/loadingScreen.ui
+++ b/engine/src/main/resources/assets/ui/loadingScreen.ui
@@ -1,6 +1,6 @@
 {
     "type" : "loadingScreen",
-    "skin" : "mainMenu",
+    "skin" : "loadingScreen",
     "contents" : {
         "type" : "RelativeLayout",
         "contents" : [


### PR DESCRIPTION
Currently, the loading screen image ships with the game, but is not in use. This PR overrides the `mainmenu` skin for the loading screen with a customized skin that sets the background image.

This allows modules to customize the loading screen by adding a file: 

    overrides\engine\textures\loadingBackground.png

