### PR TITLE
Fix block plaement near player.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -63,7 +63,7 @@ public class KinematicCharacterMover implements CharacterMover {
     /**
      * The amount of horizontal penetration to allow.
      */
-    private static final float HORIZONTAL_PENETRATION = 0.03f;
+    public static final float HORIZONTAL_PENETRATION = 0.03f;
 
     /**
      * The amount of extra distance added to horizontal movement to allow for penetration.
@@ -73,7 +73,7 @@ public class KinematicCharacterMover implements CharacterMover {
     /**
      * The amount of vertical penetration to allow.
      */
-    private static final float VERTICAL_PENETRATION = 0.04f;
+    public static final float VERTICAL_PENETRATION = 0.04f;
 
     /**
      * The amount of extra distance added to vertical movement to allow for penetration.


### PR DESCRIPTION
Without this patch it is not possible to place blocks in certain
situations:
1. You couldn't place a block at character height if you walked towards
another path blocking block that is below or above the placement position.
e.g. place a block infront of you, walk towards it till limit.
Try placing a block on top of it.

2. Blocks couldn't be placed in a neighbour block that is 1 lower than
the current character position even when the character wasn't lowered
already from the edge (and capsule collision shape).

If in doubt the block placement will now be allowed which can lead in
certain corner situations to blocks that collide with the character.
e.g. when you walk very far on the edge and then plae a block below you.
You will then sink in the block till you hit the next block below it so
it is no big deal.