### PR TITLE
Terminate on dying task processors

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -367,7 +367,7 @@ public class TerasologyEngine implements GameEngine {
             changeState(initialState);
 
             mainLoop(); // -THE- MAIN LOOP. Most of the application time and resources are spent here.
-        } catch (RuntimeException e) {
+        } catch (Throwable e) {
             logger.error("Uncaught exception, attempting clean game shutdown", e);
             throw e;
         } finally {

--- a/engine/src/main/java/org/terasology/utilities/concurrency/TaskProcessor.java
+++ b/engine/src/main/java/org/terasology/utilities/concurrency/TaskProcessor.java
@@ -18,6 +18,7 @@ package org.terasology.utilities.concurrency;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.GameThread;
 import org.terasology.monitoring.ThreadActivity;
 import org.terasology.monitoring.ThreadMonitor;
 
@@ -57,6 +58,10 @@ final class TaskProcessor<T extends Task> implements Runnable {
             } catch (RuntimeException e) {
                 ThreadMonitor.addError(e);
                 logger.error("Error in thread {}", Thread.currentThread().getName(), e);
+            } catch (Error e) {
+                GameThread.asynch(() -> {
+                    throw e;  // re-throw on game thread to terminate the entire application
+                });
             }
         }
         logger.debug("Thread shutdown safely");


### PR DESCRIPTION
Currently, uncaught errors in `TaskProcessor` are forwarded to the thread's default `UncaughtExceptionHandler`, which just prints the stack trace.

As a result, the threads die silently and game stalls while waiting for chunks.

The change in `TerasologyEngine` fixes the missing stacktrace/error report in the log file.
The change in `TaskProcessor` looks awful, but it seems to be the cleanest way to terminate.

Since the `LocalChunkProvider` is disposed only when leaving the game, it still does not get disposed in that situation leaving the other thread pools alive.

PR #1760 would actually fix this issue, because the `ThreadPoolSubsystem` is disposed properly.

Related/partly fixed: #2066 and https://github.com/MovingBlocks/CrashReporter/issues/23