### PR TITLE
Use player coordinates for target localization

### DIFF
--- a/engine/src/main/java/org/terasology/input/cameraTarget/PlayerTargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/PlayerTargetSystem.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.input.cameraTarget;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.logic.players.PlayerTargetChangedEvent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.Physics;
+import org.terasology.registry.In;
+import org.terasology.registry.Share;
+import org.terasology.world.BlockEntityRegistry;
+
+/**
+ * Tracks the targeted entity (within interaction range) of the local player.
+ */
+@RegisterSystem
+@Share(PlayerTargetSystem.class)
+public class PlayerTargetSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+
+    private TargetSystem targetSystem;
+
+    @In
+    private Physics physics;
+
+    @In
+    private BlockEntityRegistry blockRegistry;
+
+    @In
+    private LocalPlayer player;
+
+    @Override
+    public void initialise() {
+        targetSystem = new TargetSystem(blockRegistry, physics);
+    }
+
+    public EntityRef getTarget() {
+        return targetSystem.getTarget();
+    }
+
+    @Override
+    public void update(float delta) {
+        EntityRef charEntity = player.getCharacterEntity();
+        if (charEntity.exists()) {
+            // The camera position is the player's position plus the eye offset
+            Vector3f playerPos = player.getPosition();
+            Vector3f cameraPos = new Vector3f(playerPos);
+            CharacterComponent charComp = charEntity.getComponent(CharacterComponent.class);
+            cameraPos.add(0, charComp.eyeOffset, 0);
+
+            Vector3f dir = player.getViewDirection();
+            float maxDist = charComp.interactionRange;
+            if (targetSystem.updateTarget(cameraPos, dir, maxDist)) {
+                EntityRef oldTarget = targetSystem.getPreviousTarget();
+                EntityRef newTarget = targetSystem.getTarget();
+                charEntity.send(new PlayerTargetChangedEvent(oldTarget, newTarget));
+            }
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.input.cameraTarget;
+
+import java.util.Arrays;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.physics.CollisionGroup;
+import org.terasology.physics.HitResult;
+import org.terasology.physics.Physics;
+import org.terasology.physics.StandardCollisionGroup;
+import org.terasology.world.BlockEntityRegistry;
+
+public class TargetSystem {
+
+    private final BlockEntityRegistry blockRegistry;
+    private final Physics physics;
+
+    private EntityRef target = EntityRef.NULL;
+    private EntityRef prevTarget = EntityRef.NULL;
+
+    private Vector3i targetBlockPos;
+    private CollisionGroup[] filter = {StandardCollisionGroup.DEFAULT, StandardCollisionGroup.WORLD};
+
+    public TargetSystem(BlockEntityRegistry blockRegistry, Physics physics) {
+        this.blockRegistry = blockRegistry;
+        this.physics = physics;
+    }
+
+    public boolean isTargetAvailable() {
+        return target.exists() || targetBlockPos != null;
+    }
+
+    public EntityRef getPreviousTarget() {
+        return prevTarget;
+    }
+
+    public EntityRef getTarget() {
+        return target;
+    }
+
+    public void setFilter(CollisionGroup... filter) {
+        this.filter = Arrays.copyOf(filter, filter.length);
+    }
+
+    public boolean updateTarget(Vector3f pos, Vector3f dir, float maxDist) {
+
+        if (targetBlockPos != null && !target.exists()) {
+            target = blockRegistry.getEntityAt(targetBlockPos);
+        }
+
+        HitResult hitInfo = physics.rayTrace(pos, dir, maxDist, filter);
+
+        EntityRef newTarget = hitInfo.getEntity();
+
+        if (target.equals(newTarget)) {
+            return false;
+        }
+
+        if (hitInfo.isWorldHit()) {
+            targetBlockPos = hitInfo.getBlockPosition();
+        } else {
+            targetBlockPos = null;
+        }
+
+        prevTarget = target;
+        target = newTarget;
+        return true;
+    }
+}
+

--- a/engine/src/main/java/org/terasology/logic/players/PlayerTargetChangedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerTargetChangedEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.logic.players;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * Fired whenever the targeted entity changes (must be within activation range).
+ */
+public class PlayerTargetChangedEvent implements Event {
+    private EntityRef oldTarget;
+    private EntityRef newTarget;
+
+    public PlayerTargetChangedEvent(EntityRef oldTarget, EntityRef newTarget) {
+        this.oldTarget = oldTarget;
+        this.newTarget = newTarget;
+    }
+
+    public EntityRef getOldTarget() {
+        return oldTarget;
+    }
+
+    public EntityRef getNewTarget() {
+        return newTarget;
+    }
+}


### PR DESCRIPTION
This PR adds notification events whenever an entity comes into the local player's interaction range. It decouples the camera system from the player system somewhat by using player coordinates / interaction range instead of camera coordinates.

Demonstration: https://youtu.be/RA5mb7WGSWo

This is quite similar to CameraTargetSystem, which does a few things differently though.
The original camera system is still in use in two situations:

* Compute focal distance for blur effects
* Designate work areas for BehaviorTree-related code.

Sending a ping to @immortius who was talking about a cleaner separation between camera and player already.