### PR TITLE
Fix for texture overrides

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -121,8 +121,8 @@ dependencies {
     compile group: 'org.eaxy', name: 'eaxy', version: '0.1'
 
     // Our developed libs
-    compile group: 'org.terasology', name: 'gestalt-module', version: '4.1.1'
-    compile group: 'org.terasology', name: 'gestalt-asset-core', version: '4.1.1'
+    compile group: 'org.terasology', name: 'gestalt-module', version: '4.1.2'
+    compile group: 'org.terasology', name: 'gestalt-asset-core', version: '4.1.2'
     compile group: 'org.terasology', name: 'TeraMath', version: '1.1.0'
     compile group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.0.3'
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -28,11 +28,11 @@ import org.lwjgl.opengl.KHRDebugCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.AssetFactory;
+import org.terasology.assets.module.ModuleAssetDataProducer;
 import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
-import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.GameThread;
 import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.DisplayDevice;
@@ -122,9 +122,21 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         assetTypeManager.registerCoreAssetType(Texture.class, (AssetFactory<Texture, TextureData>)
                 (urn, assetType, data) -> (new OpenGLTexture(urn, assetType, data, this)), "textures", "fonts");
         assetTypeManager.registerCoreFormat(Texture.class,
-                new PNGTextureFormat(Texture.FilterMode.NEAREST, path -> path.getName(2).toString().equals("textures")));
+                new PNGTextureFormat(Texture.FilterMode.NEAREST, path -> {
+                    if (path.getName(1).toString().equals(ModuleAssetDataProducer.OVERRIDE_FOLDER)) {
+                        return path.getName(3).toString().equals("textures");
+                    } else {
+                        return path.getName(2).toString().equals("textures");
+                    }
+                }));
         assetTypeManager.registerCoreFormat(Texture.class,
-                new PNGTextureFormat(Texture.FilterMode.LINEAR, path -> path.getName(2).toString().equals("fonts")));
+                new PNGTextureFormat(Texture.FilterMode.LINEAR, path -> {
+                    if (path.getName(1).toString().equals(ModuleAssetDataProducer.OVERRIDE_FOLDER)) {
+                        return path.getName(3).toString().equals("fonts");
+                    } else {
+                        return path.getName(2).toString().equals("fonts");
+                    }
+                }));
         assetTypeManager.registerCoreAssetType(Shader.class,
                 (AssetFactory<Shader, ShaderData>) GLSLShader::new, "shaders");
         assetTypeManager.registerCoreAssetType(Material.class,


### PR DESCRIPTION
 - Updated to gestalt-asset-core 4.1.2
 - Fixed handling of default filtering for font vs texture assets to work with overrides.