### PR TITLE
Compute unit test coverage using JaCoCo

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -3,7 +3,11 @@
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config
 apply from: "$rootDir/config/gradle/artifactory.gradle"
 
+// Computes code coverage of (unit) tests
+apply plugin: 'jacoco'
+
 import groovy.json.JsonSlurper
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Java Section                                                                                                      //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -48,4 +52,24 @@ dependencies {
     compile group: 'junit', name: 'junit', version: '4.12'
     compile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     compile group: 'org.jboss.shrinkwrap', name: 'shrinkwrap-depchain-java7', version: '1.1.3'
+}
+
+jacoco {
+    toolVersion = "0.7.5.201505241946"
+}
+
+test {
+    jacoco {
+        append = false
+        excludes = ["org.terasology.protobuf.*"]
+    }
+}
+
+jacocoTestReport {
+    dependsOn test // why is this not by default?
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.enabled false
+    }
 }


### PR DESCRIPTION
This PR adds JaCoCo to the engine-tests project, which computes code coverage. The resulting exec file can be visualized by the Jenkins JaCoCo plugin, for example:

http://jenkins.terasology.org/job/TerasologyTemp/lastBuild/jacoco/

I excluded the `o.t.protobuf` package from both JaCoCo and the Jenkins plugins (which reports 0% coverage otherwise).