### PR TITLE
Remove CoreRegistry usage: Part IX

### DIFF
--- a/engine-tests/src/test/java/org/terasology/logic/behavior/FactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/FactoryTest.java
@@ -17,28 +17,15 @@ package org.terasology.logic.behavior;
 
 import com.google.common.collect.Lists;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.format.AssetDataFile;
-import org.terasology.assets.management.AssetManager;
-import org.terasology.assets.management.AssetTypeManager;
-import org.terasology.assets.management.MapAssetTypeManager;
-import org.terasology.context.Context;
-import org.terasology.context.internal.ContextImpl;
-import org.terasology.engine.module.ModuleManager;
 import org.terasology.logic.behavior.asset.BehaviorTreeData;
 import org.terasology.logic.behavior.asset.BehaviorTreeFormat;
-import org.terasology.logic.behavior.asset.NodesClassLibrary;
 import org.terasology.logic.behavior.tree.MonitorNode;
 import org.terasology.logic.behavior.tree.ParallelNode;
 import org.terasology.logic.behavior.tree.RepeatNode;
 import org.terasology.logic.behavior.tree.SequenceNode;
-import org.terasology.reflection.copy.CopyStrategyLibrary;
-import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.reflection.reflect.ReflectionReflectFactory;
-import org.terasology.registry.CoreRegistry;
-import org.terasology.testUtil.ModuleManagerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -59,7 +46,7 @@ public class FactoryTest extends TerasologyTestingEnvironment {
 
         context.put(BehaviorNodeFactory.class, nodeFactory);
         BehaviorTreeFormat loader = new BehaviorTreeFormat();
-        BehaviorTreeData data = buildSample();
+        BehaviorTreeData data = buildSample(nodeFactory);
 
         ByteArrayOutputStream os = new ByteArrayOutputStream(10000);
         loader.save(os, data);
@@ -76,7 +63,7 @@ public class FactoryTest extends TerasologyTestingEnvironment {
         Assert.assertArrayEquals(jsonActual, jsonExpected);
     }
 
-    private BehaviorTreeData buildSample() {
+    private BehaviorTreeData buildSample(BehaviorNodeFactory factory) {
         SequenceNode sequence = new SequenceNode();
         sequence.children().add(new DebugNode(1));
         sequence.children().add(new RepeatNode(new DebugNode(2)));
@@ -86,7 +73,7 @@ public class FactoryTest extends TerasologyTestingEnvironment {
         parallel.children().add(new DebugNode(3));
         BehaviorTreeData tree = new BehaviorTreeData();
         tree.setRoot(sequence);
-        tree.createRenderable();
+        tree.createRenderable(factory);
         tree.layout(null);
         return tree;
     }

--- a/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
@@ -30,6 +30,7 @@ import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.commandSystem.MethodCommand;
+import org.terasology.logic.console.commandSystem.adapter.ParameterAdapterManager;
 import org.terasology.module.Module;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.naming.Name;
@@ -142,7 +143,8 @@ public class ComponentSystemManager {
         InjectionHelper.inject(system);
 
         if (console != null) {
-            MethodCommand.registerAvailable(system);
+            ParameterAdapterManager parameterAdapterManager = context.get(ParameterAdapterManager.class);
+            MethodCommand.registerAvailable(system, console, parameterAdapterManager);
         }
 
         try {

--- a/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentSystemManager.java
@@ -30,7 +30,6 @@ import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.commandSystem.MethodCommand;
-import org.terasology.logic.console.commandSystem.adapter.ParameterAdapterManager;
 import org.terasology.module.Module;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.naming.Name;
@@ -143,8 +142,7 @@ public class ComponentSystemManager {
         InjectionHelper.inject(system);
 
         if (console != null) {
-            ParameterAdapterManager parameterAdapterManager = context.get(ParameterAdapterManager.class);
-            MethodCommand.registerAvailable(system, console, parameterAdapterManager);
+            MethodCommand.registerAvailable(system, console, context);
         }
 
         try {

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -77,7 +77,7 @@ public class StateMainMenu implements GameState {
         entityManager = context.get(EngineEntityManager.class);
 
         eventSystem = context.get(EventSystem.class);
-        context.put(Console.class, new ConsoleImpl());
+        context.put(Console.class, new ConsoleImpl(context));
 
         nuiManager = new NUIManagerInternal(context.get(CanvasRenderer.class), context);
         context.put(NUIManager.class, nuiManager);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseCommandSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseCommandSystem.java
@@ -38,7 +38,7 @@ public class InitialiseCommandSystem extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        context.put(Console.class, new ConsoleImpl());
+        context.put(Console.class, new ConsoleImpl(context));
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -67,7 +67,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager);
 
         WorldProviderCoreImpl worldProviderCore = new WorldProviderCoreImpl(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD), chunkProvider,
-                blockManager.getBlock(BlockManager.AIR_ID));
+                blockManager.getBlock(BlockManager.AIR_ID), context);
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(worldProviderCore);
         WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider);
         context.put(WorldProvider.class, worldProvider);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -74,7 +74,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         context.put(BlockEntityRegistry.class, entityWorldProvider);
         context.get(ComponentSystemManager.class).register(entityWorldProvider, "engine:BlockEntityRegistry");
 
-        DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel());
+        DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel(), context);
         context.put(CelestialSystem.class, celestialSystem);
         context.get(ComponentSystemManager.class).register(celestialSystem);
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -61,10 +61,11 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
     public boolean step() {
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer
-        context.put(LocalPlayer.class, new LocalPlayer());
+        LocalPlayer localPlayer = new LocalPlayer();
+        context.put(LocalPlayer.class, localPlayer);
         BlockManager blockManager = context.get(BlockManager.class);
 
-        RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager);
+        RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager, localPlayer);
 
         WorldProviderCoreImpl worldProviderCore = new WorldProviderCoreImpl(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD), chunkProvider,
                 blockManager.getBlock(BlockManager.AIR_ID), context);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -130,7 +130,8 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         LocalChunkProvider chunkProvider = new LocalChunkProvider(storageManager, entityManager, worldGenerator);
         context.get(ComponentSystemManager.class).register(new RelevanceSystem(chunkProvider), "engine:relevanceSystem");
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(
-                new WorldProviderCoreImpl(worldInfo, chunkProvider, blockManager.getBlock(BlockManager.AIR_ID)));
+                new WorldProviderCoreImpl(worldInfo, chunkProvider, blockManager.getBlock(BlockManager.AIR_ID), context)
+                );
         WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider);
         context.put(WorldProvider.class, worldProvider);
         chunkProvider.setBlockEntityRegistry(entityWorldProvider);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -127,7 +127,8 @@ public class InitialiseWorld extends SingleStepLoadProcess {
             return true; // We need to return true, otherwise the loading state will just call us again immediately
         }
         context.put(StorageManager.class, storageManager);
