### PR TITLE
Fix a NullPointerException in headless server 

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -32,6 +32,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.game.GameManifest;
+import org.terasology.input.InputSystem;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.ConsoleImpl;
 import org.terasology.logic.console.ConsoleSystem;
@@ -90,6 +91,7 @@ public class StateHeadlessSetup implements GameState {
 
         componentSystemManager.register(new ConsoleSystem(), "engine:ConsoleSystem");
         componentSystemManager.register(new CoreCommands(), "engine:CoreCommands");
+        componentSystemManager.register(context.get(InputSystem.class), "engine:InputSystem");
 
         EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
         LocalPlayer localPlayer = new LocalPlayer();


### PR DESCRIPTION
Fix a NullPointerException in headless server caused by #1834.

NUIManager calls isCapturingMouse of InputSystem during loading which used to fail with a NullPointerException because the InputSystem did not get dependency injected.

@immortius  please review