### PR TITLE
Add support for downloading modules at runtime.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/RemoteModuleExtension.java
+++ b/engine/src/main/java/org/terasology/engine/module/RemoteModuleExtension.java
@@ -23,7 +23,7 @@ import org.terasology.module.ModuleMetadata;
 
 /**
  * A set of module extensions for remote modules.
- * NOTE: this is copy&paste from master-server.
+ * NOTE: this is copy&paste from meta-server.
  */
 public enum RemoteModuleExtension {
 

--- a/engine/src/main/java/org/terasology/engine/module/RemoteModuleExtension.java
+++ b/engine/src/main/java/org/terasology/engine/module/RemoteModuleExtension.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.engine.module;
+
+import java.net.URL;
+import java.util.Date;
+
+import org.terasology.module.ModuleMetadata;
+
+/**
+ * A set of module extensions for remote modules.
+ * NOTE: this is copy&paste from master-server.
+ */
+public enum RemoteModuleExtension {
+
+    ARTIFACT_SIZE("artifactSize", long.class),
+    LAST_UPDATED("lastUpdated", Date.class),
+    DOWNLOAD_URL("downloadUri", URL.class);
+
+    private final String key;
+    private final Class<?> valueType;
+
+    private RemoteModuleExtension(String key, Class<?> valueType) {
+        this.key = key;
+        this.valueType = valueType;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Class<?> getValueType() {
+        return valueType;
+    }
+
+    public static URL getDownloadUrl(ModuleMetadata meta) {
+        return meta.getExtension(DOWNLOAD_URL.getKey(), URL.class);
+    }
+
+    public static void setDownloadUrl(ModuleMetadata meta, URL url) {
+        meta.setExtension(DOWNLOAD_URL.getKey(), url);
+    }
+
+    public static Date getLastUpdated(ModuleMetadata meta) {
+        return meta.getExtension(LAST_UPDATED.getKey(), Date.class);
+    }
+
+    public static void setLastUpdated(ModuleMetadata meta, Date date) {
+        meta.setExtension(LAST_UPDATED.getKey(), date);
+    }
+
+    public static long getArtifactSize(ModuleMetadata meta) {
+        return meta.getExtension(ARTIFACT_SIZE.getKey(), Long.class);
+    }
+
+    public static void setArtifactSize(ModuleMetadata meta, long size) {
+        meta.setExtension(ARTIFACT_SIZE.getKey(), size);
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/FileDownloader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/FileDownloader.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Downloads a file.
+ */
+public class FileDownloader implements Callable<Path> {
+
+    private static final Logger logger = LoggerFactory.getLogger(FileDownloader.class);
+
+    private final URL url;
+    private final Path target;
+    private final ProgressListener listener;
+
+    public FileDownloader(URL url, Path target) {
+        this(url, target, p -> { });
+    }
+
+    /**
+     * @param url
+     * @param listener a progress listener. Will be called with 0 repeatedly if size cannot be determined.
+     */
+    public FileDownloader(URL url, Path target, ProgressListener listener) {
+        this.url = url;
+        this.target = target;
+        this.listener = listener;
+    }
+
+    @Override
+    public Path call() throws IOException {
+        Path folder = target.getParent();
+        String prefix = target.getFileName().toString();
+        Path tempModuleLocation = Files.createTempFile(folder, prefix + "_", ".tmp");
+
+        tempModuleLocation.toFile().deleteOnExit();
+
+        logger.debug("Downloading {} from {}", target, url);
+
+        long length = -1;
+        URLConnection conn = url.openConnection();
+        if (conn instanceof HttpURLConnection) {
+            length = ((HttpURLConnection) conn).getContentLengthLong();
+        }
+
+        try (InputStream is = url.openStream();
+             OutputStream os = Files.newOutputStream(tempModuleLocation)) {
+            copy(is, os, length, listener);
+            Files.move(tempModuleLocation, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return target;
+    }
+
+    /**
+     * Reads all bytes from an input stream and writes them to an output stream.
+     * Copied and adapted from Files.copy().
+     */
+    private static long copy(InputStream source, OutputStream sink, long max, ProgressListener listener) throws IOException {
+        long nread = 0L;
+        int bufferSize = 0x10000;  // 64 kB
+        byte[] buf = new byte[bufferSize];
+        int n;
+        while ((n = source.read(buf)) > 0) {
+            sink.write(buf, 0, n);
+            nread += n;
+            if (max <= 0) {
+                listener.onProgress(0);
+            } else {
+                listener.onProgress((float) nread / max);
+            }
+        }
+        return nread;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ModuleListDownloader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ModuleListDownloader.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.config.NetworkConfig;
+import org.terasology.engine.TerasologyConstants;
+import org.terasology.engine.module.RemoteModuleExtension;
+import org.terasology.module.ModuleMetadata;
+import org.terasology.module.ModuleMetadataJsonAdapter;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * Downloads module meta-info from a given URL.
+ */
+class ModuleListDownloader {
+
+    private static final Logger logger = LoggerFactory.getLogger(ModuleListDownloader.class);
+
+    private final List<RemoteModule> modules = new CopyOnWriteArrayList<>();
+
+    private final ModuleMetadataJsonAdapter metaReader = new ModuleMetadataJsonAdapter();
+
+    private final String serverAddress;
+
+    /**
+     * "volatile" ensures the visibility of updates across different threads
+     */
+    private volatile String status;
+
+    private Thread dlThread;
+
+    public ModuleListDownloader(String serverAddress) {
+        this.serverAddress = serverAddress;
+        dlThread = new Thread(this::download);
+        dlThread.setName("ModuleList Downloader");
+        dlThread.start();
+
+        for (RemoteModuleExtension ext : RemoteModuleExtension.values()) {
+            metaReader.registerExtension(ext.getKey(), ext.getValueType());
+        }
+    }
+
+    /**
+     * @return a <b>thread-safe</b> list of servers
+     */
+    public List<RemoteModule> getModules() {
+        return Collections.unmodifiableList(modules);
+    }
+
+    /**
+     * @return the current status
+     */
+    public String getStatusText() {
+        return status;
+    }
+
+    public boolean isDone() {
+        return !dlThread.isAlive();
+    }
+
+    // this is run on a parallel thread
+    private void download() {
+        try {
+            try {
+                download(serverAddress);
+            } catch (Exception e) {
+                String defaultAddress = new NetworkConfig().getMasterServer();
+                if (!defaultAddress.equals(serverAddress)) {
+                    logger.warn("Download server list from {} failed. Trying default ..", serverAddress);
+                    download(defaultAddress);
+                } else {
+                    throw e;
+                }
+            }
+        } catch (Exception e) {
+            status = "Error: " + e.toString();
+            // we catch Exception here to make sure that it's being logged
+            // alternative: re-throw as RuntimeException and use
+            // Thread.setUncaughtExceptionHandler()
+            logger.error("Error downloading online server list!", e.toString());
+        }
+    }
+
+    private void download(String address) throws IOException {
+        status = "Downloading modules ..";
+
+        URL url = new URL("http", address, "/modules/list/latest");
+        try (JsonReader reader = new JsonReader(new InputStreamReader(url.openStream(), TerasologyConstants.CHARSET))) {
+
+            status = "Parsing content ..";
+
+            reader.beginArray();
+
+            while (reader.hasNext()) {
+                ModuleMetadata meta = metaReader.read(reader);
+                logger.debug("Read module {} - {}", meta.getId(), meta.getVersion());
+                RemoteModule remoteModule = new RemoteModule(meta);
+                modules.add(remoteModule);
+
+                int count = modules.size();
+                status = String.format("Retrieved %d %s", count, (count == 1) ? "entry" : "entries");
+            }
+
+            reader.endArray();
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ModuleListDownloader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ModuleListDownloader.java
@@ -123,6 +123,12 @@ class ModuleListDownloader {
 
                 int count = modules.size();
                 status = String.format("Retrieved %d %s", count, (count == 1) ? "entry" : "entries");
+
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    // ignore - this is just to create an animation anyway
+                }
             }
 
             reader.endArray();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/RemoteModule.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/RemoteModule.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import java.net.URL;
+import java.util.Collections;
+
+import org.terasology.module.BaseModule;
+import org.terasology.module.ModuleMetadata;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * TODO Type description
+ * @author Martin Steiger
+ */
+public class RemoteModule extends BaseModule {
+
+    public RemoteModule(ModuleMetadata meta) {
+        super(Collections.emptyList(), meta);
+    }
+
+    @Override
+    public ImmutableList<URL> getClasspaths() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isOnClasspath() {
+        return false;
+    }
+
+    @Override
+    public boolean isCodeModule() {
+        return true;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/RemoteModule.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/RemoteModule.java
@@ -24,10 +24,9 @@ import org.terasology.module.ModuleMetadata;
 import com.google.common.collect.ImmutableList;
 
 /**
- * TODO Type description
- * @author Martin Steiger
+ * A module that lives in a remote location.
  */
-public class RemoteModule extends BaseModule {
+class RemoteModule extends BaseModule {
 
     public RemoteModule(ModuleMetadata meta) {
         super(Collections.emptyList(), meta);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
@@ -150,24 +150,31 @@ public class SelectModulesScreen extends CoreScreenLayer {
                 });
             }
 
-            UILabel version = find("version", UILabel.class);
-            if (version != null) {
-                version.bindText(new ReadOnlyBinding<String>() {
+            UILabel installedVersion = find("installedVersion", UILabel.class);
+            if (installedVersion != null) {
+                installedVersion.bindText(new ReadOnlyBinding<String>() {
                     @Override
                     public String get() {
                         ModuleSelectionInfo sel = moduleList.getSelection();
                         if (sel == null) {
                             return "";
                         }
-                        ModuleMetadata info = sel.getMetadata();
+                        return sel.isPresent() ? sel.getMetadata().getVersion().toString() : "none";
+                    }
+                });
+            }
 
-                        String ver = info.getVersion().toString();
-
-                        if (sel.getOnlineVersion() != null) {
-                            ver += " (" + sel.getOnlineVersion().getVersion() + ")";
+            UILabel onlineVersion = find("onlineVersion", UILabel.class);
+            if (onlineVersion != null) {
+                onlineVersion.bindText(new ReadOnlyBinding<String>() {
+                    @Override
+                    public String get() {
+                        ModuleSelectionInfo sel = moduleList.getSelection();
+                        if (sel == null) {
+                            return "";
                         }
-
-                        return ver;
+                        return (sel.getOnlineVersion() != null)
+                              ? sel.getOnlineVersion().getVersion().toString() : "none";
                     }
                 });
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
@@ -43,9 +43,9 @@ import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * @author Immortius
@@ -61,6 +61,8 @@ public class SelectModulesScreen extends CoreScreenLayer {
     private Map<Name, ModuleSelectionInfo> modulesLookup;
     private List<ModuleSelectionInfo> sortedModules;
     private DependencyResolver resolver;
+    private ModuleListDownloader metaDownloader;
+    private boolean needsUpdate = true;
 
     @Override
     public void onOpened() {
@@ -75,18 +77,11 @@ public class SelectModulesScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        metaDownloader = new ModuleListDownloader(config.getNetwork().getMasterServer());
+
         resolver = new DependencyResolver(moduleManager.getRegistry());
         modulesLookup = Maps.newHashMap();
         sortedModules = Lists.newArrayList();
-
-        populateModuleInformation();
-
-        Collections.sort(sortedModules, new Comparator<ModuleSelectionInfo>() {
-            @Override
-            public int compare(ModuleSelectionInfo o1, ModuleSelectionInfo o2) {
-                return o1.getMetadata().getDisplayName().toString().compareTo(o2.getMetadata().getDisplayName().toString());
-            }
-        });
 
         final UIList<ModuleSelectionInfo> moduleList = find("moduleList", UIList.class);
         if (moduleList != null) {
@@ -160,10 +155,19 @@ public class SelectModulesScreen extends CoreScreenLayer {
                 version.bindText(new ReadOnlyBinding<String>() {
                     @Override
                     public String get() {
-                        if (moduleInfoBinding.get() != null) {
-                            return moduleInfoBinding.get().getVersion().toString();
+                        ModuleSelectionInfo sel = moduleList.getSelection();
+                        if (sel == null) {
+                            return "";
                         }
-                        return "";
+                        ModuleMetadata info = sel.getMetadata();
+
+                        String ver = info.getVersion().toString();
+
+                        if (sel.getOnlineVersion() != null) {
+                            ver += " (" + sel.getOnlineVersion().getVersion() + ")";
+                        }
+
+                        return ver;
                     }
                 });
             }
@@ -175,6 +179,30 @@ public class SelectModulesScreen extends CoreScreenLayer {
                     public String get() {
                         if (moduleInfoBinding.get() != null) {
                             return moduleInfoBinding.get().getDescription().toString();
+                        }
+                        return "";
+                    }
+                });
+            }
+
+            UILabel status = find("status", UILabel.class);
+            if (status != null) {
+                status.bindText(new ReadOnlyBinding<String>() {
+                    @Override
+                    public String get() {
+                        ModuleSelectionInfo info = moduleList.getSelection();
+                        if (info != null) {
+                            if (isSelectedGameplayModule(info)) {
+                                return "gameplay";
+                            } else if (info.isSelected() && info.isExplicitSelection()) {
+                                return "enabled";
+                            } else if (info.isSelected()) {
+                                return "dependency";
+                            } else if (info.isValidToSelect()) {
+                                return "disabled";
+                            } else {
+                                return "invalid";
+                            }
                         }
                         return "";
                     }
@@ -196,30 +224,31 @@ public class SelectModulesScreen extends CoreScreenLayer {
                 });
             }
 
-            UIButton toggle = find("toggleActivation", UIButton.class);
-            if (toggle != null) {
-                toggle.subscribe(new ActivateEventListener() {
+            UIButton toggleActivate = find("toggleActivation", UIButton.class);
+            if (toggleActivate != null) {
+                toggleActivate.subscribe(new ActivateEventListener() {
                     @Override
                     public void onActivated(UIWidget button) {
-                        if (moduleList.getSelection() != null) {
-
+                        ModuleSelectionInfo info = moduleList.getSelection();
+                        if (info != null) {
                             // Toggle
-                            if (moduleList.getSelection().isSelected() && moduleList.getSelection().isExplicitSelection()) {
-                                deselect(moduleList.getSelection());
-                            } else if (moduleList.getSelection().isValidToSelect()) {
-                                select(moduleList.getSelection());
+                            if (info.isSelected() && info.isExplicitSelection()) {
+                                deselect(info);
+                            } else if (info.isValidToSelect()) {
+                                select(info);
                             }
                         }
                     }
                 });
-                toggle.bindVisible(new ReadOnlyBinding<Boolean>() {
+                toggleActivate.bindEnabled(new ReadOnlyBinding<Boolean>() {
                     @Override
                     public Boolean get() {
-                        return moduleList.getSelection() != null
-                                && (moduleList.getSelection().isSelected() || moduleList.getSelection().isValidToSelect());
+                        ModuleSelectionInfo info = moduleList.getSelection();
+                        return info != null && info.isPresent()
+                                && (info.isSelected() || info.isValidToSelect());
                     }
                 });
-                toggle.bindText(new ReadOnlyBinding<String>() {
+                toggleActivate.bindText(new ReadOnlyBinding<String>() {
                     @Override
                     public String get() {
                         if (moduleList.getSelection() != null) {
@@ -230,6 +259,57 @@ public class SelectModulesScreen extends CoreScreenLayer {
                             }
                         }
                         return "";
+                    }
+                });
+            }
+
+            UIButton downloadButton = find("download", UIButton.class);
+            if (downloadButton != null) {
+                downloadButton.subscribe(new ActivateEventListener() {
+                    @Override
+                    public void onActivated(UIWidget button) {
+                        if (moduleList.getSelection() != null) {
+
+                            ModuleSelectionInfo info = moduleList.getSelection();
+                        }
+                    }
+                });
+
+                Predicate<ModuleSelectionInfo> canDownload = info -> info != null && !info.isPresent();
+                Predicate<ModuleSelectionInfo> canUpdate = info -> {
+                    if (info != null) {
+                        Module online = info.getOnlineVersion();
+                        if (online != null) {
+                            return online.getVersion().compareTo(info.getLatestVersion().getVersion()) > 0;
+                        }
+                        return false;
+                    }
+                    return false;
+                };
+
+                downloadButton.bindEnabled(new ReadOnlyBinding<Boolean>() {
+                    @Override
+                    public Boolean get() {
+                        ModuleSelectionInfo info = moduleList.getSelection();
+                        if (canDownload.test(info)) {
+                            return true;
+                        }
+
+                        return canUpdate.test(info);
+                    }
+                });
+                downloadButton.bindText(new ReadOnlyBinding<String>() {
+
+                    @Override
+                    public String get() {
+                        ModuleSelectionInfo info = moduleList.getSelection();
+                        if (canDownload.test(info)) {
+                            return "Download";
+                        }
+                        if (canUpdate.test(info)) {
+                            return "Update";
+                        }
+                        return "-";
                     }
                 });
             }
@@ -260,13 +340,13 @@ public class SelectModulesScreen extends CoreScreenLayer {
 
     private void updateValidToSelect() {
         List<Name> selectedModules = Lists.newArrayList();
-        for (SelectModulesScreen.ModuleSelectionInfo info : sortedModules) {
+        for (ModuleSelectionInfo info : sortedModules) {
             if (info.isSelected()) {
                 selectedModules.add(info.getMetadata().getId());
             }
         }
         Name[] selectedModulesArray = selectedModules.toArray(new Name[selectedModules.size()]);
-        for (SelectModulesScreen.ModuleSelectionInfo info : sortedModules) {
+        for (ModuleSelectionInfo info : sortedModules) {
             if (!info.isSelected()) {
                 info.setValidToSelect(resolver.resolve(info.getMetadata().getId(), selectedModulesArray).isSuccess());
             }
@@ -276,7 +356,7 @@ public class SelectModulesScreen extends CoreScreenLayer {
     private void setSelectedVersions(ResolutionResult currentSelectionResults) {
         if (currentSelectionResults.isSuccess()) {
             for (Module module : currentSelectionResults.getModules()) {
-                SelectModulesScreen.ModuleSelectionInfo info = modulesLookup.get(module.getId());
+                ModuleSelectionInfo info = modulesLookup.get(module.getId());
 
                 // the engine module is not listed
                 if (info != null) {
@@ -286,14 +366,43 @@ public class SelectModulesScreen extends CoreScreenLayer {
         }
     }
 
-    private void populateModuleInformation() {
+    private void updateModuleInformation() {
+        modulesLookup.clear();
+        sortedModules.clear();
+
         for (Name moduleId : moduleManager.getRegistry().getModuleIds()) {
             Module latestVersion = moduleManager.getRegistry().getLatestModuleVersion(moduleId);
             if (!latestVersion.isOnClasspath()) {
-                SelectModulesScreen.ModuleSelectionInfo info = new SelectModulesScreen.ModuleSelectionInfo(latestVersion);
+                ModuleSelectionInfo info = ModuleSelectionInfo.local(latestVersion);
                 modulesLookup.put(info.getMetadata().getId(), info);
                 sortedModules.add(info);
             }
+        }
+
+        for (RemoteModule remote : metaDownloader.getModules()) {
+            ModuleSelectionInfo info = modulesLookup.get(remote.getId());
+            if (info == null) {
+                info = ModuleSelectionInfo.remote(remote);
+                modulesLookup.put(remote.getId(), info);
+                sortedModules.add(info);
+            }
+            info.setOnlineVersion(remote);
+        }
+
+        Collections.sort(sortedModules, (o1, o2) ->
+            o1.getMetadata().getDisplayName().toString().compareTo(
+            o2.getMetadata().getDisplayName().toString()));
+    }
+
+    @Override
+    public void update(float delta) {
+        super.update(delta);
+
+        if (needsUpdate) {
+            if (metaDownloader.isDone()) {
+                needsUpdate = false;
+            }
+            updateModuleInformation();
         }
     }
 
@@ -329,7 +438,7 @@ public class SelectModulesScreen extends CoreScreenLayer {
 
     private List<Name> getExplicitlySelectedModules() {
         List<Name> selectedModules = Lists.newArrayList();
-        for (SelectModulesScreen.ModuleSelectionInfo info : sortedModules) {
+        for (ModuleSelectionInfo info : sortedModules) {
             if (info.isExplicitSelection()) {
                 selectedModules.add(info.getMetadata().getId());
             }
@@ -360,26 +469,61 @@ public class SelectModulesScreen extends CoreScreenLayer {
     }
 
 
-    private static class ModuleSelectionInfo {
+    private static final class ModuleSelectionInfo {
         private Module latestVersion;
         private Module selectedVersion;
+        private Module onlineVersion;
         private boolean explicitSelection;
         private boolean validToSelect = true;
 
-        public ModuleSelectionInfo(Module module) {
+        private ModuleSelectionInfo(Module module) {
             this.latestVersion = module;
+        }
+
+        public static ModuleSelectionInfo remote(Module module) {
+            ModuleSelectionInfo info = new ModuleSelectionInfo(null);
+            info.setOnlineVersion(module);
+            return info;
+        }
+
+        public static ModuleSelectionInfo local(Module module) {
+            return new ModuleSelectionInfo(module);
         }
 
         public ModuleMetadata getMetadata() {
             if (selectedVersion != null) {
                 return selectedVersion.getMetadata();
-            } else {
+            } else if (latestVersion != null) {
                 return latestVersion.getMetadata();
+            } else if (onlineVersion != null) {
+                return onlineVersion.getMetadata();
             }
+
+            return null;
+        }
+
+        public boolean isPresent() {
+            return latestVersion != null;
         }
 
         public boolean isSelected() {
             return selectedVersion != null;
+        }
+
+        public Module getOnlineVersion() {
+            return onlineVersion;
+        }
+
+        public Module getLatestVersion() {
+            return latestVersion;
+        }
+
+        public Module getSelectedVersion() {
+            return selectedVersion;
+        }
+
+        public void setOnlineVersion(Module onlineVersion) {
+            this.onlineVersion = onlineVersion;
         }
 
         public void setSelectedVersion(Module selectedVersion) {

--- a/engine/src/main/resources/assets/skins/mainmenu.skin
+++ b/engine/src/main/resources/assets/skins/mainmenu.skin
@@ -60,13 +60,16 @@
                         "item": {
                             "modes": {
                                 "gameplay": {
-                                    "text-color": "2B65ECFF"
+                                    "text-color": "8B85FFFF"
                                 },
                                 "enabled": {
                                     "text-color": "00FF00FF"
                                 },
                                 "dependency": {
                                     "text-color": "FFFF00FF"
+                                },
+                                "available": {
+                                    "text-color": "FFFFFFFF"
                                 },
                                 "disabled": {
                                     "text-color": "AAAAAAFF"

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -172,19 +172,6 @@
                                     }
                                 },
                                 {
-                                    "type" : "UILabel",
-                                    "id" : "descriptionTitle",
-                                    "text" : "Description:",
-                                    "layoutInfo" : {
-                                        "use-content-height" : true,
-                                        "position-top" : {
-                                            "target" : "BOTTOM",
-                                            "widget" : "simpleItems",
-                                            "offset" : 8
-                                        }
-                                    }
-                                },
-                                {
                                     "type" : "ScrollableArea",
                                     "content" : {
                                         "type" : "UILabel",
@@ -195,7 +182,7 @@
                                         "position-horizontal-center" : {},
                                         "position-top" : {
                                             "target" : "BOTTOM",
-                                            "widget" : "descriptionTitle",
+                                            "widget" : "simpleItems",
                                             "offset" : 8
                                         },
                                         "position-bottom" : {
@@ -212,29 +199,17 @@
                                     "horizontalSpacing" : 8,
                                     "verticalSpacing" : 8,
                                     "contents" : [
-		                                {
-		                                    "type" : "UIButton",
-		                                    "id" : "toggleActivation",
-		                                    "text" : "Activate"
-		                                },
-		                                {
-		                                    "type" : "UIButton",
-		                                    "id" : "download",
-		                                    "text" : "Download"
-		                                }
-                                    ],
-                                    "layoutInfo" : {
-                                        "height" : 24,
-                                        "position-bottom" : {
-                                            "target" : "BOTTOM"
+                                        {
+                                            "type" : "UIButton",
+                                            "id" : "toggleActivation",
+                                            "text" : "Activate"
+                                        },
+                                        {
+                                            "type" : "UIButton",
+                                            "id" : "download",
+                                            "text" : "Download"
                                         }
-                                    }
-								},
-                                {
-                                    "type" : "UILabel",
-                                    "id" : "errorMessage",
-                                    "text" : "Error",
-                                    "family" : "error",
+                                    ],
                                     "layoutInfo" : {
                                         "height" : 24,
                                         "position-bottom" : {

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -137,11 +137,20 @@
                                         },
                                         {
                                             "type" : "UILabel",
-                                            "text" : "Version: "
+                                            "text" : "Installed: "
                                         },
                                         {
                                             "type" : "UILabel",
-                                            "id" : "version",
+                                            "id" : "installedVersion",
+                                            "text" : "Module Version Goes Here"
+                                        },
+                                        {
+                                            "type" : "UILabel",
+                                            "text" : "Online: "
+                                        },
+                                        {
+                                            "type" : "UILabel",
+                                            "id" : "onlineVersion",
                                             "text" : "Module Version Goes Here"
                                         },
                                         {

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -143,6 +143,15 @@
                                             "type" : "UILabel",
                                             "id" : "version",
                                             "text" : "Module Version Goes Here"
+                                        },
+                                        {
+                                            "type" : "UILabel",
+                                            "text" : "Status: "
+                                        },
+                                        {
+                                            "type" : "UILabel",
+                                            "id" : "status",
+                                            "text" : "Module Status Goes Here"
                                         }
                                     ],
                                     "layoutInfo" : {
@@ -182,22 +191,36 @@
                                         },
                                         "position-bottom" : {
                                             "target" : "TOP",
-                                            "widget" : "toggleActivation",
+                                            "widget" : "buttonRow",
                                             "offset" : 8
                                         }
                                     }
                                 },
                                 {
-                                    "type" : "UIButton",
-                                    "id" : "toggleActivation",
-                                    "text" : "Activate",
+                                    "type" : "ColumnLayout",
+                                    "id" : "buttonRow",
+                                    "columns" : 2,
+                                    "horizontalSpacing" : 8,
+                                    "verticalSpacing" : 8,
+                                    "contents" : [
+		                                {
+		                                    "type" : "UIButton",
+		                                    "id" : "toggleActivation",
+		                                    "text" : "Activate"
+		                                },
+		                                {
+		                                    "type" : "UIButton",
+		                                    "id" : "download",
+		                                    "text" : "Download"
+		                                }
+                                    ],
                                     "layoutInfo" : {
                                         "height" : 24,
                                         "position-bottom" : {
                                             "target" : "BOTTOM"
                                         }
                                     }
-                                },
+								},
                                 {
                                     "type" : "UILabel",
                                     "id" : "errorMessage",

--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -120,7 +120,7 @@ dependencies {
             // Check for any needed module dependencies on other modules that we need at runtime
             if (id.group == 'org.terasology.modules' && id.name != "Core") {
                 File moduleSrcPath = new File(rootDir, 'modules/' + id.name)
-                File moduleJarPath = new File(rootDir, 'modules/' + id.name + id.version + '.jar')
+                File moduleJarPath = new File(rootDir, 'modules/' + id.name + '-' + id.version + '.jar')
 
                 if (moduleSrcPath.exists()) {
                     println "*** Found module dependency $id.name in source form, not copying a runtime jar from Gradle"

--- a/modules/CoreSampleGameplay/build.gradle
+++ b/modules/CoreSampleGameplay/build.gradle
@@ -116,7 +116,7 @@ dependencies {
             // Check for any needed module dependencies on other modules that we need at runtime
             if (id.group == 'org.terasology.modules' && id.name != "Core") {
                 File moduleSrcPath = new File(rootDir, 'modules/' + id.name)
-                File moduleJarPath = new File(rootDir, 'modules/' + id.name + id.version + '.jar')
+                File moduleJarPath = new File(rootDir, 'modules/' + id.name + '-' + id.version + '.jar')
 
                 if (moduleSrcPath.exists()) {
                     println "*** Found module dependency $id.name in source form, not copying a runtime jar from Gradle"


### PR DESCRIPTION
The information about modules based on their `module.txt` is retrieved from [meta.terasology.org](http://meta.terasology.org). On demand, modules can be downloaded (from Artifactory) and installed without need to restart the game.

![image](https://cloud.githubusercontent.com/assets/1820007/9233867/cbe29a4a-4135-11e5-98e0-f49a8cafe147.png)

Fixes #1754 and fixes #1787 (supercedes #1875).