### PR TITLE
Read entity height from player prefab

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -33,7 +33,6 @@ import org.terasology.network.Replicate;
  * @author Immortius
  */
 public final class CharacterComponent implements Component {
-    public Vector3f spawnPosition = new Vector3f();
     public float eyeOffset = 0.6f;
     /**
      * Specifies the maximium range at which this character is able to interact with other objects.

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -15,53 +15,165 @@
  */
 package org.terasology.logic.players;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.ComponentContainer;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.characters.CharacterComponent;
-import org.terasology.logic.inventory.InventoryUtils;
+import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.logic.players.event.SelectedItemChangedEvent;
+import org.terasology.math.AABB;
+import org.terasology.math.TeraMath;
+import org.terasology.math.geom.BaseVector2i;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.SpiralIterable;
+import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.ColorComponent;
+import org.terasology.physics.shapes.BoxShapeComponent;
+import org.terasology.physics.shapes.CapsuleShapeComponent;
+import org.terasology.physics.shapes.CylinderShapeComponent;
+import org.terasology.physics.shapes.HullShapeComponent;
+import org.terasology.physics.shapes.SphereShapeComponent;
 import org.terasology.rendering.logic.MeshComponent;
+import org.terasology.world.WorldProvider;
 
 /**
- * @author Immortius
+ * Creates new player instances.
  */
 public class PlayerFactory {
 
-    private EntityManager entityManager;
+    private static final Logger logger = LoggerFactory.getLogger(PlayerFactory.class);
 
-    public PlayerFactory(EntityManager entityManager) {
+    private EntityManager entityManager;
+    private WorldProvider worldProvider;
+
+    public PlayerFactory(EntityManager entityManager, WorldProvider worldProvider) {
         this.entityManager = entityManager;
+        this.worldProvider = worldProvider;
     }
 
-    public EntityRef newInstance(Vector3f spawnPosition, EntityRef controller) {
+    /**
+     * Creates a new player character entity. The desired spawning location is derived from
+     * the {@link LocationComponent} of the controller.
+     * @param controller the controlling client entity
+     * @return a new player character entity
+     */
+    public EntityRef newInstance(EntityRef controller) {
+
         EntityBuilder builder = entityManager.newBuilder("engine:player");
+
+        float extraSpace = 0.5f;  // spawn a little bit above the ground
+        float entityHeight = getHeightOf(builder) + extraSpace;
+
+        LocationComponent location = controller.getComponent(LocationComponent.class);
+        Vector3f spawnPosition = findSpawnPos(location.getWorldPosition(), entityHeight);
+        location.setWorldPosition(spawnPosition);
+        controller.saveComponent(location);
+
+        logger.debug("Spawing player at: {}", spawnPosition);
+
         builder.getComponent(LocationComponent.class).setWorldPosition(spawnPosition);
         builder.setOwner(controller);
-        EntityRef transferSlot = entityManager.create("engine:transferSlot");
 
         ClientComponent clientComp = controller.getComponent(ClientComponent.class);
         if (clientComp != null) {
             ColorComponent colorComp = clientComp.clientInfo.getComponent(ColorComponent.class);
-            
+
             MeshComponent meshComp = builder.getComponent(MeshComponent.class);
             meshComp.color = colorComp.color;
         }
-        
+
         CharacterComponent playerComponent = builder.getComponent(CharacterComponent.class);
-        playerComponent.spawnPosition.set(spawnPosition);
+        EntityRef transferSlot = entityManager.create("engine:transferSlot");
         playerComponent.movingItem = transferSlot;
         playerComponent.controller = controller;
 
         EntityRef player = builder.build();
 
-        player.send(new SelectedItemChangedEvent(EntityRef.NULL, InventoryUtils.getItemAt(player, 0)));
+        Location.attachChild(player, controller, new Vector3f(), new Quat4f(0, 0, 0, 1));
 
         return player;
     }
 
+    private float getHeightOf(ComponentContainer prefab) {
+        BoxShapeComponent box = prefab.getComponent(BoxShapeComponent.class);
+        if (box != null) {
+            return box.extents.getY();
+        }
+
+        CylinderShapeComponent cylinder = prefab.getComponent(CylinderShapeComponent.class);
+        if (cylinder != null) {
+            return cylinder.height;
+        }
+
+        CapsuleShapeComponent capsule = prefab.getComponent(CapsuleShapeComponent.class);
+        if (capsule != null) {
+            return capsule.height;
+        }
+
+        SphereShapeComponent sphere = prefab.getComponent(SphereShapeComponent.class);
+        if (sphere != null) {
+            return sphere.radius * 2.0f;
+        }
+
+        HullShapeComponent hull = prefab.getComponent(HullShapeComponent.class);
+        if (hull != null) {
+            AABB aabb = hull.sourceMesh.getAABB();
+            return aabb.maxY() - aabb.minY();
+        }
+
+        logger.warn("entity {} does not have any known extent specification - using default", prefab);
+        return 1.0f;
+    }
+
+    private Vector3f findSpawnPos(Vector3f targetPos, float entityHeight) {
+        int targetBlockX = TeraMath.floorToInt(targetPos.x);
+        int targetBlockY = TeraMath.floorToInt(targetPos.y);
+        int targetBlockZ = TeraMath.floorToInt(targetPos.z);
+        Vector2i center = new Vector2i(targetBlockX, targetBlockZ);
+        for (BaseVector2i pos : SpiralIterable.clockwise(center).maxRadius(3).scale(2).build()) {
+
+            Vector3i testPos = new Vector3i(pos.getX(), targetBlockY, pos.getY());
+            Vector3i spawnPos = findOpenVerticalPosition(testPos, entityHeight);
+            if (spawnPos != null) {
+                return new Vector3f(spawnPos.getX(), spawnPos.getY() + entityHeight, spawnPos.getZ());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * find a spot above the surface that is big enough for this character
+     * @param spawnPos the position to check
+     * @param height the height of the entity to spawn
+     * @return the topmost solid block <code>null</code> if none was found
+     */
+    private Vector3i findOpenVerticalPosition(Vector3i spawnPos, float height) {
+        int consecutiveAirBlocks = 0;
+        Vector3i newSpawnPos = new Vector3i(spawnPos);
+
+        // TODO: also start looking downwards if initial spawn pos is in the air
+        for (int i = 1; i < 20; i++) {
+            if (worldProvider.isBlockRelevant(newSpawnPos)) {
+                if (worldProvider.getBlock(newSpawnPos).isPenetrable()) {
+                    consecutiveAirBlocks++;
+                } else {
+                    consecutiveAirBlocks = 0;
+                }
+
+                if (consecutiveAirBlocks >= height) {
+                    newSpawnPos.subY(consecutiveAirBlocks);
+                    return newSpawnPos;
+                }
+                newSpawnPos.add(0, 1, 0);
+            }
+        }
+
+        return null;
+    }
 }

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -37,16 +37,14 @@ import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.health.DestroyEvent;
 import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.health.HealthComponent;
+import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.logic.players.event.RespawnRequestEvent;
-import org.terasology.math.TeraMath;
-import org.terasology.math.geom.BaseVector2i;
+import org.terasology.logic.players.event.SelectedItemChangedEvent;
 import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.SpiralIterable;
-import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.network.Client;
@@ -59,11 +57,6 @@ import org.terasology.registry.In;
 import org.terasology.rendering.world.ViewDistance;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.block.BlockManager;
-import org.terasology.world.chunks.ChunkConstants;
-import org.terasology.world.generation.Region;
-
-import org.terasology.world.generation.World;
 import org.terasology.world.generator.WorldGenerator;
 
 import com.google.common.collect.Lists;
@@ -75,8 +68,6 @@ import com.google.common.collect.Lists;
 public class PlayerSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 
     private static final Logger logger = LoggerFactory.getLogger(PlayerSystem.class);
-
-    private final float playerHeight = 1.5f;
 
     @In
     private EntityManager entityManager;
@@ -116,75 +107,6 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
                 i.remove();
             }
         }
-    }
-
-    private void spawnPlayer(EntityRef clientEntity) {
-
-        LocationComponent location = clientEntity.getComponent(LocationComponent.class);
-
-        Vector3f spawnPosition = findSpawnPos(location.getWorldPosition());
-        location.setWorldPosition(spawnPosition);
-        clientEntity.saveComponent(location);
-
-        logger.debug("Spawing player at: {}", spawnPosition);
-
-        ClientComponent client = clientEntity.getComponent(ClientComponent.class);
-
-        PlayerFactory playerFactory = new PlayerFactory(entityManager);
-        EntityRef playerCharacter = playerFactory.newInstance(spawnPosition, clientEntity);
-        Location.attachChild(playerCharacter, clientEntity, new Vector3f(), new Quat4f(0, 0, 0, 1));
-
-        Client clientListener = networkSystem.getOwner(clientEntity);
-        Vector3i distance = clientListener.getViewDistance().getChunkDistance();
-        updateRelevanceEntity(clientEntity, distance);
-        client.character = playerCharacter;
-        clientEntity.saveComponent(client);
-        playerCharacter.send(new OnPlayerSpawnedEvent());
-    }
-
-    private Vector3f findSpawnPos(Vector3f targetPos) {
-        int targetBlockX = TeraMath.floorToInt(targetPos.x);
-        int targetBlockY = TeraMath.floorToInt(targetPos.y);
-        int targetBlockZ = TeraMath.floorToInt(targetPos.z);
-        Vector2i center = new Vector2i(targetBlockX, targetBlockZ);
-        for (BaseVector2i pos : SpiralIterable.clockwise(center).maxRadius(3).scale(2).build()) {
-
-            Vector3i testPos = new Vector3i(pos.getX(), targetBlockY, pos.getY());
-            Vector3i spawnPos = findOpenVerticalPosition(testPos, playerHeight);
-            if (spawnPos != null) {
-                return new Vector3f(spawnPos.getX(), spawnPos.getY() + playerHeight, spawnPos.getZ());
-            }
-        }
-        return null;
-    }
-
-    /**
-     * find a spot above the surface that is big enough for this character
-     * @param spawnPos the position to check
-     * @param height the height of the entity to spawn
-     * @return the found spot or <code>null</code> if none was found
-     */
-    private Vector3i findOpenVerticalPosition(Vector3i spawnPos, float height) {
-        int consecutiveAirBlocks = 0;
-        Vector3i newSpawnPos = new Vector3i(spawnPos);
-
-        // TODO: also start looking downwards if initial spawn pos is in the air
-        for (int i = 1; i < 20; i++) {
-            if (worldProvider.isBlockRelevant(newSpawnPos)) {
-                if (worldProvider.getBlock(newSpawnPos).isPenetrable()) {
-                    consecutiveAirBlocks++;
-                } else {
-                    consecutiveAirBlocks = 0;
-                }
-                if (consecutiveAirBlocks >= height) {
-                    newSpawnPos.subY(consecutiveAirBlocks - 1);
-                    return newSpawnPos;
-                }
-                newSpawnPos.add(0, 1, 0);
-            }
-        }
-
-        return null;
     }
 
     @ReceiveEvent(components = ClientComponent.class)
@@ -320,6 +242,23 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         }
         return "Teleported to " + x + " " + y + " " + z;
     }
+
+    private void spawnPlayer(EntityRef clientEntity) {
+
+        ClientComponent client = clientEntity.getComponent(ClientComponent.class);
+
+        PlayerFactory playerFactory = new PlayerFactory(entityManager, worldProvider);
+        EntityRef playerCharacter = playerFactory.newInstance(clientEntity);
+
+        Client clientListener = networkSystem.getOwner(clientEntity);
+        Vector3i distance = clientListener.getViewDistance().getChunkDistance();
+        updateRelevanceEntity(clientEntity, distance);
+        client.character = playerCharacter;
+        clientEntity.saveComponent(client);
+        playerCharacter.send(new SelectedItemChangedEvent(EntityRef.NULL, InventoryUtils.getItemAt(playerCharacter, 0)));
+        playerCharacter.send(new OnPlayerSpawnedEvent());
+    }
+
 
     private static class SpawningClientInfo {
         public EntityRef clientEntity;


### PR DESCRIPTION
This was more effort that I first thought since..
* The height of an entity depends on the type of collision object
* The entity was created by `PlayerFactory` only after the final spawning pos. was set

So I moved a few bits from `PlayerSystem` to `PlayerFactory`, which also looks cleaner to me now. The system deals with events and entities while the factory deals with creating new player instances. Just as the names incline.

Fixes #1711 