### PR TITLE
Allow widgets inside the browser to still be interacted with

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/ui/BrowserWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/ui/BrowserWidget.java
@@ -41,9 +41,6 @@ public class BrowserWidget extends CoreWidget {
     @Override
     public void onDraw(Canvas canvas) {
         hyperlinkBoxes.clear();
-        if (displayedPage != null) {
-            DocumentRenderer.drawDocumentInRegion(displayedPage, canvas, canvas.getCurrentStyle().getFont(), canvas.getCurrentStyle().getTextColor(), canvas.size(), register);
-        }
         canvas.addInteractionRegion(
                 new BaseInteractionListener() {
                     @Override
@@ -61,6 +58,9 @@ public class BrowserWidget extends CoreWidget {
                         return true;
                     }
                 });
+        if (displayedPage != null) {
+            DocumentRenderer.drawDocumentInRegion(displayedPage, canvas, canvas.getCurrentStyle().getFont(), canvas.getCurrentStyle().getTextColor(), canvas.size(), register);
+        }
     }
 
 


### PR DESCRIPTION
Previously, the BrowserWidget would asume all the interactions done inside regardless if one of its children had an interaction region specified.  This prevented custom widgets rendered inside from showing tooltips and being clicked on.