### PR TITLE
Give NUIManager a better fitting life cycle and context instance.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -61,6 +61,8 @@ import org.terasology.network.JoinStatus;
 import org.terasology.network.NetworkMode;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.internal.CanvasRenderer;
+import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.nui.layers.mainMenu.loadingScreen.LoadingScreen;
 
 import java.util.Queue;
@@ -115,7 +117,8 @@ public class StateLoading implements GameState {
         this.context = engine.createChildContext();
         CoreRegistry.setContext(context);
 
-        this.nuiManager = context.get(NUIManager.class);
+        this.nuiManager = new NUIManagerInternal(context.get(CanvasRenderer.class), context);
+        context.put(NUIManager.class, nuiManager);
 
         EngineTime time = (EngineTime) context.get(Time.class);
         time.setPaused(true);

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -36,6 +36,7 @@ import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
 
@@ -78,8 +79,9 @@ public class StateMainMenu implements GameState {
         eventSystem = context.get(EventSystem.class);
         context.put(Console.class, new ConsoleImpl());
 
-        nuiManager = context.get(NUIManager.class);
-        ((NUIManagerInternal) nuiManager).refreshWidgetsLibrary();
+        nuiManager = new NUIManagerInternal(context.get(CanvasRenderer.class), context);
+        context.put(NUIManager.class, nuiManager);
+
         eventSystem.registerEventHandler(nuiManager);
 
         componentSystemManager = new ComponentSystemManager(context);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
@@ -22,6 +22,7 @@ import org.terasology.engine.TerasologyConstants;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.naming.Name;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.primitives.Tessellator;
 import org.terasology.rendering.primitives.TessellatorHelper;
@@ -44,9 +45,6 @@ public class InitialiseGraphics extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        NUIManager nuiManager = context.get(NUIManager.class);
-        ((NUIManagerInternal) nuiManager).refreshWidgetsLibrary();
-
         // TODO: This should be elsewhere
         // Create gelatinousCubeMesh
         Tessellator tessellator = new Tessellator();

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseGraphics.java
@@ -22,7 +22,6 @@ import org.terasology.engine.TerasologyConstants;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.naming.Name;
 import org.terasology.rendering.nui.NUIManager;
-import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.primitives.Tessellator;
 import org.terasology.rendering.primitives.TessellatorHelper;
@@ -45,6 +44,10 @@ public class InitialiseGraphics extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
+        // Refresh widget library after modules got laoded:
+        NUIManager nuiManager = context.get(NUIManager.class);
+        ((NUIManagerInternal) nuiManager).refreshWidgetsLibrary();
+
         // TODO: This should be elsewhere
         // Create gelatinousCubeMesh
         Tessellator tessellator = new Tessellator();

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
@@ -55,8 +55,7 @@ import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.assets.texture.subtexture.Subtexture;
 import org.terasology.rendering.assets.texture.subtexture.SubtextureData;
-import org.terasology.rendering.nui.NUIManager;
-import org.terasology.rendering.nui.internal.NUIManagerInternal;
+import org.terasology.rendering.nui.internal.CanvasRenderer;
 
 public class HeadlessGraphics implements EngineSubsystem {
 
@@ -92,7 +91,7 @@ public class HeadlessGraphics implements EngineSubsystem {
         context.put(DisplayDevice.class, headlessDisplay);
         initHeadless(context);
 
-        context.put(NUIManager.class, new NUIManagerInternal(new HeadlessCanvasRenderer(), context));
+        context.put(CanvasRenderer.class, new HeadlessCanvasRenderer());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -43,6 +43,7 @@ import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
@@ -81,8 +82,8 @@ public class StateHeadlessSetup implements GameState {
         eventSystem = context.get(EventSystem.class);
         context.put(Console.class, new ConsoleImpl());
 
-        NUIManager nuiManager = context.get(NUIManager.class);
-        ((NUIManagerInternal) nuiManager).refreshWidgetsLibrary();
+        NUIManager nuiManager = new NUIManagerInternal(context.get(CanvasRenderer.class), context);
+        context.put(NUIManager.class, nuiManager);
 
         componentSystemManager = new ComponentSystemManager(context);
         context.put(ComponentSystemManager.class, componentSystemManager);

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -17,7 +17,6 @@ package org.terasology.engine.subsystem.lwjgl;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-
 import org.lwjgl.LWJGLException;
 import org.lwjgl.opengl.ContextAttribs;
 import org.lwjgl.opengl.Display;
@@ -62,9 +61,8 @@ import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.assets.texture.TextureUtil;
 import org.terasology.rendering.assets.texture.subtexture.Subtexture;
 import org.terasology.rendering.assets.texture.subtexture.SubtextureData;
-import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.LwjglCanvasRenderer;
-import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.opengl.GLSLMaterial;
 import org.terasology.rendering.opengl.GLSLShader;
 import org.terasology.rendering.opengl.OpenGLMesh;
@@ -147,7 +145,7 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         initDisplay(context.get(Config.class), lwjglDisplay);
         initOpenGL(context);
 
-        context.put(NUIManager.class, new NUIManagerInternal(new LwjglCanvasRenderer(context), context));
+        context.put(CanvasRenderer.class, new LwjglCanvasRenderer(context));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
@@ -24,17 +24,14 @@ import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
-import org.terasology.engine.GameEngine;
 import org.terasology.engine.modes.GameState;
 import org.terasology.input.InputSystem;
 import org.terasology.input.lwjgl.LwjglKeyboardDevice;
 import org.terasology.input.lwjgl.LwjglMouseDevice;
-import org.terasology.rendering.nui.NUIManager;
 
 public class LwjglInput extends BaseLwjglSubsystem {
 
     private static final Logger logger = LoggerFactory.getLogger(LwjglInput.class);
-    private boolean mouseGrabbed;
     private Context context;
 
     @Override
@@ -61,16 +58,9 @@ public class LwjglInput extends BaseLwjglSubsystem {
 
     @Override
     public void preUpdate(GameState currentState, float delta) {
-        NUIManager nuiManager = context.get(NUIManager.class);
-        GameEngine engine = context.get(GameEngine.class);
-
-        // TODO: this originally occurred before GameThread.processWaitingProcesses();
-        boolean newGrabbed = engine.hasMouseFocus() && !(nuiManager.isReleasingMouse());
-        if (newGrabbed != mouseGrabbed) {
-            Mouse.setGrabbed(newGrabbed);
-            mouseGrabbed = newGrabbed;
-        }
     }
+
+
 
     @Override
     public void postUpdate(GameState currentState, float delta) {

--- a/engine/src/main/java/org/terasology/input/device/MouseDevice.java
+++ b/engine/src/main/java/org/terasology/input/device/MouseDevice.java
@@ -42,4 +42,9 @@ public interface MouseDevice extends InputDevice {
      * @return Whether the mouse cursor is visible
      */
     boolean isVisible();
+
+    /**
+     * Specifies if the mouse is grabbed and there is thus no mouse cursor that can get to a border.
+     */
+    void setGrabbed(boolean grabbed);
 }

--- a/engine/src/main/java/org/terasology/input/device/nulldevices/NullMouseDevice.java
+++ b/engine/src/main/java/org/terasology/input/device/nulldevices/NullMouseDevice.java
@@ -50,4 +50,8 @@ public class NullMouseDevice implements MouseDevice {
     public Queue<InputAction> getInputQueue() {
         return Queues.newArrayDeque();
     }
+
+    @Override
+    public void setGrabbed(boolean grabbed) {
+    }
 }

--- a/engine/src/main/java/org/terasology/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/input/lwjgl/LwjglMouseDevice.java
@@ -30,6 +30,7 @@ import java.util.Queue;
  * @author Immortius
  */
 public class LwjglMouseDevice implements MouseDevice {
+    private boolean mouseGrabbed;
 
     @Override
     public Vector2i getPosition() {
@@ -52,6 +53,14 @@ public class LwjglMouseDevice implements MouseDevice {
     }
 
     @Override
+    public void setGrabbed(boolean newGrabbed) {
+        if (newGrabbed != mouseGrabbed) {
+            mouseGrabbed = newGrabbed;
+            Mouse.setGrabbed(newGrabbed);
+        }
+    }
+
+    @Override
     public Queue<InputAction> getInputQueue() {
         Queue<InputAction> result = Queues.newArrayDeque();
 
@@ -68,4 +77,5 @@ public class LwjglMouseDevice implements MouseDevice {
 
         return result;
     }
+
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -84,7 +84,7 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
         refreshWidgetsLibrary();
     }
 
-    private void refreshWidgetsLibrary() {
+    public void refreshWidgetsLibrary() {
         widgetsLibrary = new WidgetLibrary(context);
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         for (Class<? extends UIWidget> type : environment.getSubtypesOf(UIWidget.class)) {

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.asset.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.context.Context;
+import org.terasology.engine.GameEngine;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -32,6 +33,7 @@ import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.input.BindButtonEvent;
+import org.terasology.input.InputSystem;
 import org.terasology.input.Keyboard;
 import org.terasology.input.Mouse;
 import org.terasology.input.events.KeyEvent;
@@ -382,6 +384,10 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
         for (ControlWidget widget : overlays.values()) {
             widget.update(delta);
         }
+        InputSystem inputSystem = context.get(InputSystem.class);
+        GameEngine engine = context.get(GameEngine.class);
+        inputSystem.getMouseDevice().setGrabbed(engine.hasMouseFocus() && !(this.isReleasingMouse()));
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -81,9 +81,10 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
         this.hudScreenLayer = new HUDScreenLayer();
         InjectionHelper.inject(hudScreenLayer, context);
         this.canvas = new CanvasImpl(this, context, renderer);
+        refreshWidgetsLibrary();
     }
 
-    public void refreshWidgetsLibrary() {
+    private void refreshWidgetsLibrary() {
         widgetsLibrary = new WidgetLibrary(context);
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         for (Class<? extends UIWidget> type : environment.getSubtypesOf(UIWidget.class)) {


### PR DESCRIPTION
This pull request gives NUIManager a better fitting life cycle and context instance.

The NUIManager is no longer in the engine context.

Where previously it just got "refreshed" now a new instance gets created.

Namely the first NUIManager like the first sub context for the duration
of the main menu.

When the starts loading a new NUIManager gets created that lifes again
like it's owning Context till the end of the game.

This patch fixes the issue that caused interations require two activations
when a window got closed with escape (#1761).

The first patch moves the mouse grap triggering from LwjglInput to NUIManager so that LwjglInput does not require a  NUIManager instance (which is no longer in the engine context).

@immortius I hope this change is acceptable for you and hopefully you even like it :)