### PR TITLE
Two small changes

### DIFF
--- a/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
@@ -94,7 +94,8 @@ public class ComponentSystemManager {
                     InjectionHelper.share(newSystem);
                     register(newSystem, id);
                     logger.debug("Loaded system {}", id);
-                } catch (RuntimeException | IllegalAccessException | InstantiationException e) {
+                } catch (RuntimeException | IllegalAccessException | InstantiationException
+                        | NoClassDefFoundError e) {
                     logger.error("Failed to load system {}", id, e);
                 }
             }

--- a/engine/src/main/java/org/terasology/logic/config/ModuleConfigComponent.java
+++ b/engine/src/main/java/org/terasology/logic/config/ModuleConfigComponent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.config;
+
+import org.terasology.entitySystem.Component;
+
+import java.util.Map;
+
+public class ModuleConfigComponent implements Component {
+    public String moduleName;
+    public Map<String, String> properties;
+}

--- a/engine/src/main/java/org/terasology/logic/config/ModuleConfigManager.java
+++ b/engine/src/main/java/org/terasology/logic/config/ModuleConfigManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.config;
+
+import org.terasology.module.sandbox.API;
+
+@API
+public interface ModuleConfigManager {
+    String getStringVariable(String moduleName, String propertyName, String defaultValue);
+    int getIntVariable(String moduleName, String propertyName, int defaultValue);
+    float getFloatVariable(String moduleName, String propertyName, float defaultValue);
+}

--- a/engine/src/main/java/org/terasology/logic/config/ModuleConfigManager.java
+++ b/engine/src/main/java/org/terasology/logic/config/ModuleConfigManager.java
@@ -22,4 +22,5 @@ public interface ModuleConfigManager {
     String getStringVariable(String moduleName, String propertyName, String defaultValue);
     int getIntVariable(String moduleName, String propertyName, int defaultValue);
     float getFloatVariable(String moduleName, String propertyName, float defaultValue);
+    boolean getBooleanVariable(String moduleName, String propertyName, boolean defaultValue);
 }

--- a/engine/src/main/java/org/terasology/logic/config/ModuleConfigSystem.java
+++ b/engine/src/main/java/org/terasology/logic/config/ModuleConfigSystem.java
@@ -71,6 +71,11 @@ public class ModuleConfigSystem extends BaseComponentSystem implements ModuleCon
         return getVariable(moduleName, propertyName, Float::parseFloat, defaultValue);
     }
 
+    @Override
+    public boolean getBooleanVariable(String moduleName, String propertyName, boolean defaultValue) {
+        return getVariable(moduleName, propertyName, Boolean::parseBoolean, defaultValue);
+    }
+
     private <T> T getVariable(String moduleName, String propertyName, Function<String, T> extractFunction, T defaultValue) {
         Map<String, String> moduleProperties = propertiesPerModule.get(moduleName);
         if (moduleProperties == null) {

--- a/engine/src/main/java/org/terasology/logic/config/ModuleConfigSystem.java
+++ b/engine/src/main/java/org/terasology/logic/config/ModuleConfigSystem.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+import org.terasology.registry.Share;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@RegisterSystem
+@Share(ModuleConfigManager.class)
+public class ModuleConfigSystem extends BaseComponentSystem implements ModuleConfigManager {
+    private static final Logger logger = LoggerFactory.getLogger(ModuleConfigSystem.class);
+
+    @In
+    private EntityManager entityManager;
+
+    private Map<String, Map<String, String>> propertiesPerModule = new HashMap<>();
+
+    @Override
+    public void preBegin() {
+        for (EntityRef entityRef : entityManager.getEntitiesWith(ModuleConfigComponent.class)) {
+            ModuleConfigComponent moduleConfig = entityRef.getComponent(ModuleConfigComponent.class);
+            String moduleName = moduleConfig.moduleName;
+            Map<String, String> properties;
+            if (propertiesPerModule.containsKey(moduleName)) {
+                logger.error("Encountered more than one Module Config for module - "+moduleName+", this is not recommended, " +
+                        "as the property values visible are not going to be well defined.");
+                properties = propertiesPerModule.get(moduleName);
+            } else {
+                properties = new HashMap<>();
+                propertiesPerModule.put(moduleName, properties);
+            }
+            properties.putAll(moduleConfig.properties);
+        }
+    }
+
+    @Override
+    public String getStringVariable(String moduleName, String propertyName, String defaultValue) {
+        return getVariable(moduleName, propertyName, s -> s, defaultValue);
+    }
+
+    @Override
+    public int getIntVariable(String moduleName, String propertyName, int defaultValue) {
+        return getVariable(moduleName, propertyName, Integer::parseInt, defaultValue);
+    }
+
+    @Override
+    public float getFloatVariable(String moduleName, String propertyName, float defaultValue) {
+        return getVariable(moduleName, propertyName, Float::parseFloat, defaultValue);
+    }
+
+    private <T> T getVariable(String moduleName, String propertyName, Function<String, T> extractFunction, T defaultValue) {
+        Map<String, String> moduleProperties = propertiesPerModule.get(moduleName);
+        if (moduleProperties == null) {
+            return defaultValue;
+        }
+        String propertyValue = moduleProperties.get(propertyName);
+        if (propertyValue == null) {
+            return defaultValue;
+        }
+        return extractFunction.apply(propertyValue);
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/config/ModuleConfigSystem.java
+++ b/engine/src/main/java/org/terasology/logic/config/ModuleConfigSystem.java
@@ -17,8 +17,9 @@ package org.terasology.logic.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.registry.In;
@@ -34,14 +35,14 @@ public class ModuleConfigSystem extends BaseComponentSystem implements ModuleCon
     private static final Logger logger = LoggerFactory.getLogger(ModuleConfigSystem.class);
 
     @In
-    private EntityManager entityManager;
+    private PrefabManager prefabManager;
 
     private Map<String, Map<String, String>> propertiesPerModule = new HashMap<>();
 
     @Override
     public void preBegin() {
-        for (EntityRef entityRef : entityManager.getEntitiesWith(ModuleConfigComponent.class)) {
-            ModuleConfigComponent moduleConfig = entityRef.getComponent(ModuleConfigComponent.class);
+        for (Prefab prefab : prefabManager.listPrefabs(ModuleConfigComponent.class)) {
+            ModuleConfigComponent moduleConfig = prefab.getComponent(ModuleConfigComponent.class);
             String moduleName = moduleConfig.moduleName;
             Map<String, String> properties;
             if (propertiesPerModule.containsKey(moduleName)) {


### PR DESCRIPTION
1. New component and system that allows for easy and powerful module configuration (for "modpack" developers). Decided to put it in engine, to have just one way of doing it, rather than 1 per module/module-author.
2. Preparation for optional modules - make sure that if a system is being created and it depends on a module that is optional, Terasology still starts instead of crashes with NoClassDefFoundError and just logs an error. Probably has to stay being an error, since it might be due to some other problems. Maybe just a log error message should be improved?