### PR TITLE
Fix widget size for custom skins

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -345,7 +345,8 @@ public class CanvasImpl implements CanvasControl {
         }
 
         String family = (widget.getFamily() != null) ? widget.getFamily() : state.family;
-        UIStyle elementStyle = state.skin.getStyleFor(family, widget.getClass(), UIWidget.BASE_PART, widget.getMode());
+        UISkin skin = (widget.getSkin() != null) ? widget.getSkin() : state.skin;
+        UIStyle elementStyle = skin.getStyleFor(family, widget.getClass(), UIWidget.BASE_PART, widget.getMode());
         Rect2i region = applyStyleToSize(Rect2i.createFromMinAndSize(Vector2i.zero(), sizeRestrictions), elementStyle);
         try (SubRegion ignored = subRegionForWidget(widget, region, false)) {
             Vector2i preferredSize = widget.getPreferredContentSize(this, elementStyle.getMargin().shrink(sizeRestrictions));


### PR DESCRIPTION
This brings the `calculateRestrictedSize` method in `Canvas` in line with the `drawWidget()` method.
As a result, the size/borders/margins of custom widget skins is computed correctly.

![image](https://cloud.githubusercontent.com/assets/1820007/10170546/a2136990-66d5-11e5-9618-0b5764e4ad19.png)
