### PR TITLE
More seamless tooltip functionality for custom widgets

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -30,17 +30,18 @@ import org.terasology.input.MouseInput;
 import org.terasology.input.device.KeyboardDevice;
 import org.terasology.input.device.MouseDevice;
 import org.terasology.math.Border;
-import org.terasology.math.geom.Rect2i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.BaseVector2i;
-import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Rect2i;
+import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.assets.font.Font;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.Mesh;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureRegion;
+import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Color;
 import org.terasology.rendering.nui.HorizontalAlign;
 import org.terasology.rendering.nui.InteractionListener;
@@ -394,12 +395,20 @@ public class CanvasImpl implements CanvasControl {
             if (element.isSkinAppliedByCanvas()) {
                 drawBackground();
                 try (SubRegion withMargin = subRegionForWidget(element, newStyle.getMargin().shrink(Rect2i.createFromMinAndSize(Vector2i.zero(), regionArea.size())), false)) {
-                    element.onDraw(this);
+                    drawStyledWidget(element);
                 }
             } else {
-                element.onDraw(this);
+                drawStyledWidget(element);
             }
         }
+    }
+
+    private void drawStyledWidget(UIWidget element) {
+        if (element.getTooltip() != null) {
+            // Integrated tooltip support - without this, setting a tooltip value does not make a tooltip work unless an interaction listener is explicitly added by the widget.
+            addInteractionRegion(new BaseInteractionListener());
+        }
+        element.onDraw(this);
     }
 
     private SubRegion subRegionForWidget(UIWidget widget, Rect2i region, boolean crop) {


### PR DESCRIPTION
The main meat of this is adding a base implementation of onDraw into AbstractWidget.  This allows tooltips to be displayed even if there is no other interaction region added from the subclass.  Without this, it becomes confusing why setting a tooltip on your custom widget does by default show a tooltip until you also add an interaction region.

The UIButton is back to its former self by not adding an interaction region when it is disabled.  Tooltips on a disabled buttons now happen naturally and no longer need this special treatment.

The other noise in here is getting all other widgets to call this base onDraw method.  There could be controversy on whether it is actually needed on the everything.  I did the everything for completeness sake without regard to usefulness.  Advice welcomed on any additional strategy.