### PR TITLE
Allow InjectionHelper to be used in modules.

### DIFF
--- a/engine/src/main/java/org/terasology/registry/CoreRegistry.java
+++ b/engine/src/main/java/org/terasology/registry/CoreRegistry.java
@@ -16,14 +16,12 @@
 package org.terasology.registry;
 
 import org.terasology.context.Context;
-import org.terasology.module.sandbox.API;
 
 /**
  * Registry giving access to major singleton systems, via the interface they fulfil.
  *
  * @author Immortius
  */
-@API
 public final class CoreRegistry {
     private static Context context;
 

--- a/engine/src/main/java/org/terasology/registry/In.java
+++ b/engine/src/main/java/org/terasology/registry/In.java
@@ -16,8 +16,6 @@
 
 package org.terasology.registry;
 
-import org.terasology.module.sandbox.API;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -38,7 +36,6 @@ import java.lang.annotation.Target;
  *
  * @author Immortius
  */
-@API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface In {

--- a/engine/src/main/java/org/terasology/registry/Share.java
+++ b/engine/src/main/java/org/terasology/registry/Share.java
@@ -16,8 +16,6 @@
 
 package org.terasology.registry;
 
-import org.terasology.module.sandbox.API;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -29,7 +27,6 @@ import java.lang.annotation.Target;
  *
  * @author Immortius
  */
-@API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Share {

--- a/engine/src/main/java/org/terasology/registry/package-info.java
+++ b/engine/src/main/java/org/terasology/registry/package-info.java
@@ -14,4 +14,6 @@
  * limitations under the License.
  */
 
-package org.terasology.registry;
+@API package org.terasology.registry;
+
+import org.terasology.module.sandbox.API;


### PR DESCRIPTION
Since all of the classes in the package now are API compatible,  tag the whole package with API.