### PR TITLE
Add utility to extract default key bindings from code

### DIFF
--- a/engine-tests/src/test/java/org/terasology/documentation/BindingScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/BindingScraper.java
@@ -1,0 +1,52 @@
+
+package org.terasology.documentation;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.input.DefaultBinding;
+import org.terasology.input.Input;
+import org.terasology.input.InputType;
+import org.terasology.input.RegisterBindButton;
+import org.terasology.testUtil.ModuleManagerFactory;
+
+import com.google.common.collect.TreeBasedTable;
+
+/**
+ * Enumerates all default key bindings and writes them sorted by ID to the console
+ */
+public class BindingScraper
+{
+    /**
+     * @param args (ignored)
+     * @throws Exception if the module environment cannot be loaded
+     */
+    public static void main(String[] args) throws Exception {
+        ModuleManager moduleManager = ModuleManagerFactory.create();
+
+        TreeBasedTable<String, Input, String> keyTable = TreeBasedTable.create(
+                String.CASE_INSENSITIVE_ORDER,
+                (i1, i2) -> Integer.compare(i1.getId(), i2.getId()));
+
+        for (Class<?> buttonEvent : moduleManager.getEnvironment().getTypesAnnotatedWith(RegisterBindButton.class)) {
+            DefaultBinding defBinding = buttonEvent.getAnnotation(DefaultBinding.class);
+            if (defBinding != null) {
+                if (defBinding.type() == InputType.KEY) {
+                    Input input = InputType.KEY.getInput(defBinding.id());
+
+                    RegisterBindButton info = buttonEvent.getAnnotation(RegisterBindButton.class);
+                    keyTable.put(info.category(), input, info.description());
+                }
+            }
+        }
+
+        for (String row : keyTable.rowKeySet()) {
+            System.out.println("# " + row);
+            for (Entry<Input, String> entry : keyTable.row(row).entrySet()) {
+                System.out.println("`" + entry.getKey().getDisplayName() + "` : " + entry.getValue());
+            }
+        }
+    }
+}


### PR DESCRIPTION
In response to #1975 item no. 2 - this snippet scapes all default key bindings from the code in engine.

It currently produces the following output:

`1` : Toolbar Slot 1
`2` : Toolbar Slot 2
`3` : Toolbar Slot 3
`4` : Toolbar Slot 4
`5` : Toolbar Slot 5
`6` : Toolbar Slot 6
`7` : Toolbar Slot 7
`8` : Toolbar Slot 8
`9` : Toolbar Slot 9
`0` : Toolbar Slot 10
`Q` : Drop Item
`W` : Forwards
`E` : Use Target
`I` : Open Inventory
`Left Ctrl` : Crouch / Descend
`A` : Strafe Left
`S` : Backwards
`D` : Strafe Right
`Left Shift` : Toggle Speed Temporarily
`Space` : Jump / Ascend
`Caps Lock` : Toggle Speed Permanently
`F5` : Toggle Behavior editor
# general
`Escape` : Ingame Menu
`Tab` : Show online players
`T` : Toggle Chat
`H` : Hide HUD
`Grave` : Toggle Console
`Home` : Increase View Distance
`End` : Decrease View Distance