### PR TITLE
Added support for underlined text

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
@@ -81,7 +81,7 @@ public class HeadlessCanvasRenderer implements CanvasRenderer {
 
     @Override
     public void drawText(String text, Font font, HorizontalAlign hAlign, VerticalAlign vAlign, Rect2i absoluteRegion, Color color, Color shadowColor,
-                         float alpha) {
+                         float alpha, boolean underlined) {
         // Do nothing
     }
 

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -36,6 +36,7 @@ import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.FontColor;
+import org.terasology.rendering.FontUnderline;
 import org.terasology.utilities.collection.CircularBuffer;
 
 import java.util.Arrays;
@@ -120,7 +121,7 @@ public class ConsoleImpl implements Console {
      */
     @Override
     public void addMessage(Message message) {
-        String uncoloredText = FontColor.stripColor(message.getMessage());
+        String uncoloredText = FontUnderline.strip(FontColor.stripColor(message.getMessage()));
         logger.info("[{}] {}", message.getType(), uncoloredText);
         messageHistory.add(message);
         for (ConsoleSubscriber subscriber : messageSubscribers) {

--- a/engine/src/main/java/org/terasology/rendering/FontUnderline.java
+++ b/engine/src/main/java/org/terasology/rendering/FontUnderline.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering;
+
+import org.terasology.module.sandbox.API;
+
+/**
+ * Defines a set of special characters that mark contents of a string to be underlined
+ */
+@API
+public final class FontUnderline {
+    private static final char START_UNDERLINE = 0xF001;
+    private static final char END_UNDERLINE = 0xF002;
+
+    private FontUnderline() {
+        // avoid instantiation
+    }
+
+    /**
+     * @param ch the character to test
+     * @return true for the start or end underline indicator characters
+     */
+    public static boolean isValid(char ch) {
+        return ch == START_UNDERLINE || ch == END_UNDERLINE;
+    }
+
+
+    /**
+     * Returns a string with surrounded with the start/end underline characters.
+     *
+     * @param str the text
+     * @return the encoded string
+     */
+    public static String markUnderlined(String str) {
+        return START_UNDERLINE + str + END_UNDERLINE;
+    }
+
+    /**
+     * @return the underline start character
+     */
+    public static char getStart() {
+        return START_UNDERLINE;
+    }
+
+    /**
+     * @return the underline end character
+     */
+    public static char getEnd() {
+        return END_UNDERLINE;
+    }
+
+    /**
+     * @param text The marked up text
+     * @return the same text string, but without the underline information
+     */
+    public static String strip(String text) {
+
+        StringBuffer sb = new StringBuffer(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            if (!isValid(c)) {
+                sb.append(c);
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/assets/font/Font.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/Font.java
@@ -40,6 +40,8 @@ public abstract class Font extends Asset<FontData> {
 
     public abstract int getLineHeight();
 
+    public abstract int getBaseHeight();
+
     public abstract Vector2i getSize(List<String> lines);
 
     public abstract boolean hasCharacter(Character c);

--- a/engine/src/main/java/org/terasology/rendering/assets/font/Font.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/Font.java
@@ -47,4 +47,8 @@ public abstract class Font extends Asset<FontData> {
     public abstract boolean hasCharacter(Character c);
 
     public abstract FontCharacter getCharacterData(Character c);
+
+    public abstract int getUnderlineOffset();
+
+    public abstract int getUnderlineThickness();
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontData.java
@@ -26,12 +26,22 @@ import java.util.Map;
 public class FontData implements AssetData {
     private int lineHeight;
     private int baseHeight;
+    private int underlineOffset = 2;
+    private int underlineThickness = 1;
     private Map<Integer, FontCharacter> characters;
 
     public FontData(int lineHeight, int baseHeight, Map<Integer, FontCharacter> characters) {
         this.lineHeight = lineHeight;
         this.baseHeight = baseHeight;
         this.characters = ImmutableMap.copyOf(characters);
+    }
+
+    public FontData(FontData other) {
+        this.lineHeight = other.lineHeight;
+        this.baseHeight = other.baseHeight;
+        this.underlineOffset = other.underlineOffset;
+        this.underlineThickness = other.underlineThickness;
+        this.characters = other.characters;
     }
 
     public int getLineHeight() {
@@ -46,5 +56,21 @@ public class FontData implements AssetData {
 
     public FontCharacter getCharacter(int index) {
         return characters.get(index);
+    }
+
+    public int getUnderlineOffset() {
+        return underlineOffset;
+    }
+
+    public int getUnderlineThickness() {
+        return underlineThickness;
+    }
+
+    public void setUnderlineOffset(int underlineOffset) {
+        this.underlineOffset = underlineOffset;
+    }
+
+    public void setUnderlineThickness(int underlineThickness) {
+        this.underlineThickness = underlineThickness;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontData.java
@@ -25,16 +25,20 @@ import java.util.Map;
  */
 public class FontData implements AssetData {
     private int lineHeight;
+    private int baseHeight;
     private Map<Integer, FontCharacter> characters;
 
-    public FontData(int lineHeight, Map<Integer, FontCharacter> characters) {
+    public FontData(int lineHeight, int baseHeight, Map<Integer, FontCharacter> characters) {
         this.lineHeight = lineHeight;
+        this.baseHeight = baseHeight;
         this.characters = ImmutableMap.copyOf(characters);
     }
 
     public int getLineHeight() {
         return lineHeight;
     }
+
+    public int getBaseHeight() { return baseHeight; }
 
     public Iterable<Map.Entry<Integer, FontCharacter>> getCharacters() {
         return characters.entrySet();

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontDataBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontDataBuilder.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class FontDataBuilder {
 
     private int lineHeight;
+    private int baseHeight;
     private TIntObjectMap<Texture> pages = new TIntObjectHashMap<>();
     private TIntObjectMap<Material> pageMats = new TIntObjectHashMap<>();
     private Map<Integer, FontCharacter> characters = Maps.newHashMap();
@@ -47,11 +48,15 @@ public class FontDataBuilder {
     }
 
     public FontData build() {
-        return new FontData(lineHeight, characters);
+        return new FontData(lineHeight, baseHeight, characters);
     }
 
     public void setLineHeight(int lineHeight) {
         this.lineHeight = lineHeight;
+    }
+
+    public void setBaseHeight(int baseHeight) {
+        this.baseHeight = baseHeight;
     }
 
     public void addPage(int pageId, Texture texture, Material material) {

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontFormat.java
@@ -46,6 +46,7 @@ public class FontFormat extends AbstractAssetFileFormat<FontData> {
 
     // Common patterns
     private Pattern lineHeightPattern = Pattern.compile("lineHeight=" + INTEGER_PATTERN);
+    private Pattern baseHeightPattern = Pattern.compile("base=" + INTEGER_PATTERN);
     private Pattern pagesPattern = Pattern.compile("pages=" + INTEGER_PATTERN);
 
     private Pattern pagePattern = Pattern.compile("page id=" + INTEGER_PATTERN + " file=\"(.*)\"");
@@ -150,6 +151,7 @@ public class FontFormat extends AbstractAssetFileFormat<FontData> {
             throw new IOException("Failed to load font - missing common line");
         }
         builder.setLineHeight(findInteger(lineHeightPattern, commonLine));
+        builder.setBaseHeight(findInteger(baseHeightPattern, commonLine));
         return findInteger(pagesPattern, commonLine);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontImpl.java
@@ -80,6 +80,11 @@ public final class FontImpl extends Font {
     }
 
     @Override
+    public int getBaseHeight() {
+        return data.getBaseHeight();
+    }
+
+    @Override
     public Vector2i getSize(List<String> lines) {
         int height = getLineHeight() * lines.size();
         int width = 0;

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontImpl.java
@@ -105,6 +105,16 @@ public final class FontImpl extends Font {
     }
 
     @Override
+    public int getUnderlineOffset() {
+        return data.getUnderlineOffset();
+    }
+
+    @Override
+    public int getUnderlineThickness() {
+        return data.getUnderlineThickness();
+    }
+
+    @Override
     protected void doDispose() {
         this.data = null;
     }

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
@@ -15,105 +15,204 @@
  */
 package org.terasology.rendering.assets.font;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Maps;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.FontColor;
+import org.terasology.rendering.FontUnderline;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.Mesh;
 import org.terasology.rendering.assets.mesh.MeshBuilder;
 import org.terasology.rendering.nui.Color;
 import org.terasology.rendering.nui.HorizontalAlign;
 
-import com.google.common.collect.Maps;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Immortius
  */
 public class FontMeshBuilder {
 
-    private static final float SHADOW_DEPTH = -1;
+    private static final float SHADOW_DEPTH = -2;
+    private static final int SHADOW_HORIZONTAL_OFFSET = 1;
+    private static final int SHADOW_VERTICAL_OFFSET = 1;
+    private static final int UNDERLINE_OFFSET = 2;
+    private static final int UNKNOWN = -1;
 
-    private Font font;
-    private Color defaultColor;
+    private final Material underlineMaterial;
 
-    public FontMeshBuilder(Font font) {
-        this.font = font;
+    public FontMeshBuilder(Material underlineMaterial) {
+        this.underlineMaterial = underlineMaterial;
     }
 
-    public Map<Material, Mesh> createTextMesh(List<String> lines, int width, HorizontalAlign alignment, Color baseColor, Color shadowColor) {
-        this.defaultColor = baseColor;
-        Map<Material, MeshBuilder> meshBuilders = Maps.newLinkedHashMap();
-        addLinesToMesh(lines, meshBuilders, width, alignment, shadowColor);
+    public Map<Material, Mesh> createTextMesh(Font font, List<String> lines, int width, HorizontalAlign alignment, Color baseColor, Color shadowColor, boolean underline) {
+        return new Builder(font, lines, width, alignment, baseColor, shadowColor, underline).invoke();
+    }
 
-        Map<Material, Mesh> result = Maps.newLinkedHashMap();
-        for (Map.Entry<Material, MeshBuilder> entry : meshBuilders.entrySet()) {
-            result.put(entry.getKey(), entry.getValue().build());
+    private class Builder {
+        private Font font;
+        private List<String> lines;
+        private int width;
+        private HorizontalAlign alignment;
+        private Color shadowColor;
+        private boolean baseUnderline;
+
+        private Map<Material, MeshBuilder> meshBuilders = Maps.newLinkedHashMap();
+
+        private int x;
+        private int y;
+        private boolean currentUnderline;
+        private int underlineStart = UNKNOWN;
+        private int underlineEnd = UNKNOWN;
+        private Deque<Color> previousColors = new ArrayDeque<>();
+        private Color currentColor;
+
+        public Builder(Font font, List<String> lines, int width, HorizontalAlign alignment, Color baseColor, Color shadowColor, boolean baseUnderline) {
+            this.font = font;
+            this.lines = lines;
+            this.width = width;
+            this.alignment = alignment;
+            this.shadowColor = shadowColor;
+            this.baseUnderline = baseUnderline;
+            this.currentUnderline = baseUnderline;
+            this.currentColor = baseColor;
         }
-        return result;
-    }
 
-    private void addLinesToMesh(List<String> lines, Map<Material, MeshBuilder> meshBuilders, int maxWidth, HorizontalAlign alignment, Color shadowColor) {
-        int y = 0;
-        Deque<Color> prevColors = new ArrayDeque<>();
-        Color currentColor = defaultColor;
-        
-        for (String line : lines) {
-            int w = font.getWidth(line);
-            int x = alignment.getOffset(w, maxWidth);
-            for (char c : line.toCharArray()) {
-                FontCharacter character = font.getCharacterData(c);
-                if (character != null && character.getPage() != null) {
-                    MeshBuilder builder = meshBuilders.get(character.getPageMat());
-                    if (builder == null) {
-                        builder = new MeshBuilder();
-                        meshBuilders.put(character.getPageMat(), builder);
-                    }
+        public Map<Material, Mesh> invoke() {
 
-                    if (shadowColor.a() != 0) {
-                        addCharacter(builder, character, x, y, shadowColor, 1, 1, SHADOW_DEPTH);
-                    }
-                    addCharacter(builder, character, x, y, currentColor, 0, 0, 0);
+            processLines();
 
-                    x += character.getxAdvance();
-                } else if (FontColor.isValid(c)) {
-                    if (c == FontColor.getReset()) {
-                        if (!prevColors.isEmpty()) {
-                            currentColor = prevColors.removeLast();
+            return generateResult();
+        }
+
+        private Map<Material, Mesh> generateResult() {
+            Map<Material, Mesh> result = Maps.newLinkedHashMap();
+            for (Map.Entry<Material, MeshBuilder> entry : meshBuilders.entrySet()) {
+                result.put(entry.getKey(), entry.getValue().build());
+            }
+            return result;
+        }
+
+        private MeshBuilder getBuilderFor(Material material) {
+            MeshBuilder builder = meshBuilders.get(material);
+            if (builder == null) {
+                builder = new MeshBuilder();
+                meshBuilders.put(material, builder);
+            }
+            return builder;
+        }
+
+        private void processLines() {
+            for (String line : lines) {
+                int w = font.getWidth(line);
+                x = alignment.getOffset(w, width);
+
+                for (char c : line.toCharArray()) {
+                    FontCharacter character = font.getCharacterData(c);
+                    if (character != null && character.getPage() != null) {
+                        MeshBuilder builder = getBuilderFor(character.getPageMat());
+
+                        if (shadowColor.a() != 0) {
+                            addCharacter(builder, character, shadowColor, SHADOW_HORIZONTAL_OFFSET, SHADOW_VERTICAL_OFFSET, SHADOW_DEPTH);
                         }
-                    } else {
-                        prevColors.addLast(currentColor);
-                        currentColor = FontColor.toColor(c);
+                        addCharacter(builder, character, currentColor, 0, 0, 0);
+                        updateUnderline(c, character);
+
+                        x += character.getxAdvance();
+                    } else if (FontColor.isValid(c)) {
+                        applyUnderline();
+                        processColorCode(c);
+                    } else if (FontUnderline.isValid(c)) {
+                        processUnderlineCode(c);
                     }
                 }
+                applyUnderline();
+                y += font.getLineHeight();
             }
-            y += font.getLineHeight();
+        }
+
+        private void processUnderlineCode(char c) {
+            if (!baseUnderline) {
+                if (c == FontUnderline.getStart() && !currentUnderline) {
+                    currentUnderline = true;
+                } else if (currentUnderline) {
+                    applyUnderline();
+                    currentUnderline = false;
+                }
+            }
+        }
+
+        private void processColorCode(char c) {
+            if (c == FontColor.getReset()) {
+                if (!previousColors.isEmpty()) {
+                    currentColor = previousColors.removeLast();
+
+                }
+            } else {
+                previousColors.addLast(currentColor);
+                currentColor = FontColor.toColor(c);
+            }
+        }
+
+        private void applyUnderline() {
+            if (currentUnderline && underlineStart != UNKNOWN) {
+                MeshBuilder builder = getBuilderFor(underlineMaterial);
+                if (shadowColor.a() != 0) {
+                    addUnderline(builder, underlineStart + SHADOW_HORIZONTAL_OFFSET, underlineEnd + SHADOW_HORIZONTAL_OFFSET,
+                            y + font.getBaseHeight() + SHADOW_VERTICAL_OFFSET + UNDERLINE_OFFSET, shadowColor, SHADOW_DEPTH);
+                }
+                addUnderline(builder, underlineStart, underlineEnd, y + font.getBaseHeight() + UNDERLINE_OFFSET, currentColor, 0);
+            }
+            underlineStart = UNKNOWN;
+            underlineEnd = UNKNOWN;
+        }
+
+        private void updateUnderline(char c, FontCharacter character) {
+            if (currentUnderline && !Character.isWhitespace(c)) {
+                if (underlineStart == UNKNOWN) {
+                    underlineStart = x + character.getxOffset();
+                }
+                underlineEnd = x + character.getxOffset() + character.getWidth();
+            }
+        }
+
+        private void addUnderline(MeshBuilder builder, int xStart, int xEnd, int underlineTop, Color color, float depth) {
+            float bottom = (float) underlineTop + 1;
+
+            Vector3f v1 = new Vector3f((float) xStart, (float) underlineTop, depth);
+            Vector3f v2 = new Vector3f((float) xEnd, (float) underlineTop, depth);
+            Vector3f v3 = new Vector3f((float) xEnd, bottom, depth);
+            Vector3f v4 = new Vector3f((float) xStart, bottom, depth);
+            builder.addPoly(v1, v2, v3, v4);
+            builder.addColor(color, color, color, color);
+            builder.addTexCoord(0, 0);
+            builder.addTexCoord(1, 0);
+            builder.addTexCoord(1, 1);
+            builder.addTexCoord(0, 1);
+        }
+
+        private void addCharacter(MeshBuilder builder, FontCharacter character, Color color, float xOffset, float yOffset, float depth) {
+            float top = y + character.getyOffset() + yOffset;
+            float bottom = top + character.getHeight() + yOffset;
+            float left = x + character.getxOffset() + xOffset;
+            float right = left + character.getWidth() + xOffset;
+            float texTop = character.getY();
+            float texBottom = texTop + character.getTexHeight();
+            float texLeft = character.getX();
+            float texRight = texLeft + character.getTexWidth();
+
+            Vector3f v1 = new Vector3f(left, top, depth);
+            Vector3f v2 = new Vector3f(right, top, depth);
+            Vector3f v3 = new Vector3f(right, bottom, depth);
+            Vector3f v4 = new Vector3f(left, bottom, depth);
+            builder.addPoly(v1, v2, v3, v4);
+            builder.addColor(color, color, color, color);
+            builder.addTexCoord(texLeft, texTop);
+            builder.addTexCoord(texRight, texTop);
+            builder.addTexCoord(texRight, texBottom);
+            builder.addTexCoord(texLeft, texBottom);
         }
     }
-
-    private void addCharacter(MeshBuilder builder, FontCharacter character, int x, int y, Color color, float xOffset, float yOffset, float depth) {
-        float top = y + character.getyOffset() + yOffset;
-        float bottom = top + character.getHeight() + yOffset;
-        float left = x + character.getxOffset() + xOffset;
-        float right = left + character.getWidth() + xOffset;
-        float texTop = character.getY();
-        float texBottom = texTop + character.getTexHeight();
-        float texLeft = character.getX();
-        float texRight = texLeft + character.getTexWidth();
-
-        Vector3f v1 = new Vector3f(left, top, depth);
-        Vector3f v2 = new Vector3f(right, top, depth);
-        Vector3f v3 = new Vector3f(right, bottom, depth);
-        Vector3f v4 = new Vector3f(left, bottom, depth);
-        builder.addPoly(v1, v2, v3, v4);
-        builder.addColor(color, color, color, color);
-        builder.addTexCoord(texLeft, texTop);
-        builder.addTexCoord(texRight, texTop);
-        builder.addTexCoord(texRight, texBottom);
-        builder.addTexCoord(texLeft, texBottom);
-    }
-
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
@@ -38,7 +38,6 @@ public class FontMeshBuilder {
     private static final float SHADOW_DEPTH = -2;
     private static final int SHADOW_HORIZONTAL_OFFSET = 1;
     private static final int SHADOW_VERTICAL_OFFSET = 1;
-    private static final int UNDERLINE_OFFSET = 2;
     private static final int UNKNOWN = -1;
 
     private final Material underlineMaterial;
@@ -161,9 +160,9 @@ public class FontMeshBuilder {
                 MeshBuilder builder = getBuilderFor(underlineMaterial);
                 if (shadowColor.a() != 0) {
                     addUnderline(builder, underlineStart + SHADOW_HORIZONTAL_OFFSET, underlineEnd + SHADOW_HORIZONTAL_OFFSET,
-                            y + font.getBaseHeight() + SHADOW_VERTICAL_OFFSET + UNDERLINE_OFFSET, shadowColor, SHADOW_DEPTH);
+                            y + font.getBaseHeight() + SHADOW_VERTICAL_OFFSET + font.getUnderlineOffset(), font.getUnderlineThickness(), shadowColor, SHADOW_DEPTH);
                 }
-                addUnderline(builder, underlineStart, underlineEnd, y + font.getBaseHeight() + UNDERLINE_OFFSET, currentColor, 0);
+                addUnderline(builder, underlineStart, underlineEnd, y + font.getBaseHeight() + font.getUnderlineOffset(), font.getUnderlineThickness(), currentColor, 0);
             }
             underlineStart = UNKNOWN;
             underlineEnd = UNKNOWN;
@@ -178,8 +177,8 @@ public class FontMeshBuilder {
             }
         }
 
-        private void addUnderline(MeshBuilder builder, int xStart, int xEnd, int underlineTop, Color color, float depth) {
-            float bottom = (float) underlineTop + 1;
+        private void addUnderline(MeshBuilder builder, int xStart, int xEnd, int underlineTop, int underlineThickness, Color color, float depth) {
+            float bottom = (float) underlineTop + underlineThickness;
 
             Vector3f v1 = new Vector3f((float) xStart, (float) underlineTop, depth);
             Vector3f v2 = new Vector3f((float) xEnd, (float) underlineTop, depth);

--- a/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
@@ -292,6 +292,21 @@ public interface Canvas {
     void drawTextRaw(String text, Font font, Color color, Rect2i region, HorizontalAlign hAlign, VerticalAlign vAlign);
 
     /**
+     * Draws text without using the current style, aligned within the drawWidth.  Text may include new lines.
+     * Additionally new lines will be added to prevent any given line exceeding drawWidth.
+     * If an individual word is longer than the drawWidth, it will be split mid-word.
+     *
+     * @param text       The text to draw
+     * @param font       The font to use to draw text
+     * @param color      The color of to draw the text
+     * @param underlined Whether the text should be underlined
+     * @param region     The region within which to of the text. The text will be wrapped to multiple lines if it exceeds this width
+     * @param hAlign     The horizontal alignment or justification of the text
+     * @param vAlign     The vertical alignment of the text
+     */
+    void drawTextRaw(String text, Font font, Color color, boolean underlined, Rect2i region, HorizontalAlign hAlign, VerticalAlign vAlign);
+
+    /**
      * Draws shadowed text without using the current style. Text may include new lines. This text will always be left-aligned.
      *
      * @param text        The text to draw
@@ -314,7 +329,7 @@ public interface Canvas {
     void drawTextRawShadowed(String text, Font font, Color color, Color shadowColor, Rect2i region);
 
     /**
-     * raws shadowed text without using the current style. Text may include new lines. Additionally new lines will be added to prevent any given line exceeding drawWidth.
+     * Draws shadowed text without using the current style. Text may include new lines. Additionally new lines will be added to prevent any given line exceeding drawWidth.
      * If an individual word is longer than the drawWidth, it will be split mid-word.
      *
      * @param text        The text to draw
@@ -326,6 +341,21 @@ public interface Canvas {
      * @param vAlign      The vertical alignment of the text
      */
     void drawTextRawShadowed(String text, Font font, Color color, Color shadowColor, Rect2i region, HorizontalAlign hAlign, VerticalAlign vAlign);
+
+    /**
+     * Draws shadowed text without using the current style. Text may include new lines. Additionally new lines will be added to prevent any given line exceeding drawWidth.
+     * If an individual word is longer than the drawWidth, it will be split mid-word.
+     *
+     * @param text        The text to draw
+     * @param font        The font to use to draw text
+     * @param color       The color of to draw the text
+     * @param shadowColor The color to draw the shadow
+     * @param underline   Whether the text should be underlined (by default, underlines may also be added by underline unicode)
+     * @param region      The region within which to draw this text. The text will be wrapped to new lines if it exceeds this width.
+     * @param hAlign      The horizontal alignment or justification of the text
+     * @param vAlign      The vertical alignment of the text
+     */
+    void drawTextRawShadowed(String text, Font font, Color color, Color shadowColor, boolean underline, Rect2i region, HorizontalAlign hAlign, VerticalAlign vAlign);
 
     /**
      * Draws a texture to the given area without using the current style. If the texture is a different size to the area, it will be adapted according to the ScaleMode.

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasRenderer.java
@@ -54,7 +54,8 @@ public interface CanvasRenderer {
 
     void drawTexture(TextureRegion texture, Color color, ScaleMode mode, Rect2i absoluteRegion, float ux, float uy, float uw, float uh, float alpha);
 
-    void drawText(String text, Font font, HorizontalAlign hAlign, VerticalAlign vAlign, Rect2i absoluteRegion, Color color, Color shadowColor, float alpha);
+    void drawText(String text, Font font, HorizontalAlign hAlign, VerticalAlign vAlign, Rect2i absoluteRegion, Color color,
+                  Color shadowColor, float alpha, boolean underlined);
 
     void drawTextureBordered(TextureRegion texture, Rect2i absoluteRegion, Border border, boolean tile, float ux, float uy, float uw, float uh, float alpha);
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinBuilder.java
@@ -181,6 +181,11 @@ public class UISkinBuilder {
         return this;
     }
 
+    public UISkinBuilder setTextUnderlined(boolean underlined) {
+        currentStyle.setTextUnderlined(underlined);
+        return this;
+    }
+
     public UISkinBuilder setStyleFragment(UIStyleFragment fragment) {
         currentStyle = fragment;
         return this;

--- a/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,6 +78,8 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
         try (JsonReader reader = new JsonReader(new InputStreamReader(inputs.get(0).openStream(), Charsets.UTF_8))) {
             reader.setLenient(true);
             return gson.fromJson(reader, UISkinData.class);
+        } catch (JsonParseException e) {
+            throw new IOException("Failed to load skin '" + urn + "'", e);
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/skin/UIStyle.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/skin/UIStyle.java
@@ -50,6 +50,7 @@ public class UIStyle {
     private HorizontalAlign textAlignmentH = HorizontalAlign.CENTER;
     private VerticalAlign textAlignmentV = VerticalAlign.MIDDLE;
     private boolean textShadowed;
+    private boolean textUnderlined;
 
     public UIStyle() {
     }
@@ -78,6 +79,7 @@ public class UIStyle {
         this.textShadowed = other.textShadowed;
         this.textAlignmentH = other.textAlignmentH;
         this.textAlignmentV = other.textAlignmentV;
+        this.textUnderlined = other.textUnderlined;
     }
 
     /**
@@ -210,6 +212,17 @@ public class UIStyle {
 
     public void setTextShadowed(boolean textShadowed) {
         this.textShadowed = textShadowed;
+    }
+
+    /**
+     * @return Whether drawn text should be underlined
+     */
+    public boolean isTextUnderlined() {
+        return textUnderlined;
+    }
+
+    public void setTextUnderlined(boolean textUnderlined) {
+        this.textUnderlined = textUnderlined;
     }
 
     public void setFixedWidth(int fixedWidth) {

--- a/engine/src/main/java/org/terasology/rendering/nui/skin/UIStyleFragment.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/skin/UIStyleFragment.java
@@ -72,6 +72,8 @@ public class UIStyleFragment {
     private VerticalAlign textAlignmentV;
     @SerializedName("text-shadowed")
     private Boolean textShadowed;
+    @SerializedName("text-underlined")
+    private Boolean textUnderlined;
 
 
     public void applyTo(UIStyle style) {
@@ -107,6 +109,9 @@ public class UIStyleFragment {
         }
         if (textShadowed != null) {
             style.setTextShadowed(textShadowed);
+        }
+        if (textUnderlined != null) {
+            style.setTextUnderlined(textUnderlined);
         }
         if (fixedWidth != null) {
             style.setFixedWidth(fixedWidth);
@@ -220,6 +225,14 @@ public class UIStyleFragment {
 
     public void setTextShadowed(Boolean textShadowed) {
         this.textShadowed = textShadowed;
+    }
+
+    public Boolean getTextUnderlined() {
+        return textUnderlined;
+    }
+
+    public void setTextUnderlined(Boolean textUnderlined) {
+        this.textUnderlined = textUnderlined;
     }
 
     public Integer getFixedWidth() {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -28,6 +28,7 @@ import org.terasology.math.Rect2i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector2i;
 import org.terasology.rendering.FontColor;
+import org.terasology.rendering.FontUnderline;
 import org.terasology.rendering.assets.font.Font;
 import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.BaseInteractionListener;
@@ -181,7 +182,7 @@ public class UIText extends CoreWidget {
                     Rect2i region = Rect2i.createFromMinAndSize(selectionTopLeft.x, selectionTopLeft.y, selectionWidth, font.getLineHeight());
 
                     canvas.drawTexture(cursorTexture, region, textColor);
-                    canvas.drawTextRaw(FontColor.stripColor(selectionString), font, textColor.inverse(), region);
+                    canvas.drawTextRaw(FontUnderline.strip(FontColor.stripColor(selectionString)), font, textColor.inverse(), region);
                 }
                 currentChar += innerLine.length();
                 lineOffset++;
@@ -375,7 +376,7 @@ public class UIText extends CoreWidget {
         if (hasSelection()) {
             String fullText = getText();
             String selection = fullText.substring(Math.min(selectionStart, getCursorPosition()), Math.max(selectionStart, getCursorPosition()));
-            setClipboardContents(FontColor.stripColor(selection));
+            setClipboardContents(FontUnderline.strip(FontColor.stripColor(selection)));
         }
     }
 

--- a/engine/src/main/resources/assets/materials/ui/UIUnderline.mat
+++ b/engine/src/main/resources/assets/materials/ui/UIUnderline.mat
@@ -1,0 +1,9 @@
+{
+    "shader" : "engine:font",
+    "params" : {
+        "texture" : "engine:white",
+        "color" : [1.0, 1.0, 1.0, 1.0],
+        "scale" : [1.0, 1.0],
+        "offset" : [0.0, 0.0]
+    }
+}


### PR DESCRIPTION
Addressing #1813

* Font assets now make available the vertical base of the font
* FontMeshBuilder now processes underlining, generating an additional mesh linked to an underline material
* FontMeshBuilder is now threadsafe
* FontUnderline added with support for unicode characters to mark underline start/end positions
* text-underline style added int UIStyle
* drawTextRaw methods now have parameters for switching on underline
* drawText now uses text-underline style option to underline text

I skipped underline thickness support... there's probably a bunch of underline attributes that should live with the font, but are not supported by the current format we use. Could introduce through a supplemental format. In the mean time fonts are always 2px below the base of a font, 1px thick. This should work for generally used font sizes. Large fonts not so much.

There is some awkwardness from having two types of unicode formatting options - color and underline. Both need to be separately stripped at the moment. Possible should merge the two capabilities.

@MarcinSc can you review this for suitability for your HTML renderer needs?