### PR TITLE
Rework join game dialog

### DIFF
--- a/engine/src/main/java/org/terasology/config/ServerInfo.java
+++ b/engine/src/main/java/org/terasology/config/ServerInfo.java
@@ -16,6 +16,8 @@
 
 package org.terasology.config;
 
+import com.google.common.base.Preconditions;
+
 
 /**
  * @author Immortius
@@ -23,26 +25,18 @@ package org.terasology.config;
 public class ServerInfo {
     private String name;
     private String address;
+    private String owner;
     private int port;
+    private boolean active = true;
 
-    private ServerInfo() {
+    ServerInfo() {
         // for serialization purposes
     }
 
     public ServerInfo(String name, String address, int port) {
-        if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException("Server name must not be null or empty");
-        }
-        if (address == null || address.isEmpty()) {
-            throw new IllegalArgumentException("Server address must not be null or empty");
-        }
-        if (port < 0 || port > 65535) {
-            throw new IllegalArgumentException("Server port must be in the range [0..65535]");
-        }
-
-        this.name = name;
-        this.address = address;
-        this.port = port;
+        setName(name);
+        setAddress(address);
+        setPort(port);
     }
 
     public String getName() {
@@ -50,9 +44,8 @@ public class ServerInfo {
     }
 
     public void setName(String name) {
-        if (name != null && !name.isEmpty()) {
-            this.name = name;
-        }
+        Preconditions.checkArgument(name != null && !name.isEmpty(), "Server name must not be null or empty");
+        this.name = name;
     }
 
     public String getAddress() {
@@ -60,9 +53,8 @@ public class ServerInfo {
     }
 
     public void setAddress(String address) {
-        if (address != null && !address.isEmpty()) {
-            this.address = address;
-        }
+        Preconditions.checkArgument(address != null && !address.isEmpty(), "Server address must not be null or empty");
+        this.address = address;
     }
 
     public int getPort() {
@@ -70,13 +62,29 @@ public class ServerInfo {
     }
 
     public void setPort(int port) {
-        if (port >= 0 && port <= 65535) {
-            this.port = port;
-        }
+        Preconditions.checkArgument(port >= 0 && port <= 65535, "Server port must be in the range [0..65535]");
+        this.port = port;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
     @Override
     public String toString() {
-        return "ServerInfo [name=" + name + ", address=" + address + ", port=" + port + "]";
+        return "ServerInfo [name=" + name + ", address=" + address + ", port=" + port +
+                ", owner=" + owner + ", active=" + active + "]";
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/AddServerPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/AddServerPopup.java
@@ -40,6 +40,7 @@ public class AddServerPopup extends CoreScreenLayer {
     @In
     private Config config;
     private UIText nameText;
+    private UIText ownerText;
     private UIText addressText;
     private UIText portText;
     private UIButton okButton;
@@ -51,6 +52,7 @@ public class AddServerPopup extends CoreScreenLayer {
     @Override
     public void initialise() {
         nameText = find("name", UIText.class);
+        ownerText = find("owner", UIText.class);
         addressText = find("address", UIText.class);
         portText = find("port", UIText.class);
         okButton = find("ok", UIButton.class);
@@ -61,6 +63,7 @@ public class AddServerPopup extends CoreScreenLayer {
             public void onActivated(UIWidget button) {
 
                 String name = nameText.getText();
+                String owner = ownerText.getText();
                 String address = addressText.getText();
                 Integer portBoxed = Ints.tryParse(portText.getText());
                 int port = (portBoxed != null) ? portBoxed.intValue() : TerasologyConstants.DEFAULT_PORT;
@@ -68,6 +71,7 @@ public class AddServerPopup extends CoreScreenLayer {
                 if (serverInfo == null) {
                     // create new
                     serverInfo = new ServerInfo(name, address, port);
+                    serverInfo.setOwner(owner);
 
                     config.getNetwork().add(serverInfo);
                 } else {
@@ -75,6 +79,7 @@ public class AddServerPopup extends CoreScreenLayer {
                     serverInfo.setName(name);
                     serverInfo.setAddress(address);
                     serverInfo.setPort(port);
+                    serverInfo.setOwner(owner);
                 }
 
                 if (successFunc != null) {
@@ -131,8 +136,9 @@ public class AddServerPopup extends CoreScreenLayer {
 
         serverInfo = null;
         successFunc = null;
-        nameText.setText("");
-        addressText.setText("");
+        ownerText.setText(null);
+        nameText.setText(null);
+        addressText.setText(null);
 
         portText.setText(Integer.toString(TerasologyConstants.DEFAULT_PORT));
         portText.setCursorPosition(portText.getText().length());
@@ -150,6 +156,9 @@ public class AddServerPopup extends CoreScreenLayer {
 
         nameText.setText(serverInfo.getName());
         nameText.setCursorPosition(nameText.getText().length());
+
+        ownerText.setText(serverInfo.getOwner());
+        ownerText.setCursorPosition(ownerText.getText().length());
 
         addressText.setText(serverInfo.getAddress());
         addressText.setCursorPosition(addressText.getText().length());

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -264,7 +264,7 @@ public class JoinGameScreen extends CoreScreenLayer {
                 Future<ServerInfoMessage> info = extInfo.get(visibleList.getSelection());
                 if (info != null) {
                     if (info.isDone()) {
-                        return getModulesText(info, 9);
+                        return getModulesText(info);
                     } else {
                         return "requested";
                     }
@@ -371,7 +371,7 @@ public class JoinGameScreen extends CoreScreenLayer {
         }
     }
 
-    private String getModulesText(Future<ServerInfoMessage> info, int maxElements) {
+    private String getModulesText(Future<ServerInfoMessage> info) {
         try {
             ServerInfoMessage serverInfoMessage = info.get();
 
@@ -383,10 +383,6 @@ public class JoinGameScreen extends CoreScreenLayer {
                 codedModInfo.add(FontColor.getColored(entry.toString(), color));
             }
             Collections.sort(codedModInfo, String.CASE_INSENSITIVE_ORDER);
-            if (codedModInfo.size() > maxElements) {
-                codedModInfo = codedModInfo.subList(0, maxElements - 1);
-                codedModInfo.add("...");
-            }
             return Joiner.on('\n').join(codedModInfo);
         } catch (ExecutionException | InterruptedException e) {
             return FontColor.getColored("Connection Failed!", Color.RED);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -130,7 +130,7 @@ public class JoinGameScreen extends CoreScreenLayer {
             }
         });
 
-        activateCustom.onActivated(null);
+        activateOnline.onActivated(null);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/ColumnLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/ColumnLayout.java
@@ -47,6 +47,8 @@ public class ColumnLayout extends CoreLayout<LayoutHint> {
     private boolean autoSizeColumns;
     @LayoutConfig
     private boolean fillVerticalSpace = true;
+    @LayoutConfig
+    private boolean extendLast;
 
     private List<UIWidget> widgetList = Lists.newArrayList();
 
@@ -153,14 +155,21 @@ public class ColumnLayout extends CoreLayout<LayoutHint> {
             }
             usedHeight += (rowInfos.size() - 1) * verticalSpacing;
 
+            int excessHeight = canvas.size().y - usedHeight;
             if (fillVerticalSpace) {
-                int extraSpacePerRow = (canvas.size().y - usedHeight) / rowInfos.size();
+                if (extendLast && numRows > 0) {
+                    // give all the extra space to the last entry
+                    rowInfos.get(numRows - 1).height += excessHeight;
+                } else {
+                    // distribute extra height equally
+                    int extraSpacePerRow = excessHeight / rowInfos.size();
 
-                for (RowInfo row : rowInfos) {
-                    row.height += extraSpacePerRow;
+                    for (RowInfo row : rowInfos) {
+                        row.height += extraSpacePerRow;
+                    }
                 }
             } else {
-                rowOffsetY = (canvas.size().y - usedHeight) / 2;
+                rowOffsetY = excessHeight / 2;
             }
             for (int rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
                 List<UIWidget> row = rows.get(rowIndex);

--- a/engine/src/main/resources/assets/ui/menu/addServerPopup.ui
+++ b/engine/src/main/resources/assets/ui/menu/addServerPopup.ui
@@ -48,6 +48,23 @@
                                 "contents" : [
                                     {
                                         "type" : "UILabel",
+                                        "text" : "Owner: ",
+                                        "family" : "option-grid",
+                                        "layoutInfo" : {
+                                            "relativeWidth" : 0.3
+                                        }
+                                    },
+                                    {
+                                        "type" : "UIText",
+                                        "id" : "owner"
+                                    }
+                                ]
+                            },
+                            {
+                                "type" : "RowLayout",
+                                "contents" : [
+                                    {
+                                        "type" : "UILabel",
                                         "text" : "Address: ",
                                         "family" : "option-grid",
                                         "layoutInfo" : {
@@ -76,11 +93,11 @@
                                         "id" : "port"
                                     }
                                 ]
-                            },                            
+                            },
                             {
                                "type" : "UILabel",
                                 "text" : "You can press ENTER to copy the name to the address field"
-                            },                            
+                            },
                             {
                                 "type" : "UISpace",
                                 "size" : [1, 16]

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -228,6 +228,7 @@
                                     "id" : "simpleItems",
                                     "columns" : 2,
                                     "column-widths" : [0.25, 0.75],
+                                    "extendLast" : true,
                                     "verticalSpacing" : 8,
                                     "contents" : [
                                         {
@@ -280,16 +281,23 @@
                                             "text" : "Modules: "
                                         },
                                         {
-                                            "type" : "UILabel",
-                                            "id" : "modules",
-                                            "text" : "Module Info Goes Here"
+                                            "type" : "ScrollableArea",
+                                            "content" : {
+                                                "type" : "UILabel",
+                                                "id" : "modules",
+                                                "text" : "Module Info Goes Here"
+                                            }
                                         }
                                     ],
                                     "layoutInfo" : {
-                                        "use-content-height" : true,
                                         "position-horizontal-center" : {},
                                         "position-top" : {
                                             "target" : "TOP",
+                                            "offset" : 8
+                                        },
+                                        "position-bottom" : {
+                                            "target" : "TOP",
+                                            "widget" : "join",
                                             "offset" : 8
                                         }
                                     }

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -78,17 +78,17 @@
                                     "id": "serverTypeRow",
                                     "contents" : [
                                     {
-                                        "type": "UIButton",
-                                        "id": "customButton",
-                                        "text": "Custom",
+                                        "type" : "UIButton",
+                                        "id" : "onlineButton",
+                                        "text": "Listed",
                                         "layoutInfo" : {
                                             "relativeWidth" : 0.5
                                         }
                                     },
                                     {
-                                        "type" : "UIButton",
-                                        "id" : "onlineButton",
-                                        "text": "Online"
+                                        "type": "UIButton",
+                                        "id": "customButton",
+                                        "text": "Custom"
                                     }
                                     ],
                                     "layoutInfo" : {
@@ -101,7 +101,7 @@
                                 {
                                     "type": "CardLayout",
                                     "id": "cards",
-                                    "defaultCard": "customServerListScrollArea",
+                                    "defaultCard": "onlineServerListScrollArea",
                                     "contents": [
                                         {
                                             "type" : "RelativeLayout",

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -241,6 +241,15 @@
                                         },
                                         {
                                             "type" : "UILabel",
+                                            "text" : "Owner: "
+                                        },
+                                        {
+                                            "type" : "UILabel",
+                                            "id" : "owner",
+                                            "text" : "Server Owner Goes Here"
+                                        },
+                                        {
+                                            "type" : "UILabel",
                                             "text" : "Address: "
                                         },
                                         {


### PR DESCRIPTION
This PR deals with a few related issues around the join game dialog:

* The entry "Online" was renamed to "Listed" (now at the left and default) - Fixes #1786 
* Servers are now retrieved as a stream (plus an artificially delay to achieve an animation)
* Add the "Owner" field - editable for custom entries
* Evaluate the "active" field. Inactive servers are not listed.
* Add `extendLast` layout hint for `ColumnLayout`: the last entry takes all the excess space.
* The module list is no longer truncated and scrollable instead

![image](https://cloud.githubusercontent.com/assets/1820007/8392924/268dcf74-1cfa-11e5-97a7-b882c9b70ebb.png)
