### PR TITLE
Update most library versions to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ ext {
     // Lib dir for use in manifest entries etc (like in :engine). A separate "libsDir" exists, auto-created by Gradle
     subDirLibs = 'libs'
 
-    LwjglVersion = '2.9.2'
+    LwjglVersion = '2.9.3'
 }
 
 // Declare remote repositories we're interested in - library files will be fetched from here

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -37,8 +37,8 @@ repositories {
 
 dependencies {
     checkstyle ('com.puppycrawl.tools:checkstyle:6.5')
-    pmd ('net.sourceforge.pmd:pmd-core:5.3.0')
-    pmd ('net.sourceforge.pmd:pmd-java:5.3.0')
+    pmd ('net.sourceforge.pmd:pmd-core:5.3.3')
+    pmd ('net.sourceforge.pmd:pmd-java:5.3.3')
     // the FindBugs version is set in the configuration
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -95,20 +95,20 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'
     compile group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
-    compile group: 'io.netty', name: 'netty', version: '3.10.0.Final'
+    compile group: 'io.netty', name: 'netty', version: '3.10.4.Final'
 
     // Java magic
     compile group: 'net.java.dev.jna', name: 'jna', version: '3.5.2'
     compile group: 'net.java.dev.jna', name: 'platform', version: '3.5.2'
-    compile group: 'org.reflections', name: 'reflections', version: '0.9.9'
-    compile group: 'org.javassist', name: 'javassist', version: '3.19.0-GA'
+    compile group: 'org.reflections', name: 'reflections', version: '0.9.10'
+    compile group: 'org.javassist', name: 'javassist', version: '3.20.0-GA'
     compile group: 'com.esotericsoftware', name: 'reflectasm', version: '1.11.0'
 
     // Graphics, 3D, UI, etc
     compile group: 'org.lwjgl.lwjgl', name: 'lwjgl', version: LwjglVersion
     compile group: 'org.lwjgl.lwjgl', name: 'lwjgl_util', version: LwjglVersion
     compile group: 'java3d', name: 'vecmath', version: '1.3.1' // Note: Downgraded to this release until TeraMath ready
-    compile group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.1'
+    compile group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.2'
     compile group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
     compile group: 'de.matthiasmann.twl', name: 'PNGDecoder', version: '1111'
 
@@ -123,7 +123,7 @@ dependencies {
     // Our developed libs
     compile group: 'org.terasology', name: 'gestalt-module', version: '4.1.2'
     compile group: 'org.terasology', name: 'gestalt-asset-core', version: '4.1.2'
-    compile group: 'org.terasology', name: 'TeraMath', version: '1.1.1-SNAPSHOT'
+    compile group: 'org.terasology', name: 'TeraMath', version: '1.1.2-SNAPSHOT'
     compile group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.0.3'
     compile group: 'org.terasology', name: 'splash-screen', version: '1.0.2'
 
@@ -133,8 +133,8 @@ dependencies {
     // TODO: These could be moved into facade
     compile group: 'org.terasology', name: 'CrashReporter', version: '2.1.0'
 
-    runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
-    runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.9'
+    runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3'
+    runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.12'
 
     // In addition to all the above the dev source set also needs to depend on what gets compiled in main
     devCompile sourceSets.main.output


### PR DESCRIPTION
In order to avoid complications with reflections, the gestalt library dependencies should be updated as well.

An alternative to updating simultaneously would be relying on gestalt including a set of "basic" libraries such as reflections, gson, guava, slf4j.