### PR TITLE
Report only latest log folder to CrashReporter

### DIFF
--- a/engine/src/main/java/org/terasology/engine/LoggingContext.java
+++ b/engine/src/main/java/org/terasology/engine/LoggingContext.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -58,14 +60,18 @@ public final class LoggingContext {
     /**
      * The format of the log folder timestamps
      */
-    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd_HH-mm-ss";
+    private static final DateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+
+    private static Path loggingPath = Paths.get(".");
 
     private LoggingContext() {
         // no instances
     }
 
     public static void initialize(Path logFileFolder) {
-        String pathString = logFileFolder.normalize().toString();
+        String timestamp = TIMESTAMP_FORMAT.format(new Date());
+        loggingPath = logFileFolder.resolve(timestamp).normalize();
+        String pathString = loggingPath.toString();
         System.setProperty(LOG_FILE_FOLDER, pathString);
 
         try {
@@ -94,6 +100,10 @@ public final class LoggingContext {
 //        }
     }
 
+    public static Path getLoggingPath() {
+        return loggingPath;
+    }
+
     private static void deleteLogFiles(final Path rootPath, final int maxAgeInSecs) throws IOException {
         Files.walkFileTree(rootPath, new SimpleFileVisitor<Path>() {
 
@@ -106,9 +116,8 @@ public final class LoggingContext {
                 // compare only the first subfolder
                 String relPath = rootPath.relativize(path).getName(0).toString();
 
-                SimpleDateFormat sdf = new SimpleDateFormat(TIMESTAMP_FORMAT);
                 try {
-                    Date folderDate = sdf.parse(relPath);
+                    Date folderDate = TIMESTAMP_FORMAT.parse(relPath);
                     // JAVA8: long ageInSecs = folderDate.toInstant().until(Instant.now(), ChronoUnit.SECONDS);
                     long ageInSecs = (new Date().getTime() - folderDate.getTime()) / 1000;
 

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -296,15 +296,7 @@ public final class Terasology {
     }
 
     private static void reportException(Throwable throwable) {
-        Path logPath = Paths.get(".");
-        try {
-            Path gameLogPath = PathManager.getInstance().getLogPath();
-            if (gameLogPath != null) {
-                logPath = gameLogPath;
-            }
-        } catch (Exception pathManagerConstructorFailure) {
-            throwable.addSuppressed(pathManagerConstructorFailure);
-        }
+        Path logPath = LoggingContext.getLoggingPath();
 
         if (!GraphicsEnvironment.isHeadless() && crashReportEnabled) {
             CrashReporter.report(throwable, logPath);

--- a/facades/PC/src/main/resources/logback.xml
+++ b/facades/PC/src/main/resources/logback.xml
@@ -7,8 +7,6 @@
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>
   </contextListener>
-  
-  <timestamp key="timestamp" datePattern="yyyy-MM-dd_HH-mm-ss"/>
 
   <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
     <!-- in the absence of the class attribute, it is assumed that the
@@ -20,13 +18,13 @@
     <timeout>30 seconds</timeout>
     <sift>
       <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logFileFolder}/${timestamp}/Terasology-${phase}.log</file>
+        <file>${logFileFolder}/Terasology-${phase}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
           <!-- daily rollover -->
-          <fileNamePattern>${logFileFolder}/${timestamp}/Terasology-${phase}-%d{yyyy-MM-dd}.log</fileNamePattern>
+          <fileNamePattern>${logFileFolder}/Terasology-${phase}-%d{yyyy-MM-dd}.log</fileNamePattern>
 
-          <!-- keep 10 days' worth of history -->
-          <maxHistory>10</maxHistory>
+          <!-- keep 3 days' worth of history -->
+          <maxHistory>3</maxHistory>
         </rollingPolicy>
         <encoder>
           <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>


### PR DESCRIPTION
With these changes only the logging subfolder that is actually used is reported to CrashReporter.

Fixes https://github.com/MovingBlocks/CrashReporter/issues/19