### PR TITLE
Move debug key to F2 (console now F1 and `) and tweak at doc/utility about double-bound keys

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -86,12 +86,12 @@ Note: Keys between the latest stable and latest develop build may differ.
 * [B] - Show infinite block inventory (requires "BlockPicker" module active)
 * [H] - Hide user interface
 * [T] - Toggle chat interface (effectively a mini-console that only does chat)
-* [`] - Toggle full developer console (the "grave" key, above tab)
 * [Tab] - Auto-completion in the console
 * [Home] - Increase viewing distance
 * [End] - Decrease viewing distance
 * [Escape] - Show/hide the game menu screen
-* [F1] - Toggle window focus and reveals a debug pane (only contains stuff if module(s) using it is enabled)
+* [`] OR [F1] - Toggle full developer console (the "grave" key, usually above tab)
+* [F2] - Toggle window focus and reveals a debug pane (only contains stuff if module(s) using it is enabled)
 * [F3] - Toggle debug mode and information
 * [F5] - Show behavior tree editor
 * [F12] - Take screenshot (goes to /screenshots in game data dir)
@@ -277,7 +277,7 @@ Apologies in advance for any omissions, contact [Cervator](http://forum.terasolo
 Contributors
 --------
 
-(Listed by primary team)
+(Listed by primary team in roughly chronological order)
 
 * Architects: Benjamin 'begla' Glatzel, Immortius, Kai Kratz, Andre Herber, Panserbjoern, MarcinSc, Synopia, Xanhou, mkienenb, Gimpanse / shartte, Flo_K, emanuele3d
 * Art Team: Glasz, A'nW, basilix, Double_A, eleazzaar, metouto, Perdemot, RampageMode, SuperSnark, Wolfghard, zproc, ChrisK, Maternal
@@ -285,7 +285,7 @@ Contributors
 * General: Janred, Josh, Stuthulhu, t3hk0d3, AbraCadaver, ahoehma, Brokenshakles, DizzyDragon / LinusVanElswijk, esereja, NowNewStart, pencilcheck, sdab, hagish, Philius342, temsa, nitrix, R41D3NN, Aperion, ilgarma, mcourteaux, philip-wernersbach, Xeano, Jamoozy, sdab, zriezenman, NanjoW, SleekoNiko, Eliwood, nh_99, jobernolte, emenifee, socram8888, dataupload, UltimateBudgie, maym86, aldoborrero, PrivateAlpha, CruzBishop, JoeClacks, Nate-Devv, Member1221, Jtsessions, porl, jacklin213, meniku, GeckoTheGeek42, IWhoI, Calinou, Limeth, KokPok, unpause, qreeves, Rui914, OvermindDL1, prestidigitator, chessandgo, gtugablue, sk0ut, Netopya, andrelago13, sergiomieic, MaloJaffre 
 * GUI Team: Anton "small-jeeper" Kireev, miniME89, x3ro, Halamix2
 * Logistics Team: AlbireoX, Mathias Kalb, Richard "rapodaca" Apodaca, Stellarfirefly, mkalb, MrBarsack, Philaxx, 3000Lane, MiJyn, neoascetic
-* World Team: bi0hax, ddr2, Nym Traveel, Skaldarnar, Tenson, Laurimann, MPratt, msteiger, Josharias
+* World Team: bi0hax, ddr2, Nym Traveel, Skaldarnar, Tenson, Laurimann, MatthewPratt, msteiger, Josharias
 
 Soundtrack and Sound Effects
 --------

--- a/engine-tests/src/test/java/org/terasology/documentation/BindingScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/BindingScraper.java
@@ -1,24 +1,42 @@
-
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.terasology.documentation;
 
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeMap;
-
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.TreeBasedTable;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.input.DefaultBinding;
+import org.terasology.input.DefaultBindings;
 import org.terasology.input.Input;
 import org.terasology.input.InputType;
 import org.terasology.input.RegisterBindButton;
 import org.terasology.testUtil.ModuleManagerFactory;
 
-import com.google.common.collect.TreeBasedTable;
+import java.util.Map.Entry;
 
 /**
  * Enumerates all default key bindings and writes them sorted by ID to the console
  */
-public class BindingScraper
-{
+public final class BindingScraper {
+
+    private BindingScraper() {
+        // Utility class, no instances
+    }
+
     /**
      * @param args (ignored)
      * @throws Exception if the module environment cannot be loaded
@@ -26,26 +44,52 @@ public class BindingScraper
     public static void main(String[] args) throws Exception {
         ModuleManager moduleManager = ModuleManagerFactory.create();
 
+        // Holds normal input mappings where there is only one key
         TreeBasedTable<String, Input, String> keyTable = TreeBasedTable.create(
                 String.CASE_INSENSITIVE_ORDER,
                 (i1, i2) -> Integer.compare(i1.getId(), i2.getId()));
 
+        // Holds input mappings that have both a primary and secondary key
+        SetMultimap<String, String> multiKeys = HashMultimap.create();
+
         for (Class<?> buttonEvent : moduleManager.getEnvironment().getTypesAnnotatedWith(RegisterBindButton.class)) {
             DefaultBinding defBinding = buttonEvent.getAnnotation(DefaultBinding.class);
+            RegisterBindButton info = buttonEvent.getAnnotation(RegisterBindButton.class);
             if (defBinding != null) {
+                // This handles bindings with just one key
                 if (defBinding.type() == InputType.KEY) {
                     Input input = InputType.KEY.getInput(defBinding.id());
-
-                    RegisterBindButton info = buttonEvent.getAnnotation(RegisterBindButton.class);
                     keyTable.put(info.category(), input, info.description());
+                }
+            } else {
+                // See if there is a multi-mapping for this button
+                DefaultBindings[] multiBinding = buttonEvent.getAnnotationsByType(DefaultBindings.class);
+
+                // Annotation math magic. We're expecting a DefaultBindings containing one DefaultBinding pair
+                if (multiBinding != null && multiBinding.length == 1 && multiBinding[0].value().length == 2) {
+                    String primaryKey = InputType.KEY.getInput(multiBinding[0].value()[0].id()).getDisplayName();
+                    String secondaryKey = InputType.KEY.getInput(multiBinding[0].value()[1].id()).getDisplayName();
+                    multiKeys.put(info.category(), "`" + primaryKey + "` OR `" + secondaryKey + "` : " + info.description());
                 }
             }
         }
 
         for (String row : keyTable.rowKeySet()) {
-            System.out.println("# " + row);
+            // Print the category. Some keys may not have one, group those as uncategorized
+            if (row.equals("")) {
+                System.out.println("# Uncategorized");
+            } else {
+                System.out.println("# " + row);
+            }
+
+            // Print the single-key bindings
             for (Entry<Input, String> entry : keyTable.row(row).entrySet()) {
                 System.out.println("`" + entry.getKey().getDisplayName() + "` : " + entry.getValue());
+            }
+
+            // Print the multi-key bindings
+            for (String multiKey : multiKeys.get(row)) {
+                System.out.println(multiKey);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -182,13 +182,11 @@ public final class BindsConfig {
 
     private void addBind(Name moduleName, Class<?> buttonEvent, RegisterBindButton info) {
         List<Input> defaultInputs = Lists.newArrayList();
-        for (Annotation annotation : buttonEvent.getAnnotations()) {
-            if (annotation instanceof DefaultBinding) {
-                DefaultBinding defaultBinding = (DefaultBinding) annotation;
-                Input input = defaultBinding.type().getInput(defaultBinding.id());
-                if (!data.values().contains(input)) {
-                    defaultInputs.add(input);
-                }
+        for (Annotation annotation : buttonEvent.getAnnotationsByType(DefaultBinding.class)) {
+            DefaultBinding defaultBinding = (DefaultBinding) annotation;
+            Input input = defaultBinding.type().getInput(defaultBinding.id());
+            if (!data.values().contains(input)) {
+                defaultInputs.add(input);
             }
         }
         SimpleUri bindUri = new SimpleUri(moduleName, info.id());

--- a/engine/src/main/java/org/terasology/input/DefaultBindings.java
+++ b/engine/src/main/java/org/terasology/input/DefaultBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.terasology.input;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Repeatable(DefaultBindings.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface DefaultBinding {
-    InputType type();
-
-    int id();
+public @interface DefaultBindings {
+    DefaultBinding[] value();
 }

--- a/engine/src/main/java/org/terasology/input/binds/general/ConsoleButton.java
+++ b/engine/src/main/java/org/terasology/input/binds/general/ConsoleButton.java
@@ -26,5 +26,6 @@ import org.terasology.input.RegisterBindButton;
  */
 @RegisterBindButton(id = "console", description = "Toggle Console", category = "general")
 @DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.GRAVE)
+@DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.F1)
 public class ConsoleButton extends BindButtonEvent {
 }

--- a/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
@@ -135,6 +135,7 @@ public class DebugControlSystem extends BaseComponentSystem {
             switch (event.getKey().getId()) {
                 case Keyboard.KeyId.K:
                     entity.send(new DoDamageEvent(9999, null));
+                    //TODO: Seems to be broken, which is probably not a terrible thing ... remove?
                     break;
                 case Keyboard.KeyId.F6:
                     config.getRendering().getDebug().setEnabled(!config.getRendering().getDebug().isEnabled());
@@ -159,7 +160,7 @@ public class DebugControlSystem extends BaseComponentSystem {
         }
 
         switch (event.getKey().getId()) {
-            case Keyboard.KeyId.F1:
+            case Keyboard.KeyId.F2:
                 mouseGrabbed = !mouseGrabbed;
                 DebugProperties debugProperties = (DebugProperties) nuiManager.getHUD().getHUDElement("engine:DebugProperties");
                 debugProperties.setVisible(!mouseGrabbed);

--- a/engine/src/main/resources/default.cfg
+++ b/engine/src/main/resources/default.cfg
@@ -9,43 +9,6 @@
     "writeSaveGamesEnabled": true
   },
   "input": {
-    "binds": {
-      "engine": {
-        "attack": "mouse_left",
-        "backwards": "key_s",
-        "behavior_editor": "key_f5",
-        "chat": "key_t",
-        "console": "key_grave",
-        "crouch": "key_lcontrol",
-        "decreaseViewDistance": "key_end",
-        "dropItem": "key_q",
-        "forwards": "key_w",
-        "frob": "key_e",
-        "hideHUD": "key_h",
-        "increaseViewDistance": "key_home",
-        "inventory": "key_i",
-        "jump": "key_space",
-        "left": "key_a",
-        "pause": "key_escape",
-        "right": "key_d",
-        "showOnlinePlayers": "key_tab",
-        "toggleSpeedPermanently": "key_capital",
-        "toggleSpeedTemporarily": "key_lshift",
-        "toolbarNext": "wheel_up",
-        "toolbarPrev": "wheel_down",
-        "toolbarSlot0": "key_1",
-        "toolbarSlot1": "key_2",
-        "toolbarSlot2": "key_3",
-        "toolbarSlot3": "key_4",
-        "toolbarSlot4": "key_5",
-        "toolbarSlot5": "key_6",
-        "toolbarSlot6": "key_7",
-        "toolbarSlot7": "key_8",
-        "toolbarSlot8": "key_9",
-        "toolbarSlot9": "key_0",
-        "useItem": "mouse_right"
-      }
-    },
     "mouseSensitivity": 0.075,
     "mouseYAxisInverted": false
   },


### PR DESCRIPTION
Making PR just for documentation purposes to not miss the switch for the debug system from F1 to F2 and to highlight console now being *both* the grave key and F1.