### PR TITLE
Add WorldGenerator.getWorldSeed()

### DIFF
--- a/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
@@ -48,6 +48,11 @@ public abstract class BaseFacetedWorldGenerator implements WorldGenerator, World
     }
 
     @Override
+    public String getWorldSeed() {
+        return worldSeed;
+    }
+
+    @Override
     public void setWorldSeed(final String seed) {
         worldSeed = seed;
         worldBuilder = createWorld(worldSeed.hashCode());

--- a/engine/src/main/java/org/terasology/world/generator/WorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generator/WorldGenerator.java
@@ -26,6 +26,8 @@ import org.terasology.world.generation.World;
 public interface WorldGenerator {
     SimpleUri getUri();
 
+    String getWorldSeed();
+
     void setWorldSeed(String seed);
 
     void createChunk(CoreChunk chunk);

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/AbstractBaseWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/AbstractBaseWorldGenerator.java
@@ -61,6 +61,11 @@ public abstract class AbstractBaseWorldGenerator implements WorldGenerator, Worl
     }
 
     @Override
+    public String getWorldSeed() {
+        return worldSeed;
+    }
+
+    @Override
     public void setWorldSeed(final String seed) {
         worldSeed = seed;
         for (final ChunkGenerationPass generator : generationPasses) {


### PR DESCRIPTION
Adds the missing getter for the `WorldGenerator.setWorldSeed()` method. This method also need to be added to [AnotherWorld](https://github.com/Terasology/AnotherWorld)s `PluggableWorldGenerator`.

A use case is WorldViewer who wants to display the seed that is currently used.