### PR TITLE
Introduce the concept of a Context to slowly get rid of CoreRegistry.

### DIFF
--- a/engine-tests/src/main/java/org/terasology/Environment.java
+++ b/engine-tests/src/main/java/org/terasology/Environment.java
@@ -16,11 +16,13 @@
 
 package org.terasology;
 
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.naming.Name;
-
-import com.google.common.collect.Sets;
+import org.terasology.registry.CoreRegistry;
 
 import java.io.IOException;
 import java.util.Set;
@@ -34,12 +36,13 @@ public class Environment {
 
     private static final Logger logger = LoggerFactory.getLogger(Environment.class);
 
+    protected Context context;
+
     /**
      * Default setup order
      * @param moduleNames a list of module names
      */
     public Environment(Name ... moduleNames) {
-
         try {
             reset(Sets.newHashSet(moduleNames));
         } catch (Exception e) {
@@ -49,6 +52,8 @@ public class Environment {
     }
 
     protected void reset(Set<Name> moduleNames) throws Exception {
+        this.context = new ContextImpl();
+        CoreRegistry.setContext(context);
 
         setupPathManager();
 
@@ -139,8 +144,12 @@ public class Environment {
      * @throws Exception if something goes wrong
      */
     public void close() throws Exception {
-        // nothing to do
+        CoreRegistry.setContext(null);
+        context = null;
     }
 
+    public Context getContext() {
+        return context;
+    }
 }
 

--- a/engine-tests/src/main/resources/module.txt
+++ b/engine-tests/src/main/resources/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "unittest",
-    "version" : "0.53.2",
+    "version" : "0.53.3",
     "displayName" : "Terasology Engine Test",
     "description" : "Engine unit test content"
 }

--- a/engine-tests/src/test/java/org/terasology/entitySystem/OwnershipHelperTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/OwnershipHelperTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -27,6 +28,7 @@ import org.terasology.entitySystem.entity.internal.OwnershipHelper;
 import org.terasology.entitySystem.stubs.OwnerComponent;
 import org.terasology.network.NetworkSystem;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
 import static org.mockito.Mockito.mock;
@@ -48,6 +50,7 @@ public class OwnershipHelperTest {
 
     @Before
     public void setup() {
+        CoreRegistry.setContext(new ContextImpl());
         EntitySystemBuilder builder = new EntitySystemBuilder();
 
         entityManager = builder.build(moduleManager.getEnvironment(), mock(NetworkSystem.class), new ReflectionReflectFactory());

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -16,7 +16,6 @@
 package org.terasology.entitySystem;
 
 import com.google.common.collect.Lists;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -26,6 +25,8 @@ import org.terasology.asset.AssetManagerImpl;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -80,7 +81,9 @@ public class PojoEntityManagerTest {
                 return new PojoPrefab(uri, data);
             }
         });
-        CoreRegistry.put(AssetManager.class, assetManager);
+        Context contex = new ContextImpl();
+        contex.put(AssetManager.class, assetManager);
+        CoreRegistry.setContext(contex);
     }
 
     @Before

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
@@ -18,6 +18,7 @@ package org.terasology.entitySystem;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.PojoEntityManager;
@@ -37,6 +38,7 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.registry.CoreRegistry;
 
 import java.util.List;
 
@@ -57,6 +59,7 @@ public class PojoEventSystemTests {
 
     @Before
     public void setup() {
+        CoreRegistry.setContext(new ContextImpl());
         ReflectFactory reflectFactory = new ReflectionReflectFactory();
         CopyStrategyLibrary copyStrategies = new CopyStrategyLibrary(reflectFactory);
         TypeSerializationLibrary serializationLibrary = new TypeSerializationLibrary(reflectFactory, copyStrategies);

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
@@ -23,6 +23,7 @@ import org.terasology.asset.AssetManagerImpl;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.metadata.EntitySystemLibrary;
@@ -59,6 +60,7 @@ public class PojoPrefabManagerTest {
 
     @Before
     public void setup() throws Exception {
+        CoreRegistry.setContext(new ContextImpl());
         ModuleManager moduleManager = ModuleManagerFactory.create();
         ReflectFactory reflectFactory = new ReflectionReflectFactory();
         CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
@@ -24,6 +24,7 @@ import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetManagerImpl;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityManager;
@@ -62,6 +63,7 @@ public class PrefabTest {
 
     @Before
     public void setup() throws Exception {
+        CoreRegistry.setContext(new ContextImpl());
         ModuleManager moduleManager = ModuleManagerFactory.create();
 
         AssetManager assetManager = new AssetManagerImpl(moduleManager.getEnvironment());

--- a/engine-tests/src/test/java/org/terasology/entitySystem/metadata/ComponentMetadataTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/metadata/ComponentMetadataTest.java
@@ -16,7 +16,9 @@
 
 package org.terasology.entitySystem.metadata;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.stubs.OwnerComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
@@ -24,6 +26,7 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.registry.CoreRegistry;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -35,6 +38,11 @@ public class ComponentMetadataTest {
 
     private ReflectFactory reflectFactory = new ReflectionReflectFactory();
     private CopyStrategyLibrary copyStrategies = new CopyStrategyLibrary(reflectFactory);
+
+    @Before
+    public void prepare() {
+        CoreRegistry.setContext(new ContextImpl());
+    }
 
     @Test
     public void staticFieldsIgnored() {

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/FactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/FactoryTest.java
@@ -19,6 +19,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.terasology.asset.AssetManager;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.logic.behavior.asset.BehaviorTreeData;
 import org.terasology.logic.behavior.asset.BehaviorTreeLoader;
@@ -80,14 +82,16 @@ public class FactoryTest {
 
     @Before
     public void setup() throws Exception {
+        Context context = new ContextImpl();
+        CoreRegistry.setContext(context);
         ModuleManager moduleManager = ModuleManagerFactory.create();
         ReflectionReflectFactory reflectFactory = new ReflectionReflectFactory();
-        CoreRegistry.put(ReflectFactory.class, reflectFactory);
+        context.put(ReflectFactory.class, reflectFactory);
         CopyStrategyLibrary copyStrategies = new CopyStrategyLibrary(reflectFactory);
-        CoreRegistry.put(CopyStrategyLibrary.class, copyStrategies);
-        CoreRegistry.put(ModuleManager.class, moduleManager);
+        context.put(CopyStrategyLibrary.class, copyStrategies);
+        context.put(ModuleManager.class, moduleManager);
         NodesClassLibrary nodesClassLibrary = new NodesClassLibrary(reflectFactory, copyStrategies);
-        CoreRegistry.put(NodesClassLibrary.class, nodesClassLibrary);
+        context.put(NodesClassLibrary.class, nodesClassLibrary);
         nodesClassLibrary.scan(moduleManager.getEnvironment());
     }
 }

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/PortTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/PortTest.java
@@ -19,6 +19,8 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.terasology.asset.AssetManager;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.logic.behavior.nui.Port;
 import org.terasology.logic.behavior.nui.PortList;
 import org.terasology.logic.behavior.nui.RenderableNode;
@@ -37,7 +39,9 @@ public class PortTest {
     @Before
     public void setup() {
         AssetManager assetManager = mock(AssetManager.class);
-        CoreRegistry.put(AssetManager.class, assetManager);
+        Context context = new ContextImpl();
+        context.put(AssetManager.class, assetManager);
+        CoreRegistry.setContext(context);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/math/ChunkMathTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/ChunkMathTest.java
@@ -17,6 +17,7 @@ package org.terasology.math;
 
 import org.junit.Test;
 import org.terasology.config.Config;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
 
@@ -32,6 +33,7 @@ public class ChunkMathTest {
 
     @Test
     public void regionPositions() {
+        CoreRegistry.setContext(new ContextImpl());
         CoreRegistry.put(Config.class, new Config());
 
         assertEquals(1, ChunkMath.calcChunkPos(Region3i.createFromMinMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0))).length);

--- a/engine-tests/src/test/java/org/terasology/math/IntMathTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/IntMathTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.terasology.config.Config;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.registry.CoreRegistry;
 
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ public class IntMathTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         Config config = new Config();
+        CoreRegistry.setContext(new ContextImpl());
         CoreRegistry.put(Config.class, config);
     }
 

--- a/engine-tests/src/test/java/org/terasology/network/TestNetwork.java
+++ b/engine-tests/src/test/java/org/terasology/network/TestNetwork.java
@@ -30,7 +30,6 @@ import org.terasology.identity.CertificateGenerator;
 import org.terasology.identity.CertificatePair;
 import org.terasology.network.exceptions.HostingFailedException;
 import org.terasology.network.internal.NetworkSystemImpl;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.List;
 
@@ -49,7 +48,7 @@ public class TestNetwork extends TerasologyTestingEnvironment {
         super.setup();
         CertificateGenerator generator = new CertificateGenerator();
         CertificatePair serverIdentiy = generator.generateSelfSigned();
-        CoreRegistry.get(Config.class).getSecurity().setServerCredentials(serverIdentiy.getPublicCert(), serverIdentiy.getPrivateCert());
+        context.get(Config.class).getSecurity().setServerCredentials(serverIdentiy.getPublicCert(), serverIdentiy.getPrivateCert());
     }
 
     @After
@@ -64,14 +63,14 @@ public class TestNetwork extends TerasologyTestingEnvironment {
     public void testNetwork() throws Exception {
         EngineEntityManager entityManager = getEntityManager();
         EngineTime time = mock(EngineTime.class);
-        NetworkSystem server = new NetworkSystemImpl(time);
+        NetworkSystem server = new NetworkSystemImpl(time, context);
         netSystems.add(server);
-        server.connectToEntitySystem(entityManager, CoreRegistry.get(EntitySystemLibrary.class), null);
+        server.connectToEntitySystem(entityManager, context.get(EntitySystemLibrary.class), null);
         server.host(7777, true);
 
         Thread.sleep(500);
 
-        NetworkSystem client = new NetworkSystemImpl(time);
+        NetworkSystem client = new NetworkSystemImpl(time, context);
         netSystems.add(client);
         client.join("localhost", 7777);
 
@@ -89,9 +88,9 @@ public class TestNetwork extends TerasologyTestingEnvironment {
         netComp.setNetworkId(122);
         EntityRef entity = entityManager.create(netComp);
         EngineTime time = mock(EngineTime.class);
-        NetworkSystem server = new NetworkSystemImpl(time);
+        NetworkSystem server = new NetworkSystemImpl(time, context);
         netSystems.add(server);
-        server.connectToEntitySystem(entityManager, CoreRegistry.get(EntitySystemLibrary.class), null);
+        server.connectToEntitySystem(entityManager, context.get(EntitySystemLibrary.class), null);
         server.host(7777, true);
 
         assertFalse(122 == entity.getComponent(NetworkComponent.class).getNetworkId());

--- a/engine-tests/src/test/java/org/terasology/network/internal/NetworkOwnershipTest.java
+++ b/engine-tests/src/test/java/org/terasology/network/internal/NetworkOwnershipTest.java
@@ -17,7 +17,6 @@
 package org.terasology.network.internal;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.engine.ComponentSystemManager;
@@ -30,7 +29,6 @@ import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.metadata.EntitySystemLibrary;
 import org.terasology.network.NetworkComponent;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.world.BlockEntityRegistry;
 
@@ -50,20 +48,17 @@ public class NetworkOwnershipTest extends TerasologyTestingEnvironment {
     private NetClient client;
     private EntityRef clientEntity;
 
-    @BeforeClass
-    public static void initialise() throws Exception {
-        ModuleManager moduleManager = ModuleManagerFactory.create();
-        CoreRegistry.put(ModuleManager.class, moduleManager);
-    }
 
     @Before
     public void setup() throws Exception {
         super.setup();
+        ModuleManager moduleManager = ModuleManagerFactory.create();
+        context.put(ModuleManager.class, moduleManager);
         EngineTime mockTime = mock(EngineTime.class);
-        networkSystem = new NetworkSystemImpl(mockTime);
+        networkSystem = new NetworkSystemImpl(mockTime, context);
 
-        entityManager = new EntitySystemBuilder().build(CoreRegistry.get(ModuleManager.class).getEnvironment(), networkSystem, new ReflectionReflectFactory());
-        CoreRegistry.put(ComponentSystemManager.class, new ComponentSystemManager());
+        entityManager = new EntitySystemBuilder().build(context.get(ModuleManager.class).getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        context.put(ComponentSystemManager.class, new ComponentSystemManager());
         entityManager.clear();
         client = mock(NetClient.class);
         NetworkComponent clientNetComp = new NetworkComponent();
@@ -72,7 +67,7 @@ public class NetworkOwnershipTest extends TerasologyTestingEnvironment {
         when(client.getEntity()).thenReturn(clientEntity);
         when(client.getId()).thenReturn("dummyID");
         networkSystem.mockHost();
-        networkSystem.connectToEntitySystem(entityManager, CoreRegistry.get(EntitySystemLibrary.class), mock(BlockEntityRegistry.class));
+        networkSystem.connectToEntitySystem(entityManager, context.get(EntitySystemLibrary.class), mock(BlockEntityRegistry.class));
         networkSystem.registerNetworkEntity(clientEntity);
     }
 

--- a/engine-tests/src/test/java/org/terasology/persistence/ComponentSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/ComponentSerializerTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
@@ -40,6 +41,7 @@ import org.terasology.protobuf.EntityData;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
 import static org.junit.Assert.assertEquals;
@@ -59,6 +61,7 @@ public class ComponentSerializerTest {
     @BeforeClass
     public static void setupClass() throws Exception {
         moduleManager = ModuleManagerFactory.create();
+        CoreRegistry.setContext(new ContextImpl());
     }
 
     @Before

--- a/engine-tests/src/test/java/org/terasology/persistence/EntitySerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/EntitySerializerTest.java
@@ -16,7 +16,6 @@
 package org.terasology.persistence;
 
 import com.google.common.collect.Lists;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -26,6 +25,8 @@ import org.terasology.asset.AssetManagerImpl;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
@@ -65,7 +66,10 @@ public class EntitySerializerTest {
 
     @BeforeClass
     public static void setupClass() throws Exception {
+        Context context = new ContextImpl();
+        CoreRegistry.setContext(context);
         moduleManager = ModuleManagerFactory.create();
+
         AssetManager assetManager = new AssetManagerImpl(moduleManager.getEnvironment());
         assetManager.setAssetFactory(AssetType.PREFAB, new AssetFactory<PrefabData, Prefab>() {
             @Override
@@ -73,7 +77,7 @@ public class EntitySerializerTest {
                 return new PojoPrefab(uri, data);
             }
         });
-        CoreRegistry.put(AssetManager.class, assetManager);
+        context.put(AssetManager.class, assetManager);
     }
 
     @Before

--- a/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
@@ -20,6 +20,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetType;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
 import org.terasology.engine.module.ModuleManager;
@@ -62,8 +64,10 @@ public class WorldSerializerTest {
 
     @Before
     public void setup() {
-
-        AssetManager assetManager = CoreRegistry.put(AssetManager.class, mock(AssetManager.class));
+        Context context = new ContextImpl();
+        AssetManager assetManager = mock(AssetManager.class);
+        context.put(AssetManager.class,assetManager);
+        CoreRegistry.setContext(context);
         when(assetManager.listLoadedAssets(AssetType.PREFAB, Prefab.class)).thenReturn(Collections.<Prefab>emptyList());
         EntitySystemBuilder builder = new EntitySystemBuilder();
         entityManager = builder.build(moduleManager.getEnvironment(), mock(NetworkSystem.class), new ReflectionReflectFactory());

--- a/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
@@ -19,7 +19,6 @@ package org.terasology.world;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,6 +28,8 @@ import org.terasology.asset.AssetManagerImpl;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameThread;
 import org.terasology.engine.bootstrap.EntitySystemBuilder;
@@ -104,9 +105,14 @@ public class EntityAwareWorldProviderTest {
     private Block blockInFamilyOne;
     private Block blockInFamilyTwo;
 
+    private static Context context;
+
     @BeforeClass
     public static void commonSetup() throws Exception {
-        moduleManager = CoreRegistry.put(ModuleManager.class, ModuleManagerFactory.create());
+        context = new ContextImpl();
+        CoreRegistry.setContext(context);
+        moduleManager = ModuleManagerFactory.create();
+        context.put(ModuleManager.class, moduleManager);
     }
 
     @Before

--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.input.BindAxisEvent;
@@ -145,8 +146,8 @@ public final class BindsConfig {
     /**
      * Updates a config with any binds that it may be missing, through reflection over RegisterBindButton annotations
      */
-    public void updateForChangedMods() {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+    public void updateForChangedMods(Context context) {
+        ModuleManager moduleManager = context.get(ModuleManager.class);
         DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
         for (Name moduleId : moduleManager.getRegistry().getModuleIds()) {
             if (moduleManager.getRegistry().getLatestModuleVersion(moduleId).isCodeModule()) {

--- a/engine/src/main/java/org/terasology/context/Context.java
+++ b/engine/src/main/java/org/terasology/context/Context.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.context;
+
+/**
+ * Provides classes with the utility objects that belong to the context they are running in.
+ *
+ * Use dependency injection or this interface to get at the objects you want to use.
+ *
+ *
+ * From this class there can be multiple instances. For example we have the option of letting a client and server run
+ * concurrently in one VM, by letting them work with two separate context objects.
+ *
+ * This class is intended to replace the CoreRegistry and other static means to get utility objects.
+ *
+ * Contexts must be thread save!
+ */
+public interface Context {
+
+    /**
+     * @return the object that is known in this context for this type.
+     */
+    <T> T get(Class<? extends T> type);
+
+    /**
+     * Makes the object known in this context to be the object to work with for the given type.
+     */
+    <T, U extends T> void put(Class<T> type, U object);
+
+
+    /**
+     * Removes the object of the given type from this context. Future get calls may however still return
+     * an object from the parent context for that type.
+     */
+    void remove(Class<?> type);
+}

--- a/engine/src/main/java/org/terasology/context/Context.java
+++ b/engine/src/main/java/org/terasology/context/Context.java
@@ -26,7 +26,7 @@ package org.terasology.context;
  *
  * This class is intended to replace the CoreRegistry and other static means to get utility objects.
  *
- * Contexts must be thread save!
+ * Contexts must be thread safe!
  */
 public interface Context {
 

--- a/engine/src/main/java/org/terasology/context/internal/ContextImpl.java
+++ b/engine/src/main/java/org/terasology/context/internal/ContextImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.context.internal;
+
+import com.google.common.collect.Maps;
+import org.terasology.context.Context;
+
+import java.util.Map;
+
+/**
+ * Implements the {@link Context} interface.
+ */
+public class ContextImpl implements Context {
+    private final Context parent;
+
+    private final Map<Class<? extends Object>, Object> map = Maps.newConcurrentMap();
+
+
+    /**
+     *
+     * @param parent can be null. If not null it will be used as a fallback if this context does not contain a
+     *               requested object.
+     */
+    public ContextImpl(Context parent) {
+        this.parent = parent;
+    }
+
+    public ContextImpl() {
+        this.parent = null;
+    }
+
+    @Override
+    public <T> T get(Class<? extends T> type) {
+        if (type == Context.class) {
+            return type.cast(this);
+        }
+        T result = type.cast(map.get(type));
+        if (result != null) {
+            return result;
+        }
+        if (parent != null) {
+            return parent.get(type);
+        }
+        return result;
+    }
+
+    @Override
+    public <T, U extends T> void put(Class<T> type, U object)  {
+        map.put(type, object);
+    }
+
+
+    @Override
+    public void remove(Class<?> type) {
+        map.remove(type);
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/GameEngine.java
+++ b/engine/src/main/java/org/terasology/engine/GameEngine.java
@@ -16,6 +16,7 @@
 
 package org.terasology.engine;
 
+import org.terasology.context.Context;
 import org.terasology.engine.modes.GameState;
 
 /**
@@ -111,4 +112,9 @@ public interface GameEngine extends AutoCloseable {
     void unsubscribeToStateChange(StateChangeSubscriber subscriber);
 
 
+    /**
+     * Creates a context that provides read access to the objects of the engine context and can
+     * be populated with it's own private objects.
+     */
+    public Context createChildContext();
 }

--- a/engine/src/main/java/org/terasology/engine/bootstrap/ApplyModulesUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/ApplyModulesUtil.java
@@ -18,11 +18,11 @@ package org.terasology.engine.bootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.asset.AssetManager;
+import org.terasology.context.Context;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.reflection.copy.CopyStrategy;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.copy.RegisterCopyStrategy;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.ReflectionUtil;
 
 /**
@@ -34,10 +34,10 @@ public final class ApplyModulesUtil {
     private ApplyModulesUtil() {
     }
 
-    public static void applyModules() {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+    public static void applyModules(Context context) {
+        ModuleManager moduleManager = context.get(ModuleManager.class);
 
-        CopyStrategyLibrary copyStrategyLibrary = CoreRegistry.get(CopyStrategyLibrary.class);
+        CopyStrategyLibrary copyStrategyLibrary = context.get(CopyStrategyLibrary.class);
         copyStrategyLibrary.clear();
         for (Class<? extends CopyStrategy> copyStrategy : moduleManager.getEnvironment().getSubtypesOf(CopyStrategy.class)) {
             if (copyStrategy.getAnnotation(RegisterCopyStrategy.class) == null) {
@@ -55,7 +55,7 @@ public final class ApplyModulesUtil {
             }
         }
 
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+        AssetManager assetManager = context.get(AssetManager.class);
         assetManager.setEnvironment(moduleManager.getEnvironment());
     }
 }

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -86,6 +86,7 @@ public class StateIngame implements GameState {
 
     @Override
     public void init(GameEngine engine) {
+        // context from loading state gets used.
         nuiManager = CoreRegistry.get(NUIManager.class);
         worldRenderer = CoreRegistry.get(WorldRenderer.class);
         eventSystem = CoreRegistry.get(EventSystem.class);
@@ -154,7 +155,6 @@ public class StateIngame implements GameState {
         ModuleEnvironment environment = CoreRegistry.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
         CoreRegistry.get(AssetManager.class).setEnvironment(environment);
         CoreRegistry.get(Console.class).dispose();
-        CoreRegistry.clear();
         BlockManager.getAir().setEntity(EntityRef.NULL);
         GameThread.clearWaitingProcesses();
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -113,6 +113,8 @@ public class StateLoading implements GameState {
 
     @Override
     public void init(GameEngine engine) {
+        CoreRegistry.setContext(engine.createChildContext());
+
         EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
         time.setPaused(true);
         time.setGameTime(0);

--- a/engine/src/main/java/org/terasology/engine/modes/StateSetup.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateSetup.java
@@ -53,6 +53,7 @@ public abstract class StateSetup implements GameState {
 
     @Override
     public void init(GameEngine gameEngine) {
+        CoreRegistry.setContext(gameEngine.createChildContext());
 
         // let's get the entity event system running
         entityManager = new EntitySystemBuilder().build(CoreRegistry.get(ModuleManager.class).getEnvironment(), CoreRegistry.get(NetworkSystem.class),
@@ -84,7 +85,6 @@ public abstract class StateSetup implements GameState {
         componentSystemManager.shutdown();
 
         entityManager.clear();
-        CoreRegistry.clear();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.bootstrap.ApplyModulesUtil;
 import org.terasology.engine.modes.LoadProcess;
@@ -109,7 +110,7 @@ public class JoinServer implements LoadProcess {
             moduleManager.loadEnvironment(moduleSet, true);
 
             CoreRegistry.get(Game.class).load(gameManifest);
-            ApplyModulesUtil.applyModules();
+            ApplyModulesUtil.applyModules(CoreRegistry.get(Context.class));
 
             return true;
         } else if (joinStatus.getStatus() == JoinStatus.Status.FAILED) {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterMods.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterMods.java
@@ -17,9 +17,9 @@
 package org.terasology.engine.modes.loadProcesses;
 
 import com.google.common.collect.Lists;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.bootstrap.ApplyModulesUtil;
 import org.terasology.engine.modes.StateMainMenu;
@@ -70,7 +70,7 @@ public class RegisterMods extends SingleStepLoadProcess {
                 logger.info("Activating module: {}:{}", moduleInfo.getId(), moduleInfo.getVersion());
             }
 
-            ApplyModulesUtil.applyModules();
+            ApplyModulesUtil.applyModules(CoreRegistry.get(Context.class));
         } else {
             logger.warn("Missing at least one required module or dependency: {}", moduleIds);
             CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu("Missing required module or dependency"));

--- a/engine/src/main/java/org/terasology/engine/subsystem/EngineSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/EngineSubsystem.java
@@ -16,13 +16,14 @@
 package org.terasology.engine.subsystem;
 
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.modes.GameState;
 
 public interface EngineSubsystem {
-    void preInitialise();
+    void preInitialise(Context context);
 
-    void postInitialise(Config config);
+    void postInitialise(Context context);
 
     void preUpdate(GameState currentState, float delta);
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessAudio.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessAudio.java
@@ -20,22 +20,22 @@ import org.terasology.asset.AssetType;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.nullAudio.NullAudioManager;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.EngineSubsystem;
-import org.terasology.registry.CoreRegistry;
 
 public class HeadlessAudio implements EngineSubsystem {
 
     private AudioManager audioManager;
 
     @Override
-    public void preInitialise() {
+    public void preInitialise(Context context) {
     }
 
     @Override
-    public void postInitialise(Config config) {
-        initNoSound();
+    public void postInitialise(Context context) {
+        initNoSound(context);
     }
 
     @Override
@@ -56,10 +56,10 @@ public class HeadlessAudio implements EngineSubsystem {
         audioManager.dispose();
     }
 
-    private void initNoSound() {
+    private void initNoSound(Context context) {
         audioManager = new NullAudioManager();
-        CoreRegistry.putPermanently(AudioManager.class, audioManager);
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+        context.put(AudioManager.class, audioManager);
+        AssetManager assetManager = context.get(AssetManager.class);
         assetManager.setAssetFactory(AssetType.SOUND, audioManager.getStaticSoundFactory());
         assetManager.setAssetFactory(AssetType.MUSIC, audioManager.getStreamingSoundFactory());
     }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
@@ -20,6 +20,7 @@ import org.terasology.asset.AssetManager;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.DisplayDevice;
@@ -34,7 +35,6 @@ import org.terasology.engine.subsystem.headless.device.HeadlessDisplayDevice;
 import org.terasology.engine.subsystem.headless.renderer.HeadlessCanvasRenderer;
 import org.terasology.engine.subsystem.headless.renderer.HeadlessRenderingSubsystemFactory;
 import org.terasology.engine.subsystem.headless.renderer.ShaderManagerHeadless;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.assets.animation.MeshAnimation;
 import org.terasology.rendering.assets.animation.MeshAnimationData;
@@ -66,20 +66,18 @@ import org.terasology.rendering.nui.internal.NUIManagerInternal;
 public class HeadlessGraphics implements EngineSubsystem {
 
     @Override
-    public void preInitialise() {
+    public void preInitialise(Context context) {
     }
 
     @Override
-    public void postInitialise(Config config) {
-        CoreRegistry.putPermanently(RenderingSubsystemFactory.class, new HeadlessRenderingSubsystemFactory());
+    public void postInitialise(Context context) {
+        context.put(RenderingSubsystemFactory.class, new HeadlessRenderingSubsystemFactory());
 
         HeadlessDisplayDevice headlessDisplay = new HeadlessDisplayDevice();
-        CoreRegistry.putPermanently(DisplayDevice.class, headlessDisplay);
-        initHeadless();
+        context.put(DisplayDevice.class, headlessDisplay);
+        initHeadless(context);
 
-        CoreRegistry.putPermanently(NUIManager.class, new NUIManagerInternal(new HeadlessCanvasRenderer()));
-
-        //        CoreRegistry.putPermanently(LwjglRenderingProcess.class, new HeadlessRenderingProcess());
+        context.put(NUIManager.class, new NUIManagerInternal(new HeadlessCanvasRenderer(), context));
     }
 
     @Override
@@ -98,8 +96,8 @@ public class HeadlessGraphics implements EngineSubsystem {
     public void dispose() {
     }
 
-    private void initHeadless() {
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+    private void initHeadless(Context context) {
+        AssetManager assetManager = context.get(AssetManager.class);
         assetManager.setAssetFactory(AssetType.FONT, new AssetFactory<FontData, Font>() {
             @Override
             public Font buildAsset(AssetUri uri, FontData data) {
@@ -160,7 +158,7 @@ public class HeadlessGraphics implements EngineSubsystem {
         assetManager.addResolver(AssetType.MESH, new IconMeshResolver());
 
         // TODO: why headless cares about shaders?
-        CoreRegistry.putPermanently(ShaderManager.class, new ShaderManagerHeadless());
+        context.put(ShaderManager.class, new ShaderManagerHeadless());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessInput.java
@@ -16,21 +16,21 @@
 package org.terasology.engine.subsystem.headless;
 
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.input.InputSystem;
-import org.terasology.registry.CoreRegistry;
 
 public class HeadlessInput implements EngineSubsystem {
 
     @Override
-    public void preInitialise() {
+    public void preInitialise(Context context) {
     }
 
     @Override
-    public void postInitialise(Config config) {
-        initControls();
+    public void postInitialise(Context context) {
+        initControls(context);
     }
 
     @Override
@@ -49,9 +49,9 @@ public class HeadlessInput implements EngineSubsystem {
     public void dispose() {
     }
 
-    private void initControls() {
+    private void initControls(Context context) {
         InputSystem inputSystem = new InputSystem();
-        CoreRegistry.putPermanently(InputSystem.class, inputSystem);
+        context.put(InputSystem.class, inputSystem);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessTimer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessTimer.java
@@ -16,23 +16,23 @@
 package org.terasology.engine.subsystem.headless;
 
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.engine.subsystem.headless.device.TimeSystem;
-import org.terasology.registry.CoreRegistry;
 
 public class HeadlessTimer implements EngineSubsystem {
 
     @Override
-    public void preInitialise() {
-        initTimer();
+    public void preInitialise(Context context) {
+        initTimer(context);
     }
 
     @Override
-    public void postInitialise(Config config) {
+    public void postInitialise(Context context) {
     }
 
     @Override
@@ -51,9 +51,9 @@ public class HeadlessTimer implements EngineSubsystem {
     public void dispose() {
     }
 
-    private void initTimer() {
+    private void initTimer(Context context) {
         EngineTime time = new TimeSystem();
-        CoreRegistry.putPermanently(Time.class, time);
+        context.put(Time.class, time);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/BaseLwjglSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/BaseLwjglSubsystem.java
@@ -19,6 +19,7 @@ import com.google.common.base.Charsets;
 import org.lwjgl.LWJGLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.utilities.LWJGLHelper;
 
@@ -34,7 +35,7 @@ public abstract class BaseLwjglSubsystem implements EngineSubsystem {
     private static boolean initialised;
 
     @Override
-    public synchronized void preInitialise() {
+    public synchronized void preInitialise(Context context) {
         if (!initialised) {
             initLogger();
             LWJGLHelper.initNativeLibs();

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglAudio.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglAudio.java
@@ -25,9 +25,9 @@ import org.terasology.audio.AudioManager;
 import org.terasology.audio.nullAudio.NullAudioManager;
 import org.terasology.audio.openAL.OpenALManager;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.modes.GameState;
-import org.terasology.registry.CoreRegistry;
 
 public class LwjglAudio extends BaseLwjglSubsystem {
 
@@ -36,13 +36,13 @@ public class LwjglAudio extends BaseLwjglSubsystem {
     private AudioManager audioManager;
 
     @Override
-    public synchronized void preInitialise() {
-        super.preInitialise();
+    public synchronized void preInitialise(Context context) {
+        super.preInitialise(context);
     }
 
     @Override
-    public void postInitialise(Config config) {
-        initOpenAL(config);
+    public void postInitialise(Context context) {
+        initOpenAL(context);
     }
 
     @Override
@@ -65,7 +65,8 @@ public class LwjglAudio extends BaseLwjglSubsystem {
         }
     }
 
-    private void initOpenAL(Config config) {
+    private void initOpenAL(Context context) {
+        Config config = context.get(Config.class);
         if (config.getAudio().isDisableSound()) {
             audioManager = new NullAudioManager();
         } else {
@@ -76,8 +77,8 @@ public class LwjglAudio extends BaseLwjglSubsystem {
                 audioManager = new NullAudioManager();
             }
         }
-        CoreRegistry.putPermanently(AudioManager.class, audioManager);
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+        context.put(AudioManager.class, audioManager);
+        AssetManager assetManager = context.get(AssetManager.class);
         assetManager.setAssetFactory(AssetType.SOUND, audioManager.getStaticSoundFactory());
         assetManager.setAssetFactory(AssetType.MUSIC, audioManager.getStreamingSoundFactory());
     }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglCustomViewPort.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglCustomViewPort.java
@@ -20,6 +20,7 @@ import org.lwjgl.opengl.Display;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.modes.GameState;
 
@@ -32,12 +33,12 @@ public class LwjglCustomViewPort extends BaseLwjglSubsystem {
     private Canvas customViewPort;
 
     @Override
-    public void preInitialise() {
-        super.preInitialise();
+    public void preInitialise(Context context) {
+        super.preInitialise(context);
     }
 
     @Override
-    public void postInitialise(Config config) {
+    public void postInitialise(Context context) {
         try {
             Display.setParent(customViewPort);
         } catch (LWJGLException e) {

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -15,25 +15,27 @@
  */
 package org.terasology.engine.subsystem.lwjgl;
 
+import org.lwjgl.LWJGLException;
+import org.lwjgl.opengl.Display;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.config.Config;
+import org.terasology.context.Context;
+import org.terasology.engine.subsystem.DisplayDevice;
+
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glLoadIdentity;
 import static org.lwjgl.opengl.GL11.glViewport;
 
-import org.lwjgl.LWJGLException;
-import org.lwjgl.opengl.Display;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.terasology.config.Config;
-import org.terasology.engine.subsystem.DisplayDevice;
-import org.terasology.registry.CoreRegistry;
-
 public class LwjglDisplayDevice implements DisplayDevice {
 
     private static final Logger logger = LoggerFactory.getLogger(LwjglDisplayDevice.class);
+    private Context context;
 
-    public LwjglDisplayDevice() {
+    public LwjglDisplayDevice(Context context) {
+        this.context = context;
     }
 
     @Override
@@ -57,7 +59,7 @@ public class LwjglDisplayDevice implements DisplayDevice {
                 Display.setDisplayMode(Display.getDesktopDisplayMode());
                 Display.setFullscreen(true);
             } else {
-                Config config = CoreRegistry.get(Config.class);
+                Config config = context.get(Config.class);
                 Display.setDisplayMode(config.getRendering().getDisplayMode());
                 Display.setResizable(true);
             }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
@@ -21,6 +21,7 @@ import org.lwjgl.input.Mouse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.modes.GameState;
@@ -36,14 +37,14 @@ public class LwjglInput extends BaseLwjglSubsystem {
     private boolean mouseGrabbed;
 
     @Override
-    public void preInitialise() {
-        super.preInitialise();
+    public void preInitialise(Context context) {
+        super.preInitialise(context);
     }
 
     @Override
-    public void postInitialise(Config config) {
-        initControls();
-        updateInputConfig(config);
+    public void postInitialise(Context context) {
+        initControls(context);
+        updateInputConfig(context);
         Mouse.setGrabbed(false);
     }
 
@@ -75,12 +76,13 @@ public class LwjglInput extends BaseLwjglSubsystem {
         Keyboard.destroy();
     }
 
-    private void initControls() {
+    private void initControls(Context context) {
         try {
             Keyboard.create();
             Keyboard.enableRepeatEvents(true);
             Mouse.create();
-            InputSystem inputSystem = CoreRegistry.putPermanently(InputSystem.class, new InputSystem());
+            InputSystem inputSystem = new InputSystem();
+            context.put(InputSystem.class, inputSystem);
             inputSystem.setMouseDevice(new LwjglMouseDevice());
             inputSystem.setKeyboardDevice(new LwjglKeyboardDevice());
         } catch (LWJGLException e) {
@@ -88,8 +90,9 @@ public class LwjglInput extends BaseLwjglSubsystem {
         }
     }
 
-    private void updateInputConfig(Config config) {
-        config.getInput().getBinds().updateForChangedMods();
+    private void updateInputConfig(Context context) {
+        Config config = context.get(Config.class);
+        config.getInput().getBinds().updateForChangedMods(context);
         config.save();
     }
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglTimer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglTimer.java
@@ -16,23 +16,23 @@
 package org.terasology.engine.subsystem.lwjgl;
 
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
 import org.terasology.engine.internal.TimeLwjgl;
 import org.terasology.engine.modes.GameState;
-import org.terasology.registry.CoreRegistry;
 
 public class LwjglTimer extends BaseLwjglSubsystem {
 
     @Override
-    public void preInitialise() {
-        super.preInitialise();
-        initTimer(); // Dependent on LWJGL
+    public void preInitialise(Context context) {
+        super.preInitialise(context);
+        initTimer(context); // Dependent on LWJGL
     }
 
     @Override
-    public void postInitialise(Config config) {
+    public void postInitialise(Context context) {
     }
 
     @Override
@@ -51,9 +51,9 @@ public class LwjglTimer extends BaseLwjglSubsystem {
     public void dispose() {
     }
 
-    private void initTimer() {
+    private void initTimer(Context context) {
         EngineTime time = new TimeLwjgl();
-        CoreRegistry.putPermanently(Time.class, time);
+        context.put(Time.class, time);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
+++ b/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
@@ -50,7 +50,7 @@ public class DebugPropertiesSystem extends BaseComponentSystem {
         DebugProperties debugProperties = (DebugProperties) nuiManager.getHUD().addHUDElement("engine:DebugProperties");
         debugProperties.setVisible(false);
         properties = debugProperties.getPropertyLayout();
-        CoreRegistry.putPermanently(DebugPropertiesSystem.class, this);
+        CoreRegistry.put(DebugPropertiesSystem.class, this);
     }
 
     public void addProperty(final String group, final Object o) {

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -23,12 +23,9 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
-
 import gnu.trove.map.TIntLongMap;
 import gnu.trove.map.hash.TIntLongHashMap;
-
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
@@ -43,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
 import org.terasology.config.NetworkConfig;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.SimpleUri;
@@ -65,11 +63,9 @@ import org.terasology.network.NetworkComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
 import org.terasology.network.Server;
-import org.terasology.network.ServerInfoMessage;
 import org.terasology.network.events.ConnectedEvent;
 import org.terasology.network.events.DisconnectedEvent;
 import org.terasology.network.exceptions.HostingFailedException;
-import org.terasology.network.internal.pipelineFactory.InfoRequestPipelineFactory;
 import org.terasology.network.internal.pipelineFactory.TerasologyClientPipelineFactory;
 import org.terasology.network.internal.pipelineFactory.TerasologyServerPipelineFactory;
 import org.terasology.network.serialization.NetComponentSerializeCheck;
@@ -106,7 +102,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
@@ -153,9 +148,9 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     // Client only
     private ServerImpl server;
 
-    public NetworkSystemImpl(EngineTime time) {
+    public NetworkSystemImpl(EngineTime time, Context context) {
         this.time = time;
-        this.config = CoreRegistry.get(Config.class).getNetwork();
+        this.config = context.get(Config.class).getNetwork();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/registry/InjectionHelper.java
+++ b/engine/src/main/java/org/terasology/registry/InjectionHelper.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public final class InjectionHelper {
     private static final Logger logger = LoggerFactory.getLogger(InjectionHelper.class);
 
-    public InjectionHelper(Context context) {
+    private InjectionHelper() {
     }
 
     public static void inject(final Object object, Context context) {

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -19,11 +19,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.asset.AssetManager;
+import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
+import org.terasology.context.Context;
 import org.terasology.engine.Time;
 import org.terasology.input.MouseInput;
 import org.terasology.math.Border;
@@ -83,8 +85,8 @@ public class CanvasImpl implements CanvasControl {
 
     private CanvasState state;
 
-    private Material meshMat = Assets.getMaterial("engine:UILitMesh");
-    private Texture whiteTexture = Assets.getTexture("engine:white");
+    private Material meshMat;
+    private Texture whiteTexture;
 
     private List<DrawOperation> drawOnTopOperations = Lists.newArrayList();
 
@@ -107,10 +109,13 @@ public class CanvasImpl implements CanvasControl {
 
     private CanvasRenderer renderer;
 
-    public CanvasImpl(NUIManager nuiManager, Time time, CanvasRenderer renderer) {
+    public CanvasImpl(NUIManager nuiManager, Context context, CanvasRenderer renderer) {
         this.renderer = renderer;
         this.nuiManager = nuiManager;
-        this.time = time;
+        this.time = context.get(Time.class);
+        AssetManager assetManager = context.get(AssetManager.class);
+        this.meshMat = assetManager.resolveAndLoad(AssetType.MATERIAL, "engine:UILitMesh", Material.class);
+        this.whiteTexture =assetManager.resolveAndLoad(AssetType.TEXTURE, "engine:white", Texture.class);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -17,12 +17,14 @@ package org.terasology.rendering.nui.internal;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
+import org.terasology.asset.AssetManager;
+import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
+import org.terasology.context.Context;
 import org.terasology.math.AABB;
 import org.terasology.math.Border;
 import org.terasology.math.MatrixUtils;
@@ -84,10 +86,10 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
     private static final Rect2f FULL_REGION = Rect2f.createFromMinAndSize(0, 0, 1, 1);
     private Matrix4f modelView;
     private FloatBuffer matrixBuffer = BufferUtils.createFloatBuffer(16);
-    private Mesh billboard = Assets.getMesh("engine:UIBillboard");
+    private Mesh billboard;
     private Line line = new Line();
 
-    private Material textureMat = Assets.getMaterial("engine:UITexture");
+    private Material textureMat;
 
     // Text mesh caching
     private Map<TextCacheKey, Map<Material, Mesh>> cachedText = Maps.newLinkedHashMap();
@@ -101,6 +103,14 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
     private Rect2i currentTextureCropRegion;
 
     private Map<AssetUri, FrameBufferObject> fboMap = Maps.newHashMap();
+
+
+    public LwjglCanvasRenderer(Context context) {
+        AssetManager assetManager = context.get(AssetManager.class);
+        this.textureMat = assetManager.resolveAndLoad(AssetType.MATERIAL, "engine:UITexture", Material.class);
+        this.billboard = assetManager.resolveAndLoad(AssetType.MESH, "engine:UIBillboard", Mesh.class);
+    }
+
 
     @Override
     public void preRender() {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/hud/HUDScreenLayer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/hud/HUDScreenLayer.java
@@ -24,7 +24,7 @@ import org.terasology.math.Rect2f;
 import org.terasology.math.Rect2i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector2i;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.ControlWidget;
@@ -43,7 +43,9 @@ public class HUDScreenLayer extends CoreScreenLayer {
 
     private Map<AssetUri, HUDElement> elementsLookup = Maps.newLinkedHashMap();
 
-    private AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+    @In
+    private AssetManager assetManager;
+
     private NUIManager manager;
 
     public ControlWidget addHUDElement(String uri) {

--- a/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
+++ b/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.module.DependencyResolver;
@@ -41,14 +42,17 @@ import java.util.List;
 public class WorldGeneratorManager {
     private static final Logger logger = LoggerFactory.getLogger(WorldGeneratorManager.class);
 
+    private Context context;
+
     private ImmutableList<WorldGeneratorInfo> generatorInfo;
 
-    public WorldGeneratorManager() {
+    public WorldGeneratorManager(Context context) {
+        this.context = context;
         refresh();
     }
 
     public void refresh() {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+        ModuleManager moduleManager = context.get(ModuleManager.class);
         List<WorldGeneratorInfo> infos = Lists.newArrayList();
         for (Name moduleId : moduleManager.getRegistry().getModuleIds()) {
             Module module = moduleManager.getRegistry().getLatestModuleVersion(moduleId);

--- a/engine/src/main/resources/engine-module.txt
+++ b/engine/src/main/resources/engine-module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "engine",
-    "version" : "0.53.2",
+    "version" : "0.53.3",
     "displayName" : "Terasology Engine",
     "description" : "Core engine content"
 }

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -15,13 +15,6 @@
  */
 package org.terasology.engine;
 
-import java.awt.GraphicsEnvironment;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.List;
-
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -44,9 +37,15 @@ import org.terasology.engine.subsystem.lwjgl.LwjglInput;
 import org.terasology.engine.subsystem.lwjgl.LwjglTimer;
 import org.terasology.game.GameManifest;
 import org.terasology.network.NetworkMode;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
+
+import java.awt.GraphicsEnvironment;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Class providing the main() method for launching Terasology as a PC app.
@@ -122,7 +121,7 @@ public final class Terasology {
 
         try (final TerasologyEngine engine = new TerasologyEngine(createSubsystemList())) {
 
-            Config config = CoreRegistry.get(Config.class);
+            Config config = engine.getFromEngineContext(Config.class);
 
             if (!writeSaveGamesEnabled) {
                 config.getTransients().setWriteSaveGamesEnabled(writeSaveGamesEnabled);
@@ -285,6 +284,7 @@ public final class Terasology {
             System.exit(0);
         }
     }
+
 
     private static Collection<EngineSubsystem> createSubsystemList() {
         if (isHeadless) {

--- a/modules/Core/src/test/java/org/terasology/world/generator/TreeTests.java
+++ b/modules/Core/src/test/java/org/terasology/world/generator/TreeTests.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.context.internal.ContextImpl;
 import org.terasology.core.world.generator.trees.TreeGenerator;
 import org.terasology.core.world.generator.trees.Trees;
 import org.terasology.math.Rect2i;
@@ -49,8 +50,11 @@ public class TreeTests {
 
     @BeforeClass
     public static void setup() {
+        ContextImpl context = new ContextImpl();
+        CoreRegistry.setContext(context);
+
         // Needed only as long as #1536 is unresolved
-        CoreRegistry.putPermanently(Config.class, new Config());
+        context.put(Config.class, new Config());
 
         BlockManager blockManager = Mockito.mock(BlockManager.class);
         Block air = BlockManager.getAir();
@@ -58,7 +62,7 @@ public class TreeTests {
         Mockito.when(blockManager.getBlock(Matchers.<BlockUri>any())).thenReturn(air);
         Mockito.when(blockManager.getBlock(Matchers.<String>any())).thenReturn(air);
 
-        CoreRegistry.putPermanently(BlockManager.class, blockManager);
+        context.put(BlockManager.class, blockManager);
     }
 
     @Test


### PR DESCRIPTION
Reasoning: The core registry is just like static variables and it prevents
cool stuff like having a client and headless server running in the same VM.