### PR TITLE
Fix tree trunks when the PlantPack module is also enabled.

### DIFF
--- a/modules/Core/assets/blocks/flora/tree/BirchTrunk.block
+++ b/modules/Core/assets/blocks/flora/tree/BirchTrunk.block
@@ -18,7 +18,7 @@
     "basedOn" : "core:wood",
     "displayName": "Birch Log",
     "tiles" : {
-        "topBottom" : "BirchTrunk",
-        "sides" : "BirchBark"
+        "topBottom": "Core:BirchTrunk",
+        "sides": "Core:BirchBark"
     }
 }

--- a/modules/Core/assets/blocks/flora/tree/OakTrunk.block
+++ b/modules/Core/assets/blocks/flora/tree/OakTrunk.block
@@ -25,7 +25,7 @@
     "displayName": "Oak Log",
     // Graphics
     "tiles": {
-        "sides": "OakBark",
-        "topBottom" : "OakTrunk"
+        "sides": "Core:OakBark",
+        "topBottom": "Core:OakTrunk"
     }
 }

--- a/modules/Core/assets/blocks/flora/tree/PineTrunk.block
+++ b/modules/Core/assets/blocks/flora/tree/PineTrunk.block
@@ -18,7 +18,7 @@
     "basedOn" : "core:wood",
     "displayName": "Pine Log",
     "tiles" : {
-        "topBottom" : "PineTrunk",
-        "sides" : "PineBark"
+        "topBottom": "Core:PineTrunk",
+        "sides": "Core:PineBark"
     }
 }


### PR DESCRIPTION
For some reason, when PlantPack is enabled, trees lose their bark.  I still havent figured out why this happens (hoping maybe someone has an insight), but this works around the situation for now.

To test:
1. Create a Core Gameplay game with also the PlantPack enabled
2. Find a tree
3. Despair or rejoice (depending on whether you are testing before or after)