### PR TITLE
Use Noto font for screen titles

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/InputSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/InputSettingsScreen.java
@@ -147,7 +147,7 @@ public class InputSettingsScreen extends CoreScreenLayer {
                 VerticalHint.create().fixedHeight(48).alignTopRelativeTo("title", VerticalAlign.BOTTOM));
         layout.addWidget(area,
                 HorizontalHint.create().fixedWidth(640).center(),
-                VerticalHint.create().alignTopRelativeTo("subtitle", VerticalAlign.BOTTOM).alignBottomRelativeTo("footer", VerticalAlign.TOP, 48));
+                VerticalHint.create().alignTopRelativeTo("subtitle", VerticalAlign.BOTTOM, 16).alignBottomRelativeTo("footer", VerticalAlign.TOP, 48));
         layout.addWidget(footerGrid,
                 HorizontalHint.create().center().fixedWidth(400),
                 VerticalHint.create().fixedHeight(48).alignBottom(48));

--- a/engine/src/main/resources/assets/skins/mainmenu.skin
+++ b/engine/src/main/resources/assets/skins/mainmenu.skin
@@ -43,7 +43,7 @@
             "font" : "NotoSans-Bold"
         },
         "heading-input": {
-            "font": "title",
+            "font": "NotoSans-Regular-Large",
             "text-align-horizontal": "left"
         },
         "left-label": {

--- a/engine/src/main/resources/assets/skins/mainmenu.skin
+++ b/engine/src/main/resources/assets/skins/mainmenu.skin
@@ -32,7 +32,8 @@
             }
         },
         "title": {
-            "font": "title"
+            "font": "NotoSans-Regular-Large",
+            "text-color": "F0F0F0FF"
         },
         "error": {
             "text-color": "FF4444FF"

--- a/engine/src/main/resources/assets/ui/menu/createGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/createGameScreen.ui
@@ -28,7 +28,6 @@
                     "position-horizontal-center" : {},
                     "position-top" : {
                         "target" : "BOTTOM",
-                        "offset" : 16,
                         "widget" : "title"
                     }
                 }

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -28,18 +28,19 @@
                         "position-horizontal-center" : {},
                         "position-top" : {
                             "target" : "BOTTOM",
-                            "offset" : 16,
                             "widget" : "title"
                         }
                     }
                 },
                 {
                     "type" : "UIBox",
+                    "id" : "container",
                     "layoutInfo" : {
                         "width" : 600,
                         "position-horizontal-center" : {},
                         "position-top" : {
                             "target" : "BOTTOM",
+                            "offset" : 16,
                             "widget" : "subtitle"
                         },
                         "position-bottom" : {
@@ -59,8 +60,8 @@
                         "width" : 584,
                         "position-horizontal-center" : {},
                         "position-top" : {
-                            "target" : "BOTTOM",
-                            "widget" : "subtitle",
+                            "target" : "TOP",
+                            "widget" : "container",
                             "offset" : 8
                         },
                         "position-bottom" : {

--- a/engine/src/main/resources/assets/ui/menu/previewWorldScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/previewWorldScreen.ui
@@ -28,18 +28,19 @@
                     "position-horizontal-center" : {},
                     "position-top" : {
                         "target" : "BOTTOM",
-                        "offset" : 16,
                         "widget" : "title"
                     }
                 }
             },
             {
                 "type" : "UIBox",
+                "id" : "container",
                 "layoutInfo" : {
                     "width" : 720,
                     "position-horizontal-center" : {},
                     "position-top" : {
                         "target" : "BOTTOM",
+                        "offset" : 16,
                         "widget" : "subtitle"
                     },
                     "position-bottom" : {
@@ -59,8 +60,8 @@
                     "width" : 704,
                     "position-horizontal-center" : {},
                     "position-top" : {
-                        "target" : "BOTTOM",
-                        "widget" : "subtitle",
+                        "target" : "TOP",
+                        "widget" : "container",
                         "offset" : 8
                     },
                     "position-bottom" : {

--- a/engine/src/main/resources/assets/ui/menu/selectGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectGameScreen.ui
@@ -28,7 +28,6 @@
                     "position-horizontal-center" : {},
                     "position-top" : {
                         "target" : "BOTTOM",
-                        "offset" : 16,
                         "widget" : "title"
                     }
                 }
@@ -44,6 +43,7 @@
                     "position-horizontal-center" : {},
                     "position-top" : {
                         "target" : "BOTTOM",
+                        "offset" : 16,
                         "widget" : "subtitle"
                     },
                     "position-bottom" : {

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -28,18 +28,19 @@
                         "position-horizontal-center" : {},
                         "position-top" : {
                             "target" : "BOTTOM",
-                            "offset" : 16,
                             "widget" : "title"
                         }
                     }
                 },
                 {
                     "type" : "UIBox",
+                    "id" : "container",
                     "layoutInfo" : {
                         "width" : 600,
                         "position-horizontal-center" : {},
                         "position-top" : {
                             "target" : "BOTTOM",
+                            "offset" : 16,
                             "widget" : "subtitle"
                         },
                         "position-bottom" : {
@@ -58,8 +59,8 @@
                         "width" : 584,
                         "position-horizontal-center" : {},
                         "position-top" : {
-                            "target" : "BOTTOM",
-                            "widget" : "subtitle",
+                            "target" : "TOP",
+                            "widget" : "container",
                             "offset" : 8
                         },
                         "position-bottom" : {


### PR DESCRIPTION
This PR replaces the obsolete `title` font with the (larger) Noto font. The difference in rendered size made a few adjustments necessary.

All subtitles should be at the same vertical position.

I guess we could remove the two obsolete fonts `default` and `title` now.

Fixes #2029