-        LocalChunkProvider chunkProvider = new LocalChunkProvider(storageManager, entityManager, worldGenerator);
+        LocalChunkProvider chunkProvider = new LocalChunkProvider(storageManager, entityManager, worldGenerator,
+                blockManager);
         context.get(ComponentSystemManager.class).register(new RelevanceSystem(chunkProvider), "engine:relevanceSystem");
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(
                 new WorldProviderCoreImpl(worldInfo, chunkProvider, blockManager.getBlock(BlockManager.AIR_ID), context)

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -137,7 +137,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         context.put(BlockEntityRegistry.class, entityWorldProvider);
         context.get(ComponentSystemManager.class).register(entityWorldProvider, "engine:BlockEntityRegistry");
 
-        DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel());
+        DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel(), context);
         context.put(CelestialSystem.class, celestialSystem);
         context.get(ComponentSystemManager.class).register(celestialSystem);
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -81,7 +81,7 @@ public class StateHeadlessSetup implements GameState {
         entityManager = context.get(EngineEntityManager.class);
 
         eventSystem = context.get(EventSystem.class);
-        context.put(Console.class, new ConsoleImpl());
+        context.put(Console.class, new ConsoleImpl(context));
 
         NUIManager nuiManager = new NUIManagerInternal(context.get(CanvasRenderer.class), context);
         context.put(NUIManager.class, nuiManager);

--- a/engine/src/main/java/org/terasology/logic/ai/HierarchicalAISystem.java
+++ b/engine/src/main/java/org/terasology/logic/ai/HierarchicalAISystem.java
@@ -31,7 +31,6 @@ import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -48,11 +47,17 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
 
     @In
     private WorldProvider worldProvider;
+
     @In
     private EntityManager entityManager;
+
     private Random random = new FastRandom();
     @In
     private Time time;
+
+    @In
+    private LocalPlayer localPlayer;
+
     private boolean idling;
 
     // TODO add way to recognize if attacked
@@ -87,13 +92,13 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
                       Vector3f worldPos) {
         HierarchicalAIComponent ai = entity
                 .getComponent(HierarchicalAIComponent.class);
-        long tempTime = CoreRegistry.get(Time.class).getGameTimeInMs();
+        long tempTime = time.getGameTimeInMs();
         //TODO remove next
         long lastAttack = 0;
 
         // skip update if set to skip them
         if (tempTime - ai.lastProgressedUpdateAt < ai.updateFrequency) {
-            ai.lastProgressedUpdateAt = CoreRegistry.get(Time.class)
+            ai.lastProgressedUpdateAt = time
                     .getGameTimeInMs();
             return;
         }
@@ -109,7 +114,6 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
         // find player position
         // TODO: shouldn't use local player, need some way to find nearest
         // player
-        LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
         if (localPlayer != null) {
             Vector3f dist = new Vector3f(worldPos);
             dist.sub(localPlayer.getPosition());
@@ -130,7 +134,7 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
                     if (tempTime - lastAttack > ai.damageFrequency) {
                         localPlayer.getCharacterEntity().send(
                                 new DoDamageEvent(ai.damage, EngineDamageTypes.PHYSICAL.get(), entity));
-                        lastAttack = CoreRegistry.get(Time.class).getGameTimeInMs();
+                        lastAttack = time.getGameTimeInMs();
                     }
                 }
             }
@@ -179,8 +183,7 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
                         ai.inDanger = true;
                     }
                 }
-                ai.lastChangeOfDangerAt = CoreRegistry.get(Time.class)
-                        .getGameTimeInMs();
+                ai.lastChangeOfDangerAt = time.getGameTimeInMs();
             }
         }
 
@@ -201,12 +204,10 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
                     idleChangeTime = (long) (ai.idlingUpdateTime * random.nextDouble() * ai.hectic);
                     idling = false;
                     // mark idling state changed
-                    ai.lastChangeOfidlingtAt = CoreRegistry.get(Time.class)
-                            .getGameTimeInMs();
+                    ai.lastChangeOfidlingtAt = time.getGameTimeInMs();
                 }
                 entity.saveComponent(location);
-                ai.lastProgressedUpdateAt = CoreRegistry.get(Time.class)
-                        .getGameTimeInMs();
+                ai.lastProgressedUpdateAt = time.getGameTimeInMs();
                 return;
 
             }
@@ -219,10 +220,8 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
                 entity.saveComponent(location);
 
                 // mark start idling
-                ai.lastChangeOfMovementAt = CoreRegistry.get(Time.class)
-                        .getGameTimeInMs();
-                ai.lastProgressedUpdateAt = CoreRegistry.get(Time.class)
-                        .getGameTimeInMs();
+                ai.lastChangeOfMovementAt = time.getGameTimeInMs();
+                ai.lastProgressedUpdateAt = time.getGameTimeInMs();
                 return;
             }
 
@@ -264,7 +263,7 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
         // System.out.print("\Destination set: " + targetDirection.x + ":" +targetDirection.z + "\n");
         // System.out.print("\nI am: " + worldPos.x + ":" + worldPos.z + "\n");
 
