### PR TITLE
Tune-up for height-map based world generator

### DIFF
--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
@@ -43,7 +43,7 @@ public class HeightMapWorldGenerator extends BaseFacetedWorldGenerator {
     @Override
     protected WorldBuilder createWorld(long seed) {
         return new WorldBuilder(seed)
-                .addProvider(new SeaLevelProvider())
+                .addProvider(new SeaLevelProvider(16))
                 .addProvider(new HeightMapSurfaceHeightProvider())
                 .addProvider(new PerlinHumidityProvider())
                 .addProvider(new PerlinSurfaceTemperatureProvider())


### PR DESCRIPTION
Assets can now be loaded in WorldViewer, which now allows for loading the HeightMap world:

![image](https://cloud.githubusercontent.com/assets/1820007/6789690/7d44da86-d1a2-11e4-8331-3304530dd5b2.png)

Surprisingly, it is by far the slowest world generator of all. I'm not sure why the code was like it was, but it offered many possibilities for performance improvements.

This PR performs a few of them leading to a speed-up of about 20x-50x at equal quality. Moreover, it makes the surface provider independent of chunk size and uses a dynamic scale factor instead. I also lowered the sea level for additional land mass (see the screenshot). 

In the default setting, the terrain repeats after 2048 blocks, but biomes/vegetation/etc. is procedural and thus different.