### PR TITLE
Allow obj meshes without texture coords.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/ObjMeshFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/ObjMeshFormat.java
@@ -69,10 +69,10 @@ public class ObjMeshFormat extends AbstractAssetFileFormat<MeshData> {
             if (data.getVertices() == null) {
                 throw new IOException("No vertices define");
             }
-            //if (data.getNormals() == null || data.getNormals().size() != data.getVertices().size()) {
-            //    throw new IOException("The number of normals does not match the number of vertices.");
-            //}
-            if (data.getTexCoord0() == null || data.getTexCoord0().size() / 2 != data.getVertices().size() / 3) {
+            if (!data.getNormals().isEmpty() && data.getNormals().size() != data.getVertices().size()) {
+                throw new IOException("The number of normals does not match the number of vertices.");
+            }
+            if (!data.getTexCoord0().isEmpty() && data.getTexCoord0().size() / 2 != data.getVertices().size() / 3) {
                 throw new IOException("The number of tex coords does not match the number of vertices.");
             }
 


### PR DESCRIPTION
Meshes without normals were allowed before and still are, but transparency checks seem to fail even for opaque meshes.
