### PR TITLE
Avoid blank player names

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButton.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButton.java
@@ -16,13 +16,12 @@
 package org.terasology.rendering.nui.widgets;
 
 import com.google.common.collect.Lists;
-
 import org.terasology.asset.Assets;
 import org.terasology.audio.StaticSound;
 import org.terasology.input.MouseInput;
 import org.terasology.math.geom.Vector2i;
-import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.assets.font.Font;
+import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
@@ -66,7 +65,7 @@ public class UIButton extends CoreWidget {
 
         @Override
         public boolean onMouseClick(NUIMouseClickEvent event) {
-            if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
+            if (enabled.get() && event.getMouseButton() == MouseInput.MOUSE_LEFT) {
                 down = true;
                 return true;
             }
@@ -75,7 +74,7 @@ public class UIButton extends CoreWidget {
 
         @Override
         public void onMouseRelease(NUIMouseReleaseEvent event) {
-            if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
+            if (enabled.get() && event.getMouseButton() == MouseInput.MOUSE_LEFT) {
                 if (isMouseOver()) {
                     if (getClickSound() != null) {
                         getClickSound().play(getClickVolume());
@@ -110,10 +109,7 @@ public class UIButton extends CoreWidget {
             canvas.drawTexture(image.get());
         }
         canvas.drawText(text.get());
-
-        if (enabled.get()) {
-            canvas.addInteractionRegion(interactionListener);
-        }
+        canvas.addInteractionRegion(interactionListener);
     }
 
     @Override

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -129,5 +129,6 @@
     "water-reflections": "water-reflections",
     "water-reflections-global": "water-reflections-global",
     "water-reflections-sky": "water-reflections-sky",
-    "water-reflections-ssr": "water-reflections-ssr"
+    "water-reflections-ssr": "water-reflections-ssr",
+    "missing-name-message": "missing-name-message"
 }

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -129,5 +129,6 @@
     "water-reflections": "Water Reflections", 
     "water-reflections-global": "Global", 
     "water-reflections-sky": "Sky Only", 
-    "water-reflections-ssr": "SSR (experimental)"
+    "water-reflections-ssr": "SSR (experimental)",
+    "missing-name-message": "You must enter a name"
 }

--- a/engine/src/main/resources/assets/ui/menu/playerMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/playerMenuScreen.ui
@@ -87,26 +87,36 @@
                     "position-bottom" : {
                         "target" : "TOP",
                         "offset" : 32,
-                        "widget" : "close"
+                        "widget": "actionsRow"
                     }
                 }
             },
             {
-                "type" : "UIButton",
-                "text" : "${engine:menu#back}",
-                "id" : "close",
+                "type": "RowLayout",
+                "id": "actionsRow",
+                "horizontalSpacing": 4,
+                "contents": [
+                    {
+                        "type": "UIButton",
+                        "text": "${engine:menu#dialog-ok}",
+                        "id": "ok"
+                    },
+                    {
+                        "type": "UIButton",
+                        "text": "${engine:menu#dialog-cancel}",
+                        "id": "close"
+                    }
+                ],
                 "layoutInfo" : {
+                    "width": 400,
                     "height" : 32,
-                    "width" : 200,
                     "position-horizontal-center" : {},
                     "position-bottom" : {
                         "target" : "BOTTOM",
                         "offset" : 48
                     }
                 }
-
             }
-
         ]
     }
 }


### PR DESCRIPTION
Resolves #1957

- Adds a OK/Cancel button to the player settings screen,  only committing the changes if OK is pressed.
- Adds validation to the player name to not allow blank names.
- Allows buttons to show tooltips even if disabled (so that the validation message could be shown)
- Shows the validation message when hovering over the OK button or player name text box.
- Uses the translation system for the validation message.

![image](https://cloud.githubusercontent.com/assets/5922109/10299939/339b4e68-6ba5-11e5-89e9-1b9f6177ca21.png)
![image](https://cloud.githubusercontent.com/assets/5922109/10299953/4a5c1efc-6ba5-11e5-91a7-88bd6337a7b6.png)
![image](https://cloud.githubusercontent.com/assets/5922109/10299954/4cdaecee-6ba5-11e5-83ce-e30f2bd08573.png)

Controversial things, please comment on:
- Using tooltips for validation messages
- There is no validation message if the mouse is not over the OK button or name text box.
- Tooltips on both text box and button?  or just one?  or none?
