### PR TITLE
Refactor PropertyProvider to support notifications

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorEditorScreen.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorEditorScreen.java
@@ -85,6 +85,8 @@ public class BehaviorEditorScreen extends CoreScreenLayer {
         palette = find("palette", UIList.class);
 
         behaviorEditor.bindSelection(new Binding<RenderableNode>() {
+            private PropertyProvider provider = new PropertyProvider();
+
             @Override
             public RenderableNode get() {
                 return selectedNode;
@@ -95,8 +97,7 @@ public class BehaviorEditorScreen extends CoreScreenLayer {
                 selectedNode = value;
                 properties.clear();
                 if (value != null) {
-                    PropertyProvider<?> provider = new PropertyProvider<>(value.getNode());
-                    properties.addPropertyProvider("Behavior Node", provider);
+                    properties.addProperties("Behavior Node", provider.createProperties(value.getNode()));
                 }
             }
         });
@@ -132,6 +133,8 @@ public class BehaviorEditorScreen extends CoreScreenLayer {
         });
 
         selectEntity.bindSelection(new Binding<Interpreter>() {
+            private PropertyProvider provider = new PropertyProvider();
+
             @Override
             public Interpreter get() {
                 return selectedInterpreter;
@@ -147,7 +150,8 @@ public class BehaviorEditorScreen extends CoreScreenLayer {
                     EntityRef minion = value.actor().minion();
                     entityProperties.clear();
                     for (Component component : minion.iterateComponents()) {
-                        entityProperties.addPropertyProvider(component.getClass().getSimpleName().replace("Component", ""), new PropertyProvider<>(component));
+                        String name = component.getClass().getSimpleName().replace("Component", "");
+                        entityProperties.addProperties(name, provider.createProperties(component));
                     }
                 }
                 updateDebugger();

--- a/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
+++ b/engine/src/main/java/org/terasology/logic/debug/DebugPropertiesSystem.java
@@ -54,10 +54,11 @@ public class DebugPropertiesSystem extends BaseComponentSystem {
     }
 
     public void addProperty(final String group, final Object o) {
+        PropertyProvider propertyProvider = new PropertyProvider();
         AccessController.doPrivileged(new PrivilegedAction<Object>() {
             @Override
             public Object run() {
-                properties.addPropertyProvider(group, new PropertyProvider<Object>(o));
+                properties.addProperties(group, propertyProvider.createProperties(o));
                 return null;
             }
         });

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
@@ -43,6 +43,7 @@ import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.layers.mainMenu.preview.FacetLayerPreview;
 import org.terasology.rendering.nui.layers.mainMenu.preview.PreviewGenerator;
 import org.terasology.rendering.nui.layouts.PropertyLayout;
+import org.terasology.rendering.nui.properties.Property;
 import org.terasology.rendering.nui.properties.PropertyOrdering;
 import org.terasology.rendering.nui.properties.PropertyProvider;
 import org.terasology.rendering.nui.widgets.ActivateEventListener;
@@ -57,6 +58,7 @@ import org.terasology.world.generator.plugin.TempWorldGeneratorPluginLibrary;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
@@ -164,9 +164,9 @@ public class PreviewWorldScreen extends CoreScreenLayer {
 
     private void configureProperties() {
 
-        PropertyLayout properties = find("properties", PropertyLayout.class);
-        properties.setOrdering(PropertyOrdering.byLabel());
-        properties.clear();
+        PropertyLayout propLayout = find("properties", PropertyLayout.class);
+        propLayout.setOrdering(PropertyOrdering.byLabel());
+        propLayout.clear();
 
         WorldConfigurator worldConfig = worldGenerator.getConfigurator();
 
@@ -180,9 +180,12 @@ public class PreviewWorldScreen extends CoreScreenLayer {
             }
         }
 
+        PropertyProvider provider = new PropertyProvider();
+
         for (String label : params.keySet()) {
-            PropertyProvider<?> provider = new PropertyProvider<>(params.get(label));
-            properties.addPropertyProvider(label, provider);
+            Component target = params.get(label);
+            List<Property<?, ?>> properties = provider.createProperties(target);
+            propLayout.addProperties(label, properties);
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/PropertyLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/PropertyLayout.java
@@ -16,15 +16,16 @@
 package org.terasology.rendering.nui.layouts;
 
 import com.google.common.collect.Lists;
+
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.layouts.miglayout.MigLayout;
 import org.terasology.rendering.nui.properties.Property;
 import org.terasology.rendering.nui.properties.PropertyOrdering;
-import org.terasology.rendering.nui.properties.PropertyProvider;
 import org.terasology.rendering.nui.widgets.ActivateEventListener;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UILabel;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -42,7 +43,7 @@ public class PropertyLayout extends MigLayout {
     public PropertyLayout(String id) {
         super(id);
     }
-    
+
     public void setOrdering(Comparator<? super Property<?, ?>> comparator) {
         this.propertyComparator = comparator;
     }
@@ -51,8 +52,8 @@ public class PropertyLayout extends MigLayout {
      * Adds a provider for properties to this layout. All properties appears in a list that may be collapsed/expanded.
      * Initially the list is expanded.
      */
-    public void addPropertyProvider(String groupLabel, final PropertyProvider<?> propertyProvider) {
-        if (propertyProvider.getProperties().size() > 0) {
+    public void addProperties(String groupLabel, final Collection<Property<?, ?>> properties) {
+        if (properties.size() > 0) {
             final UIButton expand = new UIButton("", "-");
             expand.setTooltip("Click to collapse");
             final UILabel headline = new UILabel(groupLabel);
@@ -71,7 +72,7 @@ public class PropertyLayout extends MigLayout {
                         button.setText("+");
                         button.setTooltip("Click to expand");
                     } else {
-                        expand(propertyProvider, layout);
+                        expand(properties, layout);
                         button.setText("-");
                         button.setTooltip("Click to collapse");
                     }
@@ -81,12 +82,12 @@ public class PropertyLayout extends MigLayout {
             addWidget(headline, new CCHint());
             addWidget(layout, new CCHint("newline, spanx 2"));
 
-            expand(propertyProvider, layout);
+            expand(properties, layout);
         }
     }
 
-    private void expand(PropertyProvider<?> propertyProvider, MigLayout layout) {
-        List<Property<?, ?>> props = Lists.newArrayList(propertyProvider.getProperties());
+    private void expand(Collection<Property<?, ?>> properties, MigLayout layout) {
+        List<Property<?, ?>> props = Lists.newArrayList(properties);
         Collections.sort(props, propertyComparator);
         for (Property<?, ?> property : props) {
             UILabel label = property.getLabel();


### PR DESCRIPTION
This PR refactors `PropertyProvider` to support customized bindings such as notifications. 

I also implemented custom bindings that decorate other bindings and send `PropertyChangeEvents` on "set" calls. The commit is https://github.com/msteiger/Terasology/commit/8e5131f31b54ac7c5aded4e495871aef26e01b48, but not part of this PR, since I doubt that String-based identification of modified fields is ideal. I'm open to suggestions.

Ping @synopia