### PR TITLE
Add support for custom type handlers

### DIFF
--- a/engine/src/main/java/org/terasology/engine/bootstrap/ClassMetaLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/ClassMetaLibrary.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.engine.bootstrap;
+
+import java.lang.annotation.Annotation;
+
+import org.terasology.module.sandbox.API;
+import org.terasology.naming.Name;
+
+/**
+ * Provides information on available classes.
+ */
+@API
+public interface ClassMetaLibrary {
+
+    /**
+     * @param type The type to find subtypes of
+     * @param <U>  The type to find subtypes of
+     * @param name the name of the name to look for (case-sensitive)
+     * @return An Iterable over all matching subtypes that appear in the module environment
+     */
+    <U> Iterable<Class<? extends U>> getSubtypesOf(Class<U> type, String name);
+
+    /**
+     * @param type The type to find subtypes of
+     * @param <U>  The type to find subtypes of
+     * @return A Iterable over all subtypes of type that appear in the module environment
+     */
+    <U> Iterable<Class<? extends U>> getSubtypesOf(Class<U> type);
+
+    /**
+     * @param annotation The annotation of interest
+     * @return All types in the environment that are either marked by the given annotation, or are subtypes
+     *         of a type marked with the annotation if the annotation is marked as @Inherited
+     */
+    Iterable<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotation);
+
+    /**
+     * Determines the module from which the give class originates from.
+     *
+     * @param type The type to find the module for
+     * @return The module providing the class, or null if it doesn't come from a module.
+     */
+    Name getModuleProviding(Class<?> type);
+}

--- a/engine/src/main/java/org/terasology/engine/bootstrap/ClassMetaLibraryImpl.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/ClassMetaLibraryImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.engine.bootstrap;
+
+import java.lang.annotation.Annotation;
+
+import org.terasology.context.Context;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.naming.Name;
+
+public class ClassMetaLibraryImpl implements ClassMetaLibrary {
+
+    private final ModuleManager moduleManager;
+
+    /**
+     * @param context the context that provides a {@link ModuleManager}.
+     */
+    public ClassMetaLibraryImpl(Context context) {
+        moduleManager = context.get(ModuleManager.class);
+    }
+
+    @Override
+    public <T> Iterable<Class<? extends T>> getSubtypesOf(Class<T> superClass, String typeId) {
+        return moduleManager.getEnvironment().getSubtypesOf(superClass,
+                type -> type.getSimpleName().equals(typeId));
+    }
+
+    @Override
+    public <U> Iterable<Class<? extends U>> getSubtypesOf(Class<U> type) {
+        return moduleManager.getEnvironment().getSubtypesOf(type);
+    }
+
+    @Override
+    public Iterable<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotation) {
+        return moduleManager.getEnvironment().getTypesAnnotatedWith(annotation);
+    }
+
+    @Override
+    public Name getModuleProviding(Class<?> type) {
+        return moduleManager.getEnvironment().getModuleProviding(type);
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/RegisterTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/RegisterTypeHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.persistence.typeHandling;
+
+import org.terasology.module.sandbox.API;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link TypeHandler} to be automatically registered at a
+ * {@link org.terasology.persistence.typeHandling.TypeSerializationLibrary TypeSerializationLibrary} on environment change.
+ * This can be used to (de)serialize custom components.
+ * <p>
+ * By default, the TypeHandler must have an empty constructor.
+ */
+@API
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RegisterTypeHandler {
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/SerializationContext.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/SerializationContext.java
@@ -192,7 +192,7 @@ public interface SerializationContext {
      * @param <T>
      * @return The serialized data
      */
-    <T> PersistedData create(T data, Class<T> type);
+    <T> PersistedData create(T data, Class<? extends T> type);
 
     /**
      * Attempts to serialize the given data using registered an appropriate type handler. Type handlers should take care not to invoke this on the type they

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonSerializationContext.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonSerializationContext.java
@@ -209,7 +209,7 @@ public class GsonSerializationContext implements SerializationContext {
     }
 
     @Override
-    public <T> PersistedData create(T data, Class<T> type) {
+    public <T> PersistedData create(T data, Class<? extends T> type) {
         return new GsonPersistedData(context.serialize(data, type));
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufDeserializationContext.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufDeserializationContext.java
@@ -16,8 +16,11 @@
 package org.terasology.persistence.typeHandling.protobuf;
 
 import com.google.common.collect.Lists;
+
 import org.terasology.persistence.typeHandling.DeserializationContext;
+import org.terasology.persistence.typeHandling.DeserializationException;
 import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 import java.util.List;
@@ -35,7 +38,11 @@ public class ProtobufDeserializationContext implements DeserializationContext {
 
     @Override
     public <T> T deserializeAs(PersistedData data, Class<T> type) {
-        return type.cast(typeSerializationLibrary.getHandlerFor(type).deserialize(data, this));
+        TypeHandler<?> handler = typeSerializationLibrary.getHandlerFor(type);
+        if (handler == null) {
+            throw new DeserializationException("No handler found for " + type);
+        }
+        return type.cast(handler.deserialize(data, this));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufSerializationContext.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufSerializationContext.java
@@ -199,7 +199,7 @@ public class ProtobufSerializationContext implements SerializationContext {
     }
 
     @Override
-    public <T> PersistedData create(T data, Class<T> type) {
+    public <T> PersistedData create(T data, Class<? extends T> type) {
         TypeHandler<T> handler = (TypeHandler<T>) library.getHandlerFor(type);
         return handler.serialize(data, this);
     }


### PR DESCRIPTION
This PR adds the `@RegisterTypeHandler` annotation that allows modules to register custom type handlers.

A simple implementation: [Tasks/TimedTaskTypeHandler](https://github.com/Terasology/Tasks/blob/develop/src/main/java/org/terasology/tasks/persistence/TimedTaskTypeHandler.java)

Delegates to custom implementations, similar to UIFormat: [Tasks/TaskTypeHandler](https://github.com/Terasology/Tasks/blob/develop/src/main/java/org/terasology/tasks/persistence/TaskTypeHandler.java)

