### PR TITLE
Added a StorageQualifier parameter to the Material methods where it is r...

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessMaterial.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessMaterial.java
@@ -55,72 +55,72 @@ public class HeadlessMaterial extends BaseMaterial {
     }
 
     @Override
-    public void setFloat(String name, float f, boolean currentOnly) {
+    public void setFloat(StorageQualifier qualifier, String name, float f, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat1(String name, FloatBuffer buffer, boolean currentOnly) {
+    public void setFloat1(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat2(String name, float f1, float f2, boolean currentOnly) {
+    public void setFloat2(StorageQualifier qualifier, String name, float f1, float f2, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat2(String name, FloatBuffer buffer, boolean currentOnly) {
+    public void setFloat2(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat3(String name, float f1, float f2, float f3, boolean currentOnly) {
+    public void setFloat3(StorageQualifier qualifier, String name, float f1, float f2, float f3, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat3(String name, FloatBuffer buffer, boolean currentOnly) {
+    public void setFloat3(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat4(String name, float f1, float f2, float f3, float f4, boolean currentOnly) {
+    public void setFloat4(StorageQualifier qualifier, String name, float f1, float f2, float f3, float f4, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setFloat4(String name, FloatBuffer buffer, boolean currentOnly) {
+    public void setFloat4(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setInt(String name, int i, boolean currentOnly) {
+    public void setInt(StorageQualifier qualifier, String name, int i, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setBoolean(String name, boolean value, boolean currentOnly) {
+    public void setBoolean(StorageQualifier qualifier, String name, boolean value, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setMatrix3(String name, Matrix3f matrix, boolean currentOnly) {
+    public void setMatrix3(StorageQualifier qualifier, String name, Matrix3f matrix, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setMatrix3(String name, FloatBuffer buffer, boolean currentOnly) {
+    public void setMatrix3(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setMatrix4(String name, Matrix4f matrix, boolean currentOnly) {
+    public void setMatrix4(StorageQualifier qualifier, String name, Matrix4f matrix, boolean currentOnly) {
         // Do nothing
     }
 
     @Override
-    public void setMatrix4(String name, FloatBuffer buffer, boolean currentOnly) {
+    public void setMatrix4(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly) {
         // Do nothing
     }
 

--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
@@ -75,6 +75,8 @@ import static org.lwjgl.opengl.GL11.glScalef;
 import static org.lwjgl.opengl.GL11.glTranslated;
 import static org.lwjgl.opengl.GL11.glTranslatef;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * @author Immortius
  */
@@ -347,10 +349,10 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
     protected void renderParticle(Particle particle, float light) {
         Material mat = Assets.getMaterial("engine:prog.particle");
 
-        mat.setFloat4("colorOffset", particle.color.x, particle.color.y, particle.color.z, particle.color.w, true);
-        mat.setFloat2("texOffset", particle.texOffset.x, particle.texOffset.y, true);
-        mat.setFloat2("texScale", particle.texSize.x, particle.texSize.y, true);
-        mat.setFloat("light", light, true);
+        mat.setFloat4(UNIFORM, "colorOffset", particle.color.x, particle.color.y, particle.color.z, particle.color.w, true);
+        mat.setFloat2(UNIFORM, "texOffset", particle.texOffset.x, particle.texOffset.y, true);
+        mat.setFloat2(UNIFORM, "texScale", particle.texSize.x, particle.texSize.y, true);
+        mat.setFloat(UNIFORM, "light", light, true);
 
         glCallList(displayList);
     }
@@ -359,11 +361,11 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
         Material mat = Assets.getMaterial("engine:prog.particle");
 
         Vector4f colorMod = block.calcColorOffsetFor(BlockPart.FRONT, biome);
-        mat.setFloat4("colorOffset", particle.color.x * colorMod.x, particle.color.y * colorMod.y, particle.color.z * colorMod.z, particle.color.w * colorMod.w, true);
+        mat.setFloat4(UNIFORM, "colorOffset", particle.color.x * colorMod.x, particle.color.y * colorMod.y, particle.color.z * colorMod.z, particle.color.w * colorMod.w, true);
 
-        mat.setFloat2("texOffset", particle.texOffset.x, particle.texOffset.y, true);
-        mat.setFloat2("texScale", particle.texSize.x, particle.texSize.y, true);
-        mat.setFloat("light", light, true);
+        mat.setFloat2(UNIFORM, "texOffset", particle.texOffset.x, particle.texOffset.y, true);
+        mat.setFloat2(UNIFORM, "texScale", particle.texSize.x, particle.texSize.y, true);
+        mat.setFloat(UNIFORM, "light", light, true);
 
         glCallList(displayList);
     }

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
@@ -58,6 +58,8 @@ import static org.lwjgl.opengl.GL11.glRotatef;
 import static org.lwjgl.opengl.GL11.glScalef;
 import static org.lwjgl.opengl.GL11.glTranslatef;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * @author Immortius
  */
@@ -139,8 +141,8 @@ public class FirstPersonRenderer extends BaseComponentSystem implements RenderSy
         shader.activateFeature(ShaderProgramFeature.FEATURE_USE_MATRIX_STACK);
 
         shader.enable();
-        shader.setFloat("sunlight", worldRenderer.getSunlightValue(), true);
-        shader.setFloat("blockLight", worldRenderer.getBlockLightValue(), true);
+        shader.setFloat(UNIFORM, "sunlight", worldRenderer.getSunlightValue(), true);
+        shader.setFloat(UNIFORM, "blockLight", worldRenderer.getBlockLightValue(), true);
         glBindTexture(GL11.GL_TEXTURE_2D, handTex.getId());
 
         glPushMatrix();
@@ -164,10 +166,10 @@ public class FirstPersonRenderer extends BaseComponentSystem implements RenderSy
 
             shader.enable();
 
-            shader.setBoolean("textured", false, true);
+            shader.setBoolean(UNIFORM, "textured", false, true);
 
-            shader.setFloat("sunlight", worldRenderer.getSunlightValue(), true);
-            shader.setFloat("blockLight", worldRenderer.getBlockLightValue(), true);
+            shader.setFloat(UNIFORM, "sunlight", worldRenderer.getSunlightValue(), true);
+            shader.setFloat(UNIFORM, "blockLight", worldRenderer.getBlockLightValue(), true);
 
             glPushMatrix();
 

--- a/engine/src/main/java/org/terasology/rendering/assets/material/BaseMaterial.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/material/BaseMaterial.java
@@ -28,6 +28,8 @@ import org.terasology.rendering.cameras.Camera;
 
 import java.nio.FloatBuffer;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 public abstract class BaseMaterial extends AbstractAsset<MaterialData> implements Material {
 
     public BaseMaterial(AssetUri uri) {
@@ -42,33 +44,33 @@ public abstract class BaseMaterial extends AbstractAsset<MaterialData> implement
 
     public abstract void enable();
 
-    public abstract void setFloat(String name, float f, boolean currentOnly);
+    public abstract void setFloat(StorageQualifier qualifier, String name, float f, boolean currentOnly);
 
-    public abstract void setFloat1(String name, FloatBuffer buffer, boolean currentOnly);
+    public abstract void setFloat1(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
-    public abstract void setFloat2(String name, float f1, float f2, boolean currentOnly);
+    public abstract void setFloat2(StorageQualifier qualifier, String name, float f1, float f2, boolean currentOnly);
 
-    public abstract void setFloat2(String name, FloatBuffer buffer, boolean currentOnly);
+    public abstract void setFloat2(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
-    public abstract void setFloat3(String name, float f1, float f2, float f3, boolean currentOnly);
+    public abstract void setFloat3(StorageQualifier qualifier, String name, float f1, float f2, float f3, boolean currentOnly);
 
-    public abstract void setFloat3(String name, FloatBuffer buffer, boolean currentOnly);
+    public abstract void setFloat3(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
-    public abstract void setFloat4(String name, float f1, float f2, float f3, float f4, boolean currentOnly);
+    public abstract void setFloat4(StorageQualifier qualifier, String name, float f1, float f2, float f3, float f4, boolean currentOnly);
 
-    public abstract void setFloat4(String name, FloatBuffer buffer, boolean currentOnly);
+    public abstract void setFloat4(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
-    public abstract void setInt(String name, int i, boolean currentOnly);
+    public abstract void setInt(StorageQualifier qualifier, String name, int i, boolean currentOnly);
 
-    public abstract void setBoolean(String name, boolean value, boolean currentOnly);
+    public abstract void setBoolean(StorageQualifier qualifier, String name, boolean value, boolean currentOnly);
 
-    public abstract void setMatrix3(String name, Matrix3f matrix, boolean currentOnly);
+    public abstract void setMatrix3(StorageQualifier qualifier, String name, Matrix3f matrix, boolean currentOnly);
 
-    public abstract void setMatrix3(String name, FloatBuffer buffer, boolean currentOnly);
+    public abstract void setMatrix3(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
-    public abstract void setMatrix4(String name, Matrix4f matrix, boolean currentOnly);
+    public abstract void setMatrix4(StorageQualifier qualifier, String name, Matrix4f matrix, boolean currentOnly);
 
-    public abstract void setMatrix4(String name, FloatBuffer buffer, boolean currentOnly);
+    public abstract void setMatrix4(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     public abstract void setTexture(String name, Texture texture);
 
@@ -83,109 +85,109 @@ public abstract class BaseMaterial extends AbstractAsset<MaterialData> implement
     public abstract void bindTextures();
 
     @Override
-    public void setFloat(String name, float f) {
-        setFloat(name, f, false);
+    public void setFloat(StorageQualifier qualifier, String name, float f) {
+        setFloat(qualifier, name, f, false);
     }
 
     @Override
-    public void setFloat1(String name, FloatBuffer buffer) {
-        setFloat1(name, buffer, false);
+    public void setFloat1(StorageQualifier qualifier, String name, FloatBuffer buffer) {
+        setFloat1(qualifier, name, buffer, false);
     }
 
     @Override
-    public void setFloat2(String name, float f1, float f2) {
-        setFloat2(name, f1, f2, false);
+    public void setFloat2(StorageQualifier qualifier, String name, float f1, float f2) {
+        setFloat2(qualifier, name, f1, f2, false);
     }
 
     @Override
-    public void setFloat2(String name, Vector2f value) {
-        setFloat2(name, value.x, value.y);
+    public void setFloat2(StorageQualifier qualifier, String name, Vector2f value) {
+        setFloat2(qualifier, name, value.x, value.y);
     }
 
     @Override
-    public void setFloat2(String name, Vector2f value, boolean currentOnly) {
-        setFloat2(name, value.x, value.y, currentOnly);
+    public void setFloat2(StorageQualifier qualifier, String name, Vector2f value, boolean currentOnly) {
+        setFloat2(qualifier, name, value.x, value.y, currentOnly);
     }
 
     @Override
-    public void setFloat2(String name, FloatBuffer buffer) {
-        setFloat2(name, buffer, false);
+    public void setFloat2(StorageQualifier qualifier, String name, FloatBuffer buffer) {
+        setFloat2(qualifier, name, buffer, false);
     }
 
     @Override
-    public void setFloat3(String name, float f1, float f2, float f3) {
-        setFloat3(name, f1, f2, f3, false);
+    public void setFloat3(StorageQualifier qualifier, String name, float f1, float f2, float f3) {
+        setFloat3(qualifier, name, f1, f2, f3, false);
     }
 
     @Override
-    public void setFloat3(String name, Vector3f value) {
-        setFloat3(name, value.x, value.y, value.z);
+    public void setFloat3(StorageQualifier qualifier, String name, Vector3f value) {
+        setFloat3(qualifier, name, value.x, value.y, value.z);
     }
 
-    public void setFloat3(String name, Vector3f value, boolean currentOnly) {
-        setFloat3(name, value.x, value.y, value.z, currentOnly);
-    }
-
-    @Override
-    public void setFloat3(String name, FloatBuffer buffer) {
-        setFloat3(name, buffer, false);
+    public void setFloat3(StorageQualifier qualifier, String name, Vector3f value, boolean currentOnly) {
+        setFloat3(qualifier, name, value.x, value.y, value.z, currentOnly);
     }
 
     @Override
-    public void setFloat4(String name, float f1, float f2, float f3, float f4) {
-        setFloat4(name, f1, f2, f3, f4, false);
+    public void setFloat3(StorageQualifier qualifier, String name, FloatBuffer buffer) {
+        setFloat3(qualifier, name, buffer, false);
     }
 
     @Override
-    public void setFloat4(String name, Vector4f value) {
-        setFloat4(name, value.x, value.y, value.z, value.w);
+    public void setFloat4(StorageQualifier qualifier, String name, float f1, float f2, float f3, float f4) {
+        setFloat4(qualifier, name, f1, f2, f3, f4, false);
     }
 
     @Override
-    public void setFloat4(String name, Vector4f value, boolean currentOnly) {
-        setFloat4(name, value.x, value.y, value.z, value.w, currentOnly);
+    public void setFloat4(StorageQualifier qualifier, String name, Vector4f value) {
+        setFloat4(qualifier, name, value.x, value.y, value.z, value.w);
     }
 
     @Override
-    public void setFloat4(String name, FloatBuffer buffer) {
-        setFloat4(name, buffer, false);
+    public void setFloat4(StorageQualifier qualifier, String name, Vector4f value, boolean currentOnly) {
+        setFloat4(qualifier, name, value.x, value.y, value.z, value.w, currentOnly);
     }
 
     @Override
-    public void setInt(String name, int i) {
-        setInt(name, i, false);
+    public void setFloat4(StorageQualifier qualifier, String name, FloatBuffer buffer) {
+        setFloat4(qualifier, name, buffer, false);
     }
 
     @Override
-    public void setBoolean(String name, boolean value) {
-        setBoolean(name, value, false);
+    public void setInt(StorageQualifier qualifier, String name, int i) {
+        setInt(qualifier, name, i, false);
     }
 
     @Override
-    public void setMatrix3(String name, Matrix3f matrix) {
-        setMatrix3(name, matrix, false);
+    public void setBoolean(StorageQualifier qualifier, String name, boolean value) {
+        setBoolean(qualifier, name, value, false);
     }
 
     @Override
-    public void setMatrix3(String name, FloatBuffer buffer) {
-        setMatrix3(name, buffer, false);
+    public void setMatrix3(StorageQualifier qualifier, String name, Matrix3f matrix) {
+        setMatrix3(qualifier, name, matrix, false);
     }
 
     @Override
-    public void setMatrix4(String name, Matrix4f matrix) {
-        setMatrix4(name, matrix, false);
+    public void setMatrix3(StorageQualifier qualifier, String name, FloatBuffer buffer) {
+        setMatrix3(qualifier, name, buffer, false);
     }
 
     @Override
-    public void setMatrix4(String name, FloatBuffer buffer) {
-        setMatrix3(name, buffer, false);
+    public void setMatrix4(StorageQualifier qualifier, String name, Matrix4f matrix) {
+        setMatrix4(qualifier, name, matrix, false);
+    }
+
+    @Override
+    public void setMatrix4(StorageQualifier qualifier, String name, FloatBuffer buffer) {
+        setMatrix3(qualifier, name, buffer, false);
     }
 
     @Override
     public void setCamera(Camera camera) {
-        setMatrix4("viewMatrix", camera.getViewMatrix());
-        setMatrix4("projMatrix", camera.getProjectionMatrix());
-        setMatrix4("viewProjMatrix", camera.getViewProjectionMatrix());
-        setMatrix4("invProjMatrix", camera.getInverseProjectionMatrix());
+        setMatrix4(UNIFORM, "viewMatrix", camera.getViewMatrix());
+        setMatrix4(UNIFORM, "projMatrix", camera.getProjectionMatrix());
+        setMatrix4(UNIFORM, "viewProjMatrix", camera.getViewProjectionMatrix());
+        setMatrix4(UNIFORM, "invProjMatrix", camera.getInverseProjectionMatrix());
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/material/Material.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/material/Material.java
@@ -33,6 +33,14 @@ import java.nio.FloatBuffer;
  */
 public interface Material extends Asset<MaterialData> {
 
+    /**
+     * Storage qualifier of GLSL (input) parameters.
+     */
+    public static enum StorageQualifier {
+        UNIFORM,
+        ATTRIBUTE
+    }
+
     void recompile();
 
     /**
@@ -41,180 +49,197 @@ public interface Material extends Asset<MaterialData> {
     void enable();
 
     /**
-     * Sets a float uniform parameter (for all feature permutations)
+     * Sets a float uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param f
      */
-    void setFloat(String name, float f);
+    void setFloat(StorageQualifier qualifier, String name, float f);
 
-    void setFloat(String name, float f, boolean currentOnly);
+    void setFloat(StorageQualifier qualifier, String name, float f, boolean currentOnly);
 
     /**
-     * Sets a float1 uniform parameter (for all feature permutations)
+     * Sets a float1 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param buffer
      */
-    void setFloat1(String name, FloatBuffer buffer);
+    void setFloat1(StorageQualifier qualifier, String name, FloatBuffer buffer);
 
-    void setFloat1(String name, FloatBuffer buffer, boolean currentOnly);
+    void setFloat1(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     /**
-     * Sets a float2 uniform parameter (for all feature permutations)
+     * Sets a float2 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param f1
      * @param f2
      */
-    void setFloat2(String name, float f1, float f2);
+    void setFloat2(StorageQualifier qualifier, String name, float f1, float f2);
 
-    void setFloat2(String name, float f1, float f2, boolean currentOnly);
+    void setFloat2(StorageQualifier qualifier, String name, float f1, float f2, boolean currentOnly);
 
     /**
-     * Sets a float2 uniform parameter (for all feature permutations)
+     * Sets a float2 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param value
      */
-    void setFloat2(String name, Vector2f value);
+    void setFloat2(StorageQualifier qualifier, String name, Vector2f value);
 
-    void setFloat2(String name, Vector2f value, boolean currentOnly);
+    void setFloat2(StorageQualifier qualifier, String name, Vector2f value, boolean currentOnly);
 
     /**
-     * Sets a float2 uniform parameter (for all feature permutations)
+     * Sets a float2 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param buffer
      */
-    void setFloat2(String name, FloatBuffer buffer);
+    void setFloat2(StorageQualifier qualifier, String name, FloatBuffer buffer);
 
-    void setFloat2(String name, FloatBuffer buffer, boolean currentOnly);
+    void setFloat2(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     /**
-     * Sets a float3 uniform parameter (for all feature permutations)
+     * Sets a float3 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param f1
      * @param f2
      * @param f3
      */
-    void setFloat3(String name, float f1, float f2, float f3);
+    void setFloat3(StorageQualifier qualifier, String name, float f1, float f2, float f3);
 
-    void setFloat3(String name, float f1, float f2, float f3, boolean currentOnly);
+    void setFloat3(StorageQualifier qualifier, String name, float f1, float f2, float f3, boolean currentOnly);
 
     /**
-     * Sets a float3 uniform parameter (for all feature permutations)
+     * Sets a float3 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param value
      */
-    void setFloat3(String name, Vector3f value);
+    void setFloat3(StorageQualifier qualifier, String name, Vector3f value);
 
-    void setFloat3(String name, Vector3f value, boolean currentOnly);
+    void setFloat3(StorageQualifier qualifier, String name, Vector3f value, boolean currentOnly);
 
     /**
-     * Sets a float3 uniform parameter (for all feature permutations)
+     * Sets a float3 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param buffer
      */
-    void setFloat3(String name, FloatBuffer buffer);
+    void setFloat3(StorageQualifier qualifier, String name, FloatBuffer buffer);
 
-    void setFloat3(String name, FloatBuffer buffer, boolean currentOnly);
+    void setFloat3(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     /**
-     * Sets a float4 uniform parameter (for all feature permutations)
+     * Sets a float4 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param f1
      * @param f2
      * @param f3
      * @param f4
      */
-    void setFloat4(String name, float f1, float f2, float f3, float f4);
+    void setFloat4(StorageQualifier qualifier, String name, float f1, float f2, float f3, float f4);
 
-    void setFloat4(String name, float f1, float f2, float f3, float f4, boolean currentOnly);
+    void setFloat4(StorageQualifier qualifier, String name, float f1, float f2, float f3, float f4, boolean currentOnly);
 
     /**
-     * Sets a float4 uniform parameter (for all feature permutations)
+     * Sets a float4 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param value
      */
-    void setFloat4(String name, Vector4f value);
+    void setFloat4(StorageQualifier qualifier, String name, Vector4f value);
 
-    void setFloat4(String name, Vector4f value, boolean currentOnly);
+    void setFloat4(StorageQualifier qualifier, String name, Vector4f value, boolean currentOnly);
 
     /**
-     * Sets a float4 uniform parameter (for all feature permutations)
+     * Sets a float4 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param buffer
      */
-    void setFloat4(String name, FloatBuffer buffer);
+    void setFloat4(StorageQualifier qualifier, String name, FloatBuffer buffer);
 
-    void setFloat4(String name, FloatBuffer buffer, boolean currentOnly);
+    void setFloat4(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     /**
-     * Sets an int uniform parameter (for all feature permutations)
+     * Sets an int uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param i
      */
-    void setInt(String name, int i);
+    void setInt(StorageQualifier qualifier, String name, int i);
 
-    void setInt(String name, int i, boolean currentOnly);
+    void setInt(StorageQualifier qualifier, String name, int i, boolean currentOnly);
 
     /**
-     * Sets a boolean (int 1 or 0) uniform parameter (for all feature permutations}
+     * Sets a boolean (int 1 or 0) uniform/attribute parameter (for all feature permutations}
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param value
      */
-    void setBoolean(String name, boolean value);
+    void setBoolean(StorageQualifier qualifier, String name, boolean value);
 
-    void setBoolean(String name, boolean value, boolean currentOnly);
+    void setBoolean(StorageQualifier qualifier, String name, boolean value, boolean currentOnly);
 
     /**
-     * Sets a matrix3 uniform parameter (for all feature permutations)
+     * Sets a matrix3 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param matrix
      */
-    void setMatrix3(String name, Matrix3f matrix);
+    void setMatrix3(StorageQualifier qualifier, String name, Matrix3f matrix);
 
-    void setMatrix3(String name, Matrix3f matrix, boolean currentOnly);
+    void setMatrix3(StorageQualifier qualifier, String name, Matrix3f matrix, boolean currentOnly);
 
     /**
-     * Sets a matrix3 uniform parameter (for all feature permutations)
+     * Sets a matrix3 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param buffer
      */
-    void setMatrix3(String name, FloatBuffer buffer);
+    void setMatrix3(StorageQualifier qualifier, String name, FloatBuffer buffer);
 
-    void setMatrix3(String name, FloatBuffer buffer, boolean currentOnly);
+    void setMatrix3(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     /**
-     * Sets a matrix4 uniform parameter (for all feature permutations)
+     * Sets a matrix4 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param matrix
      */
-    void setMatrix4(String name, Matrix4f matrix);
+    void setMatrix4(StorageQualifier qualifier, String name, Matrix4f matrix);
 
-    void setMatrix4(String name, Matrix4f matrix, boolean currentOnly);
+    void setMatrix4(StorageQualifier qualifier, String name, Matrix4f matrix, boolean currentOnly);
 
     /**
-     * Sets a matrix3 uniform parameter (for all feature permutations)
+     * Sets a matrix4 uniform/attribute parameter (for all feature permutations)
      *
+     * @param qualifier The storage qualifier of the parameter, UNIFORM or ATTRIBUTE.
      * @param name
      * @param buffer
      */
-    void setMatrix4(String name, FloatBuffer buffer);
+    void setMatrix4(StorageQualifier qualifier, String name, FloatBuffer buffer);
 
-    void setMatrix4(String name, FloatBuffer buffer, boolean currentOnly);
+    void setMatrix4(StorageQualifier qualifier, String name, FloatBuffer buffer, boolean currentOnly);
 
     /**
      * Sets a texture parameter

--- a/engine/src/main/java/org/terasology/rendering/assets/material/MaterialData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/material/MaterialData.java
@@ -23,16 +23,21 @@ import org.terasology.rendering.assets.texture.Texture;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * @author Immortius
  */
 public class MaterialData implements AssetData {
+
     private Shader shader;
     private Map<String, Texture> textures = Maps.newHashMap();
-    private Map<String, Float> floatParams = Maps.newHashMap();
-    private Map<String, float[]> floatArrayParams = Maps.newHashMap();
-    private Map<String, Integer> intParams = Maps.newHashMap();
+
+    private Map<String, Float> floatUniforms = Maps.newHashMap();
+    private Map<String, float[]> floatArrayUniforms = Maps.newHashMap();
+    private Map<String, Integer> intUniforms = Maps.newHashMap();
+
+    private Map<String, Float> floatAttributes = Maps.newHashMap();
+    private Map<String, float[]> floatArrayAttributes = Maps.newHashMap();
+
 
     public MaterialData(Shader shader) {
         checkNotNull(shader);
@@ -51,52 +56,111 @@ public class MaterialData implements AssetData {
         this.textures.put(parmName, value);
     }
 
-    public Map<String, Float> getFloatParams() {
-        return floatParams;
+    public Map<String, Float> getFloatUniforms() {
+        return floatUniforms;
     }
 
-    public void setParam(String parmName, float value) {
-        this.floatParams.put(parmName, value);
+    public Map<String, Float> getFloatAttributes() {
+        return floatAttributes;
     }
 
-    public Map<String, float[]> getFloatArrayParams() {
-        return floatArrayParams;
+    public void setParam(Material.StorageQualifier qualifier, String parmName, float value) {
+        switch (qualifier) {
+            case UNIFORM:
+                this.floatUniforms.put(parmName, value);
+                break;
+            case ATTRIBUTE:
+                this.floatAttributes.put(parmName, value);
+                break;
+            default:
+                throw noSwitchCaseImplemented(qualifier);
+        }
     }
 
-    public void setParam(String parmName, float[] value) {
-        this.floatArrayParams.put(parmName, value);
+    public Map<String, float[]> getFloatArrayUniforms() {
+        return floatArrayUniforms;
     }
 
-    public Map<String, Integer> getIntegerParams() {
-        return intParams;
+    public Map<String, float[]> getFloatArrayAttributes() {
+        return floatArrayAttributes;
     }
 
-    public void setParam(String parmName, int value) {
-        this.intParams.put(parmName, value);
+    public void setParam(Material.StorageQualifier qualifier, String parmName, float[] value) {
+        switch (qualifier) {
+            case UNIFORM:
+                this.floatArrayUniforms.put(parmName, value);
+                break;
+            case ATTRIBUTE:
+                this.floatArrayAttributes.put(parmName, value);
+                break;
+            default:
+                throw noSwitchCaseImplemented(qualifier);
+        }
     }
 
-    public void setParam(String parmName, boolean value) {
-        this.intParams.put(parmName, (value) ? 1 : 0);
+    public Map<String, Integer> getIntegerUniforms() {
+        return intUniforms;
     }
 
+    public void setParam(Material.StorageQualifier qualifier, String parmName, int value) {
+        switch (qualifier) {
+            case UNIFORM:
+                this.intUniforms.put(parmName, value);
+                break;
+            case ATTRIBUTE:
+                throw new UnsupportedOperationException("Int attributes are not supported in GLSL 1.2");
+            default:
+                throw noSwitchCaseImplemented(qualifier);
+        }
+    }
+
+    public void setParam(Material.StorageQualifier qualifier, String parmName, boolean value) {
+        final int intValue = (value) ? 1 : 0;
+
+        switch (qualifier) {
+            case UNIFORM:
+                this.intUniforms.put(parmName, intValue);
+                break;
+            case ATTRIBUTE:
+                throw new UnsupportedOperationException("Int attributes are not supported in GLSL 1.2");
+            default:
+                throw noSwitchCaseImplemented(qualifier);
+        }
+    }
 
     public void setTextureParams(Map<String, Texture> newTextureParmas) {
         this.textures.clear();
         this.textures.putAll(newTextureParmas);
     }
 
-    public void setFloatParams(Map<String, Float> floatParams) {
-        this.floatParams.clear();
-        this.floatParams.putAll(floatParams);
+    public void setFloatUniforms(Map<String, Float> floatParams) {
+        this.floatUniforms.clear();
+        this.floatUniforms.putAll(floatParams);
     }
 
-    public void setFloatArrayParams(Map<String, float[]> floatArrayParams) {
-        this.floatArrayParams.clear();
-        this.floatArrayParams.putAll(floatArrayParams);
+    public void setFloatArrayUniforms(Map<String, float[]> floatArrayParams) {
+        this.floatArrayUniforms.clear();
+        this.floatArrayUniforms.putAll(floatArrayParams);
     }
 
-    public void setIntParams(Map<String, Integer> intParams) {
-        this.intParams.clear();
-        this.intParams.putAll(intParams);
+    public void setIntUniforms(Map<String, Integer> intParams) {
+        this.intUniforms.clear();
+        this.intUniforms.putAll(intParams);
+    }
+
+    public void setFloatAttributes(Map<String, Float> floatParams) {
+        this.floatAttributes.clear();
+        this.floatAttributes.putAll(floatParams);
+    }
+
+    public void setFloatArrayAttributes(Map<String, float[]> floatArrayParams) {
+        this.floatArrayAttributes.clear();
+        this.floatArrayAttributes.putAll(floatArrayParams);
+    }
+
+    private static UnsupportedOperationException noSwitchCaseImplemented(Material.StorageQualifier qualifier) {
+        return new UnsupportedOperationException(
+                "Switch statement does not have a case in for " + qualifier
+        );
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/material/MaterialLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/material/MaterialLoader.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ *
  * @author Immortius
  */
 public class MaterialLoader implements AssetLoader<MaterialData> {
@@ -53,6 +54,22 @@ public class MaterialLoader implements AssetLoader<MaterialData> {
         gson = new GsonBuilder().registerTypeAdapter(MaterialMetadata.class, new MaterialMetadataHandler()).create();
     }
 
+    /**
+     *
+     * <p>
+     *     <strong>Note:</strong> This method works under the assumption that
+     *     the asset data only specifies uniform parameter values.
+     *     This should be reconsidered whenever the {@link  org.terasology.rendering.assets.shader.ParamType}
+     *     enum is extended.
+     * </p>
+     *
+     * @param module The module providing the asset
+     * @param stream A stream containing the assets data.
+     * @param urls   The urls related to the asset. The first url is the url providing the stream
+     * @param deltas
+     * @return
+     * @throws IOException
+     */
     @Override
     public MaterialData load(Module module, InputStream stream, List<URL> urls, List<URL> deltas) throws IOException {
         MaterialMetadata metadata = gson.fromJson(new InputStreamReader(stream, Charsets.UTF_8), MaterialMetadata.class);
@@ -64,14 +81,17 @@ public class MaterialLoader implements AssetLoader<MaterialData> {
 
         MaterialData data = new MaterialData(shader);
         data.setTextureParams(metadata.textures);
-        data.setFloatParams(metadata.floatParams);
-        data.setFloatArrayParams(metadata.floatArrayParams);
-        data.setIntParams(metadata.intParams);
+
+        data.setFloatUniforms(metadata.floatParams);
+        data.setFloatArrayUniforms(metadata.floatArrayParams);
+        data.setIntUniforms(metadata.intParams);
+
         return data;
     }
 
     private static class MaterialMetadata {
         String shader;
+
         Map<String, Texture> textures = Maps.newHashMap();
         Map<String, Float> floatParams = Maps.newHashMap();
         Map<String, float[]> floatArrayParams = Maps.newHashMap();

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/ParamType.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/ParamType.java
@@ -17,6 +17,17 @@
 package org.terasology.rendering.assets.shader;
 
 /**
+ *
+ * <p>
+ *     <strong>Note:</strong> The {@link  org.terasology.rendering.assets.material.MaterialLoader#load(
+ *          org.terasology.module.Module,
+ *          java.io.InputStream,
+ *          java.util.List,
+ *          java.util.List)
+ *     } method  works under the assumption that the asset data only specifies uniform parameter values.
+ *     This should be reconsidered whenever the ParamType enum is extended.
+ * </p>
+ *
  * @author Immortius
  */
 public enum ParamType {

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -62,6 +62,8 @@ import static org.lwjgl.opengl.GL11.glRotatef;
 import static org.lwjgl.opengl.GL11.glScalef;
 import static org.lwjgl.opengl.GL11.glTranslated;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * TODO: This should be made generic (no explicit shader or mesh) and ported directly into WorldRenderer? Later note: some GelCube functionality moved to a module
  *
@@ -205,14 +207,14 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
                 Matrix4f modelViewMatrix = MatrixUtils.calcModelViewMatrix(worldRenderer.getActiveCamera().getViewMatrix(), matrixCameraSpace);
                 MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
 
-                meshComp.material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
-                meshComp.material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
+                meshComp.material.setMatrix4(UNIFORM, "projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+                meshComp.material.setMatrix4(UNIFORM, "worldViewMatrix", tempMatrixBuffer44, true);
 
                 MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
-                meshComp.material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
-                meshComp.material.setFloat4("colorOffset", meshComp.color.rf(), meshComp.color.gf(), meshComp.color.bf(), meshComp.color.af(), true);
-                meshComp.material.setFloat("light", worldRenderer.getRenderingLightValueAt(worldPos), true);
-                meshComp.material.setFloat("sunlight", worldRenderer.getSunlightValueAt(worldPos), true);
+                meshComp.material.setMatrix3(UNIFORM, "normalMatrix", tempMatrixBuffer33, true);
+                meshComp.material.setFloat4(UNIFORM, "colorOffset", meshComp.color.rf(), meshComp.color.gf(), meshComp.color.bf(), meshComp.color.af(), true);
+                meshComp.material.setFloat(UNIFORM, "light", worldRenderer.getRenderingLightValueAt(worldPos), true);
+                meshComp.material.setFloat(UNIFORM, "sunlight", worldRenderer.getSunlightValueAt(worldPos), true);
 
                 OpenGLMesh mesh = (OpenGLMesh) meshComp.mesh;
                 meshComp.material.bindTextures();
@@ -250,9 +252,9 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
         for (Material material : meshByMaterial.keySet()) {
             OpenGLMesh lastMesh = null;
             material.enable();
-            material.setFloat("sunlight", 1.0f);
-            material.setFloat("blockLight", 1.0f);
-            material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+            material.setFloat(UNIFORM, "sunlight", 1.0f);
+            material.setFloat(UNIFORM, "blockLight", 1.0f);
+            material.setMatrix4(UNIFORM, "projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
             material.bindTextures();
 
             Set<EntityRef> entities = meshByMaterial.get(material);
@@ -293,14 +295,14 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
                     Matrix4f modelViewMatrix = MatrixUtils.calcModelViewMatrix(worldRenderer.getActiveCamera().getViewMatrix(), matrixCameraSpace);
                     MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
 
-                    material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
+                    material.setMatrix4(UNIFORM, "worldViewMatrix", tempMatrixBuffer44, true);
 
                     MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
-                    material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
+                    material.setMatrix3(UNIFORM, "normalMatrix", tempMatrixBuffer33, true);
 
-                    material.setFloat3("colorOffset", meshComp.color.rf(), meshComp.color.gf(), meshComp.color.bf(), true);
-                    material.setFloat("sunlight", worldRenderer.getSunlightValueAt(worldPos), true);
-                    material.setFloat("blockLight", worldRenderer.getBlockLightValueAt(worldPos), true);
+                    material.setFloat3(UNIFORM, "colorOffset", meshComp.color.rf(), meshComp.color.gf(), meshComp.color.bf(), true);
+                    material.setFloat(UNIFORM, "sunlight", worldRenderer.getSunlightValueAt(worldPos), true);
+                    material.setFloat(UNIFORM, "blockLight", worldRenderer.getBlockLightValueAt(worldPos), true);
 
                     lastMesh.doRender();
                 }

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -65,6 +65,8 @@ import static org.lwjgl.opengl.GL11.glPopMatrix;
 import static org.lwjgl.opengl.GL11.glPushMatrix;
 import static org.lwjgl.opengl.GL11.glVertex3f;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * @author Immortius
  */
@@ -227,10 +229,10 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                 continue;
             }
             skeletalMesh.material.enable();
-            skeletalMesh.material.setFloat("sunlight", 1.0f, true);
-            skeletalMesh.material.setFloat("blockLight", 1.0f, true);
+            skeletalMesh.material.setFloat(UNIFORM, "sunlight", 1.0f, true);
+            skeletalMesh.material.setFloat(UNIFORM, "blockLight", 1.0f, true);
 
-            skeletalMesh.material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+            skeletalMesh.material.setMatrix4(UNIFORM, "projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
             skeletalMesh.material.bindTextures();
 
             LocationComponent location = entity.getComponent(LocationComponent.class);
@@ -250,13 +252,13 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             Matrix4f modelViewMatrix = MatrixUtils.calcModelViewMatrix(worldRenderer.getActiveCamera().getViewMatrix(), matrixCameraSpace);
             MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
 
-            skeletalMesh.material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
+            skeletalMesh.material.setMatrix4(UNIFORM, "worldViewMatrix", tempMatrixBuffer44, true);
 
             MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
-            skeletalMesh.material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
+            skeletalMesh.material.setMatrix3(UNIFORM, "normalMatrix", tempMatrixBuffer33, true);
 
-            skeletalMesh.material.setFloat("sunlight", worldRenderer.getSunlightValueAt(worldPos), true);
-            skeletalMesh.material.setFloat("blockLight", worldRenderer.getBlockLightValueAt(worldPos), true);
+            skeletalMesh.material.setFloat(UNIFORM, "sunlight", worldRenderer.getSunlightValueAt(worldPos), true);
+            skeletalMesh.material.setFloat(UNIFORM, "blockLight", worldRenderer.getBlockLightValueAt(worldPos), true);
 
             // TODO: Add frustum culling here
             List<Vector3f> bonePositions = Lists.newArrayListWithCapacity(skeletalMesh.mesh.getVertexCount());
@@ -296,9 +298,9 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             glDisable(GL_DEPTH_TEST);
             Vector3f cameraPosition = worldRenderer.getActiveCamera().getPosition();
             Material material = Assets.getMaterial("engine:white");
-            material.setFloat("sunlight", 1.0f, true);
-            material.setFloat("blockLight", 1.0f, true);
-            material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+            material.setFloat(UNIFORM, "sunlight", 1.0f, true);
+            material.setFloat(UNIFORM, "blockLight", 1.0f, true);
+            material.setMatrix4(UNIFORM, "projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
             glLineWidth(2);
             Vector3f worldPos = new Vector3f();
 
@@ -320,10 +322,10 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                 Matrix4f modelViewMatrix = MatrixUtils.calcModelViewMatrix(worldRenderer.getActiveCamera().getViewMatrix(), matrixCameraSpace);
                 MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
 
-                material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
+                material.setMatrix4(UNIFORM, "worldViewMatrix", tempMatrixBuffer44, true);
 
                 MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
-                material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
+                material.setMatrix3(UNIFORM, "normalMatrix", tempMatrixBuffer33, true);
 
                 SkeletalMeshComponent skeletalMesh = entity.getComponent(SkeletalMeshComponent.class);
                 renderBone(skeletalMesh.rootBone, worldPos);

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * @author Immortius
  */
@@ -604,7 +606,7 @@ public class CanvasImpl implements CanvasControl {
         if (!state.cropRegion.overlaps(drawRegion)) {
             return;
         }
-        material.setFloat("alpha", state.getAlpha());
+        material.setFloat(UNIFORM, "alpha", state.getAlpha());
         material.bindTextures();
         renderer.drawMaterialAt(material, drawRegion);
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -74,6 +74,7 @@ import static org.lwjgl.opengl.GL11.glPopMatrix;
 import static org.lwjgl.opengl.GL11.glPushMatrix;
 import static org.lwjgl.opengl.GL11.glScalef;
 import static org.lwjgl.opengl.GL11.glTranslatef;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * @author Immortius
@@ -125,7 +126,7 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
 
         requestedCropRegion = Rect2i.createFromMinAndSize(0, 0, Display.getWidth(), Display.getHeight());
         currentTextureCropRegion = requestedCropRegion;
-        textureMat.setFloat4(CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1
+        textureMat.setFloat4(UNIFORM, CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1
                 , requestedCropRegion.minY(), requestedCropRegion.maxY() + 1);
     }
 
@@ -183,8 +184,8 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
         finalMat.mul(translateTransform);
         MatrixUtils.matrixToFloatBuffer(finalMat, matrixBuffer);
 
-        material.setFloat4(CROPPING_BOUNDARIES_PARAM, cropRegion.minX(), cropRegion.maxX() + 1, cropRegion.minY(), cropRegion.maxY() + 1);
-        material.setMatrix4("posMatrix", translateTransform);
+        material.setFloat4(UNIFORM, CROPPING_BOUNDARIES_PARAM, cropRegion.minX(), cropRegion.maxX() + 1, cropRegion.minY(), cropRegion.maxY() + 1);
+        material.setMatrix4(UNIFORM, "posMatrix", translateTransform);
         glEnable(GL11.GL_DEPTH_TEST);
         glClear(GL11.GL_DEPTH_BUFFER_BIT);
         glMatrixMode(GL11.GL_MODELVIEW);
@@ -196,7 +197,7 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
         if (matrixStackSupported) {
             material.activateFeature(ShaderProgramFeature.FEATURE_USE_MATRIX_STACK);
         }
-        material.setFloat("alpha", alpha);
+        material.setFloat(UNIFORM, "alpha", alpha);
         material.bindTextures();
         mesh.render();
         if (matrixStackSupported) {
@@ -245,7 +246,7 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
                             float ux, float uy, float uw, float uh, float alpha) {
         if (!currentTextureCropRegion.equals(requestedCropRegion)
                 && !(currentTextureCropRegion.encompasses(absoluteRegion) && requestedCropRegion.encompasses(absoluteRegion))) {
-            textureMat.setFloat4(CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1,
+            textureMat.setFloat4(UNIFORM, CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1,
                     requestedCropRegion.minY(), requestedCropRegion.maxY() + 1);
             currentTextureCropRegion = requestedCropRegion;
         }
@@ -264,41 +265,41 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
                     mesh = builder.build();
                     cachedTextures.put(key, mesh);
                 }
-                textureMat.setFloat2("scale", scale);
-                textureMat.setFloat2("offset",
+                textureMat.setFloat2(UNIFORM, "scale", scale);
+                textureMat.setFloat2(UNIFORM, "offset",
                         absoluteRegion.minX(),
                         absoluteRegion.minY());
 
-                textureMat.setFloat2("texOffset", textureArea.minX() + ux * textureArea.width(), textureArea.minY() + uy * textureArea.height());
-                textureMat.setFloat2("texSize", uw * textureArea.width(), uh * textureArea.height());
+                textureMat.setFloat2(UNIFORM, "texOffset", textureArea.minX() + ux * textureArea.width(), textureArea.minY() + uy * textureArea.height());
+                textureMat.setFloat2(UNIFORM, "texSize", uw * textureArea.width(), uh * textureArea.height());
                 break;
             }
             case SCALE_FILL: {
-                textureMat.setFloat2("offset", absoluteRegion.minX(), absoluteRegion.minY());
-                textureMat.setFloat2("scale", absoluteRegion.width(), absoluteRegion.height());
+                textureMat.setFloat2(UNIFORM, "offset", absoluteRegion.minX(), absoluteRegion.minY());
+                textureMat.setFloat2(UNIFORM, "scale", absoluteRegion.width(), absoluteRegion.height());
 
                 float texBorderX = (scale.x - absoluteRegion.width()) / scale.x * uw;
                 float texBorderY = (scale.y - absoluteRegion.height()) / scale.y * uh;
 
-                textureMat.setFloat2("texOffset", textureArea.minX() + (ux + 0.5f * texBorderX) * textureArea.width()
+                textureMat.setFloat2(UNIFORM, "texOffset", textureArea.minX() + (ux + 0.5f * texBorderX) * textureArea.width()
                         , textureArea.minY() + (uy + 0.5f * texBorderY) * textureArea.height());
-                textureMat.setFloat2("texSize", (uw - texBorderX) * textureArea.width(), (uh - texBorderY) * textureArea.height());
+                textureMat.setFloat2(UNIFORM, "texSize", (uw - texBorderX) * textureArea.width(), (uh - texBorderY) * textureArea.height());
                 break;
             }
             default: {
-                textureMat.setFloat2("scale", scale);
-                textureMat.setFloat2("offset",
+                textureMat.setFloat2(UNIFORM, "scale", scale);
+                textureMat.setFloat2(UNIFORM, "offset",
                         absoluteRegion.minX() + 0.5f * (absoluteRegion.width() - scale.x),
                         absoluteRegion.minY() + 0.5f * (absoluteRegion.height() - scale.y));
 
-                textureMat.setFloat2("texOffset", textureArea.minX() + ux * textureArea.width(), textureArea.minY() + uy * textureArea.height());
-                textureMat.setFloat2("texSize", uw * textureArea.width(), uh * textureArea.height());
+                textureMat.setFloat2(UNIFORM, "texOffset", textureArea.minX() + ux * textureArea.width(), textureArea.minY() + uy * textureArea.height());
+                textureMat.setFloat2(UNIFORM, "texSize", uw * textureArea.width(), uh * textureArea.height());
                 break;
             }
         }
 
         textureMat.setTexture("texture", texture.getTexture());
-        textureMat.setFloat4("color", color.rf(), color.gf(), color.bf(), color.af() * alpha);
+        textureMat.setFloat4(UNIFORM, "color", color.rf(), color.gf(), color.bf(), color.af() * alpha);
         textureMat.bindTextures();
         mesh.render();
     }
@@ -328,10 +329,10 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
 
         for (Map.Entry<Material, Mesh> entry : fontMesh.entrySet()) {
             entry.getKey().bindTextures();
-            entry.getKey().setFloat4(CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1,
+            entry.getKey().setFloat4(UNIFORM, CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1,
                     requestedCropRegion.minY(), requestedCropRegion.maxY() + 1);
-            entry.getKey().setFloat2("offset", offset.x, offset.y);
-            entry.getKey().setFloat("alpha", alpha);
+            entry.getKey().setFloat2(UNIFORM, "offset", offset.x, offset.y);
+            entry.getKey().setFloat(UNIFORM, "alpha", alpha);
             entry.getValue().render();
         }
     }
@@ -340,7 +341,7 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
     public void drawTextureBordered(TextureRegion texture, Rect2i region, Border border, boolean tile, float ux, float uy, float uw, float uh, float alpha) {
         if (!currentTextureCropRegion.equals(requestedCropRegion)
                 && !(currentTextureCropRegion.encompasses(region) && requestedCropRegion.encompasses(region))) {
-            textureMat.setFloat4(CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1,
+            textureMat.setFloat4(UNIFORM, CROPPING_BOUNDARIES_PARAM, requestedCropRegion.minX(), requestedCropRegion.maxX() + 1,
                     requestedCropRegion.minY(), requestedCropRegion.maxY() + 1);
             currentTextureCropRegion = requestedCropRegion;
         }
@@ -432,15 +433,15 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
             mesh = builder.build();
             cachedTextures.put(key, mesh);
         }
-        textureMat.setFloat2("scale", region.width(), region.height());
-        textureMat.setFloat2("offset", region.minX(), region.minY());
+        textureMat.setFloat2(UNIFORM, "scale", region.width(), region.height());
+        textureMat.setFloat2(UNIFORM, "offset", region.minX(), region.minY());
 
         Rect2f textureArea = texture.getRegion();
-        textureMat.setFloat2("texOffset", textureArea.minX() + ux * textureArea.width(), textureArea.minY() + uy * textureArea.height());
-        textureMat.setFloat2("texSize", uw * textureArea.width(), uh * textureArea.height());
+        textureMat.setFloat2(UNIFORM, "texOffset", textureArea.minX() + ux * textureArea.width(), textureArea.minY() + uy * textureArea.height());
+        textureMat.setFloat2(UNIFORM, "texSize", uw * textureArea.width(), uh * textureArea.height());
 
         textureMat.setTexture("texture", texture.getTexture());
-        textureMat.setFloat4("color", 1, 1, 1, alpha);
+        textureMat.setFloat4(UNIFORM, "color", 1, 1, 1, alpha);
         textureMat.bindTextures();
         mesh.render();
     }

--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
@@ -138,6 +138,7 @@ import static org.lwjgl.opengl.GL11.glVertex3i;
 import static org.lwjgl.opengl.GL11.glViewport;
 import static org.lwjgl.opengl.GL15.GL_READ_ONLY;
 import static org.lwjgl.opengl.GL20.glStencilOpSeparate;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * The Default Rendering Process class.
@@ -976,18 +977,18 @@ public class LwjglRenderingProcess {
 
         float as = (float) vpWidth / vpHeight;
 
-        program.setFloat4("ocHmdWarpParam", OculusVrHelper.getDistortionParams()[0], OculusVrHelper.getDistortionParams()[1],
+        program.setFloat4(UNIFORM, "ocHmdWarpParam", OculusVrHelper.getDistortionParams()[0], OculusVrHelper.getDistortionParams()[1],
                 OculusVrHelper.getDistortionParams()[2], OculusVrHelper.getDistortionParams()[3], true);
 
         float ocLensCenter = (renderingStage == WorldRenderingStage.RIGHT_EYE) ? -1.0f * OculusVrHelper.getLensViewportShift() : OculusVrHelper.getLensViewportShift();
 
-        program.setFloat2("ocLensCenter", x + (w + ocLensCenter * 0.5f) * 0.5f, y + h * 0.5f, true);
-        program.setFloat2("ocScreenCenter", x + w * 0.5f, y + h * 0.5f, true);
+        program.setFloat2(UNIFORM, "ocLensCenter", x + (w + ocLensCenter * 0.5f) * 0.5f, y + h * 0.5f, true);
+        program.setFloat2(UNIFORM, "ocScreenCenter", x + w * 0.5f, y + h * 0.5f, true);
 
         float scaleFactor = 1.0f / OculusVrHelper.getScaleFactor();
 
-        program.setFloat2("ocScale", (w / 2) * scaleFactor, (h / 2) * scaleFactor * as, true);
-        program.setFloat2("ocScaleIn", (2 / w), (2 / h) / as, true);
+        program.setFloat2(UNIFORM, "ocScale", (w / 2) * scaleFactor, (h / 2) * scaleFactor * as, true);
+        program.setFloat2(UNIFORM, "ocScaleIn", (2 / w), (2 / h) / as, true);
     }
 
     private void renderFinalScene() {
@@ -1043,19 +1044,19 @@ public class LwjglRenderingProcess {
         if (targetFbo != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             targetFbo.bindTexture();
-            program.setInt("texSceneOpaque", texId++);
+            program.setInt(UNIFORM, "texSceneOpaque", texId++);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             targetFbo.bindDepthTexture();
-            program.setInt("texSceneOpaqueDepth", texId++);
+            program.setInt(UNIFORM, "texSceneOpaqueDepth", texId++);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             targetFbo.bindNormalsTexture();
-            program.setInt("texSceneOpaqueNormals", texId++);
+            program.setInt(UNIFORM, "texSceneOpaqueNormals", texId++);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             targetFbo.bindLightBufferTexture();
-            program.setInt("texSceneOpaqueLightBuffer", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueLightBuffer", texId++, true);
         }
 
         bindFbo(target + "PingPong");
@@ -1087,8 +1088,8 @@ public class LwjglRenderingProcess {
         Material material = Assets.getMaterial("engine:prog.blur");
 
         material.enable();
-        material.setFloat("radius", 8.0f, true);
-        material.setFloat2("texelSize", 1.0f / skyBand.width, 1.0f / skyBand.height, true);
+        material.setFloat(UNIFORM, "radius", 8.0f, true);
+        material.setFloat2(UNIFORM, "texelSize", 1.0f / skyBand.width, 1.0f / skyBand.height, true);
 
         if (id == 0) {
             bindFboTexture("sceneOpaque");
@@ -1147,8 +1148,8 @@ public class LwjglRenderingProcess {
             return;
         }
 
-        ssaoShader.setFloat2("texelSize", 1.0f / ssao.width, 1.0f / ssao.height, true);
-        ssaoShader.setFloat2("noiseTexelSize", 1.0f / 4.0f, 1.0f / 4.0f, true);
+        ssaoShader.setFloat2(UNIFORM, "texelSize", 1.0f / ssao.width, 1.0f / ssao.height, true);
+        ssaoShader.setFloat2(UNIFORM, "noiseTexelSize", 1.0f / 4.0f, 1.0f / 4.0f, true);
 
         ssao.bind();
 
@@ -1191,7 +1192,7 @@ public class LwjglRenderingProcess {
             return;
         }
 
-        shader.setFloat2("texelSize", 1.0f / ssao.width, 1.0f / ssao.height, true);
+        shader.setFloat2(UNIFORM, "texelSize", 1.0f / ssao.width, 1.0f / ssao.height, true);
         ssao.bind();
 
         glViewport(0, 0, ssao.width, ssao.height);
@@ -1218,7 +1219,7 @@ public class LwjglRenderingProcess {
 
     private void generateHighPass() {
         Material program = Assets.getMaterial("engine:prog.highp");
-        program.setFloat("highPassThreshold", bloomHighPassThreshold, true);
+        program.setFloat(UNIFORM, "highPassThreshold", bloomHighPassThreshold, true);
         program.enable();
 
         FBO highPass = getFBO("sceneHighPass");
@@ -1234,7 +1235,7 @@ public class LwjglRenderingProcess {
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         sceneOpaque.bindTexture();
-        program.setInt("tex", texId++);
+        program.setInt(UNIFORM, "tex", texId++);
 
 //        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
 //        sceneOpaque.bindDepthTexture();
@@ -1255,7 +1256,7 @@ public class LwjglRenderingProcess {
         Material material = Assets.getMaterial("engine:prog.blur");
         material.enable();
 
-        material.setFloat("radius", overallBlurRadiusFactor * renderingConfig.getBlurRadius(), true);
+        material.setFloat(UNIFORM, "radius", overallBlurRadiusFactor * renderingConfig.getBlurRadius(), true);
 
         FBO blur = getFBO("sceneBlur" + id);
 
@@ -1263,7 +1264,7 @@ public class LwjglRenderingProcess {
             return;
         }
 
-        material.setFloat2("texelSize", 1.0f / blur.width, 1.0f / blur.height, true);
+        material.setFloat2(UNIFORM, "texelSize", 1.0f / blur.width, 1.0f / blur.height, true);
 
         blur.bind();
 
@@ -1288,7 +1289,7 @@ public class LwjglRenderingProcess {
         Material shader = Assets.getMaterial("engine:prog.blur");
 
         shader.enable();
-        shader.setFloat("radius", bloomBlurRadius, true);
+        shader.setFloat(UNIFORM, "radius", bloomBlurRadius, true);
 
         FBO bloom = getFBO("sceneBloom" + id);
 
@@ -1296,7 +1297,7 @@ public class LwjglRenderingProcess {
             return;
         }
 
-        shader.setFloat2("texelSize", 1.0f / bloom.width, 1.0f / bloom.height, true);
+        shader.setFloat2(UNIFORM, "texelSize", 1.0f / bloom.width, 1.0f / bloom.height, true);
 
         bloom.bind();
 
@@ -1325,7 +1326,7 @@ public class LwjglRenderingProcess {
             int sizePrev = TeraMath.pow(2, i + 1);
 
             int size = TeraMath.pow(2, i);
-            shader.setFloat("size", size, true);
+            shader.setFloat(UNIFORM, "size", size, true);
 
             bindFbo("scene" + size);
             glViewport(0, 0, size, size);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
@@ -24,6 +24,8 @@ import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Basic shader parameters for all shader program.
  *
@@ -42,34 +44,34 @@ public class ShaderParametersBase implements ShaderParameters {
     @Override
     public void applyParameters(Material program) {
 
-        program.setFloat("viewingDistance", CoreRegistry.get(Config.class).getRendering().getViewDistance().getChunkDistance().x * 8.0f);
+        program.setFloat(UNIFORM, "viewingDistance", CoreRegistry.get(Config.class).getRendering().getViewDistance().getChunkDistance().x * 8.0f);
 
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
 
         if (worldRenderer != null && backdropProvider != null) {
-            program.setFloat("daylight", backdropProvider.getDaylight(), true);
-            program.setFloat("swimming", worldRenderer.isHeadUnderWater() ? 1.0f : 0.0f, true);
-            program.setFloat("tick", worldRenderer.getTick(), true);
-            program.setFloat("sunlightValueAtPlayerPos", worldRenderer.getSmoothedPlayerSunlightValue(), true);
+            program.setFloat(UNIFORM, "daylight", backdropProvider.getDaylight(), true);
+            program.setFloat(UNIFORM, "swimming", worldRenderer.isHeadUnderWater() ? 1.0f : 0.0f, true);
+            program.setFloat(UNIFORM, "tick", worldRenderer.getTick(), true);
+            program.setFloat(UNIFORM, "sunlightValueAtPlayerPos", worldRenderer.getSmoothedPlayerSunlightValue(), true);
 
             Camera activeCamera = worldRenderer.getActiveCamera();
             if (activeCamera != null) {
                 final Vector3f cameraDir = activeCamera.getViewingDirection();
                 final Vector3f cameraPosition = activeCamera.getPosition();
 
-                program.setFloat3("cameraPosition", cameraPosition.x, cameraPosition.y, cameraPosition.z, true);
-                program.setFloat3("cameraDirection", cameraDir.x, cameraDir.y, cameraDir.z, true);
-                program.setFloat3("cameraParameters", activeCamera.getzNear(), activeCamera.getzFar(), 0.0f, true);
+                program.setFloat3(UNIFORM, "cameraPosition", cameraPosition.x, cameraPosition.y, cameraPosition.z, true);
+                program.setFloat3(UNIFORM, "cameraDirection", cameraDir.x, cameraDir.y, cameraDir.z, true);
+                program.setFloat3(UNIFORM, "cameraParameters", activeCamera.getzNear(), activeCamera.getzFar(), 0.0f, true);
             }
 
             Vector3f sunDirection = backdropProvider.getSunDirection(false);
-            program.setFloat3("sunVec", sunDirection.x, sunDirection.y, sunDirection.z, true);
+            program.setFloat3(UNIFORM, "sunVec", sunDirection.x, sunDirection.y, sunDirection.z, true);
         }
 
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
         if (worldProvider != null) {
-            program.setFloat("time", worldProvider.getTime().getDays());
+            program.setFloat(UNIFORM, "time", worldProvider.getTime().getDays());
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBlock.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBlock.java
@@ -22,6 +22,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * Shader parameters for the Block shader program.
@@ -47,9 +48,9 @@ public class ShaderParametersBlock extends ShaderParametersBase {
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
         glBindTexture(GL11.GL_TEXTURE_2D, terrainTex.getId());
 
-        program.setFloat3("colorOffset", 1.0f, 1.0f, 1.0f, true);
-        program.setBoolean("textured", true, true);
-        program.setFloat("alpha", 1.0f, true);
+        program.setFloat3(UNIFORM, "colorOffset", 1.0f, 1.0f, 1.0f, true);
+        program.setBoolean(UNIFORM, "textured", true, true);
+        program.setFloat(UNIFORM, "alpha", 1.0f, true);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
@@ -27,6 +27,7 @@ import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * Shader parameters for the Chunk shader program.
@@ -91,70 +92,70 @@ public class ShaderParametersChunk extends ShaderParametersBase {
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, terrain.getId());
-        program.setInt("textureAtlas", texId++, true);
+        program.setInt(UNIFORM, "textureAtlas", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, water.getId());
-        program.setInt("textureWater", texId++, true);
+        program.setInt(UNIFORM, "textureWater", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, lava.getId());
-        program.setInt("textureLava", texId++, true);
+        program.setInt(UNIFORM, "textureLava", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, waterNormal.getId());
-        program.setInt("textureWaterNormal", texId++, true);
+        program.setInt(UNIFORM, "textureWaterNormal", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, waterNormalAlt.getId());
-        program.setInt("textureWaterNormalAlt", texId++, true);
+        program.setInt(UNIFORM, "textureWaterNormalAlt", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, effects.getId());
-        program.setInt("textureEffects", texId++, true);
+        program.setInt(UNIFORM, "textureEffects", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         LwjglRenderingProcess.getInstance().bindFboTexture("sceneReflected");
-        program.setInt("textureWaterReflection", texId++, true);
+        program.setInt(UNIFORM, "textureWaterReflection", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
-        program.setInt("texSceneOpaque", texId++, true);
+        program.setInt(UNIFORM, "texSceneOpaque", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             glBindTexture(GL11.GL_TEXTURE_2D, terrainNormal.getId());
-            program.setInt("textureAtlasNormal", texId++, true);
+            program.setInt(UNIFORM, "textureAtlasNormal", texId++, true);
 
             if (CoreRegistry.get(Config.class).getRendering().isParallaxMapping()) {
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 glBindTexture(GL11.GL_TEXTURE_2D, terrainHeight.getId());
-                program.setInt("textureAtlasHeight", texId++, true);
+                program.setInt(UNIFORM, "textureAtlasHeight", texId++, true);
             }
         }
 
         Vector4f lightingSettingsFrag = new Vector4f();
         lightingSettingsFrag.z = waterSpecExp;
-        program.setFloat4("lightingSettingsFrag", lightingSettingsFrag, true);
+        program.setFloat4(UNIFORM, "lightingSettingsFrag", lightingSettingsFrag, true);
 
         Vector4f waterSettingsFrag = new Vector4f();
         waterSettingsFrag.x = waterNormalBias;
         waterSettingsFrag.y = waterRefraction;
         waterSettingsFrag.z = waterFresnelBias;
         waterSettingsFrag.w = waterFresnelPow;
-        program.setFloat4("waterSettingsFrag", waterSettingsFrag, true);
+        program.setFloat4(UNIFORM, "waterSettingsFrag", waterSettingsFrag, true);
 
         Vector4f alternativeWaterSettingsFrag = new Vector4f();
         alternativeWaterSettingsFrag.x = waterTint;
-        program.setFloat4("alternativeWaterSettingsFrag", alternativeWaterSettingsFrag, true);
+        program.setFloat4(UNIFORM, "alternativeWaterSettingsFrag", alternativeWaterSettingsFrag, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isAnimateWater()) {
-            program.setFloat("waveIntensFalloff", waveIntensFalloff, true);
-            program.setFloat("waveSizeFalloff", waveSizeFalloff, true);
-            program.setFloat("waveSize", waveSize, true);
-            program.setFloat("waveSpeedFalloff", waveSpeedFalloff, true);
-            program.setFloat("waveSpeed", waveSpeed, true);
-            program.setFloat("waveIntens", waveIntens, true);
-            program.setFloat("waterOffsetY", waterOffsetY, true);
-            program.setFloat("waveOverallScale", waveOverallScale, true);
+            program.setFloat(UNIFORM, "waveIntensFalloff", waveIntensFalloff, true);
+            program.setFloat(UNIFORM, "waveSizeFalloff", waveSizeFalloff, true);
+            program.setFloat(UNIFORM, "waveSize", waveSize, true);
+            program.setFloat(UNIFORM, "waveSpeedFalloff", waveSpeedFalloff, true);
+            program.setFloat(UNIFORM, "waveSpeed", waveSpeed, true);
+            program.setFloat(UNIFORM, "waveIntens", waveIntens, true);
+            program.setFloat(UNIFORM, "waterOffsetY", waterOffsetY, true);
+            program.setFloat(UNIFORM, "waveOverallScale", waveOverallScale, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isParallaxMapping()
                 && CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {
-            program.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
+            program.setFloat4(UNIFORM, "parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -26,6 +26,8 @@ import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Shader parameters for the Combine shader program.
  *
@@ -55,19 +57,19 @@ public class ShaderParametersCombine extends ShaderParametersBase {
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindTexture();
-            program.setInt("texSceneOpaque", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaque", texId++, true);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindDepthTexture();
-            program.setInt("texSceneOpaqueDepth", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueDepth", texId++, true);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindNormalsTexture();
-            program.setInt("texSceneOpaqueNormals", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueNormals", texId++, true);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindLightBufferTexture();
-            program.setInt("texSceneOpaqueLightBuffer", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueLightBuffer", texId++, true);
         }
 
         FBO sceneReflectiveRefractive = LwjglRenderingProcess.getInstance().getFBO("sceneReflectiveRefractive");
@@ -75,48 +77,48 @@ public class ShaderParametersCombine extends ShaderParametersBase {
         if (sceneReflectiveRefractive != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneReflectiveRefractive.bindTexture();
-            program.setInt("texSceneReflectiveRefractive", texId++, true);
+            program.setInt(UNIFORM, "texSceneReflectiveRefractive", texId++, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isLocalReflections()) {
             if (sceneReflectiveRefractive != null) {
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 sceneReflectiveRefractive.bindNormalsTexture();
-                program.setInt("texSceneReflectiveRefractiveNormals", texId++, true);
+                program.setInt(UNIFORM, "texSceneReflectiveRefractiveNormals", texId++, true);
             }
 
             Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
             if (activeCamera != null) {
-                program.setMatrix4("invProjMatrix", activeCamera.getInverseProjectionMatrix(), true);
-                program.setMatrix4("projMatrix", activeCamera.getProjectionMatrix(), true);
+                program.setMatrix4(UNIFORM, "invProjMatrix", activeCamera.getInverseProjectionMatrix(), true);
+                program.setMatrix4(UNIFORM, "projMatrix", activeCamera.getProjectionMatrix(), true);
             }
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isSsao()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
-            program.setInt("texSsao", texId++, true);
+            program.setInt(UNIFORM, "texSsao", texId++, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isOutline()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().bindFboTexture("sobel");
-            program.setInt("texEdges", texId++, true);
+            program.setInt(UNIFORM, "texEdges", texId++, true);
 
-            program.setFloat("outlineDepthThreshold", outlineDepthThreshold, true);
-            program.setFloat("outlineThickness", outlineThickness, true);
+            program.setFloat(UNIFORM, "outlineDepthThreshold", outlineDepthThreshold, true);
+            program.setFloat(UNIFORM, "outlineThickness", outlineThickness, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isInscattering()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
-            program.setInt("texSceneSkyBand", texId++, true);
+            program.setInt(UNIFORM, "texSceneSkyBand", texId++, true);
 
             Vector4f skyInscatteringSettingsFrag = new Vector4f();
             skyInscatteringSettingsFrag.y = skyInscatteringStrength;
             skyInscatteringSettingsFrag.z = skyInscatteringLength;
             skyInscatteringSettingsFrag.w = skyInscatteringThreshold;
-            program.setFloat4("skyInscatteringSettingsFrag", skyInscatteringSettingsFrag, true);
+            program.setFloat4(UNIFORM, "skyInscatteringSettingsFrag", skyInscatteringSettingsFrag, true);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
@@ -23,6 +23,8 @@ import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Shader parameters for the Debug shader program.
  *
@@ -41,83 +43,83 @@ public class ShaderParametersDebug extends ShaderParametersBase {
             case SHADOW_MAP:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case OPAQUE_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case OPAQUE_NORMALS:
             case OPAQUE_SUNLIGHT:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboNormalsTexture("sceneOpaque");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case OPAQUE_DEPTH:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case OPAQUE_LIGHT_BUFFER:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboLightBufferTexture("sceneOpaque");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case TRANSPARENT_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sceneReflectiveRefractive");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case SSAO:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case SOBEL:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sobel");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case BAKED_OCCLUSION:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case RECONSTRUCTED_POSITION:
                 Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
                 if (activeCamera != null) {
-                    program.setMatrix4("invProjMatrix", activeCamera.getInverseProjectionMatrix(), true);
+                    program.setMatrix4(UNIFORM, "invProjMatrix", activeCamera.getInverseProjectionMatrix(), true);
                 }
 
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case BLOOM:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case HIGH_PASS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sceneHighPass");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case SKY_BAND:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             case LIGHT_SHAFTS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 LwjglRenderingProcess.getInstance().bindFboTexture("lightShafts");
-                program.setInt("texDebug", texId++, true);
+                program.setInt(UNIFORM, "texDebug", texId++, true);
                 break;
             default:
                 break;
         }
 
-        program.setInt("debugRenderingStage", CoreRegistry.get(Config.class).getRendering().getDebug().getStage().getIndex());
+        program.setInt(UNIFORM, "debugRenderingStage", CoreRegistry.get(Config.class).getRendering().getDebug().getStage().getIndex());
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -20,6 +20,8 @@ import org.terasology.editor.EditorRange;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Shader parameters for the Post-processing shader program.
  *
@@ -38,9 +40,9 @@ public class ShaderParametersHdr extends ShaderParametersBase {
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
         LwjglRenderingProcess.getInstance().bindFboTexture("scenePrePost");
 
-        program.setInt("texScene", 0, true);
-        program.setFloat("exposure", LwjglRenderingProcess.getInstance().getExposure() * exposureBias, true);
-        program.setFloat("whitePoint", whitePoint, true);
+        program.setInt(UNIFORM, "texScene", 0, true);
+        program.setFloat(UNIFORM, "exposure", LwjglRenderingProcess.getInstance().getExposure() * exposureBias, true);
+        program.setFloat(UNIFORM, "whitePoint", whitePoint, true);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -29,6 +29,7 @@ import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * Shader parameters for the LightBufferPass shader program.
@@ -47,32 +48,32 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindDepthTexture();
-            program.setInt("texSceneOpaqueDepth", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueDepth", texId++, true);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindNormalsTexture();
-            program.setInt("texSceneOpaqueNormals", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueNormals", texId++, true);
 
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindLightBufferTexture();
-            program.setInt("texSceneOpaqueLightBuffer", texId++, true);
+            program.setInt(UNIFORM, "texSceneOpaqueLightBuffer", texId++, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isDynamicShadows()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
-            program.setInt("texSceneShadowMap", texId++, true);
+            program.setInt(UNIFORM, "texSceneShadowMap", texId++, true);
 
             Camera lightCamera = CoreRegistry.get(WorldRenderer.class).getLightCamera();
             Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
 
             if (lightCamera != null && activeCamera != null) {
-                program.setMatrix4("lightViewProjMatrix", lightCamera.getViewProjectionMatrix(), true);
-                program.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
+                program.setMatrix4(UNIFORM, "lightViewProjMatrix", lightCamera.getViewProjectionMatrix(), true);
+                program.setMatrix4(UNIFORM, "invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
 
                 Vector3f activeCameraToLightSpace = new Vector3f();
                 activeCameraToLightSpace.sub(activeCamera.getPosition(), lightCamera.getPosition());
-                program.setFloat3("activeCameraToLightSpace", activeCameraToLightSpace.x, activeCameraToLightSpace.y, activeCameraToLightSpace.z, true);
+                program.setFloat3(UNIFORM, "activeCameraToLightSpace", activeCameraToLightSpace.x, activeCameraToLightSpace.y, activeCameraToLightSpace.z, true);
             }
 
             if (CoreRegistry.get(Config.class).getRendering().isCloudShadows()) {
@@ -80,7 +81,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
 
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 glBindTexture(GL11.GL_TEXTURE_2D, clouds.getId());
-                program.setInt("texSceneClouds", texId++, true);
+                program.setInt(UNIFORM, "texSceneClouds", texId++, true);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -27,6 +27,8 @@ import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Shader parameters for the Light Shaft shader program.
  *
@@ -54,16 +56,16 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             scene.bindTexture();
-            program.setInt("texScene", texId++, true);
+            program.setInt(UNIFORM, "texScene", texId++, true);
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             scene.bindDepthTexture();
-            program.setInt("texDepth", texId++, true);
+            program.setInt(UNIFORM, "texDepth", texId++, true);
         }
 
-        program.setFloat("density", density, true);
-        program.setFloat("exposure", exposure, true);
-        program.setFloat("weight", weight, true);
-        program.setFloat("decay", decay, true);
+        program.setFloat(UNIFORM, "density", density, true);
+        program.setFloat(UNIFORM, "exposure", exposure, true);
+        program.setFloat(UNIFORM, "weight", weight, true);
+        program.setFloat(UNIFORM, "decay", decay, true);
 
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
@@ -82,8 +84,8 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
             sunPositionScreenSpace.z /= sunPositionScreenSpace.w;
             sunPositionScreenSpace.w = 1.0f;
 
-            program.setFloat("lightDirDotViewDir", activeCamera.getViewingDirection().dot(sunDirection), true);
-            program.setFloat2("lightScreenPos", (sunPositionScreenSpace.x + 1.0f) / 2.0f, (sunPositionScreenSpace.y + 1.0f) / 2.0f, true);
+            program.setFloat(UNIFORM, "lightDirDotViewDir", activeCamera.getViewingDirection().dot(sunDirection), true);
+            program.setFloat2(UNIFORM, "lightScreenPos", (sunPositionScreenSpace.x + 1.0f) / 2.0f, (sunPositionScreenSpace.y + 1.0f) / 2.0f, true);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
@@ -19,6 +19,8 @@ import org.lwjgl.opengl.GL13;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Shader parameters for the Combine shader program.
  *
@@ -33,7 +35,7 @@ public class ShaderParametersOcDistortion extends ShaderParametersBase {
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         LwjglRenderingProcess.getInstance().bindFboTexture("sceneFinal");
-        program.setInt("texSceneFinal", texId++, true);
+        program.setInt(UNIFORM, "texSceneFinal", texId++, true);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -35,6 +35,7 @@ import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * Shader parameters for the Post-processing shader program.
@@ -57,15 +58,15 @@ public class ShaderParametersPost extends ShaderParametersBase {
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         LwjglRenderingProcess.getInstance().bindFboTexture("sceneToneMapped");
-        program.setInt("texScene", texId++, true);
+        program.setInt(UNIFORM, "texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().getBlurIntensity() != 0) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().getFBO("sceneBlur1").bindTexture();
-            program.setInt("texBlur", texId++, true);
+            program.setInt(UNIFORM, "texBlur", texId++, true);
 
             if (cameraTargetSystem != null) {
-                program.setFloat("focalDistance", cameraTargetSystem.getFocalDistance(), true); //for use in DOF effect
+                program.setFloat(UNIFORM, "focalDistance", cameraTargetSystem.getFocalDistance(), true); //for use in DOF effect
             }
         }
 
@@ -74,7 +75,7 @@ public class ShaderParametersPost extends ShaderParametersBase {
         if (colorGradingLut != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             glBindTexture(GL12.GL_TEXTURE_3D, colorGradingLut.getId());
-            program.setInt("texColorGradingLut", texId++, true);
+            program.setInt(UNIFORM, "texColorGradingLut", texId++, true);
         }
 
         FBO sceneCombined = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
@@ -82,7 +83,7 @@ public class ShaderParametersPost extends ShaderParametersBase {
         if (sceneCombined != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneCombined.bindDepthTexture();
-            program.setInt("texDepth", texId++, true);
+            program.setInt(UNIFORM, "texDepth", texId++, true);
 
             AssetUri noiseTextureUri = TextureUtil.getTextureUriForWhiteNoise(1024, 0x1234, 0, 512);
             Texture filmGrainNoiseTexture = Assets.getTexture(noiseTextureUri.toSimpleString());
@@ -90,19 +91,19 @@ public class ShaderParametersPost extends ShaderParametersBase {
             if (CoreRegistry.get(Config.class).getRendering().isFilmGrain()) {
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 glBindTexture(GL11.GL_TEXTURE_2D, filmGrainNoiseTexture.getId());
-                program.setInt("texNoise", texId++, true);
-                program.setFloat("grainIntensity", filmGrainIntensity, true);
-                program.setFloat("noiseOffset", rand.nextFloat(), true);
+                program.setInt(UNIFORM, "texNoise", texId++, true);
+                program.setFloat(UNIFORM, "grainIntensity", filmGrainIntensity, true);
+                program.setFloat(UNIFORM, "noiseOffset", rand.nextFloat(), true);
 
-                program.setFloat2("noiseSize", filmGrainNoiseTexture.getWidth(), filmGrainNoiseTexture.getHeight(), true);
-                program.setFloat2("renderTargetSize", sceneCombined.width, sceneCombined.height, true);
+                program.setFloat2(UNIFORM, "noiseSize", filmGrainNoiseTexture.getWidth(), filmGrainNoiseTexture.getHeight(), true);
+                program.setFloat2(UNIFORM, "renderTargetSize", sceneCombined.width, sceneCombined.height, true);
             }
         }
 
         Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
         if (activeCamera != null && CoreRegistry.get(Config.class).getRendering().isMotionBlur()) {
-            program.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
-            program.setMatrix4("prevViewProjMatrix", activeCamera.getPrevViewProjectionMatrix(), true);
+            program.setMatrix4(UNIFORM, "invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
+            program.setMatrix4(UNIFORM, "prevViewProjMatrix", activeCamera.getPrevViewProjectionMatrix(), true);
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
@@ -28,6 +28,7 @@ import org.terasology.rendering.opengl.LwjglRenderingProcess;
 import org.terasology.rendering.world.WorldRenderer;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * Shader parameters for the Post-processing shader program.
@@ -49,27 +50,27 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
         super.applyParameters(program);
 
         Vector3f tint = CoreRegistry.get(WorldRenderer.class).getTint();
-        program.setFloat3("inLiquidTint", tint.x, tint.y, tint.z, true);
+        program.setFloat3(UNIFORM, "inLiquidTint", tint.x, tint.y, tint.z, true);
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
-        program.setInt("texScene", texId++, true);
+        program.setInt(UNIFORM, "texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isBloom()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
-            program.setInt("texBloom", texId++, true);
+            program.setInt(UNIFORM, "texBloom", texId++, true);
 
-            program.setFloat("bloomFactor", bloomFactor, true);
+            program.setFloat(UNIFORM, "bloomFactor", bloomFactor, true);
         }
 
-        program.setFloat2("aberrationOffset", aberrationOffsetX, aberrationOffsetY, true);
+        program.setFloat2(UNIFORM, "aberrationOffset", aberrationOffsetX, aberrationOffsetY, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isLightShafts()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             LwjglRenderingProcess.getInstance().bindFboTexture("lightShafts");
-            program.setInt("texLightShafts", texId++, true);
+            program.setInt(UNIFORM, "texLightShafts", texId++, true);
         }
 
         Texture vignetteTexture = Assets.getTexture("engine:vignette");
@@ -77,7 +78,7 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
         if (vignetteTexture != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             glBindTexture(GL11.GL_TEXTURE_2D, vignetteTexture.getId());
-            program.setInt("texVignette", texId++, true);
+            program.setInt(UNIFORM, "texVignette", texId++, true);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -40,6 +40,7 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
 
 /**
  * Shader parameters for the Post-processing shader program.
@@ -85,7 +86,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
 
             ssaoSamples.flip();
         }
-        material.setFloat3("ssaoSamples", ssaoSamples);
+        material.setFloat3(UNIFORM, "ssaoSamples", ssaoSamples);
     }
 
     @Override
@@ -99,25 +100,25 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);
             scene.bindDepthTexture();
-            program.setInt("texDepth", texId++, true);
+            program.setInt(UNIFORM, "texDepth", texId++, true);
             GL13.glActiveTexture(GL13.GL_TEXTURE1);
             scene.bindNormalsTexture();
-            program.setInt("texNormals", texId++, true);
+            program.setInt(UNIFORM, "texNormals", texId++, true);
         }
 
         Texture ssaoNoiseTexture = updateNoiseTexture();
 
         GL13.glActiveTexture(GL13.GL_TEXTURE2);
         glBindTexture(GL11.GL_TEXTURE_2D, ssaoNoiseTexture.getId());
-        program.setInt("texNoise", texId++, true);
+        program.setInt(UNIFORM, "texNoise", texId++, true);
 
-        program.setFloat4("ssaoSettings", ssaoStrength, ssaoRad, 0.0f, 0.0f, true);
+        program.setFloat4(UNIFORM, "ssaoSettings", ssaoStrength, ssaoRad, 0.0f, 0.0f, true);
 
         if (CoreRegistry.get(WorldRenderer.class) != null) {
             Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
             if (activeCamera != null) {
-                program.setMatrix4("invProjMatrix", activeCamera.getInverseProjectionMatrix(), true);
-                program.setMatrix4("projMatrix", activeCamera.getProjectionMatrix(), true);
+                program.setMatrix4(UNIFORM, "invProjMatrix", activeCamera.getInverseProjectionMatrix(), true);
+                program.setMatrix4(UNIFORM, "projMatrix", activeCamera.getProjectionMatrix(), true);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
@@ -27,6 +27,8 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.world.WorldProvider;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Parameters for the sky shader program.
  *
@@ -71,25 +73,25 @@ public class ShaderParametersSky extends ShaderParametersBase {
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, Assets.getTexture("engine:sky90").getId());
-        program.setInt("texSky90", texId++, true);
+        program.setInt(UNIFORM, "texSky90", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, Assets.getTexture("engine:sky180").getId());
-        program.setInt("texSky180", texId++, true);
+        program.setInt(UNIFORM, "texSky180", texId++, true);
 
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
 
         if (worldProvider != null && backdropProvider != null) {
-            program.setFloat("colorExp", backdropProvider.getColorExp(), true);
+            program.setFloat(UNIFORM, "colorExp", backdropProvider.getColorExp(), true);
 
             Vector3f sunDirection = backdropProvider.getSunDirection(false);
             Vector3d zenithColor = getAllWeatherZenith(sunDirection.y, backdropProvider.getTurbidity());
 
-            program.setFloat("sunAngle", backdropProvider.getSunPositionAngle(), true);
-            program.setFloat("turbidity", backdropProvider.getTurbidity(), true);
-            program.setFloat3("zenith", (float) zenithColor.x, (float) zenithColor.y, (float) zenithColor.z, true);
+            program.setFloat(UNIFORM, "sunAngle", backdropProvider.getSunPositionAngle(), true);
+            program.setFloat(UNIFORM, "turbidity", backdropProvider.getTurbidity(), true);
+            program.setFloat3(UNIFORM, "zenith", (float) zenithColor.x, (float) zenithColor.y, (float) zenithColor.z, true);
         }
 
-        program.setFloat4("skySettings", sunExponent, moonExponent, skyDaylightBrightness, skyNightBrightness, true);
+        program.setFloat4(UNIFORM, "skySettings", sunExponent, moonExponent, skyDaylightBrightness, skyNightBrightness, true);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -21,6 +21,8 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Shader parameters for the Post-processing shader program.
  *
@@ -42,14 +44,14 @@ public class ShaderParametersSobel extends ShaderParametersBase {
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);
             scene.bindDepthTexture();
-            program.setInt("texDepth", 0);
+            program.setInt(UNIFORM, "texDepth", 0);
 
-            program.setFloat("texelWidth", 1.0f / scene.width);
-            program.setFloat("texelHeight", 1.0f / scene.height);
+            program.setFloat(UNIFORM, "texelWidth", 1.0f / scene.width);
+            program.setFloat(UNIFORM, "texelHeight", 1.0f / scene.height);
         }
 
-        program.setFloat("pixelOffsetX", pixelOffsetX);
-        program.setFloat("pixelOffsetY", pixelOffsetY);
+        program.setFloat(UNIFORM, "pixelOffsetX", pixelOffsetX);
+        program.setFloat(UNIFORM, "pixelOffsetY", pixelOffsetY);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -54,6 +54,8 @@ import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.RenderableChunk;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * @author Benjamin Glatzel
  */
@@ -462,25 +464,25 @@ public final class WorldRendererImpl implements WorldRenderer {
         Vector3f lightViewPosition = new Vector3f(worldPosition);
         playerCamera.getViewMatrix().transformPoint(lightViewPosition);
 
-        program.setFloat3("lightViewPos", lightViewPosition.x, lightViewPosition.y, lightViewPosition.z, true);
+        program.setFloat3(UNIFORM, "lightViewPos", lightViewPosition.x, lightViewPosition.y, lightViewPosition.z, true);
 
         Matrix4f modelMatrix = new Matrix4f();
         modelMatrix.set(lightComponent.lightAttenuationRange);
 
         modelMatrix.setTranslation(worldPosition);
-        program.setMatrix4("modelMatrix", modelMatrix, true);
+        program.setMatrix4(UNIFORM, "modelMatrix", modelMatrix, true);
 
         if (!geometryOnly) {
-            program.setFloat3("lightColorDiffuse", lightComponent.lightColorDiffuse.x, lightComponent.lightColorDiffuse.y, lightComponent.lightColorDiffuse.z, true);
-            program.setFloat3("lightColorAmbient", lightComponent.lightColorAmbient.x, lightComponent.lightColorAmbient.y, lightComponent.lightColorAmbient.z, true);
+            program.setFloat3(UNIFORM, "lightColorDiffuse", lightComponent.lightColorDiffuse.x, lightComponent.lightColorDiffuse.y, lightComponent.lightColorDiffuse.z, true);
+            program.setFloat3(UNIFORM, "lightColorAmbient", lightComponent.lightColorAmbient.x, lightComponent.lightColorAmbient.y, lightComponent.lightColorAmbient.z, true);
 
-            program.setFloat4("lightProperties", lightComponent.lightAmbientIntensity, lightComponent.lightDiffuseIntensity,
+            program.setFloat4(UNIFORM, "lightProperties", lightComponent.lightAmbientIntensity, lightComponent.lightDiffuseIntensity,
                     lightComponent.lightSpecularIntensity, lightComponent.lightSpecularPower, true);
         }
 
         if (lightComponent.lightType == LightComponent.LightType.POINT) {
             if (!geometryOnly) {
-                program.setFloat4("lightExtendedProperties", lightComponent.lightAttenuationRange * 0.975f, lightComponent.lightAttenuationFalloff, 0.0f, 0.0f, true);
+                program.setFloat4(UNIFORM, "lightExtendedProperties", lightComponent.lightAttenuationRange * 0.975f, lightComponent.lightAttenuationFalloff, 0.0f, 0.0f, true);
             }
 
             LightGeometryHelper.renderSphereGeometry();
@@ -554,15 +556,15 @@ public final class WorldRendererImpl implements WorldRenderer {
                     chunkShader.activateFeature(ShaderProgramFeature.FEATURE_ALPHA_REJECT);
                 }
 
-                chunkShader.setFloat3("chunkPositionWorld", chunkPosition.x * ChunkConstants.SIZE_X,
+                chunkShader.setFloat3(UNIFORM, "chunkPositionWorld", chunkPosition.x * ChunkConstants.SIZE_X,
                         chunkPosition.y * ChunkConstants.SIZE_Y,
                         chunkPosition.z * ChunkConstants.SIZE_Z);
-                chunkShader.setFloat("animated", chunk.isAnimated() ? 1.0f : 0.0f);
+                chunkShader.setFloat(UNIFORM, "animated", chunk.isAnimated() ? 1.0f : 0.0f);
 
                 if (mode == ChunkRenderMode.REFLECTION) {
-                    chunkShader.setFloat("clip", camera.getClipHeight());
+                    chunkShader.setFloat(UNIFORM, "clip", camera.getClipHeight());
                 } else {
-                    chunkShader.setFloat("clip", 0.0f);
+                    chunkShader.setFloat(UNIFORM, "clip", 0.0f);
                 }
 
                 chunkShader.enable();

--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -43,6 +43,8 @@ import org.terasology.world.chunks.ChunkConstants;
 
 import java.util.Map;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * Stores all information for a specific block type.
  *
@@ -596,8 +598,8 @@ public final class Block {
         mat.activateFeature(ShaderProgramFeature.FEATURE_USE_MATRIX_STACK);
 
         mat.enable();
-        mat.setFloat("sunlight", sunlight);
-        mat.setFloat("blockLight", blockLight);
+        mat.setFloat(UNIFORM, "sunlight", sunlight);
+        mat.setFloat(UNIFORM, "blockLight", blockLight);
 
         if (mesh == null || mesh.isDisposed()) {
             generateMesh();

--- a/engine/src/main/java/org/terasology/world/block/loader/WorldAtlasImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/WorldAtlasImpl.java
@@ -58,6 +58,8 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
+import static org.terasology.rendering.assets.material.Material.StorageQualifier.UNIFORM;
+
 /**
  * @author Immortius
  */
@@ -205,8 +207,8 @@ public class WorldAtlasImpl implements WorldAtlas {
 
         MaterialData terrainMatData = new MaterialData(Assets.getShader("engine:block"));
         terrainMatData.setParam("textureAtlas", terrainTex);
-        terrainMatData.setParam("colorOffset", new float[]{1, 1, 1});
-        terrainMatData.setParam("textured", true);
+        terrainMatData.setParam(UNIFORM, "colorOffset", new float[]{1, 1, 1});
+        terrainMatData.setParam(UNIFORM, "textured", true);
         Assets.generateAsset(new AssetUri(AssetType.MATERIAL, "engine:terrain"), terrainMatData, Material.class);
 
         createTextureAtlas(terrainTex);


### PR DESCRIPTION
**Summary:**
This PR adds support for attribute parameters in shaders/materials. This is achieved by adding a storage qualifier parameter to the Material interface methods.

As a consequence of this, all `Material.set*(...)` calls have been updated. Previously, these calls could be assumed to set uniforms. This assumption now has to be made explicit using the new parameter.

**Motivation:**
Attributes are required for instanced rendering of particles.
Attributes are useful in general where similar objects are rendered (in batch) using the same shader, but with different input values for each object.