### PR TITLE
Use card layout for different server types

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/databinding/ListSelectionBinding.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/databinding/ListSelectionBinding.java
@@ -22,7 +22,7 @@ import org.terasology.rendering.nui.widgets.UIList;
  */
 public class ListSelectionBinding<T> implements Binding<T> {
 
-    UIList<T> list;
+    private final UIList<T> list;
 
     public ListSelectionBinding(UIList<T> list) {
         this.list = list;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -42,7 +42,6 @@ import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.databinding.BindHelper;
-import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.databinding.IntToStringBinding;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
@@ -120,15 +119,7 @@ public class JoinGameScreen extends CoreScreenLayer {
         };
         WidgetUtil.trySubscribe(this, "onlineButton", activateOnline);
 
-        Binding<Boolean> customSelectedBinding = new ReadOnlyBinding<Boolean>() {
-
-            @Override
-            public Boolean get() {
-                return visibleList == customServerList;
-            }
-        };
-
-        bindCustomButtons(customSelectedBinding);
+        bindCustomButtons();
         bindInfoLabels();
 
         WidgetUtil.trySubscribe(this, "close", new ActivateEventListener() {
@@ -292,11 +283,10 @@ public class JoinGameScreen extends CoreScreenLayer {
 
     }
 
-    private void bindCustomButtons(Binding<Boolean> customSelectedBinding) {
+    private void bindCustomButtons() {
 
         UIButton add = find("add", UIButton.class);
         if (add != null) {
-            add.bindEnabled(customSelectedBinding);
             add.subscribe(button -> {
                 AddServerPopup popup = getManager().pushScreen(AddServerPopup.ASSET_URI, AddServerPopup.class);
                 // select the entry if added successfully
@@ -306,7 +296,6 @@ public class JoinGameScreen extends CoreScreenLayer {
 
         UIButton edit = find("edit", UIButton.class);
         if (edit != null) {
-            edit.bindEnabled(customSelectedBinding);
             edit.subscribe(button -> {
               AddServerPopup popup = getManager().pushScreen(AddServerPopup.ASSET_URI, AddServerPopup.class);
               ServerInfo info = visibleList.getSelection();
@@ -319,7 +308,6 @@ public class JoinGameScreen extends CoreScreenLayer {
 
         UIButton removeButton = find("remove", UIButton.class);
         if (removeButton != null) {
-            removeButton.bindEnabled(customSelectedBinding);
             removeButton.subscribe(button -> {
                 ServerInfo info = visibleList.getSelection();
                 if (info != null) {

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -74,15 +74,58 @@
                             "type" : "RelativeLayout",
                             "contents" : [
                                 {
-                                    "type" : "ScrollableArea",
-                                    "content" : {
-                                        "type" : "UIList",
-                                        "id" : "serverList",
-                                        "family" : "module-list"
+                                    "type": "RowLayout",
+                                    "id": "serverTypeRow",
+                                    "contents" : [
+                                    {
+                                        "type": "UIButton",
+                                        "id": "customButton",
+                                        "text": "Custom",
+                                        "layoutInfo" : {
+                                            "relativeWidth" : 0.5
+                                        }
                                     },
+                                    {
+                                        "type" : "UIButton",
+                                        "id" : "onlineButton",
+                                        "text": "Online"
+                                    }
+                                    ],
                                     "layoutInfo" : {
+                                        "use-content-height" : true,
                                         "position-top" : {
                                             "target" : "TOP"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "CardLayout",
+                                    "id": "cards",
+                                    "defaultCard": "customServerListScrollArea",
+                                    "contents": [
+                                        {
+                                            "type" : "ScrollableArea",
+                                            "id" : "customServerListScrollArea",
+                                            "content" : {
+                                                "type" : "UIList",
+                                                "id" : "customServerList",
+                                                "family" : "module-list"
+                                            }
+                                        },
+                                        {
+                                            "type" : "ScrollableArea",
+                                            "id" : "onlineServerListScrollArea",
+                                            "content" : {
+                                                "type" : "UIList",
+                                                "id" : "onlineServerList",
+                                                "family" : "module-list"
+                                            }
+                                        }
+                                    ],
+                                    "layoutInfo" : {
+                                        "position-top" : {
+                                            "target" : "BOTTOM",
+                                            "widget" : "serverTypeRow"
                                         },
                                         "position-bottom" : {
                                             "target" : "TOP",

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -104,22 +104,107 @@
                                     "defaultCard": "customServerListScrollArea",
                                     "contents": [
                                         {
-                                            "type" : "ScrollableArea",
+                                            "type" : "RelativeLayout",
                                             "id" : "customServerListScrollArea",
-                                            "content" : {
-                                                "type" : "UIList",
-                                                "id" : "customServerList",
-                                                "family" : "module-list"
+                                            "contents" : [
+                                            {
+                                                "type" : "ScrollableArea",
+                                                "content" : {
+                                                    "type" : "UIList",
+                                                    "id" : "customServerList",
+                                                    "family" : "module-list"
+                                                },
+                                                "layoutInfo" : {
+                                                    "position-top" : {
+                                                        "target" : "TOP"
+                                                    },
+                                                    "position-bottom" : {
+                                                        "target" : "TOP",
+                                                        "widget" : "edit",
+                                                        "offset" : 8
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "type" : "UIButton",
+                                                "id" : "edit",
+                                                "text" : "Edit",
+                                                "layoutInfo" : {
+                                                    "use-content-height" : true,
+                                                    "width" : 135,
+                                                    "position-bottom" : {
+                                                        "target" : "TOP",
+                                                        "widget" : "add",
+                                                        "offset" : 8
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "type" : "UIButton",
+                                                "id" : "remove",
+                                                "text" : "Remove",
+                                                "layoutInfo" : {
+                                                    "use-content-height" : true,
+                                                    "position-left" : {
+                                                        "target" : "RIGHT",
+                                                        "widget" : "edit",
+                                                        "offset" : 8
+                                                    },
+                                                    "position-bottom" : {
+                                                        "target" : "TOP",
+                                                        "widget" : "add",
+                                                        "offset" : 8
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "type" : "UIButton",
+                                                "id" : "add",
+                                                "text" : "Add New",
+                                                "layoutInfo" : {
+                                                    "use-content-height" : true,
+                                                    "position-bottom" : {
+                                                        "target" : "BOTTOM"
+                                                    }
+                                                }
                                             }
+                                            ]
                                         },
                                         {
-                                            "type" : "ScrollableArea",
+                                            "type" : "RelativeLayout",
                                             "id" : "onlineServerListScrollArea",
-                                            "content" : {
-                                                "type" : "UIList",
-                                                "id" : "onlineServerList",
-                                                "family" : "module-list"
+                                            "contents" : [
+                                            {
+                                                "type" : "ScrollableArea",
+                                                "content" : {
+                                                    "type" : "UIList",
+                                                    "id" : "onlineServerList",
+                                                    "family" : "module-list"
+                                                },
+                                                "layoutInfo" : {
+                                                    "position-top" : {
+                                                        "target" : "TOP"
+                                                    },
+                                                    "position-bottom" : {
+                                                        "target" : "TOP",
+                                                        "widget" : "download",
+                                                        "offset" : 4
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "type" : "UILabel",
+                                                "id" : "download",
+                                                "text" : "<download info text>",
+                                                "layoutInfo" : {
+                                                    "use-content-height" : true,
+                                                    "position-bottom" : {
+                                                        "target" : "BOTTOM",
+                                                        "offset" : 4
+                                                    }
+                                                }
                                             }
+                                            ]
                                         }
                                     ],
                                     "layoutInfo" : {
@@ -127,63 +212,6 @@
                                             "target" : "BOTTOM",
                                             "widget" : "serverTypeRow"
                                         },
-                                        "position-bottom" : {
-                                            "target" : "TOP",
-                                            "widget" : "download"
-                                        }
-                                    }
-                                },
-                                {
-                                    "type" : "UILabel",
-                                    "id" : "download",
-                                    "text" : "<download info text>",
-                                    "layoutInfo" : {
-                                        "use-content-height" : true,
-                                        "position-bottom" : {
-                                            "target" : "TOP",
-                                            "widget" : "edit",
-                                            "offset" : 8
-                                        }
-                                    }
-                                },
-                                {
-                                    "type" : "UIButton",
-                                    "id" : "edit",
-                                    "text" : "Edit",
-                                    "layoutInfo" : {
-                                        "use-content-height" : true,
-                                        "width" : 135,
-                                        "position-bottom" : {
-                                            "target" : "TOP",
-                                            "widget" : "add",
-                                            "offset" : 8
-                                        }
-                                    }
-                                },
-                                {
-                                    "type" : "UIButton",
-                                    "id" : "remove",
-                                    "text" : "Remove",
-                                    "layoutInfo" : {
-                                        "use-content-height" : true,
-                                        "position-left" : {
-                                            "target" : "RIGHT",
-                                            "widget" : "edit",
-                                            "offset" : 8
-                                        },
-                                        "position-bottom" : {
-                                            "target" : "TOP",
-                                            "widget" : "add",
-                                            "offset" : 8
-                                        }
-                                    }
-                                },
-                                {
-                                    "type" : "UIButton",
-                                    "id" : "add",
-                                    "text" : "Add New",
-                                    "layoutInfo" : {
-                                        "use-content-height" : true,
                                         "position-bottom" : {
                                             "target" : "BOTTOM"
                                         }


### PR DESCRIPTION
The PR separates user-defined game servers from those that are retrieved online through a "tabbed" list:

![image](https://cloud.githubusercontent.com/assets/1820007/8271218/85071d56-180b-11e5-8c58-865bb9308eca.png)

The second commit also moves the editing controls to the "custom" tab and the download status label to the "online" tab. This clarifies the different server types better than adding the `(custom)` tag to the name as it was before.