### PR TITLE
Name tags

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -33,6 +33,10 @@ import org.terasology.network.Replicate;
  * @author Immortius
  */
 public final class CharacterComponent implements Component {
+    /**
+     * Recommended height from center at which name tags should be placed if there is one.
+     */
+    public float nameTagOffset = 0.8f;
     public float eyeOffset = 0.6f;
     /**
      * Specifies the maximium range at which this character is able to interact with other objects.

--- a/engine/src/main/java/org/terasology/logic/nameTags/NameTagClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/nameTags/NameTagClientSystem.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.nameTags;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.location.Location;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.In;
+import org.terasology.rendering.logic.FloatingTextComponent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class NameTagClientSystem extends BaseComponentSystem {
+    private static final Logger logger = LoggerFactory.getLogger(NameTagClientSystem.class);
+
+    private Map<EntityRef, EntityRef> nameTagEntityToFloatingTextMap = new HashMap<>();
+
+    @In
+    private EntityManager entityManager;
+
+
+    @ReceiveEvent(components = {NameTagComponent.class, LocationComponent.class})
+    public void onNameTagOwnerActivated(OnActivatedComponent event, EntityRef entity,
+                                    NameTagComponent nameTagComponent) {
+        createOrUpdateNameTagFor(entity, nameTagComponent);
+    }
+
+    @ReceiveEvent(components = {NameTagComponent.class })
+    public void onDisplayNameChange(OnChangedComponent event, EntityRef entity,
+                                    NameTagComponent nameTagComponent) {
+        createOrUpdateNameTagFor(entity, nameTagComponent);
+    }
+
+
+    private void createOrUpdateNameTagFor(EntityRef entity, NameTagComponent nameTagComponent) {
+        EntityRef nameTag = nameTagEntityToFloatingTextMap.get(entity);
+        Vector3f offset = new Vector3f(0, nameTagComponent.yOffset, 0);
+        if (nameTag != null) {
+            FloatingTextComponent floatingText = nameTag.getComponent(FloatingTextComponent.class);
+            floatingText.text = nameTagComponent.text;
+            floatingText.textColor = nameTagComponent.textColor;
+            nameTag.saveComponent(floatingText);
+            LocationComponent nameTagLoc = nameTag.getComponent(LocationComponent.class);
+            nameTagLoc.setLocalPosition(offset);
+            nameTag.saveComponent(nameTagLoc);
+        } else {
+            EntityBuilder nameTagBuilder = entityManager.newBuilder();
+            FloatingTextComponent floatingTextComponent = new FloatingTextComponent();
+            nameTagBuilder.addComponent(floatingTextComponent);
+            LocationComponent locationComponent = new LocationComponent();
+            nameTagBuilder.addComponent(locationComponent);
+            floatingTextComponent.text = nameTagComponent.text;
+            floatingTextComponent.textColor = nameTagComponent.textColor;
+            nameTagBuilder.setOwner(entity);
+            nameTagBuilder.setPersistent(false);
+
+            nameTag = nameTagBuilder.build();
+            nameTagEntityToFloatingTextMap.put(entity, nameTag);
+
+            Location.attachChild(entity, nameTag, offset, new Quat4f(1, 0, 0, 0));
+        }
+    }
+
+    private void destroyNameTagOf(EntityRef entity) {
+        EntityRef nameTag = nameTagEntityToFloatingTextMap.remove(entity);
+        if (nameTag != null) {
+            nameTag.destroy();
+        }
+    }
+
+
+    @ReceiveEvent(components = {NameTagComponent.class })
+    public void onNameTagOwnerRemoved(BeforeDeactivateComponent event, EntityRef entity) {
+        destroyNameTagOf(entity);
+    }
+
+    @Override
+    public void shutdown() {
+        /* Explicitly no deletion of name tag entities as some system might not be in the right state anymore.
+         * Since they aren't persistent it does not make any difference anyway.
+         */
+        nameTagEntityToFloatingTextMap.clear();
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/nameTags/NameTagComponent.java
+++ b/engine/src/main/java/org/terasology/logic/nameTags/NameTagComponent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.nameTags;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.rendering.nui.Color;
+
+/**
+ * Will make the entity have a name tag overhead in the 3D view.
+ *
+ * The text on name tag is based on the {@link org.terasology.logic.common.DisplayNameComponent} this entity.
+ *
+ * The color of the name tag is based on the {@link org.terasology.network.ColorComponent} of this entity
+ */
+public class NameTagComponent implements Component {
+
+    public float yOffset = 0.3f;
+
+    public String text;
+
+    public Color textColor = Color.WHITE;
+
+}

--- a/engine/src/main/java/org/terasology/logic/nameTags/PlayerNameTagSystem.java
+++ b/engine/src/main/java/org/terasology/logic/nameTags/PlayerNameTagSystem.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.nameTags;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.common.DisplayNameComponent;
+import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
+import org.terasology.network.ClientComponent;
+import org.terasology.network.ClientInfoComponent;
+import org.terasology.network.ColorComponent;
+import org.terasology.network.NetworkSystem;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.Color;
+
+
+/**
+ * Creates name tags for chacters controlled by players based on their name.
+ *
+ * Once there is the intention to implement multiple differnt name tag generation rules for players feel free to move
+ * this system into a module so that it isn't always enabled.
+ */
+@RegisterSystem(RegisterMode.CLIENT)
+public class PlayerNameTagSystem extends BaseComponentSystem {
+    private static final Logger logger = LoggerFactory.getLogger(NameTagClientSystem.class);
+
+    @In
+    private NetworkSystem networkSystem;
+
+    /**
+     * Listening for {@link OnPlayerSpawnedEvent} does not work, as it is an authority event that does not get
+     * processed at clients. That is why we listen for the activation.
+     */
+    @ReceiveEvent(components = CharacterComponent.class)
+    public void onCharacterActivation(OnActivatedComponent event, EntityRef characterEntity,
+                                      CharacterComponent characterComponent) {
+        EntityRef ownerEntity = networkSystem.getOwnerEntity(characterEntity);
+        if (ownerEntity == null) {
+            return; // NPC
+        }
+
+        ClientComponent clientComponent = ownerEntity.getComponent(ClientComponent.class);
+        if (clientComponent == null) {
+            logger.warn("Can't create player based name tag for character as owner has no client component");
+            return;
+        }
+        EntityRef clientInfoEntity = clientComponent.clientInfo;
+
+        DisplayNameComponent displayNameComponent = clientInfoEntity.getComponent(DisplayNameComponent.class);
+        if (displayNameComponent == null) {
+            logger.error("Can't create player based name tag for character as client info has no DisplayNameComponent");
+            return;
+        }
+        String name = displayNameComponent.name;
+
+        float yOffset = characterComponent.nameTagOffset;
+
+        Color color = Color.WHITE;
+        ColorComponent colorComponent = clientInfoEntity.getComponent(ColorComponent.class);
+        if (colorComponent != null) {
+            color = colorComponent.color;
+        }
+
+        NameTagComponent nameTagComponent = characterEntity.getComponent(NameTagComponent.class);
+        boolean newComponent = nameTagComponent == null;
+        if (nameTagComponent == null) {
+            nameTagComponent = new NameTagComponent();
+        }
+        nameTagComponent.text = name;
+        nameTagComponent.textColor = color;
+        nameTagComponent.yOffset = yOffset;
+        if (newComponent) {
+            characterEntity.addComponent(nameTagComponent);
+        } else {
+            characterEntity.saveComponent(nameTagComponent);
+        }
+
+    }
+
+
+    @ReceiveEvent
+    public void onDisplayNameChange(OnChangedComponent event, EntityRef clientInfoEntity,
+                                    DisplayNameComponent displayNameComponent) {
+        ClientInfoComponent clientInfoComp = clientInfoEntity.getComponent(ClientInfoComponent.class);
+        if (clientInfoComp == null) {
+            return; // not a client info object
+        }
+
+        EntityRef clientEntity = clientInfoComp.client;
+        if (!clientEntity.exists()) {
+            return; // offline players aren't visible: nothing to do
+        }
+
+        ClientComponent clientComponent = clientEntity.getComponent(ClientComponent.class);
+        if (clientComponent == null) {
+            logger.warn("Can't update name tag as client entity lacks ClietnComponent");
+            return;
+        }
+
+        EntityRef characterEntity = clientComponent.character;
+        if (characterEntity == null || !characterEntity.exists()) {
+            return; // player has no character, nothing to do
+        }
+
+        NameTagComponent nameTagComponent = characterEntity.getComponent(NameTagComponent.class);
+        if (nameTagComponent == null) {
+            logger.warn("Tried to update the name tag component with a new player name but it was missing");
+
+        }
+
+        nameTagComponent.text = displayNameComponent.name;
+        characterEntity.saveComponent(nameTagComponent);
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
@@ -40,6 +40,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.logic.NearestSortingList;
+import org.terasology.rendering.opengl.OpenGLUtil;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -296,7 +297,7 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
         for (Particle particle : particleEffect.particles) {
             glPushMatrix();
             glTranslatef(particle.position.x, particle.position.y, particle.position.z);
-            applyOrientation();
+            OpenGLUtil.applyBillboardOrientation();
             glScalef(particle.size, particle.size, particle.size);
 
             float light = worldRenderer.getRenderingLightValueAt(new Vector3f(worldPos.x + particle.position.x,
@@ -314,7 +315,7 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
         for (Particle particle : particleEffect.particles) {
             glPushMatrix();
             glTranslatef(particle.position.x, particle.position.y, particle.position.z);
-            applyOrientation();
+            OpenGLUtil.applyBillboardOrientation();
             glScalef(particle.size, particle.size, particle.size);
 
             float light = worldRenderer.getRenderingLightValueAt(new Vector3f(worldPos.x + particle.position.x,
@@ -327,24 +328,7 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
     }
 
 
-    private void applyOrientation() {
-        // Fetch the current modelview matrix
-        final FloatBuffer model = BufferUtils.createFloatBuffer(16);
-        GL11.glGetFloat(GL11.GL_MODELVIEW_MATRIX, model);
 
-        // And undo all rotations and scaling
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 3; j++) {
-                if (i == j) {
-                    model.put(i * 4 + j, 1.0f);
-                } else {
-                    model.put(i * 4 + j, 0.0f);
-                }
-            }
-        }
-
-        GL11.glLoadMatrix(model);
-    }
 
     protected void renderParticle(Particle particle, float light) {
         Material mat = Assets.getMaterial("engine:prog.particle").get();

--- a/engine/src/main/java/org/terasology/network/ClientInfoComponent.java
+++ b/engine/src/main/java/org/terasology/network/ClientInfoComponent.java
@@ -17,6 +17,7 @@
 package org.terasology.network;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
 
 /**
  * The component that marks an entity as being a Client Info Entity.
@@ -34,4 +35,10 @@ public final class ClientInfoComponent implements Component {
      */
     @NoReplicate
     public String playerId;
+
+    /**
+     * Set to the client entity if it is connected, otherwise it is EntityRef.NULL.
+     */
+    @Replicate
+    public EntityRef client = EntityRef.NULL;
 }

--- a/engine/src/main/java/org/terasology/network/internal/AbstractClient.java
+++ b/engine/src/main/java/org/terasology/network/internal/AbstractClient.java
@@ -45,6 +45,10 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public void disconnect() {
+        EntityRef clientInfoEntity = clientEntity.getComponent(ClientComponent.class).clientInfo;
+        ClientInfoComponent clientInfoComp = clientInfoEntity.getComponent(ClientInfoComponent.class);
+        clientInfoComp.client = EntityRef.NULL;
+        clientInfoEntity.saveComponent(clientInfoComp);
         clientEntity.destroy();
     }
 
@@ -68,6 +72,13 @@ public abstract class AbstractClient implements Client {
         if (!clientInfo.exists()) {
             clientInfo = createClientInfoEntity(entityManager);
         }
+        ClientInfoComponent clientInfoComp = clientInfo.getComponent(ClientInfoComponent.class);
+        clientInfoComp.client = clientEntity;
+        clientInfo.saveComponent(clientInfoComp);
+
+        ClientComponent clientComponent = clientEntity.getComponent(ClientComponent.class);
+        clientComponent.clientInfo = clientInfo;
+        clientEntity.saveComponent(clientComponent);
 
         addOrSetColorComponent(clientInfo, color);
 
@@ -76,10 +87,6 @@ public abstract class AbstractClient implements Client {
             String bestAvailableName = findUniquePlayerName(preferredName, entityManager, clientInfo);
             addOrSetDisplayNameComponent(clientInfo, bestAvailableName);
         }
-
-        ClientComponent clientComponent = clientEntity.getComponent(ClientComponent.class);
-        clientComponent.clientInfo = clientInfo;
-        clientEntity.saveComponent(clientComponent);
     }
 
     private void addOrSetColorComponent(EntityRef clientInfo, Color color) {

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -296,7 +296,15 @@ public class BulletPhysics implements PhysicsEngine {
             updateKinematicSettings(entity.getComponent(RigidBodyComponent.class), rigidBody);
             return true;
         } else {
-            newRigidBody(entity);
+            /*
+             * During the destruction of the entity it can happen that the rigged body is already destroyed while
+             * the location component changes.
+             * e.g. because another component that was attached via the LocationComponent gets removed.
+             *
+             * In such a situation it would be wrong to recreate the rigid body as it can't be updated properly after
+             * the destruction of the entity.
+             *
+             */
             return false;
         }
 

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.logic;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.rendering.nui.Color;
+
+/**
+ * Makes the game render the specified text at the current location of the enitity.
+ */
+public class FloatingTextComponent implements Component {
+    public String text;
+    public Color textColor = Color.WHITE;
+    public Color textShadowColor = Color.BLACK;
+}

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -1,0 +1,179 @@
+package org.terasology.rendering.logic;
+
+import com.google.api.client.util.Maps;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.RenderSystem;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.font.Font;
+import org.terasology.rendering.assets.font.FontMeshBuilder;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.assets.mesh.Mesh;
+import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.nui.Color;
+import org.terasology.rendering.nui.HorizontalAlign;
+import org.terasology.rendering.opengl.OpenGLUtil;
+import org.terasology.world.WorldProvider;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glScaled;
+import static org.lwjgl.opengl.GL11.glTranslated;
+
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class FloatingTextRenderer extends BaseComponentSystem implements  RenderSystem {
+
+    private static final int PIXEL_PER_METER = 100;
+
+    private static final float METER_PER_PIXEL= 1.0f / PIXEL_PER_METER;
+
+    @In
+    private EntityManager entityManager;
+
+    @In
+    private AssetManager assetManager;
+
+    @In
+    private WorldProvider worldProvider;
+
+    @In
+    private Camera camera;
+
+    private Font font;
+    private Material underlineMaterial;
+    private Map<EntityRef, Map<Material, Mesh>> entityMeshCache = Maps.newHashMap();
+
+    @Override
+    public void initialise() {
+        this.font = assetManager.getAsset("engine:default", Font.class).get();
+        this.underlineMaterial = assetManager.getAsset("engine:UIUnderline", Material.class).get();
+    }
+
+    private void render(Iterable<EntityRef> floatingTextEntities) {
+        glDisable(GL_DEPTH_TEST);
+
+        Vector3f cameraPosition = camera.getPosition();
+
+        for (EntityRef entity : floatingTextEntities) {
+            LocationComponent location = entity.getComponent(LocationComponent.class);
+            if (location == null) {
+                continue;
+            }
+
+            Vector3f worldPos = location.getWorldPosition();
+            if (!worldProvider.isBlockRelevant(worldPos)) {
+                continue;
+            }
+
+            FloatingTextComponent floatingText = entity.getComponent(FloatingTextComponent.class);
+
+            String text = floatingText.text;
+            Color baseColor = floatingText.textColor;
+            Color shadowColor = floatingText.textShadowColor;
+            boolean underline = false;
+            int textWidth = font.getWidth(text);
+
+            FontMeshBuilder meshBuilder = new FontMeshBuilder(underlineMaterial);
+
+            Map<Material, Mesh> meshMap = entityMeshCache.get(entity);
+            if (meshMap == null) {
+                meshMap = meshBuilder
+                        .createTextMesh(font, Arrays.asList(text), textWidth, HorizontalAlign.CENTER, baseColor,
+                                shadowColor, underline);
+                entityMeshCache.put(entity, meshMap);
+            }
+            glPushMatrix();
+
+
+            glTranslated(worldPos.x - cameraPosition.x, worldPos.y - cameraPosition.y, worldPos.z - cameraPosition.z);
+            OpenGLUtil.applyBillboardOrientation();
+            glScaled(METER_PER_PIXEL, -METER_PER_PIXEL, METER_PER_PIXEL);
+            glTranslated(-(textWidth/2.0), 0.0, 0.0);
+            for (Map.Entry<Material, Mesh> meshMapEntry : meshMap.entrySet()) {
+                Mesh mesh = meshMapEntry.getValue();
+                Material material = meshMapEntry.getKey();
+                material.enable();
+                material.bindTextures();
+                material.setFloat4("croppingBoundaries", Float.MIN_VALUE, Float.MAX_VALUE,
+                        Float.MIN_VALUE, Float.MAX_VALUE);
+                material.setFloat2("offset", 0.0f, 0.0f);
+                material.setFloat("alpha", 1.0f);
+                mesh.render();
+            }
+
+            glPopMatrix();
+        }
+        glEnable(GL_DEPTH_TEST);
+    }
+
+    private void diposeMeshMap(Map<Material, Mesh> meshMap) {
+        for (Map.Entry<Material, Mesh> meshMapEntry : meshMap.entrySet()) {
+            Mesh mesh = meshMapEntry.getValue();
+            mesh.dispose();
+            // Note: Material belongs to font and must not be disposed
+        }
+    }
+
+    @Override
+    public void renderOpaque() {
+    }
+
+    @Override
+    public void renderAlphaBlend() {
+        render(entityManager.getEntitiesWith(FloatingTextComponent.class, LocationComponent.class));
+    }
+
+    @Override
+    public void renderFirstPerson() {
+    }
+
+    @Override
+    public void renderOverlay() {
+    }
+
+    @Override
+    public void renderShadows() {
+    }
+
+    @ReceiveEvent(components = {FloatingTextComponent.class })
+    public void onDisplayNameChange(OnChangedComponent event, EntityRef entity) {
+        disposeCachedMeshOfEntity(entity);
+    }
+
+
+    @ReceiveEvent(components = {FloatingTextComponent.class })
+    public void onNameTagOwnerRemoved(BeforeDeactivateComponent event, EntityRef entity) {
+        disposeCachedMeshOfEntity(entity);
+    }
+
+    private void disposeCachedMeshOfEntity(EntityRef entity) {
+        Map<Material, Mesh> meshMap = entityMeshCache.remove(entity);
+        if (meshMap != null) {
+            diposeMeshMap(meshMap);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        for (Map<Material, Mesh> meshMap: entityMeshCache.values()) {
+            diposeMeshMap(meshMap);
+        }
+        entityMeshCache.clear();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/opengl/OpenGLUtil.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/OpenGLUtil.java
@@ -1,0 +1,41 @@
+package org.terasology.rendering.opengl;
+
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+
+import java.nio.FloatBuffer;
+
+/**
+ * @author Immortius <immortius@gmail.com>
+ * @author Florian <florian@fkoeberle.de>.
+
+ */
+public class OpenGLUtil {
+
+    private OpenGLUtil() {
+        // Utility class, no instance required
+    }
+
+    /**
+     * Removes the rotation and scale part of the current OpenGL matrix.
+     * Can be used to render billboards like particles.
+     */
+    public static void applyBillboardOrientation() {
+        // Fetch the current modelview matrix
+        final FloatBuffer model = BufferUtils.createFloatBuffer(16);
+        GL11.glGetFloat(GL11.GL_MODELVIEW_MATRIX, model);
+
+        // And undo all rotations and scaling
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                if (i == j) {
+                    model.put(i * 4 + j, 1.0f);
+                } else {
+                    model.put(i * 4 + j, 0.0f);
+                }
+            }
+        }
+
+        GL11.glLoadMatrix(model);
+    }
+}


### PR DESCRIPTION
This pull request adds:
* A FloatingTextComponent that can be used to make an entity show a text at it's current location in 3d space
* A NameTagComponent that when added to make it simpler to show a text with a offset over an entity. It uses an entity with a FloatingTextComponent to do that internally.
* A system that uses the NameTagComponents to show name tags over players. 
* A command for renaming users (to test that the name tags update)

The system is currently implemented in the engine, but in future we can move it out into a module. That way it could become possible to implement a different name tag generation rule that also uses the NameTagComponent. e.g. one that shows team name tags.

Also it is possible to replace the NameTagComponent visualization if we wanted to do that as it is an abstraction.