### PR TITLE
Remove CoreRegistry usage: Part II

### DIFF
--- a/engine-tests/src/main/java/org/terasology/DisplayEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/DisplayEnvironment.java
@@ -31,9 +31,6 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.entitySystem.prefab.internal.PojoPrefab;
 import org.terasology.naming.Name;
-import org.terasology.registry.CoreRegistry;
-import org.terasology.rendering.ShaderManager;
-import org.terasology.rendering.ShaderManagerLwjgl;
 import org.terasology.rendering.assets.animation.MeshAnimation;
 import org.terasology.rendering.assets.animation.MeshAnimationData;
 import org.terasology.rendering.assets.animation.MeshAnimationImpl;
@@ -87,7 +84,7 @@ public class DisplayEnvironment extends HeadlessEnvironment {
 
         try {
             Display.setDisplayMode(new DisplayMode(1, 1));
-            Display.create(CoreRegistry.get(Config.class).getRendering().getPixelFormat());
+            Display.create(context.get(Config.class).getRendering().getPixelFormat());
         } catch (LWJGLException e) {
             throw new IllegalStateException(e);
         }
@@ -95,8 +92,8 @@ public class DisplayEnvironment extends HeadlessEnvironment {
 
     @Override
     protected void setupAssetManager() {
-        AssetManager assetManager = new AssetManagerImpl(CoreRegistry.get(ModuleManager.class).getEnvironment());
-        CoreRegistry.put(AssetManager.class, assetManager);
+        AssetManager assetManager = new AssetManagerImpl(context.get(ModuleManager.class).getEnvironment());
+        context.put(AssetManager.class, assetManager);
         AssetType.registerAssetTypes(assetManager);
 
         assetManager.setAssetFactory(AssetType.PREFAB, new AssetFactory<PrefabData, Prefab>() {
@@ -149,7 +146,7 @@ public class DisplayEnvironment extends HeadlessEnvironment {
                 return new MeshAnimationImpl(uri, data);
             }
         });
-        CoreRegistry.get(AssetManager.class).setAssetFactory(AssetType.UI_SKIN, new AssetFactory<UISkinData, UISkin>() {
+        context.get(AssetManager.class).setAssetFactory(AssetType.UI_SKIN, new AssetFactory<UISkinData, UISkin>() {
             @Override
             public UISkin buildAsset(AssetUri uri, UISkinData data) {
                 return new UISkin(uri, data);
@@ -164,7 +161,7 @@ public class DisplayEnvironment extends HeadlessEnvironment {
         blockFamilyFactoryRegistry.setBlockFamilyFactory("horizontal", new HorizontalBlockFamilyFactory());
         blockFamilyFactoryRegistry.setBlockFamilyFactory("alignToSurface", new AttachedToSurfaceFamilyFactory());
         BlockManagerImpl blockManager = new BlockManagerImpl(new WorldAtlasImpl(4096), blockFamilyFactoryRegistry);
-        CoreRegistry.put(BlockManager.class, blockManager);
+        context.put(BlockManager.class, blockManager);
     }
 
     @Override

--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -32,7 +32,7 @@ import org.terasology.config.Config;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.modes.loadProcesses.LoadPrefabs;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
@@ -50,7 +50,6 @@ import org.terasology.network.internal.NetworkSystemImpl;
 import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.internal.ReadWriteStorageManager;
 import org.terasology.physics.CollisionGroupManager;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.rendering.nui.skin.UISkinData;
 import org.terasology.testUtil.ModuleManagerFactory;
@@ -109,13 +108,8 @@ public class HeadlessEnvironment extends Environment {
 
     @Override
     protected void setupEntitySystem() {
-        ModuleManager moduleManager = context.get(ModuleManager.class);
-        NetworkSystem networkSystem = context.get(NetworkSystem.class);
-
-        EntitySystemBuilder builder = new EntitySystemBuilder();
-        EngineEntityManager engineEntityManager = builder.build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
-
-        context.put(EngineEntityManager.class, engineEntityManager);
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
     }
 
     @Override

--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -31,7 +31,7 @@ import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.modes.loadProcesses.LoadPrefabs;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
@@ -41,7 +41,6 @@ import org.terasology.network.internal.NetworkSystemImpl;
 import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.internal.ReadWriteStorageManager;
 import org.terasology.physics.CollisionGroupManager;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.world.block.BlockManager;
 
 import java.nio.file.FileSystem;
@@ -100,7 +99,10 @@ public abstract class TerasologyTestingEnvironment {
         context.put(Time.class, mockTime);
         NetworkSystemImpl networkSystem = new NetworkSystemImpl(mockTime, context);
         context.put(NetworkSystem.class, networkSystem);
-        engineEntityManager = new EntitySystemBuilder().build(context.get(ModuleManager.class).getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        engineEntityManager = context.get(EngineEntityManager.class);
+
         Path savePath = PathManager.getInstance().getSavePath("world1");
         context.put(StorageManager.class, new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), engineEntityManager));
 

--- a/engine-tests/src/test/java/org/terasology/entitySystem/OwnershipHelperTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/OwnershipHelperTest.java
@@ -20,14 +20,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.terasology.context.internal.ContextImpl;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.entity.internal.OwnershipHelper;
 import org.terasology.entitySystem.stubs.OwnerComponent;
 import org.terasology.network.NetworkSystem;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
@@ -50,10 +49,13 @@ public class OwnershipHelperTest {
 
     @Before
     public void setup() {
-        CoreRegistry.setContext(new ContextImpl());
-        EntitySystemBuilder builder = new EntitySystemBuilder();
-
-        entityManager = builder.build(moduleManager.getEnvironment(), mock(NetworkSystem.class), new ReflectionReflectFactory());
+        ContextImpl context = new ContextImpl();
+        context.put(ModuleManager.class, moduleManager);
+        context.put(NetworkSystem.class, mock(NetworkSystem.class));
+        CoreRegistry.setContext(context);
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = context.get(EngineEntityManager.class);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
@@ -59,12 +59,13 @@ public class PojoEventSystemTests {
 
     @Before
     public void setup() {
-        CoreRegistry.setContext(new ContextImpl());
+        ContextImpl context = new ContextImpl();
+        CoreRegistry.setContext(context);
         ReflectFactory reflectFactory = new ReflectionReflectFactory();
         CopyStrategyLibrary copyStrategies = new CopyStrategyLibrary(reflectFactory);
         TypeSerializationLibrary serializationLibrary = new TypeSerializationLibrary(reflectFactory, copyStrategies);
 
-        EntitySystemLibrary entitySystemLibrary = new EntitySystemLibrary(reflectFactory, copyStrategies, serializationLibrary);
+        EntitySystemLibrary entitySystemLibrary = new EntitySystemLibrary(context, serializationLibrary);
         compLibrary = entitySystemLibrary.getComponentLibrary();
         entityManager = new PojoEntityManager();
         entityManager.setComponentLibrary(entitySystemLibrary.getComponentLibrary());

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
@@ -60,14 +60,15 @@ public class PojoPrefabManagerTest {
 
     @Before
     public void setup() throws Exception {
-        CoreRegistry.setContext(new ContextImpl());
+        ContextImpl context = new ContextImpl();
+        CoreRegistry.setContext(context);
         ModuleManager moduleManager = ModuleManagerFactory.create();
         ReflectFactory reflectFactory = new ReflectionReflectFactory();
         CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);
         TypeSerializationLibrary lib = new TypeSerializationLibrary(reflectFactory, copyStrategyLibrary);
         lib.add(Vector3f.class, new Vector3fTypeHandler());
         lib.add(Quat4f.class, new Quat4fTypeHandler());
-        entitySystemLibrary = new EntitySystemLibrary(reflectFactory, copyStrategyLibrary, lib);
+        entitySystemLibrary = new EntitySystemLibrary(context, lib);
         componentLibrary = entitySystemLibrary.getComponentLibrary();
         prefabManager = new PojoPrefabManager();
         AssetManager assetManager = new AssetManagerImpl(moduleManager.getEnvironment());
@@ -77,7 +78,7 @@ public class PojoPrefabManagerTest {
                 return new PojoPrefab(uri, data);
             }
         });
-        CoreRegistry.put(AssetManager.class, assetManager);
+        context.put(AssetManager.class, assetManager);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
@@ -25,9 +25,8 @@ import org.terasology.asset.AssetManagerImpl;
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.context.internal.ContextImpl;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
-import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.entitySystem.prefab.PrefabManager;
@@ -37,7 +36,6 @@ import org.terasology.entitySystem.stubs.OrderedMapTestComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
@@ -63,12 +61,13 @@ public class PrefabTest {
 
     @Before
     public void setup() throws Exception {
-        CoreRegistry.setContext(new ContextImpl());
+        ContextImpl context = new ContextImpl();
+        CoreRegistry.setContext(context);
         ModuleManager moduleManager = ModuleManagerFactory.create();
+        context.put(ModuleManager.class, moduleManager);
 
         AssetManager assetManager = new AssetManagerImpl(moduleManager.getEnvironment());
-        CoreRegistry.put(ModuleManager.class, moduleManager);
-        CoreRegistry.put(AssetManager.class, assetManager);
+        context.put(AssetManager.class, assetManager);
         AssetType.registerAssetTypes(assetManager);
         assetManager.setAssetFactory(AssetType.PREFAB, new AssetFactory<PrefabData, Prefab>() {
             @Override
@@ -78,7 +77,9 @@ public class PrefabTest {
         });
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
-        EntityManager em = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        context.put(NetworkSystem.class, networkSystem);
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
         prefabManager = new PojoPrefabManager();
     }
 

--- a/engine-tests/src/test/java/org/terasology/entitySystem/metadata/ComponentMetadataTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/metadata/ComponentMetadataTest.java
@@ -18,6 +18,7 @@ package org.terasology.entitySystem.metadata;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.terasology.context.Context;
 import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.stubs.OwnerComponent;
@@ -26,7 +27,6 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
-import org.terasology.registry.CoreRegistry;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -36,17 +36,20 @@ import static org.junit.Assert.assertTrue;
  */
 public class ComponentMetadataTest {
 
+    private Context context;
     private ReflectFactory reflectFactory = new ReflectionReflectFactory();
     private CopyStrategyLibrary copyStrategies = new CopyStrategyLibrary(reflectFactory);
 
     @Before
     public void prepare() {
-        CoreRegistry.setContext(new ContextImpl());
+        context = new ContextImpl();
+        context.put(ReflectFactory.class, reflectFactory);
+        context.put(CopyStrategyLibrary.class, copyStrategies);
     }
 
     @Test
     public void staticFieldsIgnored() {
-        EntitySystemLibrary entitySystemLibrary = new EntitySystemLibrary(reflectFactory, copyStrategies, new TypeSerializationLibrary(reflectFactory, copyStrategies));
+        EntitySystemLibrary entitySystemLibrary = new EntitySystemLibrary(context, new TypeSerializationLibrary(reflectFactory, copyStrategies));
         ComponentLibrary lib = entitySystemLibrary.getComponentLibrary();
         lib.register(new SimpleUri("unittest:string"), StringComponent.class);
         ComponentMetadata<StringComponent> metadata = lib.getMetadata(StringComponent.class);
@@ -55,7 +58,7 @@ public class ComponentMetadataTest {
 
     @Test
     public void ownsReferencesPopulated() {
-        EntitySystemLibrary entitySystemLibrary = new EntitySystemLibrary(reflectFactory, copyStrategies, new TypeSerializationLibrary(reflectFactory, copyStrategies));
+        EntitySystemLibrary entitySystemLibrary = new EntitySystemLibrary(context, new TypeSerializationLibrary(reflectFactory, copyStrategies));
         ComponentLibrary lib = entitySystemLibrary.getComponentLibrary();
         lib.register(new SimpleUri("unittest:owner"), OwnerComponent.class);
         ComponentMetadata<OwnerComponent> metadata = lib.getMetadata(OwnerComponent.class);

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/FactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/FactoryTest.java
@@ -45,12 +45,14 @@ import static org.mockito.Mockito.mock;
  * @author synopia
  */
 public class FactoryTest {
+    private Context context;
+
     @Test
     public void testSaveLoad() throws IOException {
         AssetManager assetManager = mock(AssetManager.class);
-        CoreRegistry.put(AssetManager.class, assetManager);
+        context.put(AssetManager.class, assetManager);
         BehaviorNodeFactory nodeFactory = mock(BehaviorNodeFactory.class);
-        CoreRegistry.put(BehaviorNodeFactory.class, nodeFactory);
+        context.put(BehaviorNodeFactory.class, nodeFactory);
         BehaviorTreeLoader loader = new BehaviorTreeLoader();
         BehaviorTreeData data = buildSample();
 
@@ -82,7 +84,7 @@ public class FactoryTest {
 
     @Before
     public void setup() throws Exception {
-        Context context = new ContextImpl();
+        this.context = new ContextImpl();
         CoreRegistry.setContext(context);
         ModuleManager moduleManager = ModuleManagerFactory.create();
         ReflectionReflectFactory reflectFactory = new ReflectionReflectFactory();
@@ -90,7 +92,7 @@ public class FactoryTest {
         CopyStrategyLibrary copyStrategies = new CopyStrategyLibrary(reflectFactory);
         context.put(CopyStrategyLibrary.class, copyStrategies);
         context.put(ModuleManager.class, moduleManager);
-        NodesClassLibrary nodesClassLibrary = new NodesClassLibrary(reflectFactory, copyStrategies);
+        NodesClassLibrary nodesClassLibrary = new NodesClassLibrary(context);
         context.put(NodesClassLibrary.class, nodesClassLibrary);
         nodesClassLibrary.scan(moduleManager.getEnvironment());
     }

--- a/engine-tests/src/test/java/org/terasology/network/internal/NetworkOwnershipTest.java
+++ b/engine-tests/src/test/java/org/terasology/network/internal/NetworkOwnershipTest.java
@@ -21,14 +21,16 @@ import org.junit.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
+import org.terasology.entitySystem.entity.internal.PojoEntityManager;
 import org.terasology.entitySystem.metadata.EntitySystemLibrary;
 import org.terasology.network.NetworkComponent;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.network.NetworkSystem;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.world.BlockEntityRegistry;
 
@@ -56,8 +58,11 @@ public class NetworkOwnershipTest extends TerasologyTestingEnvironment {
         context.put(ModuleManager.class, moduleManager);
         EngineTime mockTime = mock(EngineTime.class);
         networkSystem = new NetworkSystemImpl(mockTime, context);
+        context.put(NetworkSystem.class, networkSystem);
 
-        entityManager = new EntitySystemBuilder().build(context.get(ModuleManager.class).getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = (PojoEntityManager) context.get(EntityManager.class);
         context.put(ComponentSystemManager.class, new ComponentSystemManager());
         entityManager.clear();
         client = mock(NetClient.class);

--- a/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/WorldSerializerTest.java
@@ -23,7 +23,7 @@ import org.terasology.asset.AssetType;
 import org.terasology.context.Context;
 import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -32,12 +32,10 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.stubs.GetterSetterComponent;
 import org.terasology.entitySystem.stubs.IntegerComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
-import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.serializers.PrefabSerializer;
 import org.terasology.persistence.serializers.WorldSerializer;
 import org.terasology.persistence.serializers.WorldSerializerImpl;
 import org.terasology.protobuf.EntityData;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
@@ -65,12 +63,14 @@ public class WorldSerializerTest {
     @Before
     public void setup() {
         Context context = new ContextImpl();
+        context.put(ModuleManager.class, moduleManager);
         AssetManager assetManager = mock(AssetManager.class);
         context.put(AssetManager.class,assetManager);
         CoreRegistry.setContext(context);
         when(assetManager.listLoadedAssets(AssetType.PREFAB, Prefab.class)).thenReturn(Collections.<Prefab>emptyList());
-        EntitySystemBuilder builder = new EntitySystemBuilder();
-        entityManager = builder.build(moduleManager.getEnvironment(), mock(NetworkSystem.class), new ReflectionReflectFactory());
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = context.get(EngineEntityManager.class);
         entityManager.getComponentLibrary().register(new SimpleUri("test", "gettersetter"), GetterSetterComponent.class);
         entityManager.getComponentLibrary().register(new SimpleUri("test", "string"), StringComponent.class);
         entityManager.getComponentLibrary().register(new SimpleUri("test", "integer"), IntegerComponent.class);

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -31,7 +31,7 @@ import org.terasology.context.Context;
 import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -49,7 +49,6 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.ChunkStore;
 import org.terasology.persistence.PlayerStore;
 import org.terasology.persistence.StorageManager;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.world.WorldProvider;
@@ -101,10 +100,11 @@ public class StorageManagerTest {
     private Block testBlock2;
     private EntityRef character;
     private Path savePath;
+    private Context context;
 
     @Before
     public void setup() throws Exception {
-        Context context = new ContextImpl();
+        context = new ContextImpl();
         CoreRegistry.setContext(context);
         JavaArchive homeArchive = ShrinkWrap.create(JavaArchive.class);
         FileSystem vfs = ShrinkWrapFileSystems.newFileSystem(homeArchive);
@@ -121,8 +121,11 @@ public class StorageManagerTest {
         context.put(AssetManager.class, new AssetManagerImpl(moduleManager.getEnvironment()));
         context.put(NetworkSystem.class, networkSystem);
 
-        entityManager = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem,
-                new ReflectionReflectFactory());
+
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+
+        entityManager = context.get(EngineEntityManager.class);
 
         esm = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), entityManager, false);
         context.put(StorageManager.class, esm);
@@ -229,7 +232,11 @@ public class StorageManagerTest {
 
         esm.waitForCompletionOfPreviousSaveAndStartSaving();
         esm.finishSavingAndShutdown();
-        EngineEntityManager newEntityManager = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
+
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
+
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), newEntityManager, false);
         newSM.loadGlobalStore();
 
@@ -247,7 +254,9 @@ public class StorageManagerTest {
         esm.waitForCompletionOfPreviousSaveAndStartSaving();
         esm.finishSavingAndShutdown();
 
-        EngineEntityManager newEntityManager = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), newEntityManager, false);
         newSM.loadGlobalStore();
 
@@ -296,7 +305,9 @@ public class StorageManagerTest {
         esm.waitForCompletionOfPreviousSaveAndStartSaving();
         esm.finishSavingAndShutdown();
 
-        EngineEntityManager newEntityManager = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), newEntityManager,
                 storeChunkInZips);
         newSM.loadGlobalStore();
@@ -329,7 +340,9 @@ public class StorageManagerTest {
         esm.waitForCompletionOfPreviousSaveAndStartSaving();
         esm.finishSavingAndShutdown();
 
-        EngineEntityManager newEntityManager = new EntitySystemBuilder().build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(), newEntityManager, false);
         newSM.loadGlobalStore();
 

--- a/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
@@ -32,7 +32,7 @@ import org.terasology.context.Context;
 import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameThread;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -59,7 +59,6 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.network.NetworkComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.testUtil.WorldProviderCoreStub;
@@ -126,14 +125,16 @@ public class EntityAwareWorldProviderTest {
                 return new PojoPrefab(uri, data);
             }
         });
-        EntitySystemBuilder builder = new EntitySystemBuilder();
-
-        CoreRegistry.put(ComponentSystemManager.class, mock(ComponentSystemManager.class));
+        context.put(ComponentSystemManager.class, mock(ComponentSystemManager.class));
 
         blockManager = CoreRegistry.put(BlockManager.class, new BlockManagerImpl(mock(WorldAtlas.class), new DefaultBlockFamilyFactoryRegistry()));
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
-        entityManager = builder.build(moduleManager.getEnvironment(), networkSystem, new ReflectionReflectFactory());
+        context.put(NetworkSystem.class, networkSystem);
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+
+        entityManager = context.get(EngineEntityManager.class);
         worldStub = new WorldProviderCoreStub();
         worldProvider = new EntityAwareWorldProvider(worldStub, entityManager);
 

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -96,7 +96,7 @@ public class EntitySystemSetupUtil {
         entityManager.setTypeSerializerLibrary(typeSerializationLibrary);
 
         // Entity System Library
-        EntitySystemLibrary library = new EntitySystemLibrary(reflectFactory, copyStrategyLibrary, typeSerializationLibrary);
+        EntitySystemLibrary library = new EntitySystemLibrary(context, typeSerializationLibrary);
         context.put(EntitySystemLibrary.class, library);
         entityManager.setComponentLibrary(library.getComponentLibrary());
         context.put(ComponentLibrary.class, library.getComponentLibrary());
@@ -116,7 +116,7 @@ public class EntitySystemSetupUtil {
         context.put(OneOfProviderFactory.class, new OneOfProviderFactory());
 
         // Behaviour Trees Node Library
-        NodesClassLibrary nodesClassLibrary = new NodesClassLibrary(reflectFactory, copyStrategyLibrary);
+        NodesClassLibrary nodesClassLibrary = new NodesClassLibrary(context);
         context.put(NodesClassLibrary.class, nodesClassLibrary);
         nodesClassLibrary.scan(environment);
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -18,9 +18,9 @@ package org.terasology.engine.modes;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.Time;
@@ -72,6 +72,7 @@ public class StateLoading implements GameState {
 
     private static final Logger logger = LoggerFactory.getLogger(StateLoading.class);
 
+    private Context context;
     private GameManifest gameManifest;
     private NetworkMode netMode;
     private Queue<LoadProcess> loadProcesses = Queues.newArrayDeque();
@@ -113,13 +114,14 @@ public class StateLoading implements GameState {
 
     @Override
     public void init(GameEngine engine) {
-        CoreRegistry.setContext(engine.createChildContext());
+        this.context = engine.createChildContext();
+        CoreRegistry.setContext(context);
 
         EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
         time.setPaused(true);
         time.setGameTime(0);
 
-        CoreRegistry.get(Game.class).load(gameManifest);
+        context.get(Game.class).load(gameManifest);
         switch (netMode) {
             case CLIENT:
                 initClient();
@@ -148,7 +150,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new RegisterBiomes(gameManifest));
         loadProcesses.add(new CacheBlocks());
         loadProcesses.add(new InitialiseGraphics());
-        loadProcesses.add(new InitialiseEntitySystem());
+        loadProcesses.add(new InitialiseEntitySystem(context));
         loadProcesses.add(new LoadPrefabs());
         loadProcesses.add(new ProcessBlockPrefabs());
         loadProcesses.add(new RegisterInputSystem());
@@ -173,7 +175,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new RegisterBiomes(gameManifest));
         loadProcesses.add(new CacheBlocks());
         loadProcesses.add(new InitialiseGraphics());
-        loadProcesses.add(new InitialiseEntitySystem());
+        loadProcesses.add(new InitialiseEntitySystem(context));
         loadProcesses.add(new LoadPrefabs());
         loadProcesses.add(new ProcessBlockPrefabs());
         loadProcesses.add(new RegisterInputSystem());

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -96,7 +96,6 @@ public class StateLoading implements GameState {
         Preconditions.checkArgument(netMode != NetworkMode.CLIENT);
 
         this.gameManifest = gameManifest;
-        this.nuiManager = CoreRegistry.get(NUIManager.class);
         this.netMode = netMode;
     }
 
@@ -107,7 +106,6 @@ public class StateLoading implements GameState {
      */
     public StateLoading(JoinStatus joinStatus) {
         this.gameManifest = new GameManifest();
-        this.nuiManager = CoreRegistry.get(NUIManager.class);
         this.netMode = NetworkMode.CLIENT;
         this.joinStatus = joinStatus;
     }
@@ -117,7 +115,9 @@ public class StateLoading implements GameState {
         this.context = engine.createChildContext();
         CoreRegistry.setContext(context);
 
-        EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
+        this.nuiManager = context.get(NUIManager.class);
+
+        EngineTime time = (EngineTime) context.get(Time.class);
         time.setPaused(true);
         time.setGameTime(0);
 
@@ -143,53 +143,53 @@ public class StateLoading implements GameState {
     }
 
     private void initClient() {
-        loadProcesses.add(new JoinServer(gameManifest, joinStatus));
+        loadProcesses.add(new JoinServer(context, gameManifest, joinStatus));
         loadProcesses.add(new CacheTextures());
-        loadProcesses.add(new RegisterBlockFamilyFactories());
-        loadProcesses.add(new RegisterBlocks(gameManifest));
-        loadProcesses.add(new RegisterBiomes(gameManifest));
+        loadProcesses.add(new RegisterBlockFamilyFactories(context));
+        loadProcesses.add(new RegisterBlocks(context, gameManifest));
+        loadProcesses.add(new RegisterBiomes(context, gameManifest));
         loadProcesses.add(new CacheBlocks());
-        loadProcesses.add(new InitialiseGraphics());
+        loadProcesses.add(new InitialiseGraphics(context));
         loadProcesses.add(new InitialiseEntitySystem(context));
         loadProcesses.add(new LoadPrefabs());
-        loadProcesses.add(new ProcessBlockPrefabs());
-        loadProcesses.add(new RegisterInputSystem());
-        loadProcesses.add(new RegisterSystems(netMode));
-        loadProcesses.add(new InitialiseCommandSystem());
-        loadProcesses.add(new InitialiseRemoteWorld(gameManifest));
-        loadProcesses.add(new InitialisePhysics());
-        loadProcesses.add(new InitialiseSystems());
-        loadProcesses.add(new PreBeginSystems());
-        loadProcesses.add(new CreateRemoteWorldEntity());
-        loadProcesses.add(new PostBeginSystems());
-        loadProcesses.add(new SetupRemotePlayer());
-        loadProcesses.add(new AwaitCharacterSpawn());
-        loadProcesses.add(new PrepareWorld());
+        loadProcesses.add(new ProcessBlockPrefabs(context));
+        loadProcesses.add(new RegisterInputSystem(context));
+        loadProcesses.add(new RegisterSystems(context, netMode));
+        loadProcesses.add(new InitialiseCommandSystem(context));
+        loadProcesses.add(new InitialiseRemoteWorld(context, gameManifest));
+        loadProcesses.add(new InitialisePhysics(context));
+        loadProcesses.add(new InitialiseSystems(context));
+        loadProcesses.add(new PreBeginSystems(context));
+        loadProcesses.add(new CreateRemoteWorldEntity(context));
+        loadProcesses.add(new PostBeginSystems(context));
+        loadProcesses.add(new SetupRemotePlayer(context));
+        loadProcesses.add(new AwaitCharacterSpawn(context));
+        loadProcesses.add(new PrepareWorld(context));
     }
 
     private void initHost() {
-        loadProcesses.add(new RegisterMods(gameManifest));
+        loadProcesses.add(new RegisterMods(context, gameManifest));
         loadProcesses.add(new CacheTextures());
-        loadProcesses.add(new RegisterBlockFamilyFactories());
-        loadProcesses.add(new RegisterBlocks(gameManifest));
-        loadProcesses.add(new RegisterBiomes(gameManifest));
+        loadProcesses.add(new RegisterBlockFamilyFactories(context));
+        loadProcesses.add(new RegisterBlocks(context, gameManifest));
+        loadProcesses.add(new RegisterBiomes(context, gameManifest));
         loadProcesses.add(new CacheBlocks());
-        loadProcesses.add(new InitialiseGraphics());
+        loadProcesses.add(new InitialiseGraphics(context));
         loadProcesses.add(new InitialiseEntitySystem(context));
         loadProcesses.add(new LoadPrefabs());
-        loadProcesses.add(new ProcessBlockPrefabs());
-        loadProcesses.add(new RegisterInputSystem());
-        loadProcesses.add(new RegisterSystems(netMode));
-        loadProcesses.add(new InitialiseCommandSystem());
+        loadProcesses.add(new ProcessBlockPrefabs(context));
+        loadProcesses.add(new RegisterInputSystem(context));
+        loadProcesses.add(new RegisterSystems(context, netMode));
+        loadProcesses.add(new InitialiseCommandSystem(context));
         loadProcesses.add(new InitialiseWorld(gameManifest, context));
-        loadProcesses.add(new EnsureSaveGameConsistency());
-        loadProcesses.add(new InitialisePhysics());
-        loadProcesses.add(new InitialiseSystems());
-        loadProcesses.add(new LoadEntities());
-        loadProcesses.add(new PreBeginSystems());
-        loadProcesses.add(new InitialiseBlockTypeEntities());
-        loadProcesses.add(new CreateWorldEntity());
-        loadProcesses.add(new InitialiseWorldGenerator());
+        loadProcesses.add(new EnsureSaveGameConsistency(context));
+        loadProcesses.add(new InitialisePhysics(context));
+        loadProcesses.add(new InitialiseSystems(context));
+        loadProcesses.add(new LoadEntities(context));
+        loadProcesses.add(new PreBeginSystems(context));
+        loadProcesses.add(new InitialiseBlockTypeEntities(context));
+        loadProcesses.add(new CreateWorldEntity(context));
+        loadProcesses.add(new InitialiseWorldGenerator(context));
         if (netMode.isServer()) {
             boolean dedicated;
             if (netMode == NetworkMode.DEDICATED_SERVER) {
@@ -199,14 +199,14 @@ public class StateLoading implements GameState {
             } else {
                 throw new IllegalStateException("Invalid server mode: " + netMode);
             }
-            loadProcesses.add(new StartServer(dedicated));
+            loadProcesses.add(new StartServer(context, dedicated));
         }
-        loadProcesses.add(new PostBeginSystems());
+        loadProcesses.add(new PostBeginSystems(context));
         if (netMode.hasLocalClient()) {
-            loadProcesses.add(new SetupLocalPlayer());
-            loadProcesses.add(new AwaitCharacterSpawn());
+            loadProcesses.add(new SetupLocalPlayer(context));
+            loadProcesses.add(new AwaitCharacterSpawn(context));
         }
-        loadProcesses.add(new PrepareWorld());
+        loadProcesses.add(new PrepareWorld(context));
     }
 
     private void popStep() {
@@ -223,7 +223,7 @@ public class StateLoading implements GameState {
 
     @Override
     public void dispose() {
-        EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
+        EngineTime time = (EngineTime) context.get(Time.class);
         time.setPaused(false);
     }
 
@@ -233,8 +233,8 @@ public class StateLoading implements GameState {
 
     @Override
     public void update(float delta) {
-        GameEngine gameEngine = CoreRegistry.get(GameEngine.class);
-        EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
+        GameEngine gameEngine = context.get(GameEngine.class);
+        EngineTime time = (EngineTime) context.get(Time.class);
         long startTime = time.getRawTimeInMs();
         while (current != null && time.getRawTimeInMs() - startTime < 20 && !gameEngine.hasPendingState()) {
             if (current.step()) {
@@ -244,7 +244,7 @@ public class StateLoading implements GameState {
         if (current == null) {
             nuiManager.closeScreen(loadingScreen);
             nuiManager.setHUDVisible(true);
-            CoreRegistry.get(GameEngine.class).changeState(new StateIngame(gameManifest));
+            context.get(GameEngine.class).changeState(new StateIngame(gameManifest));
         } else {
             float progressValue = (progress + current.getExpectedCost() * current.getProgress()) / maxProgress;
             loadingScreen.updateStatus(current.getMessage(), progressValue);

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -181,7 +181,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new RegisterInputSystem());
         loadProcesses.add(new RegisterSystems(netMode));
         loadProcesses.add(new InitialiseCommandSystem());
-        loadProcesses.add(new InitialiseWorld(gameManifest));
+        loadProcesses.add(new InitialiseWorld(gameManifest, context));
         loadProcesses.add(new EnsureSaveGameConsistency());
         loadProcesses.add(new InitialisePhysics());
         loadProcesses.add(new InitialiseSystems());

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -21,9 +21,8 @@ import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.LoggingContext;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.modes.loadProcesses.RegisterInputSystem;
-import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
@@ -35,9 +34,6 @@ import org.terasology.logic.console.ConsoleSystem;
 import org.terasology.logic.console.commands.CoreCommands;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.ClientComponent;
-import org.terasology.network.NetworkSystem;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
@@ -76,8 +72,8 @@ public class StateMainMenu implements GameState {
         CoreRegistry.setContext(context);
 
         //let's get the entity event system running
-        entityManager = new EntitySystemBuilder().build(context.get(ModuleManager.class).getEnvironment(),
-                context.get(NetworkSystem.class), context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = context.get(EngineEntityManager.class);
 
         eventSystem = context.get(EventSystem.class);
         context.put(Console.class, new ConsoleImpl());

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -98,7 +98,7 @@ public class StateMainMenu implements GameState {
         inputSystem = context.get(InputSystem.class);
 
         // TODO: REMOVE this and handle refreshing of core game state at the engine level - see Issue #1127
-        new RegisterInputSystem().step();
+        new RegisterInputSystem(context).step();
 
         EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
         LocalPlayer localPlayer = new LocalPlayer();

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitCharacterSpawn.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitCharacterSpawn.java
@@ -16,8 +16,8 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.engine.modes.LoadProcess;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.players.LocalPlayer;
@@ -29,7 +29,12 @@ import org.terasology.rendering.world.WorldRenderer;
  */
 public class AwaitCharacterSpawn implements LoadProcess {
 
+    private final Context context;
     private WorldRenderer worldRenderer;
+
+    public AwaitCharacterSpawn(Context context) {
+        this.context = context;
+    }
 
     @Override
     public String getMessage() {
@@ -38,14 +43,14 @@ public class AwaitCharacterSpawn implements LoadProcess {
 
     @Override
     public boolean step() {
-        ComponentSystemManager componentSystemManager = CoreRegistry.get(ComponentSystemManager.class);
+        ComponentSystemManager componentSystemManager = context.get(ComponentSystemManager.class);
         for (UpdateSubscriberSystem updater : componentSystemManager.iterateUpdateSubscribers()) {
             updater.update(0.0f);
         }
-        LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
+        LocalPlayer localPlayer = context.get(LocalPlayer.class);
         ClientComponent client = localPlayer.getClientEntity().getComponent(ClientComponent.class);
         if (client != null && client.character.exists()) {
-            worldRenderer.setPlayer(CoreRegistry.get(LocalPlayer.class));
+            worldRenderer.setPlayer(context.get(LocalPlayer.class));
             return true;
         } else {
             worldRenderer.getChunkProvider().completeUpdate();
@@ -56,7 +61,7 @@ public class AwaitCharacterSpawn implements LoadProcess {
 
     @Override
     public void begin() {
-        worldRenderer = CoreRegistry.get(WorldRenderer.class);
+        worldRenderer = context.get(WorldRenderer.class);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/CreateRemoteWorldEntity.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/CreateRemoteWorldEntity.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldComponent;
 
@@ -29,6 +29,12 @@ import org.terasology.world.WorldComponent;
  */
 public class CreateRemoteWorldEntity extends SingleStepLoadProcess {
 
+    private final Context context;
+
+    public CreateRemoteWorldEntity(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Linking world";
@@ -36,8 +42,8 @@ public class CreateRemoteWorldEntity extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
-        WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
+        EntityManager entityManager = context.get(EntityManager.class);
+        WorldRenderer worldRenderer = context.get(WorldRenderer.class);
 
         EntityRef worldEntity = entityManager.create();
         worldEntity.addComponent(new WorldComponent());

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/CreateWorldEntity.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/CreateWorldEntity.java
@@ -18,11 +18,11 @@ package org.terasology.engine.modes.loadProcesses;
 
 import com.google.common.base.Optional;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.generator.WorldConfigurator;
@@ -35,6 +35,13 @@ import java.util.Map;
  * @author Immortius
  */
 public class CreateWorldEntity extends SingleStepLoadProcess {
+
+    private final Context context;
+
+    public CreateWorldEntity(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Creating World Entity...";
@@ -42,8 +49,8 @@ public class CreateWorldEntity extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
-        WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
+        EntityManager entityManager = context.get(EntityManager.class);
+        WorldRenderer worldRenderer = context.get(WorldRenderer.class);
 
         Iterator<EntityRef> worldEntityIterator = entityManager.getEntitiesWith(WorldComponent.class).iterator();
         // TODO: Move the world renderer bits elsewhere
@@ -53,7 +60,7 @@ public class CreateWorldEntity extends SingleStepLoadProcess {
 
             // get the world generator config from the world entity
             // replace the world generator values from the components in the world entity
-            WorldGenerator worldGenerator = CoreRegistry.get(WorldGenerator.class);
+            WorldGenerator worldGenerator = context.get(WorldGenerator.class);
             Optional<WorldConfigurator> ocf = worldGenerator.getConfigurator();
 
             if (ocf.isPresent()) {
@@ -74,12 +81,12 @@ public class CreateWorldEntity extends SingleStepLoadProcess {
             worldRenderer.getChunkProvider().setWorldEntity(worldEntity);
 
             // transfer all world generation parameters from Config to WorldEntity
-            WorldGenerator worldGenerator = CoreRegistry.get(WorldGenerator.class);
+            WorldGenerator worldGenerator = context.get(WorldGenerator.class);
             Optional<WorldConfigurator> ocf = worldGenerator.getConfigurator();
 
             if (ocf.isPresent()) {
                 SimpleUri generatorUri = worldGenerator.getUri();
-                Config config = CoreRegistry.get(Config.class);
+                Config config = context.get(Config.class);
 
                 // get the map of properties from the world generator.  Replace its values with values from the config set by the UI.
                 // Also set all the components to the world entity.

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/EnsureSaveGameConsistency.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/EnsureSaveGameConsistency.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.engine.modes.LoadProcess;
 import org.terasology.persistence.StorageManager;
-import org.terasology.registry.CoreRegistry;
 
 import java.io.IOException;
 
@@ -27,7 +27,11 @@ import java.io.IOException;
  * @author Florian
  */
 public class EnsureSaveGameConsistency implements LoadProcess {
+    private final Context context;
 
+    public EnsureSaveGameConsistency(Context context) {
+        this.context = context;
+    }
 
     @Override
     public String getMessage() {
@@ -37,7 +41,7 @@ public class EnsureSaveGameConsistency implements LoadProcess {
     @Override
     public boolean step() {
         try {
-            CoreRegistry.get(StorageManager.class).checkAndRepairSaveIfNecessary();
+            context.get(StorageManager.class).checkAndRepairSaveIfNecessary();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseBlockTypeEntities.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseBlockTypeEntities.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.internal.BlockManagerImpl;
@@ -26,6 +26,12 @@ import org.terasology.world.block.typeEntity.BlockTypeEntityGenerator;
  */
 public class InitialiseBlockTypeEntities extends SingleStepLoadProcess {
 
+    private final Context context;
+
+    public InitialiseBlockTypeEntities(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialising Block Type Entities";
@@ -33,8 +39,8 @@ public class InitialiseBlockTypeEntities extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        BlockManagerImpl blockManager = (BlockManagerImpl) CoreRegistry.get(BlockManager.class);
-        blockManager.subscribe(new BlockTypeEntityGenerator(CoreRegistry.get(EntityManager.class), blockManager));
+        BlockManagerImpl blockManager = (BlockManagerImpl) context.get(BlockManager.class);
+        blockManager.subscribe(new BlockTypeEntityGenerator(context.get(EntityManager.class), blockManager));
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseCommandSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseCommandSystem.java
@@ -16,7 +16,7 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.ConsoleImpl;
 
@@ -24,6 +24,13 @@ import org.terasology.logic.console.ConsoleImpl;
  * @author Immortius
  */
 public class InitialiseCommandSystem extends SingleStepLoadProcess {
+
+    private Context context;
+
+    public InitialiseCommandSystem(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialising Command System...";
@@ -31,7 +38,7 @@ public class InitialiseCommandSystem extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        CoreRegistry.put(Console.class, new ConsoleImpl());
+        context.put(Console.class, new ConsoleImpl());
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseEntitySystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseEntitySystem.java
@@ -16,17 +16,20 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
-import org.terasology.engine.module.ModuleManager;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.registry.CoreRegistry;
-import org.terasology.engine.bootstrap.EntitySystemBuilder;
-import org.terasology.network.NetworkSystem;
+import org.terasology.context.Context;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 
 /**
  * @author Immortius
  */
 public class InitialiseEntitySystem extends SingleStepLoadProcess {
+
+    private final Context context;
+
+    public InitialiseEntitySystem(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialising Entity System...";
@@ -34,9 +37,7 @@ public class InitialiseEntitySystem extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
-        new EntitySystemBuilder().build(moduleManager.getEnvironment(), CoreRegistry.get(NetworkSystem.class),
-                CoreRegistry.get(ReflectFactory.class), CoreRegistry.get(CopyStrategyLibrary.class));
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
@@ -17,10 +17,9 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
+import org.terasology.context.Context;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.math.geom.Vector4f;
-import org.terasology.registry.CoreRegistry;
-import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.primitives.Tessellator;
@@ -30,6 +29,13 @@ import org.terasology.rendering.primitives.TessellatorHelper;
  * @author Immortius
  */
 public class InitialiseGraphics extends SingleStepLoadProcess {
+
+    private final Context context;
+
+    public InitialiseGraphics(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialising Graphics";
@@ -37,7 +43,7 @@ public class InitialiseGraphics extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        NUIManager nuiManager = CoreRegistry.get(NUIManager.class);
+        NUIManager nuiManager = context.get(NUIManager.class);
         ((NUIManagerInternal) nuiManager).refreshWidgetsLibrary();
 
         // TODO: This should be elsewhere

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialisePhysics.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialisePhysics.java
@@ -15,16 +15,22 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.physics.Physics;
 import org.terasology.physics.bullet.BulletPhysics;
 import org.terasology.physics.engine.PhysicsEngine;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 
 /**
  * @author Immortius
  */
 public class InitialisePhysics extends SingleStepLoadProcess {
+    private final Context context;
+
+    public InitialisePhysics(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Turning on gravity";
@@ -32,9 +38,9 @@ public class InitialisePhysics extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        BulletPhysics physicsEngine = new BulletPhysics(CoreRegistry.get(WorldProvider.class));
-        CoreRegistry.put(Physics.class, physicsEngine);
-        CoreRegistry.put(PhysicsEngine.class, physicsEngine);
+        BulletPhysics physicsEngine = new BulletPhysics(context.get(WorldProvider.class));
+        context.put(Physics.class, physicsEngine);
+        context.put(PhysicsEngine.class, physicsEngine);
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseSystems.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseSystems.java
@@ -16,18 +16,25 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.metadata.EntitySystemLibrary;
 import org.terasology.network.NetworkSystem;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.BlockEntityRegistry;
 
 /**
  * @author Immortius
  */
 public class InitialiseSystems extends SingleStepLoadProcess {
+
+    private final Context context;
+
+    public InitialiseSystems(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialising Systems...";
@@ -35,12 +42,12 @@ public class InitialiseSystems extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        EngineEntityManager entityManager = (EngineEntityManager) CoreRegistry.get(EntityManager.class);
-        EntitySystemLibrary entitySystemLibrary = CoreRegistry.get(EntitySystemLibrary.class);
-        BlockEntityRegistry blockEntityRegistry = CoreRegistry.get(BlockEntityRegistry.class);
+        EngineEntityManager entityManager = (EngineEntityManager) context.get(EntityManager.class);
+        EntitySystemLibrary entitySystemLibrary = context.get(EntitySystemLibrary.class);
+        BlockEntityRegistry blockEntityRegistry = context.get(BlockEntityRegistry.class);
 
-        CoreRegistry.get(NetworkSystem.class).connectToEntitySystem(entityManager, entitySystemLibrary, blockEntityRegistry);
-        ComponentSystemManager csm = CoreRegistry.get(ComponentSystemManager.class);
+        context.get(NetworkSystem.class).connectToEntitySystem(entityManager, entitySystemLibrary, blockEntityRegistry);
+        ComponentSystemManager csm = context.get(ComponentSystemManager.class);
         csm.initialise();
 
         return true;

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -16,12 +16,10 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
-import java.io.IOException;
-import java.nio.file.Path;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.TerasologyConstants;
@@ -38,9 +36,6 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.internal.ReadOnlyStorageManager;
 import org.terasology.persistence.internal.ReadWriteStorageManager;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.backdrop.Skysphere;
@@ -60,9 +55,12 @@ import org.terasology.world.internal.EntityAwareWorldProvider;
 import org.terasology.world.internal.WorldInfo;
 import org.terasology.world.internal.WorldProviderCoreImpl;
 import org.terasology.world.internal.WorldProviderWrapper;
-import org.terasology.world.sun.CelestialSystem;
 import org.terasology.world.sun.BasicCelestialModel;
+import org.terasology.world.sun.CelestialSystem;
 import org.terasology.world.sun.DefaultCelestialSystem;
+
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * @author Immortius
@@ -72,9 +70,11 @@ public class InitialiseWorld extends SingleStepLoadProcess {
     private static final Logger logger = LoggerFactory.getLogger(InitialiseWorld.class);
 
     private GameManifest gameManifest;
+    private Context context;
 
-    public InitialiseWorld(GameManifest gameManifest) {
+    public InitialiseWorld(GameManifest gameManifest, Context context) {
         this.gameManifest = gameManifest;
+        this.context = context;
     }
 
     @Override
@@ -85,9 +85,8 @@ public class InitialiseWorld extends SingleStepLoadProcess {
     @Override
     public boolean step() {
 
-        ModuleEnvironment environment = CoreRegistry.get(ModuleManager.class).getEnvironment();
-        CoreRegistry.put(WorldGeneratorPluginLibrary.class, new DefaultWorldGeneratorPluginLibrary(environment,
-                CoreRegistry.get(ReflectFactory.class), CoreRegistry.get(CopyStrategyLibrary.class)));
+        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
+        context.put(WorldGeneratorPluginLibrary.class, new DefaultWorldGeneratorPluginLibrary(environment, context));
 
         WorldInfo worldInfo = gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD);
         if (worldInfo.getSeed() == null || worldInfo.getSeed().isEmpty()) {
@@ -98,23 +97,23 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         logger.info("World seed: \"{}\"", worldInfo.getSeed());
 
         // TODO: Separate WorldRenderer from world handling in general
-        WorldGeneratorManager worldGeneratorManager = CoreRegistry.get(WorldGeneratorManager.class);
+        WorldGeneratorManager worldGeneratorManager = context.get(WorldGeneratorManager.class);
         WorldGenerator worldGenerator;
         try {
             worldGenerator = worldGeneratorManager.createGenerator(worldInfo.getWorldGenerator());
             // setting the world seed will create the world builder
             worldGenerator.setWorldSeed(worldInfo.getSeed());
-            CoreRegistry.put(WorldGenerator.class, worldGenerator);
+            context.put(WorldGenerator.class, worldGenerator);
         } catch (UnresolvedWorldGeneratorException e) {
             logger.error("Unable to load world generator {}. Available world generators: {}",
                     worldInfo.getWorldGenerator(), worldGeneratorManager.getWorldGenerators());
-            CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu("Failed to resolve world generator."));
+            context.get(GameEngine.class).changeState(new StateMainMenu("Failed to resolve world generator."));
             return true; // We need to return true, otherwise the loading state will just call us again immediately
         }
 
         // Init. a new world
-        EngineEntityManager entityManager = (EngineEntityManager) CoreRegistry.get(EntityManager.class);
-        boolean writeSaveGamesEnabled = CoreRegistry.get(Config.class).getTransients().isWriteSaveGamesEnabled();
+        EngineEntityManager entityManager = (EngineEntityManager) context.get(EntityManager.class);
+        boolean writeSaveGamesEnabled = context.get(Config.class).getTransients().isWriteSaveGamesEnabled();
         Path savePath = PathManager.getInstance().getSavePath(gameManifest.getTitle());
         StorageManager storageManager;
         try {
@@ -123,37 +122,37 @@ public class InitialiseWorld extends SingleStepLoadProcess {
                     : new ReadOnlyStorageManager(savePath, environment, entityManager);
         } catch (IOException e) {
             logger.error("Unable to create storage manager!", e);
-            CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu("Unable to create storage manager!"));
+            context.get(GameEngine.class).changeState(new StateMainMenu("Unable to create storage manager!"));
             return true; // We need to return true, otherwise the loading state will just call us again immediately
         }
-        CoreRegistry.put(StorageManager.class, storageManager);
+        context.put(StorageManager.class, storageManager);
         LocalChunkProvider chunkProvider = new LocalChunkProvider(storageManager, entityManager, worldGenerator);
-        CoreRegistry.get(ComponentSystemManager.class).register(new RelevanceSystem(chunkProvider), "engine:relevanceSystem");
+        context.get(ComponentSystemManager.class).register(new RelevanceSystem(chunkProvider), "engine:relevanceSystem");
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(new WorldProviderCoreImpl(worldInfo, chunkProvider));
         WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider);
-        CoreRegistry.put(WorldProvider.class, worldProvider);
+        context.put(WorldProvider.class, worldProvider);
         chunkProvider.setBlockEntityRegistry(entityWorldProvider);
-        CoreRegistry.put(BlockEntityRegistry.class, entityWorldProvider);
-        CoreRegistry.get(ComponentSystemManager.class).register(entityWorldProvider, "engine:BlockEntityRegistry");
+        context.put(BlockEntityRegistry.class, entityWorldProvider);
+        context.get(ComponentSystemManager.class).register(entityWorldProvider, "engine:BlockEntityRegistry");
 
         DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel());
-        CoreRegistry.put(CelestialSystem.class, celestialSystem);
-        CoreRegistry.get(ComponentSystemManager.class).register(celestialSystem);
+        context.put(CelestialSystem.class, celestialSystem);
+        context.get(ComponentSystemManager.class).register(celestialSystem);
 
         Skysphere skysphere = new Skysphere();
         BackdropProvider backdropProvider = skysphere;
         BackdropRenderer backdropRenderer = skysphere;
-        CoreRegistry.put(BackdropProvider.class, backdropProvider);
-        CoreRegistry.put(BackdropRenderer.class, backdropRenderer);
+        context.put(BackdropProvider.class, backdropProvider);
+        context.put(BackdropRenderer.class, backdropRenderer);
 
-        RenderingSubsystemFactory engineSubsystemFactory = CoreRegistry.get(RenderingSubsystemFactory.class);
+        RenderingSubsystemFactory engineSubsystemFactory = context.get(RenderingSubsystemFactory.class);
         WorldRenderer worldRenderer = engineSubsystemFactory.createWorldRenderer(backdropProvider, backdropRenderer,
-                                                                                 worldProvider, chunkProvider, CoreRegistry.get(LocalPlayerSystem.class));
-        CoreRegistry.put(WorldRenderer.class, worldRenderer);
+                                                                                 worldProvider, chunkProvider, context.get(LocalPlayerSystem.class));
+        context.put(WorldRenderer.class, worldRenderer);
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer
-        CoreRegistry.put(LocalPlayer.class, new LocalPlayer());
-        CoreRegistry.put(Camera.class, worldRenderer.getActiveCamera());
+        context.put(LocalPlayer.class, new LocalPlayer());
+        context.put(Camera.class, worldRenderer.getActiveCamera());
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
@@ -16,7 +16,7 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.generator.WorldGenerator;
 
@@ -29,6 +29,12 @@ import org.terasology.world.generator.WorldGenerator;
  */
 public class InitialiseWorldGenerator extends SingleStepLoadProcess {
 
+    private final Context context;
+
+    public InitialiseWorldGenerator(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialize world generator ...";
@@ -37,10 +43,10 @@ public class InitialiseWorldGenerator extends SingleStepLoadProcess {
     @Override
     public boolean step() {
 
-        WorldGenerator worldGenerator = CoreRegistry.get(WorldGenerator.class);
+        WorldGenerator worldGenerator = context.get(WorldGenerator.class);
         worldGenerator.initialize();
 
-        WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
+        WorldRenderer worldRenderer = context.get(WorldRenderer.class);
         worldRenderer.getActiveCamera().setReflectionHeight(worldGenerator.getWorld().getSeaLevel());
 
         return true;

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadEntities.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadEntities.java
@@ -18,10 +18,11 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.persistence.StorageManager;
+import org.terasology.registry.CoreRegistry;
 
 import java.io.IOException;
 
@@ -32,7 +33,10 @@ public class LoadEntities extends SingleStepLoadProcess {
 
     private static final Logger logger = LoggerFactory.getLogger(LoadEntities.class);
 
-    public LoadEntities() {
+    private final Context context;
+
+    public LoadEntities(Context context) {
+        this.context = context;
     }
 
     @Override
@@ -42,7 +46,7 @@ public class LoadEntities extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        EntityManager em = CoreRegistry.get(EntityManager.class);
+        EntityManager em = context.get(EntityManager.class);
         boolean entityCreated = false;
         for (EntityRef entity : em.getAllEntities()) {
             entityCreated = true;
@@ -51,7 +55,7 @@ public class LoadEntities extends SingleStepLoadProcess {
         if (entityCreated) {
             throw new IllegalStateException("Entity creation detected during component system initialisation, game load aborting");
         }
-        StorageManager storageManager = CoreRegistry.get(StorageManager.class);
+        StorageManager storageManager = context.get(StorageManager.class);
         try {
             storageManager.loadGlobalStore();
         } catch (IOException e) {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PostBeginSystems.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PostBeginSystems.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.ComponentSystem;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Iterator;
 
@@ -25,6 +25,12 @@ import java.util.Iterator;
  * @author Immortius
  */
 public class PostBeginSystems extends StepBasedLoadProcess {
+
+    private final Context context;
+
+    public PostBeginSystems(Context context) {
+        this.context = context;
+    }
 
     private Iterator<ComponentSystem> componentSystems;
 
@@ -43,7 +49,7 @@ public class PostBeginSystems extends StepBasedLoadProcess {
 
     @Override
     public void begin() {
-        ComponentSystemManager csm = CoreRegistry.get(ComponentSystemManager.class);
+        ComponentSystemManager csm = context.get(ComponentSystemManager.class);
         componentSystems = csm.iterateAll().iterator();
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PreBeginSystems.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PreBeginSystems.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.ComponentSystem;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Iterator;
 
@@ -25,6 +25,12 @@ import java.util.Iterator;
  * @author Immortius
  */
 public class PreBeginSystems extends StepBasedLoadProcess {
+
+    private final Context context;
+
+    public PreBeginSystems(Context context) {
+        this.context = context;
+    }
 
     private Iterator<ComponentSystem> componentSystems;
 
@@ -43,7 +49,7 @@ public class PreBeginSystems extends StepBasedLoadProcess {
 
     @Override
     public void begin() {
-        ComponentSystemManager csm = CoreRegistry.get(ComponentSystemManager.class);
+        ComponentSystemManager csm = context.get(ComponentSystemManager.class);
         componentSystems = csm.iterateAll().iterator();
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PrepareWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PrepareWorld.java
@@ -18,7 +18,7 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
 import org.terasology.engine.modes.LoadProcess;
@@ -30,8 +30,13 @@ import org.terasology.rendering.world.WorldRenderer;
 public class PrepareWorld implements LoadProcess {
     private static final Logger logger = LoggerFactory.getLogger(PrepareWorld.class);
 
+    private final Context context;
     private long startTime;
     private WorldRenderer worldRenderer;
+
+    public PrepareWorld(Context context) {
+        this.context = context;
+    }
 
     @Override
     public String getMessage() {
@@ -43,15 +48,15 @@ public class PrepareWorld implements LoadProcess {
         if (worldRenderer.pregenerateChunks()) {
             return true;
         }
-        EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
+        EngineTime time = (EngineTime) context.get(Time.class);
         long totalTime = time.getRawTimeInMs() - startTime;
         return totalTime > 5000;
     }
 
     @Override
     public void begin() {
-        worldRenderer = CoreRegistry.get(WorldRenderer.class);
-        EngineTime time = (EngineTime) CoreRegistry.get(Time.class);
+        worldRenderer = context.get(WorldRenderer.class);
+        EngineTime time = (EngineTime) context.get(Time.class);
         startTime = time.getRawTimeInMs();
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/ProcessBlockPrefabs.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/ProcessBlockPrefabs.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.engine.modes.loadProcesses;
 
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.internal.BlockManagerImpl;
@@ -26,6 +26,12 @@ import org.terasology.world.block.internal.BlockPrefabManager;
  */
 public class ProcessBlockPrefabs extends SingleStepLoadProcess {
 
+    private final Context context;
+
+    public ProcessBlockPrefabs(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Initialising Block Type Entities";
@@ -33,8 +39,8 @@ public class ProcessBlockPrefabs extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        BlockManagerImpl blockManager = (BlockManagerImpl) CoreRegistry.get(BlockManager.class);
-        blockManager.subscribe(new BlockPrefabManager(CoreRegistry.get(EntityManager.class), blockManager));
+        BlockManagerImpl blockManager = (BlockManagerImpl) context.get(BlockManager.class);
+        blockManager.subscribe(new BlockPrefabManager(context.get(EntityManager.class), blockManager));
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBiomes.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBiomes.java
@@ -16,11 +16,11 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
+import org.terasology.context.Context;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.game.GameManifest;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.NetworkSystem;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.biomes.BiomeRegistry;
 
@@ -29,9 +29,11 @@ import org.terasology.world.biomes.BiomeRegistry;
  */
 public class RegisterBiomes extends SingleStepLoadProcess {
 
-    private GameManifest gameManifest;
+    private final Context context;
+    private final GameManifest gameManifest;
 
-    public RegisterBiomes(GameManifest gameManifest) {
+    public RegisterBiomes(Context context, GameManifest gameManifest) {
+        this.context = context;
         this.gameManifest = gameManifest;
     }
 
@@ -42,8 +44,8 @@ public class RegisterBiomes extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        NetworkSystem networkSystem = CoreRegistry.get(NetworkSystem.class);
-        ModuleEnvironment moduleEnvironment = CoreRegistry.get(ModuleManager.class).getEnvironment();
+        NetworkSystem networkSystem = context.get(NetworkSystem.class);
+        ModuleEnvironment moduleEnvironment = context.get(ModuleManager.class).getEnvironment();
 
         BiomeManager biomeManager;
         if (networkSystem.getMode().isAuthority()) {
@@ -53,8 +55,8 @@ public class RegisterBiomes extends SingleStepLoadProcess {
         } else {
             biomeManager = new BiomeManager(moduleEnvironment, gameManifest.getBiomeIdMap());
         }
-        CoreRegistry.put(BiomeManager.class, biomeManager);
-        CoreRegistry.put(BiomeRegistry.class, biomeManager); // This registration is for other modules
+        context.put(BiomeManager.class, biomeManager);
+        context.put(BiomeRegistry.class, biomeManager); // This registration is for other modules
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBlockFamilyFactories.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBlockFamilyFactories.java
@@ -18,9 +18,9 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.module.ModuleEnvironment;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.block.family.BlockFamilyFactory;
 import org.terasology.world.block.family.BlockFamilyFactoryRegistry;
 import org.terasology.world.block.family.DefaultBlockFamilyFactoryRegistry;
@@ -32,6 +32,12 @@ import org.terasology.world.block.family.RegisterBlockFamilyFactory;
 public class RegisterBlockFamilyFactories extends SingleStepLoadProcess {
     private static final Logger logger = LoggerFactory.getLogger(RegisterBlockFamilyFactories.class);
 
+    private final Context context;
+
+    public RegisterBlockFamilyFactories(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Registering BlockFamilyFactories...";
@@ -40,11 +46,11 @@ public class RegisterBlockFamilyFactories extends SingleStepLoadProcess {
     @Override
     public boolean step() {
         DefaultBlockFamilyFactoryRegistry registry = new DefaultBlockFamilyFactoryRegistry();
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+        ModuleManager moduleManager = context.get(ModuleManager.class);
 
         loadFamilies(registry, moduleManager.getEnvironment());
 
-        CoreRegistry.put(BlockFamilyFactoryRegistry.class, registry);
+        context.put(BlockFamilyFactoryRegistry.class, registry);
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBlocks.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBlocks.java
@@ -17,7 +17,7 @@
 package org.terasology.engine.modes.loadProcesses;
 
 import org.terasology.config.Config;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.game.GameManifest;
 import org.terasology.network.NetworkSystem;
 import org.terasology.world.block.BlockManager;
@@ -30,10 +30,11 @@ import org.terasology.world.block.loader.WorldAtlasImpl;
  * @author Immortius
  */
 public class RegisterBlocks extends SingleStepLoadProcess {
+    private final Context context;
+    private final GameManifest gameManifest;
 
-    private GameManifest gameManifest;
-
-    public RegisterBlocks(GameManifest gameManifest) {
+    public RegisterBlocks(Context context, GameManifest gameManifest) {
+        this.context = context;
         this.gameManifest = gameManifest;
     }
 
@@ -44,19 +45,19 @@ public class RegisterBlocks extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        NetworkSystem networkSystem = CoreRegistry.get(NetworkSystem.class);
-        WorldAtlas atlas = new WorldAtlasImpl(CoreRegistry.get(Config.class).getRendering().getMaxTextureAtlasResolution());
-        CoreRegistry.put(WorldAtlas.class, atlas);
+        NetworkSystem networkSystem = context.get(NetworkSystem.class);
+        WorldAtlas atlas = new WorldAtlasImpl(context.get(Config.class).getRendering().getMaxTextureAtlasResolution());
+        context.put(WorldAtlas.class, atlas);
 
         BlockManagerImpl blockManager;
-        BlockFamilyFactoryRegistry blockFamilyFactoryRegistry = CoreRegistry.get(BlockFamilyFactoryRegistry.class);
+        BlockFamilyFactoryRegistry blockFamilyFactoryRegistry = context.get(BlockFamilyFactoryRegistry.class);
         if (networkSystem.getMode().isAuthority()) {
             blockManager = new BlockManagerImpl(atlas, gameManifest.getRegisteredBlockFamilies(), gameManifest.getBlockIdMap(), true, blockFamilyFactoryRegistry);
-            blockManager.subscribe(CoreRegistry.get(NetworkSystem.class));
+            blockManager.subscribe(context.get(NetworkSystem.class));
         } else {
             blockManager = new BlockManagerImpl(atlas, gameManifest.getRegisteredBlockFamilies(), gameManifest.getBlockIdMap(), false, blockFamilyFactoryRegistry);
         }
-        CoreRegistry.put(BlockManager.class, blockManager);
+        context.put(BlockManager.class, blockManager);
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterInputSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterInputSystem.java
@@ -20,12 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.BindsConfig;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.input.InputSystem;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.logic.players.LocalPlayerSystem;
-import org.terasology.registry.CoreRegistry;
 
 /**
  * @author Immortius
@@ -34,6 +34,11 @@ public class RegisterInputSystem extends SingleStepLoadProcess {
 
     private static final Logger logger = LoggerFactory.getLogger(RegisterInputSystem.class);
 
+    private final Context context;
+
+    public RegisterInputSystem(Context context) {
+        this.context = context;
+    }
     @Override
     public String getMessage() {
         return "Setting up Input Systems...";
@@ -41,19 +46,19 @@ public class RegisterInputSystem extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        ComponentSystemManager componentSystemManager = CoreRegistry.get(ComponentSystemManager.class);
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+        ComponentSystemManager componentSystemManager = context.get(ComponentSystemManager.class);
+        ModuleManager moduleManager = context.get(ModuleManager.class);
 
         LocalPlayerSystem localPlayerSystem = new LocalPlayerSystem();
         componentSystemManager.register(localPlayerSystem, "engine:localPlayerSystem");
-        CoreRegistry.put(LocalPlayerSystem.class, localPlayerSystem);
+        context.put(LocalPlayerSystem.class, localPlayerSystem);
 
         CameraTargetSystem cameraTargetSystem = new CameraTargetSystem();
-        CoreRegistry.put(CameraTargetSystem.class, cameraTargetSystem);
+        context.put(CameraTargetSystem.class, cameraTargetSystem);
         componentSystemManager.register(cameraTargetSystem, "engine:CameraTargetSystem");
 
-        BindsConfig bindsConfig = CoreRegistry.get(Config.class).getInput().getBinds();
-        InputSystem inputSystem = CoreRegistry.get(InputSystem.class);
+        BindsConfig bindsConfig = context.get(Config.class).getInput().getBinds();
+        InputSystem inputSystem = context.get(InputSystem.class);
         componentSystemManager.register(inputSystem, "engine:InputSystem");
 
         bindsConfig.applyBinds(inputSystem, moduleManager);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterMods.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterMods.java
@@ -31,7 +31,6 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.ResolutionResult;
 import org.terasology.naming.Name;
 import org.terasology.naming.NameVersion;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.List;
 
@@ -42,9 +41,11 @@ public class RegisterMods extends SingleStepLoadProcess {
 
     private static final Logger logger = LoggerFactory.getLogger(RegisterMods.class);
 
-    private GameManifest gameManifest;
+    private final Context context;
+    private final GameManifest gameManifest;
 
-    public RegisterMods(GameManifest gameManifest) {
+    public RegisterMods(Context context, GameManifest gameManifest) {
+        this.context = context;
         this.gameManifest = gameManifest;
     }
 
@@ -55,7 +56,7 @@ public class RegisterMods extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+        ModuleManager moduleManager = context.get(ModuleManager.class);
         List<Name> moduleIds = Lists.newArrayListWithCapacity(gameManifest.getModules().size());
         for (NameVersion moduleInfo : gameManifest.getModules()) {
             moduleIds.add(moduleInfo.getName());
@@ -70,10 +71,10 @@ public class RegisterMods extends SingleStepLoadProcess {
                 logger.info("Activating module: {}:{}", moduleInfo.getId(), moduleInfo.getVersion());
             }
 
-            ApplyModulesUtil.applyModules(CoreRegistry.get(Context.class));
+            ApplyModulesUtil.applyModules(context.get(Context.class));
         } else {
             logger.warn("Missing at least one required module or dependency: {}", moduleIds);
-            CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu("Missing required module or dependency"));
+            context.get(GameEngine.class).changeState(new StateMainMenu("Missing required module or dependency"));
         }
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterSystems.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterSystems.java
@@ -18,23 +18,24 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.network.NetworkMode;
-import org.terasology.registry.CoreRegistry;
 
 /**
  * @author Immortius
  */
 public class RegisterSystems extends SingleStepLoadProcess {
-    private static final Logger logger = LoggerFactory.getLogger(RegisterSystems.class);
-    private NetworkMode netMode;
+    private final Context context;
+    private final NetworkMode netMode;
     private ComponentSystemManager componentSystemManager;
 
-    public RegisterSystems(NetworkMode netMode) {
+    public RegisterSystems(Context context, NetworkMode netMode) {
+        this.context = context;
         this.netMode = netMode;
     }
 
@@ -45,10 +46,10 @@ public class RegisterSystems extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        componentSystemManager = CoreRegistry.get(ComponentSystemManager.class);
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+        componentSystemManager = context.get(ComponentSystemManager.class);
+        ModuleManager moduleManager = context.get(ModuleManager.class);
 
-        TerasologyEngine terasologyEngine = (TerasologyEngine) CoreRegistry.get(GameEngine.class);
+        TerasologyEngine terasologyEngine = (TerasologyEngine) context.get(GameEngine.class);
         for (EngineSubsystem subsystem : terasologyEngine.getSubsystems()) {
             subsystem.registerSystems(componentSystemManager);
         }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/SetupLocalPlayer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/SetupLocalPlayer.java
@@ -18,7 +18,7 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.terasology.config.Config;
 import org.terasology.config.PlayerConfig;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.Client;
 import org.terasology.network.NetworkSystem;
@@ -27,6 +27,13 @@ import org.terasology.network.NetworkSystem;
  * @author Immortius
  */
 public class SetupLocalPlayer extends SingleStepLoadProcess {
+
+    private final Context context;
+
+    public SetupLocalPlayer(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Setting up local player";
@@ -34,9 +41,9 @@ public class SetupLocalPlayer extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        PlayerConfig playerConfig = CoreRegistry.get(Config.class).getPlayer();
-        Client localClient = CoreRegistry.get(NetworkSystem.class).joinLocal(playerConfig.getName(), playerConfig.getColor());
-        CoreRegistry.get(LocalPlayer.class).setClientEntity(localClient.getEntity());
+        PlayerConfig playerConfig = context.get(Config.class).getPlayer();
+        Client localClient = context.get(NetworkSystem.class).joinLocal(playerConfig.getName(), playerConfig.getColor());
+        context.get(LocalPlayer.class).setClientEntity(localClient.getEntity());
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/SetupRemotePlayer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/SetupRemotePlayer.java
@@ -16,7 +16,7 @@
 
 package org.terasology.engine.modes.loadProcesses;
 
-import org.terasology.registry.CoreRegistry;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.NetworkSystem;
@@ -26,6 +26,13 @@ import org.terasology.network.internal.NetworkSystemImpl;
  * @author Immortius
  */
 public class SetupRemotePlayer extends SingleStepLoadProcess {
+
+    private final Context context;
+
+    public SetupRemotePlayer(Context context) {
+        this.context = context;
+    }
+
     @Override
     public String getMessage() {
         return "Awaiting player data";
@@ -33,10 +40,10 @@ public class SetupRemotePlayer extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        NetworkSystemImpl networkSystem = (NetworkSystemImpl) CoreRegistry.get(NetworkSystem.class);
+        NetworkSystemImpl networkSystem = (NetworkSystemImpl) context.get(NetworkSystem.class);
         EntityRef client = networkSystem.getServer().getClientEntity();
         if (client.exists()) {
-            CoreRegistry.get(LocalPlayer.class).setClientEntity(client);
+            context.get(LocalPlayer.class).setClientEntity(client);
             return true;
         }
         return false;

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/StartServer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/StartServer.java
@@ -17,9 +17,9 @@
 package org.terasology.engine.modes.loadProcesses;
 
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.network.NetworkSystem;
 import org.terasology.network.exceptions.HostingFailedException;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
 
@@ -28,12 +28,14 @@ import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
  */
 public class StartServer extends SingleStepLoadProcess {
 
-    private boolean dedicated;
+    private final Context context;
+    private final boolean dedicated;
 
     /**
      * @param dedicated true, if server should be dedicated (i.e. with local client)
      */
-    public StartServer(boolean dedicated) {
+    public StartServer(Context context, boolean dedicated) {
+        this.context = context;
         this.dedicated = dedicated;
     }
 
@@ -45,11 +47,11 @@ public class StartServer extends SingleStepLoadProcess {
     @Override
     public boolean step() {
         try {
-            Config config = CoreRegistry.get(Config.class);
+            Config config = context.get(Config.class);
             int port = config.getTransients().getServerPort();
-            CoreRegistry.get(NetworkSystem.class).host(port, dedicated);
+            context.get(NetworkSystem.class).host(port, dedicated);
         } catch (HostingFailedException e) {
-            CoreRegistry.get(NUIManager.class).pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Failed to Host",
+            context.get(NUIManager.class).pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Failed to Host",
                     e.getMessage() + " - Reverting to single player");
         }
         return true;

--- a/engine/src/main/java/org/terasology/entitySystem/metadata/ComponentLibrary.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/ComponentLibrary.java
@@ -18,6 +18,7 @@ package org.terasology.entitySystem.metadata;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.Component;
 import org.terasology.module.Module;
@@ -38,8 +39,8 @@ public class ComponentLibrary extends AbstractClassLibrary<Component> {
 
     private static final Logger logger = LoggerFactory.getLogger(ComponentLibrary.class);
 
-    public ComponentLibrary(ReflectFactory factory, CopyStrategyLibrary copyStrategies) {
-        super(factory, copyStrategies);
+    public ComponentLibrary(Context context) {
+        super(context);
     }
 
     private ComponentLibrary(ComponentLibrary componentLibrary, CopyStrategyLibrary newCopyStrategies) {

--- a/engine/src/main/java/org/terasology/entitySystem/metadata/EntitySystemLibrary.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/EntitySystemLibrary.java
@@ -16,8 +16,7 @@
 
 package org.terasology.entitySystem.metadata;
 
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
+import org.terasology.context.Context;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 /**
@@ -31,10 +30,10 @@ public class EntitySystemLibrary {
     private final ComponentLibrary componentLibrary;
     private final EventLibrary eventLibrary;
 
-    public EntitySystemLibrary(ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategies, TypeSerializationLibrary typeSerializationLibrary) {
+    public EntitySystemLibrary(Context context, TypeSerializationLibrary typeSerializationLibrary) {
         this.typeSerializationLibrary = typeSerializationLibrary;
-        this.componentLibrary = new ComponentLibrary(reflectFactory, copyStrategies);
-        this.eventLibrary = new EventLibrary(reflectFactory, copyStrategies);
+        this.componentLibrary = new ComponentLibrary(context);
+        this.eventLibrary = new EventLibrary(context);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/metadata/EventLibrary.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/EventLibrary.java
@@ -17,12 +17,13 @@ package org.terasology.entitySystem.metadata;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.reflection.metadata.AbstractClassLibrary;
-import org.terasology.reflection.metadata.ClassMetadata;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.reflection.copy.CopyStrategyLibrary;
+import org.terasology.reflection.metadata.AbstractClassLibrary;
+import org.terasology.reflection.metadata.ClassMetadata;
+import org.terasology.reflection.reflect.ReflectFactory;
 
 /**
  * The library for metadata about events (and their fields).
@@ -33,8 +34,8 @@ public class EventLibrary extends AbstractClassLibrary<Event> {
 
     private static final Logger logger = LoggerFactory.getLogger(EventLibrary.class);
 
-    public EventLibrary(ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategies) {
-        super(reflectFactory, copyStrategies);
+    public EventLibrary(Context context) {
+        super(context);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorNodeFactory.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorNodeFactory.java
@@ -38,8 +38,8 @@ import org.terasology.logic.behavior.asset.NodesClassLibrary;
 import org.terasology.logic.behavior.tree.Node;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.reflection.metadata.FieldMetadata;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
+import org.terasology.registry.Share;
 import org.terasology.rendering.assets.animation.MeshAnimation;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
@@ -60,6 +60,7 @@ import java.util.Map;
  * @author synopia
  */
 @RegisterSystem
+@Share(BehaviorNodeFactory.class)
 public class BehaviorNodeFactory extends BaseComponentSystem {
     private static final Logger logger = LoggerFactory.getLogger(BehaviorNodeFactory.class);
 
@@ -85,10 +86,6 @@ public class BehaviorNodeFactory extends BaseComponentSystem {
 
     private List<AssetUri> sounds = Lists.newArrayList();
     private List<AssetUri> music = Lists.newArrayList();
-
-    public BehaviorNodeFactory() {
-        CoreRegistry.put(BehaviorNodeFactory.class, this);
-    }
 
     @Override
     public void postBegin() {

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/NodesClassLibrary.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/NodesClassLibrary.java
@@ -17,6 +17,7 @@ package org.terasology.logic.behavior.asset;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.logic.behavior.tree.Node;
 import org.terasology.module.ModuleEnvironment;
@@ -33,8 +34,8 @@ import org.terasology.reflection.reflect.ReflectFactory;
 public class NodesClassLibrary extends AbstractClassLibrary<Node> {
     private static final Logger logger = LoggerFactory.getLogger(NodesClassLibrary.class);
 
-    public NodesClassLibrary(ReflectFactory factory, CopyStrategyLibrary copyStrategies) {
-        super(factory, copyStrategies);
+    public NodesClassLibrary(Context context) {
+        super(context);
     }
 
     public void scan(ModuleEnvironment environment) {

--- a/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
+++ b/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
@@ -19,8 +19,8 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.module.sandbox.API;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
+import org.terasology.registry.Share;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.layouts.PropertyLayout;
 import org.terasology.rendering.nui.properties.PropertyProvider;
@@ -33,24 +33,24 @@ import java.security.PrivilegedAction;
  *         <br><br>
  *         Debug property editor. Usage:
  *         <br><br>
- *         CoreRegistry.get(DebugPropertiesSystem.class).addProperty("Model 1", model);
+ *         context.get(DebugPropertiesSystem.class).addProperty("Model 1", model);
  *         <br><br>
  *         Ingame press F1 to see the property editor. Only annotated fields will show up.
  */
 @API
 @RegisterSystem(RegisterMode.CLIENT)
+@Share(DebugPropertiesSystem.class)
 public class DebugPropertiesSystem extends BaseComponentSystem {
     @In
-    NUIManager nuiManager;
+    private NUIManager nuiManager;
 
-    PropertyLayout properties;
+    private PropertyLayout properties;
 
     @Override
     public void initialise() {
         DebugProperties debugProperties = (DebugProperties) nuiManager.getHUD().addHUDElement("engine:DebugProperties");
         debugProperties.setVisible(false);
         properties = debugProperties.getPropertyLayout();
-        CoreRegistry.put(DebugPropertiesSystem.class, this);
     }
 
     public void addProperty(final String group, final Object o) {

--- a/engine/src/main/java/org/terasology/reflection/metadata/AbstractClassLibrary.java
+++ b/engine/src/main/java/org/terasology/reflection/metadata/AbstractClassLibrary.java
@@ -20,13 +20,13 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.module.Module;
 import org.terasology.naming.Name;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Iterator;
 import java.util.List;
@@ -40,16 +40,17 @@ import java.util.Set;
  */
 public abstract class AbstractClassLibrary<T> implements ClassLibrary<T> {
 
-    private ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+    private ModuleManager moduleManager;
     protected final CopyStrategyLibrary copyStrategyLibrary;
     private ReflectFactory reflectFactory;
 
     private Map<Class<? extends T>, ClassMetadata<? extends T, ?>> classLookup = Maps.newHashMap();
     private Table<Name, Name, ClassMetadata<? extends T, ?>> uriLookup = HashBasedTable.create();
 
-    public AbstractClassLibrary(ReflectFactory factory, CopyStrategyLibrary copyStrategies) {
-        this.reflectFactory = factory;
-        this.copyStrategyLibrary = copyStrategies;
+    public AbstractClassLibrary(Context context) {
+        this.moduleManager = context.get(ModuleManager.class);
+        this.reflectFactory = context.get(ReflectFactory.class);
+        this.copyStrategyLibrary = context.get(CopyStrategyLibrary.class);
     }
 
     public AbstractClassLibrary(AbstractClassLibrary<T> factory, CopyStrategyLibrary copyStrategies) {

--- a/engine/src/main/java/org/terasology/reflection/metadata/DefaultClassLibrary.java
+++ b/engine/src/main/java/org/terasology/reflection/metadata/DefaultClassLibrary.java
@@ -17,9 +17,10 @@ package org.terasology.reflection.metadata;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
+import org.terasology.engine.SimpleUri;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.engine.SimpleUri;
 
 /**
  * A simple implementation of ClassLibrary. It provides ClassMetadata for a type of class. These classes are identified through their simple name.
@@ -30,8 +31,8 @@ import org.terasology.engine.SimpleUri;
 public final class DefaultClassLibrary<T> extends AbstractClassLibrary<T> {
     private static final Logger logger = LoggerFactory.getLogger(DefaultClassLibrary.class);
 
-    public DefaultClassLibrary(ReflectFactory factory, CopyStrategyLibrary copyStrategies) {
-        super(factory, copyStrategies);
+    public DefaultClassLibrary(Context context) {
+        super(context);
     }
 
     protected <C extends T> ClassMetadata<C, ?> createMetadata(Class<C> type, ReflectFactory factory, CopyStrategyLibrary copyStrategies, SimpleUri uri) {

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -44,9 +44,7 @@ import org.terasology.input.events.MouseWheelEvent;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.ClientComponent;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.metadata.ClassLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.rendering.nui.ControlWidget;
 import org.terasology.rendering.nui.CoreScreenLayer;
@@ -104,7 +102,7 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     }
 
     public void refreshWidgetsLibrary() {
-        widgetsLibrary = new WidgetLibrary(context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
+        widgetsLibrary = new WidgetLibrary(context);
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         for (Class<? extends UIWidget> type : environment.getSubtypesOf(UIWidget.class)) {
             widgetsLibrary.register(new SimpleUri(environment.getModuleProviding(type), type.getSimpleName()), type);

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/WidgetLibrary.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/WidgetLibrary.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.nui.internal;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.metadata.AbstractClassLibrary;
@@ -31,8 +32,8 @@ public class WidgetLibrary extends AbstractClassLibrary<UIWidget> {
 
     private static final Logger logger = LoggerFactory.getLogger(WidgetLibrary.class);
 
-    public WidgetLibrary(ReflectFactory factory, CopyStrategyLibrary copyStrategies) {
-        super(factory, copyStrategies);
+    public WidgetLibrary(Context context) {
+        super(context);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfigWorldGenScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfigWorldGenScreen.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.Component;
@@ -59,13 +60,16 @@ public class ConfigWorldGenScreen extends CoreScreenLayer {
     @In
     private Config config;
 
+    @In
+    private Context context;
+
     private Map<String, Component> params;
 
     @Override
     public void onOpened() {
         super.onOpened();
 
-        CoreRegistry.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary());
+        CoreRegistry.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(context));
 
         PropertyLayout properties = find("properties", PropertyLayout.class);
         properties.setOrdering(PropertyOrdering.byLabel());

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfigWorldGenScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfigWorldGenScreen.java
@@ -23,7 +23,6 @@ import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.Component;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.UIWidget;
@@ -69,7 +68,7 @@ public class ConfigWorldGenScreen extends CoreScreenLayer {
     public void onOpened() {
         super.onOpened();
 
-        CoreRegistry.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(context));
+        context.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(context));
 
         PropertyLayout properties = find("properties", PropertyLayout.class);
         properties.setOrdering(PropertyOrdering.byLabel());

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
@@ -22,6 +22,7 @@ import org.terasology.asset.AssetType;
 import org.terasology.asset.AssetUri;
 import org.terasology.asset.Assets;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.math.TeraMath;
@@ -29,7 +30,6 @@ import org.terasology.module.DependencyResolver;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.ResolutionResult;
 import org.terasology.naming.Name;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
@@ -70,6 +70,9 @@ public class PreviewWorldScreen extends CoreScreenLayer {
 
     @In
     private Config config;
+
+    @In
+    private Context context;
     
     private final int imageSize = 384;
 
@@ -91,7 +94,7 @@ public class PreviewWorldScreen extends CoreScreenLayer {
     public void onOpened() {
         super.onOpened();
 
-        CoreRegistry.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary());
+        context.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(context));
         SimpleUri worldGenUri = config.getWorldGeneration().getDefaultGenerator();
 
         try {
@@ -191,7 +194,7 @@ public class PreviewWorldScreen extends CoreScreenLayer {
         previewImage.setVisible(false);
         errorLabel.setVisible(false);
 
-        final NUIManager manager = CoreRegistry.get(NUIManager.class);
+        final NUIManager manager = context.get(NUIManager.class);
         final WaitPopup<ByteBufferResult> popup = manager.pushScreen(WaitPopup.ASSET_URI, WaitPopup.class);
         popup.setMessage("Updating Preview", "Please wait ...");
 

--- a/engine/src/main/java/org/terasology/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
+++ b/engine/src/main/java/org/terasology/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
@@ -15,17 +15,15 @@
  */
 package org.terasology.world.generator.plugin;
 
-import java.util.List;
-
+import com.google.common.collect.Lists;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.module.ModuleEnvironment;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.metadata.ClassLibrary;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.reflection.metadata.DefaultClassLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
 
-import com.google.common.collect.Lists;
+import java.util.List;
 
 /**
  * @author Immortius
@@ -34,8 +32,8 @@ public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginL
 
     private ClassLibrary<WorldGeneratorPlugin> library;
 
-    public DefaultWorldGeneratorPluginLibrary(ModuleEnvironment moduleEnvironment, ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategyLibrary) {
-        library = new DefaultClassLibrary<>(reflectFactory, copyStrategyLibrary);
+    public DefaultWorldGeneratorPluginLibrary(ModuleEnvironment moduleEnvironment, Context context) {
+        library = new DefaultClassLibrary<>(context);
         for (Class entry : moduleEnvironment.getTypesAnnotatedWith(RegisterPlugin.class)) {
             if (WorldGeneratorPlugin.class.isAssignableFrom(entry)) {
                 library.register(new SimpleUri(moduleEnvironment.getModuleProviding(entry), entry.getSimpleName()), entry);

--- a/engine/src/main/java/org/terasology/world/generator/plugin/TempWorldGeneratorPluginLibrary.java
+++ b/engine/src/main/java/org/terasology/world/generator/plugin/TempWorldGeneratorPluginLibrary.java
@@ -15,20 +15,17 @@
  */
 package org.terasology.world.generator.plugin;
 
-import java.util.Set;
-
+import com.google.common.collect.Sets;
 import org.terasology.asset.AssetManager;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.module.DependencyInfo;
 import org.terasology.module.Module;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.naming.Name;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.registry.CoreRegistry;
 
-import com.google.common.collect.Sets;
+import java.util.Set;
 
 /**
  * A fake environment so that plugins can be loaded for configuration.
@@ -36,14 +33,14 @@ import com.google.common.collect.Sets;
  */
 public class TempWorldGeneratorPluginLibrary extends DefaultWorldGeneratorPluginLibrary {
 
-    public TempWorldGeneratorPluginLibrary() {
-        super(getEnv(), CoreRegistry.get(ReflectFactory.class), CoreRegistry.get(CopyStrategyLibrary.class));
+    public TempWorldGeneratorPluginLibrary(Context context) {
+        super(getEnv(context), context);
     }
 
-    private static ModuleEnvironment getEnv() {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
-        Config config = CoreRegistry.get(Config.class);
+    private static ModuleEnvironment getEnv(Context context) {
+        ModuleManager moduleManager = context.get(ModuleManager.class);
+        AssetManager assetManager = context.get(AssetManager.class);
+        Config config = context.get(Config.class);
 
         Set<Module> selectedModules = Sets.newHashSet();
         for (Name moduleName : config.getDefaultModSelection().listModules()) {


### PR DESCRIPTION
Part II of a possibly long series to get rid of CoreRegistry usage.

This pull request requires #1721 to be merged first. See #1721 and its comments for an explanation of why the CoreRegistry usage gets removed.

It contains no big refactorings except maybe for the commit https://github.com/MovingBlocks/Terasology/commit/1cbac8a7d1549026ca8627965a9cbb68db291546 that converts EntitySystemBuilder into a static utility class as suggested by a TODO statement.