### PR TITLE
Refactor ModuleManager

### DIFF
--- a/engine-tests/src/main/java/org/terasology/testUtil/ModuleManagerFactory.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/ModuleManagerFactory.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.module.ModuleManagerImpl;
 import org.terasology.module.ClasspathModule;
 import org.terasology.module.ModuleMetadata;
 import org.terasology.module.ModuleMetadataReader;
@@ -35,7 +36,7 @@ public final class ModuleManagerFactory {
     }
 
     public static ModuleManager create() throws Exception {
-        ModuleManager moduleManager = new ModuleManager();
+        ModuleManager moduleManager = new ModuleManagerImpl();
         try (Reader reader = new InputStreamReader(ModuleManagerFactory.class.getResourceAsStream("/module.txt"), TerasologyConstants.CHARSET)) {
             ModuleMetadata metadata = new ModuleMetadataReader().read(reader);
             moduleManager.getRegistry().add(ClasspathModule.create(metadata, ModuleManagerFactory.class));

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -32,6 +32,7 @@ import org.terasology.config.RenderingConfig;
 import org.terasology.engine.bootstrap.ApplyModulesUtil;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.module.ModuleManagerImpl;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.engine.splash.SplashScreen;
 import org.terasology.engine.subsystem.DisplayDevice;
@@ -283,7 +284,7 @@ public class TerasologyEngine implements GameEngine {
     private void initManagers() {
 
         SplashScreen.getInstance().post("Loading modules ...");
-        ModuleManager moduleManager = CoreRegistry.putPermanently(ModuleManager.class, new ModuleManager());
+        ModuleManager moduleManager = CoreRegistry.putPermanently(ModuleManager.class, new ModuleManagerImpl());
 
         SplashScreen.getInstance().post("Loading reflections ...");
         ReflectFactory reflectFactory = CoreRegistry.putPermanently(ReflectFactory.class, new ReflectionReflectFactory());

--- a/engine/src/main/java/org/terasology/engine/module/ModuleExtension.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleExtension.java
@@ -16,24 +16,10 @@
 
 package org.terasology.engine.module;
 
-import java.util.Set;
+public interface ModuleExtension {
 
-import org.terasology.module.Module;
-import org.terasology.module.ModuleEnvironment;
-import org.terasology.module.ModuleMetadataReader;
-import org.terasology.module.ModuleRegistry;
+    String getKey();
 
-/**
- * TODO Type description
- * @author Martin Steiger
- */
-public interface ModuleManager {
-
-    ModuleRegistry getRegistry();
-
-    ModuleEnvironment getEnvironment();
-
-    ModuleEnvironment loadEnvironment(Set<Module> modules, boolean asPrimary);
-
-    ModuleMetadataReader getModuleMetadataReader();
+    Class<?> getValueType();
 }
+

--- a/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.module;
+
+import com.google.common.collect.Sets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.TerasologyConstants;
+import org.terasology.engine.paths.PathManager;
+import org.terasology.module.ClasspathModule;
+import org.terasology.module.DependencyInfo;
+import org.terasology.module.Module;
+import org.terasology.module.ModuleEnvironment;
+import org.terasology.module.ModuleLoader;
+import org.terasology.module.ModuleMetadata;
+import org.terasology.module.ModuleMetadataReader;
+import org.terasology.module.ModulePathScanner;
+import org.terasology.module.ModuleRegistry;
+import org.terasology.module.TableModuleRegistry;
+import org.terasology.module.sandbox.APIScanner;
+import org.terasology.module.sandbox.BytecodeInjector;
+import org.terasology.module.sandbox.ModuleSecurityManager;
+import org.terasology.module.sandbox.ModuleSecurityPolicy;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ReflectPermission;
+import java.net.URISyntaxException;
+import java.security.Policy;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author Immortius
+ */
+public class ModuleManagerImpl implements ModuleManager {
+
+    private ModuleSecurityManager moduleSecurityManager;
+
+    private ModuleRegistry registry;
+    private ModuleEnvironment environment;
+    private ModuleMetadataReader metadataReader;
+
+    public ModuleManagerImpl() {
+        metadataReader = new ModuleMetadataReader();
+        for (ModuleExtension ext : StandardModuleExtension.values()) {
+            metadataReader.registerExtension(ext.getKey(), ext.getValueType());
+        }
+        Module engineModule;
+        try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/engine-module.txt"), TerasologyConstants.CHARSET)) {
+            ModuleMetadata metadata = metadataReader.read(reader);
+            engineModule = ClasspathModule.create(metadata, getClass(), Module.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read engine metadata", e);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Failed to convert engine library location to path", e);
+        }
+
+        registry = new TableModuleRegistry();
+        registry.add(engineModule);
+        ModulePathScanner scanner = new ModulePathScanner(new ModuleLoader(metadataReader));
+        scanner.getModuleLoader().setModuleInfoPath(TerasologyConstants.MODULE_INFO_FILENAME);
+        scanner.scan(registry, PathManager.getInstance().getModulePaths());
+
+        DependencyInfo engineDep = new DependencyInfo();
+        engineDep.setId(engineModule.getId());
+        engineDep.setMinVersion(engineModule.getVersion());
+        engineDep.setMaxVersion(engineModule.getVersion().getNextPatchVersion());
+
+        for (Module mod : registry) {
+            if (mod != engineModule) {
+                mod.getMetadata().getDependencies().add(engineDep);
+            }
+        }
+
+        setupSandbox();
+        loadEnvironment(Sets.newHashSet(engineModule), true);
+    }
+
+    private void setupSandbox() {
+        moduleSecurityManager = new ModuleSecurityManager();
+        // TODO: This one org.terasology entry is a hack and needs a proper fix
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("org.terasology.world.biomes");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("org.terasology.math.geom");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.lang");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.lang.ref");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.math");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.util");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.util.concurrent");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.util.concurrent.atomic");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.util.concurrent.locks");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.util.regex");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.awt");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.awt.geom");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("java.awt.image");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.annotations");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.cache");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.collect");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.base");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.math");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.primitives");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.google.common.util.concurrent");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.decorator");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.function");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.iterator");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.iterator.hash");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.list");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.list.array");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.list.linked");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.map");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.map.hash");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.map.custom_hash");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.procedure");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.procedure.array");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.queue");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.set");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.set.hash");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.stack");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.stack.array");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("gnu.trove.strategy");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("javax.vecmath");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.yourkit.runtime");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("com.bulletphysics.linearmath");
+        moduleSecurityManager.getBasePermissionSet().addAPIPackage("sun.reflect");
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(com.esotericsoftware.reflectasm.MethodAccess.class);
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(IOException.class);
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(InvocationTargetException.class);
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(LoggerFactory.class);
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(Logger.class);
+
+        APIScanner apiScanner = new APIScanner(moduleSecurityManager);
+        for (Module module : registry) {
+            if (module.isOnClasspath()) {
+                apiScanner.scan(module);
+            }
+        }
+
+        moduleSecurityManager.getBasePermissionSet().grantPermission("com.google.gson", ReflectPermission.class);
+        moduleSecurityManager.getBasePermissionSet().grantPermission("com.google.gson.internal", ReflectPermission.class);
+
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(java.nio.ByteBuffer.class);
+        moduleSecurityManager.getBasePermissionSet().addAPIClass(java.nio.IntBuffer.class);
+
+        Policy.setPolicy(new ModuleSecurityPolicy());
+        System.setSecurityManager(moduleSecurityManager);
+    }
+
+    @Override
+    public ModuleRegistry getRegistry() {
+        return registry;
+    }
+
+    @Override
+    public ModuleEnvironment getEnvironment() {
+        return environment;
+    }
+
+    @Override
+    public ModuleEnvironment loadEnvironment(Set<Module> modules, boolean asPrimary) {
+        Set<Module> finalModules = Sets.newLinkedHashSet(modules);
+        for (Module module : registry) {
+            if (module.isOnClasspath()) {
+                finalModules.add(module);
+            }
+        }
+        ModuleEnvironment newEnvironment = new ModuleEnvironment(finalModules, moduleSecurityManager, Collections.<BytecodeInjector>emptyList());
+        if (asPrimary) {
+            if (environment != null) {
+                environment.close();
+            }
+            environment = newEnvironment;
+        }
+        return newEnvironment;
+    }
+
+    @Override
+    public ModuleMetadataReader getModuleMetadataReader() {
+        return metadataReader;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/module/StandardModuleExtension.java
+++ b/engine/src/main/java/org/terasology/engine/module/StandardModuleExtension.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.engine.module;
+
+import org.terasology.engine.SimpleUri;
+import org.terasology.module.Module;
+
+/**
+ * A set of standard module extensions.
+ * @author Martin Steiger
+ */
+public enum StandardModuleExtension implements ModuleExtension {
+
+    SERVER_SIDE_ONLY("serverSideOnly", Boolean.class),
+    IS_GAMEPLAY("isGameplay", Boolean.class),
+    DEFAULT_WORLD_GENERATOR("defaultWorldGenerator", String.class);
+
+    private final String key;
+    private final Class<?> valueType;
+
+    private StandardModuleExtension(String key, Class<?> valueType) {
+        this.key = key;
+        this.valueType = valueType;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public Class<?> getValueType() {
+        return valueType;
+    }
+
+    public static boolean isServerSideOnly(Module module) {
+        Boolean serverSideOnly = module.getMetadata().getExtension(SERVER_SIDE_ONLY.getKey(), Boolean.class);
+        return serverSideOnly != null && serverSideOnly;
+    }
+
+    public static boolean isGameplayModule(Module module) {
+        Boolean isGameplay = module.getMetadata().getExtension(IS_GAMEPLAY.getKey(), Boolean.class);
+        return isGameplay != null && isGameplay;
+    }
+
+    public static SimpleUri getDefaultWorldGenerator(Module module) {
+        String ext = module.getMetadata().getExtension(DEFAULT_WORLD_GENERATOR.getKey(), String.class);
+        return ext != null ? new SimpleUri(ext) : null;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -24,6 +24,7 @@ import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.modes.StateLoading;
 import org.terasology.engine.modes.StateSetup;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.module.StandardModuleExtension;
 import org.terasology.game.GameManifest;
 import org.terasology.module.Module;
 import org.terasology.naming.Name;
@@ -83,8 +84,8 @@ public class StateHeadlessSetup extends StateSetup {
             // find the first gameplay module that is available, it should have a preferred world gen
             for (Name moduleName : config.getDefaultModSelection().listModules()) {
                 Module module = moduleManager.getRegistry().getLatestModuleVersion(moduleName);
-                if (moduleManager.isGameplayModule(module)) {
-                    SimpleUri defaultWorldGenerator = moduleManager.getDefaultWorldGenerator(module);
+                if (StandardModuleExtension.isGameplayModule(module)) {
+                    SimpleUri defaultWorldGenerator = StandardModuleExtension.getDefaultWorldGenerator(module);
                     worldGenConfig.setDefaultGenerator(defaultWorldGenerator);
                     break;
                 }

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -47,6 +47,7 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.module.StandardModuleExtension;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
@@ -820,8 +821,7 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
             serverInfoMessageBuilder.setReflectionHeight(worldGen.getWorld().getSeaLevel());
         }
         for (Module module : CoreRegistry.get(ModuleManager.class).getEnvironment()) {
-            Boolean serverSideOnly = module.getMetadata().getExtension(ModuleManager.SERVER_SIDE_ONLY_EXT, Boolean.class);
-            if (serverSideOnly == null || !serverSideOnly) {
+            if (!StandardModuleExtension.isServerSideOnly(module)) {
                 serverInfoMessageBuilder.addModule(NetData.ModuleInfo.newBuilder()
                         .setModuleId(module.getId().toString())
                         .setModuleVersion(module.getVersion().toString()).build());

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -26,6 +26,7 @@ import org.terasology.engine.SimpleUri;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.modes.StateLoading;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.module.StandardModuleExtension;
 import org.terasology.game.GameManifest;
 import org.terasology.module.DependencyInfo;
 import org.terasology.module.DependencyResolver;
@@ -126,7 +127,7 @@ public class CreateGameScreen extends CoreScreenLayer {
                     // find the first gameplay module that is available
                     for (Module module : moduleManager.getRegistry()) {
                         // module is null if it is no longer present
-                        if (module != null && moduleManager.isGameplayModule(module)) {
+                        if (module != null && StandardModuleExtension.isGameplayModule(module)) {
                             set(module);
                             return selected;
                         }
@@ -334,7 +335,7 @@ public class CreateGameScreen extends CoreScreenLayer {
 
         // Set the default generator of the selected gameplay module
         if (module != null) {
-            SimpleUri defaultWorldGenerator = moduleManager.getDefaultWorldGenerator(module);
+            SimpleUri defaultWorldGenerator = StandardModuleExtension.getDefaultWorldGenerator(module);
             if (defaultWorldGenerator != null) {
                 for (WorldGeneratorInfo worldGenInfo : worldGeneratorManager.getWorldGenerators()) {
                     if (worldGenInfo.getUri().equals(defaultWorldGenerator)) {
@@ -352,7 +353,7 @@ public class CreateGameScreen extends CoreScreenLayer {
         for (Name moduleId : moduleManager.getRegistry().getModuleIds()) {
             Module latestVersion = moduleManager.getRegistry().getLatestModuleVersion(moduleId);
             if (!latestVersion.isOnClasspath()) {
-                if (moduleManager.isGameplayModule(latestVersion)) {
+                if (StandardModuleExtension.isGameplayModule(latestVersion)) {
                     gameplayModules.add(latestVersion);
                 }
             }


### PR DESCRIPTION
This PR extracts an interface out of the `ModuleManager` class. It also separates the querying of module metadata, which is independent from the actual implementation of `ModuleManager`.

As a consequence, the module manager can no longer directly override the retrieval of this metadata. However, it can customize the loading process and thus retain its influence.

Only the first 4 lines in the constructor of `ModuleManagerImpl` were changed. GitHub gets confused with the renaming/modification.