### PR TITLE
Use terasology.org as default host for master-server

### DIFF
--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Lists;
  */
 public class NetworkConfig {
 
-    private List<ServerInfo> servers = Lists.newArrayList(new ServerInfo("localhost", "localhost", 25777));
+    private List<ServerInfo> servers = Lists.newArrayList(new ServerInfo("localhost", "localhost", TerasologyConstants.DEFAULT_PORT));
 
     /**
      * Available upstream bandwidth in kilobits per second
@@ -42,7 +42,7 @@ public class NetworkConfig {
     /**
      * The master server URL
      */
-    private String masterServer = "https://master-server.herokuapp.com/servers/list";
+    private String masterServer = "master-server.terasology.org";
 
     public void clear() {
         servers.clear();


### PR DESCRIPTION
Heroku is changing its hosting policy and pricing scheme, which is less suitable for 24/7 online services. 

I hereby suggest changing the default server URL in `NetworkConfig` to [master-server.terasology.org](https://master-server.terasology.org), which can be configured to redirect request to any URL. This should facilitate migrating away from Heroku.

**NOTE**: the URL must be configured to forward to `master-server.herokuapp.com` before this PR can be merged.

This PR also contains a few related tweaks (partly based on new Java 8 features).