### PR TITLE
Update world gen. configuration with Component clones

### DIFF
--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -129,11 +129,16 @@ public final class EnvironmentSwitchHandler {
     }
 
 
-    public void handleSwitchToPreviewEnivronment(Context context, ModuleEnvironment environment) {
+    public void handleSwitchToPreviewEnvironment(Context context, ModuleEnvironment environment) {
         cheapAssetManagerUpdate(context, environment);
+        ComponentLibrary library = new ComponentLibrary(context);
+        context.put(ComponentLibrary.class, library);
+
+        registerComponents(library, environment);
     }
 
-    public void handleSwitchBackFromPreviewEnivronment(Context context) {
+    public void handleSwitchBackFromPreviewEnvironment(Context context) {
+        // The newly created ComponentLibrary instance cannot be invalidated in context
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         cheapAssetManagerUpdate(context, environment);
     }
@@ -147,7 +152,7 @@ public final class EnvironmentSwitchHandler {
     private void unregisterPrefabFormats(ModuleAwareAssetTypeManager assetTypeManager) {
         if (registeredPrefabFormat != null) {
             assetTypeManager.removeCoreFormat(Prefab.class, registeredPrefabFormat);
-            registeredPrefabFormat =null;
+            registeredPrefabFormat = null;
         }
         if (registeredPrefabDeltaFormat != null) {
             assetTypeManager.removeCoreDeltaFormat(Prefab.class, registeredPrefabDeltaFormat);

--- a/engine/src/main/java/org/terasology/rendering/nui/properties/PropertyProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/properties/PropertyProvider.java
@@ -114,6 +114,8 @@ public class PropertyProvider {
         TextMapper<?> textBinding = null;
         if (type == String.class) {
             textBinding = new StringTextBinding();
+        } else if (type == Boolean.TYPE || type == Boolean.class) {
+            textBinding = new BooleanTextBinding();
         } else if (type == Integer.TYPE || type == Integer.class) {
             textBinding = new IntegerTextBinding();
         } else if (type == Float.TYPE || type == Float.class) {
@@ -231,17 +233,7 @@ public class PropertyProvider {
             Object[] items = cls.getEnumConstants();
             UIDropdown dropdown = new UIDropdown();
             dropdown.bindOptions(new DefaultBinding(Arrays.asList(items)));
-            Binding binding = new Binding() {
-                @Override
-                public Object get() {
-                    return fieldMetadata.getValueChecked(target);
-                }
-
-                @Override
-                public void set(Object value) {
-                    fieldMetadata.setValue(target, value);
-                }
-            };
+            Binding binding = createTextBinding(target, fieldMetadata);
             dropdown.bindSelection(binding);
             String label = fromLabelOrId(info.label(), id);
             return new Property<>(label, binding, dropdown, info.description());
@@ -253,22 +245,15 @@ public class PropertyProvider {
         public Property create(Object target, final FieldMetadata<Object, ?> fieldMetadata, String id, OneOf.Provider info) {
             UIDropdown dropdown = new UIDropdown();
             OneOfProviderFactory factory = CoreRegistry.get(OneOfProviderFactory.class);
-            dropdown.bindOptions(factory.get(info.name()));
+            Binding<?> listBinding = factory.get(info.name());
+            if (listBinding != null) {
+                dropdown.bindOptions(listBinding);
+            }
             ItemRenderer<?> itemRenderer = factory.getItemRenderer(info.name());
             if (itemRenderer != null) {
                 dropdown.setOptionRenderer(itemRenderer);
             }
-            Binding binding = new Binding() {
-                @Override
-                public Object get() {
-                    return fieldMetadata.getValueChecked(target);
-                }
-
-                @Override
-                public void set(Object value) {
-                    fieldMetadata.setValue(target, value);
-                }
-            };
+            Binding binding = createTextBinding(target, fieldMetadata);
             dropdown.bindSelection(binding);
             String label = fromLabelOrId(info.label(), id);
             return new Property<>(label, binding, dropdown, info.description());

--- a/engine/src/main/java/org/terasology/rendering/nui/properties/PropertyProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/properties/PropertyProvider.java
@@ -110,7 +110,7 @@ public class PropertyProvider {
         return null;
     }
 
-    protected <T> TextMapper<T> createTextMapping(Class<?> type) {
+    private <T> TextMapper<T> createTextMapping(Class<?> type) {
         TextMapper<?> textBinding = null;
         if (type == String.class) {
             textBinding = new StringTextBinding();
@@ -126,6 +126,9 @@ public class PropertyProvider {
         return (TextMapper<T>) textBinding;
     }
 
+    protected <T> Binding<T> createTextBinding(Object target, final FieldMetadata<Object, T> fieldMetadata) {
+        return new TextBinding<T>(target, fieldMetadata);
+    }
 
     protected Binding<Float> createFloatBinding(Object target, final FieldMetadata<Object, ?> fieldMetadata) {
         Class<?> type = fieldMetadata.getType();
@@ -202,7 +205,7 @@ public class PropertyProvider {
         @Override
         public Property create(Object target, FieldMetadata<Object, ?> fieldMetadata, String id, Checkbox info) {
             UICheckbox checkbox = new UICheckbox();
-            Binding<Boolean> binding = new TextBinding(target, (FieldMetadata<Object, Boolean>) fieldMetadata);
+            Binding<Boolean> binding = createTextBinding(target, (FieldMetadata<Object, Boolean>) fieldMetadata);
             checkbox.bindChecked(binding);
             String label = fromLabelOrId(info.label(), id);
             return new Property<>(label, binding, checkbox, info.description());
@@ -214,7 +217,7 @@ public class PropertyProvider {
         public Property create(Object target, FieldMetadata<Object, ?> fieldMetadata, String id, OneOf.List info) {
             UIDropdown<String> dropdown = new UIDropdown<>();
             dropdown.bindOptions(new DefaultBinding<>(Arrays.asList(info.items())));
-            Binding<String> binding = new TextBinding(target, (FieldMetadata<Object, String>) fieldMetadata);
+            Binding<String> binding = createTextBinding(target, (FieldMetadata<Object, String>) fieldMetadata);
             dropdown.bindSelection(binding);
             String label = fromLabelOrId(info.label(), id);
             return new Property<>(label, binding, dropdown, info.description());
@@ -277,7 +280,7 @@ public class PropertyProvider {
         public Property create(Object target, FieldMetadata<Object, ?> fieldMetadata, String id, TextField info) {
             UITextEntry<T> text = new UITextEntry<>();
 
-            Binding<T> textBinding = new TextBinding(target, (FieldMetadata<Object, T>) fieldMetadata);
+            Binding<T> textBinding = createTextBinding(target, (FieldMetadata<Object, T>) fieldMetadata);
             TextMapper<T> textMapper = createTextMapping(fieldMetadata.getType());
             text.setFormatter(textMapper);
             text.setParser(textMapper);


### PR DESCRIPTION
This PR changes the current property binding scheme for world gen. configuration. Previously, fields were modified directly through PropertyProvider's reflection system. This has the drawback that world gens are not notified (or only afterwards) that a parameter has changed.

This PR uses copies of configuration components and calls worldConfig.setProperty() as usual. This allows the world gen. to update accordingly (reload a height map, clear caches) or even decline the new parameter set.

I had to change `handleSwitchToPreviewEnvironment.handleSwitchToPreviewEnvironment` so it would update the `ComponentLibrary` with the new module environment. It also uses the sub-context now. Unfortunately, this update cannot be undone atm. Since this is using the sub-context only, it should be ok though.

To test this try the HeightMap world gen. or PolyWorld. Both should work nicely now even when the height map / graph density is modified. 