### PR TITLE
Remove CoreRegistry usage: Part VII - Add depenency injection support to WorldGenerators.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -101,7 +101,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         WorldGeneratorManager worldGeneratorManager = context.get(WorldGeneratorManager.class);
         WorldGenerator worldGenerator;
         try {
-            worldGenerator = worldGeneratorManager.createGenerator(worldInfo.getWorldGenerator());
+            worldGenerator = worldGeneratorManager.createGenerator(worldInfo.getWorldGenerator(), context);
             // setting the world seed will create the world builder
             worldGenerator.setWorldSeed(worldInfo.getSeed());
             context.put(WorldGenerator.class, worldGenerator);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/PreviewWorldScreen.java
@@ -127,7 +127,7 @@ public class PreviewWorldScreen extends CoreScreenLayer {
                 EnvironmentSwitchHandler environmentSwitchHandler = context.get(EnvironmentSwitchHandler.class);
                 environmentSwitchHandler.handleSwitchToPreviewEnivronment(context, environment);
                 genTexture();
-                worldGenerator = worldGeneratorManager.searchForWorldGenerator(worldGenUri, environment);
+                worldGenerator = worldGeneratorManager.createWorldGenerator(worldGenUri, subContext, environment);
                 worldGenerator.setWorldSeed(seed.getText());
                 previewGen = new FacetLayerPreview(environment, worldGenerator);
                 configureProperties();

--- a/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
@@ -35,15 +35,13 @@ public abstract class BaseFacetedWorldGenerator implements WorldGenerator, World
     private final SimpleUri uri;
 
     private String worldSeed;
-    private final WorldBuilder worldBuilder;
+    private WorldBuilder worldBuilder;
     private World world;
 
-    private final FacetedWorldConfigurator worldConfigurator;
+    private FacetedWorldConfigurator configurator;
 
     public BaseFacetedWorldGenerator(SimpleUri uri) {
         this.uri = uri;
-        this.worldBuilder = createWorld();
-        this.worldConfigurator = worldBuilder.createConfigurator();
     }
 
     @Override
@@ -59,7 +57,7 @@ public abstract class BaseFacetedWorldGenerator implements WorldGenerator, World
     @Override
     public void setWorldSeed(final String seed) {
         worldSeed = seed;
-        worldBuilder.setSeed(seed.hashCode());
+        getWorldBuilder().setSeed(seed.hashCode());
 
         // reset the world to lazy load it again later
         world = null;
@@ -79,17 +77,29 @@ public abstract class BaseFacetedWorldGenerator implements WorldGenerator, World
 
     @Override
     public WorldConfigurator getConfigurator() {
-        return worldConfigurator;
+        if (configurator == null) {
+            configurator = getWorldBuilder().createConfigurator();
+        }
+        return configurator;
     }
 
     @Override
     public World getWorld() {
         // build the world as late as possible so that we can do configuration and 2d previews
         if (world == null) {
-            world = worldBuilder.build();
+            world = getWorldBuilder().build();
         }
         return world;
     }
+
+    private WorldBuilder getWorldBuilder() {
+        if (worldBuilder == null) {
+            worldBuilder = createWorld();
+        }
+        return worldBuilder;
+    }
+
+
 
     @Override
     public Color get(String layerName, Rect2i area) {

--- a/engine/src/main/java/org/terasology/world/generator/RegisterWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generator/RegisterWorldGenerator.java
@@ -15,13 +15,15 @@
  */
 package org.terasology.world.generator;
 
+import org.terasology.registry.In;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author Immortius
+ * Marks a class as world generator. Field annotated with {@link In} will be injected after construction.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/FlatWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/FlatWorldGenerator.java
@@ -15,20 +15,19 @@
  */
 package org.terasology.core.world.generator.worldGenerators;
 
-import org.terasology.context.Context;
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
+import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.FlatSurfaceHeightProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
-import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
 import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
@@ -41,9 +40,12 @@ public class FlatWorldGenerator extends BaseFacetedWorldGenerator {
         super(uri);
     }
 
+    @In
+    private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
+
     @Override
     protected WorldBuilder createWorld() {
-        return new WorldBuilder(CoreRegistry.get(WorldGeneratorPluginLibrary.class))
+        return new WorldBuilder(worldGeneratorPluginLibrary)
                 .addProvider(new SeaLevelProvider(32))
                         // height of 40 so that it is far enough from sea level so that it doesnt just create beachfront
                 .addProvider(new FlatSurfaceHeightProvider(40))

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
@@ -15,20 +15,19 @@
  */
 package org.terasology.core.world.generator.worldGenerators;
 
-import org.terasology.context.Context;
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
+import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.HeightMapSurfaceHeightProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
-import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
 import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
@@ -43,9 +42,13 @@ public class HeightMapWorldGenerator extends BaseFacetedWorldGenerator {
         super(uri);
     }
 
+
+    @In
+    private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
+
     @Override
     protected WorldBuilder createWorld() {
-        return new WorldBuilder(CoreRegistry.get(WorldGeneratorPluginLibrary.class))
+        return new WorldBuilder(worldGeneratorPluginLibrary)
                 .setSeaLevel(16)
                 .addProvider(new SeaLevelProvider(16))
                 .addProvider(new HeightMapSurfaceHeightProvider())

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/PerlinFacetedWorldGenerator.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.core.world.generator.worldGenerators;
 
-import org.terasology.context.Context;
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
+import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.EnsureSpawnableChunkZeroProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinBaseSurfaceProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinHillsAndMountainsProvider;
@@ -27,13 +27,12 @@ import org.terasology.core.world.generator.facetProviders.PerlinRiverProvider;
 import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
-import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.World2dPreviewProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
 import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
@@ -49,9 +48,13 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
         super(uri);
     }
 
+
+    @In
+    private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
+
     @Override
     protected WorldBuilder createWorld() {
-        return new WorldBuilder(CoreRegistry.get(WorldGeneratorPluginLibrary.class))
+        return new WorldBuilder(worldGeneratorPluginLibrary)
                 .addProvider(new World2dPreviewProvider())
                 .addProvider(new SeaLevelProvider())
                 .addProvider(new PerlinHumidityProvider())


### PR DESCRIPTION
Add depenency injection support to WorldGenerators to get rid of CoreRegistry usage.