### PR TITLE
Use CodeMetric config 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     natives group: 'org.lwjgl.lwjgl', name: 'lwjgl', version: LwjglVersion
 
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
-    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.0.0', ext: 'zip'
+    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.1.0', ext: 'zip'
 }
 
 task extractWindowsNatives(type:Sync) {


### PR DESCRIPTION
The most significant change in 1.1.0 is that `@author` tags are now flagged.