### PR TITLE
Add Updates annotation in facet depencency chain

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/generation/WorldBuilderTest.java
@@ -24,6 +24,8 @@ import org.terasology.world.generation.facets.base.BaseFacet3D;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class WorldBuilderTest {
 
@@ -91,7 +93,37 @@ public class WorldBuilderTest {
         assertEquals(Region3i.createFromMinAndSize(new Vector3i(-4, -1, -4), new Vector3i(9, 3, 9)), facet2.getWorldRegion());
     }
 
+
+    @Test
+    public void testUpdating() {
+        WorldBuilder worldBuilder = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        worldBuilder.setSeed(12);
+        worldBuilder.addProvider(new Facet1Provider());
+        worldBuilder.addProvider(new Facet2Provider());
+        worldBuilder.addProvider(new Facet3Provider());
+        worldBuilder.addProvider(new Facet4Provider());
+        worldBuilder.addProvider(new FacetUpdater());
+
+        Region3i regionToGenerate = Region3i.createFromCenterExtents(new Vector3i(), 1);
+
+        World world;
+        Region regionData;
+
+        // try checking updated facet
+        world = worldBuilder.build();
+        regionData = world.getWorldData(regionToGenerate);
+        assertTrue(regionData.getFacet(Facet1.class).updated);
+        assertTrue(regionData.getFacet(Facet4.class).updated);
+
+        // try checking generated facet
+        world = worldBuilder.build();
+        regionData = world.getWorldData(regionToGenerate);
+        assertNotNull(regionData.getFacet(Facet3.class));
+        assertTrue(regionData.getFacet(Facet4.class).updated);
+    }
+
     public static class Facet1 extends BaseFacet3D {
+        public boolean updated;
         public Facet1(Region3i targetRegion, Border3D border) {
             super(targetRegion, border);
         }
@@ -110,18 +142,16 @@ public class WorldBuilderTest {
     }
 
     public static class Facet4 extends BaseFacet3D {
+        public boolean updated;
         public Facet4(Region3i targetRegion, Border3D border) {
             super(targetRegion, border);
+
         }
     }
 
     @Produces(Facet1.class)
     @Requires(@Facet(value = Facet2.class, border = @FacetBorder(sides = 2)))
     public static class Facet1Provider implements FacetProvider {
-        @Override
-        public void setSeed(long seed) {
-
-        }
 
         @Override
         public void process(GeneratingRegion region) {
@@ -132,10 +162,6 @@ public class WorldBuilderTest {
 
     @Produces(Facet2.class)
     public static class Facet2Provider implements FacetProvider {
-        @Override
-        public void setSeed(long seed) {
-
-        }
 
         @Override
         public void process(GeneratingRegion region) {
@@ -147,10 +173,6 @@ public class WorldBuilderTest {
     @Produces(Facet3.class)
     @Requires(@Facet(value = Facet1.class, border = @FacetBorder(sides = 1)))
     public static class Facet3Provider implements FacetProvider {
-        @Override
-        public void setSeed(long seed) {
-
-        }
 
         @Override
         public void process(GeneratingRegion region) {
@@ -162,15 +184,27 @@ public class WorldBuilderTest {
     @Produces(Facet4.class)
     @Requires(@Facet(value = Facet2.class, border = @FacetBorder(sides = 3)))
     public static class Facet4Provider implements FacetProvider {
-        @Override
-        public void setSeed(long seed) {
-
-        }
 
         @Override
         public void process(GeneratingRegion region) {
             Facet4 facet = new Facet4(region.getRegion(), region.getBorderForFacet(Facet4.class));
             region.setRegionFacet(Facet4.class, facet);
+        }
+    }
+
+    @Requires(@Facet(Facet2.class))
+    @Produces(Facet3.class)
+    @Updates({@Facet(Facet1.class), @Facet(Facet4.class)})
+    public static class FacetUpdater implements FacetProvider {
+
+        @Override
+        public void process(GeneratingRegion region) {
+            Facet3 facet = new Facet3(region.getRegion(), region.getBorderForFacet(Facet3.class));
+            Facet1 facet1 = region.getRegionFacet(Facet1.class);
+            Facet4 facet4 = region.getRegionFacet(Facet4.class);
+            facet1.updated = true;
+            facet4.updated = true;
+            region.setRegionFacet(Facet3.class, facet);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/world/generation/Facet.java
+++ b/engine/src/main/java/org/terasology/world/generation/Facet.java
@@ -30,13 +30,6 @@ public @interface Facet {
     Class<? extends WorldFacet> value();
 
     /**
-     * This allows a facet provider to be ordered after the completion of a facet - this should be used where a provider
-     * uses one or more facets to produce a derivative facet.
-     * @return Whether the facet should be complete before this system is called (for @Requires)
-     */
-    boolean complete() default true;
-
-    /**
      * @return The desired minimum border around the main facet data
      */
     FacetBorder border() default @FacetBorder;

--- a/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
@@ -20,12 +20,15 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -156,7 +159,7 @@ public class WorldBuilder {
 
     private ListMultimap<Class<? extends WorldFacet>, FacetProvider> determineProviderChains() {
         ListMultimap<Class<? extends WorldFacet>, FacetProvider> result = ArrayListMultimap.create();
-        Set<Class<? extends WorldFacet>> facets = Sets.newHashSet();
+        Set<Class<? extends WorldFacet>> facets = new LinkedHashSet<>();
         for (FacetProvider provider : providersList) {
             Produces produces = provider.getClass().getAnnotation(Produces.class);
             if (produces != null) {
@@ -171,6 +174,18 @@ public class WorldBuilder {
         }
         for (Class<? extends WorldFacet> facet : facets) {
             determineProviderChainFor(facet, result);
+            if (logger.isDebugEnabled()) {
+                StringBuilder text = new StringBuilder(facet.getSimpleName());
+                text.append(" --> ");
+                Iterator<FacetProvider> it = result.get(facet).iterator();
+                while (it.hasNext()) {
+                    text.append(it.next().getClass().getSimpleName());
+                    if (it.hasNext()) {
+                        text.append(", ");
+                    }
+                }
+                logger.debug(text.toString());
+            }
         }
 
         return result;
@@ -186,26 +201,47 @@ public class WorldBuilder {
         Set<FacetProvider> orderedProviders = Sets.newLinkedHashSet();
 
         // first add all @Produces facet providers
+        FacetProvider producer = null;
         for (FacetProvider provider : providersList) {
             if (producesFacet(provider, facet)) {
-                Requires requirements = provider.getClass().getAnnotation(Requires.class);
-                if (requirements != null) {
-                    for (Facet requirement : requirements.value()) {
-                        determineProviderChainFor(requirement.value(), result);
-                        orderedProviders.addAll(result.get(requirement.value()));
-                    }
+                if (producer != null) {
+                    logger.warn("Facet already produced by {} and overwritten by {}", producer, provider);
+                }
+                // add all required facets for producing provider
+                for (Facet requirement : requiredFacets(provider)) {
+                    determineProviderChainFor(requirement.value(), result);
+                    orderedProviders.addAll(result.get(requirement.value()));
+                }
+                // add all updated facets for producing provider
+                for (Facet updated : updatedFacets(provider)) {
+                    determineProviderChainFor(updated.value(), result);
+                    orderedProviders.addAll(result.get(updated.value()));
                 }
                 orderedProviders.add(provider);
+                producer = provider;
             }
         }
+
+        if (producer == null) {
+            logger.warn("No facet provider found that produces {}", facet);
+        }
+
         // then add all @Updates facet providers
         for (FacetProvider provider : providersList) {
             if (updatesFacet(provider, facet)) {
-                Requires requirements = provider.getClass().getAnnotation(Requires.class);
-                if (requirements != null) {
-                    for (Facet requirement : requirements.value()) {
-                        determineProviderChainFor(requirement.value(), result);
-                        orderedProviders.addAll(result.get(requirement.value()));
+                // add all required facets for updating provider
+                for (Facet requirement : requiredFacets(provider)) {
+                    determineProviderChainFor(requirement.value(), result);
+                    orderedProviders.addAll(result.get(requirement.value()));
+                }
+                // the provider updates this and other facets
+                // just add producers for the other facets
+                for (Facet updated : updatedFacets(provider)) {
+                    for (FacetProvider fp : providersList) {
+                        // only add @Produces providers to avoid infinite recursion
+                        if (producesFacet(fp, updated.value())) {
+                            orderedProviders.add(fp);
+                        }
                     }
                 }
                 orderedProviders.add(provider);
@@ -213,6 +249,22 @@ public class WorldBuilder {
         }
         result.putAll(facet, orderedProviders);
         facetCalculationInProgress.remove(facet);
+    }
+
+    private Facet[] requiredFacets(FacetProvider provider) {
+        Requires requirements = provider.getClass().getAnnotation(Requires.class);
+        if (requirements != null) {
+            return requirements.value();
+        }
+        return new Facet[0];
+    }
+
+    private Facet[] updatedFacets(FacetProvider provider) {
+        Updates updates = provider.getClass().getAnnotation(Updates.class);
+        if (updates != null) {
+            return updates.value();
+        }
+        return new Facet[0];
     }
 
     private boolean producesFacet(FacetProvider provider, Class<? extends WorldFacet> facet) {


### PR DESCRIPTION
Providers are processed in the order they are added to the WorldBuilder. This ensures deterministic behavior.

Fixes #1912