### PR TITLE
LwjglRenderingProcess no longer a singleton, Dimension instances used more extensively

### DIFF
--- a/engine-tests/src/main/java/org/terasology/DisplayEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/DisplayEnvironment.java
@@ -155,9 +155,6 @@ public class DisplayEnvironment extends HeadlessEnvironment {
                 return new UISkin(uri, data);
             }
         });
-
-        // TODO: move somewhere else
-        CoreRegistry.put(ShaderManager.class, new ShaderManagerLwjgl()).initShaders();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
+++ b/engine/src/main/java/org/terasology/editor/properties/SceneProperties.java
@@ -38,9 +38,9 @@ public class SceneProperties implements PropertyProvider {
         if (backdropRenderer != null) {
             result.addAll(new ReflectionProvider(backdropRenderer).getProperties());
         }
-        LwjglRenderingProcess postRenderer = LwjglRenderingProcess.getInstance();
-        if (postRenderer != null) {
-            result.addAll(new ReflectionProvider(postRenderer).getProperties());
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        if (renderingProcess != null) {
+            result.addAll(new ReflectionProvider(renderingProcess).getProperties());
         }
         return result;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
@@ -37,8 +37,6 @@ public class InitialiseGraphics extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        CoreRegistry.get(ShaderManager.class).initShaders();
-
         NUIManager nuiManager = CoreRegistry.get(NUIManager.class);
         ((NUIManagerInternal) nuiManager).refreshWidgetsLibrary();
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
@@ -158,8 +158,9 @@ public class HeadlessGraphics implements EngineSubsystem {
         assetManager.addResolver(AssetType.TEXTURE, new ColorTextureAssetResolver());
         assetManager.addResolver(AssetType.TEXTURE, new NoiseTextureAssetResolver());
         assetManager.addResolver(AssetType.MESH, new IconMeshResolver());
+
+        // TODO: why headless cares about shaders?
         CoreRegistry.putPermanently(ShaderManager.class, new ShaderManagerHeadless());
-        CoreRegistry.get(ShaderManager.class).initShaders();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -250,7 +250,6 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         assetManager.addResolver(AssetType.TEXTURE, new NoiseTextureAssetResolver());
         assetManager.addResolver(AssetType.MESH, new IconMeshResolver());
         CoreRegistry.putPermanently(ShaderManager.class, new ShaderManagerLwjgl());
-        CoreRegistry.get(ShaderManager.class).initShaders();
     }
 
     private void checkOpenGL() {

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -80,7 +80,7 @@ public class MenuControlSystem extends BaseComponentSystem {
     public void onKeyDown(KeyDownEvent event, EntityRef entity) {
         switch (event.getKey().getId()) {
             case Keyboard.KeyId.F12:
-                LwjglRenderingProcess.getInstance().takeScreenshot();
+                CoreRegistry.get(LwjglRenderingProcess.class).takeScreenshot();
                 CoreRegistry.get(AudioManager.class).playSound(Assets.getSound("engine:camera"));
                 break;
             default:

--- a/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
@@ -188,7 +188,7 @@ public class FBO {
     /**
      * @return Returns the width and height of the FrameBuffer, as a Dimensions object.
      */
-    public Dimensions getDimensions() {
+    public Dimensions dimensions() {
         return dimensions;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglRenderingProcess.java
@@ -119,8 +119,6 @@ public class LwjglRenderingProcess {
 
     private static final Logger logger = LoggerFactory.getLogger(LwjglRenderingProcess.class);
 
-    private static LwjglRenderingProcess instance;
-
     /* PROPERTIES */
     @EditorRange(min = 0.0f, max = 10.0f)
     private float hdrExposureDefault = 2.5f;
@@ -151,7 +149,7 @@ public class LwjglRenderingProcess {
     private PBO readBackPBOCurrent;
 
     // I could have named them fullResolution, halfResolution and so on. But halfScale is actually
-    // -both- fullScale's dimension halved, leading to -a quarter- of its resolution. Following
+    // -both- fullScale's dimensions halved, leading to -a quarter- of its resolution. Following
     // this logic one32thScale would have to be named one1024thResolution and the otherwise
     // straightforward connection between variable names and dimensions would have been lost. -- manu3d
     private Dimensions fullScale;
@@ -182,20 +180,6 @@ public class LwjglRenderingProcess {
 
     public LwjglRenderingProcess() {
         initialize();
-    }
-
-    /**
-     * Returns (and creates – if necessary) the static instance
-     * of this helper class.
-     *
-     * @return The instance
-     */
-    public static LwjglRenderingProcess getInstance() {
-        if (instance == null) {
-            instance = new LwjglRenderingProcess();
-        }
-
-        return instance;
     }
 
     public void initialize() {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
@@ -88,6 +88,8 @@ public class ShaderParametersChunk extends ShaderParametersBase {
             return;
         }
 
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, terrain.getId());
@@ -108,10 +110,10 @@ public class ShaderParametersChunk extends ShaderParametersBase {
         glBindTexture(GL11.GL_TEXTURE_2D, effects.getId());
         program.setInt("textureEffects", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        LwjglRenderingProcess.getInstance().bindFboTexture("sceneReflected");
+        renderingProcess.bindFboTexture("sceneReflected");
         program.setInt("textureWaterReflection", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+        renderingProcess.bindFboTexture("sceneOpaque");
         program.setInt("texSceneOpaque", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -50,7 +50,8 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         int texId = 0;
 
-        FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FBO sceneOpaque = renderingProcess.getFBO("sceneOpaque");
 
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -70,7 +71,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
             program.setInt("texSceneOpaqueLightBuffer", texId++, true);
         }
 
-        FBO sceneReflectiveRefractive = LwjglRenderingProcess.getInstance().getFBO("sceneReflectiveRefractive");
+        FBO sceneReflectiveRefractive = renderingProcess.getFBO("sceneReflectiveRefractive");
 
         if (sceneReflectiveRefractive != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -94,13 +95,13 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isSsao()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
+            renderingProcess.bindFboTexture("ssaoBlurred");
             program.setInt("texSsao", texId++, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isOutline()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().bindFboTexture("sobel");
+            renderingProcess.bindFboTexture("sobel");
             program.setInt("texEdges", texId++, true);
 
             program.setFloat("outlineDepthThreshold", outlineDepthThreshold, true);
@@ -109,7 +110,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isInscattering()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
+            renderingProcess.bindFboTexture("sceneSkyBand1");
             program.setInt("texSceneSkyBand", texId++, true);
 
             Vector4f skyInscatteringSettingsFrag = new Vector4f();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
@@ -37,51 +37,53 @@ public class ShaderParametersDebug extends ShaderParametersBase {
 
         int texId = 0;
 
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+
         switch (config.getRendering().getDebug().getStage()) {
             case SHADOW_MAP:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
+                renderingProcess.bindFboDepthTexture("sceneShadowMap");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+                renderingProcess.bindFboTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_NORMALS:
             case OPAQUE_SUNLIGHT:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboNormalsTexture("sceneOpaque");
+                renderingProcess.bindFboNormalsTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_DEPTH:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
+                renderingProcess.bindFboDepthTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_LIGHT_BUFFER:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboLightBufferTexture("sceneOpaque");
+                renderingProcess.bindFboLightBufferTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case TRANSPARENT_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sceneReflectiveRefractive");
+                renderingProcess.bindFboTexture("sceneReflectiveRefractive");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SSAO:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("ssaoBlurred");
+                renderingProcess.bindFboTexture("ssaoBlurred");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SOBEL:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sobel");
+                renderingProcess.bindFboTexture("sobel");
                 program.setInt("texDebug", texId++, true);
                 break;
             case BAKED_OCCLUSION:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+                renderingProcess.bindFboTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case RECONSTRUCTED_POSITION:
@@ -91,27 +93,27 @@ public class ShaderParametersDebug extends ShaderParametersBase {
                 }
 
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneOpaque");
+                renderingProcess.bindFboDepthTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case BLOOM:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
+                renderingProcess.bindFboTexture("sceneBloom2");
                 program.setInt("texDebug", texId++, true);
                 break;
             case HIGH_PASS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sceneHighPass");
+                renderingProcess.bindFboTexture("sceneHighPass");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SKY_BAND:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("sceneSkyBand1");
+                renderingProcess.bindFboTexture("sceneSkyBand1");
                 program.setInt("texDebug", texId++, true);
                 break;
             case LIGHT_SHAFTS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                LwjglRenderingProcess.getInstance().bindFboTexture("lightShafts");
+                renderingProcess.bindFboTexture("lightShafts");
                 program.setInt("texDebug", texId++, true);
                 break;
             default:

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.shader;
 
 import org.lwjgl.opengl.GL13;
 import org.terasology.editor.EditorRange;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
@@ -35,11 +36,13 @@ public class ShaderParametersHdr extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
-        LwjglRenderingProcess.getInstance().bindFboTexture("scenePrePost");
+        renderingProcess.bindFboTexture("scenePrePost");
 
         program.setInt("texScene", 0, true);
-        program.setFloat("exposure", LwjglRenderingProcess.getInstance().getExposure() * exposureBias, true);
+        program.setFloat("exposure", renderingProcess.getExposure() * exposureBias, true);
         program.setFloat("whitePoint", whitePoint, true);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -41,7 +41,8 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        FBO sceneOpaque = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FBO sceneOpaque = renderingProcess.getFBO("sceneOpaque");
 
         int texId = 0;
         if (sceneOpaque != null) {
@@ -60,7 +61,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isDynamicShadows()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().bindFboDepthTexture("sceneShadowMap");
+            renderingProcess.bindFboDepthTexture("sceneShadowMap");
             program.setInt("texSceneShadowMap", texId++, true);
 
             Camera lightCamera = CoreRegistry.get(WorldRenderer.class).getLightCamera();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -47,7 +47,8 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FBO scene = renderingProcess.getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
@@ -16,6 +16,7 @@
 package org.terasology.rendering.shader;
 
 import org.lwjgl.opengl.GL13;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
 
@@ -32,7 +33,7 @@ public class ShaderParametersOcDistortion extends ShaderParametersBase {
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        LwjglRenderingProcess.getInstance().bindFboTexture("sceneFinal");
+        CoreRegistry.get(LwjglRenderingProcess.class).bindFboTexture("sceneFinal");
         program.setInt("texSceneFinal", texId++, true);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -53,15 +53,16 @@ public class ShaderParametersPost extends ShaderParametersBase {
         super.applyParameters(program);
 
         CameraTargetSystem cameraTargetSystem = CoreRegistry.get(CameraTargetSystem.class);
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        LwjglRenderingProcess.getInstance().bindFboTexture("sceneToneMapped");
+        renderingProcess.bindFboTexture("sceneToneMapped");
         program.setInt("texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().getBlurIntensity() != 0) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().getFBO("sceneBlur1").bindTexture();
+            renderingProcess.getFBO("sceneBlur1").bindTexture();
             program.setInt("texBlur", texId++, true);
 
             if (cameraTargetSystem != null) {
@@ -77,7 +78,7 @@ public class ShaderParametersPost extends ShaderParametersBase {
             program.setInt("texColorGradingLut", texId++, true);
         }
 
-        FBO sceneCombined = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO sceneCombined = renderingProcess.getFBO("sceneOpaque");
 
         if (sceneCombined != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
@@ -48,17 +48,19 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+
         Vector3f tint = CoreRegistry.get(WorldRenderer.class).getTint();
         program.setFloat3("inLiquidTint", tint.x, tint.y, tint.z, true);
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        LwjglRenderingProcess.getInstance().bindFboTexture("sceneOpaque");
+        renderingProcess.bindFboTexture("sceneOpaque");
         program.setInt("texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isBloom()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().bindFboTexture("sceneBloom2");
+            renderingProcess.bindFboTexture("sceneBloom2");
             program.setInt("texBloom", texId++, true);
 
             program.setFloat("bloomFactor", bloomFactor, true);
@@ -68,7 +70,7 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isLightShafts()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            LwjglRenderingProcess.getInstance().bindFboTexture("lightShafts");
+            renderingProcess.bindFboTexture("lightShafts");
             program.setInt("texLightShafts", texId++, true);
         }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -92,7 +92,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO scene = CoreRegistry.get(LwjglRenderingProcess.class).getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.shader;
 
 import org.lwjgl.opengl.GL13;
 import org.terasology.editor.EditorRange;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.LwjglRenderingProcess;
@@ -37,7 +38,7 @@ public class ShaderParametersSobel extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        FBO scene = LwjglRenderingProcess.getInstance().getFBO("sceneOpaque");
+        FBO scene = CoreRegistry.get(LwjglRenderingProcess.class).getFBO("sceneOpaque");
 
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);


### PR DESCRIPTION
The [first commit](https://github.com/MovingBlocks/Terasology/commit/47ec5d348448357c9dc59bce418aa738882576d8) is an easy and hopefully uncontroversial one:
* it takes advantage of FBO.Dimensions instances throughout to simplify FBO generation code and dimensions handling, making more explicit the sizes of the FBOs involved and any change to them.
* it also add a couple of small method wrapping unsightly glViewport() calls into setViewportToFullScale() and setViewportTo().

The [second commit](https://github.com/MovingBlocks/Terasology/commit/09a6c9203d256a0e7d212c0171bd238e190166ed) is only a little more involved because it changes the LwjglRenderingProcess class from a singleton obtainable via its getInstance() method to an object instantiated by the WorldRenderer upon construction, and then made available throughout the application via the CoreRegistry. 

This allows for a more explicit control of the life cycle of the instance. Previously the instance was implicitely created by ShaderParameters instances within ShaderManager.initShaders() during Display initialization, well before the rendering process (or the shaders for that matter) were actually needed. Shaders are now initialized just after the rendering process is initialized, during WorldRenderer construction.

This second commit deals, perhaps a bit bluntly, also with shader initialization in headless mode. The headless version of the ShaderManager was used to call its initShaders() method a number times in headless. initShaders() is however an empty method and I removed calls to it. In hindsight, as I write this, this was perhaps unnecessary and maybe even wrong. An headless mode smoke test didn't reveal any problem with the changes though. And what do shaders do in headless mode anyway?


Finally, as a reference to where I am heading, you can take advantage of the last commit on [this branch](https://github.com/emanuele3d/Terasology/tree/RendererChangesBKP).