### PR TITLE
Fixed small bug in screenshot code.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
@@ -1416,7 +1416,7 @@ public class LwjglRenderingProcess {
 
         takeScreenshot = false;
         overwriteRtWidth = 0;
-        overwriteRtWidth = 0;
+        overwriteRtHeight = 0;
 
         createOrUpdateFullscreenFbos();
     }
@@ -1520,5 +1520,5 @@ public class LwjglRenderingProcess {
         fboLookup.put(title, fbo2);
         fboLookup.put(title + "PingPong", fbo1);
     }
-
 }
+


### PR DESCRIPTION
To take a screenshot the game video resolution is temporarily lowered or increased to match screenshot size. Once the screenshot is taken the resolution should be set back to the previous values. A small cut and paste error prevented this in the height dimension, but this was noticeable only (and especially) when attempting to take screenshots of reduced size. This commit fixes the problem by changing the faulty line to its intended form.