### PR TITLE
Prevent the world generator selection from reverting

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
@@ -306,7 +306,7 @@ public class SelectModulesScreen extends CoreScreenLayer {
                 moduleConfig.addModule(info.getMetadata().getId());
             }
         }
-        if (!moduleConfig.hasModule(config.getWorldGeneration().getDefaultGenerator().getModuleName())) {
+        if (!modulesLookup.get(config.getWorldGeneration().getDefaultGenerator().getModuleName()).isSelected()) {
             config.getWorldGeneration().setDefaultGenerator(new SimpleUri());
         }
         config.save();


### PR DESCRIPTION
Only explicitly selected modules get set on the config.  This checks instead the selected modules from the UI which respect dependencies.