### PR TITLE
Beefs up the railgun again

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -108,7 +108,7 @@ May vary by version and based on what modules are enabled
 * Axe / Pickaxe / Shovel - Faster right-click removal of some blocks
 * Torch - Shiny! Place with left click. Try throwing these in water at night
 * Explosion tool - Big bada boom!
-* Railgun  - Bigger bada boom, in a straight line!
+* Railgun  - Bigger bada boom, in a straight line! *Use with caution! May causes severe lag*
 * Goodie chest - place it and open with 'e' for assorted goodies
 
 More or completely alternative line-ups with certain modules / world types selected

--- a/engine/src/main/java/org/terasology/logic/actions/TunnelAction.java
+++ b/engine/src/main/java/org/terasology/logic/actions/TunnelAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,14 +36,20 @@ import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 
-/**
- * @author Immortius
- */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class TunnelAction extends BaseComponentSystem {
 
-    private static final int MAX_DESTROYED_BLOCKS = 1000;
+    /** The most blocks that can be destroyed before the action ends (counts duplicates, so actually way lower */
+    private static final int MAX_DESTROYED_BLOCKS = 5000;
+
+    /** How many effects to display at the most */
     private static final int MAX_PARTICLE_EFFECTS = 4;
+
+    /** The max number of "steps" we'll take along the direction of the tunnel to pick explosive points */
+    private static final int MAX_TUNNEL_DEPTH = 64;
+
+    /** The max number of rays to cast at each chosen spot in the path of the tunnel to hit target blocks */
+    private static final int MAX_RAYS_CAST = 512;
 
     @In
     private WorldProvider worldProvider;
@@ -78,13 +84,13 @@ public class TunnelAction extends BaseComponentSystem {
 
         int particleEffects = 0;
         int blockCounter = MAX_DESTROYED_BLOCKS;
-        for (int s = 0; s <= 512; s++) {
+        for (int s = 0; s <= MAX_TUNNEL_DEPTH; s++) {
             origin.add(dir);
             if (!worldProvider.isBlockRelevant(origin)) {
                 break;
             }
 
-            for (int i = 0; i < 64; i++) {
+            for (int i = 0; i < MAX_RAYS_CAST; i++) {
                 Vector3f direction = random.nextVector3f(1.0f);
                 Vector3f impulse = new Vector3f(direction);
                 impulse.scale(200);


### PR DESCRIPTION
Railgun has been a shadow of itself for too long. No more!

This simply tweaks the config (and pulls out a couple magic numbers) to make it vastly more destructive again. Naturally that also makes it more laggy.

The main source of the lag is the resulting physics from bouncy loose blocks, and a few shots down into the ground will push any machine to its knees. Shooting up to decapitate hills and trees is more amusing and forgiving. The exact way blocks are chosen as targets is also highly inefficient but I'm not sure how much it impacts the performance (it may be what can freeze the game for a moment, then the physics drags down the FPS after)

Making this in part to see if anybody is interested in a little homework to add on top of this:

- [ ] Consider alternative selection of blocks. Currently the action steps along the direction the player is facing and essentially sets off an explosion every few blocks. The explosion is (with this PR) made up by 512 rays cast in random directions from the origin (with lots of overlap), and if I understand it right furthermore each ray can hit up to 4 blocks along its direction. Instead maybe just destroy a central shape (3D plus sign? 27 block cube?) + a percentage of all blocks in a given range from the center (loop through block locations and destroy at 50% chance). Or do that to pop most the blocks then do a few rays that reach further.and makes it look more natural.
- [ ] Consider not dropping a physics block for every destroyed block. We used to only drop a few vs. how many blocks are destroyed. If we turn down this number the physics will lag less
- [ ] Alternatively scale this as more blocks drop (I like this idea) - the lower the max blocks destroyed counter gets the fewer blocks are dropped at each step (they still get destroyed but the longer the blast goes on the less "productive" it gets). This allows for glorious block showers from surgical strikes but won't fill a shaft going straight down with a huge amount of dropped blocks.
- [ ] Consider varying the size of the resulting physics cubes. They used to drop at nearly full size which made them vastly more visible at range (decapitating distant hills resulted in a shower of highly visible blocks)
- [ ] Consider adding more power to the physics blocks so they'll fly further if able to
- [ ] Move this out of the engine already ;-)
- [ ] Make it configurable in config.cfg or something for end-users to play with

I might turn this into a separate ticket if nobody feels like playing with it now. But c'mon! It's a railgun :D