### PR TITLE
Fix for #1856

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -166,10 +166,17 @@ public final class ChunkMeshUpdateManager {
             ChunkView chunkView = worldProvider.getLocalView(c.getPosition());
             if (chunkView != null) {
                 c.setDirty(false);
-                newMesh = tessellator.generateMesh(chunkView, ChunkConstants.SIZE_Y, 0);
+                chunkView.readLock();
+                try {
+                    if (chunkView.isValidView()) {
+                        newMesh = tessellator.generateMesh(chunkView, ChunkConstants.SIZE_Y, 0);
 
-                c.setPendingMesh(newMesh);
-                ChunkMonitor.fireChunkTessellated(c.getPosition(), newMesh);
+                        c.setPendingMesh(newMesh);
+                        ChunkMonitor.fireChunkTessellated(c.getPosition(), newMesh);
+                    }
+                } finally {
+                    chunkView.readUnlock();
+                }
 
             }
             chunkMeshUpdateManager.finishedProcessing(c);

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -25,7 +25,7 @@ import org.terasology.world.liquid.LiquidData;
  * A chunk view is a way of accessing multiple chunks for modification in a performant manner.
  * Chunk views also support relative subviewing - looking at an area of the world with a uniform offset to block positions
  * <br><br>
- * ChunkViews must be locked because write operations can be enacted - any write operations requested outside of a lock
+ * ChunkViews must be locked before write operations can be enacted - any write operations requested outside of a lock
  * are ignored.
  *
  * @author Immortius
@@ -224,12 +224,22 @@ public interface ChunkView {
     /**
      * Locks the chunk view, enabling write operations
      */
-    void lock();
+    void writeLock();
 
     /**
      * Unlocks the chunk view, disabling write operations
      */
-    void unlock();
+    void writeUnlock();
+
+    /**
+     * Locks the chunk view, enabling write operations
+     */
+    void readLock();
+
+    /**
+     * Unlocks the chunk view, disabling write operations
+     */
+    void readUnlock();
 
     /**
      * @return Whether the chunk view is locked and hence whether write operations are allowed.

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -84,9 +84,13 @@ public interface CoreChunk {
 
     Region3i getRegion();
 
-    void lock();
+    void writeLock();
 
-    void unlock();
+    void writeUnlock();
+
+    void readLock();
+
+    void readUnlock();
 
     boolean isLocked();
 

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -239,7 +239,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
         ReadyChunkInfo readyChunkInfo = lightMerger.completeMerge();
         if (readyChunkInfo != null) {
             Chunk chunk = readyChunkInfo.getChunk();
-            chunk.lock();
+            chunk.writeLock();
             try {
                 chunk.markReady();
                 updateAdjacentChunksReadyFieldOf(chunk);
@@ -288,7 +288,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
                     region.chunkReady(chunk);
                 }
             } finally {
-                chunk.unlock();
+                chunk.writeUnlock();
             }
         }
     }
@@ -381,7 +381,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
             return false;
         }
 
-        chunk.lock();
+        chunk.writeLock();
         try {
             if (!chunk.isReady()) {
                 // Chunk hasn't been finished or changed, so just drop it.
@@ -411,7 +411,7 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
 
             return true;
         } finally {
-            chunk.unlock();
+            chunk.writeUnlock();
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -25,7 +25,6 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.biomes.Biome;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.Block;
-import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.RenderableChunk;
@@ -271,22 +270,36 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     }
 
     @Override
-    public void lock() {
+    public void writeLock() {
         if (!locked.get()) {
             for (RenderableChunk chunk : chunks) {
-                chunk.lock();
+                chunk.writeLock();
             }
             locked.set(true);
         }
     }
 
     @Override
-    public void unlock() {
+    public void writeUnlock() {
         if (locked.get()) {
             locked.set(false);
             for (RenderableChunk chunk : chunks) {
-                chunk.unlock();
+                chunk.writeUnlock();
             }
+        }
+    }
+
+    @Override
+    public void readLock() {
+        for (RenderableChunk chunk : chunks) {
+            chunk.readLock();
+        }
+    }
+
+    @Override
+    public void readUnlock() {
+        for (RenderableChunk chunk : chunks) {
+            chunk.readUnlock();
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -185,9 +185,9 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
-            chunk.lock();
+            chunk.writeLock();
             Block oldBlockType = chunk.setBlock(blockPos, type);
-            chunk.unlock();
+            chunk.writeUnlock();
             if (oldBlockType != type) {
                 BlockChange oldChange = blockChanges.get(worldPos);
                 if (oldChange == null) {
@@ -210,7 +210,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     private void notifyBlockChanged(Vector3i pos, Block type, Block oldType) {
-        // TODO: Could use a read/write lock.
+        // TODO: Could use a read/write writeLock.
         // TODO: Review, should only happen on main thread (as should changes to listeners)
         synchronized (listeners) {
             for (WorldChangeListener listener : listeners) {
@@ -220,7 +220,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     private void notifyBiomeChanged(Vector3i pos, Biome newBiome, Biome originalBiome) {
-        // TODO: Could use a read/write lock.
+        // TODO: Could use a read/write writeLock.
         // TODO: Review, should only happen on main thread (as should changes to listeners)
         synchronized (listeners) {
             for (WorldChangeListener listener : listeners) {
@@ -234,7 +234,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            chunk.lock();
+            chunk.writeLock();
             try {
                 Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
                 LiquidData liquidState = chunk.getLiquid(blockPos);
@@ -243,7 +243,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                     return true;
                 }
             } finally {
-                chunk.unlock();
+                chunk.writeUnlock();
             }
         }
         return false;
@@ -291,9 +291,9 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
-            chunk.lock();
+            chunk.writeLock();
             Biome oldBiomeType = chunk.setBiome(blockPos.x, blockPos.y, blockPos.z, biome);
-            chunk.unlock();
+            chunk.writeUnlock();
             if (oldBiomeType != biome) {
                 BiomeChange oldChange = biomeChanges.get(worldPos);
                 if (oldChange == null) {

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightMerger.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightMerger.java
@@ -87,7 +87,7 @@ public class LightMerger<T> {
         localChunks[CENTER_INDEX] = chunk;
         for (Chunk localChunk : localChunks) {
             if (localChunk != null) {
-                localChunk.lock();
+                localChunk.writeLock();
             }
         }
         try {
@@ -127,7 +127,7 @@ public class LightMerger<T> {
         } finally {
             for (Chunk localChunk : localChunks) {
                 if (localChunk != null) {
-                    localChunk.unlock();
+                    localChunk.writeUnlock();
                 }
             }
         }


### PR DESCRIPTION
Introduces read/write lock separation for chunks. Tesselation takes a read lock, which blocks the chunk provider from disposing the chunk.
This needs to be tested to ensure it doesn't introduce stutters.