### PR TITLE
Fix a full stopper NullPointerExcpetion in remote client.

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -77,6 +77,7 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
 
     public RemoteChunkProvider(BlockManager blockManager, LocalPlayer localPlayer) {
         this.blockManager = blockManager;
+        this.localPlayer = localPlayer;
         pipeline = new ChunkGenerationPipeline(new ChunkTaskRelevanceComparator());
         ChunkMonitor.fireChunkProviderInitialized(this);
     }


### PR DESCRIPTION
Remote client was broken, as you got a NullPointerException. This commit fixes it again.