### PR TITLE
Warn on unresolvable modules in WorldGeneratorManager

### DIFF
--- a/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
+++ b/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
@@ -72,6 +72,8 @@ public class WorldGeneratorManager {
                     } catch (Exception e) {
                         logger.error("Error loading world generator in module {}, skipping", module.getId(), e);
                     }
+                } else {
+                    logger.warn("Could not resolve dependencies for module: {}", module);
                 }
             }
         }


### PR DESCRIPTION
Make WorldGeneratorManager report unresolvable modules to clarify why some world generators are not listed.