### PR TITLE
Prepare Javadoc for Java8

### DIFF
--- a/engine-tests/src/main/java/org/terasology/Environment.java
+++ b/engine-tests/src/main/java/org/terasology/Environment.java
@@ -36,7 +36,7 @@ public class Environment {
 
     /**
      * Default setup order
-     * @param modules
+     * @param moduleNames a list of module names
      */
     public Environment(Name ... moduleNames) {
 

--- a/engine-tests/src/main/java/org/terasology/entitySystem/stubs/EntityRefComponent.java
+++ b/engine-tests/src/main/java/org/terasology/entitySystem/stubs/EntityRefComponent.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EntityRefComponent implements Component {
 

--- a/engine-tests/src/main/java/org/terasology/entitySystem/stubs/GetterSetterComponent.java
+++ b/engine-tests/src/main/java/org/terasology/entitySystem/stubs/GetterSetterComponent.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class GetterSetterComponent implements Component {
     public transient boolean getterUsed;

--- a/engine-tests/src/main/java/org/terasology/entitySystem/stubs/IntegerComponent.java
+++ b/engine-tests/src/main/java/org/terasology/entitySystem/stubs/IntegerComponent.java
@@ -18,7 +18,7 @@ package org.terasology.entitySystem.stubs;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class IntegerComponent implements Component {
     public int value;

--- a/engine-tests/src/main/java/org/terasology/entitySystem/stubs/StringComponent.java
+++ b/engine-tests/src/main/java/org/terasology/entitySystem/stubs/StringComponent.java
@@ -18,7 +18,7 @@ package org.terasology.entitySystem.stubs;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class StringComponent implements Component {
     public static String staticValue = "Test";

--- a/engine-tests/src/main/java/org/terasology/testUtil/TeraAssert.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/TeraAssert.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Lists;
 
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class TeraAssert {
     private TeraAssert() {

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PojoEntityManagerTest {
     private static ModuleManager moduleManager;

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PojoEventSystemTests {
 

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
@@ -46,8 +46,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * @author Immortius <immortius@gmail.com>
- * @author Rasmus 'Cervator' Praestholm <cervator@gmail.com>
+ * @author Immortius
+ * @author Rasmus 'Cervator' Praestholm
  */
 public class PojoPrefabManagerTest {
 

--- a/engine-tests/src/test/java/org/terasology/logic/inventory/InventoryAuthoritySystemTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/inventory/InventoryAuthoritySystemTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class InventoryAuthoritySystemTest {
     private InventoryAuthoritySystem inventoryAuthoritySystem;

--- a/engine-tests/src/test/java/org/terasology/logic/location/LocationComponentTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/location/LocationComponentTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class LocationComponentTest extends TerasologyTestingEnvironment {
 

--- a/engine-tests/src/test/java/org/terasology/math/SideTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/SideTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class SideTest {
 

--- a/engine-tests/src/test/java/org/terasology/persistence/EntityDataJSONFormatTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/EntityDataJSONFormatTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EntityDataJSONFormatTest {
 

--- a/engine-tests/src/test/java/org/terasology/persistence/EntitySerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/EntitySerializerTest.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EntitySerializerTest {
 

--- a/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class WorldSerializerTest {
 

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class StorageManagerTest {
 

--- a/engine/src/dev/java/org/terasology/benchmark/BasicBenchmarkResult.java
+++ b/engine/src/dev/java/org/terasology/benchmark/BasicBenchmarkResult.java
@@ -19,7 +19,7 @@ package org.terasology.benchmark;
 /**
  * BasicBenchmarkResult extends BenchmarkResult and adds three basic columns for pretty printing.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class BasicBenchmarkResult extends BenchmarkResult {
 

--- a/engine/src/dev/java/org/terasology/benchmark/Benchmark.java
+++ b/engine/src/dev/java/org/terasology/benchmark/Benchmark.java
@@ -18,7 +18,7 @@ package org.terasology.benchmark;
 /**
  * Benchmark is an abstract class which is used to implement one particular benchmark.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public interface Benchmark {
 

--- a/engine/src/dev/java/org/terasology/benchmark/BenchmarkCallback.java
+++ b/engine/src/dev/java/org/terasology/benchmark/BenchmarkCallback.java
@@ -18,7 +18,7 @@ package org.terasology.benchmark;
 /**
  * BenchmarkCallback allows to watch the progress of the execution of one or many benchmarks.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public interface BenchmarkCallback {
 

--- a/engine/src/dev/java/org/terasology/benchmark/BenchmarkError.java
+++ b/engine/src/dev/java/org/terasology/benchmark/BenchmarkError.java
@@ -21,7 +21,7 @@ import com.google.common.base.Preconditions;
  * BenchmarkError encapsulates an error that occurred during a benchmark.
  * It stores the type of the error and the exception object.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class BenchmarkError {
 

--- a/engine/src/dev/java/org/terasology/benchmark/BenchmarkResult.java
+++ b/engine/src/dev/java/org/terasology/benchmark/BenchmarkResult.java
@@ -25,7 +25,7 @@ import java.util.List;
  * BenchmarkResult records the results and the errors of the execution of one particular benchmark.
  * It also maintains a list of columns which are very useful for pretty printing the results.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class BenchmarkResult {
 

--- a/engine/src/dev/java/org/terasology/benchmark/Benchmarks.java
+++ b/engine/src/dev/java/org/terasology/benchmark/Benchmarks.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * Benchmarks contains methods to execute one or many benchmarks with support for a progress callback as well as
  * a simple pretty printer for benchmark results.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public final class Benchmarks {
 

--- a/engine/src/dev/java/org/terasology/benchmark/PrintToConsoleCallback.java
+++ b/engine/src/dev/java/org/terasology/benchmark/PrintToConsoleCallback.java
@@ -21,7 +21,7 @@ import java.text.NumberFormat;
 /**
  * PrintToConsoleCallback implements BenchmarkCallback and simply prints everything to the console.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class PrintToConsoleCallback implements BenchmarkCallback {
 

--- a/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/BenchmarkTeraArray.java
+++ b/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/BenchmarkTeraArray.java
@@ -22,7 +22,7 @@ import org.terasology.world.chunks.blockdata.TeraArray;
 /**
  * BenchmarkTeraArray is the base class for benchmarking tera arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class BenchmarkTeraArray implements Benchmark {
 

--- a/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/BenchmarkTeraArrayRead.java
+++ b/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/BenchmarkTeraArrayRead.java
@@ -20,7 +20,7 @@ import org.terasology.world.chunks.blockdata.TeraArray;
 /**
  * BenchmarkTeraArrayRead implements a simple read performance benchmark for tera arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class BenchmarkTeraArrayRead extends BenchmarkTeraArray {
 

--- a/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/BenchmarkTeraArrayWrite.java
+++ b/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/BenchmarkTeraArrayWrite.java
@@ -20,7 +20,7 @@ import org.terasology.world.chunks.blockdata.TeraArray;
 /**
  * BenchmarkTeraArrayWrite implements a simple write performance benchmark for tera arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class BenchmarkTeraArrayWrite extends BenchmarkTeraArray {
 

--- a/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/TeraArraysBenchmark.java
+++ b/engine/src/dev/java/org/terasology/benchmark/chunks/arrays/TeraArraysBenchmark.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * TeraArraysBenchmark simplifies the execution of the benchmarks for tera arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 @SuppressWarnings("unused")
 public final class TeraArraysBenchmark {

--- a/engine/src/main/java/org/terasology/asset/AbstractAsset.java
+++ b/engine/src/main/java/org/terasology/asset/AbstractAsset.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 
 /**
  * Base class for all Assets that ensures that they
- * @author Immortius <immortius@gmail.com>
- * @author Florian <florian@fkoeberle.de>
+ * @author Immortius
+ * @author Florian
  */
 public abstract class AbstractAsset<T extends AssetData> implements Asset<T> {
     private static final Logger logger = LoggerFactory.getLogger(AbstractAsset.class);

--- a/engine/src/main/java/org/terasology/asset/Asset.java
+++ b/engine/src/main/java/org/terasology/asset/Asset.java
@@ -18,14 +18,14 @@ package org.terasology.asset;
 
 /**
  * Interface common to all assets.
- * <p/>
+ * <br><br>
  * An asset is a resource that is used by the game - a texture, sound, block definition and the like. These are typically
  * loaded from a module, although they can also be created at runtime. Each asset is identified by a URI that uniquely
  * identifies it and can be used to obtain it. This uri provides a lightweight way to serialize a reference to an Asset.
- * <p/>
+ * <br><br>
  * Assets are created from a specific type of asset data - this allows for implementation specific assets (e.g. OpenAL
  * sounds or Null sounds if the NullSoundManager is in use).
- * <p/>
+ * <br><br>
  * Assets may be reloaded by providing a new batch of data, or disposed to free resources - disposed assets may no
  * longer be used until reloaded.
  *

--- a/engine/src/main/java/org/terasology/asset/AssetData.java
+++ b/engine/src/main/java/org/terasology/asset/AssetData.java
@@ -20,11 +20,11 @@ package org.terasology.asset;
  * AssetData is the implementation agnostic data for an asset - typically it isn't dependant on either the source format
  * or the implementation consuming the resource. For instance, for a texture the asset data would not depend on the
  * format of the image the texture is sourced from, nor whether textures are handled by LWJGL or some other renderer.
- * <p/>
+ * <br><br>
  * This separation allows support for multiple implementations on either end, as well as the direct procedural creation
  * of assets. It should be noted that there may be multiple implementations of Asset Data in some cases as well, although
  * these cases should be rare.
- * <p/>
+ * <br><br>
  * AssetData is information used to create and reload assets
  */
 public interface AssetData {

--- a/engine/src/main/java/org/terasology/asset/AssetLoader.java
+++ b/engine/src/main/java/org/terasology/asset/AssetLoader.java
@@ -35,7 +35,7 @@ public interface AssetLoader<T extends AssetData> {
      * Loads an asset. The module containing the asset is provided, along with an stream, and the urls relating to the
      * asset. In simple cases there is just one url, but in some cases an asset is composed of multiple files so the
      * urls for each file is provided. In these cases the stream is for the first url.
-     * <p/>
+     * <br><br>
      * The provided stream is cleaned up by the caller, and doesn't have to be closed by this method.
      *
      * @param module The module providing the asset

--- a/engine/src/main/java/org/terasology/asset/AssetType.java
+++ b/engine/src/main/java/org/terasology/asset/AssetType.java
@@ -49,7 +49,7 @@ import java.util.Map;
  * An AssetType defines a type of resource accessible through the AssetManager.
  *
  * @author Immortius
- * @author Lucas Jenss <public@x3ro.de>
+ * @author Lucas Jenss
  */
 public enum AssetType {
     PREFAB("prefab", "prefabs", "prefab", new PrefabLoader(), true),

--- a/engine/src/main/java/org/terasology/asset/package-info.java
+++ b/engine/src/main/java/org/terasology/asset/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * This package provides a system for loading and managing Assets - these are resources used by Terasology that are loaded from modules.
- * <p/>
+ * <br><br>
  * The asset system features support for:
  * <ul>
  *      <li>Multiple file formats for an asset (with an AssetLoader per format)</li>

--- a/engine/src/main/java/org/terasology/audio/AudioEndListener.java
+++ b/engine/src/main/java/org/terasology/audio/AudioEndListener.java
@@ -17,7 +17,7 @@ package org.terasology.audio;
 
 /**
  * Is called by AudioManager to inform about end of playing music or sound.
- * <p/>
+ * <br><br>
  * Notice: The code in onAudioEnd is run in the update() method of the AudioManager once the sound/music ends playing.
  */
 public interface AudioEndListener {

--- a/engine/src/main/java/org/terasology/audio/AudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/AudioManager.java
@@ -59,7 +59,7 @@ public interface AudioManager {
 
     /**
      * Update AudioManager sound sources
-     * <p/>
+     * <br><br>
      * Should be called in main game loop
      */
     void update(float delta);

--- a/engine/src/main/java/org/terasology/audio/AudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/AudioManager.java
@@ -20,7 +20,7 @@ import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface AudioManager {
     float MAX_DISTANCE = 100.0f;

--- a/engine/src/main/java/org/terasology/audio/StreamingSound.java
+++ b/engine/src/main/java/org/terasology/audio/StreamingSound.java
@@ -23,8 +23,6 @@ public interface StreamingSound extends Sound<StreamingSoundData> {
 
     /**
      * Reset sound state (clears buffers, reset cached info)
-     *
-     * @return
      */
     void reset();
 

--- a/engine/src/main/java/org/terasology/audio/events/package-info.java
+++ b/engine/src/main/java/org/terasology/audio/events/package-info.java
@@ -17,14 +17,14 @@
 /**
  * This package provides a low-level system for describing classes and fields, with support for construction and field access. Essentially it is a simplified reflection
  * framework.
- * <p/>
+ * <br><br>
  * To support this functionality, a copy-strategy library is used to provide copying support for types. This is used instead of cloning because
  * <ol>
  *     <li>Not all types support cloning, including types outside of our control</li>
  *     <li>Cloning doesn't allow for possible performance improvements though runtime generated code</li>
  *     <li>Cloning is generally a poorly implemented feature of Java - copy constructors and methods are preferred</li>
  * </ol>
- * <p/>
+ * <br><br>
  * Additionally, ReflectFactory is used to provide support for construction and field access, to allow for alternate implementations.
  */
 @API package org.terasology.audio.events;

--- a/engine/src/main/java/org/terasology/audio/loaders/OggReader.java
+++ b/engine/src/main/java/org/terasology/audio/loaders/OggReader.java
@@ -34,13 +34,13 @@ import java.nio.ByteOrder;
 
 /**
  * Decompresses an Ogg file.
- * <p/>
+ * <br><br>
  * How to use:<br>
  * 1. Create OggInputStream passing in the input stream of the packed ogg file<br>
  * 2. Fetch format and sampling rate using getFormat() and getRate(). Use it to
  * initialize the sound player.<br>
  * 3. Read the PCM data using one of the read functions, and feed it to your player.
- * <p/>
+ * <br><br>
  * OggInputStream provides a read(ByteBuffer, int, int) that can be used to read
  * data directly into a native buffer.
  */
@@ -222,7 +222,7 @@ public class OggReader extends FilterInputStream {
 
     /**
      * Returns 0 after EOF is reached, otherwise always return 1.
-     * <p/>
+     * <br><br>
      * Programs should not count on this method to return the actual number of
      * bytes that could be read without blocking.
      *

--- a/engine/src/main/java/org/terasology/config/PermissionConfig.java
+++ b/engine/src/main/java/org/terasology/config/PermissionConfig.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class PermissionConfig {
     /**

--- a/engine/src/main/java/org/terasology/editor/TeraEd.java
+++ b/engine/src/main/java/org/terasology/editor/TeraEd.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 /**
  * TeraEd main class.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 @SuppressWarnings("serial")
 public final class TeraEd extends JWindow {

--- a/engine/src/main/java/org/terasology/editor/properties/Property.java
+++ b/engine/src/main/java/org/terasology/editor/properties/Property.java
@@ -16,7 +16,7 @@
 package org.terasology.editor.properties;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public interface Property<T> {
 

--- a/engine/src/main/java/org/terasology/editor/properties/PropertyProvider.java
+++ b/engine/src/main/java/org/terasology/editor/properties/PropertyProvider.java
@@ -18,7 +18,7 @@ package org.terasology.editor.properties;
 import java.util.List;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public interface PropertyProvider<T> {
     /**

--- a/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
+++ b/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
@@ -24,7 +24,7 @@ import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import java.util.List;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class SceneProperties implements PropertyProvider {
     @Override

--- a/engine/src/main/java/org/terasology/editor/ui/MainWindow.java
+++ b/engine/src/main/java/org/terasology/editor/ui/MainWindow.java
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 /**
  * TeraEd main class.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 @SuppressWarnings("serial")
 public final class MainWindow extends JFrame implements ActionListener, WindowListener, StateChangeSubscriber {

--- a/engine/src/main/java/org/terasology/editor/ui/PropertyPanel.java
+++ b/engine/src/main/java/org/terasology/editor/ui/PropertyPanel.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class PropertyPanel extends JPanel {
 

--- a/engine/src/main/java/org/terasology/editor/ui/PropertySlider.java
+++ b/engine/src/main/java/org/terasology/editor/ui/PropertySlider.java
@@ -24,7 +24,7 @@ import javax.swing.event.ChangeListener;
 import java.awt.*;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class PropertySlider extends JPanel implements ChangeListener {
 

--- a/engine/src/main/java/org/terasology/editor/ui/Viewport.java
+++ b/engine/src/main/java/org/terasology/editor/ui/Viewport.java
@@ -23,7 +23,7 @@ import java.awt.*;
 /**
  * TeraEd main class.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 @SuppressWarnings("serial")
 public final class Viewport extends Canvas {

--- a/engine/src/main/java/org/terasology/engine/ComponentFieldUri.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentFieldUri.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 /**
  * A URI to identify a field of a component in terasology.
- * These URIs are always in the form: <module-name>:<object-name>.<fieldName>. They are case-insensitive (using
+ * These URIs are always in the form: {@literal <module-name>:<object-name>.<fieldName>}. They are case-insensitive (using
  * English casing), and have a "normalized" form that is lower case.
  *
  * @author Florian

--- a/engine/src/main/java/org/terasology/engine/ComponentFieldUri.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentFieldUri.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * These URIs are always in the form: <module-name>:<object-name>.<fieldName>. They are case-insensitive (using
  * English casing), and have a "normalized" form that is lower case.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @API
 public final class ComponentFieldUri implements Uri {

--- a/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * </ul>
  * It becomes active when initialise() is called, and inactive when shutdown() is called.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class ComponentSystemManager {
 

--- a/engine/src/main/java/org/terasology/engine/GameThread.java
+++ b/engine/src/main/java/org/terasology/engine/GameThread.java
@@ -49,7 +49,7 @@ public final class GameThread {
 
     /**
      * Runs a process on the game thread, not waiting for it to run.
-     * <p/>
+     * <br><br>
      * If the current thread is the game thread, then the process runs immediately
      *
      * @param process
@@ -64,7 +64,7 @@ public final class GameThread {
 
     /**
      * Runs a process on the game thread, waiting for it to run (the current thread is blocked).
-     * <p/>
+     * <br><br>
      * If the current thread is the game thread, then the process runs immediately
      *
      * @param process

--- a/engine/src/main/java/org/terasology/engine/SimpleUri.java
+++ b/engine/src/main/java/org/terasology/engine/SimpleUri.java
@@ -21,8 +21,9 @@ import org.terasology.module.sandbox.API;
 import org.terasology.naming.Name;
 
 /**
- * A URI to identify standard objects in Terasology - components, events, etc. These URIs are always in the form: <module-name>:<object-name>. They are case-insensitive (using
- * English casing), and have a "normalized" form that is lower case.
+ * A URI to identify standard objects in Terasology - components, events, etc.
+ * These URIs are always in the form: {@literal <module-name>:<object-name>}.
+ * They are case-insensitive (using English casing), and have a "normalized" form that is lower case.
  *
  * @author synopia
  */

--- a/engine/src/main/java/org/terasology/engine/Uri.java
+++ b/engine/src/main/java/org/terasology/engine/Uri.java
@@ -22,7 +22,7 @@ import org.terasology.naming.Name;
  * Uris are used to identify resources, like assets and systems introduced by mods. Uris can then be serialized/deserialized to and from Strings.
  * Uris are case-insensitive. They have a normalised form which is lower-case (using English casing).
  * Uris are immutable.
- * <p/>
+ * <br><br>
  * All uris include a module name as part of their structure.
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/engine/modes/GameState.java
+++ b/engine/src/main/java/org/terasology/engine/modes/GameState.java
@@ -19,7 +19,7 @@ package org.terasology.engine.modes;
 import org.terasology.engine.GameEngine;
 
 /**
- * @author Anton Kireev <adeon.k87@gmail.com>
+ * @author Anton Kireev
  * @version 0.1
  *
  * A GameState encapsulates a different set of systems and managers being initialized

--- a/engine/src/main/java/org/terasology/engine/modes/LoadProcess.java
+++ b/engine/src/main/java/org/terasology/engine/modes/LoadProcess.java
@@ -35,8 +35,6 @@ public interface LoadProcess {
 
     /**
      * Begins the loading
-     *
-     * @return The total number of expected steps for this LoadProcess, 0 if nothing to do
      */
     void begin();
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -55,8 +55,8 @@ import java.util.Collections;
 /**
  * Play mode.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Anton Kireev <adeon.k87@gmail.com>
+ * @author Benjamin Glatzel
+ * @author Anton Kireev
  * @version 0.1
  */
 public class StateIngame implements GameState {

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -46,9 +46,9 @@ import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
  * The class implements the main game menu.
  * <br><br>
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Anton Kireev <adeon.k87@gmail.com>
- * @author Marcel Lehwald <marcel.lehwald@googlemail.com>
+ * @author Benjamin Glatzel
+ * @author Anton Kireev
+ * @author Marcel Lehwald
  * @version 0.3
  */
 public class StateMainMenu implements GameState {

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -44,7 +44,7 @@ import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
 
 /**
  * The class implements the main game menu.
- * <p/>
+ * <br><br>
  *
  * @author Benjamin Glatzel <benjamin.glatzel@me.com>
  * @author Anton Kireev <adeon.k87@gmail.com>

--- a/engine/src/main/java/org/terasology/engine/modes/StateSetup.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateSetup.java
@@ -38,9 +38,9 @@ import org.terasology.rendering.nui.internal.NUIManagerInternal;
 /**
  * The class provides the basics for the setup stage for the game, where the game parameters are defined
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Anton Kireev <adeon.k87@gmail.com>
- * @author Marcel Lehwald <marcel.lehwald@googlemail.com>
+ * @author Benjamin Glatzel
+ * @author Anton Kireev
+ * @author Marcel Lehwald
  * @version 0.3
  */
 public abstract class StateSetup implements GameState {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/EnsureSaveGameConsistency.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/EnsureSaveGameConsistency.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 /**
  * Repairs the save game when it is in an inconsistent state after a crash.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class EnsureSaveGameConsistency implements LoadProcess {
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
@@ -22,7 +22,7 @@ import org.terasology.world.generator.WorldGenerator;
 
 /**
  * Initialize the world generator.
- * <br/><br/>
+ * <br><br>
  * This is done after the world entity has been created/loaded so that
  * world generation config. is available at the time of initialization.
  * @author Martin Steiger

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -39,10 +39,10 @@ import java.util.List;
 /**
  * The class is game selection menu replacement for the headless server.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Anton Kireev <adeon.k87@gmail.com>
- * @author Marcel Lehwald <marcel.lehwald@googlemail.com>
- * @author Florian <florian@fkoeberle.de>
+ * @author Benjamin Glatzel
+ * @author Anton Kireev
+ * @author Marcel Lehwald
+ * @author Florian
  */
 public class StateHeadlessSetup extends StateSetup {
 

--- a/engine/src/main/java/org/terasology/entitySystem/Component.java
+++ b/engine/src/main/java/org/terasology/entitySystem/Component.java
@@ -22,7 +22,7 @@ package org.terasology.entitySystem;
  *     <li> can be inspected and/or edited by one or more {@link org.terasology.entitySystem.systems.ComponentSystem}s.</li>
  * </ul>
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface Component {
 

--- a/engine/src/main/java/org/terasology/entitySystem/Owns.java
+++ b/engine/src/main/java/org/terasology/entitySystem/Owns.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 /**
  * When used in a Component on a EntityRef, List&lt;EntityRef> or Set&lt;EntityRef> field, denotes that the Entity
  * will assume ownership of the entity or entities contained in that field.
- * <p/>
+ * <br><br>
  * This means:
  * <ul>
  * <li>The owned entity will be persisted and restored along with its owner.</li>

--- a/engine/src/main/java/org/terasology/entitySystem/Owns.java
+++ b/engine/src/main/java/org/terasology/entitySystem/Owns.java
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * When used in a Component on a EntityRef, List&lt;EntityRef> or Set&lt;EntityRef> field, denotes that the Entity
- * will assume ownership of the entity or entities contained in that field.
+ * When used in a Component on a EntityRef, {@literal List<EntityRef>} or {@literal Set<EntityRef> field},
+ * denotes that the Entity will assume ownership of the entity or entities contained in that field.
  * <br><br>
  * This means:
  * <ul>

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -26,7 +26,7 @@ import org.terasology.math.geom.Vector3f;
 import java.util.Map;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface EntityManager {
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -25,7 +25,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 /**
  * A wrapper around an entity id providing access to common functionality
  **
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public abstract class EntityRef implements MutableComponentContainer {
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/ComponentTable.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/ComponentTable.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * A table for storing entities and components. Focused on allowing iteration across a components of a given type
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 class ComponentTable {
     private Map<Class, TLongObjectMap<Component>> store = Maps.newConcurrentMap();

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/ComponentTable.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/ComponentTable.java
@@ -129,7 +129,7 @@ class ComponentTable {
 
     /**
      * Produces an iterator for iterating over all entities
-     * <p/>
+     * <br><br>
      * This is not designed to be performant, and in general usage entities should not be iterated over.
      *
      * @return An iterator over all entity ids.

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -31,7 +31,7 @@ public interface EngineEntityManager extends LowLevelEntityManager {
 
     /**
      * Creates an entity but doesn't send any lifecycle events.
-     * <p/>
+     * <br><br>
      * This is used by the block entity system to give an illusion of permanence to temporary block entities.
      *
      * @param components
@@ -41,7 +41,7 @@ public interface EngineEntityManager extends LowLevelEntityManager {
 
     /**
      * Creates an entity but doesn't send any lifecycle events.
-     * <p/>
+     * <br><br>
      * This is used by the block entity system to give an illusion of permanence to temporary block entities.
      *
      * @param prefab
@@ -53,7 +53,7 @@ public interface EngineEntityManager extends LowLevelEntityManager {
 
     /**
      * Destroys an entity without sending lifecycle events.
-     * <p/>
+     * <br><br>
      * This is used by the block entity system to give an illusion of permanence to temporary block entities.
      *
      * @param entity

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -23,7 +23,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface EngineEntityManager extends LowLevelEntityManager {
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityDestroySubscriber.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityDestroySubscriber.java
@@ -21,7 +21,7 @@ import org.terasology.entitySystem.entity.EntityRef;
  * See {@link EngineEntityManager#subscribeForDestruction(EntityDestroySubscriber)}.
  *
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public interface EntityDestroySubscriber {
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
@@ -25,7 +25,7 @@ import org.terasology.persistence.StorageManager;
 /**
  * Component for storing entity system information on an entity
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EntityInfoComponent implements Component {
     public Prefab parentPrefab = new NullPrefab();

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 /**
  * Null entity implementation - acts the same as an empty entity, except you cannot add anything to it.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class NullEntityRef extends EntityRef {
     private static NullEntityRef instance = new NullEntityRef();

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -61,7 +61,7 @@ import java.util.Set;
 /**
  * Prototype entity manager. Not intended for final use, but a stand in for experimentation.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PojoEntityManager implements LowLevelEntityManager, EngineEntityManager {
     public static final long NULL_ID = 0;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityRef.java
@@ -21,7 +21,7 @@ import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.network.NetworkComponent;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PojoEntityRef extends BaseEntityRef {
     private long id;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeDeactivateComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeDeactivateComponent.java
@@ -25,7 +25,7 @@ import org.terasology.entitySystem.event.Event;
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class BeforeDeactivateComponent implements Event {
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeDeactivateComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeDeactivateComponent.java
@@ -21,7 +21,7 @@ import org.terasology.entitySystem.event.Event;
 /**
  * When a component is about to leave the active state, either due to being removed, the entity it is attached to being destroyed,
  * or the entity being stored, this event is sent.
- * <p/>
+ * <br><br>
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeEntityCreated.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeEntityCreated.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 /**
  * @deprecated Use the prefab delta system instead (create a json file under /deltas/moduleName/prefabs/prefabName.prefab with the desired changes)
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @Deprecated
 public class BeforeEntityCreated implements Event {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeRemoveComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/BeforeRemoveComponent.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.event.Event;
 
 /**
  * When a component is about to be removed from an entity, or an entity is about to be destroyed, this event is sent.
- * <p/>
+ * <br><br>
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnActivatedComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnActivatedComponent.java
@@ -21,7 +21,7 @@ import org.terasology.entitySystem.event.Event;
 /**
  * This event occurs after an entity is created, an entity is loaded or a component is added to an entity. This occurs
  * after OnAddedComponent where relevant.
- * <p/>
+ * <br><br>
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnActivatedComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnActivatedComponent.java
@@ -25,7 +25,7 @@ import org.terasology.entitySystem.event.Event;
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class OnActivatedComponent implements Event {
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnAddedComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnAddedComponent.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.event.Event;
 
 /**
  * This event is sent when an entity is created or a component added to an existing entity.
- * <p/>
+ * <br><br>
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnChangedComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnChangedComponent.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.event.Event;
 
 /**
  * This event occurs whenever a component is changed and saved.
- * <p/>
+ * <br><br>
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *

--- a/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnChangedComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/lifecycleEvents/OnChangedComponent.java
@@ -24,7 +24,7 @@ import org.terasology.entitySystem.event.Event;
  * Note that this event will only be received by @ReceiveEvent methods where all components in its list are present and
  * at least one is involved in the action causing the event.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class OnChangedComponent implements Event {
 

--- a/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
@@ -20,7 +20,7 @@ import gnu.trove.list.TFloatList;
 import gnu.trove.list.array.TFloatArrayList;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public abstract class AbstractValueModifiableEvent implements Event {
     private float baseValue;

--- a/engine/src/main/java/org/terasology/entitySystem/event/Event.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/Event.java
@@ -18,7 +18,7 @@ package org.terasology.entitySystem.event;
 /**
  * Marker interface for classes that can be sent to entities as events
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface Event {
 }

--- a/engine/src/main/java/org/terasology/entitySystem/event/ReceiveEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/ReceiveEvent.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation is used to mark up methods that can be registered to receive events through the EventSystem
- * <p/>
+ * <br><br>
  * These methods should have the form
  * <code>public void handlerMethod(EventType event, EntityRef entity)</code>
  *

--- a/engine/src/main/java/org/terasology/entitySystem/event/ReceiveEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/ReceiveEvent.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * These methods should have the form
  * <code>public void handlerMethod(EventType event, EntityRef entity)</code>
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystem.java
@@ -24,7 +24,7 @@ import org.terasology.entitySystem.systems.ComponentSystem;
 /**
  * Event system propagates events to registered handlers
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface EventSystem {
 

--- a/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
@@ -67,7 +67,7 @@ import java.util.concurrent.BlockingQueue;
 /**
  * An implementation of the EventSystem.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EventSystemImpl implements EventSystem {
 

--- a/engine/src/main/java/org/terasology/entitySystem/metadata/ComponentLibrary.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/ComponentLibrary.java
@@ -32,7 +32,7 @@ import org.terasology.reflection.reflect.ReflectFactory;
 /**
  * The library for metadata about components (and their fields).
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class ComponentLibrary extends AbstractClassLibrary<Component> {
 

--- a/engine/src/main/java/org/terasology/entitySystem/metadata/EventLibrary.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/EventLibrary.java
@@ -27,7 +27,7 @@ import org.terasology.entitySystem.event.Event;
 /**
  * The library for metadata about events (and their fields).
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EventLibrary extends AbstractClassLibrary<Event> {
 

--- a/engine/src/main/java/org/terasology/entitySystem/metadata/MetadataUtil.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/MetadataUtil.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.Component;
 import java.util.Locale;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class MetadataUtil {
 

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/Prefab.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/Prefab.java
@@ -27,7 +27,7 @@ import java.util.List;
  * An entity prefab describes the recipe for creating an entity.
  * Like an entity it groups a collection of components.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public abstract class Prefab extends AbstractAsset<PrefabData> implements ComponentContainer, Asset<PrefabData> {
 

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/PrefabManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/PrefabManager.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 /**
  * A PrefabManager keep Prefabs organized and available to the game engine.
  *
- * @author Immortius <immortius@gmail.com>
- * @author Rasmus 'Cervator' Praestholm <cervator@gmail.com>
+ * @author Immortius
+ * @author Rasmus 'Cervator' Praestholm
  */
 // TODO: This is basically unnecessary now, remove and just use Assets?
 public interface PrefabManager {

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefab.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefab.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PojoPrefab extends Prefab {
 

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
@@ -29,8 +29,8 @@ import java.util.Collection;
 /**
  * Basic implementation of PrefabManager.
  *
- * @author Immortius <immortius@gmail.com>
- * @author Rasmus 'Cervator' Praestholm <cervator@gmail.com>
+ * @author Immortius
+ * @author Rasmus 'Cervator' Praestholm
  * @see PrefabManager
  */
 public class PojoPrefabManager implements PrefabManager {

--- a/engine/src/main/java/org/terasology/entitySystem/systems/ComponentSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/ComponentSystem.java
@@ -16,7 +16,7 @@
 package org.terasology.entitySystem.systems;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface ComponentSystem {
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/systems/RenderSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/RenderSystem.java
@@ -16,7 +16,7 @@
 package org.terasology.entitySystem.systems;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface RenderSystem extends ComponentSystem {
 

--- a/engine/src/main/java/org/terasology/entitySystem/systems/UpdateSubscriberSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/UpdateSubscriberSystem.java
@@ -33,7 +33,7 @@ package org.terasology.entitySystem.systems;
  *     </li>
  *   </ul>
  * </p>
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface UpdateSubscriberSystem extends ComponentSystem {
 

--- a/engine/src/main/java/org/terasology/entitySystem/systems/UpdateSubscriberSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/UpdateSubscriberSystem.java
@@ -16,9 +16,8 @@
 package org.terasology.entitySystem.systems;
 
 /**
- * <p>
  * Interface for component systems that needs to be updated every time the engine is updated.
- * </p>
+ * <br><br>
  * <p><b>Note:</b> Usage of the UpdateSubscriberSystem interface is discouraged unless truly needed.
  * For most systems receiving the update call on every engine frame is overkill.
  * In most cases it will be sufficient to:
@@ -32,7 +31,6 @@ package org.terasology.entitySystem.systems;
  *       system update function at a specific times.
  *     </li>
  *   </ul>
- * </p>
  * @author Immortius
  */
 public interface UpdateSubscriberSystem extends ComponentSystem {

--- a/engine/src/main/java/org/terasology/identity/PublicIdentityCertificate.java
+++ b/engine/src/main/java/org/terasology/identity/PublicIdentityCertificate.java
@@ -89,7 +89,7 @@ public class PublicIdentityCertificate {
 
     /**
      * Encrypts data such that it can only be decrypted by the paired private certificate, which is held by the certificate owner.
-     * <p/>
+     * <br><br>
      * Note that only a limited amount of data can be encrypted in this fashion - for large exchanges this should be used
      * to establish shared symmetric key which can then be used for the main exchange.
      *

--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -56,7 +56,7 @@ import java.util.Map;
 
 /**
  * This system processes input, sending it out as events against the LocalPlayer entity.
- * <p/>
+ * <br><br>
  * In addition to raw keyboard and mouse input, the system handles Bind Buttons and Bind Axis, which can be mapped
  * to one or more inputs.
  */

--- a/engine/src/main/java/org/terasology/input/binds/movement/ToggleSpeedPermanentlyButton.java
+++ b/engine/src/main/java/org/terasology/input/binds/movement/ToggleSpeedPermanentlyButton.java
@@ -23,7 +23,7 @@ import org.terasology.input.Keyboard;
 import org.terasology.input.RegisterBindButton;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @RegisterBindButton(id = "toggleSpeedPermanently", description = "Toggle Speed Permanently")
 @DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.CAPS_LOCK)

--- a/engine/src/main/java/org/terasology/input/binds/movement/ToggleSpeedTemporarilyButton.java
+++ b/engine/src/main/java/org/terasology/input/binds/movement/ToggleSpeedTemporarilyButton.java
@@ -24,7 +24,7 @@ import org.terasology.input.RegisterBindButton;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @RegisterBindButton(id = "toggleSpeedTemporarily", description = "Toggle Speed Temporarily")
 @DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.LEFT_SHIFT)

--- a/engine/src/main/java/org/terasology/input/internal/BindableButtonImpl.java
+++ b/engine/src/main/java/org/terasology/input/internal/BindableButtonImpl.java
@@ -36,7 +36,7 @@ import java.util.Set;
 /**
  * A BindableButton is pseudo button that is controlled by one or more actual inputs (whether keys, mouse buttons or the
  * mouse wheel).
- * <p/>
+ * <br><br>
  * When the BindableButton changes state it sends out events like an actual key or button does. It also allows direct
  * subscription via the {@link org.terasology.input.BindButtonSubscriber} interface.
  */

--- a/engine/src/main/java/org/terasology/logic/actions/ExplosionAction.java
+++ b/engine/src/main/java/org/terasology/logic/actions/ExplosionAction.java
@@ -36,7 +36,7 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class ExplosionAction extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/logic/actions/ExplosionActionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/actions/ExplosionActionComponent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.actions;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class ExplosionActionComponent implements Component {
     public ActionTarget relativeTo = ActionTarget.Instigator;

--- a/engine/src/main/java/org/terasology/logic/actions/PlaySoundAction.java
+++ b/engine/src/main/java/org/terasology/logic/actions/PlaySoundAction.java
@@ -31,8 +31,8 @@ import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
 
 /**
- * @author Immortius <immortius@gmail.com>
- * @author Florian <florian@fkoeberle.de>
+ * @author Immortius
+ * @author Florian
  */
 @RegisterSystem(RegisterMode.ALWAYS)
 public class PlaySoundAction extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/logic/actions/PlaySoundActionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/actions/PlaySoundActionComponent.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * When activated, plays a random sound
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PlaySoundActionComponent implements Component {
     public List<StaticSound> sounds = Lists.newArrayList();

--- a/engine/src/main/java/org/terasology/logic/actions/TunnelAction.java
+++ b/engine/src/main/java/org/terasology/logic/actions/TunnelAction.java
@@ -37,7 +37,7 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class TunnelAction extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/logic/actions/TunnelActionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/actions/TunnelActionComponent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.actions;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class TunnelActionComponent implements Component {
 

--- a/engine/src/main/java/org/terasology/logic/ai/HierarchicalAIComponent.java
+++ b/engine/src/main/java/org/terasology/logic/ai/HierarchicalAIComponent.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Esa-Petri Tirkkonen <esereja@yahoo.co.uk>
+ * @author Esa-Petri Tirkkonen
  */
 public final class HierarchicalAIComponent implements Component {
 

--- a/engine/src/main/java/org/terasology/logic/ai/HierarchicalAISystem.java
+++ b/engine/src/main/java/org/terasology/logic/ai/HierarchicalAISystem.java
@@ -40,7 +40,7 @@ import org.terasology.world.WorldProvider;
 /**
  * Hierarchical AI, idea from robotics
  *
- * @author Esa-Petri Tirkkonen <esereja@yahoo.co.uk>
+ * @author Esa-Petri Tirkkonen
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class HierarchicalAISystem extends BaseComponentSystem implements

--- a/engine/src/main/java/org/terasology/logic/ai/SimpleAIComponent.java
+++ b/engine/src/main/java/org/terasology/logic/ai/SimpleAIComponent.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class SimpleAIComponent implements Component {
 

--- a/engine/src/main/java/org/terasology/logic/ai/SimpleAISystem.java
+++ b/engine/src/main/java/org/terasology/logic/ai/SimpleAISystem.java
@@ -36,7 +36,7 @@ import org.terasology.utilities.random.Random;
 import org.terasology.world.WorldProvider;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class SimpleAISystem extends BaseComponentSystem implements UpdateSubscriberSystem {

--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -53,10 +53,10 @@ import java.util.Map;
 
 /**
  * Behavior tree system
- * <p/>
+ * <br><br>
  * Each entity with BehaviorComponent is kept under control by this system. For each such entity a behavior tree
  * is loaded and an interpreter is started.
- * <p/>
+ * <br><br>
  * Modifications made to a behavior tree will reflect to all entities using this tree.
  *
  * @author synopia

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTree.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTree.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 /**
  * Behavior tree asset. Can be loaded and saved into json.
- * <p/>
+ * <br><br>
  * This asset keeps track of the tree of Nodes and the associated RenderableNodes. If there are no RenderableNodes,
  * the helper class will generate and layout some.
  *

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTreeLoader.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTreeLoader.java
@@ -50,10 +50,10 @@ import java.util.Map;
 
 /**
  * Loader for behavior assets. Can also save assets into json format.
- * <p/>
+ * <br><br>
  * If there are both, Nodes and Renderables tree, both are loaded/saved. To ensure, the nodes get associated to
  * the correct renderable, additional ids are introduced (only in the json file).
- * <p/>
+ * <br><br>
  *
  * @author synopia
  */

--- a/engine/src/main/java/org/terasology/logic/behavior/nui/Port.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/nui/Port.java
@@ -31,7 +31,7 @@ import org.terasology.rendering.nui.InteractionListener;
  * - InputPort (one per RenderableNode)
  * - OutputPort (unlimited per RenderableNode, may be restricted by the type of the node)
  * - InsertPort ("virtual" port, to allow connections placed between two existing ones)
- * <p/>
+ * <br><br>
  * Input/Output ports may have a target. This is always of the opposite type.
  * When setting a target to a port, the node of the InputPort is added to the child list of the node of the OutputPort.
  *

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/Actor.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/Actor.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 /**
  * The actor is a decorated entity, which can act on a behavior tree using an Interpreter.
- * <p/>
+ * <br><br>
  * Besides the actual entity, a blackboard is stored for each actor. Every node may read or write to this blackboard,
  * to communicate their states or exchange variables with other nodes.
  *

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/CounterNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/CounterNode.java
@@ -19,11 +19,11 @@ import org.terasology.module.sandbox.API;
 import org.terasology.rendering.nui.properties.Range;
 
 /**
- * Starts child a limit number of times.<br/>
- * <br/>
- * <b>SUCCESS</b>: when child finished with <b>SUCCESS</b>n times.<br/>
- * <b>FAILURE</b>: as soon as child finishes with <b>FAILURE</b>.<br/>
- * <br/>
+ * Starts child a limit number of times.<br>
+ * <br>
+ * <b>SUCCESS</b>: when child finished with <b>SUCCESS</b>n times.<br>
+ * <b>FAILURE</b>: as soon as child finishes with <b>FAILURE</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/Interpreter.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/Interpreter.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * An interpreter evaluates a behavior tree. This is done by creating tasks for an actor for the nodes of the BT.
  * If a task returns RUNNING, the task is placed to the active list and asked next tick again.
  * Finished nodes may create new tasks, which are placed to the active list.
- * <p/>
+ * <br><br>
  *
  * @author synopia
  */

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/InverterNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/InverterNode.java
@@ -16,11 +16,11 @@
 package org.terasology.logic.behavior.tree;
 
 /**
- * Inverts the child.<br/>
- * <br/>
- * <b>SUCCESS</b>: when child finishes <b>FAILURE</b>.<br/>
- * <b>FAILURE</b>: when child finishes <b>SUCCESS</b>.<br/>
- * <br/>
+ * Inverts the child.<br>
+ * <br>
+ * <b>SUCCESS</b>: when child finishes <b>FAILURE</b>.<br>
+ * <b>FAILURE</b>: when child finishes <b>SUCCESS</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 public class InverterNode extends DecoratorNode {

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/LookupNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/LookupNode.java
@@ -19,11 +19,11 @@ import org.terasology.logic.behavior.asset.BehaviorTree;
 import org.terasology.rendering.nui.properties.OneOf;
 
 /**
- * Node that runs a behavior tree.<br/>
- * <br/>
- * <b>SUCCESS</b>: when tree finishes with <b>SUCCESS</b>.<br/>
- * <b>FAILURE</b>: when tree finishes with <b>FAILURE</b>.<br/>
- * <br/>
+ * Node that runs a behavior tree.<br>
+ * <br>
+ * <b>SUCCESS</b>: when tree finishes with <b>SUCCESS</b>.<br>
+ * <b>FAILURE</b>: when tree finishes with <b>FAILURE</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 public class LookupNode extends Node {

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/MonitorNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/MonitorNode.java
@@ -18,10 +18,10 @@ package org.terasology.logic.behavior.tree;
 import org.terasology.module.sandbox.API;
 
 /**
- * <br/>
- * <b>SUCCESS</b>: as soon as one child node finishes SUCCESS<br/>
- * <b>FAILURE</b>: as soon as one child node finishes <b>FAILURE</b>.<br/>
- * <br/>
+ * <br>
+ * <b>SUCCESS</b>: as soon as one child node finishes SUCCESS<br>
+ * <b>FAILURE</b>: as soon as one child node finishes <b>FAILURE</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/Node.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/Node.java
@@ -20,7 +20,7 @@ import org.terasology.module.sandbox.API;
 /**
  * Base class for nodes in a behavior tree. Each node must implement the create() method to create tasks, that are
  * evaluated by an interpreter.
- * <p/>
+ * <br><br>
  * Node properties may be stored in this class, while state properties for a specific interpreter run be placed in the
  * task class (i.e. actual/next children to evaluate).
  *

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/ParallelNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/ParallelNode.java
@@ -19,11 +19,11 @@ import org.terasology.module.sandbox.API;
 import org.terasology.rendering.nui.properties.OneOf;
 
 /**
- * All children are evaluated in parallel. Policies for success and failure will define when this node finishes and in which state.<br/>
- * <br/>
- * <b>SUCCESS</b>: when success policy is fulfilled (one or all children <b>SUCCESS</b>).<br/>
- * <b>FAILURE</b>, when failure policy is fulfilled (one or all children <b>FAILURE</b>).<br/>
- * <br/>
+ * All children are evaluated in parallel. Policies for success and failure will define when this node finishes and in which state.<br>
+ * <br>
+ * <b>SUCCESS</b>: when success policy is fulfilled (one or all children <b>SUCCESS</b>).<br>
+ * <b>FAILURE</b>, when failure policy is fulfilled (one or all children <b>FAILURE</b>).<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/PlayMusicNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/PlayMusicNode.java
@@ -24,12 +24,12 @@ import org.terasology.registry.In;
 import org.terasology.rendering.nui.properties.OneOf;
 
 /**
- * <b>Properties</b>: <b>music</b><br/>
- * <br/>
- * <b>RUNNING</b>: while music is playing<br/>
- * <b>SUCCESS</b>: once music ends playing<br/>
- * <b>FAILURE</b>: otherwise<br/>
- * <br/>
+ * <b>Properties</b>: <b>music</b><br>
+ * <br>
+ * <b>RUNNING</b>: while music is playing<br>
+ * <b>SUCCESS</b>: once music ends playing<br>
+ * <b>FAILURE</b>: otherwise<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 public class PlayMusicNode extends Node {

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/PlaySoundNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/PlaySoundNode.java
@@ -26,12 +26,12 @@ import org.terasology.rendering.nui.properties.OneOf;
 import org.terasology.rendering.nui.properties.Range;
 
 /**
- * <b>Properties</b>: <b>sound</b>, <b>volume</b><br/>
- * <br/>
- * <b>RUNNING</b>: while sound is playing<br/>
- * <b>SUCCESS</b>: once sound ends playing<br/>
- * <b>FAILURE</b>: otherwise<br/>
- * <br/>
+ * <b>Properties</b>: <b>sound</b>, <b>volume</b><br>
+ * <br>
+ * <b>RUNNING</b>: while sound is playing<br>
+ * <b>SUCCESS</b>: once sound ends playing<br>
+ * <b>FAILURE</b>: otherwise<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 public class PlaySoundNode extends Node {

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/RepeatNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/RepeatNode.java
@@ -18,11 +18,11 @@ package org.terasology.logic.behavior.tree;
 import org.terasology.module.sandbox.API;
 
 /**
- * Repeats the child node forever.<br/>
- * <br/>
- * <b>SUCCESS</b>: Never.<br/>
- * <b>FAILURE</b>: as soon as decorated node finishes with <b>FAILURE</b>.<br/>
- * <br/>
+ * Repeats the child node forever.<br>
+ * <br>
+ * <b>SUCCESS</b>: Never.<br>
+ * <b>FAILURE</b>: as soon as decorated node finishes with <b>FAILURE</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/SelectorNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/SelectorNode.java
@@ -20,12 +20,12 @@ import org.terasology.module.sandbox.API;
 import java.util.Iterator;
 
 /**
- * Evaluates the children one by one.<br/>
- * Starts next child, if previous child finishes with <b>FAILURE</b>.<br/>
- * <br/>
- * <b>SUCCESS</b>: as soon as a child finishes <b>SUCCESS</b>.<br/>
- * <b>FAILURE</b>: when all children finished with <b>FAILURE</b>.<br/>
- * <br/>
+ * Evaluates the children one by one.<br>
+ * Starts next child, if previous child finishes with <b>FAILURE</b>.<br>
+ * <br>
+ * <b>SUCCESS</b>: as soon as a child finishes <b>SUCCESS</b>.<br>
+ * <b>FAILURE</b>: when all children finished with <b>FAILURE</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/SequenceNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/SequenceNode.java
@@ -20,12 +20,12 @@ import org.terasology.module.sandbox.API;
 import java.util.Iterator;
 
 /**
- * Evaluates the children one by one.<br/>
- * Starts next child, if previous child finishes with <b>SUCCESS</b>.<br/>
- * <br/>
- * <b>SUCCESS</b>: when all children finishes <b>SUCCESS</b>.<br/>
- * <b>FAILURE</b>: as soon as a child finished with <b>FAILURE</b>.<br/>
- * <br/>
+ * Evaluates the children one by one.<br>
+ * Starts next child, if previous child finishes with <b>SUCCESS</b>.<br>
+ * <br>
+ * <b>SUCCESS</b>: when all children finishes <b>SUCCESS</b>.<br>
+ * <b>FAILURE</b>: as soon as a child finished with <b>FAILURE</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/TimerNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/TimerNode.java
@@ -18,11 +18,11 @@ package org.terasology.logic.behavior.tree;
 import org.terasology.rendering.nui.properties.Range;
 
 /**
- * Starts the decorated node.<br/>
- * <br/>
- * <b>SUCCESS</b>: as soon as decorated node finishes with <b>SUCCESS</b>.<br/>
- * <b>FAILURE</b>: after x seconds.<br/>
- * <br/>
+ * Starts the decorated node.<br>
+ * <br>
+ * <b>SUCCESS</b>: as soon as decorated node finishes with <b>SUCCESS</b>.<br>
+ * <b>FAILURE</b>: after x seconds.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 public class TimerNode extends DecoratorNode {

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/TreeAccessor.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/TreeAccessor.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 /**
  * Interface to access a tree structure.
- * <p/>
+ * <br><br>
  * Using a ChainedTreeAccessor the modification made to a tree is reflected to all trees in the chain.
  *
  * @author synopia

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/WrapperNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/WrapperNode.java
@@ -16,8 +16,8 @@
 package org.terasology.logic.behavior.tree;
 
 /**
- * Always finishes with <b>SUCCESS</b>.<br/>
- * <br/>
+ * Always finishes with <b>SUCCESS</b>.<br>
+ * <br>
  * Auto generated javadoc - modify README.markdown instead!
  */
 public class WrapperNode extends DecoratorNode {

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -42,15 +42,15 @@ public final class CharacterComponent implements Component {
     public float interactionRange = 5f;
     /**
      * The current interaction target of a character which has been authorized by the authority (e.g. the server).
-     * <p/>
+     * <br><br>
      * Modules should not modify this field directly.
      */
     public EntityRef authorizedInteractionTarget = EntityRef.NULL;
     /**
      * This field is only set for clients (including clients that are servers).
-     * <p/>
+     * <br><br>
      * It contains the number of the activationId that caused the interaction start.
-     * <p/>
+     * <br><br>
      * The field is used to tell the client which interaction got canceled. Thus if the client has started another
      * interaction when it receives the old cancel, it won't wrongly cancel the new interaction.
      */
@@ -59,7 +59,7 @@ public final class CharacterComponent implements Component {
     /**
      * This field is only set for clients (including clients that are servers). The clients set it
      * best to their knowledge.
-     * <p/>
+     * <br><br>
      * The events {@link org.terasology.logic.characters.interactions.InteractionStartPredicted} and
      * {@link org.terasology.logic.characters.interactions.InteractionEndPredicted} inform about changes of this
      * field.
@@ -68,9 +68,9 @@ public final class CharacterComponent implements Component {
 
     /**
      * This field is only set for clients (including clients that are servers).
-     * <p/>
+     * <br><br>
      * It contains the number of the activationId that caused the interaction start.
-     * <p/>
+     * <br><br>
      * The field is used to determine if a incoming interaction cancel is for the current interaction or not.
      */
     public int predictedInteractionId;

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -30,7 +30,7 @@ import org.terasology.network.Replicate;
 /**
  * Information common to characters (the physical body of players and creatures)
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class CharacterComponent implements Component {
     public Vector3f spawnPosition = new Vector3f();

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterMovementComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterMovementComponent.java
@@ -28,7 +28,7 @@ import org.terasology.rendering.nui.properties.Range;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class CharacterMovementComponent implements Component {
 

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterSoundComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterSoundComponent.java
@@ -23,7 +23,7 @@ import org.terasology.entitySystem.Component;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class CharacterSoundComponent implements Component {
 

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterSoundSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterSoundSystem.java
@@ -47,7 +47,7 @@ import org.terasology.world.block.Block;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>, Limeth
+ * @author Immortius, Limeth
  */
 @RegisterSystem(RegisterMode.ALWAYS)
 public class CharacterSoundSystem extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -49,7 +49,7 @@ import org.terasology.world.block.Block;
  * <li>If an slope is hit, slide up it</li>
  * <li>Finally sweep downwards to undo any stepping, and for falling</li>
  * </ol>
- * <p/>
+ * <br><br>
  * TODO: Refactor to allow additional movement modes.
  * TODO: Detect entry and exit from water while ghosting.
  *
@@ -157,7 +157,7 @@ public class KinematicCharacterMover implements CharacterMover {
     /**
      * Checks whether a character should change movement mode (from being underwater or in a ladder). A higher and lower point of the
      * character is tested for being in water, only if both points are in water does the character count as swimming.
-     * <p/>
+     * <br><br>
      * Sends the OnEnterLiquidEvent and OnLeaveLiquidEvent events.
      *
      * @param movementComp The movement component of the character.

--- a/engine/src/main/java/org/terasology/logic/characters/StandComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/StandComponent.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * The component gets currently only used to define the idle stand animations.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class StandComponent implements Component {
     /**

--- a/engine/src/main/java/org/terasology/logic/characters/WalkComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/WalkComponent.java
@@ -25,7 +25,7 @@ import java.util.List;
  * The component gets currently only used as container for the walk animations,
  * but will in future also store the walk speed.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class WalkComponent implements Component {
     /**

--- a/engine/src/main/java/org/terasology/logic/characters/events/ActivationPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/ActivationPredicted.java
@@ -21,8 +21,8 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Florian <florian@fkoeberle.de>
- * @author Immortius <immortius@gmail.com>
+ * @author Florian
+ * @author Immortius
  */
 public class ActivationPredicted implements Event {
 

--- a/engine/src/main/java/org/terasology/logic/characters/events/ActivationRequest.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/ActivationRequest.java
@@ -22,7 +22,7 @@ import org.terasology.network.NetworkEvent;
 import org.terasology.network.ServerEvent;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @ServerEvent(lagCompensate = true)
 public class ActivationRequest extends NetworkEvent {

--- a/engine/src/main/java/org/terasology/logic/characters/events/ActivationRequestDenied.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/ActivationRequestDenied.java
@@ -27,7 +27,7 @@ import org.terasology.entitySystem.event.Event;
  * This is an authority internal event. If a reaction should be sent the client is up to the systems that process this
  * event..
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class ActivationRequestDenied implements Event {
     private int activationId;

--- a/engine/src/main/java/org/terasology/logic/characters/events/FootstepEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/FootstepEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.characters.events;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class FootstepEvent implements Event {
 

--- a/engine/src/main/java/org/terasology/logic/characters/events/HorizontalCollisionEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/HorizontalCollisionEvent.java
@@ -18,8 +18,8 @@ package org.terasology.logic.characters.events;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Immortius <immortius@gmail.com>
- * @author Esa-Petri Tirkkonen <esereja@yahoo.co.uk>
+ * @author Immortius
+ * @author Esa-Petri Tirkkonen
  */
 public class HorizontalCollisionEvent extends CollisionEvent {
 

--- a/engine/src/main/java/org/terasology/logic/characters/events/JumpEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/JumpEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.characters.events;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class JumpEvent implements Event {
 }

--- a/engine/src/main/java/org/terasology/logic/characters/events/VerticalCollisionEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/VerticalCollisionEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.characters.events;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class VerticalCollisionEvent extends CollisionEvent {
 

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndEvent.java
@@ -20,9 +20,9 @@ import org.terasology.network.OwnerEvent;
 
 /**
  * Represents the end of an interaction between for example a character and a container.
- * <p/>
+ * <br><br>
  * The event is sent via the character.
- * <p/>
+ * <br><br>
  * The event is sent by the server to the owner of the character..
  *
  * @author Florian <florian@fkoeberle.de>

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndEvent.java
@@ -25,7 +25,7 @@ import org.terasology.network.OwnerEvent;
  * <br><br>
  * The event is sent by the server to the owner of the character..
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @OwnerEvent
 public class InteractionEndEvent implements Event {

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndPredicted.java
@@ -31,7 +31,7 @@ import org.terasology.module.sandbox.API;
  * When event handler runs, the  predictedInteractionTarget field of the instigator's
  * CharacterComponent will already be updated to the new value.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @API
 public class InteractionEndPredicted implements Event {

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndRequest.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionEndRequest.java
@@ -21,7 +21,7 @@ import org.terasology.network.ServerEvent;
 /**
  * Request the server to cancel the current interaction.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @ServerEvent
 public class InteractionEndRequest implements Event {

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionScreenComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionScreenComponent.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.Component;
 /**
  * Entities with this component will show an UI during interactions.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class InteractionScreenComponent implements Component {
     public String screen;

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionStartPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionStartPredicted.java
@@ -29,7 +29,7 @@ import org.terasology.module.sandbox.API;
  * When event handler runs, the  predictedInteractionTarget field of the instigator's
  * CharacterComponent will already be updated to the new value.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @API
 public class InteractionStartPredicted implements Event {

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionStartPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionStartPredicted.java
@@ -21,11 +21,11 @@ import org.terasology.module.sandbox.API;
 
 /**
  * Sent to the client by itself at the start of an interaction between a character and a target.
- * <p/>
+ * <br><br>
  * THe event is sent to the target entity.
- * <p/>
+ * <br><br>
  * This event is not intended to be sent by modules.
- * <p/>
+ * <br><br>
  * When event handler runs, the  predictedInteractionTarget field of the instigator's
  * CharacterComponent will already be updated to the new value.
  *

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
@@ -37,8 +37,8 @@ import org.terasology.rendering.nui.ScreenLayerClosedEvent;
 
 /**
  *
- * @author Immortius <immortius@gmail.com>
- * @author Florian <florian@fkoeberle.de>
+ * @author Immortius
+ * @author Florian
  *
  */
 @RegisterSystem(RegisterMode.ALWAYS)

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionTargetComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionTargetComponent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.characters.interactions;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class InteractionTargetComponent implements Component {
 }

--- a/engine/src/main/java/org/terasology/logic/common/ActivateEvent.java
+++ b/engine/src/main/java/org/terasology/logic/common/ActivateEvent.java
@@ -22,7 +22,7 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 // TODO: This should not be consumable. Instead have a consumable BeforeActivate event to allow cancellation
 public class ActivateEvent extends AbstractConsumableEvent {

--- a/engine/src/main/java/org/terasology/logic/common/InspectionToolComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/InspectionToolComponent.java
@@ -23,7 +23,7 @@ import org.terasology.network.Replicate;
  * Component of the inspection tool which can be used to view the json data of
  * entities. This component can also be used to test external references.
  * 
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class InspectionToolComponent implements Component {
     @Replicate

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -47,7 +47,7 @@ import java.util.Set;
 /**
  * The console handles commands and messages.
  *
- * @author Marcel Lehwald <marcel.lehwald@googlemail.com>
+ * @author Marcel Lehwald
  */
 public class ConsoleImpl implements Console {
     private static final String PARAM_SPLIT_REGEX = " (?=([^\"]*\"[^\"]*\")*[^\"]*$)";

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/annotations/Command.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/annotations/Command.java
@@ -25,19 +25,19 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a method to be available as a command in the console, if it is in a ComponentSystem.
- * <p/>
+ * <br><br>
  * Command names are case-insensitive.
  * Command methods can have an {@link org.terasology.entitySystem.entity.EntityRef} parameter at the end,
  * which will be populated with the entity of the client calling the command.
  * Parameters should be annotated by the {@link CommandParam} annotation.
- * <p/>
+ * <br><br>
  * It is possible (and encouraged) to use other parameter types instead of {@link String}.
  * The parameter type can also be a one-dimensional array. The default delimiter is a comma ({@code ,}),
  * to change the delimiter, provide the {@code arrayDelimiter} argument to the linked {@link CommandParam}.
  * Array delimiters can be escaped using the {@code Command.ARRAY_DELIMITER_ESCAPE_CHARACTER}.
  * To make a command accept a variable amount of arguments (varargs), set the {@link CommandParam}'s
  * {@code arrayDelimiter} to {@code Command.ARRAY_DELIMITER_VARARGS}.
- * <p/>
+ * <br><br>
  * An example varargs command:
  * <pre>{@code
  * @literal@CommandDefinition(value = "tell", shortDescription = "Sends a private message to a user")

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/annotations/Command.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/annotations/Command.java
@@ -39,16 +39,15 @@ import java.lang.annotation.Target;
  * {@code arrayDelimiter} to {@code Command.ARRAY_DELIMITER_VARARGS}.
  * <br><br>
  * An example varargs command:
- * <pre>{@code
- * @literal@CommandDefinition(value = "tell", shortDescription = "Sends a private message to a user")
+ * <pre>
+ * {@literal @}Command(value = "tell", shortDescription = "Sends a private message to a user")
  * public String tellCommand(
- *      @literal@Sender EntityRef sender,
- *      @literal@CommandParameter("user") String user,
- *      @literal@CommandParameter(value = "message", arrayDelimiter = Command.ARRAY_DELIMITER_VARARGS) String[] messageArray
- * ) {
- *     return "You -> " + user + ": " + Joiner.on(' ').join(messageArray);
+ *        {@literal @}Sender EntityRef sender,
+ *        {@literal @}CommandParam("user") String user,
+ *        {@literal @}CommandParam(value = "message", arrayDelimiter = Command.ARRAY_DELIMITER_VARARGS) String[] messageArray) {
+ *     return "You: " + user + ": " + Joiner.on(' ').join(messageArray);
  * }
- * }</pre>
+ * </pre>
  *
  * @author Immortius, Limeth
  */

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/UsernameSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/UsernameSuggester.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * Suggests user names of all users even if they aren't online.
  *
  * @author Limeth
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class UsernameSuggester implements CommandParameterSuggester<String> {
     @Override

--- a/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
+++ b/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
@@ -30,11 +30,11 @@ import java.security.PrivilegedAction;
 
 /**
  * @author synopia
- *         <p/>
+ *         <br><br>
  *         Debug property editor. Usage:
- *         <p/>
+ *         <br><br>
  *         CoreRegistry.get(DebugPropertiesSystem.class).addProperty("Model 1", model);
- *         <p/>
+ *         <br><br>
  *         Ingame press F1 to see the property editor. Only annotated fields will show up.
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/delay/AddDelayedActionEvent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/AddDelayedActionEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.delay;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use DelayManager::addDelayedAction instead.
  */
 @Deprecated

--- a/engine/src/main/java/org/terasology/logic/delay/CancelDelayedActionEvent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/CancelDelayedActionEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.delay;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use DelayManager::cancelDelayedAction instead.
  */
 @Deprecated

--- a/engine/src/main/java/org/terasology/logic/delay/DelayManager.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayManager.java
@@ -33,7 +33,7 @@ import org.terasology.entitySystem.entity.EntityRef;
  * For periodic action, the period starts counting from the invocation of the last PeriodicActionTriggeredEvent, so if
  * there is a delay on the system, there will be larger gaps between invocations.
  *
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public interface DelayManager {
     /**

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionComponent.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * Not for public use. Use DelayManager instead.
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @ForceBlockActive
 public final class DelayedActionComponent implements Component {

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 @Share(value = DelayManager.class)

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionTriggeredEvent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionTriggeredEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.delay;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class DelayedActionTriggeredEvent implements Event {
     private String actionId;

--- a/engine/src/main/java/org/terasology/logic/delay/HasDelayedActionEvent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/HasDelayedActionEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.delay;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use DelayManager::hasDelayedAction instead.
  */
 @Deprecated

--- a/engine/src/main/java/org/terasology/logic/delay/PeriodicActionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/PeriodicActionComponent.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * Not for public use. Use DelayManager instead.
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @ForceBlockActive
 public final class PeriodicActionComponent implements Component {

--- a/engine/src/main/java/org/terasology/logic/delay/PeriodicActionTriggeredEvent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/PeriodicActionTriggeredEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.delay;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class PeriodicActionTriggeredEvent implements Event {
     private String actionId;

--- a/engine/src/main/java/org/terasology/logic/health/BeforeDamagedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/health/BeforeDamagedEvent.java
@@ -21,7 +21,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 
 /**
  * This event is sent to allow damage to be modified or cancelled, before it is processed.
- * <p/>
+ * <br><br>
  * Damage modifications are accumulated as additions/subtractions (modifiers) and multipliers.
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/logic/health/DestroyEvent.java
+++ b/engine/src/main/java/org/terasology/logic/health/DestroyEvent.java
@@ -22,7 +22,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 /**
  * Sent to request the destruction of an entity.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class DestroyEvent implements Event {
     private EntityRef instigator;

--- a/engine/src/main/java/org/terasology/logic/health/DoDamageEvent.java
+++ b/engine/src/main/java/org/terasology/logic/health/DoDamageEvent.java
@@ -22,7 +22,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 /**
  * This event should be sent to cause damage to an entity.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class DoDamageEvent implements Event {
     private int amount;

--- a/engine/src/main/java/org/terasology/logic/health/FullHealthEvent.java
+++ b/engine/src/main/java/org/terasology/logic/health/FullHealthEvent.java
@@ -21,7 +21,7 @@ import org.terasology.entitySystem.event.Event;
 /**
  * Event sent upon an entity reaching full health if previously on less than full health.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class FullHealthEvent implements Event {
     private EntityRef instigator;

--- a/engine/src/main/java/org/terasology/logic/health/HealthChangedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/health/HealthChangedEvent.java
@@ -22,7 +22,7 @@ import org.terasology.entitySystem.event.Event;
 /**
  * This event (or a subtype) is sent whenever health changes
  *
- * @author Marcel Lehwald <marcel.lehwald@googlemail.com>
+ * @author Marcel Lehwald
  */
 public class HealthChangedEvent implements Event {
     private EntityRef instigator;

--- a/engine/src/main/java/org/terasology/logic/health/HealthComponent.java
+++ b/engine/src/main/java/org/terasology/logic/health/HealthComponent.java
@@ -20,7 +20,7 @@ import org.terasology.network.Replicate;
 import org.terasology.rendering.nui.properties.TextField;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class HealthComponent implements Component {
     // Configuration options

--- a/engine/src/main/java/org/terasology/logic/health/HealthSystem.java
+++ b/engine/src/main/java/org/terasology/logic/health/HealthSystem.java
@@ -40,7 +40,7 @@ import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class HealthSystem extends BaseComponentSystem implements UpdateSubscriberSystem {

--- a/engine/src/main/java/org/terasology/logic/inventory/InventoryAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/InventoryAuthoritySystem.java
@@ -42,8 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
- * @author Florian <florian@fkoeberle.de>
+ * @author Marcin Sciesinski
+ * @author Florian
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 @Share(value = InventoryManager.class)

--- a/engine/src/main/java/org/terasology/logic/inventory/InventoryClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/InventoryClientSystem.java
@@ -37,8 +37,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
- * @author Florian <florian@fkoeberle.de>
+ * @author Marcin Sciesinski
+ * @author Florian
  */
 @RegisterSystem(RegisterMode.REMOTE_CLIENT)
 @Share(value = InventoryManager.class)

--- a/engine/src/main/java/org/terasology/logic/inventory/InventoryComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/InventoryComponent.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * Allows an entity to store items.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @ForceBlockActive
 public final class InventoryComponent implements Component, ReplicationCheck {

--- a/engine/src/main/java/org/terasology/logic/inventory/InventoryUtils.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/InventoryUtils.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public final class InventoryUtils {
     private InventoryUtils() {

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
@@ -26,7 +26,7 @@ import org.terasology.rendering.assets.texture.TextureRegion;
 /**
  * Item data is stored using this component
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class ItemComponent implements Component {
     /**

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemDifferentiating.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemDifferentiating.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemSystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemSystem.java
@@ -25,7 +25,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class ItemSystem extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/logic/inventory/action/GiveItemAction.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/action/GiveItemAction.java
@@ -26,7 +26,7 @@ import java.util.List;
  * This action adds the item into the inventory of the entity it was sent to. The item is either completely consumed
  * or not modified at all. If it was consumed, the isConsumed() will return <code>true</code>.
  *
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use InventoryManager method instead.
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/inventory/action/MoveItemAction.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/action/MoveItemAction.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use InventoryManager method instead.
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/inventory/action/RemoveItemAction.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/action/RemoveItemAction.java
@@ -26,7 +26,7 @@ import java.util.List;
  * Removed the specified item from the inventory of the entity it was sent to. If the remove was successful, the
  * event will be consumed.
  *
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use InventoryManager method instead.
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/inventory/action/SwitchItemAction.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/action/SwitchItemAction.java
@@ -20,7 +20,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  * @deprecated Use InventoryManager method instead.
  */
 @API

--- a/engine/src/main/java/org/terasology/logic/inventory/block/DropBlockInventoryComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/block/DropBlockInventoryComponent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.inventory.block;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class DropBlockInventoryComponent implements Component {
 }

--- a/engine/src/main/java/org/terasology/logic/inventory/block/RetainBlockInventoryComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/block/RetainBlockInventoryComponent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.inventory.block;
 import org.terasology.entitySystem.Component;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public final class RetainBlockInventoryComponent implements Component {
 }

--- a/engine/src/main/java/org/terasology/logic/inventory/events/AbstractMoveItemRequest.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/AbstractMoveItemRequest.java
@@ -22,7 +22,7 @@ import org.terasology.network.ServerEvent;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @ServerEvent
 public abstract class AbstractMoveItemRequest implements Event {

--- a/engine/src/main/java/org/terasology/logic/inventory/events/BeforeItemPutInInventory.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/BeforeItemPutInInventory.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class BeforeItemPutInInventory extends AbstractConsumableEvent {
     private EntityRef instigator;

--- a/engine/src/main/java/org/terasology/logic/inventory/events/BeforeItemRemovedFromInventory.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/BeforeItemRemovedFromInventory.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class BeforeItemRemovedFromInventory extends AbstractConsumableEvent {
     private EntityRef instigator;

--- a/engine/src/main/java/org/terasology/logic/inventory/events/InventorySlotStackSizeChangedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/InventorySlotStackSizeChangedEvent.java
@@ -18,7 +18,7 @@ package org.terasology.logic.inventory.events;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class InventorySlotStackSizeChangedEvent implements Event {
     private int slot;

--- a/engine/src/main/java/org/terasology/logic/inventory/events/MoveItemAmountRequest.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/MoveItemAmountRequest.java
@@ -21,7 +21,7 @@ import org.terasology.network.ServerEvent;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @ServerEvent
 public class MoveItemAmountRequest extends AbstractMoveItemRequest {

--- a/engine/src/main/java/org/terasology/logic/inventory/events/MoveItemRequest.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/MoveItemRequest.java
@@ -22,7 +22,7 @@ import org.terasology.network.ServerEvent;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @ServerEvent
 public class MoveItemRequest extends AbstractMoveItemRequest implements Event {

--- a/engine/src/main/java/org/terasology/logic/inventory/events/MoveItemToSlotsRequest.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/MoveItemToSlotsRequest.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * Usually triggered by a shift click on an item.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @ServerEvent
 public class MoveItemToSlotsRequest extends AbstractMoveItemRequest {

--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 /**
  * Component represent the location and facing of an entity in the world
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class LocationComponent implements Component, ReplicationCheck {
 

--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEffectComponent.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEffectComponent.java
@@ -28,8 +28,8 @@ import org.terasology.world.block.family.BlockFamily;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Immortius
+ * @author Benjamin Glatzel
  */
 public final class BlockParticleEffectComponent implements Component {
 

--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
@@ -76,7 +76,7 @@ import static org.lwjgl.opengl.GL11.glTranslated;
 import static org.lwjgl.opengl.GL11.glTranslatef;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 // TODO: Generalise for non-block particles
 // TODO: Dispose display lists

--- a/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
@@ -44,7 +44,7 @@ import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  * @author Immortius
  */
 @RegisterSystem(RegisterMode.CLIENT)

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
@@ -59,7 +59,7 @@ import static org.lwjgl.opengl.GL11.glScalef;
 import static org.lwjgl.opengl.GL11.glTranslatef;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.CLIENT)
 public class FirstPersonRenderer extends BaseComponentSystem implements RenderSystem {

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -35,7 +35,7 @@ import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.registry.CoreRegistry;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class LocalPlayer {
 

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -144,8 +144,8 @@ public class LocalPlayer {
      * Can be used by modules to trigger the activation of a player owned entity like an item.
      *
      * The method has been made for the usage on the client. It triggers a {@link ActivationPredicted} event
-     * on the client and a {@link ActivationRequest} event on the server which will lead to a {@link ActivateEvent}
-     * on the server.
+     * on the client and a {@link ActivationRequest} event on the server which will lead
+     * to a {@link org.terasology.logic.common.ActivateEvent} on the server.
      *
      * @param usedOwnedEntity an entity owned by the player like an item.
      *

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -66,7 +66,7 @@ import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.regions.BlockRegionComponent;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 // TODO: This needs a really good cleanup
 // TODO: Move more input stuff to a specific input system?

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -28,7 +28,7 @@ import org.terasology.network.ColorComponent;
 import org.terasology.rendering.logic.MeshComponent;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class PlayerFactory {
 

--- a/engine/src/main/java/org/terasology/math/AABB.java
+++ b/engine/src/main/java/org/terasology/math/AABB.java
@@ -36,7 +36,7 @@ import com.google.common.base.Objects;
  * An axis-aligned bounding box. Provides basic support for inclusion
  * and intersection tests.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class AABB {
 

--- a/engine/src/main/java/org/terasology/math/Border.java
+++ b/engine/src/main/java/org/terasology/math/Border.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 /**
  * The size of a border, supporting independent widths on each side.
- * <p/>
+ * <br><br>
  * Immutable
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -23,7 +23,7 @@ import org.terasology.world.chunks.ChunkConstants;
 /**
  * Collection of math functions.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class ChunkMath {
 

--- a/engine/src/main/java/org/terasology/math/Matrix4i.java
+++ b/engine/src/main/java/org/terasology/math/Matrix4i.java
@@ -85,7 +85,7 @@ public class Matrix4i {
 
     /**
      * Sets the matrix to the given matrix as an int array.
-     * <p/>
+     * <br><br>
      * The given array must have at least 16 values.
      *
      * @param values The matrix

--- a/engine/src/main/java/org/terasology/math/MatrixUtils.java
+++ b/engine/src/main/java/org/terasology/math/MatrixUtils.java
@@ -26,7 +26,7 @@ import java.nio.FloatBuffer;
 /**
  * Collection of matrix utilities.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class MatrixUtils {
 

--- a/engine/src/main/java/org/terasology/math/Pitch.java
+++ b/engine/src/main/java/org/terasology/math/Pitch.java
@@ -17,7 +17,7 @@ package org.terasology.math;
 
 /**
  * Enumeration for pitch
- * <p/>
+ * <br><br>
  * Pitch, yaw and roll enumerations are all very similar, but separated to allow for safer usage in Rotation.
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/math/Roll.java
+++ b/engine/src/main/java/org/terasology/math/Roll.java
@@ -17,7 +17,7 @@ package org.terasology.math;
 
 /**
  * Enumeration for Roll.
- * <p/>
+ * <br><br>
  * Pitch, yaw and roll enumerations are all very similar, but separated to allow for safer usage in Rotation.
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/math/Rotation.java
+++ b/engine/src/main/java/org/terasology/math/Rotation.java
@@ -27,7 +27,7 @@ import org.terasology.math.geom.Quat4f;
 
 /**
  * Rotation provides easy access to 90 degree increments of rotations - intended for block-related rotations.
- * <p/>
+ * <br><br>
  * Uses the fly weight pattern to cache the 64 combinations of rotation.
  *
  * @author Immortius <immortius@gmail.com>

--- a/engine/src/main/java/org/terasology/math/Rotation.java
+++ b/engine/src/main/java/org/terasology/math/Rotation.java
@@ -30,7 +30,7 @@ import org.terasology.math.geom.Quat4f;
  * <br><br>
  * Uses the fly weight pattern to cache the 64 combinations of rotation.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class Rotation {
 

--- a/engine/src/main/java/org/terasology/math/Side.java
+++ b/engine/src/main/java/org/terasology/math/Side.java
@@ -28,9 +28,9 @@ import java.util.EnumMap;
  * Note that the FRONT of the block faces towards the player - this means Left and Right are a player's right and left.
  * See Direction for an enumeration of directions in terms of the player's perspective.
  *
- * @author Immortius <immortius@gmail.com>
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Rasmus 'Cervator' Praestholm <cervator@gmail.com>
+ * @author Immortius
+ * @author Benjamin Glatzel
+ * @author Rasmus 'Cervator' Praestholm
  */
 public enum Side {
     TOP(Vector3i.up(), true, false, true),

--- a/engine/src/main/java/org/terasology/math/Side.java
+++ b/engine/src/main/java/org/terasology/math/Side.java
@@ -24,7 +24,7 @@ import java.util.EnumMap;
 
 /**
  * The six sides of a block and a slew of related utility.
- * <p/>
+ * <br><br>
  * Note that the FRONT of the block faces towards the player - this means Left and Right are a player's right and left.
  * See Direction for an enumeration of directions in terms of the player's perspective.
  *

--- a/engine/src/main/java/org/terasology/math/SideBitFlag.java
+++ b/engine/src/main/java/org/terasology/math/SideBitFlag.java
@@ -28,7 +28,7 @@ import java.util.Set;
 /**
  * Utility class for representing a set of sides as a byte
  *
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public final class SideBitFlag {
     private static TObjectByteMap<Side> sideBits = new TObjectByteHashMap<>();

--- a/engine/src/main/java/org/terasology/math/TeraMath.java
+++ b/engine/src/main/java/org/terasology/math/TeraMath.java
@@ -23,7 +23,7 @@ import org.terasology.world.chunks.ChunkConstants;
 /**
  * Collection of math functions.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class TeraMath {
 

--- a/engine/src/main/java/org/terasology/math/TeraMath.java
+++ b/engine/src/main/java/org/terasology/math/TeraMath.java
@@ -360,7 +360,7 @@ public final class TeraMath {
 
     /**
      * Modulus operation, where the result has the same sign as the divisor.
-     * <p/>
+     * <br><br>
      * Modulus(a, b) differs from a % b in that the result of the first has the
      * same sign as a, while the latter has the same sign as b.
      *
@@ -375,7 +375,7 @@ public final class TeraMath {
 
     /**
      * Modulus operation, where the result has the same sign as the divisor.
-     * <p/>
+     * <br><br>
      * Modulus(a, b) differs from a % b in that the result of the first has the
      * same sign as a, while the latter has the same sign as b.
      *
@@ -390,7 +390,7 @@ public final class TeraMath {
 
     /**
      * Modulus operation, where the result has the same sign as the dividend.
-     * <p/>
+     * <br><br>
      * Modulus(a, b) equals a % b.
      * This function (alias) exists primarily to be used in places where both modulus and % are used,
      * to make a clearer distinction between the two operations.
@@ -406,7 +406,7 @@ public final class TeraMath {
 
     /**
      * Modulus operation, where the result has the same sign as the dividend.
-     * <p/>
+     * <br><br>
      * Modulus(a, b) equals a % b.
      * This function (alias) exists primarily to be used in places where both modulus and % are used,
      * to make a clearer distinction between the two operations.
@@ -675,7 +675,7 @@ public final class TeraMath {
 
     /**
      * Lowest power of two greater or equal to val
-     * <p/>
+     * <br><br>
      * For values &lt;= 0 returns 0
      * For values &gt;= 2 ^ 30 returns 0. (2^30 is the largest power of 2 that fits within a int).
      *

--- a/engine/src/main/java/org/terasology/math/Vector3iUtil.java
+++ b/engine/src/main/java/org/terasology/math/Vector3iUtil.java
@@ -20,7 +20,7 @@ import org.terasology.math.geom.Vector3i;
 /**
  * Vector3i - integer vector class in the style of VecMath.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class Vector3iUtil {
     private Vector3iUtil() {

--- a/engine/src/main/java/org/terasology/math/Yaw.java
+++ b/engine/src/main/java/org/terasology/math/Yaw.java
@@ -17,7 +17,7 @@ package org.terasology.math;
 
 /**
  * Enumeration for yaw
- * <p/>
+ * <br><br>
  * Pitch, yaw and roll enumerations are all very similar, but separated to allow for safer usage in Rotation.
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/monitoring/PerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/monitoring/PerformanceMonitor.java
@@ -23,10 +23,10 @@ import org.terasology.monitoring.impl.PerformanceMonitorInternal;
 /**
  * Maintains a running average of time taken by different activities. Activities call to denote when they
  * start and stop.
- * <p/>
+ * <br><br>
  * Activities may be nested, and while a nested activity is running the out activities are paused and time passing
  * is not assigned to them.
- * <p/>
+ * <br><br>
  * Performance monitor is intended only for use by the main thread of Terasology, and does not handle
  * activities being started and ended on other threads at this time.
  *

--- a/engine/src/main/java/org/terasology/monitoring/PerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/monitoring/PerformanceMonitor.java
@@ -30,7 +30,7 @@ import org.terasology.monitoring.impl.PerformanceMonitorInternal;
  * Performance monitor is intended only for use by the main thread of Terasology, and does not handle
  * activities being started and ended on other threads at this time.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class PerformanceMonitor {
     private static PerformanceMonitorInternal instance;

--- a/engine/src/main/java/org/terasology/monitoring/impl/NullPerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/monitoring/impl/NullPerformanceMonitor.java
@@ -20,7 +20,7 @@ import gnu.trove.map.hash.TObjectDoubleHashMap;
 import org.terasology.monitoring.Activity;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class NullPerformanceMonitor implements PerformanceMonitorInternal {
     private static final NullActivity NULL_ACTIVITY = new NullActivity();

--- a/engine/src/main/java/org/terasology/monitoring/impl/PerformanceMonitorImpl.java
+++ b/engine/src/main/java/org/terasology/monitoring/impl/PerformanceMonitorImpl.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * Active implementation of Performance Monitor
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  *         TODO: Check to ensure activities are being started and stopped correctly
  *         TODO: Remove activities with 0 time
  */

--- a/engine/src/main/java/org/terasology/monitoring/impl/PerformanceMonitorInternal.java
+++ b/engine/src/main/java/org/terasology/monitoring/impl/PerformanceMonitorInternal.java
@@ -21,7 +21,7 @@ import org.terasology.monitoring.Activity;
 /**
  * Base interface for performance monitor implementations.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface PerformanceMonitorInternal {
     void rollCycle();

--- a/engine/src/main/java/org/terasology/network/OwnerEvent.java
+++ b/engine/src/main/java/org/terasology/network/OwnerEvent.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for events that are run on the owning client of the entity the event is sent to.
- * <p/>
+ * <br><br>
  * If the net owner is null, or a local player the event is run on the server.
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/persistence/PlayerStore.java
+++ b/engine/src/main/java/org/terasology/persistence/PlayerStore.java
@@ -49,7 +49,7 @@ public interface PlayerStore {
 
     /**
      * Sets the location which should be loaded for the player when they rejoin the game.
-     * <p/>
+     * <br><br>
      * This is set automatically to the character's location if a character is stored.
      *
      * @param location

--- a/engine/src/main/java/org/terasology/persistence/WorldDumper.java
+++ b/engine/src/main/java/org/terasology/persistence/WorldDumper.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 /**
  * Used to create a dump of the current state of the world (specifically, entities)
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class WorldDumper {
 

--- a/engine/src/main/java/org/terasology/persistence/internal/AbstractStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/AbstractStorageManager.java
@@ -51,7 +51,7 @@ import java.util.zip.GZIPInputStream;
  * to read from a data store.
  *
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  * @author Martin Steiger
  */
 public abstract class AbstractStorageManager implements StorageManager {

--- a/engine/src/main/java/org/terasology/persistence/internal/CompressedChunkBuilder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/CompressedChunkBuilder.java
@@ -30,7 +30,7 @@ import java.util.zip.GZIPOutputStream;
  * Provides an easy to get a compressed version of a chunk. Either the chunk most have a snapshot of it's state
  * or it must be an unloaded chunk which no longer changes.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class CompressedChunkBuilder {
     private EntityData.EntityStore entityStore;

--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
@@ -28,7 +28,7 @@ import org.terasology.entitySystem.prefab.Prefab;
  * Currently it gets used by the StorageManager to create entity refs on the main thread for storage off the main
  * thread. During the storage the entities will be bound to the entity manager that is private the the saving thread.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class DelayedEntityRef extends EntityRef {
     private final long id;

--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRefCopyStrategy.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRefCopyStrategy.java
@@ -22,7 +22,7 @@ import org.terasology.reflection.copy.CopyStrategy;
  * This copy strategy return {@link DelayedEntityRef}s for persistent entities that exists.
  * For non persistent entities or entities that do no longer exist it returns {@link EntityRef#NULL}.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 class DelayedEntityRefCopyStrategy implements CopyStrategy<EntityRef> {
 

--- a/engine/src/main/java/org/terasology/persistence/internal/EntityDelta.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/EntityDelta.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class EntityDelta {
     private Set<Class<? extends Component>> removedComponents = Sets.newHashSet();

--- a/engine/src/main/java/org/terasology/persistence/internal/EntitySetDeltaRecorder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/EntitySetDeltaRecorder.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * the point of the last auto save. By doing so the auto save can access a snapshot of all entities on
  * off the main thread.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 class EntitySetDeltaRecorder {
     private final ComponentLibrary componentLibrary;

--- a/engine/src/main/java/org/terasology/persistence/internal/EntityStorer.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/EntityStorer.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * Utility class for the construction of a EntityData.EntityStore structure for storing the entities on disk..
  *
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 final class EntityStorer {
 

--- a/engine/src/main/java/org/terasology/persistence/internal/GlobalStoreBuilder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/GlobalStoreBuilder.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 final class GlobalStoreBuilder {
 

--- a/engine/src/main/java/org/terasology/persistence/internal/PlayerStoreBuilder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/PlayerStoreBuilder.java
@@ -27,7 +27,7 @@ import java.util.Set;
  *
  * Has all the data of a player to create save it with a copy of the entity manager.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 class PlayerStoreBuilder {
     private Long characterEntityId;

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
@@ -86,7 +86,7 @@ public final class ReadWriteStorageManager extends AbstractStorageManager implem
     /**
      * This lock should be hold during read and write operation in the world directory. Currently it is being hold
      * during reads of chunks or players as they are crruently the only data that needs to be loaded during the game.
-     * <p/>
+     * <br><br>
      * This lock ensures that reading threads can properly finish reading even when for example the ZIP file with the
      * chunks got replaced with a newer version. Chunks that are getting saved get loaded from memory. It can however
      * still be that a thread tries to load another chunk from the same ZIP file that contains the chunk that needs to

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
@@ -75,7 +75,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public final class ReadWriteStorageManager extends AbstractStorageManager implements EntityDestroySubscriber, EntityChangeSubscriber, DelayedEntityRefFactory {
     private static final Logger logger = LoggerFactory.getLogger(ReadWriteStorageManager.class);

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
@@ -59,7 +59,7 @@ import java.util.concurrent.locks.Lock;
 
 /**
  * Task that writes a previously created memory snapshot of the game to the disk.
- * <p/>
+ * <br><br>
  * The result of this task can be obtained via {@link #getResult()}.
  *
  * @author Florian <florian@fkoeberle.de>

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransaction.java
@@ -62,7 +62,7 @@ import java.util.concurrent.locks.Lock;
  * <br><br>
  * The result of this task can be obtained via {@link #getResult()}.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class SaveTransaction extends AbstractTask {
     private static final Logger logger = LoggerFactory.getLogger(SaveTransaction.class);

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionBuilder.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionBuilder.java
@@ -28,7 +28,7 @@ import java.util.concurrent.locks.Lock;
 /**
  * Utility class for creating {@link SaveTransaction} instances.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 class SaveTransactionBuilder {
     private final Lock worldDirectoryWriteLock;

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionHelper.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionHelper.java
@@ -30,7 +30,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 /**
  * Helper class for methods around {@link SaveTransaction}s that are also needed outside of the save transaction.
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class SaveTransactionHelper {
     private static final Logger logger = LoggerFactory.getLogger(SaveTransactionHelper.class);

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionHelper.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionHelper.java
@@ -63,7 +63,7 @@ public class SaveTransactionHelper {
     /**
      * Merges all outstanding changes into the save game. If this operation gets interrupted it can be started again
      * without any file corruption when the file system supports atomic moves.
-     * <p/>
+     * <br><br>
      * The write lock for the save directory should be acquired before this method gets called.
      */
     public void mergeChanges() throws IOException {

--- a/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionResult.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/SaveTransactionResult.java
@@ -17,7 +17,7 @@ package org.terasology.persistence.internal;
 
 /**
  * Represents the result of a {@link SaveTransaction}
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 final class SaveTransactionResult {
     private final Throwable catchedThrowable;

--- a/engine/src/main/java/org/terasology/persistence/internal/StoragePathProvider.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/StoragePathProvider.java
@@ -22,7 +22,7 @@ import org.terasology.math.geom.Vector3i;
 import java.nio.file.Path;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class StoragePathProvider {
     private static final String PLAYERS_PATH = "players";

--- a/engine/src/main/java/org/terasology/persistence/serializers/ComponentSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/ComponentSerializer.java
@@ -43,10 +43,10 @@ import java.util.Map;
 /**
  * ComponentSerializer provides the ability to serialize and deserialize between Components and the protobuf
  * EntityData.Component
- * <p/>
+ * <br><br>
  * If provided with a idTable, then the components will be serialized and deserialized using those ids rather
  * than the names of each component, saving some space.
- * <p/>
+ * <br><br>
  * When serializing, a FieldSerializeCheck can be provided to determine whether each field should be serialized or not
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/persistence/serializers/EntityDataJSONFormat.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntityDataJSONFormat.java
@@ -43,7 +43,7 @@ import java.util.Map;
 
 /**
  * Converts between the EntityData types and JSON.
- * <p/>
+ * <br><br>
  * This means that serialization between JSON and Entities/Prefabs is a two step process, with EntityData as an
  * intermediate step - it was done this way because it is much simpler to write gson handlers for the small number of
  * EntityData types than to dynamically build handlers for every component type (and have gson properly handle missing

--- a/engine/src/main/java/org/terasology/persistence/serializers/EntityDataJSONFormat.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntityDataJSONFormat.java
@@ -49,7 +49,7 @@ import java.util.Map;
  * EntityData types than to dynamically build handlers for every component type (and have gson properly handle missing
  * types). This can be revisited in the future.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 // TODO: More javadoc
 public final class EntityDataJSONFormat {

--- a/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
@@ -34,10 +34,10 @@ import java.util.Set;
 
 /**
  * Provides the ability to serialize and deserialize entities to the EntityData.Entity proto buffer format.
- * <p/>
+ * <br><br>
  * As with the component serializer, a component id mapping can be provided to have components serialized against
  * ids rather than name strings.
- * <p/>
+ * <br><br>
  * It is also possible to set whether entity ids will be handled or ignored - if ignored then deserialized entities will
  * be given new ids.
  *

--- a/engine/src/main/java/org/terasology/persistence/serializers/PrefabSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/PrefabSerializer.java
@@ -36,10 +36,10 @@ import java.util.Map;
 
 /**
  * Provides the ability to serialize and deserialize prefabs to the EntityData.Prefab proto buffer format.
- * <p/>
+ * <br><br>
  * As with the component serializer, a component id mapping can be provided to have components serialized against
  * ids rather than name strings.
- * <p/>
+ * <br><br>
  * It is also possible to set whether entity ids will be handled or ignored - if ignored then deserialized entities will
  * be given new ids.
  *

--- a/engine/src/main/java/org/terasology/persistence/serializers/PrefabSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/PrefabSerializer.java
@@ -121,7 +121,7 @@ public class PrefabSerializer {
      * Deserializes a prefab
      *
      * @param prefabData
-     * @param
+     * @param deltas
      * @return The deserialized prefab
      */
     public PrefabData deserialize(EntityData.Prefab prefabData, List<EntityData.Prefab> deltas) {

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializer.java
@@ -20,7 +20,7 @@ import org.terasology.protobuf.EntityData;
 /**
  * Serializes an entity system, with all prefabs and entities.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface WorldSerializer {
 

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
@@ -44,7 +44,7 @@ import java.util.Map;
 /**
  * Implementation of WorldSerializer for EngineEntityManager.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class WorldSerializerImpl implements WorldSerializer {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/Serializer.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/Serializer.java
@@ -71,7 +71,7 @@ public class Serializer {
 
     /**
      * Serializes the given value, that was originally obtained from the given field.
-     * <p/>
+     * <br><br>
      * This is provided for performance, to avoid obtaining the same value twice.
      *
      * @param rawValue The value to serialize

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/SimpleTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/SimpleTypeHandler.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Abstract class for type handlers where collections of the type are simply handled by nesting individually serialized values into another value - that is there is
  * no special manner in which they are handled.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public abstract class SimpleTypeHandler<T> implements TypeHandler<T> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/BooleanTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/BooleanTypeHandler.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class BooleanTypeHandler implements TypeHandler<Boolean> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ByteTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ByteTypeHandler.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class ByteTypeHandler implements TypeHandler<Byte> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/DoubleTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/DoubleTypeHandler.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class DoubleTypeHandler implements TypeHandler<Double> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/EnumTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/EnumTypeHandler.java
@@ -31,7 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EnumTypeHandler<T extends Enum> implements TypeHandler<T> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/FloatTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/FloatTypeHandler.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class FloatTypeHandler implements TypeHandler<Float> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/IntTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/IntTypeHandler.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class IntTypeHandler implements TypeHandler<Integer> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ListTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ListTypeHandler.java
@@ -24,7 +24,7 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class ListTypeHandler<T> extends SimpleTypeHandler<List<T>> {
     private TypeHandler<T> contentsType;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/LongTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/LongTypeHandler.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class LongTypeHandler implements TypeHandler<Long> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/MappedContainerTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/MappedContainerTypeHandler.java
@@ -29,7 +29,7 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import java.util.Map;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class MappedContainerTypeHandler<T> extends SimpleTypeHandler<T> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/StringMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/StringMapTypeHandler.java
@@ -25,7 +25,7 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import java.util.Map;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class StringMapTypeHandler<T> extends SimpleTypeHandler<Map<String, T>> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockFamilyTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockFamilyTypeHandler.java
@@ -21,7 +21,7 @@ import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.family.BlockFamily;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class BlockFamilyTypeHandler extends StringRepresentationTypeHandler<BlockFamily> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockTypeHandler.java
@@ -21,7 +21,7 @@ import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class BlockTypeHandler extends StringRepresentationTypeHandler<Block> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Quat4fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Quat4fTypeHandler.java
@@ -25,7 +25,7 @@ import org.terasology.persistence.typeHandling.SerializationContext;
 import org.terasology.persistence.typeHandling.SimpleTypeHandler;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class Quat4fTypeHandler extends SimpleTypeHandler<Quat4f> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2fTypeHandler.java
@@ -26,7 +26,7 @@ import org.terasology.persistence.typeHandling.SerializationContext;
 import org.terasology.persistence.typeHandling.SimpleTypeHandler;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class Vector2fTypeHandler extends SimpleTypeHandler<Vector2f> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2iTypeHandler.java
@@ -24,7 +24,7 @@ import org.terasology.persistence.typeHandling.SerializationContext;
 import org.terasology.persistence.typeHandling.SimpleTypeHandler;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class Vector2iTypeHandler extends SimpleTypeHandler<Vector2i> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3fTypeHandler.java
@@ -25,7 +25,7 @@ import org.terasology.persistence.typeHandling.SerializationContext;
 import org.terasology.persistence.typeHandling.SimpleTypeHandler;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class Vector3fTypeHandler extends SimpleTypeHandler<Vector3f> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3iTypeHandler.java
@@ -24,7 +24,7 @@ import org.terasology.persistence.typeHandling.SerializationContext;
 import org.terasology.persistence.typeHandling.SimpleTypeHandler;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class Vector3iTypeHandler extends SimpleTypeHandler<Vector3i> {
 

--- a/engine/src/main/java/org/terasology/physics/Physics.java
+++ b/engine/src/main/java/org/terasology/physics/Physics.java
@@ -40,7 +40,7 @@ public interface Physics {
     /**
      * Scans the given area for physics objects of the given groups and returns
      * a list of the entities of the physics objects in the given area.
-     * <p/>
+     * <br><br>
      * If an Entity has multiple physics objects with the right collision group
      * in this area, this entity will be found multiple times in the returned
      * list.
@@ -57,7 +57,7 @@ public interface Physics {
     /**
      * Scans the given area for physics objects of the given groups and returns
      * a list of the entities of the physics objects in the given area.
-     * <p/>
+     * <br><br>
      * If an Entity has multiple physics objects with the right collision group
      * in this area, this entity will be found multiple times in the returned
      * list.

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -94,7 +94,7 @@ import java.util.Set;
 /**
  * Physics engine implementation using TeraBullet (a customised version of JBullet)
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class BulletPhysics implements PhysicsEngine {
 

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -600,7 +600,7 @@ public class BulletPhysics implements PhysicsEngine {
      * The shape is determined based on the shape component of the given entity.
      * If the entity has somehow got multiple shapes, only one is picked. The
      * order of priority is: Sphere, Capsule, Cylinder, arbitrary.
-     * <p/>
+     * <br><br>
      * TODO: Flyweight this (take scale as parameter)
      *
      * @param entity the entity to get the shape of.

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 /**
  * The physics engine provides access to physics functionality like ray tracing.
- * <p/>
+ * <br><br>
  * TODO: Move physics methods that should only be used by the engine/physics implementing system into another interface that inherits this.
  *
  * @author Xanhou
@@ -140,7 +140,7 @@ public interface PhysicsEngine extends Physics {
     /**
      * Warning: Do not remove physics entities while iterating with the returned iterator. <br>
      * You may create a list of entities to remove and remove them afterwards)
-     * <p/>
+     * <br><br>
      * This method is more efficient than getPhysicsEntities().
      *
      * @return An iterator that iterates over all entities that have a rigidBody
@@ -152,10 +152,10 @@ public interface PhysicsEngine extends Physics {
      * Removes the CharacterCollider associated with the given entity from the
      * physics engine. The collider object of this entity will no longer be
      * valid.
-     * <p/>
+     * <br><br>
      * If no CharacterCollider was attached to the entity, a warning is logged
      * and this method return false.
-     * <p/>
+     * <br><br>
      * Make sure not to make another call to getCharacterCollider() if you are
      * destroying the entity, as this will create a new CharacterCollider for
      * the entity.
@@ -171,10 +171,10 @@ public interface PhysicsEngine extends Physics {
      * engine. The RigidBody object returned by the newRigidBody(EntityRef) or
      * getRigidBody(EntityRef) method will no longer be valid for this entity un
      * till newRigidBody is called again, so be careful!
-     * <p/>
+     * <br><br>
      * If no rigid body was attached to the entity, a warning is logged and this
      * method return false.
-     * <p/>
+     * <br><br>
      * Make sure not to make another call to getRigidBody() if you are
      * destroying the entity, as this will create a new RigidBody for
      * the entity.
@@ -188,10 +188,10 @@ public interface PhysicsEngine extends Physics {
     /**
      * Removes the trigger associated with the given entity from the physics
      * engine.
-     * <p/>
+     * <br><br>
      * If no trigger was attached to the entity, a warning is logged and this
      * method return false.
-     * <p/>
+     * <br><br>
      * Make sure not to make another call to updateTrigger() if you are
      * destroying the entity, as this will create a new trigger for
      * the entity.
@@ -216,7 +216,7 @@ public interface PhysicsEngine extends Physics {
      * entity. If the given entity had no rigidBody in the physics engine, it
      * will be created. Updating an entity without RigidBody is seen as bad
      * practise and hence a warning is logged.
-     * <p/>
+     * <br><br>
      * This method also updates the position of the rigid body in line with
      * the location of the entity. If this method is not called, then the
      * position of the rigid body would be overwritten by the next physics
@@ -233,7 +233,7 @@ public interface PhysicsEngine extends Physics {
      * a TriggerComponent, LocationComponent and ShapeComponent to have a
      * trigger. When updating an existing trigger the location and scale are
      * updated.
-     * <p/>
+     * <br><br>
      * An entity with a trigger attached to it will generate collision pairs
      * when it collides or intersects with other objects. A good example of its
      * usage is picking up items. By creating a trigger for a player, a

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
@@ -138,7 +138,7 @@ public interface PhysicsEngine extends Physics {
     boolean hasCharacterCollider(EntityRef entity);
 
     /**
-     * Warning: Do not remove physics entities while iterating with the returned iterator. <br/>
+     * Warning: Do not remove physics entities while iterating with the returned iterator. <br>
      * You may create a list of entities to remove and remove them afterwards)
      * <p/>
      * This method is more efficient than getPhysicsEntities().

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
@@ -101,7 +101,7 @@ public interface PhysicsEngine extends Physics {
     /**
      * Returns the rigid body associated with the given entity. If no such
      * RigidBody exists, a new one is created and returned.
-     * </p>
+     * <br><br>
      * Note that you should not wait with calling this method until using the
      * rigid body. As soon as the rigid body should exist in the physics engine,
      * this method should be called to create the rigid body.

--- a/engine/src/main/java/org/terasology/physics/engine/RigidBody.java
+++ b/engine/src/main/java/org/terasology/physics/engine/RigidBody.java
@@ -21,9 +21,9 @@ import org.terasology.math.geom.Vector3f;
 
 /**
  * A rigid body is a physics object whose movement and location is controlled by the physics engine. Rigid bodies move under gravity and bounce off each other and the world.
- * <p/>
+ * <br><br>
  * After being removed from the physics engine this object is no longer valid and should not be used anymore.
- * <p/>
+ * <br><br>
  * TODO: add the methods to apply forces
  *
  * @author Xanhou

--- a/engine/src/main/java/org/terasology/physics/package-info.java
+++ b/engine/src/main/java/org/terasology/physics/package-info.java
@@ -17,12 +17,12 @@
 /**
  * This package provides physics support for Terasology -
  * ray tracing, character movement, collision detection and rigid bodies.
- * <p/>
+ * <br><br>
  * The core of the physics support is the PhysicsEngine class. This
  * interface should be available from the CoreRegistry, using
  * CoreRegistry.get(PhysicsEngine.class). From there most of the physics
  * behaviour can be accessed.
- * <p/>
+ * <br><br>
  * Besides the PhysicsEngine and the interfaces and classes returned by it or
  * required by it, there are three other groups of classes.
  * <ul>

--- a/engine/src/main/java/org/terasology/reflection/MappedContainer.java
+++ b/engine/src/main/java/org/terasology/reflection/MappedContainer.java
@@ -24,8 +24,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to mark simple classes that for mapped serialization (this is, they serialize to a map of field name -> value).
- * These classes must not have recursive nested elements (the flatter they are the better), and must not depend on objects appearing multiple times in their structure
+ * This annotation is used to mark simple classes that for mapped serialization
+ * (this is, they serialize to a map of field name to value).
+ * <br><br>
+ * These classes must not have recursive nested elements (the flatter they are the better),
+ * and must not depend on objects appearing multiple times in their structure
  * being the same object - when deserialized each object will be a separate instance.
  */
 @API

--- a/engine/src/main/java/org/terasology/reflection/copy/CopyStrategyLibrary.java
+++ b/engine/src/main/java/org/terasology/reflection/copy/CopyStrategyLibrary.java
@@ -37,7 +37,7 @@ import java.util.Set;
 
 /**
  * A library of copy strategies.
- * <p/>
+ * <br><br>
  * This library is should be initialised by registering strategies for a number of core types.  Then as strategies are requested for unknown types,
  * new strategies are generated for those types.
  * The library knows how to generate strategies for Lists, Sets, Maps and types marked with the MappedContainer annotation.

--- a/engine/src/main/java/org/terasology/reflection/metadata/ClassMetadata.java
+++ b/engine/src/main/java/org/terasology/reflection/metadata/ClassMetadata.java
@@ -41,10 +41,10 @@ import java.util.Map;
 
 /**
  * Class Metadata provides information on a class and its fields, and the ability to create, copy or manipulate an instance of the class.
- * <p/>
+ * <br><br>
  * Subclasses can be created to hold additional information for specific types of objects.  These may override createField()
  * to change how fields are processed and possibly switch to a subtype of FieldMetadata that holds additional information.
- * <p/>
+ * <br><br>
  * Consumed classes are required to have a default constructor (this may be private)
  *
  * @author Immortius

--- a/engine/src/main/java/org/terasology/reflection/package-info.java
+++ b/engine/src/main/java/org/terasology/reflection/package-info.java
@@ -17,14 +17,14 @@
 /**
  * This package provides a low-level system for describing classes and fields, with support for construction and field access. Essentially it is a simplified reflection
  * framework.
- * <p/>
+ * <br><br>
  * To support this functionality, a copy-strategy library is used to provide copying support for types. This is used instead of cloning because
  * <ol>
  *     <li>Not all types support cloning, including types outside of our control</li>
  *     <li>Cloning doesn't allow for possible performance improvements though runtime generated code</li>
  *     <li>Cloning is generally a poorly implemented feature of Java - copy constructors and methods are preferred</li>
  * </ol>
- * <p/>
+ * <br><br>
  * Additionally, ReflectFactory is used to provide support for construction and field access, to allow for alternate implementations.
  */
 package org.terasology.reflection;

--- a/engine/src/main/java/org/terasology/reflection/reflect/ObjectConstructor.java
+++ b/engine/src/main/java/org/terasology/reflection/reflect/ObjectConstructor.java
@@ -17,7 +17,7 @@ package org.terasology.reflection.reflect;
 
 /**
  * Providers the ability to construct an instance of a type.
- * <p/>
+ * <br><br>
  * These types must provide a default constructor, which will be invoked.
  *
  * @param <T> The type of the class to construct instances of

--- a/engine/src/main/java/org/terasology/registry/CoreRegistry.java
+++ b/engine/src/main/java/org/terasology/registry/CoreRegistry.java
@@ -26,7 +26,7 @@ import java.util.Set;
 /**
  * Registry giving access to major singleton systems, via the interface they fulfil.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @API
 public final class CoreRegistry {

--- a/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
@@ -83,7 +83,7 @@ public class AABBRenderer implements BlockOverlayRenderer {
 
     /**
      * Renders this AABB.
-     * <p/>
+     * <br><br>
      *
      * @param lineThickness The thickness of the line
      */

--- a/engine/src/main/java/org/terasology/rendering/FontColor.java
+++ b/engine/src/main/java/org/terasology/rendering/FontColor.java
@@ -23,7 +23,7 @@ import org.terasology.rendering.nui.Color;
  * Defines a set of special characters that manipulate the font color of a rendered text string.
  * Use {@link #toChar(int, int, int)}# to get such a char and append it to the text string at the desired position.
  * Use {@link #getReset()} to reset the color back to the default.
- * <br/> 
+ * <br> 
  * <b>Note:</b> The resolution is only 4 bit per channel (not 8 as usual). 
  * @author Martin Steiger
  */

--- a/engine/src/main/java/org/terasology/rendering/RenderHelper.java
+++ b/engine/src/main/java/org/terasology/rendering/RenderHelper.java
@@ -22,7 +22,7 @@ import org.terasology.rendering.opengl.GLSLMaterial;
 import org.terasology.rendering.shader.ShaderParametersChunk;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class RenderHelper {
 

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -56,7 +56,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Provides support for loading and applying shaders.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderManagerLwjgl implements ShaderManager {
 

--- a/engine/src/main/java/org/terasology/rendering/VertexBufferObjectUtil.java
+++ b/engine/src/main/java/org/terasology/rendering/VertexBufferObjectUtil.java
@@ -25,7 +25,7 @@ import java.nio.ShortBuffer;
 /**
  * Provides support for buffering Vertex Buffer Objects.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class VertexBufferObjectUtil {
 

--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/MeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/MeshBuilder.java
@@ -147,7 +147,7 @@ public class MeshBuilder {
 
     /**
      * Add vertices, texture coordinate and indices for a box specified by offset and size.
-     * <p/>
+     * <br><br>
      * Use the texture mapper to change how texture coordinates (u and v) are applied to each vertex.
      */
     public MeshBuilder addBox(Vector3f offset, Vector3f size, float u, float v) {

--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/ObjMeshLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/ObjMeshLoader.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Importer for Wavefront obj files. Supports core obj mesh data
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 
 public class ObjMeshLoader implements AssetLoader<MeshData> {

--- a/engine/src/main/java/org/terasology/rendering/assets/texture/ColorTextureAssetResolver.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/ColorTextureAssetResolver.java
@@ -28,7 +28,7 @@ import org.terasology.rendering.nui.Color;
  * Resolves references to engine:color.RRGGBBAA texture assets,
  * where RR is the red hex value in lowercase,
  * and GG, BB, and AA are green, blue, and alpha, respectively.
- * <p/>
+ * <br><br>
  * The color is parsed from the name of the asset, then TextureDataFactory is used to create
  * a TextureData object which is used to build the Texture.
  *

--- a/engine/src/main/java/org/terasology/rendering/assets/texture/NoiseTextureAssetResolver.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/NoiseTextureAssetResolver.java
@@ -27,7 +27,7 @@ import org.terasology.naming.Name;
 
 /**
  * Resolves references to <code>engine:noise</code> texture assets,
- * <br/><br/>
+ * <br><br>
  * The noise parameters are parsed from the name of the asset, then TextureDataFactory is used to create
  * a TextureData object which is used to build the Texture.
  *

--- a/engine/src/main/java/org/terasology/rendering/assets/texture/TextureUtil.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/TextureUtil.java
@@ -36,7 +36,7 @@ public final class TextureUtil {
     /**
      * Returns a AssetUri which represents a Texture of that color.
      *
-     * @param color, including alpha, of the texture to represent.
+     * @param color including alpha, of the texture to represent.
      * @return an asset Uri for the texture
      */
     public static AssetUri getTextureUriForColor(Color color) {
@@ -49,9 +49,12 @@ public final class TextureUtil {
     }
 
     /**
-     * Returns a AssetUri which represents a Texture of that color.
+     * Returns a AssetUri which represents a Texture that contains white noise
      *
-     * @param color, including alpha, of the texture to represent.
+     * @param size the size of the texture (both width and height)
+     * @param seed the seed value for the noise generator
+     * @param min the minimum noise value (can be lower than 0 and will be clamped then)
+     * @param max the minimum noise value (can be larger than 255 and will be clamped then)
      * @return an asset Uri for the texture
      */
     public static AssetUri getTextureUriForWhiteNoise(int size, long seed, int min, int max) {
@@ -63,13 +66,12 @@ public final class TextureUtil {
     }
 
     /**
-     * Method to convert the color string hex representation back to a color.
+     * Method to append the color string hex representation back to a string buffer.
      * Package-only access as it is for internal use in ColorTextureAssetResolver,
      * but should be here for maintenance with the color-to-color-string code.
      *
      * @param sb    StringBuilder into which to append name
      * @param color represented by hexColorName
-     * @return hexColorName RRGGBBAA in lower-case hex notation
      */
     private static void appendColorName(StringBuilder sb, Color color) {
         int red = color.r();

--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -38,8 +38,8 @@ import static org.lwjgl.opengl.GL11.glNewList;
 /**
  * Skysphere based on the Perez all weather luminance model.
  *
- * @author Anthony Kireev <adeon.k87@gmail.com>
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Anthony Kireev
+ * @author Benjamin Glatzel
  */
 public class Skysphere implements BackdropProvider, BackdropRenderer{
 

--- a/engine/src/main/java/org/terasology/rendering/cameras/Camera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/Camera.java
@@ -25,13 +25,13 @@ import org.terasology.math.geom.Vector3f;
 /**
  * Provides global access to fonts.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 
 /**
  * Camera base class.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public abstract class Camera {
 

--- a/engine/src/main/java/org/terasology/rendering/cameras/FrustumPlane.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/FrustumPlane.java
@@ -18,7 +18,7 @@ package org.terasology.rendering.cameras;
 /**
  * Represents a plane of a view frustum.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class FrustumPlane {
 

--- a/engine/src/main/java/org/terasology/rendering/cameras/OculusStereoCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/OculusStereoCamera.java
@@ -29,7 +29,7 @@ import static org.lwjgl.opengl.GL11.glMatrixMode;
 /**
  * Camera which can be used to render stereoscopic images of the scene for the Oculus Rift.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class OculusStereoCamera extends Camera {
 

--- a/engine/src/main/java/org/terasology/rendering/cameras/OrthographicCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/OrthographicCamera.java
@@ -24,7 +24,7 @@ import static org.lwjgl.opengl.GL11.glMatrixMode;
 /**
  * Simple default camera.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class OrthographicCamera extends Camera {
 

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -32,7 +32,7 @@ import static org.lwjgl.opengl.GL11.glMatrixMode;
 /**
  * Simple default camera.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class PerspectiveCamera extends Camera {
     // Values used for smoothing

--- a/engine/src/main/java/org/terasology/rendering/cameras/ViewFrustum.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/ViewFrustum.java
@@ -26,7 +26,7 @@ import java.nio.FloatBuffer;
 /**
  * View frustum usable for frustum culling.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ViewFrustum {
 

--- a/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
@@ -50,12 +50,12 @@ import org.terasology.math.geom.Vector3f;
 
 /**
  * Importer for Collada data exchange model files.
- * <p/>
+ * <br><br>
  * The development of this loader was greatly influenced by
  * http://www.wazim.com/Collada_Tutorial_1.htm
- * <p/>
+ * <br><br>
  * TODO: Consider documenting this class similar to what has been done at this web page:
- * <p/>
+ * <br><br>
  * http://docs.garagegames.com/torque-3d/official/content/documentation/Artist%20Guide/Formats/ColladaLoader.html
  *
  * @author mkienenb@gmail.com

--- a/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
@@ -22,7 +22,7 @@ import org.terasology.network.Replicate;
 import org.terasology.network.ReplicationCheck;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 // TODO: Split into multiple components? Point, Directional?
 public final class LightComponent implements Component, ReplicationCheck {

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshComponent.java
@@ -23,7 +23,7 @@ import org.terasology.rendering.nui.Color;
 import org.terasology.world.block.ForceBlockActive;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @ForceBlockActive
 public final class MeshComponent implements Component {

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -65,7 +65,7 @@ import static org.lwjgl.opengl.GL11.glTranslated;
 /**
  * TODO: This should be made generic (no explicit shader or mesh) and ported directly into WorldRenderer? Later note: some GelCube functionality moved to a module
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.CLIENT)
 public class MeshRenderer extends BaseComponentSystem implements RenderSystem {

--- a/engine/src/main/java/org/terasology/rendering/logic/NearestSortingList.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/NearestSortingList.java
@@ -33,13 +33,13 @@ import java.util.TimerTask;
 /**
  * This data structure takes Entities with a location in the world and sorts
  * them based on their distance to an other entity.
- * <p/>
+ * <br><br>
  * The sorting is done in a background thread.
- * <p/>
+ * <br><br>
  * When retrieving Entities from this container, no guarantees are given on the
  * sorting of the entities. This class only tries to keep the elements sorted,
  * but does not guarantee it.
- * <p/>
+ * <br><br>
  * It it therefor use full for graphics purposes, to keep track of the nearest
  * entities to draw.
  *
@@ -184,7 +184,7 @@ public class NearestSortingList implements Iterable<EntityRef> {
      * Fills the given array with Entities from this container. Attempts are
      * made to put the Entities nearest to the player in this array and nearer
      * entities are expected, but not guaranteed to be at a lower index.
-     * <p/>
+     * <br><br>
      * This is the most memory friendly way to obtain elements from this
      * container.
      *
@@ -281,12 +281,12 @@ public class NearestSortingList implements Iterable<EntityRef> {
     /**
      * Stops the background sorting without deleting clearing this container.
      * This is required for proper clean-up.
-     * <p/>
+     * <br><br>
      * Note that if a sorting process is running while this method is called,
      * the sorting process finishes sorting this method will wait for it to
      * finish. Afterwards the sorting is not scheduled again until the
      * initialize method is called again.
-     * <p/>
+     * <br><br>
      * Note that calling stop() and clear() can be done in any order and the
      * specified behaviour will be exactly the same. If there is a difference it
      * is an insignificant performance loss or win if.

--- a/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
@@ -134,7 +134,7 @@ public interface Canvas {
 
     /**
      * Draws a widget to the given region of the current canvas. Skin settings are applied, unless element.isSkinAppliedByCanvas() returns false.
-     * <p/>
+     * <br><br>
      * This method will update the skin settings for the given element and its current mode.  Min/max and fixed size settings will be applied, along with horizontal
      * and vertical alignment as necessary. If element.isSkinAppliedByCanvas() returns true, any background will be drawn and margin applied to remaining region to
      * determine the region provided to the element for drawing content.
@@ -208,11 +208,11 @@ public interface Canvas {
      * becomes the new offset (0,0), and the value size() is the width/height of the SubRegion. All canvas state is specific
      * to a region, so a new sub-region will have offset/text color and other options returned to default. When a sub-region
      * ends the previous canvas settings are restored.
-     * <p/>
+     * <br><br>
      * SubRegions allow UI elements to be draw in isolation without having to know about their location on the screen.
      * SubRegions can be marked as cropped, in which case any drawing that falls outside of the region
      * will not appear.
-     * <p/>
+     * <br><br>
      * SubRegions are an AutoClosable, so ideally are used as a resource in a try-block, to ensure they are closed
      * when no longer needed.
      * <pre>
@@ -230,7 +230,7 @@ public interface Canvas {
 
     /**
      * Allocates a sub region for drawing to a target texture, until that SubRegion is closed.
-     * <p/>
+     * <br><br>
      * For each (texture) uri a FrameBufferObject and a target texture is created.
      * Notice, the resulting texture is flipped. To draw it in the right order use:
      * <pre>
@@ -240,7 +240,7 @@ public interface Canvas {
      * Texture texture = Assets.get(uri, Texture.class);
      * canvas.drawTextureRaw(texture, screenRegion, ScaleMode.SCALE_FIT, 0, 1f, 1f, -1f);
      * </pre>
-     * <p/>
+     * <br><br>
      *
      * @param uri    The URI to access the texture
      * @param size   the size of the texture.
@@ -427,7 +427,7 @@ public interface Canvas {
 
     /**
      * Draws a material to a given area.
-     * <p/>
+     * <br><br>
      * Other than cropping and positioning the material relative to the current region of the canvas, it is up to the material as to how it behaves.
      * The "alpha" parameter of the material, if any, will be set to the current alpha of the canvas.
      *

--- a/engine/src/main/java/org/terasology/rendering/nui/Color.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/Color.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * Color is a representation of a RGBA color. Color components can be set and accessed via floats ranging from 0-1, or ints ranging from 0-255.
  * Color is immutable and thread safe.
- * <p/>
+ * <br><br>
  * There are a plethora of Color classes, but none that are quite suitable IMO:
  * <ul>
  * <li>vecmaths - doesn't access with r/g/b/a, separation by representation is awkward, feature bland.</li>

--- a/engine/src/main/java/org/terasology/rendering/nui/ScreenLayerClosedEvent.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/ScreenLayerClosedEvent.java
@@ -23,7 +23,7 @@ import org.terasology.network.OwnerEvent;
 /**
  * The event is sent to the UI layer
  *
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 @OwnerEvent
 @API

--- a/engine/src/main/java/org/terasology/rendering/nui/databinding/IntToFloatBinding.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/databinding/IntToFloatBinding.java
@@ -28,15 +28,15 @@ public final class IntToFloatBinding implements Binding<Float> {
 
     private final Binding<Integer> intBinding;
     private final RoundingMode roundingMode;
-    
+
     /**
      * Uses {@link RoundingMode#HALF_UP}.
-     * @param ip
+     * @param intBinding the original binding that is wrapped
      */
     public IntToFloatBinding(Binding<Integer> intBinding) {
         this(intBinding, RoundingMode.HALF_UP);
     }
-    
+
     public IntToFloatBinding(Binding<Integer> intBinding, RoundingMode rm) {
         this.intBinding = intBinding;
         this.roundingMode = rm;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/InspectionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/InspectionScreen.java
@@ -26,7 +26,7 @@ import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UIText;
 
 /**
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class InspectionScreen extends BaseInteractionScreen {
     private UIText fullDescriptionLabel;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ContainerScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ContainerScreen.java
@@ -24,7 +24,7 @@ import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class ContainerScreen extends CoreScreenLayer {
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
@@ -25,7 +25,7 @@ import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class InventoryScreen extends CoreScreenLayer {
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/CameraSetting.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/CameraSetting.java
@@ -16,7 +16,7 @@
 package org.terasology.rendering.nui.layers.mainMenu.videoSettings;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public enum CameraSetting {
     NORMAL("Normal", 1),

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/miglayout/MigLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/miglayout/MigLayout.java
@@ -43,9 +43,9 @@ import java.util.Map;
 
 /**
  * MigLayout Binding
- * <p/>
+ * <br><br>
  * see: http://www.miglayout.com/
- * <p/>
+ * <br><br>
  * Created by synopia on 06.01.14.
  */
 public class MigLayout extends CoreLayout<MigLayout.CCHint> implements ContainerWrapper {

--- a/engine/src/main/java/org/terasology/rendering/oculusVr/OculusVrHelper.java
+++ b/engine/src/main/java/org/terasology/rendering/oculusVr/OculusVrHelper.java
@@ -21,7 +21,7 @@ import org.terasology.TeraOVR;
 /**
  * Helper class for the Oculus Rift.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class OculusVrHelper {
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLMaterial.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLMaterial.java
@@ -53,7 +53,7 @@ import java.util.Set;
 
 /**
  * @author Immortius
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class GLSLMaterial extends BaseMaterial {
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -62,7 +62,7 @@ import javax.swing.JOptionPane;
 
 /**
  * GLSL Shader Program Instance class.
- * <p/>
+ * <br><br>
  * Provides actual shader compilation and manipulation support.
  *
  * @author Benjamin Glatzel <benjamin.glatzel@me.com>

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -65,7 +65,7 @@ import javax.swing.JOptionPane;
  * <br><br>
  * Provides actual shader compilation and manipulation support.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class GLSLShader extends AbstractAsset<ShaderData> implements Shader {
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
@@ -142,7 +142,7 @@ import static org.lwjgl.opengl.GL20.glStencilOpSeparate;
 /**
  * The Default Rendering Process class.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class LwjglRenderingProcess {
 

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Generates tessellated chunk meshes from chunks.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class ChunkTessellator {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParameters.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParameters.java
@@ -22,7 +22,7 @@ import org.terasology.rendering.assets.material.Material;
  * be used to automatically set shader parameters when the
  * corresponding shader program gets activated.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public interface ShaderParameters {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
@@ -27,7 +27,7 @@ import org.terasology.world.WorldProvider;
 /**
  * Basic shader parameters for all shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersBase implements ShaderParameters {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBlock.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBlock.java
@@ -26,7 +26,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the Block shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 // TODO: Put these values in a material and use that.
 public class ShaderParametersBlock extends ShaderParametersBase {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
@@ -31,7 +31,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the Chunk shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersChunk extends ShaderParametersBase {
     @EditorRange(min = 0.0f, max = 2.0f)

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -29,7 +29,7 @@ import org.terasology.rendering.world.WorldRenderer;
 /**
  * Shader parameters for the Combine shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersCombine extends ShaderParametersBase {
     @EditorRange(min = 0.001f, max = 0.005f)

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
@@ -26,7 +26,7 @@ import org.terasology.rendering.world.WorldRenderer;
 /**
  * Shader parameters for the Debug shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersDebug extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDefault.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDefault.java
@@ -24,7 +24,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the Block shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersDefault extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -23,7 +23,7 @@ import org.terasology.rendering.opengl.LwjglRenderingProcess;
 /**
  * Shader parameters for the Post-processing shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersHdr extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightBufferPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightBufferPass.java
@@ -20,7 +20,7 @@ import org.terasology.rendering.assets.material.Material;
 /**
  * Shader parameters for the LightBufferPass shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersLightBufferPass extends ShaderParametersBase {
     @Override

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -33,7 +33,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the LightBufferPass shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -30,7 +30,7 @@ import org.terasology.rendering.world.WorldRenderer;
 /**
  * Shader parameters for the Light Shaft shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersLightShaft extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
@@ -22,7 +22,7 @@ import org.terasology.rendering.opengl.LwjglRenderingProcess;
 /**
  * Shader parameters for the Combine shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersOcDistortion extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersParticle.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersParticle.java
@@ -20,7 +20,7 @@ import org.terasology.rendering.assets.material.Material;
 /**
  * Shader parameters for the Particle shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersParticle extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -39,7 +39,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the Post-processing shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersPost extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
@@ -32,7 +32,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the Post-processing shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersPrePost extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -44,7 +44,7 @@ import static org.lwjgl.opengl.GL11.glBindTexture;
 /**
  * Shader parameters for the Post-processing shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersSSAO extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersShadowMap.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersShadowMap.java
@@ -20,7 +20,7 @@ import org.terasology.rendering.assets.material.Material;
 /**
  * Shader parameters for the Shadow Map shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersShadowMap extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
@@ -30,7 +30,7 @@ import org.terasology.world.WorldProvider;
 /**
  * Parameters for the sky shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersSky extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -24,7 +24,7 @@ import org.terasology.rendering.opengl.LwjglRenderingProcess;
 /**
  * Shader parameters for the Post-processing shader program.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class ShaderParametersSobel extends ShaderParametersBase {
 

--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Provides the mechanism for updating and generating chunk meshes.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class ChunkMeshUpdateManager {
     private static final int NUM_TASK_THREADS = 8;

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -55,7 +55,7 @@ import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.RenderableChunk;
 
 /**
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public final class WorldRendererImpl implements WorldRenderer {
 

--- a/engine/src/main/java/org/terasology/rendering/world/selection/BlockSelectionRenderSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/world/selection/BlockSelectionRenderSystem.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 /**
  * System to render registered BlockSelections.
- * <p/>
+ * <br><br>
  * This system is not currently thread-safe.
  *
  * @author synopia mkienenb@gmail.com

--- a/engine/src/main/java/org/terasology/rendering/world/selection/BlockSelectionRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/selection/BlockSelectionRenderer.java
@@ -45,7 +45,7 @@ import static org.lwjgl.opengl.GL11.glTranslated;
 
 /**
  * Renders a selection. Is used by the BlockSelectionSystem.
- * <p/>
+ * <br><br>
  * TODO total overhaul of this class. its neither good code, nor optimized in any way!
  *
  * @author synopia

--- a/engine/src/main/java/org/terasology/utilities/CamelCaseMatcher.java
+++ b/engine/src/main/java/org/terasology/utilities/CamelCaseMatcher.java
@@ -37,7 +37,7 @@ public final class CamelCaseMatcher {
     }
 
     /**
-     * @param commandName
+     * @param queryStr
      * @param commands
      * @return
      */
@@ -59,9 +59,9 @@ public final class CamelCaseMatcher {
 
             if (m.find()) {
                 matches.add(m.group());
-            } 
+            }
         }
-        
+
         return matches;
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/FilesUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/FilesUtil.java
@@ -24,7 +24,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class FilesUtil {
 

--- a/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
+++ b/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
@@ -46,7 +46,7 @@ public final class LWJGLHelper {
             logger.warn("Could not load optional TeraOVR native libraries - Oculus support disabled");
         }
     }
-    
+
     private static void initLibraryPaths() {
         switch (LWJGLUtil.getPlatform()) {
             case LWJGLUtil.PLATFORM_MACOSX:

--- a/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
+++ b/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
@@ -25,7 +25,7 @@ import org.terasology.rendering.oculusVr.OculusVrHelper;
 /**
  * Helper class to have LWJGL loading logic in a central spot
  *
- * @author Rasmus 'Cervator' Praestholm - cervator@gmail.com
+ * @author Rasmus 'Cervator' Praestholm
  */
 public final class LWJGLHelper {
 

--- a/engine/src/main/java/org/terasology/utilities/OrdinalIndicator.java
+++ b/engine/src/main/java/org/terasology/utilities/OrdinalIndicator.java
@@ -31,7 +31,7 @@ public final class OrdinalIndicator {
      * Returns the ordinal indicator of an integer.
      * <br><br>
      * Most readable when called with class name:
-     * OrdinalIndicator.of(22) -> "nd"
+     * OrdinalIndicator.of(22) returns "nd"
      *
      * @param number the integer
      * @return The ordinal indicator ("st", "nd", "rd" or "th").
@@ -65,7 +65,7 @@ public final class OrdinalIndicator {
      * Returns the integer combined with it's ordinal indicator as String.
      * <br><br>
      * Most readable when called with class name:
-     * OrdinalIndicator.addedTo(22) -> "22nd"
+     * OrdinalIndicator.addedTo(22) returns "22nd"
      *
      * @param x the integer
      * @return The integer with it's ordinal indicator attached.

--- a/engine/src/main/java/org/terasology/utilities/OrdinalIndicator.java
+++ b/engine/src/main/java/org/terasology/utilities/OrdinalIndicator.java
@@ -29,7 +29,7 @@ public final class OrdinalIndicator {
 
     /**
      * Returns the ordinal indicator of an integer.
-     * <p/>
+     * <br><br>
      * Most readable when called with class name:
      * OrdinalIndicator.of(22) -> "nd"
      *
@@ -63,7 +63,7 @@ public final class OrdinalIndicator {
 
     /**
      * Returns the integer combined with it's ordinal indicator as String.
-     * <p/>
+     * <br><br>
      * Most readable when called with class name:
      * OrdinalIndicator.addedTo(22) -> "22nd"
      *

--- a/engine/src/main/java/org/terasology/utilities/collection/CharSequenceIterator.java
+++ b/engine/src/main/java/org/terasology/utilities/collection/CharSequenceIterator.java
@@ -19,7 +19,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * @author Marcos Vives Del Sol <socram8888@gmail.com>
+ * @author Marcos Vives Del Sol
  */
 public class CharSequenceIterator implements Iterator<Character> {
 

--- a/engine/src/main/java/org/terasology/utilities/collection/EnumBooleanMap.java
+++ b/engine/src/main/java/org/terasology/utilities/collection/EnumBooleanMap.java
@@ -22,7 +22,7 @@ import java.util.EnumSet;
  * EnumMap for storing primitive booleans against each enum value.
  * Values default to false
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class EnumBooleanMap<ENUM extends Enum<ENUM>> {
     private EnumSet<ENUM> store;

--- a/engine/src/main/java/org/terasology/utilities/procedural/DiscreteWhiteNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/DiscreteWhiteNoise.java
@@ -21,7 +21,7 @@ import org.terasology.math.TeraMath;
 /**
  * This implementation is based on Robert Jenkins' 96 bit mix function as described in
  * in "Integer Hash Function" by Thomas Wang, Jan 1997. The original code is public domain.
- * <br/><br/>
+ * <br><br>
  * This implementation rounds float parameters to the closest integer value. Use it in combination
  * with BrownianNoise at lacunarity = 2.0.
  * @author Martin Steiger

--- a/engine/src/main/java/org/terasology/utilities/procedural/PerlinNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/PerlinNoise.java
@@ -21,7 +21,7 @@ import org.terasology.utilities.random.FastRandom;
 /**
  * Improved Perlin noise based on the reference implementation by Ken Perlin.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class PerlinNoise extends AbstractNoise implements Noise2D, Noise3D {
 

--- a/engine/src/main/java/org/terasology/utilities/procedural/SimplexNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/SimplexNoise.java
@@ -20,21 +20,21 @@ import org.terasology.utilities.random.FastRandom;
 
 /**
  * A speed-improved simplex noise algorithm for Simplex noise in 2D, 3D and 4D.
- * <p/>
+ * <br><br>
  * Based on example code by Stefan Gustavson (stegu@itn.liu.se).
  * Optimisations by Peter Eastman (peastman@drizzle.stanford.edu).
  * Better rank ordering method by Stefan Gustavson in 2012.
- * <p/>
+ * <br><br>
  * This could be speeded up even further, but it's useful as it is.
- * <p/>
+ * <br><br>
  * Version 2012-03-09
- * <p/>
+ * <br><br>
  * This code was placed in the public domain by its original author,
  * Stefan Gustavson. You may use it as you see fit, but
  * attribution is appreciated.
- * <p/>
+ * <br><br>
  * See http://staffwww.itn.liu.se/~stegu/
- * <p/>
+ * <br><br>
  * msteiger: Introduced seed value
  */
 public class SimplexNoise extends AbstractNoise implements Noise2D, Noise3D {

--- a/engine/src/main/java/org/terasology/utilities/procedural/Voronoi.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/Voronoi.java
@@ -52,7 +52,7 @@ public class Voronoi {
 
     /**
      * @param at
-     * @param numPoints Should be <= 5. The number of points to return
+     * @param numPoints Should be &le; 5. The number of points to return
      * @return
      */
     public VoronoiResult[] getClosestPoints(Vector2f at, int numPoints) {

--- a/engine/src/main/java/org/terasology/utilities/random/FastRandom.java
+++ b/engine/src/main/java/org/terasology/utilities/random/FastRandom.java
@@ -20,7 +20,7 @@ import org.terasology.module.sandbox.API;
 /**
  * Random number generator based on the Xorshift generator by George Marsaglia.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 @API
 public class FastRandom extends Random {

--- a/engine/src/main/java/org/terasology/utilities/random/MersenneRandom.java
+++ b/engine/src/main/java/org/terasology/utilities/random/MersenneRandom.java
@@ -21,8 +21,8 @@ import ec.util.MersenneTwisterFast;
 
 /**
  * Random number generator based on the Mersenne Primer Twister implementation of Sean Luke.
- * The MersenneTwister code is based on standard MT19937 C/C++ code by Takuji Nishimura.<br/><br/>
- * Reference: Makato Matsumoto and Takuji Nishimura: <br/>
+ * The MersenneTwister code is based on standard MT19937 C/C++ code by Takuji Nishimura.<br><br>
+ * Reference: Makato Matsumoto and Takuji Nishimura: <br>
  * "Mersenne Twister: A 623-Dimensionally Equidistributed Uniform Pseudo-Random Number Generator"
  *
  * @author Martin Steiger

--- a/engine/src/main/java/org/terasology/utilities/random/Random.java
+++ b/engine/src/main/java/org/terasology/utilities/random/Random.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * Interface for random number generators.
  *
- * @author Marcos Vives Del Sol <socram8888@gmail.com>
+ * @author Marcos Vives Del Sol
  */
 @API
 public abstract class Random {

--- a/engine/src/main/java/org/terasology/utilities/tree/SpaceTree.java
+++ b/engine/src/main/java/org/terasology/utilities/tree/SpaceTree.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * A data structure that allows to add, remove and find nearest nodes in an N-dimensional space.
  * This can be used to locate entities (or block entities) nearest to player of a specific type, provided that system
- * using it keeps track of all loaded & active entities of this specific type.
+ * using it keeps track of all loaded &amp; active entities of this specific type.
  * <br><br>
  * For three dimensions this is an octree and for two dimensions this is quadtree implementations.
  * <br><br>

--- a/engine/src/main/java/org/terasology/utilities/tree/SpaceTree.java
+++ b/engine/src/main/java/org/terasology/utilities/tree/SpaceTree.java
@@ -30,9 +30,9 @@ import java.util.Set;
  * A data structure that allows to add, remove and find nearest nodes in an N-dimensional space.
  * This can be used to locate entities (or block entities) nearest to player of a specific type, provided that system
  * using it keeps track of all loaded & active entities of this specific type.
- * <p/>
+ * <br><br>
  * For three dimensions this is an octree and for two dimensions this is quadtree implementations.
- * <p/>
+ * <br><br>
  * It is possible to provide a DistanceFunction in the constructor that will be used instead of EuclideanDistanceFunction.
  * This allows to prefer a specific axis (i.e. objects above/below have higher priority than front/back or sides) or
  * it might have some other applications. Please note, that if it is used, the distance returned in an "Entry" is

--- a/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
+++ b/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
@@ -24,7 +24,7 @@ import org.terasology.world.block.Block;
 /**
  * Manages creation and lookup of entities linked to blocks
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface BlockEntityRegistry {
 

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -24,7 +24,7 @@ import org.terasology.world.liquid.LiquidData;
 /**
  * A chunk view is a way of accessing multiple chunks for modification in a performant manner.
  * Chunk views also support relative subviewing - looking at an area of the world with a uniform offset to block positions
- * <p/>
+ * <br><br>
  * ChunkViews must be locked because write operations can be enacted - any write operations requested outside of a lock
  * are ignored.
  *

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -24,7 +24,7 @@ import org.terasology.world.liquid.LiquidData;
 /**
  * Provides the basic interface for all world providers.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public interface WorldProvider extends WorldProviderCore {
 

--- a/engine/src/main/java/org/terasology/world/biomes/BiomeManager.java
+++ b/engine/src/main/java/org/terasology/world/biomes/BiomeManager.java
@@ -198,7 +198,7 @@ public class BiomeManager implements BiomeRegistry {
     /**
      * @return A biome that can be used to avoid a null pointer in cases where the real biome is unknown, i.e.
      * when the chunk has not yet been loaded.
-     * <p/>
+     * <br><br>
      * TODO: Decide how a caller can determine that he got the unknown biome and not the real one.
      */
     public static Biome getUnknownBiome() {

--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -46,8 +46,8 @@ import java.util.Map;
 /**
  * Stores all information for a specific block type.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Rasmus 'Cervator' Praestholm <cervator@gmail.com>
+ * @author Benjamin Glatzel
+ * @author Rasmus 'Cervator' Praestholm
  */
 // TODO: Make this immutable, add a block builder class?
 public final class Block {

--- a/engine/src/main/java/org/terasology/world/block/BlockComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockComponent.java
@@ -22,7 +22,7 @@ import org.terasology.network.Replicate;
 /**
  * Used for entities representing a block in the world
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class BlockComponent implements Component {
     @Replicate

--- a/engine/src/main/java/org/terasology/world/block/BlockManager.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockManager.java
@@ -59,7 +59,7 @@ public abstract class BlockManager implements BlockSoundsRegistry {
 
     /**
      * Retrieve all {@code BlockUri}s that match the given string.
-     * <p/>
+     * <br><br>
      * In order to resolve the {@code BlockUri}s, every package is searched for the given uri pattern.
      *
      * @param uri the uri pattern to match

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -56,7 +56,7 @@ import org.terasology.world.block.regions.BlockRegionComponent;
 /**
  * Event handler for events affecting block entities
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem
 public class BlockEntitySystem extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/world/block/entity/damage/BlockDamageRenderer.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/damage/BlockDamageRenderer.java
@@ -56,7 +56,7 @@ import static org.lwjgl.opengl.GL11.glTranslated;
 import static org.lwjgl.opengl.GL11.glTranslatef;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 @RegisterSystem(RegisterMode.CLIENT)
 public class BlockDamageRenderer extends BaseComponentSystem implements RenderSystem {

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/LargeBlockUpdateFinished.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/LargeBlockUpdateFinished.java
@@ -18,7 +18,7 @@ package org.terasology.world.block.entity.neighbourUpdate;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class LargeBlockUpdateFinished implements Event {
 }

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/LargeBlockUpdateStarting.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/LargeBlockUpdateStarting.java
@@ -18,7 +18,7 @@ package org.terasology.world.block.entity.neighbourUpdate;
 import org.terasology.entitySystem.event.Event;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class LargeBlockUpdateStarting implements Event {
 }

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
@@ -38,7 +38,7 @@ import org.terasology.world.block.family.UpdatesWithNeighboursFamily;
 import java.util.Set;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implements UpdateSubscriberSystem {

--- a/engine/src/main/java/org/terasology/world/block/entity/placement/BlockPlacingSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/placement/BlockPlacingSystem.java
@@ -30,7 +30,7 @@ import org.terasology.world.block.Block;
 import java.util.Map;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class BlockPlacingSystem extends BaseComponentSystem {

--- a/engine/src/main/java/org/terasology/world/block/entity/placement/PlaceBlocks.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/placement/PlaceBlocks.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class PlaceBlocks extends AbstractConsumableEvent {
     private Map<Vector3i, Block> blocks;

--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -26,7 +26,7 @@ import org.terasology.world.block.BlockUri;
 import java.util.Map;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class AttachedToSurfaceFamily extends AbstractBlockFamily {
     private Map<Side, Block> blocks = Maps.newEnumMap(Side.class);

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
@@ -27,7 +27,7 @@ import org.terasology.world.block.BlockUri;
  * This will enable such effects as players picking up a block with one orientation and it grouping
  * with the same block with different orientations, and placing it in different directions.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface BlockFamily {
 

--- a/engine/src/main/java/org/terasology/world/block/family/HorizontalBlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/HorizontalBlockFamily.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * Block group for blocks that can be oriented around the vertical axis.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class HorizontalBlockFamily extends AbstractBlockFamily implements SideDefinedBlockFamily {
 

--- a/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 /**
  * The standard block group consisting of a single symmetrical block that doesn't need rotations
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class SymmetricFamily extends AbstractBlockFamily {
 

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
@@ -254,7 +254,7 @@ public class BlockManagerImpl extends BlockManager {
 
     /**
      * Retrieve all {@code BlockUri}s that match the given string.
-     * <p/>
+     * <br><br>
      * In order to resolve the {@code BlockUri}s, every package is searched for the given uri pattern.
      *
      * @param uri the uri pattern to match

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemComponent.java
@@ -23,7 +23,7 @@ import org.terasology.world.block.family.BlockFamily;
 /**
  * Combined with ItemComponent, represents a held block
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public final class BlockItemComponent implements Component {
     @Replicate(FieldReplicateType.SERVER_TO_OWNER)

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
@@ -27,7 +27,7 @@ import org.terasology.rendering.logic.LightComponent;
 import org.terasology.world.block.family.BlockFamily;
 
 /**
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class BlockItemFactory {
     private EntityManager entityManager;

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockSoundsFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockSoundsFactory.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 /**
  * Creates block sounds objects from data driven block sounds definitions.
- * <p/>
+ * <br><br>
  * Responsible for resolving the actual sound assets referenced by the block sounds definition.
  */
 public class BlockSoundsFactory {

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockMeshPart.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockMeshPart.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
  * Describes the elements composing part of a block mesh. Multiple parts are patched together to define the mesh
  * for a block, or its appearance in the world.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public class BlockMeshPart {
     private static final float BORDER = 1f / 128f;

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
@@ -26,7 +26,7 @@ import org.terasology.world.block.BlockPart;
 /**
  * Describes a shape that a block can take. The shape may also be rotated if not symmetrical.
  *
- * @author Immortius <immortius@gmail.com>
+ * @author Immortius
  */
 public interface BlockShape extends Asset<BlockShapeData> {
 

--- a/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequiredComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequiredComponent.java
@@ -24,7 +24,7 @@ import org.terasology.entitySystem.Component;
  * If the supporting block is removed or changed to one that does not support attachment, the block
  * (attachment) will be destroyed. The check for which side this block entity is attached to is done via BlockMeshPart.
  *
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class AttachSupportRequiredComponent implements Component {
 }

--- a/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupportSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupportSystem.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @RegisterSystem
 @Share(BlockStructuralSupportRegistry.class)

--- a/engine/src/main/java/org/terasology/world/block/structure/SideBlockSupportRequiredComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/SideBlockSupportRequiredComponent.java
@@ -25,7 +25,7 @@ import org.terasology.entitySystem.Component;
  * As an example - a chandelier would have topAllowed=true, most of building blocks for houses would be -
  * bottomAllowed=true, sideAllowed=true, table (furniture) would be bottomAllowed=true.
  *
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public class SideBlockSupportRequiredComponent implements Component {
     public boolean topAllowed;

--- a/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
@@ -76,7 +76,6 @@ public interface ChunkProvider {
      * Retrieves the ChunkRelevanceRegion object for the given entity
      *
      * @param entity
-     * @return The chunk relevance region, or null
      */
     void updateRelevanceEntity(EntityRef entity, Vector3i distance);
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraArray.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraArray.java
@@ -31,7 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * TeraArray is the base class used to store block related data in Chunks.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraArray {
 
@@ -148,7 +148,7 @@ public abstract class TeraArray {
      * This is the interface for tera array factories. Every tera array is required to implement a factory.
      * It should be implemented as a static subclass of the corresponding tera array class and it should be called Factory.
      *
-     * @author Manuel Brotz <manu.brotz@gmx.ch>
+     * @author Manuel Brotz
      * @see org.terasology.world.chunks.blockdata.TeraDenseArray16Bit.Factory
      */
     public interface Factory<T extends TeraArray> {
@@ -169,7 +169,7 @@ public abstract class TeraArray {
      * {@link org.terasology.world.chunks.blockdata.TeraArray.BasicSerializationHandler TeraArray.BasicSerializationHandler}
      * instead of using this interface directly. It should be implemented as a static subclass of the corresponding tera array class.
      *
-     * @author Manuel Brotz <manu.brotz@gmx.ch>
+     * @author Manuel Brotz
      * @see org.terasology.world.chunks.blockdata.TeraArray.BasicSerializationHandler
      */
     public interface SerializationHandler<T extends TeraArray> {
@@ -189,7 +189,7 @@ public abstract class TeraArray {
      * Extending this class is the recommended way to implement serialization handlers for tera arrays.
      * Tera arrays should implement their serialization handlers as a static subclass called SerializationHandler.
      *
-     * @author Manuel Brotz <manu.brotz@gmx.ch>
+     * @author Manuel Brotz
      * @see org.terasology.world.chunks.blockdata.TeraDenseArray16Bit.SerializationHandler
      * @see org.terasology.world.chunks.blockdata.TeraDenseArray16Bit.Factory
      */

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraArrayUtils.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraArrayUtils.java
@@ -19,7 +19,7 @@ package org.terasology.world.chunks.blockdata;
 /**
  * TeraArrayUtils contains some methods used in some TeraArray implementations.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public final class TeraArrayUtils {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * TeraDenseArray is the base class used to implement dense arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraDenseArray extends TeraArray {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray16Bit.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray16Bit.java
@@ -26,7 +26,7 @@ import java.nio.ShortBuffer;
  * TeraDenseArray16Bit implements a dense array with elements of 16 bit size.
  * Its elements are in the range -32'768 through +32'767 and it internally uses the short type to store its elements.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class TeraDenseArray16Bit extends TeraDenseArray {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray4Bit.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray4Bit.java
@@ -24,7 +24,7 @@ import org.terasology.world.chunks.deflate.TeraVisitingDeflator;
  * TeraDenseArray4Bit implements a dense array with elements of 4 bit size.
  * Its elements are in the range 0 - 15 and it increases memory efficiency by storing two elements per byte.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public final class TeraDenseArray4Bit extends TeraDenseArrayByte {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray8Bit.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArray8Bit.java
@@ -24,7 +24,7 @@ import org.terasology.world.chunks.deflate.TeraVisitingDeflator;
  * TeraDenseArray8Bit implements a dense array with elements of 8 bit size.
  * Its elements are in the range -128 through +127 and it stores one element per byte.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public final class TeraDenseArray8Bit extends TeraDenseArrayByte {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArrayByte.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraDenseArrayByte.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 /**
  * TeraDenseArrayByte is the base class used to implement dense arrays with elements of size 4 bit or 8 bit.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraDenseArrayByte extends TeraDenseArray {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray.java
@@ -20,7 +20,7 @@ package org.terasology.world.chunks.blockdata;
 /**
  * TeraSparseArray is the base class used to implement sparse arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraSparseArray extends TeraArray {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray16Bit.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray16Bit.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
  * Its elements are in the range -32'768 through +32'767 and it internally uses the short type to store its elements.
  * It can reduce memory consumption through sparse memory allocation.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class TeraSparseArray16Bit extends TeraSparseArray {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray4Bit.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray4Bit.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
  * Its elements are in the range 0 - 15 and it increases memory efficiency by storing two elements per byte.
  * It can further reduce memory consumption through sparse memory allocation.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public final class TeraSparseArray4Bit extends TeraSparseArrayByte {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray8Bit.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArray8Bit.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
  * Its elements are in the range -128 through +127 and it stores one element per byte.
  * It can reduce memory consumption through sparse memory allocation.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public final class TeraSparseArray8Bit extends TeraSparseArrayByte {
 

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArrayByte.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/TeraSparseArrayByte.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 /**
  * TeraSparseArrayByte is the base class used to implement sparse arrays with elements of size 4 bit or 8 bit.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraSparseArrayByte extends TeraSparseArray {
 

--- a/engine/src/main/java/org/terasology/world/chunks/deflate/TeraDeflator.java
+++ b/engine/src/main/java/org/terasology/world/chunks/deflate/TeraDeflator.java
@@ -21,7 +21,7 @@ import org.terasology.world.chunks.blockdata.TeraArray;
 /**
  * TeraDeflator is the abstract base class used to implement chunk deflation.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraDeflator {
 

--- a/engine/src/main/java/org/terasology/world/chunks/deflate/TeraNullDeflator.java
+++ b/engine/src/main/java/org/terasology/world/chunks/deflate/TeraNullDeflator.java
@@ -21,7 +21,7 @@ import org.terasology.world.chunks.blockdata.TeraArray;
 /**
  * TeraNullDeflator performs no deflation at all. It just returns the passed array.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public class TeraNullDeflator extends TeraDeflator {
 

--- a/engine/src/main/java/org/terasology/world/chunks/deflate/TeraStandardDeflator.java
+++ b/engine/src/main/java/org/terasology/world/chunks/deflate/TeraStandardDeflator.java
@@ -24,7 +24,7 @@ import org.terasology.world.chunks.blockdata.TeraSparseArray8Bit;
 /**
  * TeraStandardDeflator implements a simple deflation algorithm for 4, 8 and 16-bit dense and sparse arrays.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  * @note Currently it is optimized for chunks of size 16x256x16 blocks.
  * @todo Implement deflation for sparse arrays.
  */

--- a/engine/src/main/java/org/terasology/world/chunks/deflate/TeraStandardDeflator.java
+++ b/engine/src/main/java/org/terasology/world/chunks/deflate/TeraStandardDeflator.java
@@ -22,41 +22,41 @@ import org.terasology.world.chunks.blockdata.TeraSparseArray4Bit;
 import org.terasology.world.chunks.blockdata.TeraSparseArray8Bit;
 
 /**
- * TeraStandardDeflator implements a simple deflation algorithm for 4, 8 and 16-bit dense and sparse arrays.
+ * TeraStandardDeflator implements a simple deflation algorithm for 4, 8 and 16-bit dense and sparse arrays.<br>
+ * <b>NOTE:</b> Currently it is optimized for chunks of size 16x256x16 blocks.<br>
+ * TODO: Implement deflation for sparse arrays.
  *
  * @author Manuel Brotz
- * @note Currently it is optimized for chunks of size 16x256x16 blocks.
- * @todo Implement deflation for sparse arrays.
  */
 public class TeraStandardDeflator extends TeraVisitingDeflator {
-    
+
     /*
      *  16-bit variant
      *  ==============
-     *  
+     *
      *  dense chunk  : 4 + 12 + (65536 * 2)                                                   = 131088
      *  sparse chunk : (4 + 12 + (256 * 2)) + (4 + 12 + (256 × 4)) + ((12 + (256 * 2)) × 256) = 135712
      *  difference   : 135712 - 131088                                                        =   4624
      *  min. deflate : 4624 / (12 + (256 * 2))                                                =      8.8
-     *  
-     *  
+     *
+     *
      *  8-bit variant
      *  =============
-     *  
+     *
      *  dense chunk  : 4 + 12 + 65536                                                   = 65552
      *  sparse chunk : (4 + 12 + 256) + (4 + 12 + (256 × 4)) + ((12 + 256) × 256)       = 69920
      *  difference   : 69920 - 65552                                                    =  4368
      *  min. deflate : 4368 / (12 + 256)                                                =    16.3
-     *  
-     *  
+     *
+     *
      *  4-bit variant
      *  =============
-     *  
+     *
      *  dense chunk  : 4 + 12 + (65536 / 2)                                             = 32784
      *  sparse chunk : (4 + 12 + 256) + (4 + 12 + (256 × 4)) + ((12 + (256 / 2)) × 256) = 37152
      *  difference   : 37152 - 32784                                                    =  4368
      *  min. deflate : 4368 / (12 + (256 / 2))                                          =    31.2
-     *  
+     *
      */
 
     // TODO dynamically calculate DEFLATE_MINIMUM_*, they only work for chunks with dimension 16x256x16

--- a/engine/src/main/java/org/terasology/world/chunks/deflate/TeraVisitingDeflator.java
+++ b/engine/src/main/java/org/terasology/world/chunks/deflate/TeraVisitingDeflator.java
@@ -23,7 +23,7 @@ import org.terasology.world.chunks.blockdata.TeraArray;
  * TeraVisitingDeflator uses the visitor pattern to gain access to the internal implementation details of specific
  * TeraArrays. This allows to implement fast deflation algorithms.
  *
- * @author Manuel Brotz <manu.brotz@gmx.ch>
+ * @author Manuel Brotz
  */
 public abstract class TeraVisitingDeflator extends TeraDeflator {
 

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -52,9 +52,9 @@ import java.util.concurrent.locks.ReentrantLock;
  * Chunks are tessellated on creation and saved to vertex arrays. From those VBOs are generated
  * which are then used for the actual rendering process.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Manuel Brotz <manu.brotz@gmx.ch>
- * @author Florian <florian@fkoeberle.de>
+ * @author Benjamin Glatzel
+ * @author Manuel Brotz
+ * @author Florian
  */
 public class ChunkImpl implements Chunk {
 

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -48,7 +48,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * Chunks are the basic components of the world. Each chunk contains a fixed amount of blocks
  * determined by its dimensions. They are used to manage the world efficiently and
  * to reduce the batch count within the render loop.
- * <p/>
+ * <br><br>
  * Chunks are tessellated on creation and saved to vertex arrays. From those VBOs are generated
  * which are then used for the actual rendering process.
  *

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -81,7 +81,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvider {
 

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -55,7 +55,7 @@ import java.util.concurrent.BlockingQueue;
 
 /**
  * @author Immortius
- * @author Florian <florian@fkoeberle.de>
+ * @author Florian
  */
 public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvider {
 

--- a/engine/src/main/java/org/terasology/world/generation/facets/base/BooleanFieldFacet2D.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/base/BooleanFieldFacet2D.java
@@ -22,7 +22,7 @@ import org.terasology.world.generation.WorldFacet2D;
  * A {@link WorldFacet2D}-based facet that provides boolean values
  * for rectangular area (see {@link #getWorldRegion()} and {@link #getRelativeRegion()}).
  * Its entries are accessible through both relative and world coordinates (in blocks).
- * <br/><br/>
+ * <br><br>
  * All methods throw {@link IllegalArgumentException} if coordinates are not inside the respective region.
  * @author Immortius
  * @author Martin Steiger

--- a/engine/src/main/java/org/terasology/world/generator/WorldConfigurator.java
+++ b/engine/src/main/java/org/terasology/world/generator/WorldConfigurator.java
@@ -27,7 +27,7 @@ public interface WorldConfigurator  {
 
     /**
      * The values are supposed to be annotated with {@link org.terasology.rendering.nui.properties.Property}
-     * @return a map (label->object)
+     * @return a map (label to object)
      */
     Map<String, Component> getProperties();
 }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 /**
  * Provides the basic interface for all world providers.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public interface WorldProviderCore {
 

--- a/engine/src/main/java/org/terasology/world/selection/BlockSelectionComponent.java
+++ b/engine/src/main/java/org/terasology/world/selection/BlockSelectionComponent.java
@@ -23,15 +23,15 @@ import org.terasology.rendering.assets.texture.Texture;
 
 /**
  * @author mkienenb
- *         <p/>
+ *         <br><br>
  *         Use this component to track and draw a region of selected blocks.
  * @author synopia
- *         <p/>
+ *         <br><br>
  *         One example use is with the LocalPlayerBlockSelectionByItemSystem.
  *         Add this component to any item entity, to make the item to a selection item. When using such items, a temporary
  *         selection is placed in the world. First use sets the starting point, second use finishes the selection and
  *         a ApplyBlockSelectionEvent is fired to the player using the selection item.
- *         <p/>
+ *         <br><br>
  */
 @API
 public class BlockSelectionComponent implements Component {

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -50,17 +50,17 @@ import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
 
 /**
  * Class providing the main() method for launching Terasology as a PC app.
- * <p/>
+ * <br><br>
  * Through the following launch arguments default locations to store logs and
  * game saves can be overridden, by using the current directory or a specified
  * one as the home directory. Furthermore, Terasology can be launched headless,
  * to save resources while acting as a server or to run in an environment with
  * no graphics, audio or input support. Additional arguments are available to
  * reload the latest game on startup and to disable crash reporting.
- * <p/>
+ * <br><br>
  * Available launch arguments:
- * <p/>
- * <table>
+ * <br><br>
+ * <table summary="Launch arguments">
  * <tbody>
  * <tr><td>-homedir</td><td>Use the current directory as the home directory.</td></tr>
  * <tr><td>-homedir=path</td><td>Use the specified path as the home directory.</td></tr>
@@ -71,15 +71,15 @@ import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
  * <tr><td>-serverPort=xxxxx</td><td>Change the server port.</td></tr>
  * </tbody>
  * </table>
- * <p/>
+ * <br><br>
  * When used via command line an usage help and some examples can be obtained via:
- * <p/>
+ * <br><br>
  * terasology -help    or    terasology /?
- * <p/>
- * In case of crashes Terasology logs available information in <logpath>/Terasology.log
+ * <br><br>
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
- * @author Kireev   Anton   <adeon.k87@gmail.com>
+ * @author Benjamin Glatzel
+ * @author Anton Kireev
+ * @author and many others
  */
 
 public final class Terasology {

--- a/modules/Core/src/main/java/org/terasology/core/logic/blockDropGrammar/BlockDropGrammarComponent.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/blockDropGrammar/BlockDropGrammarComponent.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 public final class BlockDropGrammarComponent implements Component {
     public List<String> blockDrops;

--- a/modules/Core/src/main/java/org/terasology/core/logic/blockDropGrammar/BlockDropGrammarSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/blockDropGrammar/BlockDropGrammarSystem.java
@@ -40,7 +40,7 @@ import org.terasology.world.block.items.BlockItemFactory;
 import java.util.List;
 
 /**
- * @author Marcin Sciesinski <marcins78@gmail.com>
+ * @author Marcin Sciesinski
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class BlockDropGrammarSystem extends BaseComponentSystem {

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/PositionFilters.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/PositionFilters.java
@@ -37,7 +37,7 @@ public final class PositionFilters {
     /**
      * Filters based on the vector's y value
      *
-     * @return a predicate that returns true only if (y > height)
+     * @return a predicate that returns true only if (y &gt; height)
      */
     public static Predicate<Vector3i> minHeight(final int height) {
         return heightRange(height, Integer.MAX_VALUE);
@@ -46,7 +46,7 @@ public final class PositionFilters {
     /**
      * Filters based on the vector's y value
      *
-     * @return a predicate that returns true only if (y < height)
+     * @return a predicate that returns true only if (y &lt; height)
      */
     public static Predicate<Vector3i> maxHeight(final int height) {
         return heightRange(Integer.MIN_VALUE, height);
@@ -55,7 +55,7 @@ public final class PositionFilters {
     /**
      * Filters based on the vector's y value
      *
-     * @return a predicate that returns true only if (y > minHeight) and (y < maxHeight)
+     * @return a predicate that returns true only if (y &gt; minHeight) and (y &lt; maxHeight)
      */
     public static Predicate<Vector3i> heightRange(final int minHeight, final int maxHeight) {
         return new Predicate<Vector3i>() {
@@ -72,7 +72,7 @@ public final class PositionFilters {
      * Filters based on the density
      *
      * @param density the density facet that contains all tested coords.
-     * @return a predicate that returns true if (density >= 0) and (density < 0) for the block at (y - 1)
+     * @return a predicate that returns true if (density &ge; 0) and (density &lt; 0) for the block at (y - 1)
      */
     public static Predicate<Vector3i> density(final DensityFacet density) {
         return new Predicate<Vector3i>() {

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SurfaceObjectProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SurfaceObjectProvider.java
@@ -121,8 +121,6 @@ public abstract class SurfaceObjectProvider<B, T> implements FacetProvider {
 
     /**
      * Clears all registered population densities
-     *
-     * @see SurfaceObjectProvider#register(B, T, float)
      */
     protected void clearProbabilities() {
         probsTable.clear();
@@ -131,7 +129,7 @@ public abstract class SurfaceObjectProvider<B, T> implements FacetProvider {
     /**
      * @param x    the x coordinate
      * @param z    the z coordinate
-     * @param objs a map (objType -> probability)
+     * @param objs a map (objType to probability)
      * @return a random pick from the map or <code>null</code>
      */
     protected T getType(int x, int z, Map<T, Float> objs) {

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/trees/AbstractTreeGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/trees/AbstractTreeGenerator.java
@@ -23,7 +23,7 @@ import org.terasology.world.chunks.CoreChunk;
 /**
  * Object generators are used to generate objects like trees etc.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public abstract class AbstractTreeGenerator implements TreeGenerator {
 

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/trees/TreeGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/trees/TreeGenerator.java
@@ -23,7 +23,7 @@ import org.terasology.world.chunks.CoreChunk;
 /**
  * Object generators are used to generate objects like trees etc.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public interface TreeGenerator {
 

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/trees/TreeGeneratorCactus.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/trees/TreeGeneratorCactus.java
@@ -23,7 +23,7 @@ import org.terasology.world.chunks.CoreChunk;
 /**
  * Cactus generator.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class TreeGeneratorCactus extends AbstractTreeGenerator {
 

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/trees/TreeGeneratorLSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/trees/TreeGeneratorLSystem.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * Allows the generation of complex trees based on L-Systems.
  *
- * @author Benjamin Glatzel <benjamin.glatzel@me.com>
+ * @author Benjamin Glatzel
  */
 public class TreeGeneratorLSystem extends AbstractTreeGenerator {
 


### PR DESCRIPTION
This PR fixes most of the Javadoc errors. A few more tricky ones remain and will be dealt with separately.

I left the `@author` tags in, but removed the email address hoping that this approach suits all or at least most developers.