### PR TITLE
Fix TeraMath version to 1.1.0

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     // Our developed libs
     compile group: 'org.terasology', name: 'gestalt-module', version: '4.1.1'
     compile group: 'org.terasology', name: 'gestalt-asset-core', version: '4.1.1'
-    compile group: 'org.terasology', name: 'TeraMath', version: '+', changing: true
+    compile group: 'org.terasology', name: 'TeraMath', version: '1.1.0'
     compile group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.0.3'
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)


### PR DESCRIPTION
This avoids checking repeatedly for new versions, which is not necessary.