### PR TITLE
Adjustments for IconMeshes to center around their origin

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
@@ -173,14 +173,12 @@ public class FirstPersonRenderer extends BaseComponentSystem implements RenderSy
 
             glPushMatrix();
 
-            float textureScale = Math.max(iconTexture.getWidth(), iconTexture.getHeight()) / 16f;
-
-            glTranslatef(1.0f, -0.7f + bobOffset - handMovementAnimationOffset * 0.5f, (-1.5f - handMovementAnimationOffset * 0.5f) * (float) Math.pow(textureScale, 0.5));
+            glTranslatef(1.0f, -0.7f + bobOffset - handMovementAnimationOffset * 0.5f, 0.25f + (-1.5f - handMovementAnimationOffset * 0.5f));
             glRotatef(-handMovementAnimationOffset * 64.0f, 1.0f, 0.0f, 0.0f);
             glRotatef(-20f, 1.0f, 0.0f, 0.0f);
             glRotatef(-80f, 0.0f, 1.0f, 0.0f);
             glRotatef(45f, 0.0f, 0.0f, 1.0f);
-            float scale = 0.75f * (float) Math.pow(textureScale, 0.5);
+            float scale = 0.75f;
             glScalef(scale, scale, scale);
 
             if (iconTexture instanceof Asset<?>) {

--- a/engine/src/main/java/org/terasology/rendering/iconmesh/IconMeshFactory.java
+++ b/engine/src/main/java/org/terasology/rendering/iconmesh/IconMeshFactory.java
@@ -92,7 +92,7 @@ public final class IconMeshFactory {
 
                 if (a > alphaLimit) {
                     Vector4f color = new Vector4f(r / 255f, g / 255f, b / 255f, a / 255f);
-                    TessellatorHelper.addBlockMesh(tessellator, color, 2f / textureSize, 1.0f, 0.5f, 2f / textureSize * x - 0.5f, 2f / textureSize * (15 - y) - 1f, 0f);
+                    TessellatorHelper.addBlockMesh(tessellator, color, 2f / textureSize, 1.0f, 0.5f, 2f / textureSize * x - 1f, 2f / textureSize * (tex.getHeight() - y - 1) - 1f, 0f);
 
                     if (withContour) {
                         int newX = 0;


### PR DESCRIPTION
- Centers icon meshes around their origin.  
- Adjust FirstPersonRenderer so that higher dpi textures occupy the same space as the 16x16 counterparts when held.

I used the ItemRendering module to show the origin...
Before:
![terasology-150707111736-1152x720](https://cloud.githubusercontent.com/assets/5922109/8559607/a789d0f2-24c3-11e5-934d-01c4769f5f66.jpg)
![terasology-150707111752-1152x720](https://cloud.githubusercontent.com/assets/5922109/8559608/a78f7aac-24c3-11e5-8774-40afca7bf2cf.jpg)

After:
![terasology-150707160554-1152x720](https://cloud.githubusercontent.com/assets/5922109/8559642/fa3e417a-24c3-11e5-8f45-91725c2882a9.jpg)
![terasology-150707160556-1152x720](https://cloud.githubusercontent.com/assets/5922109/8559643/fa452c60-24c3-11e5-8c24-382cd3251d65.jpg)
