### PR TITLE
Improve support for Canvas FBOs

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
@@ -17,6 +17,7 @@ package org.terasology.engine.subsystem.headless.renderer;
 
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Border;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Quat4f;
@@ -70,7 +71,7 @@ public class HeadlessCanvasRenderer implements CanvasRenderer {
     }
 
     @Override
-    public FrameBufferObject getFBO(ResourceUrn uri, Vector2i region) {
+    public FrameBufferObject getFBO(ResourceUrn uri, BaseVector2i region) {
         return null;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/Canvas.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.nui;
 
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Border;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Quat4f;
@@ -246,7 +247,7 @@ public interface Canvas {
      * @param size the size of the texture.
      * @return A SubRegion, to be closed when no long needed
      */
-    SubRegion subRegionFBO(ResourceUrn uri, Vector2i size);
+    SubRegion subRegionFBO(ResourceUrn uri, BaseVector2i size);
 
     /**
      * When drawOnTop is set to true, subsequent drawing will be on top of everything else.

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -32,6 +32,7 @@ import org.terasology.input.device.MouseDevice;
 import org.terasology.math.Border;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.TeraMath;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
@@ -277,7 +278,7 @@ public class CanvasImpl implements CanvasControl {
     }
 
     @Override
-    public SubRegion subRegionFBO(ResourceUrn uri, Vector2i size) {
+    public SubRegion subRegionFBO(ResourceUrn uri, BaseVector2i size) {
         return new SubRegionFBOImpl(uri, size);
     }
 
@@ -830,7 +831,7 @@ public class CanvasImpl implements CanvasControl {
         private FrameBufferObject fbo;
         private CanvasState previousState;
 
-        private SubRegionFBOImpl(ResourceUrn uri, Vector2i size) {
+        private SubRegionFBOImpl(ResourceUrn uri, BaseVector2i size) {
             previousState = state;
 
             fbo = renderer.getFBO(uri, size);

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasRenderer.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.nui.internal;
 
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Border;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Quat4f;
@@ -44,7 +45,7 @@ public interface CanvasRenderer {
 
     void crop(Rect2i cropRegion);
 
-    FrameBufferObject getFBO(ResourceUrn urn, Vector2i size);
+    FrameBufferObject getFBO(ResourceUrn urn, BaseVector2i size);
 
     void drawMesh(Mesh mesh, Material material, Rect2i drawRegion, Rect2i cropRegion, Quat4f rotation, Vector3f offset, float scale, float alpha);
 

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -30,6 +30,7 @@ import org.terasology.math.MatrixUtils;
 import org.terasology.math.Rect2f;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.TeraMath;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Matrix4f;
 import org.terasology.math.geom.Quat4f;
@@ -104,7 +105,7 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
     private Rect2i requestedCropRegion;
     private Rect2i currentTextureCropRegion;
 
-    private Map<ResourceUrn, FrameBufferObject> fboMap = Maps.newHashMap();
+    private Map<ResourceUrn, LwjglFrameBufferObject> fboMap = Maps.newHashMap();
 
 
     public LwjglCanvasRenderer(Context context) {
@@ -249,9 +250,14 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
     }
 
     @Override
-    public FrameBufferObject getFBO(ResourceUrn urn, Vector2i size) {
-        FrameBufferObject frameBufferObject = fboMap.get(urn);
-        if (frameBufferObject == null) {
+    public FrameBufferObject getFBO(ResourceUrn urn, BaseVector2i size) {
+        LwjglFrameBufferObject frameBufferObject = fboMap.get(urn);
+        if (frameBufferObject == null || !Assets.getTexture(urn).isPresent()) {
+            // If a FBO exists, but no texture, then the texture was disposed
+            // TODO: update fboMap whenever a texture is disposed (or convert FBO instances to assets?)
+            if (frameBufferObject != null) {
+                frameBufferObject.dispose();
+            }
             frameBufferObject = new LwjglFrameBufferObject(urn, size);
             fboMap.put(urn, frameBufferObject);
         }

--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglFrameBufferObject.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglFrameBufferObject.java
@@ -91,6 +91,9 @@ public class LwjglFrameBufferObject implements FrameBufferObject {
         glOrtho(0, Display.getWidth(), Display.getHeight(), 0, 0, 2048f);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
+
+        // reset color mask
+        GL11.glColorMask(true, true, true, true);
     }
 
     @Override
@@ -108,5 +111,12 @@ public class LwjglFrameBufferObject implements FrameBufferObject {
         glOrtho(0, size.x(), size.y(), 0, 0, 2048f);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
+
+        // clear and fill with full alpha, then disable writing alpha values
+        // thus, blending semi-transparent billboards works as expected
+        GL11.glClearColor(0f, 0f, 0f, 1f);
+        GL11.glClear(GL11.GL_COLOR_BUFFER_BIT);
+        GL11.glClearColor(0f, 0f, 0f, 0f);  // reset
+        GL11.glColorMask(true, true, true, false);
     }
 }


### PR DESCRIPTION
This PR updates the implementation of framebuffer objects (FBOs):

* Use nearest neighbor filtering instead of bilinear filtering to avoid ugly borders with scaled textures.
* Use standard viewport rather than inverting the y-axis and adding 1
* Dispose and reload FBO when the linked texture was disposed
* Use an immutable vector to store FBO size.

In both old and current implementation, FBOs are created by `Canvas.subRegionFBO`, but are never disposed. Maybe this could be triggered on texture asset disposal? Or maybe FBOs should be assets, too?

I did not find any usages of the subRegionFBO() method. If there were, they might need tweaks (flip y-axis).