### PR TITLE
Make the download button in the module selection screen also download all required modules

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfirmPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ConfirmPopup.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.widgets.UILabel;
+
+/**
+ * Ask the user to confirm or cancel an action.
+ */
+public class ConfirmPopup extends CoreScreenLayer {
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:confirmPopup!instance");
+
+    private Runnable okHandler;
+
+    @Override
+    public void initialise() {
+        WidgetUtil.trySubscribe(this, "ok",(button) -> {
+            getManager().popScreen();
+            okHandler.run();
+        });
+        WidgetUtil.trySubscribe(this, "cancel", (button) -> getManager().popScreen());
+    }
+
+    public void setMessage(String title, String message) {
+        UILabel titleLabel = find("title", UILabel.class);
+        if (titleLabel != null) {
+            titleLabel.setText(title);
+        }
+
+        UILabel messageLabel = find("message", UILabel.class);
+        if (messageLabel != null) {
+            messageLabel.setText(message);
+        }
+    }
+
+
+    /**
+     * @param runnable will be called when the user clicks okay
+     */
+    public void setOkHandler(Runnable runnable) {
+        this.okHandler = runnable;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
@@ -722,7 +722,21 @@ public class SelectModulesScreen extends CoreScreenLayer {
             if (latestVersion == null) {
                 return true;
             }
-            return onlineVersion.getVersion().compareTo(latestVersion.getVersion()) > 0;
+            int versionCompare = onlineVersion.getVersion().compareTo(latestVersion.getVersion());
+            if (versionCompare > 0) {
+                return true;
+            } else if (versionCompare == 0) {
+                /*
+                 * Multiple binaries get released as the same snapshot version, A version name match thus does not
+                 * gurantee that we have the newest version already if it is a snapshot version.
+                 *
+                 * Having the user redownload the same binary again is not ideal, but it is better then ahving the user
+                 * being stuck on an outdated snapshot binary.
+                 */
+                return onlineVersion.getVersion().isSnapshot();
+            } else {
+                return false;
+            }
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
@@ -360,6 +360,12 @@ public class SelectModulesScreen extends CoreScreenLayer {
 
         LinkedHashMap<URL, Path> urlToTargetMap = determineDownloadUrlsFor(modulesToDownload);
 
+        ConfirmPopup confirmPopup = getManager().pushScreen(ConfirmPopup.ASSET_URI, ConfirmPopup.class);
+        confirmPopup.setMessage("Confirm Download", modulesToDownload.size()  +" modules will be downloaded");
+        confirmPopup.setOkHandler(() -> downloadModules(urlToTargetMap));
+    }
+
+    private void downloadModules(LinkedHashMap<URL, Path> urlToTargetMap) {
         final WaitPopup<List<Path>> popup = getManager().pushScreen(WaitPopup.ASSET_URI, WaitPopup.class);
         ModuleLoader loader = new ModuleLoader(moduleManager.getModuleMetadataReader());
         loader.setModuleInfoPath(TerasologyConstants.MODULE_INFO_FILENAME);
@@ -382,7 +388,6 @@ public class SelectModulesScreen extends CoreScreenLayer {
         progressListener.onProgress(0);
         MultiFileDownloader operation = new MultiFileDownloader(urlToTargetMap, progressListener);
         popup.startOperation(operation, true);
-
     }
 
     private LinkedHashMap<URL, Path> determineDownloadUrlsFor(List<ModuleSelectionInfo> modulesToDownload) {

--- a/engine/src/main/resources/assets/ui/confirmPopup.ui
+++ b/engine/src/main/resources/assets/ui/confirmPopup.ui
@@ -1,0 +1,65 @@
+{
+    "type" : "confirmPopup",
+    "skin" : "messageBox",
+    "contents" : {
+        "type" : "relativeLayout",
+            "contents" : [
+                {
+                    "type" : "UIBox",
+                    "layoutInfo" : {
+                        "width" : 500,
+                        "use-content-height" : true,
+                        "position-horizontal-center" : {},
+                        "position-vertical-center" : {}
+                    },
+                    "content" : {
+                        "type" : "ColumnLayout",
+                        "columns" : 1,
+                        "verticalSpacing" : 8,
+                        "contents" : [
+                            {
+                                "type" : "UILabel",
+                                "text" : "Title",
+                                "id" : "title",
+                                "family" : "title"
+                            },
+                            {
+                                "type" : "UISpace",
+                                "size" : [1, 16]
+                            },
+                            {
+                                "type" : "UILabel",
+                                "text" : "Message",
+                                "id" : "message"
+
+                            },
+                            {
+                                "type" : "UISpace",
+                                "size" : [1, 16]
+                            },
+                            {
+                                "type" : "RowLayout",
+                                "horizontalSpacing" : 4,
+                                "contents" : [
+                                    {
+                                        "type" : "UIButton",
+                                        "text" : "Cancel",
+                                        "id" : "cancel"
+                                    },
+                                    {
+                                        "type" : "UIButton",
+                                        "text" : "Ok",
+                                        "id" : "ok"
+                                    }
+                                ],
+                                "layoutInfo" : {
+                                    "width" : 200,
+                                    "position-right": {}
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+    }
+}


### PR DESCRIPTION
This pull request makes the "Download" button in the module selection screen also download all required modules.

Before the download starts the user is asked to confirm that he indeed wants to download that number of modules.

Only modules that haven't been downloaded in the newest version will be downloaded. If a module is however at a snapshot version it will always be redownloaded, as we can't tell if it has changed or not.