### PR TITLE
Better handling of unloaded blocks

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -68,7 +68,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager, localPlayer);
 
         WorldProviderCoreImpl worldProviderCore = new WorldProviderCoreImpl(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD), chunkProvider,
-                blockManager.getBlock(BlockManager.AIR_ID), context);
+                blockManager.getBlock(BlockManager.UNLOADED_ID), context);
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(worldProviderCore, context);
         WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider);
         context.put(WorldProvider.class, worldProvider);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -133,7 +133,8 @@ public class InitialiseWorld extends SingleStepLoadProcess {
                 blockManager, biomeManager);
         context.get(ComponentSystemManager.class).register(new RelevanceSystem(chunkProvider), "engine:relevanceSystem");
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(
-                new WorldProviderCoreImpl(worldInfo, chunkProvider, blockManager.getBlock(BlockManager.AIR_ID), context)
+                new WorldProviderCoreImpl(worldInfo, chunkProvider, blockManager.getBlock(BlockManager.UNLOADED_ID),
+                        context)
                 , context);
         WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider);
         context.put(WorldProvider.class, worldProvider);

--- a/engine/src/main/java/org/terasology/world/block/BlockManager.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockManager.java
@@ -27,6 +27,7 @@ import java.util.Map;
 public abstract class BlockManager {
 
     public static final BlockUri AIR_ID = new BlockUri(new ResourceUrn("engine:air"));
+    public static final BlockUri UNLOADED_ID = new BlockUri(new ResourceUrn("engine:unloaded"));
 
     /**
      * @return A map of the mapping between Block Uris and Ids

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -262,7 +262,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getLiquid(blockPos);
         }
-        logger.warn("Attempted to access unavailable chunk via liquid data at {}, {}, {}", x, y, z);
         return new LiquidData();
     }
 
@@ -274,7 +273,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getBlock(blockPos);
         }
-        logger.warn("Attempted to access unavailable chunk via block at {}, {}, {}", x, y, z);
         return defaultBlock;
     }
 
@@ -286,7 +284,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(pos);
             return chunk.getBiome(blockPos.x, blockPos.y, blockPos.z);
         }
-        logger.warn("Attempted to access unavailable chunk via block at {}, {}, {}", pos.x, pos.y, pos.z);
         return BiomeManager.getUnknownBiome();
     }
 
@@ -328,7 +325,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getLight(blockPos);
         }
-        logger.warn("Attempted to access unavailable chunk via light at {}, {}, {}", x, y, z);
         return 0;
     }
 
@@ -340,7 +336,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getSunlight(blockPos);
         }
-        logger.warn("Attempted to access unavailable chunk via sunlight at {}, {}, {}", x, y, z);
         return 0;
     }
 
@@ -352,7 +347,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return (byte) Math.max(chunk.getSunlight(blockPos), chunk.getLight(blockPos));
         }
-        logger.warn("Attempted to access unavailable chunk via total light at {}, {}, {}", x, y, z);
         return 0;
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -83,15 +83,15 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     private Map<Vector3i, BiomeChange> biomeChanges = Maps.newHashMap();
     private List<BatchPropagator> propagators = Lists.newArrayList();
 
-    private Block defaultBlock;
+    private Block unloadedBlock;
 
     public WorldProviderCoreImpl(String title, String seed, long time, SimpleUri worldGenerator,
-                                 GeneratingChunkProvider chunkProvider, Block defaultBlock, Context context) {
+                                 GeneratingChunkProvider chunkProvider, Block unloadedBlock, Context context) {
         this.title = (title == null) ? seed : title;
         this.seed = seed;
         this.worldGenerator = worldGenerator;
         this.chunkProvider = chunkProvider;
-        this.defaultBlock = defaultBlock;
+        this.unloadedBlock = unloadedBlock;
         this.entityManager = context.get(EntityManager.class);
         context.put(ChunkProvider.class, chunkProvider);
 
@@ -107,10 +107,10 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         propagators.add(sunlightPropagator);
     }
 
-    public WorldProviderCoreImpl(WorldInfo info, GeneratingChunkProvider chunkProvider, Block defaultBlock,
+    public WorldProviderCoreImpl(WorldInfo info, GeneratingChunkProvider chunkProvider, Block unloadedBlock,
                                  Context context) {
-        this(info.getTitle(), info.getSeed(), info.getTime(), info.getWorldGenerator(), chunkProvider, defaultBlock,
-                context);
+        this(info.getTitle(), info.getSeed(), info.getTime(), info.getWorldGenerator(), chunkProvider,
+                unloadedBlock, context);
     }
 
     @Override
@@ -273,7 +273,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return chunk.getBlock(blockPos);
         }
-        return defaultBlock;
+        return unloadedBlock;
     }
 
     @Override

--- a/engine/src/main/resources/assets/blocks/unloaded.block
+++ b/engine/src/main/resources/assets/blocks/unloaded.block
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+    "translucent": true,
+    "invisible": true,
+    "targetable": false,
+    "penetrable": false,
+    "replacementAllowed": false,
+    "shadowCasting": false,
+    "attachmentAllowed": false,
+    "hardness": 0,
+    "displayName": "Unloaded",
+    "rotation": "symmetric",
+    "sounds": "none",
+    "shape": "engine:none"
+}


### PR DESCRIPTION
There is currently a lot of spam about attempts to access unloaded blocks.  e.g.
* right at start, when the chunk isn't loaded yet but the game already performs a ray cast to check which block the player is currently looking at
* When you throw an item into a chunk that isn't loaded there will be infinite spam about unloaded block access as the phsyic engine tries to handle the interaction of the item with the world.

This pull requests solves both issues by
* Firstly not spamming warnings about it
* Introducing a new block type engine:unloaded that all unloaded blocks have. Unloaded blocks can neither be penetrated nor be destroyed.

Thus if you try to throw an item in an unloaded chunk it will just bounce back.