### PR TITLE
Download list of available game servers

### DIFF
--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -16,23 +16,33 @@
 
 package org.terasology.config;
 
-import com.google.common.collect.Lists;
-
-import java.util.Iterator;
 import java.util.List;
 
 import org.terasology.engine.TerasologyConstants;
 
+import com.google.common.collect.Lists;
+
 /**
  * @author Immortius
  */
-public class NetworkConfig implements Iterable<ServerInfo> {
+public class NetworkConfig {
+
     private List<ServerInfo> servers = Lists.newArrayList();
-    // Available upstream bandwidth in kilobits per second
+
+    /**
+     * Available upstream bandwidth in kilobits per second
+     */
     private int upstreamBandwidth = 1024;
 
-    // the port that is used for hosting
+    /**
+     * The port that is used for hosting
+     */
     private int serverPort = TerasologyConstants.DEFAULT_PORT;
+
+    /**
+     * The master server URL
+     */
+    private String masterServer = "https://master-server.herokuapp.com/servers/list";
 
     public void clear() {
         servers.clear();
@@ -54,11 +64,6 @@ public class NetworkConfig implements Iterable<ServerInfo> {
         this.serverPort = serverPort;
     }
 
-    @Override
-    public Iterator<ServerInfo> iterator() {
-        return servers.iterator();
-    }
-
     public void add(ServerInfo serverInfo) {
         servers.add(serverInfo);
     }
@@ -73,5 +78,13 @@ public class NetworkConfig implements Iterable<ServerInfo> {
 
     public void setServers(List<ServerInfo> servers) {
         this.servers = servers;
+    }
+
+    public String getMasterServer() {
+        return masterServer;
+    }
+
+    public void setMasterServer(String masterServer) {
+        this.masterServer = masterServer;
     }
 }

--- a/engine/src/main/java/org/terasology/config/ServerInfo.java
+++ b/engine/src/main/java/org/terasology/config/ServerInfo.java
@@ -16,6 +16,7 @@
 
 package org.terasology.config;
 
+
 /**
  * @author Immortius
  */
@@ -24,6 +25,10 @@ public class ServerInfo {
     private String address;
     private int port;
 
+    private ServerInfo() {
+        // for serialization purposes
+    }
+
     public ServerInfo(String name, String address, int port) {
         if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Server name must not be null or empty");
@@ -31,6 +36,10 @@ public class ServerInfo {
         if (address == null || address.isEmpty()) {
             throw new IllegalArgumentException("Server address must not be null or empty");
         }
+        if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Server port must be in the range [0..65535]");
+        }
+
         this.name = name;
         this.address = address;
         this.port = port;
@@ -61,6 +70,13 @@ public class ServerInfo {
     }
 
     public void setPort(int port) {
-        this.port = port;
+        if (port >= 0 && port <= 65535) {
+            this.port = port;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ServerInfo [name=" + name + ", address=" + address + ", port=" + port + "]";
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CombinedListBinding.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CombinedListBinding.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+
+/**
+ * TODO Type description
+ * @author Martin Steiger
+ */
+public class CombinedListBinding<T> extends ReadOnlyBinding<List<T>> {
+
+    private final List<T> servers = new ArrayList<>();
+
+    private final List<T> list1;
+    private final List<T> list2;
+
+    /**
+     * @param locals
+     */
+    public CombinedListBinding(List<T> list1, List<T> list2) {
+        this.list1 = list1;
+        this.list2 = list2;
+    }
+
+    @Override
+    public List<T> get() {
+        servers.clear();
+        servers.addAll(list1);
+        servers.addAll(list2);
+        return servers;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -88,6 +88,17 @@ public class JoinGameScreen extends CoreScreenLayer {
             UILabel port = find("port", UILabel.class);
             port.bindText(new IntToStringBinding(BindHelper.bindBoundBeanProperty("port", infoBinding, ServerInfo.class, int.class)));
 
+            ReadOnlyBinding<Boolean> localSelectedServerOnly = new ReadOnlyBinding<Boolean>() {
+                @Override
+                public Boolean get() {
+                    if (infoBinding.get() == null) {
+                        return false;
+                    }
+
+                    return locals.contains(infoBinding.get());
+                }
+            };
+
             WidgetUtil.trySubscribe(this, "add", new ActivateEventListener() {
                 @Override
                 public void onActivated(UIWidget button) {
@@ -96,16 +107,7 @@ public class JoinGameScreen extends CoreScreenLayer {
             });
             UIButton edit = find("edit", UIButton.class);
             if (edit != null) {
-                edit.bindEnabled(new ReadOnlyBinding<Boolean>() {
-                    @Override
-                    public Boolean get() {
-                        if (infoBinding.get() == null) {
-                            return false;
-                        }
-
-                        return locals.contains(infoBinding.get());
-                    }
-                });
+                edit.bindEnabled(localSelectedServerOnly);
                 edit.subscribe(new ActivateEventListener() {
                     @Override
                     public void onActivated(UIWidget button) {
@@ -142,13 +144,15 @@ public class JoinGameScreen extends CoreScreenLayer {
                 }
             };
 
-            UIButton editButton = find("edit", UIButton.class);
             UIButton removeButton = find("remove", UIButton.class);
-            UIButton joinButton = find("join", UIButton.class);
+            if (removeButton != null) {
+                removeButton.bindEnabled(localSelectedServerOnly);
+            }
 
-//            editButton.bindEnabled(hasSelection);  --- has been set already
-            removeButton.bindEnabled(hasSelection);
-            joinButton.bindEnabled(hasSelection);
+            UIButton joinButton = find("join", UIButton.class);
+            if (joinButton != null) {
+                joinButton.bindEnabled(hasSelection);
+            }
         }
 
         WidgetUtil.trySubscribe(this, "close", new ActivateEventListener() {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/OnlineServerListBinding.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/OnlineServerListBinding.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.config.ServerInfo;
+import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.sun.org.apache.xerces.internal.util.URI;
+
+/**
+ * TODO Type description
+ * @author Martin Steiger
+ */
+public class OnlineServerListBinding extends ReadOnlyBinding<List<ServerInfo>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(OnlineServerListBinding.class);
+
+    private final List<ServerInfo> servers;
+
+    /**
+     * @param locals
+     */
+    public OnlineServerListBinding(List<ServerInfo> locals) {
+        this.servers = Lists.newCopyOnWriteArrayList(locals);
+
+        Thread dlThread = new Thread(new Downloader());
+        dlThread.setName("ServerList Downloader");
+        dlThread.start();
+    }
+
+    @Override
+    public List<ServerInfo> get() {
+        return servers;
+    }
+
+    private class Downloader implements Runnable {
+        @Override
+        public void run() {
+            try {
+                URL url = new URL("http://master-server.herokuapp.com/servers/list");
+                Charset cs = StandardCharsets.UTF_8;
+                Gson gson = new GsonBuilder().create();
+
+                @SuppressWarnings("serial")
+                Type entryListType = new TypeToken<List<ServerInfo>>() { /**/ }.getType();
+
+                try (Reader reader = new InputStreamReader(url.openStream(), cs)) {
+                    List<ServerInfo> onlineServers = gson.fromJson(reader, entryListType);
+                    for (ServerInfo entry : onlineServers) {
+                        logger.debug("Retrieved online game server {}", entry);
+                    }
+                    servers.addAll(onlineServers);
+                }
+            } catch (Exception e) {
+                // we catch Exception here to make sure that it's being logged
+                logger.error("Error downloading online server list!", e);
+            }
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ServerListDownloader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ServerListDownloader.java
@@ -16,6 +16,7 @@
 
 package org.terasology.rendering.nui.layers.mainMenu;
 
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
@@ -43,16 +44,21 @@ class ServerListDownloader {
         @Override
         public void run() {
             try {
-                status = "Starting to download ..";
+                status = "Downloading server list ..";
 
                 @SuppressWarnings("serial")
                 Type entryListType = new TypeToken<List<ServerInfo>>() { /**/ }.getType();
                 URL url = new URL(serverAddress);
 
-                status = "Parsing content ..";
-
                 try (Reader reader = new InputStreamReader(url.openStream(), cs)) {
+
+                    status = "Parsing content ..";
+
                     List<ServerInfo> onlineServers = GSON.fromJson(reader, entryListType);
+                    if (onlineServers == null) {
+                        throw new IOException("Invalid server list file content!");
+                    }
+
                     for (ServerInfo entry : onlineServers) {
                         logger.debug("Retrieved online game server {}", entry);
                     }

--- a/engine/src/main/resources/assets/skins/mainmenu.skin
+++ b/engine/src/main/resources/assets/skins/mainmenu.skin
@@ -38,7 +38,8 @@
             "text-color": "FF4444FF"
         },
         "highlight": {
-            "text-color": "FFFF00FF"
+            "text-color": "FFFF00FF",
+            "font" : "NotoSans-Bold"
         },
         "heading-input": {
             "font": "title",

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -52,6 +52,7 @@
                 {
                     "type" : "ColumnLayout",
                     "columns" : 2,
+                    "column-widths" : [0.4, 0.6],
                     "verticalSpacing" : 16,
                     "horizontalSpacing" : 8,
                     "layoutInfo" : {
@@ -122,7 +123,7 @@
                                     "type" : "ColumnLayout",
                                     "id" : "simpleItems",
                                     "columns" : 2,
-                                    "columnWidths" : [0.3, 0.7],
+                                    "column-widths" : [0.25, 0.75],
                                     "verticalSpacing" : 8,
                                     "contents" : [
                                         {
@@ -169,7 +170,7 @@
                                     "text" : "Join",
                                     "family" : "highlight",
                                     "layoutInfo" : {
-                                        "use-content-height" : true,
+                                        "height" : 40,
                                         "position-bottom" : {
                                             "target" : "BOTTOM"
                                         }

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -71,36 +71,35 @@
                     },
                     "contents" : [
                         {
-                            "type" : "ScrollableArea",
-                            "content" : {
-                                "type" : "UIList",
-                                "id" : "serverList",
-                                "family" : "module-list"
-                            }
-                        },
-                        {
-                            "type" : "RelativeLayout",
-                            "family" : "description",
-                            "contents" : [
+                        	"type" : "RelativeLayout",
+                        	"contents" : [
                                 {
-                                    "type" : "UIButton",
-                                    "id" : "add",
-                                    "text" : "Add",
-                                    "layoutInfo" : {
-                                        "use-content-height" : true,
+		                            "type" : "ScrollableArea",
+		                            "content" : {
+		                                "type" : "UIList",
+		                                "id" : "serverList",
+		                                "family" : "module-list"
+		                            },
+		                            "layoutInfo" : {
                                         "position-top" : {
                                             "target" : "TOP"
+                                        },
+                                        "position-bottom" : {
+                                            "target" : "TOP",
+                                            "widget" : "edit",
+                                            "offset" : 8
                                         }
                                     }
-                                },
+		                        },
                                 {
                                     "type" : "UIButton",
                                     "id" : "edit",
                                     "text" : "Edit",
                                     "layoutInfo" : {
                                         "use-content-height" : true,
-                                        "position-top" : {
-                                            "target" : "BOTTOM",
+                                        "width" : 135,
+                                        "position-bottom" : {
+                                            "target" : "TOP",
                                             "widget" : "add",
                                             "offset" : 8
                                         }
@@ -112,13 +111,35 @@
                                     "text" : "Remove",
                                     "layoutInfo" : {
                                         "use-content-height" : true,
-                                        "position-top" : {
-                                            "target" : "BOTTOM",
+                                        "position-left" : {
+                                            "target" : "RIGHT",
                                             "widget" : "edit",
+                                            "offset" : 8
+                                        },
+                                        "position-bottom" : {
+                                            "target" : "TOP",
+                                            "widget" : "add",
                                             "offset" : 8
                                         }
                                     }
                                 },
+                                {
+                                    "type" : "UIButton",
+                                    "id" : "add",
+                                    "text" : "Add New",
+                                    "layoutInfo" : {
+                                        "use-content-height" : true,
+                                        "position-bottom" : {
+                                            "target" : "BOTTOM"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type" : "RelativeLayout",
+                            "family" : "description",
+                            "contents" : [
                                 {
                                     "type" : "ColumnLayout",
                                     "id" : "simpleItems",
@@ -158,8 +179,7 @@
                                         "use-content-height" : true,
                                         "position-horizontal-center" : {},
                                         "position-top" : {
-                                            "target" : "BOTTOM",
-                                            "widget" : "remove",
+                                            "target" : "TOP",
                                             "offset" : 8
                                         }
                                     }

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -71,16 +71,16 @@
                     },
                     "contents" : [
                         {
-                        	"type" : "RelativeLayout",
-                        	"contents" : [
+                            "type" : "RelativeLayout",
+                            "contents" : [
                                 {
-		                            "type" : "ScrollableArea",
-		                            "content" : {
-		                                "type" : "UIList",
-		                                "id" : "serverList",
-		                                "family" : "module-list"
-		                            },
-		                            "layoutInfo" : {
+                                    "type" : "ScrollableArea",
+                                    "content" : {
+                                        "type" : "UIList",
+                                        "id" : "serverList",
+                                        "family" : "module-list"
+                                    },
+                                    "layoutInfo" : {
                                         "position-top" : {
                                             "target" : "TOP"
                                         },
@@ -90,7 +90,7 @@
                                             "offset" : 8
                                         }
                                     }
-		                        },
+                                },
                                 {
                                     "type" : "UIButton",
                                     "id" : "edit",
@@ -180,6 +180,19 @@
                                         "position-horizontal-center" : {},
                                         "position-top" : {
                                             "target" : "TOP",
+                                            "offset" : 8
+                                        }
+                                    }
+                                },
+                                {
+                                    "type" : "UILabel",
+                                    "id" : "download",
+                                    "text" : "<download info text>",
+                                    "layoutInfo" : {
+                                        "use-content-height" : true,
+                                        "position-bottom" : {
+                                            "target" : "TOP",
+                                            "widget" : "join",
                                             "offset" : 8
                                         }
                                     }


### PR DESCRIPTION
This PR modifies the "Join Game" screen by adding the functionality to download a list of available game servers from an external source.

This source is a Jetty-based servlet, hosted on a Heroku instance (connected to a Amazon EC2 PostgreSQL database). It runs in my personal account, but I'm happy to transfer it (no credit card required). The GitHub repository is here: https://github.com/MovingBlocks/master-server

![image](https://cloud.githubusercontent.com/assets/1820007/6651813/1d1242dc-ca56-11e4-8569-46225fd9ff27.png)
