### PR TITLE
Cached seed in WorldBuilder to remove order-dependence between setSeed() and addProvider()

### DIFF
--- a/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
@@ -43,8 +43,12 @@ public class WorldBuilder {
     private final Set<Class<? extends WorldFacet>> facetCalculationInProgress = Sets.newHashSet();
     private final List<WorldRasterizer> rasterizers = Lists.newArrayList();
     private int seaLevel = 32;
+    private Long seed;
 
     public WorldBuilder addProvider(FacetProvider provider) {
+        if (seed != null) {
+            provider.setSeed(seed);
+        }
         providersList.add(provider);
         return this;
     }
@@ -80,6 +84,7 @@ public class WorldBuilder {
         for (FacetProvider provider : providersList) {
             provider.setSeed(seed);
         }
+        this.seed = seed;
     }
 
     public World build() {


### PR DESCRIPTION
The old WorldBuilder implementation called setSeed() on providers when they were added.  This does the same, simply caching the last seed set in a Long field (after passing through to already added providers) and also passing it through to new providers if non-null.  Helps with backwards compatibility, so updating modules like AnotherWorld to use the new API is relatively painless.