### PR TITLE
PerformanceMonitor: augmented javadocs, some refactoring

### DIFF
--- a/engine/src/main/java/org/terasology/monitoring/PerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/monitoring/PerformanceMonitor.java
@@ -42,36 +42,41 @@ public final class PerformanceMonitor {
 
     /**
      * Indicates the start of an activity. All started activities must either be ended with a call to endActivity()
-     * (see example 1) or take advantage of the autocloseable interface implemented by Activity (see example 2).
+     * (see example 1) or take advantage of the autocloseable interface implemented by Activity (see example 2).<br>
+     * <br>
      *
      * Example 1 - explicitly ending an activity:
-     *
-     *      PerformanceMonitor.startActivity("myActivity")
-     *      doSomething();
-     *      PerformanceMonitor.endActivity()
+     * <pre>
+     * PerformanceMonitor.startActivity("myActivity")
+     * doSomething();
+     * PerformanceMonitor.endActivity()
+     * </pre>
      *
      * Example 2 - the end of the activity is handled internally:
-     *
-     *      try (Activity ignored = PerformanceMonitor.startActivity("myActivity") {
-     *          doSomething();
-     *      }
+     * <pre>
+     * try (Activity ignored = PerformanceMonitor.startActivity("myActivity") {
+     *     doSomething();
+     * }
+     * </pre>
      *
      * The latter case is particularly useful whenever the activity's code has a number of possible exit paths,
-     * as it might be undesirable or simply non-trivial to add an endActivity() call at the end of each.
+     * as it might be undesirable or simply non-trivial to add an endActivity() call at the end of each.<br>
+     * <br>
      *
-     * Activities may be nested. Example:
+     * Activities may be nested. Example: (the indentation pattern is not strictly necessary)
+     * <pre>
+     * PerformanceMonitor.startActivity("myActivity")
+     * doSomething();
      *
-     *      PerformanceMonitor.startActivity("myActivity")
-     *      doSomething();
+     *     PerformanceMonitor.startActivity("myNestedActivity")
+     *     doSomethingNested();
+     *     PerformanceMonitor.endActivity()
      *
-     *          PerformanceMonitor.startActivity("myNestedActivity")
-     *          doSomethingNested();
-     *          PerformanceMonitor.endActivity()
+     * doSomethingElse()
+     * PerformanceMonitor.endActivity()
+     * </pre>
      *
-     *      doSomethingElse()
-     *      PerformanceMonitor.endActivity()
-     *
-     * @param activityName the name of the activity stating.
+     * @param activityName the name of the activity starting.
      */
     public static Activity startActivity(String activityName) {
         return instance.startActivity(activityName);
@@ -93,7 +98,7 @@ public final class PerformanceMonitor {
 
     /**
      * Returns a mapping from the name of an activity to a running mean of its execution times, over a number of cycles.
-     *
+     * <br><br>
      * Activities may be nested, and while a nested activity is running the collection of data from outer activities
      * is paused and time passing is not assigned to them.
      *
@@ -105,13 +110,15 @@ public final class PerformanceMonitor {
 
     /**
      * Returns a mapping from the name of an activity to the activity's largest execution time, decayed by time.
-     *
+     * <br><br>
      * Without decay this method would return the absolute largest execution time for each activity, since
      * it was first started. Instead, this method returns the largest -most recent- execution time for
      * each activity.
      *
      * @return a mapping from activity name to largest most recent execution time per cycle.
      */
+    // TODO: change to return the largest execution time over the monitored interval - no decay involved. See comment in
+    // TODO: https://github.com/emanuele3d/Terasology/commit/36cf9bf23b42f76793a5d5968ef4e25986aa9706#commitcomment-11445526
     public static TObjectDoubleMap<String> getDecayingSpikes() {
         return instance.getDecayingSpikes();
     }
@@ -119,10 +126,10 @@ public final class PerformanceMonitor {
     /**
      * Returns a mapping from the name of an activity to a running mean of allocated memory during
      * the execution of the activity, over a number of cycles.
-     *
+     * <br><br>
      * Activities may be nested, and while a nested activity is running the collection of data from
      * outer activities is paused and allocated memory is not assigned to them.
-     *
+     * <br><br>
      * No guarantee can be given that the memory allocated during the execution of an activity is
      * entirely due to the activity. Other threads for example might increase or decrease the
      * figure.
@@ -135,7 +142,7 @@ public final class PerformanceMonitor {
 
     /**
      * Enables or disables the Performance Monitoring system.
-     *
+     * <br><br>
      * When disabled all data is purged and calls to startActivity()/endActivity() and rollCycle() are ignored.
      *
      * @param enabled True turns the Performance Monitoring system ON. False turns it OFF.


### PR DESCRIPTION
I wanted to learn more about the PerformanceMonitor, in the context of creating a new set of metrics that can be seen pressing the F4 key. In the process of going through the code I saw a number of
opportunities for improving the javadocs and, to a minor extent, improving the readability of the code.

This PR attempts to fullfill those opportunities. 

The [first commit](36cf9bf23b42f76793a5d5968ef4e25986aa9706) should be relatively uncontroversial: it just adds or refine javadocs to PerformanceMonitor and does some minor refactoring to PerformanceMonitorImpl. I imagine however the wording on some of the javadocs could be further refined.

The usefulness of the [second commit](ba965b1cd7c842d3433a9c28fdfb17c9d02173cc) is perhaps more debatable: primarily it makes the rollCycle() method more concise and readable by explicitly defining and instantiating (once) procedure classes rather than using anonymous ones. Furthermore it refactors getRunningMean() and getAllocatedMean() using a similar strategy.

Should the second commit be a step too far, I will anyway submit shortly a second, parallel PR including only the first commit. Cervator suggests that if this PR goes through the other one will be automatically closed. If this PR is too much, the other one will represent plan B.