-        ai.lastProgressedUpdateAt = CoreRegistry.get(Time.class).getGameTimeInMs();
+        ai.lastProgressedUpdateAt = time.getGameTimeInMs();
     }
 
     private boolean foodInFront() {

--- a/engine/src/main/java/org/terasology/logic/ai/SimpleAISystem.java
+++ b/engine/src/main/java/org/terasology/logic/ai/SimpleAISystem.java
@@ -48,6 +48,8 @@ public class SimpleAISystem extends BaseComponentSystem implements UpdateSubscri
     private Random random = new FastRandom();
     @In
     private Time time;
+    @In
+    private LocalPlayer localPlayer;
 
     @Override
     public void update(float delta) {
@@ -63,7 +65,6 @@ public class SimpleAISystem extends BaseComponentSystem implements UpdateSubscri
 
             Vector3f drive = new Vector3f();
             // TODO: shouldn't use local player, need some way to find nearest player
-            LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
             if (localPlayer != null) {
                 Vector3f dist = new Vector3f(worldPos);
                 dist.sub(localPlayer.getPosition());
@@ -76,7 +77,7 @@ public class SimpleAISystem extends BaseComponentSystem implements UpdateSubscri
                     entity.saveComponent(ai);
                 } else {
                     // Random walk
-                    if (CoreRegistry.get(Time.class).getGameTimeInMs() - ai.lastChangeOfDirectionAt > 12000 || ai.followingPlayer) {
+                    if (time.getGameTimeInMs() - ai.lastChangeOfDirectionAt > 12000 || ai.followingPlayer) {
                         ai.movementTarget.set(worldPos.x + random.nextFloat(-500.0f, 500.0f), worldPos.y, worldPos.z + random.nextFloat(-500.0f, 500.0f));
                         ai.lastChangeOfDirectionAt = time.getGameTimeInMs();
                         ai.followingPlayer = false;

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTree.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTree.java
@@ -18,6 +18,7 @@ package org.terasology.logic.behavior.asset;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.logic.behavior.BehaviorNodeFactory;
 import org.terasology.logic.behavior.nui.RenderableNode;
 import org.terasology.logic.behavior.tree.Node;
 
@@ -62,9 +63,9 @@ public class BehaviorTree extends Asset<BehaviorTreeData> {
         return data.getRenderableNode(node);
     }
 
-    public List<RenderableNode> getRenderableNodes() {
+    public List<RenderableNode> getRenderableNodes(BehaviorNodeFactory factory) {
         if (!data.hasRenderable()) {
-            data.createRenderable();
+            data.createRenderable(factory);
             layout(null);
         }
         return data.getRenderableNodes();
@@ -89,8 +90,8 @@ public class BehaviorTree extends Asset<BehaviorTreeData> {
         this.data = null;
     }
 
-    public RenderableNode createNode(Node node) {
-        RenderableNode renderable = data.createRenderable(node);
+    public RenderableNode createNode(Node node, BehaviorNodeFactory factory) {
+        RenderableNode renderable = data.createRenderable(node, factory);
         data.layout(renderable);
         return renderable;
     }

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTreeData.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/BehaviorTreeData.java
@@ -26,7 +26,6 @@ import org.terasology.logic.behavior.BehaviorNodeComponent;
 import org.terasology.logic.behavior.BehaviorNodeFactory;
 import org.terasology.logic.behavior.nui.RenderableNode;
 import org.terasology.logic.behavior.tree.Node;
-import org.terasology.registry.CoreRegistry;
 
 import java.awt.geom.Rectangle2D;
 import java.util.Collections;
@@ -49,23 +48,23 @@ public class BehaviorTreeData implements AssetData {
         this.renderableRoot = renderableRoot;
     }
 
-    public RenderableNode createNode(Node node) {
-        BehaviorNodeComponent nodeComponent = CoreRegistry.get(BehaviorNodeFactory.class).getNodeComponent(node);
+    public RenderableNode createNode(Node node, BehaviorNodeFactory factory) {
+        BehaviorNodeComponent nodeComponent = factory.getNodeComponent(node);
         RenderableNode self = new RenderableNode(nodeComponent);
         self.setNode(node);
         renderableNodes.put(node, self);
         return self;
     }
 
-    public void createRenderable() {
-        renderableRoot = createRenderable(root);
+    public void createRenderable(BehaviorNodeFactory factory) {
+        renderableRoot = createRenderable(root, factory);
     }
 
-    public RenderableNode createRenderable(Node node) {
+    public RenderableNode createRenderable(Node node, BehaviorNodeFactory factory) {
         return node.visit(null, new Node.Visitor<RenderableNode>() {
             @Override
             public RenderableNode visit(RenderableNode parent, Node node) {
-                RenderableNode self = createNode(node);
+                RenderableNode self = createNode(node, factory);
                 if (parent != null) {
                     parent.withoutModel().insertChild(-1, self);
                 }

--- a/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorDebugger.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorDebugger.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.behavior.nui;
 
+import org.terasology.logic.behavior.BehaviorNodeFactory;
 import org.terasology.logic.behavior.asset.BehaviorTree;
 import org.terasology.logic.behavior.tree.Interpreter;
 import org.terasology.logic.behavior.tree.Node;
@@ -27,7 +28,10 @@ public class BehaviorDebugger implements Interpreter.Debugger {
     private BehaviorTree tree;
     private int ticksToRun = -1;
 
-    public BehaviorDebugger() {
+    private BehaviorNodeFactory nodeFactory;
+
+    public BehaviorDebugger(BehaviorNodeFactory nodeFactory) {
+        this.nodeFactory = nodeFactory;
     }
 
     public void pause() {
@@ -69,7 +73,7 @@ public class BehaviorDebugger implements Interpreter.Debugger {
         if (tree == null) {
             return;
         }
-        for (RenderableNode renderableNode : tree.getRenderableNodes()) {
+        for (RenderableNode renderableNode : tree.getRenderableNodes(nodeFactory)) {
             renderableNode.setStatus(null);
         }
     }

--- a/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorEditorScreen.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorEditorScreen.java
@@ -76,7 +76,7 @@ public class BehaviorEditorScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
-        debugger = new BehaviorDebugger();
+        debugger = new BehaviorDebugger(nodeFactory);
         entityProperties = find("entity_properties", PropertyLayout.class);
         behaviorEditor = find("tree", BehaviorEditor.class);
         properties = find("properties", PropertyLayout.class);

--- a/engine/src/main/java/org/terasology/logic/behavior/nui/RenderableNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/nui/RenderableNode.java
@@ -16,19 +16,16 @@
 package org.terasology.logic.behavior.nui;
 
 import com.google.common.collect.Lists;
-
 import org.terasology.asset.Assets;
 import org.terasology.input.Keyboard;
 import org.terasology.input.MouseInput;
 import org.terasology.input.device.KeyboardDevice;
 import org.terasology.logic.behavior.BehaviorNodeComponent;
-import org.terasology.logic.behavior.BehaviorNodeFactory;
 import org.terasology.logic.behavior.tree.Node;
 import org.terasology.logic.behavior.tree.Status;
 import org.terasology.logic.behavior.tree.TreeAccessor;
 import org.terasology.math.Vector2i;
 import org.terasology.math.geom.Vector2f;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
@@ -135,7 +132,7 @@ public class RenderableNode extends CoreWidget implements ZoomableLayout.Positio
         canvas.drawText(text);
 
         if (editor != null) {
-            canvas.addInteractionRegion(moveListener, CoreRegistry.get(BehaviorNodeFactory.class).getNodeComponent(node).description);
+            canvas.addInteractionRegion(moveListener, data.description);
         }
         portList.onDraw(canvas);
     }

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.console.commandSystem.ConsoleCommand;
 import org.terasology.logic.console.commandSystem.exceptions.CommandExecutionException;
@@ -34,7 +35,6 @@ import org.terasology.logic.permission.PermissionManager;
 import org.terasology.naming.Name;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkSystem;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.FontColor;
 import org.terasology.rendering.FontUnderline;
 import org.terasology.utilities.collection.CircularBuffer;
@@ -61,7 +61,13 @@ public class ConsoleImpl implements Console {
     private final Map<Name, ConsoleCommand> commandRegistry = Maps.newHashMap();
     private final Set<ConsoleSubscriber> messageSubscribers = Sets.newSetFromMap(new MapMaker().weakKeys().<ConsoleSubscriber, Boolean>makeMap());
 
-    private NetworkSystem networkSystem = CoreRegistry.get(NetworkSystem.class);
+    private NetworkSystem networkSystem;
+    private Context context;
+
+    public ConsoleImpl(Context context) {
+        this.networkSystem = context.get(NetworkSystem.class);
+        this.context = context;
+    }
 
     /**
      * Registers a {@link org.terasology.logic.console.commandSystem.ConsoleCommand}.
@@ -264,7 +270,7 @@ public class ConsoleImpl implements Console {
     private boolean clientHasPermission(EntityRef callingClient, String requiredPermission) {
         Preconditions.checkNotNull(callingClient, "The calling client must not be null!");
 
-        PermissionManager permissionManager = CoreRegistry.get(PermissionManager.class);
+        PermissionManager permissionManager = context.get(PermissionManager.class);
         boolean hasPermission = true;
 
         if (permissionManager != null && requiredPermission != null

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/AbstractCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/AbstractCommand.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Primitives;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.console.commandSystem.exceptions.CommandExecutionException;
 import org.terasology.logic.console.commandSystem.exceptions.CommandInitializationException;
@@ -62,7 +63,7 @@ public abstract class AbstractCommand implements ConsoleCommand {
     private String usage;
 
     public AbstractCommand(Name name, String requiredPermission, boolean runOnServer, String description, String helpText,
-                           SpecificAccessibleObject<Method> executionMethod) {
+                           SpecificAccessibleObject<Method> executionMethod, Context context) {
         Preconditions.checkNotNull(executionMethod);
         Preconditions.checkNotNull(description);
         Preconditions.checkNotNull(helpText);
@@ -74,7 +75,7 @@ public abstract class AbstractCommand implements ConsoleCommand {
         this.helpText = helpText;
         this.executionMethod = executionMethod;
 
-        constructParametersNotNull();
+        constructParametersNotNull(context);
         registerParameters();
         validateExecutionMethod();
         initUsage();
@@ -83,10 +84,10 @@ public abstract class AbstractCommand implements ConsoleCommand {
     /**
      * @return A list of parameter types provided to the execution method.
      */
-    protected abstract List<Parameter> constructParameters();
+    protected abstract List<Parameter> constructParameters(Context context);
 
-    private void constructParametersNotNull() {
-        List<Parameter> constructedParameters = constructParameters();
+    private void constructParametersNotNull(Context context) {
+        List<Parameter> constructedParameters = constructParameters(context);
 
         if (constructedParameters == null || constructedParameters.size() <= 0) {
             commandParameters = ImmutableList.of();

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameter.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameter.java
@@ -17,11 +17,12 @@ package org.terasology.logic.console.commandSystem;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Primitives;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.console.commandSystem.adapter.ParameterAdapterManager;
 import org.terasology.logic.console.commandSystem.exceptions.CommandParameterParseException;
 import org.terasology.logic.console.commandSystem.exceptions.SuggesterInstantiationException;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.InjectionHelper;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -75,110 +76,102 @@ public final class CommandParameter<T> implements Parameter {
 
     public static <T> CommandParameter single(String name, Class<T> type, boolean required,
                                               CommandParameterSuggester<T> suggester,
-                                              ParameterAdapterManager parameterAdapterManager) {
+                                              Context context) {
         if (type.isArray()) {
             throw new IllegalArgumentException("The type of a simple CommandParameterDefinition must not be an array!");
         }
-
+        ParameterAdapterManager parameterAdapterManager = context.get(ParameterAdapterManager.class);
         return new CommandParameter(name, type, required, suggester, parameterAdapterManager);
     }
 
     public static <T> CommandParameter single(String name, Class<T> type, boolean required,
                                               Class<? extends CommandParameterSuggester<T>> suggesterClass,
-                                              ParameterAdapterManager parameterAdapterManager)
+                                              Context context)
             throws SuggesterInstantiationException {
-        try {
-            CommandParameterSuggester<T> suggester = suggesterClass != null ? suggesterClass.newInstance() : null;
-            return single(name, type, required, suggester, parameterAdapterManager);
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new SuggesterInstantiationException(e);
+        CommandParameterSuggester<T> suggester = optionallyCreateSuggestor(suggesterClass, context);
+        return single(name, type, required, suggester, context);
+    }
+
+    private static <T> CommandParameterSuggester<T> optionallyCreateSuggestor(
+            Class<? extends CommandParameterSuggester<T>> suggestorClass,
+            Context context) {
+        if (suggestorClass == null) {
+            return null;
         }
+        return InjectionHelper.createWithConstructorInjection(suggestorClass, context);
     }
 
     @SuppressWarnings("unchecked")
     public static CommandParameter single(String name, Class<?> type, boolean required,
-                                          ParameterAdapterManager parameterAdapterManager) {
-        return single(name, type, required, (CommandParameterSuggester) null, parameterAdapterManager);
+                                          Context context) {
+        return single(name, type, required, (CommandParameterSuggester) null, context);
     }
 
     public static <T> CommandParameter array(String name, Class<T> childType, Character arrayDelimiter,
                                              boolean required, CommandParameterSuggester<T> suggester,
-                                             ParameterAdapterManager parameterAdapterManager) {
+                                             Context  context) {
         if (childType.isArray()) {
             throw new IllegalArgumentException("The child type of an array CommandParameterDefinition must not be an array!");
         }
 
         Class<?> type = getArrayClass(childType);
-
+        ParameterAdapterManager parameterAdapterManager = context.get(ParameterAdapterManager.class);
         return new CommandParameter(name, type, required, suggester, parameterAdapterManager);
     }
 
     public static <T> CommandParameter array(String name, Class<T> childType, Character arrayDelimiter,
                                              boolean required,
                                              Class<? extends CommandParameterSuggester<T>> suggesterClass,
-                                             ParameterAdapterManager parameterAdapterManager)
+                                             Context context)
             throws SuggesterInstantiationException {
-        try {
-            CommandParameterSuggester<T> suggester = suggesterClass != null ? suggesterClass.newInstance() : null;
-            return array(name, childType, arrayDelimiter, required, suggester, parameterAdapterManager);
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new SuggesterInstantiationException(e);
-        }
+        CommandParameterSuggester<T> suggester = optionallyCreateSuggestor(suggesterClass, context);
+        return array(name, childType, arrayDelimiter, required, suggester, context);
     }
 
     @SuppressWarnings("unchecked")
     public static CommandParameter array(String name, Class<?> childType, Character arrayDelimiter,
-                                         boolean required, ParameterAdapterManager parameterAdapterManager) {
+                                         boolean required, Context context) {
         return array(name, childType, arrayDelimiter, required, (CommandParameterSuggester) null,
-                parameterAdapterManager);
+                context);
     }
 
     public static <T> CommandParameter array(String name, Class<T> childType, boolean required,
                                              CommandParameterSuggester<T> suggester,
-                                             ParameterAdapterManager parameterAdapterManager) {
-        return array(name, childType, null, required, suggester, parameterAdapterManager);
+                                             Context context) {
+        return array(name, childType, null, required, suggester, context);
     }
 
     public static <T> CommandParameter array(String name, Class<T> childType, boolean required,
                                              Class<? extends CommandParameterSuggester<T>> suggesterClass,
-                                             ParameterAdapterManager parameterAdapterManager)
+                                             Context context)
             throws SuggesterInstantiationException {
-        try {
-            CommandParameterSuggester<T> suggester = suggesterClass != null ? suggesterClass.newInstance() : null;
-            return array(name, childType, required, suggester, parameterAdapterManager);
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new SuggesterInstantiationException(e);
-        }
+        CommandParameterSuggester<T> suggester = optionallyCreateSuggestor(suggesterClass, context);
+        return array(name, childType, required, suggester, context);
     }
 
     @SuppressWarnings("unchecked")
     public static CommandParameter array(String name, Class<?> childType, boolean required,
-                                         ParameterAdapterManager parameterAdapterManager) {
-        return array(name, childType, required, (CommandParameterSuggester) null, parameterAdapterManager);
+                                         Context context) {
+        return array(name, childType, required, (CommandParameterSuggester) null, context);
     }
 
     public static <T> CommandParameter varargs(String name, Class<T> childType, boolean required,
                                                CommandParameterSuggester<T> suggester,
-                                               ParameterAdapterManager parameterAdapterManager) {
-        return array(name, childType, required, suggester, parameterAdapterManager);
+                                               Context context) {
+        return array(name, childType, required, suggester, context);
     }
 
     public static <T> CommandParameter varargs(String name, Class<T> childType, boolean required,
-                                               Class<? extends CommandParameterSuggester<T>> suggester,
-                                               ParameterAdapterManager parameterAdapterManager)
+                                               Class<? extends CommandParameterSuggester<T>> suggesterClass,
+                                               Context context)
             throws SuggesterInstantiationException {
-        try {
-            return varargs(name, childType, required, suggester != null ? suggester.newInstance() : null,
-                    parameterAdapterManager);
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new SuggesterInstantiationException(e);
-        }
+        return varargs(name, childType, required, optionallyCreateSuggestor(suggesterClass, context), context);
     }
 
     @SuppressWarnings("unchecked")
     public static CommandParameter varargs(String name, Class<?> childType, boolean required,
-                                           ParameterAdapterManager parameterAdapterManager) {
-        return varargs(name, childType, required, (CommandParameterSuggester) null, parameterAdapterManager);
+                                           Context context) {
+        return varargs(name, childType, required, (CommandParameterSuggester) null, context);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameterSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameterSuggester.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.console.commandSystem;
 
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.module.sandbox.API;
 
@@ -23,7 +24,7 @@ import java.util.Set;
 /**
  * A class used for suggesting command parameter values
  *
- * @author Limeth
+ * Constructor arguments will be filled from the {@link Context} via dependency injection.
  */
 @API
 public interface CommandParameterSuggester<T> {

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
@@ -22,12 +22,13 @@ import com.google.common.collect.Lists;
 import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.logic.console.Console;
-import org.terasology.logic.console.commandSystem.adapter.ParameterAdapterManager;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.naming.Name;
+import org.terasology.registry.InjectionHelper;
 import org.terasology.utilities.reflection.SpecificAccessibleObject;
 
 import java.lang.annotation.Annotation;
@@ -41,13 +42,10 @@ import java.util.Set;
  */
 public final class MethodCommand extends AbstractCommand {
     private static final Logger logger = LoggerFactory.getLogger(MethodCommand.class);
-    private ParameterAdapterManager parameterAdapterManager;
 
     private MethodCommand(Name name, String requiredPermission, boolean runOnServer, String description, String helpText,
-                          SpecificAccessibleObject<Method> executionMethod,
-                          ParameterAdapterManager parameterAdapterManager) {
-        super(name, requiredPermission, runOnServer, description, helpText, executionMethod);
-        this.parameterAdapterManager = parameterAdapterManager;
+                          SpecificAccessibleObject<Method> executionMethod, Context context) {
+        super(name, requiredPermission, runOnServer, description, helpText, executionMethod, context);
     }
 
     /**
@@ -58,7 +56,7 @@ public final class MethodCommand extends AbstractCommand {
      * @return The command reference object created
      */
     public static MethodCommand referringTo(SpecificAccessibleObject<Method> specificMethod,
-                                            ParameterAdapterManager parameterAdapterManager) {
+                                            Context context) {
         Method method = specificMethod.getAccessibleObject();
         Command commandAnnotation = method.getAnnotation(Command.class);
 
@@ -78,14 +76,14 @@ public final class MethodCommand extends AbstractCommand {
                 commandAnnotation.runOnServer(),
                 commandAnnotation.shortDescription(),
                 commandAnnotation.helpText(),
-                specificMethod, parameterAdapterManager
+                specificMethod, context
         );
     }
 
     /**
      * Registers all available command methods annotated with {@link org.terasology.logic.console.commandSystem.annotations.Command}.
      */
-    public static void registerAvailable(Object provider, Console console, ParameterAdapterManager parameterAdapterManager) {
+    public static void registerAvailable(Object provider, Console console, Context context) {
         Predicate<? super Method> predicate = Predicates.<Method>and(ReflectionUtils.withModifier(Modifier.PUBLIC), ReflectionUtils.withAnnotation(Command.class));
         Set<Method> commandMethods = ReflectionUtils.getAllMethods(provider.getClass(), predicate);
 
@@ -93,7 +91,7 @@ public final class MethodCommand extends AbstractCommand {
             logger.debug("Registering command method {} in class {}", method.getName(), method.getDeclaringClass().getCanonicalName());
             try {
                 SpecificAccessibleObject<Method> specificMethod = new SpecificAccessibleObject<>(method, provider);
-                MethodCommand command = referringTo(specificMethod, parameterAdapterManager);
+                MethodCommand command = referringTo(specificMethod, context);
                 console.registerCommand(command);
                 logger.debug("Registered command method {} in class {}", method.getName(), method.getDeclaringClass().getCanonicalName());
             } catch (RuntimeException t) {
@@ -103,7 +101,7 @@ public final class MethodCommand extends AbstractCommand {
     }
 
     @Override
-    protected List<Parameter> constructParameters() {
+    protected List<Parameter> constructParameters(Context context) {
         SpecificAccessibleObject<Method> specificExecutionMethod = getExecutionMethod();
         Method executionMethod = specificExecutionMethod.getAccessibleObject();
         Class<?>[] methodParameters = executionMethod.getParameterTypes();
@@ -112,14 +110,14 @@ public final class MethodCommand extends AbstractCommand {
 
         for (int i = 0; i < methodParameters.length; i++) {
             parameters.add(getParameterTypeFor(methodParameters[i], methodParameterAnnotations[i],
-                    parameterAdapterManager));
+                    context));
         }
 
         return parameters;
     }
 
     private static Parameter getParameterTypeFor(Class<?> type, Annotation[] annotations,
-                                                 ParameterAdapterManager parameterAdapterManager) {
+                                                 Context context) {
         for (Annotation annotation : annotations) {
             if (annotation instanceof CommandParam) {
                 CommandParam parameterAnnotation
@@ -127,20 +125,15 @@ public final class MethodCommand extends AbstractCommand {
                 String name = parameterAnnotation.value();
                 Class<? extends CommandParameterSuggester> suggesterClass = parameterAnnotation.suggester();
                 boolean required = parameterAnnotation.required();
-                CommandParameterSuggester suggester;
-
-                try {
-                    suggester = suggesterClass.newInstance();
-                } catch (InstantiationException | IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
+                CommandParameterSuggester  suggester = InjectionHelper.createWithConstructorInjection(suggesterClass,
+                        context);
 
                 if (type.isArray()) {
                     Class<?> childType = type.getComponentType();
 
-                    return CommandParameter.array(name, childType, required, suggester, parameterAdapterManager);
+                    return CommandParameter.array(name, childType, required, suggester, context);
                 } else {
-                    return CommandParameter.single(name, type, required, suggester, parameterAdapterManager);
+                    return CommandParameter.single(name, type, required, suggester, context);
                 }
             } else if (annotation instanceof Sender) {
                 return MarkerParameters.SENDER;

--- a/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
@@ -22,7 +22,6 @@ import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.permission.PermissionManager;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 
@@ -34,6 +33,10 @@ public class ClientCommands extends BaseComponentSystem {
     @In
     private CameraTargetSystem cameraTargetSystem;
 
+    @In
+    private WorldProvider worldProvider;
+
+
     @Command(shortDescription = "Displays debug information on the target entity")
     public String debugTarget() {
         EntityRef cameraTarget = cameraTargetSystem.getTarget();
@@ -43,9 +46,7 @@ public class ClientCommands extends BaseComponentSystem {
     @Command(shortDescription = "Sets the current world time of the in days for the local player",
             requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setWorldTime(@CommandParam("day") float day) {
-        WorldProvider world = CoreRegistry.get(WorldProvider.class);
-        world.getTime().setDays(day);
-
+        worldProvider.getTime().setDays(day);
         return "World time changed";
     }
 }

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/BlockFamilySuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/BlockFamilySuggester.java
@@ -16,22 +16,27 @@
 package org.terasology.logic.console.suggesters;
 
 import com.google.common.collect.Sets;
-import org.terasology.asset.Assets;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
-import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 
 import java.util.Set;
 
 /**
- * @author Limeth
+ * Suggests block families.
  */
 public class BlockFamilySuggester implements CommandParameterSuggester<ResourceUrn> {
+    private final AssetManager assetManager;
+
+    public BlockFamilySuggester(AssetManager assetManager) {
+        this.assetManager = assetManager;
+    }
+
     @Override
     public Set<ResourceUrn> suggest(EntityRef sender, Object... resolvedParameters) {
-        Iterable<ResourceUrn> iterable = Assets.list(BlockFamilyDefinition.class);
+        Iterable<ResourceUrn> iterable = assetManager.getAvailableAssets(BlockFamilyDefinition.class);
 
         return Sets.newHashSet(iterable);
     }

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/CommandNameSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/CommandNameSuggester.java
@@ -18,10 +18,9 @@ package org.terasology.logic.console.suggesters;
 import com.google.common.collect.Sets;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.console.Console;
-import org.terasology.logic.console.commandSystem.ConsoleCommand;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
+import org.terasology.logic.console.commandSystem.ConsoleCommand;
 import org.terasology.naming.Name;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Collection;
 import java.util.Set;
@@ -29,10 +28,15 @@ import java.util.Set;
 /**
  * @author Limeth
  */
-public class CommandNameSuggester implements CommandParameterSuggester<Name> {
+public final class CommandNameSuggester implements CommandParameterSuggester<Name> {
+    private final Console console;
+
+    public CommandNameSuggester(Console console) {
+        this.console = console;
+    }
+
     @Override
     public Set<Name> suggest(EntityRef sender, Object... resolvedParameters) {
-        Console console = CoreRegistry.get(Console.class);
         Collection<ConsoleCommand> commands = console.getCommands();
         Set<Name> suggestions = Sets.newHashSetWithExpectedSize(commands.size());
 

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/OnlineUsernameSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/OnlineUsernameSuggester.java
@@ -21,7 +21,6 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
 import org.terasology.network.ClientComponent;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Set;
 
@@ -31,10 +30,15 @@ import java.util.Set;
  *
  * @author Limeth
  */
-public class OnlineUsernameSuggester implements CommandParameterSuggester<String> {
+public final class OnlineUsernameSuggester implements CommandParameterSuggester<String> {
+    private final EntityManager entityManager;
+
+    public OnlineUsernameSuggester(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
     @Override
     public Set<String> suggest(EntityRef sender, Object... resolvedParameters) {
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
         Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
         Set<String> clientNames = Sets.newHashSet();
 

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/PrefabSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/PrefabSuggester.java
@@ -20,17 +20,21 @@ import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Set;
 
 /**
- * @author Limeth
+ * Suggegests prefabs.
  */
-public class PrefabSuggester implements CommandParameterSuggester<Prefab> {
+public final class PrefabSuggester implements CommandParameterSuggester<Prefab> {
+    private final AssetManager assetManager;
+
+    public PrefabSuggester(AssetManager assetManager) {
+        this.assetManager = assetManager;
+    }
+
     @Override
     public Set<Prefab> suggest(EntityRef sender, Object... resolvedParameters) {
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
         Iterable<Prefab> loadedPrefabs = assetManager.getLoadedAssets(Prefab.class);
 
         return Sets.newHashSet(loadedPrefabs);

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/UsernameSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/UsernameSuggester.java
@@ -21,21 +21,21 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
 import org.terasology.network.ClientInfoComponent;
-import org.terasology.registry.CoreRegistry;
 
 import java.util.Set;
 
 /**
  * Suggests user names of all users even if they aren't online.
- *
- * @author Limeth
- * @author Florian
  */
-public class UsernameSuggester implements CommandParameterSuggester<String> {
+public final class UsernameSuggester implements CommandParameterSuggester<String> {
+    private final EntityManager entityManager;
+
+    public UsernameSuggester(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
     @Override
     public Set<String> suggest(EntityRef sender, Object... resolvedParameters) {
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
-
         Set<String> clientNames = Sets.newHashSet();
         for (EntityRef clientInfo : entityManager.getEntitiesWith(ClientInfoComponent.class)) {
             DisplayNameComponent displayNameComponent = clientInfo.getComponent(DisplayNameComponent.class);

--- a/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
@@ -65,7 +65,7 @@ public class ConsoleScreen extends CoreScreenLayer {
 
         commandLine = find("commandLine", UICommandEntry.class);
         getManager().setFocus(commandLine);
-        commandLine.setTabCompletionEngine(new CyclingTabCompletionEngine(console));
+        commandLine.setTabCompletionEngine(new CyclingTabCompletionEngine(console, localPlayer));
         commandLine.bindCommandHistory(new ReadOnlyBinding<List<String>>() {
             @Override
             public List<String> get() {

--- a/engine/src/main/java/org/terasology/logic/console/ui/CyclingTabCompletionEngine.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/CyclingTabCompletionEngine.java
@@ -28,7 +28,6 @@ import org.terasology.logic.console.commandSystem.ConsoleCommand;
 import org.terasology.logic.console.commandSystem.exceptions.CommandSuggestionException;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.naming.Name;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.FontColor;
 import org.terasology.utilities.CamelCaseMatcher;
 
@@ -50,9 +49,11 @@ public class CyclingTabCompletionEngine implements TabCompletionEngine {
     private Message previousMessage;
     private Collection<String> commandNames;
     private String query;
+    private LocalPlayer localPlayer;
 
-    public CyclingTabCompletionEngine(Console console) {
+    public CyclingTabCompletionEngine(Console console, LocalPlayer localPlayer) {
         this.console = console;
+        this.localPlayer = localPlayer;
     }
 
     private boolean updateCommandNamesIfNecessary() {
@@ -87,7 +88,7 @@ public class CyclingTabCompletionEngine implements TabCompletionEngine {
         }
 
         String currentValue = commandParameters.size() >= suggestedIndex ? commandParameters.get(suggestedIndex - 1) : null;
-        EntityRef sender = CoreRegistry.get(LocalPlayer.class).getClientEntity();
+        EntityRef sender = localPlayer.getClientEntity();
 
         try {
             return command.suggest(currentValue, finishedParameters, sender);

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionCommands.java
@@ -29,7 +29,6 @@ import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.console.suggesters.UsernameSuggester;
 import org.terasology.network.ClientComponent;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 
 import java.util.HashSet;
@@ -55,7 +54,7 @@ public class PermissionCommands extends BaseComponentSystem {
                     + "Please note that the debug permission will only be granted if the debug setting is on.",
             runOnServer = true, requiredPermission = PermissionManager.NO_PERMISSION)
     public String usePermissionKey(@CommandParam("key") String key, @Sender EntityRef client) {
-        PermissionConfig permissionConfig = CoreRegistry.get(Config.class).getPermission();
+        PermissionConfig permissionConfig = config.getPermission();
         String expectedKey = permissionConfig.getOneTimeAuthorizationKey();
 
         if (expectedKey != null && !expectedKey.equals("") && key.equals(expectedKey)) {

--- a/engine/src/main/java/org/terasology/registry/InjectionHelper.java
+++ b/engine/src/main/java/org/terasology/registry/InjectionHelper.java
@@ -19,12 +19,15 @@ import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
+import org.terasology.util.reflection.ParameterProvider;
+import org.terasology.util.reflection.SimpleClassFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author Immortius
@@ -109,4 +112,14 @@ public final class InjectionHelper {
         }
     }
 
+
+    public static <E> E createWithConstructorInjection(Class<? extends E> clazz, Context context) {
+        SimpleClassFactory simpleClassFactory = new SimpleClassFactory(new ParameterProvider() {
+            @Override
+            public <T> Optional<T> get(Class<T> x) {
+                return Optional.of(context.get(x));
+            }
+        });
+        return simpleClassFactory.instantiateClass(clazz).get();
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -69,6 +69,8 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private static final int SHADOW_FRUSTUM_BOUNDS = 500;
 
+    private final Context context;
+
     private final BackdropRenderer backdropRenderer;
     private final BackdropProvider backdropProvider;
     private final WorldProvider worldProvider;
@@ -106,7 +108,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         Z_PRE_PASS
     }
 
-    private ComponentSystemManager systemManager = CoreRegistry.get(ComponentSystemManager.class);
+    private ComponentSystemManager systemManager;
 
     private final Config config;
     private final RenderingConfig renderingConfig;
@@ -117,12 +119,14 @@ public final class WorldRendererImpl implements WorldRenderer {
     private PostProcessor postProcessor;
 
     public WorldRendererImpl(Context context, GLBufferPool bufferPool) {
+        this.context = context;
         this.worldProvider = context.get(WorldProvider.class);
         this.backdropProvider = context.get(BackdropProvider.class);
         this.backdropRenderer = context.get(BackdropRenderer.class);
         this.config = context.get(Config.class);
         this.renderingConfig = config.getRendering();
         this.renderingDebugConfig = renderingConfig.getDebug();
+        this.systemManager = context.get(ComponentSystemManager.class);
 
         // TODO: won't need localPlayerSystem here once camera is in the ES proper
         if (renderingConfig.isOculusVrSupport()) {
@@ -157,17 +161,17 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private void initRenderingSupport() {
         renderingProcess = new LwjglRenderingProcess();
-        CoreRegistry.put(LwjglRenderingProcess.class, renderingProcess);
+        context.put(LwjglRenderingProcess.class, renderingProcess);
 
         graphicState = new GraphicState(renderingProcess);
         postProcessor = new PostProcessor(renderingProcess, graphicState);
-        CoreRegistry.put(PostProcessor.class, postProcessor);
+        context.put(PostProcessor.class, postProcessor);
 
         renderingProcess.setGraphicState(graphicState);
         renderingProcess.setPostProcessor(postProcessor);
         renderingProcess.initialize();
 
-        CoreRegistry.get(ShaderManager.class).initShaders();
+        context.get(ShaderManager.class).initShaders();
         postProcessor.initializeMaterials();
         initMaterials();
     }
@@ -461,7 +465,7 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         simple.enable();
         simple.setCamera(playerCamera);
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
+        EntityManager entityManager = context.get(EntityManager.class);
         for (EntityRef entity : entityManager.getEntitiesWith(LightComponent.class, LocationComponent.class)) {
             LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
             LightComponent lightComponent = entity.getComponent(LightComponent.class);
@@ -474,7 +478,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         */
 
         graphicState.preRenderSetupLightGeometry();
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
+        EntityManager entityManager = context.get(EntityManager.class);
         for (EntityRef entity : entityManager.getEntitiesWith(LightComponent.class, LocationComponent.class)) {
             LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
             LightComponent lightComponent = entity.getComponent(LightComponent.class);

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -38,7 +38,6 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.monitoring.chunk.ChunkMonitor;
 import org.terasology.persistence.ChunkStore;
 import org.terasology.persistence.StorageManager;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.concurrency.TaskMaster;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.block.BeforeDeactivateBlocks;
@@ -114,11 +113,12 @@ public class LocalChunkProvider implements ChunkProvider, GeneratingChunkProvide
 
     private LightMerger<ReadyChunkInfo> lightMerger = new LightMerger<>(this);
 
-    public LocalChunkProvider(StorageManager storageManager, EntityManager entityManager, WorldGenerator generator) {
-        this.blockManager = CoreRegistry.get(BlockManager.class);
+    public LocalChunkProvider(StorageManager storageManager, EntityManager entityManager, WorldGenerator generator,
+                              BlockManager blockManager) {
         this.storageManager = storageManager;
         this.entityManager = entityManager;
         this.generator = generator;
+        this.blockManager = blockManager;
         this.pipeline = new ChunkGenerationPipeline(new ChunkTaskRelevanceComparator());
         this.unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 4);
         ChunkMonitor.fireChunkProviderInitialized(this);

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -31,7 +31,6 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.monitoring.chunk.ChunkMonitor;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
@@ -74,7 +73,9 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
 
     private LightMerger<Chunk> lightMerger = new LightMerger<>(this);
 
-    public RemoteChunkProvider(BlockManager blockManager) {
+    private LocalPlayer localPlayer;
+
+    public RemoteChunkProvider(BlockManager blockManager, LocalPlayer localPlayer) {
         this.blockManager = blockManager;
         pipeline = new ChunkGenerationPipeline(new ChunkTaskRelevanceComparator());
         ChunkMonitor.fireChunkProviderInitialized(this);
@@ -315,9 +316,7 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
         }
     }
 
-    private static class ChunkTaskRelevanceComparator implements Comparator<ChunkTask> {
-
-        private LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
+    private class ChunkTaskRelevanceComparator implements Comparator<ChunkTask> {
 
         @Override
         public int compare(ChunkTask o1, ChunkTask o2) {
@@ -331,8 +330,6 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
     }
 
     private class ReadyChunkRelevanceComparator implements Comparator<Chunk> {
-
-        private LocalPlayer localPlayer = CoreRegistry.get(LocalPlayer.class);
 
         @Override
         public int compare(Chunk o1, Chunk o2) {

--- a/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
+++ b/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
@@ -27,7 +27,6 @@ import org.terasology.module.Module;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.ResolutionResult;
 import org.terasology.naming.Name;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.world.generator.RegisterWorldGenerator;
 import org.terasology.world.generator.UnresolvedWorldGeneratorException;
@@ -105,7 +104,7 @@ public class WorldGeneratorManager {
      * @return The instantiated world generator.
      */
     public WorldGenerator createGenerator(SimpleUri uri, Context context) throws UnresolvedWorldGeneratorException {
-        ModuleManager moduleManager = CoreRegistry.get(ModuleManager.class);
+        ModuleManager moduleManager = context.get(ModuleManager.class);
         Module module = moduleManager.getEnvironment().get(uri.getModuleName());
         if (module == null) {
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -23,13 +23,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.biomes.Biome;
@@ -75,6 +75,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     private GeneratingChunkProvider chunkProvider;
     private WorldTime worldTime;
+    private EntityManager entityManager;
 
     private final List<WorldChangeListener> listeners = Lists.newArrayList();
 
@@ -84,13 +85,15 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     private Block defaultBlock;
 
-    public WorldProviderCoreImpl(String title, String seed, long time, SimpleUri worldGenerator, GeneratingChunkProvider chunkProvider, Block defaultBlock) {
+    public WorldProviderCoreImpl(String title, String seed, long time, SimpleUri worldGenerator,
+                                 GeneratingChunkProvider chunkProvider, Block defaultBlock, Context context) {
         this.title = (title == null) ? seed : title;
         this.seed = seed;
         this.worldGenerator = worldGenerator;
         this.chunkProvider = chunkProvider;
         this.defaultBlock = defaultBlock;
-        CoreRegistry.put(ChunkProvider.class, chunkProvider);
+        this.entityManager = context.get(EntityManager.class);
+        context.put(ChunkProvider.class, chunkProvider);
 
         this.worldTime = new WorldTimeImpl();
         worldTime.setMilliseconds(time);
@@ -104,13 +107,15 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         propagators.add(sunlightPropagator);
     }
 
-    public WorldProviderCoreImpl(WorldInfo info, GeneratingChunkProvider chunkProvider, Block defaultBlock) {
-        this(info.getTitle(), info.getSeed(), info.getTime(), info.getWorldGenerator(), chunkProvider, defaultBlock);
+    public WorldProviderCoreImpl(WorldInfo info, GeneratingChunkProvider chunkProvider, Block defaultBlock,
+                                 Context context) {
+        this(info.getTitle(), info.getSeed(), info.getTime(), info.getWorldGenerator(), chunkProvider, defaultBlock,
+                context);
     }
 
     @Override
     public EntityRef getWorldEntity() {
-        Iterator<EntityRef> iterator = CoreRegistry.get(EntityManager.class).getEntitiesWith(WorldComponent.class).iterator();
+        Iterator<EntityRef> iterator = entityManager.getEntitiesWith(WorldComponent.class).iterator();
         if (iterator.hasNext()) {
             return iterator.next();
         }

--- a/engine/src/main/java/org/terasology/world/sun/DefaultCelestialSystem.java
+++ b/engine/src/main/java/org/terasology/world/sun/DefaultCelestialSystem.java
@@ -16,20 +16,19 @@
 
 package org.terasology.world.sun;
 
-import static org.terasology.world.time.WorldTime.DAY_LENGTH;
-
-import java.math.RoundingMode;
-
+import com.google.common.math.LongMath;
+import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.time.WorldTime;
 
-import com.google.common.math.LongMath;
+import java.math.RoundingMode;
+
+import static org.terasology.world.time.WorldTime.DAY_LENGTH;
 
 /**
  * A base class that fires events at
@@ -44,8 +43,11 @@ public class DefaultCelestialSystem extends BaseComponentSystem implements Celes
 
     private final CelestialModel model;
 
-    public DefaultCelestialSystem(CelestialModel model) {
-        WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
+    private final EntityManager entityManager;
+
+    public DefaultCelestialSystem(CelestialModel model, Context context) {
+        WorldProvider worldProvider = context.get(WorldProvider.class);
+        entityManager = context.get(EntityManager.class);
         worldTime = worldProvider.getTime();
         lastUpdate = worldTime.getMilliseconds();
         this.model = model;
@@ -104,7 +106,6 @@ public class DefaultCelestialSystem extends BaseComponentSystem implements Celes
     }
 
     protected EntityRef getWorldEntity() {
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
         for (EntityRef entity : entityManager.getEntitiesWith(WorldComponent.class)) {
             return entity;
         }


### PR DESCRIPTION
Some CoreRegistry removals that doesn't break any of the modules I had checked out.

Noteworthy is only the introduction of constructor based dependency injection for command parameter suggestors.