### PR TITLE
Harden EventSystem against failures in modules

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
@@ -437,11 +437,7 @@ public class EventSystemImpl implements EventSystem {
                     params[i + 2] = entity.getComponent(componentParams.get(i));
                 }
                 method.invoke(handler, params);
-            } catch (IllegalAccessException ex) {
-                logger.error("Failed to invoke event", ex);
-            } catch (IllegalArgumentException ex) {
-                logger.error("Failed to invoke event", ex);
-            } catch (InvocationTargetException ex) {
+            } catch (Exception ex) {
                 logger.error("Failed to invoke event", ex);
             }
         }
@@ -509,7 +505,7 @@ public class EventSystemImpl implements EventSystem {
                         PerformanceMonitor.endActivity();
                     }
                 }
-            } catch (IllegalArgumentException ex) {
+            } catch (Exception ex) {
                 logger.error("Failed to invoke event", ex);
             }
         }


### PR DESCRIPTION
Currently, the entire game crashes if a `@ReceiveEvent` method in a module throws an exception.

I think that it should log the exception and continue instead. This leads to improved game experience and is also easier to debug the broken code.