### PR TITLE
Rename gradle run task for shader editor

### DIFF
--- a/facades/TeraEd/build.gradle
+++ b/facades/TeraEd/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'application'
 // The Editor facade is responsible for the (shader) editor - a plain Java application runnable on PCs
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config
@@ -8,13 +7,32 @@ apply from: "$rootDir/config/gradle/artifactory.gradle"
 version = project(':engine').version
 println "TeraEd VERSION: $version"
 
-mainClassName = 'org.terasology.editor.TeraEd'
-
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.facades'
 
 dependencies {
     compile project(':engine')
+}
+
+task runEditor(type:JavaExec) {
+    description = "Run 'TeraEd' to configure graphics shader parameters in a standard PC application"
+
+    // Dependencies: natives + all modules & the PC facade itself (which will trigger the engine)
+    dependsOn rootProject.extractNatives
+    dependsOn rootProject.moduleClasses
+    dependsOn classes
+
+    // Run arguments
+    main = 'org.terasology.editor.TeraEd'
+    workingDir = rootDir
+    String[] runArgs = ["-homedir"]
+    args runArgs
+
+    // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
+    classpath sourceSets.main.output.classesDir
+    classpath sourceSets.main.output.resourcesDir
+    classpath project(':engine').sourceSets.main.output.classesDir
+    classpath project(':engine').configurations.runtime
 }
 
 // Prep an IntelliJ module for the facade


### PR DESCRIPTION
This is a more of a workaround rather than a proper fix. Maybe we should file a feature request over at gradle?

Adapted from http://stackoverflow.com/questions/28728488/rename-gradle-task

Fixes #2045 