### PR TITLE
Moving FBO and PBO classes out of LwjglRenderingProcess

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.opengl;
+
+import org.lwjgl.opengl.GL11;
+
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
+
+/**
+ * Created by manu on 15.03.2015.
+ */
+public class FBO {
+    public int fboId;
+    public int textureId;
+    public int depthStencilTextureId;
+    public int depthStencilRboId;
+    public int normalsTextureId;
+    public int lightBufferTextureId;
+
+    public int width;
+    public int height;
+
+    public void bind() {
+        //if (this != currentlyBoundFbo) {
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fboId);
+        //    currentlyBoundFbo = this;
+        //}
+    }
+
+    public void unbind() {
+        //if (currentlyBoundFbo != null) {
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+        //    currentlyBoundFbo = null;
+        //}
+    }
+
+    public void bindDepthTexture() {
+        //if (currentlyBoundTextureId != depthStencilTextureId) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, depthStencilTextureId);
+        //currentlyBoundTextureId = depthStencilTextureId;
+        //}
+    }
+
+    public void bindTexture() {
+        //if (currentlyBoundTextureId != textureId) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureId);
+        //currentlyBoundTextureId = textureId;
+        //}
+    }
+
+    public void bindNormalsTexture() {
+        //if (currentlyBoundTextureId != normalsTextureId) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, normalsTextureId);
+        //currentlyBoundTextureId = normalsTextureId;
+        //}
+    }
+
+    public void bindLightBufferTexture() {
+        //if (currentlyBoundTextureId != lightBufferTextureId) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, lightBufferTextureId);
+        //currentlyBoundTextureId = lightBufferTextureId;
+        //}
+    }
+
+    public void unbindTexture() {
+        //if (currentlyBoundTextureId != 0) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, 0);
+        //currentlyBoundTextureId = 0;
+        //}
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
@@ -1521,4 +1521,9 @@ public class LwjglRenderingProcess {
         fboLookup.put(title + "PingPong", fbo1);
     }
 
+    public void setConfigObjects(RenderingConfig newRenderingConfig, RenderingDebugConfig newRenderingDebugConfig) {
+        this.renderingConfig = newRenderingConfig;
+        this.renderingDebugConfig = newRenderingDebugConfig;
+    }
+
 }

--- a/engine/src/main/java/org/terasology/rendering/opengl/PBO.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/PBO.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.opengl;
+
+import org.lwjgl.BufferUtils;
+
+import java.nio.ByteBuffer;
+
+import static org.lwjgl.opengl.ARBBufferObject.*;
+import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_EXT;
+import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
+import static org.lwjgl.opengl.EXTPixelBufferObject.GL_PIXEL_PACK_BUFFER_EXT;
+import static org.lwjgl.opengl.GL11.glReadPixels;
+import static org.lwjgl.opengl.GL15.GL_READ_ONLY;
+
+/**
+ * Created by manu on 15.03.2015.
+ */
+public class PBO {
+    private int pboId;
+    private ByteBuffer cachedBuffer;
+
+    public PBO(int width, int height) {
+        pboId = glGenBuffersARB();
+
+        int byteSize = width * height * 4;
+        cachedBuffer = BufferUtils.createByteBuffer(byteSize);
+
+        bind();
+        glBufferDataARB(GL_PIXEL_PACK_BUFFER_EXT, byteSize, GL_STREAM_READ_ARB);
+        unbind();
+    }
+
+    public void bind() {
+        glBindBufferARB(GL_PIXEL_PACK_BUFFER_EXT, pboId);
+    }
+
+    public void unbind() {
+        glBindBufferARB(GL_PIXEL_PACK_BUFFER_EXT, 0);
+    }
+
+    public void copyFromFBO(int fboId, int width, int height, int format, int type) {
+        bind();
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fboId);
+        glReadPixels(0, 0, width, height, format, type, 0);
+        unbind();
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+    }
+
+    public ByteBuffer readBackPixels() {
+        bind();
+
+        cachedBuffer = glMapBufferARB(GL_PIXEL_PACK_BUFFER_EXT, GL_READ_ONLY, cachedBuffer);
+
+        // Maybe fix for the issues appearing on some platforms where accessing the "cachedBuffer" causes a JVM exception and therefore a crash...
+        ByteBuffer resultBuffer = BufferUtils.createByteBuffer(cachedBuffer.capacity());
+        resultBuffer.put(cachedBuffer);
+        cachedBuffer.rewind();
+        resultBuffer.flip();
+
+        glUnmapBufferARB(GL_PIXEL_PACK_BUFFER_EXT);
+        unbind();
+
+        return resultBuffer;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -22,6 +22,7 @@ import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
@@ -49,7 +50,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         int texId = 0;
 
-        LwjglRenderingProcess.FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -69,7 +70,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
             program.setInt("texSceneOpaqueLightBuffer", texId++, true);
         }
 
