### PR TITLE
Improvements to the BlockRegion system

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/regions/ActAsBlockComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/ActAsBlockComponent.java
@@ -17,7 +17,6 @@ package org.terasology.world.block.regions;
 
 
 import org.terasology.entitySystem.Component;
-import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.family.BlockFamily;
 
 /**
@@ -27,4 +26,5 @@ import org.terasology.world.block.family.BlockFamily;
  */
 public final class ActAsBlockComponent implements Component {
     public BlockFamily block;
+    public boolean dropBlocksInRegion;
 }

--- a/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.regions;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -38,7 +39,8 @@ public class BlockRegionSystem extends BaseComponentSystem {
     @In
     private BlockManager blockManager;
 
-    @ReceiveEvent
+    // trivial priority so that all other logic can happen to the region before erasing the blocks in the region
+    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
     public void onDestroyed(DoDestroyEvent event, EntityRef entity, BlockRegionComponent blockRegion) {
         for (Vector3i blockPosition : blockRegion.region) {
             worldProvider.setBlock(blockPosition, blockManager.getBlock(BlockManager.AIR_ID));


### PR DESCRIPTION
- Allow block regions to drop all the blocks in the region instead of the single block that they act like (opt in).
- Automatically add health to the region entity similar to the ActAsBlock block would have.
- Simplify the ActAsBlock CreateBlockDropsEvent handler into a single event handler.