### PR TITLE
Compose component name for nested classes

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/metadata/MetadataUtil.java
+++ b/engine/src/main/java/org/terasology/entitySystem/metadata/MetadataUtil.java
@@ -29,6 +29,11 @@ public final class MetadataUtil {
 
     public static String getComponentClassName(Class<? extends Component> componentClass) {
         String name = componentClass.getSimpleName();
+        Class<?> outer = componentClass.getEnclosingClass();
+        if (outer != null) {
+            name = outer.getSimpleName() + name;
+        }
+
         int index = name.toLowerCase(Locale.ENGLISH).lastIndexOf("component");
         if (index != -1) {
             return name.substring(0, index);

--- a/engine/src/main/java/org/terasology/reflection/metadata/AbstractClassLibrary.java
+++ b/engine/src/main/java/org/terasology/reflection/metadata/AbstractClassLibrary.java
@@ -20,6 +20,9 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
@@ -39,6 +42,8 @@ import java.util.Set;
  * @author Immortius
  */
 public abstract class AbstractClassLibrary<T> implements ClassLibrary<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractClassLibrary.class);
 
     private ModuleManager moduleManager;
     protected final CopyStrategyLibrary copyStrategyLibrary;
@@ -87,7 +92,10 @@ public abstract class AbstractClassLibrary<T> implements ClassLibrary<T> {
 
         if (metadata != null) {
             classLookup.put(clazz, metadata);
-            uriLookup.put(uri.getObjectName(), uri.getModuleName(), metadata);
+            ClassMetadata<? extends T, ?> prev = uriLookup.put(uri.getObjectName(), uri.getModuleName(), metadata);
+            if (prev != null && !prev.equals(metadata)) {
+                logger.warn("Duplicate entry for '{}': {} and {}", uri, prev.getType(), metadata.getType());
+            }
         }
     }
 


### PR DESCRIPTION
Currently, component names are solely defined by their class names. This can be a problem for world generator configurations. The facet providers' configuration data is attached as a component to the world entity so it can be saved/loaded through the entity system. These names need to be unique - see #1924.

This leads to some rather long names such as `PerlinHillsAndMountainsProvider.PerlinHillsAndMountainsProviderConfiguration`

This PR resolves the issue by adding the enclosing class name (if available) to the component name. The nested class name could then simply be `Configuration` for more than one facet provider.

This PR also adds a warning if two different classes are registered for the same component name.

Closes #1924 