-        LwjglRenderingProcess.FBO sceneReflectiveRefractive = LwjglRenderingProcess.getInstance().getFBO("sceneReflectiveRefractive");
+        FBO sceneReflectiveRefractive = LwjglRenderingProcess.getInstance().getFBO("sceneReflectiveRefractive");
 
         if (sceneReflectiveRefractive != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -24,6 +24,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
@@ -40,7 +41,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess.FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         int texId = 0;
         if (sceneOpaque != null) {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -23,6 +23,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
@@ -46,7 +47,7 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess.FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -28,6 +28,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureUtil;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
@@ -76,7 +77,7 @@ public class ShaderParametersPost extends ShaderParametersBase {
             program.setInt("texColorGradingLut", texId++, true);
         }
 
-        LwjglRenderingProcess.FBO sceneCombined = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO sceneCombined = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         if (sceneCombined != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -30,6 +30,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
@@ -91,7 +92,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess.FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -18,6 +18,7 @@ package org.terasology.rendering.shader;
 import org.lwjgl.opengl.GL13;
 import org.terasology.editor.EditorRange;
 import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 /**
@@ -36,7 +37,7 @@ public class ShaderParametersSobel extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess.FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
 
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.rendering.world;
 
+import org.terasology.config.RenderingConfig;
 import org.terasology.math.Region3i;
 import org.terasology.math.Vector3i;
 import org.terasology.world.chunks.ChunkProvider;
@@ -43,4 +44,6 @@ public interface RenderableWorld {
 
     String getMetrics();
     ChunkProvider getChunkProvider();
+
+    void setRenderingConfig(RenderingConfig newRenderingConfig);
 }

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -250,7 +250,6 @@ public class RenderableWorldImpl implements RenderableWorld {
     public void generateVBOs() {
         PerformanceMonitor.startActivity("Building Mesh VBOs");
         ChunkMesh pendingMesh;
-        ChunkMesh mesh;
         chunkMeshUpdateManager.setCameraPosition(playerCamera.getPosition());
         for (RenderableChunk chunk : chunkMeshUpdateManager.availableChunksForUpdate()) {
 
@@ -407,6 +406,11 @@ public class RenderableWorldImpl implements RenderableWorld {
         return builder.toString();
     }
 
+    public void setRenderingConfig(RenderingConfig newRenderingConfig) {
+        renderingConfig = newRenderingConfig;
+    }
+
+
     private static float squaredDistanceToCamera(RenderableChunk chunk, Vector3f cameraPosition) {
          // For performance reasons, to avoid instantiating too many vectors in a frequently called method,
         // comments are in use instead of appropriately named vectors.
@@ -464,5 +468,4 @@ public class RenderableWorldImpl implements RenderableWorld {
             }
         }
     }
-
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -207,6 +207,12 @@ public final class WorldRendererImpl implements WorldRenderer {
         statRenderedTriangles = 0;
     }
 
+    private void refreshConfigObjects() {
+        config = CoreRegistry.get(Config.class);
+        renderingConfig = config.getRendering();
+        renderingDebugConfig = renderingConfig.getDebug();
+    }
+
     private void preRenderUpdate(WorldRenderingStage renderingStage) {
 
         currentRenderingStage = renderingStage;
@@ -219,6 +225,10 @@ public final class WorldRendererImpl implements WorldRenderer {
         // this is done to execute this code block only once per frame
         // instead of once per eye in a stereo setup.
         if (isFirstRenderingStageForCurrentFrame) {
+            refreshConfigObjects();
+            renderableWorld.setRenderingConfig(renderingConfig);
+            LwjglRenderingProcess.getInstance().setConfigObjects(renderingConfig, renderingDebugConfig);
+
             tick += secondsSinceLastFrame * 1000;  // Updates the tick variable that animation is based on.
             smoothedPlayerSunlightValue = TeraMath.lerp(smoothedPlayerSunlightValue, getSunlightValue(), secondsSinceLastFrame);
 


### PR DESCRIPTION
MiniPR to warm up the water for the refactoring of LwjglRenderingProcess.

The [first commit](https://github.com/MovingBlocks/Terasology/commit/271561989cfa3d90d48798e29d4b34978db861b4) extracts the PBO and FBO classes from the LwjglRenderingProcess class and into their own files.  All other changes in this commit (i.e. changes to the ShaderParameter* files) are consequences of the FBO's new location. 

This first commit is not strictly necessary. However, LwjglRenderingProcess.java is a 1500 lines file and this is just a first easy step to reduce its size and complexity. More will follow.

The [second commit](https://github.com/MovingBlocks/Terasology/commit/86408d3a16f16aade74c2fd96154e5016f1833b9)  adds two member variables to LwjglRenderingProcess: renderingConfig and renderingDebugConfig. These are initialized once and then reused in place of CoreRegistry(Config.class).getRendering() and renderingConfig.getDebug() throughout the class.
