### PR TITLE
Avoid causing crashes when a component has a null string.

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
@@ -31,12 +31,20 @@ public abstract class StringRepresentationTypeHandler<T> implements TypeHandler<
 
     @Override
     public PersistedData serialize(T value, SerializationContext context) {
-        return context.create(getAsString(value));
+        String stringValue = getAsString(value);
+        if (stringValue == null) {
+            return context.createNull();
+        } else {
+            return context.create(stringValue);
+        }
     }
 
     @Override
     public T deserialize(PersistedData data, DeserializationContext context) {
-        return getFromString(data.getAsString());
+        if (data.isString()) {
+            return getFromString(data.getAsString());
+        }
+        return null;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/NumberTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/NumberTypeHandler.java
@@ -33,12 +33,18 @@ public class NumberTypeHandler implements TypeHandler<Number> {
 
     @Override
     public PersistedData serialize(Number value, SerializationContext context) {
-        return context.create(value.doubleValue());
+        if (value != null) {
+            return context.create(value.doubleValue());
+        }
+        return context.createNull();
     }
 
     @Override
     public Number deserialize(PersistedData data, DeserializationContext context) {
-        return data.getAsDouble();
+        if (data.isNumber()) {
+            return data.getAsDouble();
+        }
+        return null;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/StringTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/StringTypeHandler.java
@@ -31,22 +31,31 @@ public class StringTypeHandler implements TypeHandler<String> {
 
     @Override
     public PersistedData serialize(String value, SerializationContext context) {
-        return context.create(value);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value);
+        }
     }
 
     @Override
     public String deserialize(PersistedData data, DeserializationContext context) {
-        return data.getAsString();
+        if (data.isString()) {
+            return data.getAsString();
+        }
+        return null;
     }
 
     @Override
     public PersistedData serializeCollection(Collection<String> value, SerializationContext context) {
         return context.createStrings(value);
-
     }
 
     @Override
     public List<String> deserializeCollection(PersistedData data, DeserializationContext context) {
-        return Lists.newArrayList(data.getAsArray().getAsStringArray());
+        if (data.isArray()) {
+            return Lists.newArrayList(data.getAsArray().getAsStringArray());
+        }
+        return Lists.newArrayList();
     }
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockFamilyTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockFamilyTypeHandler.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.persistence.typeHandling.extensionTypes;
 
-import org.terasology.registry.CoreRegistry;
 import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.family.BlockFamily;
@@ -33,6 +32,9 @@ public class BlockFamilyTypeHandler extends StringRepresentationTypeHandler<Bloc
 
     @Override
     public String getAsString(BlockFamily item) {
+        if (item == null) {
+            return "";
+        }
         return item.getURI().toString();
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/BlockTypeHandler.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.persistence.typeHandling.extensionTypes;
 
-import org.terasology.registry.CoreRegistry;
 import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
@@ -33,6 +32,9 @@ public class BlockTypeHandler extends StringRepresentationTypeHandler<Block> {
 
     @Override
     public String getAsString(Block item) {
+        if (item == null) {
+            return "";
+        }
         return item.getURI().toString();
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/CollisionGroupTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/CollisionGroupTypeHandler.java
@@ -16,7 +16,6 @@
 
 package org.terasology.persistence.typeHandling.extensionTypes;
 
-import org.terasology.registry.CoreRegistry;
 import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 import org.terasology.physics.CollisionGroup;
 import org.terasology.physics.CollisionGroupManager;
@@ -34,6 +33,9 @@ public class CollisionGroupTypeHandler extends StringRepresentationTypeHandler<C
 
     @Override
     public String getAsString(CollisionGroup item) {
+        if (item == null) {
+            return "";
+        }
         return item.getName();
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ColorTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ColorTypeHandler.java
@@ -16,7 +16,6 @@
 package org.terasology.persistence.typeHandling.extensionTypes;
 
 import gnu.trove.list.TIntList;
-
 import org.terasology.persistence.typeHandling.DeserializationContext;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
@@ -31,7 +30,11 @@ public class ColorTypeHandler extends SimpleTypeHandler<Color> {
 
     @Override
     public PersistedData serialize(Color value, SerializationContext context) {
-        return context.create(value.r(), value.g(), value.b(), value.a());
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.r(), value.g(), value.b(), value.a());
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/PrefabTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/PrefabTypeHandler.java
@@ -30,6 +30,9 @@ public class PrefabTypeHandler extends StringRepresentationTypeHandler<Prefab> {
 
     @Override
     public String getAsString(Prefab item) {
+        if (item == null) {
+            return "";
+        }
         return item.getName();
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/BorderTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/BorderTypeHandler.java
@@ -16,12 +16,12 @@
 package org.terasology.persistence.typeHandling.mathTypes;
 
 import com.google.common.collect.Maps;
+import org.terasology.math.Border;
 import org.terasology.persistence.typeHandling.DeserializationContext;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataMap;
 import org.terasology.persistence.typeHandling.SerializationContext;
 import org.terasology.persistence.typeHandling.SimpleTypeHandler;
-import org.terasology.math.Border;
 
 import java.util.Map;
 
@@ -36,17 +36,24 @@ public class BorderTypeHandler extends SimpleTypeHandler<Border> {
 
     @Override
     public PersistedData serialize(Border value, SerializationContext context) {
-        Map<String, PersistedData> map = Maps.newLinkedHashMap();
-        map.put(LEFT_FIELD, context.create(value.getLeft()));
-        map.put(RIGHT_FIELD, context.create(value.getRight()));
-        map.put(TOP_FIELD, context.create(value.getTop()));
-        map.put(BOTTOM_FIELD, context.create(value.getBottom()));
-        return context.create(map);
+        if (value != null) {
+            Map<String, PersistedData> map = Maps.newLinkedHashMap();
+            map.put(LEFT_FIELD, context.create(value.getLeft()));
+            map.put(RIGHT_FIELD, context.create(value.getRight()));
+            map.put(TOP_FIELD, context.create(value.getTop()));
+            map.put(BOTTOM_FIELD, context.create(value.getBottom()));
+            return context.create(map);
+        }
+
+        return context.createNull();
     }
 
     @Override
     public Border deserialize(PersistedData data, DeserializationContext context) {
-        PersistedDataMap map = data.getAsValueMap();
-        return new Border(map.getAsInteger(LEFT_FIELD), map.getAsInteger(RIGHT_FIELD), map.getAsInteger(TOP_FIELD), map.getAsInteger(BOTTOM_FIELD));
+        if (data.isValueMap()) {
+            PersistedDataMap map = data.getAsValueMap();
+            return new Border(map.getAsInteger(LEFT_FIELD), map.getAsInteger(RIGHT_FIELD), map.getAsInteger(TOP_FIELD), map.getAsInteger(BOTTOM_FIELD));
+        }
+        return null;
     }
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/IntegerRangeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/IntegerRangeHandler.java
@@ -18,11 +18,13 @@ package org.terasology.persistence.typeHandling.mathTypes;
 import org.terasology.math.IntegerRange;
 import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 
-import java.util.Iterator;
-
 public class IntegerRangeHandler extends StringRepresentationTypeHandler<IntegerRange> {
     @Override
     public String getAsString(IntegerRange item) {
+        if (item == null) {
+            return "";
+        }
+
         StringBuilder sb = new StringBuilder();
 
         Integer currentRangeStart = null;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Quat4fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Quat4fTypeHandler.java
@@ -16,7 +16,6 @@
 package org.terasology.persistence.typeHandling.mathTypes;
 
 import gnu.trove.list.TFloatList;
-
 import org.terasology.math.geom.Quat4f;
 import org.terasology.persistence.typeHandling.DeserializationContext;
 import org.terasology.persistence.typeHandling.PersistedData;
@@ -31,7 +30,12 @@ public class Quat4fTypeHandler extends SimpleTypeHandler<Quat4f> {
 
     @Override
     public PersistedData serialize(Quat4f value, SerializationContext context) {
-        return context.create(value.x, value.y, value.z, value.w);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.x, value.y, value.z, value.w);
+        }
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2fTypeHandler.java
@@ -17,7 +17,6 @@
 package org.terasology.persistence.typeHandling.mathTypes;
 
 import com.google.common.collect.Maps;
-
 import org.terasology.math.Rect2f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.persistence.typeHandling.DeserializationContext;
@@ -38,18 +37,25 @@ public class Rect2fTypeHandler extends SimpleTypeHandler<Rect2f> {
 
     @Override
     public PersistedData serialize(Rect2f value, SerializationContext context) {
-        Map<String, PersistedData> map = Maps.newLinkedHashMap();
-        map.put(MIN_FIELD, context.create(value.min(), Vector2f.class));
-        map.put(SIZE_FIELD, context.create(value.size(), Vector2f.class));
-        return context.create(map);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            Map<String, PersistedData> map = Maps.newLinkedHashMap();
+            map.put(MIN_FIELD, context.create(value.min(), Vector2f.class));
+            map.put(SIZE_FIELD, context.create(value.size(), Vector2f.class));
+            return context.create(map);
+        }
     }
 
     @Override
     public Rect2f deserialize(PersistedData data, DeserializationContext context) {
-        PersistedDataMap map = data.getAsValueMap();
-        Vector2f min = context.deserializeAs(map.get(MIN_FIELD), Vector2f.class);
-        Vector2f size = context.deserializeAs(map.get(SIZE_FIELD), Vector2f.class);
-        return Rect2f.createFromMinAndSize(min, size);
+        if (data.isValueMap()) {
+            PersistedDataMap map = data.getAsValueMap();
+            Vector2f min = context.deserializeAs(map.get(MIN_FIELD), Vector2f.class);
+            Vector2f size = context.deserializeAs(map.get(SIZE_FIELD), Vector2f.class);
+            return Rect2f.createFromMinAndSize(min, size);
+        }
+        return null;
     }
 
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2iTypeHandler.java
@@ -37,18 +37,25 @@ public class Rect2iTypeHandler extends SimpleTypeHandler<Rect2i> {
 
     @Override
     public PersistedData serialize(Rect2i value, SerializationContext context) {
-        Map<String, PersistedData> map = Maps.newLinkedHashMap();
-        map.put(MIN_FIELD, context.create(value.min(), Vector2i.class));
-        map.put(SIZE_FIELD, context.create(value.size(), Vector2i.class));
-        return context.create(map);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            Map<String, PersistedData> map = Maps.newLinkedHashMap();
+            map.put(MIN_FIELD, context.create(value.min(), Vector2i.class));
+            map.put(SIZE_FIELD, context.create(value.size(), Vector2i.class));
+            return context.create(map);
+        }
     }
 
     @Override
     public Rect2i deserialize(PersistedData data, DeserializationContext context) {
-        PersistedDataMap map = data.getAsValueMap();
-        Vector2i min = context.deserializeAs(map.get(MIN_FIELD), Vector2i.class);
-        Vector2i size = context.deserializeAs(map.get(SIZE_FIELD), Vector2i.class);
-        return Rect2i.createFromMinAndSize(min, size);
+        if (data.isValueMap()) {
+            PersistedDataMap map = data.getAsValueMap();
+            Vector2i min = context.deserializeAs(map.get(MIN_FIELD), Vector2i.class);
+            Vector2i size = context.deserializeAs(map.get(SIZE_FIELD), Vector2i.class);
+            return Rect2i.createFromMinAndSize(min, size);
+        }
+        return null;
     }
 
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Region3iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Region3iTypeHandler.java
@@ -38,18 +38,25 @@ public class Region3iTypeHandler extends SimpleTypeHandler<Region3i> {
 
     @Override
     public PersistedData serialize(Region3i value, SerializationContext context) {
-        Map<String, PersistedData> map = Maps.newLinkedHashMap();
-        map.put(MIN_FIELD, context.create(value.min(), Vector3i.class));
-        map.put(SIZE_FIELD, context.create(value.size(), Vector3i.class));
-        return context.create(map);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            Map<String, PersistedData> map = Maps.newLinkedHashMap();
+            map.put(MIN_FIELD, context.create(value.min(), Vector3i.class));
+            map.put(SIZE_FIELD, context.create(value.size(), Vector3i.class));
+            return context.create(map);
+        }
     }
 
     @Override
     public Region3i deserialize(PersistedData data, DeserializationContext context) {
-        PersistedDataMap map = data.getAsValueMap();
-        Vector3i min = context.deserializeAs(map.get(MIN_FIELD), Vector3i.class);
-        Vector3i size = context.deserializeAs(map.get(SIZE_FIELD), Vector3i.class);
-        return Region3i.createFromMinAndSize(min, size);
+        if (data.isValueMap()) {
+            PersistedDataMap map = data.getAsValueMap();
+            Vector3i min = context.deserializeAs(map.get(MIN_FIELD), Vector3i.class);
+            Vector3i size = context.deserializeAs(map.get(SIZE_FIELD), Vector3i.class);
+            return Region3i.createFromMinAndSize(min, size);
+        }
+        return null;
     }
 
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2fTypeHandler.java
@@ -17,7 +17,6 @@ package org.terasology.persistence.typeHandling.mathTypes;
 
 
 import gnu.trove.list.TFloatList;
-
 import org.terasology.math.geom.Vector2f;
 import org.terasology.persistence.typeHandling.DeserializationContext;
 import org.terasology.persistence.typeHandling.PersistedData;
@@ -32,7 +31,12 @@ public class Vector2fTypeHandler extends SimpleTypeHandler<Vector2f> {
 
     @Override
     public PersistedData serialize(Vector2f value, SerializationContext context) {
-        return context.create(value.x, value.y);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.x, value.y);
+        }
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2iTypeHandler.java
@@ -30,7 +30,11 @@ public class Vector2iTypeHandler extends SimpleTypeHandler<Vector2i> {
 
     @Override
     public PersistedData serialize(Vector2i value, SerializationContext context) {
-        return context.create(value.x, value.y);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.x, value.y);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3fTypeHandler.java
@@ -16,7 +16,6 @@
 package org.terasology.persistence.typeHandling.mathTypes;
 
 import gnu.trove.list.TFloatList;
-
 import org.terasology.math.geom.Vector3f;
 import org.terasology.persistence.typeHandling.DeserializationContext;
 import org.terasology.persistence.typeHandling.PersistedData;
@@ -31,7 +30,11 @@ public class Vector3fTypeHandler extends SimpleTypeHandler<Vector3f> {
 
     @Override
     public PersistedData serialize(Vector3f value, SerializationContext context) {
-        return context.create(value.x, value.y, value.z);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.x, value.y, value.z);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3iTypeHandler.java
@@ -30,7 +30,11 @@ public class Vector3iTypeHandler extends SimpleTypeHandler<Vector3i> {
 
     @Override
     public PersistedData serialize(Vector3i value, SerializationContext context) {
-        return context.create(value.x, value.y, value.z);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.x, value.y, value.z);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector4fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector4fTypeHandler.java
@@ -17,7 +17,6 @@ package org.terasology.persistence.typeHandling.mathTypes;
 
 
 import gnu.trove.list.TFloatList;
-
 import org.terasology.math.geom.Vector4f;
 import org.terasology.persistence.typeHandling.DeserializationContext;
 import org.terasology.persistence.typeHandling.PersistedData;
@@ -32,7 +31,11 @@ public class Vector4fTypeHandler extends SimpleTypeHandler<Vector4f> {
 
     @Override
     public PersistedData serialize(Vector4f value, SerializationContext context) {
-        return context.create(value.x, value.y, value.z, value.w);
+        if (value == null) {
+            return context.createNull();
+        } else {
+            return context.create(value.x, value.y, value.z, value.w);
+        }
     }
 
     @Override


### PR DESCRIPTION
This needs some discussion. 

I would like to be a little more flexible with components and strings.  Currently if you let a null string be sent to the serializer for saving a world, it crashes the game.  It would lower the bar to entry for new module developers if we allowed for null values without crashes, less things to know and code around.

Could we be a little more lenient in these cases?  Is there any other considerations to making this kind of change?  Possibly this could be extended to other types as well?