### PR TITLE
Fix character encoding issues in source files

### DIFF
--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -11,6 +11,12 @@ apply plugin: 'findbugs'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+javadoc.options.encoding = 'UTF-8'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
     mavenCentral()

--- a/engine/src/main/java/org/terasology/input/Keyboard.java
+++ b/engine/src/main/java/org/terasology/input/Keyboard.java
@@ -265,7 +265,7 @@ public final class Keyboard {
         F19(KeyId.F19, "KEY_F19", "F19"),
         CONVERT(KeyId.CONVERT, "KEY_CONVERT", "Convert"), // Japanese Keyboard key (for converting Hiragana characters to Kanji?)
         NOCONVERT(KeyId.NOCONVERT, "KEY_NOCONVERT", "No Convert"), // Japanese Keyboard key
-        YEN(KeyId.YEN, "KEY_YEN", "¥"), // Japanese keyboard key for yen
+        YEN(KeyId.YEN, "KEY_YEN", "\u00A5"), // Japanese keyboard key for yen
         NUMPAD_EQUALS(KeyId.NUMPAD_EQUALS, "KEY_NUMPADEQUALS", "Numpad ="),
         CIRCUMFLEX(KeyId.CIRCUMFLEX, "KEY_CIRCUMFLEX", "^"), // Japanese keyboard
         AT(KeyId.AT, "KEY_AT", "@"), // (NEC PC98)
@@ -277,7 +277,7 @@ public final class Keyboard {
         UNLABELED(KeyId.UNLABELED, "KEY_UNLABELED", "Unlabelled"), // (J3100) (a mystery button?)
         NUMPAD_ENTER(KeyId.NUMPAD_ENTER, "KEY_NUMPADENTER", "Numpad Enter"),
         RIGHT_CTRL(KeyId.RIGHT_CTRL, "KEY_RCONTROL", "Right Ctrl"),
-        SECTION(KeyId.SECTION, "KEY_SECTION", "§"),
+        SECTION(KeyId.SECTION, "KEY_SECTION", "\u00A7"),
         NUMPAD_COMMA(KeyId.NUMPAD_COMMA, "KEY_NUMPADCOMMA", "Numpad ,"), // (NEC PC98)
         NUMPAD_DIVIDE(KeyId.NUMPAD_DIVIDE, "KEY_DIVIDE", "Numpad /"),
         PRINT_SCREEN(KeyId.PRINT_SCREEN, "KEY_SYSRQ", "Print Screen"),

--- a/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
@@ -838,7 +838,7 @@ public class ColladaLoader {
                         float texCoordS = faceInput.texCoordSource.floatValues[index * texCoordStride + 0];
                         float texCoordT = faceInput.texCoordSource.floatValues[index * texCoordStride + 1];
 
-                        // For texture coordinates, COLLADA’s right-handed coordinate system applies;
+                        // For texture coordinates, COLLADA's right-handed coordinate system applies;
                         // therefore, an ST texture coordinate of [0,0] maps to the lower-left texel of a texture image
                         texCoord0Param.add(texCoordS);
                         texCoord0Param.add(1 - texCoordT);

--- a/engine/src/main/java/org/terasology/world/chunks/deflate/TeraStandardDeflator.java
+++ b/engine/src/main/java/org/terasology/world/chunks/deflate/TeraStandardDeflator.java
@@ -35,7 +35,7 @@ public class TeraStandardDeflator extends TeraVisitingDeflator {
      *  ==============
      *
      *  dense chunk  : 4 + 12 + (65536 * 2)                                                   = 131088
-     *  sparse chunk : (4 + 12 + (256 * 2)) + (4 + 12 + (256 × 4)) + ((12 + (256 * 2)) × 256) = 135712
+     *  sparse chunk : (4 + 12 + (256 * 2)) + (4 + 12 + (256 x 4)) + ((12 + (256 * 2)) x 256) = 135712
      *  difference   : 135712 - 131088                                                        =   4624
      *  min. deflate : 4624 / (12 + (256 * 2))                                                =      8.8
      *
@@ -44,7 +44,7 @@ public class TeraStandardDeflator extends TeraVisitingDeflator {
      *  =============
      *
      *  dense chunk  : 4 + 12 + 65536                                                   = 65552
-     *  sparse chunk : (4 + 12 + 256) + (4 + 12 + (256 × 4)) + ((12 + 256) × 256)       = 69920
+     *  sparse chunk : (4 + 12 + 256) + (4 + 12 + (256 x 4)) + ((12 + 256) x 256)       = 69920
      *  difference   : 69920 - 65552                                                    =  4368
      *  min. deflate : 4368 / (12 + 256)                                                =    16.3
      *
@@ -53,7 +53,7 @@ public class TeraStandardDeflator extends TeraVisitingDeflator {
      *  =============
      *
      *  dense chunk  : 4 + 12 + (65536 / 2)                                             = 32784
-     *  sparse chunk : (4 + 12 + 256) + (4 + 12 + (256 × 4)) + ((12 + (256 / 2)) × 256) = 37152
+     *  sparse chunk : (4 + 12 + 256) + (4 + 12 + (256 x 4)) + ((12 + (256 / 2)) x 256) = 37152
      *  difference   : 37152 - 32784                                                    =  4368
      *  min. deflate : 4368 / (12 + (256 / 2))                                          =    31.2
      *


### PR DESCRIPTION
I stumbled over this when one of the Jenkins slave agents complained about invalid chars in java source files. So I replaced all non-ASCII characters and used escaped unicode instead. Easy fix.

That said, explicitly defining the encoding to `UTF-8` for `javac` should fix the same issue at least for the java compiler.

While I think that sticking with plain ASCII is reasonable for source files (translation files are certainly different), I didn't want to enforce this and went for `UTF-8` instead.

