### PR TITLE
Make sure that outdated prefab formats get unregistered.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -29,7 +29,7 @@ import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.context.internal.ContextImpl;
-import org.terasology.engine.bootstrap.ApplyModulesUtil;
+import org.terasology.engine.bootstrap.EnvironmentSwitchHandler;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.module.ModuleManagerImpl;
@@ -192,7 +192,10 @@ public class TerasologyEngine implements GameEngine {
 
             changeStatus(TerasologyEngineStatus.INITIALIZING_ASSET_MANAGEMENT);
             initAssets();
-            ApplyModulesUtil.applyModules(context);
+            EnvironmentSwitchHandler environmentSwitcher = new EnvironmentSwitchHandler();
+            context.put(EnvironmentSwitchHandler.class, environmentSwitcher);
+
+            environmentSwitcher.handleSwitchToGameEnvironment(context);
 
             postInitSubsystems();
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -18,13 +18,13 @@ package org.terasology.engine.modes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.TeraOVR;
-import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.audio.AudioManager;
 import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.GameThread;
+import org.terasology.engine.bootstrap.EnvironmentSwitchHandler;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
@@ -151,10 +151,10 @@ public class StateIngame implements GameState {
         if (storageManager != null) {
             storageManager.finishSavingAndShutdown();
         }
-        ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
-        ModuleEnvironment environment = context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
 
-        context.get(ModuleAwareAssetTypeManager.class).switchEnvironment(environment);
+        ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
+        context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
+        context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnivronment(context);
         if (oldEnvironment != null) {
             oldEnvironment.close();
         }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
-import org.terasology.engine.bootstrap.ApplyModulesUtil;
+import org.terasology.engine.bootstrap.EnvironmentSwitchHandler;
 import org.terasology.engine.modes.LoadProcess;
 import org.terasology.engine.modes.StateMainMenu;
 import org.terasology.engine.module.ModuleManager;
@@ -131,7 +131,8 @@ public class JoinServer implements LoadProcess {
 
             context.get(Game.class).load(gameManifest);
 
-            applyModuleThread = new Thread(() -> ApplyModulesUtil.applyModules(context.get(Context.class)));
+            EnvironmentSwitchHandler environmentSwitchHandler = context.get(EnvironmentSwitchHandler.class);
+            applyModuleThread = new Thread(() -> environmentSwitchHandler.handleSwitchToGameEnvironment(context));
             applyModuleThread.start();
 
             return false;

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterMods.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterMods.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
-import org.terasology.engine.bootstrap.ApplyModulesUtil;
+import org.terasology.engine.bootstrap.EnvironmentSwitchHandler;
 import org.terasology.engine.modes.StateMainMenu;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.game.GameManifest;
@@ -87,7 +87,8 @@ public class RegisterMods extends SingleStepLoadProcess {
                     logger.info("Activating module: {}:{}", moduleInfo.getId(), moduleInfo.getVersion());
                 }
 
-                applyModulesThread = new Thread(() -> ApplyModulesUtil.applyModules(context.get(Context.class)));
+                EnvironmentSwitchHandler environmentSwitchHandler = context.get(EnvironmentSwitchHandler.class);
+                applyModulesThread = new Thread(() -> environmentSwitchHandler.handleSwitchToGameEnvironment(context));
                 applyModulesThread.start();
                 return false;
             } else {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
@@ -24,6 +24,7 @@ import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.context.internal.ContextImpl;
 import org.terasology.engine.SimpleUri;
+import org.terasology.engine.bootstrap.EnvironmentSwitchHandler;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.Component;
 import org.terasology.math.TeraMath;
@@ -123,7 +124,8 @@ public class PreviewWorldScreen extends CoreScreenLayer {
                 CoreRegistry.setContext(subContext);
                 environment = moduleManager.loadEnvironment(result.getModules(), false);
                 subContext.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(environment, subContext));
-                assetTypeManager.switchEnvironment(environment);
+                EnvironmentSwitchHandler environmentSwitchHandler = context.get(EnvironmentSwitchHandler.class);
+                environmentSwitchHandler.handleSwitchToPreviewEnivronment(context, environment);
                 genTexture();
                 worldGenerator = worldGeneratorManager.searchForWorldGenerator(worldGenUri, environment);
                 worldGenerator.setWorldSeed(seed.getText());
@@ -197,7 +199,8 @@ public class PreviewWorldScreen extends CoreScreenLayer {
         CoreRegistry.setContext(context);
 
         if (environment != null) {
-            assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
+            EnvironmentSwitchHandler environmentSwitchHandler = context.get(EnvironmentSwitchHandler.class);
+            environmentSwitchHandler.handleSwitchBackFromPreviewEnivronment(context);
             environment.close();
             environment = null;
         }


### PR DESCRIPTION
A new EnvironmentSwitchHandler class has been introduced that has
now the job of switching the environment of the asset manager.

It ensures that oudated prefab formats gets unregistered
in time.

ApplyModulesUtil has been removed as it's job gets now done by
EnvironmentSwitchHandler.

This should fix #1815, but I haven't tested it yet. 

@Josharias Can you please check if this fixes your issue?

@immortius I hope you are fine with that solution. If you don't agree I can give further arguments why I didn't go for the ClassFactory approach.