### PR TITLE
Support entity generation for world gens.

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityStore.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityStore.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity;
+
+import com.google.common.collect.Maps;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.MutableComponentContainer;
+import org.terasology.entitySystem.prefab.Prefab;
+
+import java.util.Map;
+
+/**
+ * An entity store provides the ability to set up an entity before creating it.
+ */
+public class EntityStore implements MutableComponentContainer {
+
+    private Map<Class<? extends Component>, Component> components = Maps.newHashMap();
+    private Prefab prefab;
+
+    public EntityStore() {
+        // no prefab
+    }
+
+    /**
+     * @param prefab
+     */
+    public EntityStore(Prefab prefab) {
+        this.prefab = prefab;
+    }
+
+    @Override
+    public boolean hasComponent(Class<? extends Component> component) {
+        return components.keySet().contains(component);
+    }
+
+    @Override
+    public <T extends Component> T getComponent(Class<T> componentClass) {
+        return componentClass.cast(components.get(componentClass));
+    }
+
+    @Override
+    public <T extends Component> T addComponent(T component) {
+        components.put(component.getClass(), component);
+        return component;
+    }
+
+    @Override
+    public void removeComponent(Class<? extends Component> componentClass) {
+        components.remove(componentClass);
+    }
+
+    @Override
+    public void saveComponent(Component component) {
+        components.put(component.getClass(), component);
+    }
+
+    public Prefab getPrefab() {
+        return prefab;
+    }
+
+    @Override
+    public Iterable<Component> iterateComponents() {
+        return components.values();
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ReadyChunkInfo.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ReadyChunkInfo.java
@@ -15,8 +15,12 @@
  */
 package org.terasology.world.chunks.internal;
 
+import java.util.List;
+
 import gnu.trove.list.TIntList;
 import gnu.trove.map.TShortObjectMap;
+
+import org.terasology.entitySystem.entity.EntityStore;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.persistence.ChunkStore;
 import org.terasology.world.chunks.Chunk;
@@ -30,20 +34,27 @@ public class ReadyChunkInfo {
     private ChunkStore chunkStore;
     private Chunk chunk;
     private boolean newChunk;
+    private List<EntityStore> entities;
 
-    public ReadyChunkInfo(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings) {
+    public ReadyChunkInfo(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings, List<EntityStore> entities) {
         this.pos = chunk.getPosition();
         this.blockPositionMapppings = blockPositionMapppings;
         this.newChunk = true;
         this.chunk = chunk;
+        this.entities = entities;
     }
 
-    public ReadyChunkInfo(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings, ChunkStore chunkStore) {
+    public ReadyChunkInfo(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings, ChunkStore chunkStore, List<EntityStore> entities) {
         this.pos = chunk.getPosition();
         this.blockPositionMapppings = blockPositionMapppings;
         this.chunkStore = chunkStore;
         this.newChunk = chunkStore == null;
         this.chunk = chunk;
+        this.entities = entities;
+    }
+
+    public List<EntityStore> getEntities() {
+        return entities;
     }
 
     public Vector3i getPos() {

--- a/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
@@ -71,8 +71,8 @@ public abstract class BaseFacetedWorldGenerator implements WorldGenerator, World
     }
 
     @Override
-    public void createChunk(CoreChunk chunk) {
-        world.rasterizeChunk(chunk);
+    public void createChunk(CoreChunk chunk, EntityBuffer buffer) {
+        world.rasterizeChunk(chunk, buffer);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/generation/EntityBuffer.java
+++ b/engine/src/main/java/org/terasology/world/generation/EntityBuffer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.world.generation;
+
+import org.terasology.entitySystem.entity.EntityStore;
+
+/**
+ * A buffer for {@link EntityStore} instances.
+ */
+public interface EntityBuffer {
+
+    void enqueue(EntityStore entity);
+}

--- a/engine/src/main/java/org/terasology/world/generation/EntityProvider.java
+++ b/engine/src/main/java/org/terasology/world/generation/EntityProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.world.generation;
+
+
+/**
+ * Enqueues prefabs or components in the form to be converted into entities
+ * later in the process of chunk finalization.
+ */
+public interface EntityProvider {
+
+    default void initialize() { }
+
+    void process(Region region, EntityBuffer buffer);
+}

--- a/engine/src/main/java/org/terasology/world/generation/World.java
+++ b/engine/src/main/java/org/terasology/world/generation/World.java
@@ -34,7 +34,7 @@ public interface World {
      */
     int getSeaLevel();
 
-    void rasterizeChunk(CoreChunk chunk);
+    void rasterizeChunk(CoreChunk chunk, EntityBuffer buffer);
 
     /**
      * @return a <b>new</b> set containing all facet classes

--- a/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
@@ -40,6 +40,7 @@ public class WorldBuilder {
     private final List<FacetProvider> providersList = Lists.newArrayList();
     private final Set<Class<? extends WorldFacet>> facetCalculationInProgress = Sets.newHashSet();
     private final List<WorldRasterizer> rasterizers = Lists.newArrayList();
+    private final List<EntityProvider> entityProviders = new ArrayList<>();
     private int seaLevel = 32;
     private Long seed;
 
@@ -56,6 +57,11 @@ public class WorldBuilder {
 
     public WorldBuilder addRasterizer(WorldRasterizer rasterizer) {
         rasterizers.add(rasterizer);
+        return this;
+    }
+
+    public WorldBuilder addEntities(EntityProvider entityProvider) {
+        entityProviders.add(entityProvider);
         return this;
     }
 
@@ -89,7 +95,7 @@ public class WorldBuilder {
             provider.setSeed(seed);
         }
         ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains = determineProviderChains();
-        return new WorldImpl(providerChains, rasterizers, determineBorders(providerChains), seaLevel);
+        return new WorldImpl(providerChains, rasterizers, entityProviders, determineBorders(providerChains), seaLevel);
     }
 
     private Map<Class<? extends WorldFacet>, Border3D> determineBorders(ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains) {

--- a/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
@@ -34,15 +34,18 @@ import com.google.common.collect.Sets;
 public class WorldImpl implements World {
     private final ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains;
     private final List<WorldRasterizer> worldRasterizers;
+    private final List<EntityProvider> entityProviders;
     private final Map<Class<? extends WorldFacet>, Border3D> borders;
     private final int seaLevel;
 
     public WorldImpl(ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains,
                      List<WorldRasterizer> worldRasterizers,
+                     List<EntityProvider> entityProviders,
                      Map<Class<? extends WorldFacet>, Border3D> borders,
                      int seaLevel) {
         this.facetProviderChains = facetProviderChains;
         this.worldRasterizers = worldRasterizers;
+        this.entityProviders = entityProviders;
         this.borders = borders;
         this.seaLevel = seaLevel;
     }
@@ -58,10 +61,13 @@ public class WorldImpl implements World {
     }
 
     @Override
-    public void rasterizeChunk(CoreChunk chunk) {
+    public void rasterizeChunk(CoreChunk chunk, EntityBuffer buffer) {
         Region chunkRegion = getWorldData(chunk.getRegion());
         for (WorldRasterizer rasterizer : worldRasterizers) {
             rasterizer.generateChunk(chunk, chunkRegion);
+        }
+        for (EntityProvider entityProvider : entityProviders) {
+            entityProvider.process(chunkRegion, buffer);
         }
     }
 
@@ -95,6 +101,10 @@ public class WorldImpl implements World {
 
         for (WorldRasterizer rasterizer : worldRasterizers) {
             rasterizer.initialize();
+        }
+
+        for (EntityProvider entityProvider : entityProviders) {
+            entityProvider.initialize();
         }
     }
 }

--- a/engine/src/main/java/org/terasology/world/generation/impl/EntityBufferImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/impl/EntityBufferImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.world.generation.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.terasology.entitySystem.entity.EntityStore;
+import org.terasology.world.generation.EntityBuffer;
+
+/**
+ * A list-based implementation of {@link EntityBuffer}.
+ */
+public class EntityBufferImpl implements EntityBuffer {
+
+    private final List<EntityStore> queue = new ArrayList<>();
+
+    @Override
+    public void enqueue(EntityStore entity) {
+        queue.add(entity);
+    }
+
+    /**
+     * @return an unmodifiable list of all enqueued elements.
+     */
+    public List<EntityStore> getAll() {
+        return Collections.unmodifiableList(queue);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/world/generator/WorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generator/WorldGenerator.java
@@ -21,10 +21,8 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.spawner.FixedSpawner;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generation.EntityBuffer;
 import org.terasology.world.generation.World;
-
-
-import java.util.Optional;
 
 public interface WorldGenerator {
     SimpleUri getUri();
@@ -33,7 +31,7 @@ public interface WorldGenerator {
 
     void setWorldSeed(String seed);
 
-    void createChunk(CoreChunk chunk);
+    void createChunk(CoreChunk chunk, EntityBuffer buffer);
 
     void initialize();
 

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/AbstractBaseWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/AbstractBaseWorldGenerator.java
@@ -25,6 +25,7 @@ import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.nui.Color;
 import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generation.EntityBuffer;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.World;
 import org.terasology.world.generation.WorldFacet;
@@ -37,7 +38,6 @@ import org.terasology.world.generator.WorldGenerator2DPreview;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -92,7 +92,7 @@ public abstract class AbstractBaseWorldGenerator implements WorldGenerator, Worl
     }
 
     @Override
-    public void createChunk(final CoreChunk chunk) {
+    public void createChunk(final CoreChunk chunk, EntityBuffer buffer) {
         for (final ChunkGenerationPass generator : generationPasses) {
             try {
                 generator.generateChunk(chunk);


### PR DESCRIPTION
This is a functional draft/concept that allows world generators to create arbitrary entities. See [this image for an illustration](http://i.imgur.com/pyHC4Ap.png).

The idea is that `EntityProvider` instances can be registered in the world generator. Since entities need to be created on the game thread, the responsible components are first queued in `EntityStore` containers  before they are actually created as part of the chunk finalization process.

One issue is that Prefab components need to be copied and the copy library is part of the `EntityManager`. Thus, prefabs are stored as well.

~~Multiplayer / loading from file storage has not yet been considered well enough.~~

Comments?