### PR TITLE
Added new mode for the DebugOverlay (the stats cycled with F4)

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
@@ -68,7 +68,8 @@ public class DebugOverlay extends CoreScreenLayer {
     private WorldProvider worldProvider;
 
     private List<MetricsMode> metricsModes = Lists.newArrayList(new NullMetricsMode(), new RunningMeansMode(), new SpikesMode(),
-            new AllocationsMode(), new RunningThreadsMode(), new WorldRendererMode(), new NetworkStatsMode());
+            new AllocationsMode(), new RunningThreadsMode(), new WorldRendererMode(), new NetworkStatsMode(),
+            new RenderingExecTimeMeansMode("Rendering - Execution Time: Running Means - Sorted Alphabetically"));
     private int currentMode;
     private UILabel metricsLabel;
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/RenderingExecTimeMeansMode.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/RenderingExecTimeMeansMode.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.ingame.metrics;
+
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.procedure.TObjectDoubleProcedure;
+import org.terasology.monitoring.PerformanceMonitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+/**
+ * Like other MetricsMode implementations, an instance of this class will output a list of activities registered
+ * with the PerformanceMonitor and the execution time running means for each, in milliseconds.
+ * <br><br>
+ * Differently from other implementations, this class filters out all activities that are not prefixed
+ * with the strings "WorldRenderer::" and "PostProcessor::". Furthermore, it orders the activities alphabetically
+ * and poses no limit on the number of items displayed. Finally it places the time value on the left, making an
+ * attempt to align the digits, while the name of the associated activity is on the right, after a separator.
+ */
+public class RenderingExecTimeMeansMode extends MetricsMode {
+
+    private StringBuilder builder = new StringBuilder();
+    private ArrayList<MetricsEntry> processedEntries = new ArrayList<>();
+    private AlphabeticalAscendingComparator inAscendingAlphabeticalOrder = new AlphabeticalAscendingComparator();
+
+    private TObjectDoubleProcedure<String> matchingCriteria = new FilterByStartWith();
+    private EntryAdder addEntryToProcessedEntries = new EntryAdder();
+
+    public RenderingExecTimeMeansMode(String name) {
+        super(name);
+    }
+
+    @Override
+    public String getMetrics() {
+        builder.setLength(0);
+        builder.append(getName());
+        builder.append("\n");
+
+        processMetrics(PerformanceMonitor.getRunningMean(), builder);
+
+        return builder.toString();
+    }
+
+    private void processMetrics(TObjectDoubleMap<String> activitiesToMetricsMap, StringBuilder builder) {
+        activitiesToMetricsMap.retainEntries(matchingCriteria);
+
+        processedEntries.clear();
+        activitiesToMetricsMap.forEachEntry(addEntryToProcessedEntries);
+        Collections.sort(processedEntries, inAscendingAlphabeticalOrder);
+
+        for (MetricsEntry entry : processedEntries) {
+            builder.append(String.format("%,10.2f", entry.metricsValue));
+            builder.append("ms - ");
+            builder.append(entry.activityName);
+            builder.append("\n");
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public boolean isPerformanceManagerMode() {
+        return true;
+    }
+
+    private class FilterByStartWith implements TObjectDoubleProcedure<String> {
+        @Override
+        public boolean execute(String activityName, double metricsValue) {
+            return activityName.startsWith("WorldRenderer::") || activityName.startsWith("PostProcessor::");
+        }
+    }
+
+    private class MetricsEntry {
+        public String activityName;
+        public double metricsValue;
+
+        public MetricsEntry(String activityName, double metricsValue) {
+            this.activityName = activityName;
+            this.metricsValue = metricsValue;
+        }
+    }
+
+    private class EntryAdder implements TObjectDoubleProcedure<String> {
+        @Override
+        public boolean execute(String activityName, double metricsValue) {
+            processedEntries.add(new MetricsEntry(activityName, metricsValue));
+            return true;
+        }
+    }
+
+    private static class AlphabeticalAscendingComparator implements Comparator<MetricsEntry> {
+        @Override
+        public int compare(MetricsEntry firstEntry, MetricsEntry secondEntry) {
+            return firstEntry.activityName.compareTo(secondEntry.activityName);
+        }
+    }
+}


### PR DESCRIPTION
Added a new mode to the DebugOverlay, specialized on execution time running means for rendering code only. 

While functional, the new mode filters out (does not display) activities registered with the performance monitor that are not prefixed by the strings "WorldRenderer::" or "PostProcessor::". At the time of this commit no activity is prefixed with those strings and as such the new mode displays only its title. Those prefixes will be added some time after PR #1745 has been dealt with.

Additionally, differently from various time-related modes already in place, the new mode sorts the list of post-filter activities alphabetically, and formats each item to list the time value on the left and the activity name on the right, after a separator. I.e.:

```
  0.31ms - PostProcessor::Activity 1
  0.17ms - WorldRenderer::Activity 2
  1.87ms - WorldRenderer::Activity 3
```

Some issues: 
* I'm using String.format() to format the time value and also attempt to align it. If the number of digits is not the same however (i.e. 1.00ms vs 10.00ms) alignment doesn't work, most likely because the font used by the specific UI element is not a mono-spaced font. Any way I could change that?
* I've also been wondering if it'd be possible to add color to specific words or lines. This would allow the highlighting of times and activities that fulfill some criteria, i.e. when a running mean goes above 20ms it gets marked in orange and when it goes above 40ms it gets marked in red.
* For the past couple of weeks I experimented with a much more generic solution, i.e. one where arbitrary objects for sourcing, filtering, sorting and formatting the data could be provided upon construction and even set at runtime. Eventually I opted for the simpler, inflexible solution seen here, for the time being. EDIT: I opened issue #1773 on the matter.