### PR TITLE
Introduce initialize() method for FacetProvider

### DIFF
--- a/engine/src/main/java/org/terasology/world/generation/FacetProvider.java
+++ b/engine/src/main/java/org/terasology/world/generation/FacetProvider.java
@@ -20,7 +20,19 @@ package org.terasology.world.generation;
  */
 public interface FacetProvider {
 
-    void setSeed(long seed);
+    /**
+     * @param seed the seed value (typically used for random number generators)
+     */
+    default void setSeed(long seed) {
+        // don't do anything
+    }
+
+    /**
+     * This is always called after {@link #setSeed(long)}.
+     */
+    default void initialize() {
+        // don't do anything
+    }
 
     void process(GeneratingRegion region);
 }

--- a/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.world.generation;
 
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,6 +86,13 @@ public class WorldImpl implements World {
 
     @Override
     public void initialize() {
+        // throw them all in a set to remove duplicates
+        Collection<FacetProvider> facetProviders = new LinkedHashSet<>(facetProviderChains.values());
+
+        for (FacetProvider facetProvider : facetProviders) {
+            facetProvider.initialize();
+        }
+
         for (WorldRasterizer rasterizer : worldRasterizers) {
             rasterizer.initialize();
         }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/HeightMapSurfaceHeightProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/HeightMapSurfaceHeightProvider.java
@@ -59,6 +59,11 @@ public class HeightMapSurfaceHeightProvider implements ConfigurableFacetProvider
 
     @Override
     public void setSeed(long seed) {
+        initialize();
+    }
+
+    @Override
+    public void initialize() {
         logger.info("Reading height map..");
 
         Texture texture = Assets.getTexture("core", configuration.heightMap);


### PR DESCRIPTION
I would actually prefer to move the empty method implementations into a new class `AbstractFacetProvider` or `FacetProviderAdapter`, but this would require changing dozends of files. 

Also, default methods were introduced specifically for *interface evolution*, so this is probably a good fit - it just feels strange.