### PR TITLE
Scrollbar: check for division-by-zero, and remove handle when larger than scrollbar size

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIScrollbar.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIScrollbar.java
@@ -47,14 +47,6 @@ public class UIScrollbar extends CoreWidget {
     private boolean dragging;
     private int mouseOffset;
 
-    public UIScrollbar() {
-        this(true);
-    }
-
-    public UIScrollbar(boolean vertical) {
-        this.vertical = vertical;
-    }
-
     private InteractionListener handleListener = new BaseInteractionListener() {
 
         @Override
@@ -90,16 +82,16 @@ public class UIScrollbar extends CoreWidget {
         @Override
         public boolean onMouseClick(MouseInput button, Vector2i pos) {
             if (button == MouseInput.MOUSE_LEFT) {
+                mouseOffset = (sliderSize > handleSize) ? (handleSize / 2) : 0;
                 if (vertical) {
                     updatePosition(pos.y - mouseOffset);
 
-                    setValue(TeraMath.clamp(pos.y - handleSize / 2, 0, sliderSize) * getRange() / sliderSize);
+                    setValue(TeraMath.clamp(pos.y - mouseOffset, 0, sliderSize) * getRange() / sliderSize);
                 } else {
                     updatePosition(pos.x - mouseOffset);
 
-                    setValue(TeraMath.clamp(pos.x - handleSize / 2, 0, sliderSize) * getRange() / sliderSize);
+                    setValue(TeraMath.clamp(pos.x - mouseOffset, 0, sliderSize) * getRange() / sliderSize);
                 }
-                mouseOffset = handleSize / 2;
                 dragging = true;
                 return true;
             }
@@ -121,6 +113,14 @@ public class UIScrollbar extends CoreWidget {
         }
     };
 
+    public UIScrollbar() {
+        this(true);
+    }
+
+    public UIScrollbar(boolean vertical) {
+        this.vertical = vertical;
+    }
+
     @Override
     public void onDraw(Canvas canvas) {
         if (vertical) {
@@ -138,7 +138,7 @@ public class UIScrollbar extends CoreWidget {
             sliderSize = canvas.size().x - canvas.getCurrentStyle().getFixedWidth();
         }
 
-        if (sliderSize > 0) {
+        if (sliderSize > handleSize) {
             int drawLocation = pixelOffsetFor(getValue());
             Rect2i handleRegion;
             if (vertical) {
@@ -168,7 +168,8 @@ public class UIScrollbar extends CoreWidget {
     }
 
     private int pixelOffsetFor(int newValue) {
-        return sliderSize * newValue / getRange();
+        final int r = getRange();
+        return (r > 0) ? (sliderSize * newValue / r) : 0;
     }
 
     @Override
@@ -219,7 +220,7 @@ public class UIScrollbar extends CoreWidget {
 
     private void updatePosition(int pixelPos) {
         int newPosition = TeraMath.clamp(pixelPos, 0, sliderSize);
-        setValue(newPosition * getRange() / sliderSize);
+        setValue((sliderSize > 0) ? (newPosition * getRange() / sliderSize) : 0);
     }
 
 }


### PR DESCRIPTION
Fixing divide-by-zero crash.  Previewing a new "Core Gameplay/Perlin" world with a window size that is too large results in scrollbar range of 0, and causes a crash with the following stack trace:

java.lang.ArithmeticException: / by zero
    at org.terasology.rendering.nui.widgets.UIScrollbar.pixelOffsetFor(UIScrollbar.java:171) ~[classes/:na]
    at org.terasology.rendering.nui.widgets.UIScrollbar.onDraw(UIScrollbar.java:142) ~[classes/:na]
    at org.terasology.rendering.nui.internal.CanvasImpl.drawWidget(CanvasImpl.java:376) ~[classes/:na]
    at org.terasology.rendering.nui.layouts.ScrollableArea.layoutWithJustVertical(ScrollableArea.java:153) ~[classes/:na]
    at org.terasology.rendering.nui.layouts.ScrollableArea.onDraw(ScrollableArea.java:95) ~[classes/:na]
    at org.terasology.rendering.nui.internal.CanvasImpl.drawWidget(CanvasImpl.java:376) ~[classes/:na]
    at org.terasology.rendering.nui.layouts.relative.RelativeLayout.onDraw(RelativeLayout.java:69) ~[classes/:na]
    at org.terasology.rendering.nui.internal.CanvasImpl.drawWidget(CanvasImpl.java:376) ~[classes/:na]
    at org.terasology.rendering.nui.layouts.ColumnLayout.onDraw(ColumnLayout.java:174) ~[classes/:na]
    at org.terasology.rendering.nui.internal.CanvasImpl.drawWidget(CanvasImpl.java:376) ~[classes/:na]
    at org.terasology.rendering.nui.layouts.relative.RelativeLayout.onDraw(RelativeLayout.java:69) ~[classes/:na]
    at org.terasology.rendering.nui.internal.CanvasImpl.drawWidget(CanvasImpl.java:376) ~[classes/:na]
    at org.terasology.rendering.nui.CoreScreenLayer.onDraw(CoreScreenLayer.java:103) ~[classes/:na]
    at org.terasology.rendering.nui.internal.CanvasImpl.drawWidget(CanvasImpl.java:376) ~[classes/:na]
    at org.terasology.rendering.nui.internal.NUIManagerInternal.render(NUIManagerInternal.java:377) ~[classes/:na]
    at org.terasology.engine.modes.StateMainMenu.render(StateMainMenu.java:152) ~[classes/:na]
    at org.terasology.engine.subsystem.lwjgl.LwjglGraphics.postUpdate(LwjglGraphics.java:118) ~[classes/:na]
    at org.terasology.engine.TerasologyEngine.mainLoop(TerasologyEngine.java:486) ~[classes/:na]
    at org.terasology.engine.TerasologyEngine.run(TerasologyEngine.java:397) ~[classes/:na]
    at org.terasology.engine.Terasology.main(Terasology.java:151) [main/:na]

Also, there's no point in drawing the scrollbar handle if the scrollbar is too small.  Removed rendering of the handle in this case, and made the mouse offset of a drag on the scroll region 0.