### PR TITLE
Dump all classes that are annotated with @API

### DIFF
--- a/engine-tests/src/test/java/org/terasology/documentation/ApiScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/ApiScraper.java
@@ -1,0 +1,38 @@
+
+package org.terasology.documentation;
+
+import java.net.URL;
+
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.module.ModuleEnvironment;
+import org.terasology.module.sandbox.API;
+import org.terasology.testUtil.ModuleManagerFactory;
+
+/**
+ * Enumerates all classes and packages that are annotated with {@link API}.
+ */
+public class ApiScraper
+{
+    /**
+     * @param args (ignored)
+     * @throws Exception if the module environment cannot be loaded
+     */
+    public static void main(String[] args) throws Exception {
+        ModuleManager moduleManager = ModuleManagerFactory.create();
+        ModuleEnvironment environment = moduleManager.getEnvironment();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        for (Class<?> apiClass : environment.getTypesAnnotatedWith(API.class)) {
+            if (apiClass.isSynthetic()) {
+                // This is a package-info
+                String pkgName = apiClass.getPackage().getName();
+                URL url = classLoader.getResource(pkgName.replace('.', '/'));
+                if (url.getProtocol().equals("file")) {
+                    System.out.println("Package: " + pkgName);
+                }
+            } else {
+                System.out.println("Class: " + apiClass);
+            }
+        }
+    }
+}


### PR DESCRIPTION
A follow-up for #2051 that doesn't have too much value as it is now. It could be converted into a Gradle task or extended to also parse or test for JavaDoc comments ([DocLets](https://docs.oracle.com/javase/6/docs/technotes/guides/javadoc/doclet/overview.html)).

Moreover, the package/source file names can be fed to the JavaDoc command line to generate documentation only for `@API` annotated classes:

http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#processingofsourcefiles

@Cervator let me know how you want to proceed.