### PR TITLE
Bring back the previously saved game time when loading a game.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -122,7 +122,7 @@ public class StateLoading implements GameState {
 
         EngineTime time = (EngineTime) context.get(Time.class);
         time.setPaused(true);
-        time.setGameTime(0);
+        time.setGameTime(gameManifest.getTime());
 
         context.get(Game.class).load(gameManifest);
         switch (netMode) {


### PR DESCRIPTION
This also resolves https://github.com/Terasology/EventualSkills/issues/4.

