### PR TITLE
Remove CoreRegistry usage: Part V

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
@@ -69,7 +69,7 @@ public class PojoEventSystemTests {
         compLibrary = entitySystemLibrary.getComponentLibrary();
         entityManager = new PojoEntityManager();
         entityManager.setComponentLibrary(entitySystemLibrary.getComponentLibrary());
-        entityManager.setPrefabManager(new PojoPrefabManager());
+        entityManager.setPrefabManager(new PojoPrefabManager(context));
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
         eventSystem = new EventSystemImpl(entitySystemLibrary.getEventLibrary(), networkSystem);

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
@@ -69,7 +69,6 @@ public class PojoPrefabManagerTest {
         lib.add(Quat4f.class, new Quat4fTypeHandler());
         entitySystemLibrary = new EntitySystemLibrary(context, lib);
         componentLibrary = entitySystemLibrary.getComponentLibrary();
-        prefabManager = new PojoPrefabManager();
 
         ModuleAwareAssetTypeManager assetTypeManager = new ModuleAwareAssetTypeManager();
         assetTypeManager.registerCoreAssetType(Prefab.class,
@@ -77,6 +76,8 @@ public class PojoPrefabManagerTest {
 
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
         context.put(AssetManager.class, assetTypeManager.getAssetManager());
+
+        prefabManager = new PojoPrefabManager(context);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
@@ -76,7 +76,7 @@ public class PrefabTest {
         context.put(NetworkSystem.class, networkSystem);
         EntitySystemSetupUtil.addReflectionBasedLibraries(context);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
-        prefabManager = new PojoPrefabManager();
+        prefabManager = new PojoPrefabManager(context);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PrefabTest.java
@@ -25,16 +25,19 @@ import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.prefab.internal.PojoPrefab;
 import org.terasology.entitySystem.prefab.internal.PojoPrefabManager;
+import org.terasology.entitySystem.prefab.internal.PrefabFormat;
 import org.terasology.entitySystem.stubs.MappedContainerComponent;
 import org.terasology.entitySystem.stubs.OrderedMapTestComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
@@ -65,17 +68,23 @@ public class PrefabTest {
         ModuleManager moduleManager = ModuleManagerFactory.create();
         context.put(ModuleManager.class, moduleManager);
 
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+
         ModuleAwareAssetTypeManager assetTypeManager = new ModuleAwareAssetTypeManager();
         assetTypeManager.registerCoreAssetType(Prefab.class,
                 (AssetFactory<Prefab, PrefabData>) PojoPrefab::new, "prefabs");
+        ComponentLibrary componentLibrary = context.get(ComponentLibrary.class);
+        TypeSerializationLibrary typeSerializationLibrary = context.get(TypeSerializationLibrary.class);
+        PrefabFormat prefabFormat = new PrefabFormat(componentLibrary, typeSerializationLibrary);
+        assetTypeManager.registerCoreFormat(Prefab.class, prefabFormat);
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
         context.put(AssetManager.class, assetTypeManager.getAssetManager());
 
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
         context.put(NetworkSystem.class, networkSystem);
-        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+
         prefabManager = new PojoPrefabManager(context);
     }
 

--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -21,7 +21,6 @@ import org.lwjgl.opengl.PixelFormat;
 import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.events.ChangeViewRangeRequest;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.cameras.PerspectiveCameraSettings;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.CameraSetting;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.ScreenshotSize;

--- a/engine/src/main/java/org/terasology/engine/bootstrap/ApplyModulesUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/ApplyModulesUtil.java
@@ -28,6 +28,7 @@ import org.terasology.entitySystem.metadata.EventLibrary;
 import org.terasology.entitySystem.metadata.MetadataUtil;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.internal.PrefabDeltaFormat;
+import org.terasology.entitySystem.prefab.internal.PrefabFormat;
 import org.terasology.entitySystem.systems.internal.DoNotAutoRegister;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -94,12 +95,14 @@ public final class ApplyModulesUtil {
         ModuleAwareAssetTypeManager assetTypeManager = context.get(ModuleAwareAssetTypeManager.class);
 
         /*
-         * The registring of the assset delta formats is done in this method, because it needs to be done before
+         * The registring of the prefab formats is done in this method, because it needs to be done before
          * the environment switch. It can't be done before this method gets called because the ComponentLibrary isn't
          * existing then yet.
          *
          * This method is propably something that should be refactored in future.
          */
+        PrefabFormat prefabFormat = new PrefabFormat(componentLibrary, typeSerializationLibrary);
+        assetTypeManager.registerCoreFormat(Prefab.class, prefabFormat);
         PrefabDeltaFormat prefabDeltaFormat = new PrefabDeltaFormat(componentLibrary, typeSerializationLibrary);
         assetTypeManager.registerCoreDeltaFormat(Prefab.class, prefabDeltaFormat);
 

--- a/engine/src/main/java/org/terasology/engine/bootstrap/ApplyModulesUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/ApplyModulesUtil.java
@@ -17,17 +17,17 @@ package org.terasology.engine.bootstrap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.context.Context;
 import org.terasology.assets.module.ModuleAwareAssetTypeManager;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.event.Event;
-import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.metadata.EntitySystemLibrary;
 import org.terasology.entitySystem.metadata.EventLibrary;
 import org.terasology.entitySystem.metadata.MetadataUtil;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.internal.PrefabDeltaFormat;
 import org.terasology.entitySystem.systems.internal.DoNotAutoRegister;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -82,15 +82,27 @@ public final class ApplyModulesUtil {
         // Entity System Library
         EntitySystemLibrary library = new EntitySystemLibrary(context, typeSerializationLibrary);
         context.put(EntitySystemLibrary.class, library);
-        context.put(ComponentLibrary.class, library.getComponentLibrary());
+        ComponentLibrary componentLibrary = library.getComponentLibrary();
+        context.put(ComponentLibrary.class, componentLibrary);
         context.put(EventLibrary.class, library.getEventLibrary());
 
-        registerComponents(library.getComponentLibrary(), moduleManager.getEnvironment());
+        registerComponents(componentLibrary, moduleManager.getEnvironment());
 
         BlockFamilyFactoryRegistry blockFamilyFactoryRegistry = context.get(BlockFamilyFactoryRegistry.class);
         loadFamilies((DefaultBlockFamilyFactoryRegistry) blockFamilyFactoryRegistry, moduleManager.getEnvironment());
 
         ModuleAwareAssetTypeManager assetTypeManager = context.get(ModuleAwareAssetTypeManager.class);
+
+        /*
+         * The registring of the assset delta formats is done in this method, because it needs to be done before
+         * the environment switch. It can't be done before this method gets called because the ComponentLibrary isn't
+         * existing then yet.
+         *
+         * This method is propably something that should be refactored in future.
+         */
+        PrefabDeltaFormat prefabDeltaFormat = new PrefabDeltaFormat(componentLibrary, typeSerializationLibrary);
+        assetTypeManager.registerCoreDeltaFormat(Prefab.class, prefabDeltaFormat);
+
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
 
     }

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -103,7 +103,7 @@ public final class EntitySystemSetupUtil {
         entityManager.setTypeSerializerLibrary(typeSerializationLibrary);
 
         // Prefab Manager
-        PrefabManager prefabManager = new PojoPrefabManager();
+        PrefabManager prefabManager = new PojoPrefabManager(context);
         entityManager.setPrefabManager(prefabManager);
         context.put(PrefabManager.class, prefabManager);
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadEntities.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadEntities.java
@@ -22,7 +22,6 @@ import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.persistence.StorageManager;
-import org.terasology.registry.CoreRegistry;
 
 import java.io.IOException;
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterInputSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterInputSystem.java
@@ -18,11 +18,8 @@ package org.terasology.engine.modes.loadProcesses;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.config.BindsConfig;
-import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
-import org.terasology.engine.module.ModuleManager;
 import org.terasology.input.InputSystem;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.logic.players.LocalPlayerSystem;
@@ -47,7 +44,6 @@ public class RegisterInputSystem extends SingleStepLoadProcess {
     @Override
     public boolean step() {
         ComponentSystemManager componentSystemManager = context.get(ComponentSystemManager.class);
-        ModuleManager moduleManager = context.get(ModuleManager.class);
 
         LocalPlayerSystem localPlayerSystem = new LocalPlayerSystem();
         componentSystemManager.register(localPlayerSystem, "engine:localPlayerSystem");
@@ -57,11 +53,8 @@ public class RegisterInputSystem extends SingleStepLoadProcess {
         context.put(CameraTargetSystem.class, cameraTargetSystem);
         componentSystemManager.register(cameraTargetSystem, "engine:CameraTargetSystem");
 
-        BindsConfig bindsConfig = context.get(Config.class).getInput().getBinds();
         InputSystem inputSystem = context.get(InputSystem.class);
         componentSystemManager.register(inputSystem, "engine:InputSystem");
-
-        bindsConfig.applyBinds(inputSystem, moduleManager);
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/HeadlessStateChangeListener.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/HeadlessStateChangeListener.java
@@ -20,7 +20,6 @@ import org.terasology.engine.StateChangeSubscriber;
 import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.modes.StateMainMenu;
-import org.terasology.registry.CoreRegistry;
 
 /**
  * This listener checks whether the engine goes back to the main menu, which for a headless server signals the server

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -38,7 +38,6 @@ import org.terasology.engine.GameThread;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.RenderingSubsystemFactory;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.ShaderManagerLwjgl;
 import org.terasology.rendering.assets.animation.MeshAnimation;
@@ -102,6 +101,8 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
 
     private BlockingDeque<Runnable> displayThreadActions = Queues.newLinkedBlockingDeque();
 
+    private Context context;
+
     @Override
     public void initialise(Context context) {
 
@@ -137,6 +138,7 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
 
     @Override
     public void postInitialise(Context context) {
+        this.context = context;
         context.put(RenderingSubsystemFactory.class, new LwjglRenderingSubsystemFactory(bufferPool));
 
         LwjglDisplayDevice lwjglDisplay = new LwjglDisplayDevice(context);
@@ -162,7 +164,7 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
             actions.forEach(Runnable::run);
         }
 
-        int frameLimit = CoreRegistry.get(Config.class).getRendering().getFrameLimit();
+        int frameLimit = context.get(Config.class).getRendering().getFrameLimit();
         if (frameLimit > 0) {
             Display.sync(frameLimit);
         }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
@@ -29,13 +29,13 @@ import org.terasology.engine.modes.GameState;
 import org.terasology.input.InputSystem;
 import org.terasology.input.lwjgl.LwjglKeyboardDevice;
 import org.terasology.input.lwjgl.LwjglMouseDevice;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
 
 public class LwjglInput extends BaseLwjglSubsystem {
 
     private static final Logger logger = LoggerFactory.getLogger(LwjglInput.class);
     private boolean mouseGrabbed;
+    private Context context;
 
     @Override
     public void preInitialise(Context context) {
@@ -53,15 +53,16 @@ public class LwjglInput extends BaseLwjglSubsystem {
 
     @Override
     public void postInitialise(Context context) {
-        initControls(context);
-        updateInputConfig(context);
+        this.context = context;
+        initControls();
+        updateInputConfig();
         Mouse.setGrabbed(false);
     }
 
     @Override
     public void preUpdate(GameState currentState, float delta) {
-        NUIManager nuiManager = CoreRegistry.get(NUIManager.class);
-        GameEngine engine = CoreRegistry.get(GameEngine.class);
+        NUIManager nuiManager = context.get(NUIManager.class);
+        GameEngine engine = context.get(GameEngine.class);
 
         // TODO: this originally occurred before GameThread.processWaitingProcesses();
         boolean newGrabbed = engine.hasMouseFocus() && !(nuiManager.isReleasingMouse());
@@ -86,7 +87,7 @@ public class LwjglInput extends BaseLwjglSubsystem {
         Keyboard.destroy();
     }
 
-    private void initControls(Context context) {
+    private void initControls() {
         try {
             Keyboard.create();
             Keyboard.enableRepeatEvents(true);
@@ -100,7 +101,7 @@ public class LwjglInput extends BaseLwjglSubsystem {
         }
     }
 
-    private void updateInputConfig(Context context) {
+    private void updateInputConfig() {
         Config config = context.get(Config.class);
         config.getInput().getBinds().updateForChangedMods(context);
         config.save();

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
@@ -15,13 +15,14 @@
  */
 package org.terasology.entitySystem.prefab.internal;
 
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import org.terasology.asset.Assets;
 import org.terasology.assets.management.AssetManager;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Collection;
 
@@ -34,13 +35,21 @@ import java.util.Collection;
  */
 public class PojoPrefabManager implements PrefabManager {
 
+    private final AssetManager assetManager;
+
+    public PojoPrefabManager(Context context) {
+        this.assetManager = context.get(AssetManager.class);
+    }
+
+
     /**
      * {@inheritDoc}
      */
     @Override
     public Prefab getPrefab(String name) {
         if (!name.isEmpty()) {
-            return Assets.getPrefab(name).orElse(null);
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
+            return assetManager.getAsset(name, Prefab.class).orElse(null);
         }
         return null;
 
@@ -51,7 +60,8 @@ public class PojoPrefabManager implements PrefabManager {
      */
     @Override
     public boolean exists(String name) {
-        return Assets.getPrefab(name) != null;
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
+        return assetManager.getAsset(name, Prefab.class) != null;
     }
 
     /**
@@ -59,7 +69,7 @@ public class PojoPrefabManager implements PrefabManager {
      */
     @Override
     public Iterable<Prefab> listPrefabs() {
-        return CoreRegistry.get(AssetManager.class).getLoadedAssets(Prefab.class);
+        return assetManager.getLoadedAssets(Prefab.class);
     }
 
     /**
@@ -69,7 +79,7 @@ public class PojoPrefabManager implements PrefabManager {
     public Collection<Prefab> listPrefabs(Class<? extends Component> comp) {
         Collection<Prefab> prefabs = Sets.newHashSet();
 
-        for (Prefab p : CoreRegistry.get(AssetManager.class).getLoadedAssets(Prefab.class)) {
+        for (Prefab p : assetManager.getLoadedAssets(Prefab.class)) {
             if (p.getComponent(comp) != null) {
                 prefabs.add(p);
             }

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
@@ -16,7 +16,6 @@
 package org.terasology.entitySystem.prefab.internal;
 
 import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.context.Context;
@@ -47,12 +46,10 @@ public class PojoPrefabManager implements PrefabManager {
      */
     @Override
     public Prefab getPrefab(String name) {
-        if (!name.isEmpty()) {
-            Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
-            return assetManager.getAsset(name, Prefab.class).orElse(null);
+        if (Strings.isNullOrEmpty(name)) {
+            return null;
         }
-        return null;
-
+        return assetManager.getAsset(name, Prefab.class).orElse(null);
     }
 
     /**
@@ -60,7 +57,9 @@ public class PojoPrefabManager implements PrefabManager {
      */
     @Override
     public boolean exists(String name) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
+        if (Strings.isNullOrEmpty(name)) {
+            return false;
+        }
         return assetManager.getAsset(name, Prefab.class).isPresent();
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
@@ -61,7 +61,7 @@ public class PojoPrefabManager implements PrefabManager {
     @Override
     public boolean exists(String name) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
-        return assetManager.getAsset(name, Prefab.class) != null;
+        return assetManager.getAsset(name, Prefab.class).isPresent();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PrefabDeltaFormat.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PrefabDeltaFormat.java
@@ -18,14 +18,12 @@ package org.terasology.entitySystem.prefab.internal;
 import com.google.common.base.Charsets;
 import org.terasology.assets.format.AbstractAssetAlterationFileFormat;
 import org.terasology.assets.format.AssetDataFile;
-import org.terasology.assets.module.annotations.RegisterAssetDeltaFileFormat;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.PrefabSerializer;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.protobuf.EntityData;
-import org.terasology.registry.CoreRegistry;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -34,11 +32,15 @@ import java.io.InputStreamReader;
 /**
  * @author Immortius
  */
-@RegisterAssetDeltaFileFormat
 public class PrefabDeltaFormat extends AbstractAssetAlterationFileFormat<PrefabData> {
 
-    public PrefabDeltaFormat() {
+    private final ComponentLibrary componentLibrary;
+    private final TypeSerializationLibrary typeSerializationLibrary;
+
+    public PrefabDeltaFormat(ComponentLibrary componentLibrary, TypeSerializationLibrary typeSerializationLibrary) {
         super("prefab");
+        this.componentLibrary = componentLibrary;
+        this.typeSerializationLibrary = typeSerializationLibrary;
     }
 
     @Override
@@ -46,8 +48,6 @@ public class PrefabDeltaFormat extends AbstractAssetAlterationFileFormat<PrefabD
 
         try (BufferedReader deltaReader = new BufferedReader(new InputStreamReader(assetDataFile.openStream(), Charsets.UTF_8))) {
             EntityData.Prefab delta = EntityDataJSONFormat.readPrefab(deltaReader);
-            ComponentLibrary componentLibrary = CoreRegistry.get(ComponentLibrary.class);
-            TypeSerializationLibrary typeSerializationLibrary = CoreRegistry.get(TypeSerializationLibrary.class);
             PrefabSerializer serializer = new PrefabSerializer(componentLibrary, typeSerializationLibrary);
             serializer.deserializeDeltaOnto(delta, assetData);
         }

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PrefabFormat.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PrefabFormat.java
@@ -19,15 +19,12 @@ import com.google.common.base.Charsets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
-import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
-import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.PrefabSerializer;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.protobuf.EntityData;
-import org.terasology.registry.CoreRegistry;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -37,11 +34,15 @@ import java.util.List;
 /**
  * @author Immortius
  */
-@RegisterAssetFileFormat
 public class PrefabFormat extends AbstractAssetFileFormat<PrefabData> {
 
-    public PrefabFormat() {
+    private ComponentLibrary componentLibrary;
+    private TypeSerializationLibrary typeSerializationLibrary;
+
+    public PrefabFormat(ComponentLibrary componentLibrary, TypeSerializationLibrary typeSerializationLibrary) {
         super("prefab");
+        this.componentLibrary = componentLibrary;
+        this.typeSerializationLibrary = typeSerializationLibrary;
     }
 
     @Override
@@ -49,8 +50,6 @@ public class PrefabFormat extends AbstractAssetFileFormat<PrefabData> {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputs.get(0).openStream(), Charsets.UTF_8))) {
             EntityData.Prefab prefabData = EntityDataJSONFormat.readPrefab(reader);
             if (prefabData != null) {
-                ComponentLibrary componentLibrary = CoreRegistry.get(ComponentLibrary.class);
-                TypeSerializationLibrary typeSerializationLibrary = CoreRegistry.get(TypeSerializationLibrary.class);
                 PrefabSerializer serializer = new PrefabSerializer(componentLibrary, typeSerializationLibrary);
                 return serializer.deserialize(prefabData);
             } else {

--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -17,9 +17,12 @@ package org.terasology.input;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.terasology.config.BindsConfig;
 import org.terasology.config.Config;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.SimpleUri;
+import org.terasology.engine.Time;
+import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
@@ -68,10 +71,16 @@ public class InputSystem extends BaseComponentSystem {
     private GameEngine engine;
 
     @In
+    private Time time;
+
+    @In
     private LocalPlayer localPlayer;
 
     @In
     private CameraTargetSystem targetSystem;
+
+    @In
+    private ModuleManager moduleManager;
 
     private MouseDevice mouse = new NullMouseDevice();
     private KeyboardDevice keyboard = new NullKeyboardDevice();
@@ -108,8 +117,14 @@ public class InputSystem extends BaseComponentSystem {
         return registerBindButton(bindId, displayName, new BindButtonEvent());
     }
 
+    @Override
+    public void initialise() {
+        BindsConfig bindsConfig = config.getInput().getBinds();
+        bindsConfig.applyBinds(this, moduleManager);
+    }
+
     public BindableButton registerBindButton(SimpleUri bindId, String displayName, BindButtonEvent event) {
-        BindableButtonImpl bind = new BindableButtonImpl(bindId, displayName, event);
+        BindableButtonImpl bind = new BindableButtonImpl(bindId, displayName, event, time);
         buttonLookup.put(bindId, bind);
         buttonBinds.add(bind);
         return bind;

--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -48,7 +48,6 @@ import org.terasology.input.internal.BindableAxisImpl;
 import org.terasology.input.internal.BindableButtonImpl;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.Vector2i;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 
 import java.util.List;
@@ -68,6 +67,12 @@ public class InputSystem extends BaseComponentSystem {
     @In
     private GameEngine engine;
 
+    @In
+    private LocalPlayer localPlayer;
+
+    @In
+    private CameraTargetSystem targetSystem;
+
     private MouseDevice mouse = new NullMouseDevice();
     private KeyboardDevice keyboard = new NullKeyboardDevice();
 
@@ -82,21 +87,6 @@ public class InputSystem extends BaseComponentSystem {
     private Map<MouseInput, BindableButtonImpl> mouseButtonBinds = Maps.newHashMap();
     private BindableButtonImpl mouseWheelUpBind;
     private BindableButtonImpl mouseWheelDownBind;
-
-    private LocalPlayer localPlayer;
-    private CameraTargetSystem targetSystem;
-
-    @Override
-    public void initialise() {
-        localPlayer = CoreRegistry.get(LocalPlayer.class);
-        targetSystem = CoreRegistry.get(CameraTargetSystem.class);
-    }
-
-    @Override
-    public void shutdown() {
-        localPlayer = null;
-        targetSystem = null;
-    }
 
     public void setMouseDevice(MouseDevice mouseDevice) {
         this.mouse = mouseDevice;

--- a/engine/src/main/java/org/terasology/input/internal/BindableButtonImpl.java
+++ b/engine/src/main/java/org/terasology/input/internal/BindableButtonImpl.java
@@ -28,7 +28,6 @@ import org.terasology.input.ButtonState;
 import org.terasology.input.Input;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.List;
 import java.util.Set;
@@ -54,7 +53,6 @@ public class BindableButtonImpl implements BindableButton {
     private long lastActivateTime;
 
     private boolean consumedActivation;
-
     private Time time;
 
     /**
@@ -63,11 +61,11 @@ public class BindableButtonImpl implements BindableButton {
      * @param id
      * @param event
      */
-    public BindableButtonImpl(SimpleUri id, String displayName, BindButtonEvent event) {
+    public BindableButtonImpl(SimpleUri id, String displayName, BindButtonEvent event, Time time) {
         this.id = id;
         this.displayName = displayName;
         this.buttonEvent = event;
-        time = CoreRegistry.get(Time.class);
+        this.time = time;
     }
 
     @Override


### PR DESCRIPTION
Another pull request to reduce CoreRegistry usage.

It also fixes the PojoPrefabManager#exists method which was broken. I am not sure if that was causing any noticable bugs.

The place where the prefab formats get now registered isn't ideal, but it's the only place where it currently can be done. See discusion with @immortius in https://github.com/MovingBlocks/gestalt/issues/35 for more information.

Also noteworthy about this pull request is that the patch 465cd39e7aa157c7e4bc4bb65b84a7f9d3bc8447 moves the `applyBinds` call from `RegisterInputSystem#step` to `InputSystem#initialise`. That  way the `InputSystem` is initialized when the `applyBinds` method gets called. 

I also think it might be a good idea to move the  `applyBinds` logic from BindsConfig to InputSystem as the former is to me more a data holding object. Also we might want to introduce a InputBindingsChangedEvent that gets procssed by InputSystem.


