### PR TITLE
Decouple the selected inventory slot from the player systems

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -86,10 +86,6 @@ public final class CharacterComponent implements Component {
     @Replicate(FieldReplicateType.SERVER_TO_OWNER)
     public EntityRef controller = EntityRef.NULL;
 
-    // What inventory slot the character has selected (this currently also determines held item, will need to review based on gameplay)
-    public int selectedItem;
-    public float handAnimation;
-
     public Quat4f getLookRotation() {
         Quat4f lookRotation = new Quat4f(TeraMath.DEG_TO_RAD * yaw, TeraMath.DEG_TO_RAD * pitch, 0);
         return lookRotation;

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterHeldItemComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterHeldItemComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.logic.players.event;
+package org.terasology.logic.characters;
 
-import org.terasology.entitySystem.event.Event;
-import org.terasology.network.ServerEvent;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.network.Replicate;
 
-/**
- */
-@ServerEvent
-public class SelectItemRequest implements Event {
+public class CharacterHeldItemComponent implements Component {
 
-    private int slot;
+    @Replicate
+    public EntityRef selectedItem = EntityRef.NULL;
 
-    protected SelectItemRequest() {
-    }
-
-    public SelectItemRequest(int slot) {
-        this.slot = slot;
-    }
-
-    public int getSlot() {
-        return slot;
-    }
+    public float handAnimation;
 }

--- a/engine/src/main/java/org/terasology/logic/characters/events/ChangeHeldItemRequest.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/ChangeHeldItemRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.characters.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.ServerEvent;
+
+@ServerEvent
+public class ChangeHeldItemRequest implements Event {
+
+    private EntityRef item;
+
+    protected ChangeHeldItemRequest() {
+    }
+
+    public ChangeHeldItemRequest(EntityRef item) {
+        this.item = item;
+    }
+
+    public EntityRef getItem() {
+        return item;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/characters/events/HeldItemChangedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/HeldItemChangedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.characters.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+/**
+ */
+public class HeldItemChangedEvent implements Event {
+    private EntityRef oldItem;
+    private EntityRef newItem;
+
+    public HeldItemChangedEvent(EntityRef oldItem, EntityRef newItem) {
+        this.oldItem = oldItem;
+        this.newItem = newItem;
+    }
+
+    public EntityRef getOldItem() {
+        return oldItem;
+    }
+
+    public EntityRef getNewItem() {
+        return newItem;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/inventory/SelectedInventorySlotComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/SelectedInventorySlotComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.inventory;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.network.Replicate;
+
+public class SelectedInventorySlotComponent implements Component {
+    @Replicate
+    public int slot;
+}

--- a/engine/src/main/java/org/terasology/logic/inventory/events/ChangeSelectedInventorySlotRequest.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/ChangeSelectedInventorySlotRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2015 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.logic.players.event;
+package org.terasology.logic.inventory.events;
 
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.network.ServerEvent;
 
-/**
- */
-public class SelectedItemChangedEvent implements Event {
-    private EntityRef oldItem;
-    private EntityRef newItem;
+@ServerEvent
+public class ChangeSelectedInventorySlotRequest implements Event {
 
-    public SelectedItemChangedEvent(EntityRef oldItem, EntityRef newItem) {
-        this.oldItem = oldItem;
-        this.newItem = newItem;
+    private int slot;
+
+    protected ChangeSelectedInventorySlotRequest() {
     }
 
-    public EntityRef getOldItem() {
-        return oldItem;
+    public ChangeSelectedInventorySlotRequest(int slot) {
+        this.slot = slot;
     }
 
-    public EntityRef getNewItem() {
-        return newItem;
+    public int getSlot() {
+        return slot;
     }
 }

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonRenderer.java
@@ -23,9 +23,8 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.RenderSystem;
-import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.characters.CharacterHeldItemComponent;
 import org.terasology.logic.characters.CharacterMovementComponent;
-import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector4f;
@@ -86,8 +85,8 @@ public class FirstPersonRenderer extends BaseComponentSystem implements RenderSy
 
     @Override
     public void renderFirstPerson() {
-        CharacterComponent character = localPlayer.getCharacterEntity().getComponent(CharacterComponent.class);
-        if (character == null) {
+        CharacterHeldItemComponent characterHeldItemComponent = localPlayer.getCharacterEntity().getComponent(CharacterHeldItemComponent.class);
+        if (characterHeldItemComponent == null) {
             return;
         }
         CharacterMovementComponent charMoveComp = localPlayer.getCharacterEntity().getComponent(CharacterMovementComponent.class);
@@ -95,10 +94,9 @@ public class FirstPersonRenderer extends BaseComponentSystem implements RenderSy
             return;
         }
         float bobOffset = calcBobbingOffset(charMoveComp.footstepDelta, (float) java.lang.Math.PI / 8f, 0.05f);
-        float handMovementAnimationOffset = character.handAnimation;
+        float handMovementAnimationOffset = characterHeldItemComponent.handAnimation;
 
-        int invSlotIndex = character.selectedItem;
-        EntityRef heldItem = InventoryUtils.getItemAt(localPlayer.getCharacterEntity(), invSlotIndex);
+        EntityRef heldItem = characterHeldItemComponent.selectedItem;
         ItemComponent heldItemComp = heldItem.getComponent(ItemComponent.class);
         BlockItemComponent blockItem = heldItem.getComponent(BlockItemComponent.class);
         if (blockItem != null && blockItem.blockFamily != null) {

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -36,12 +36,12 @@ import org.terasology.input.binds.movement.VerticalMovementAxis;
 import org.terasology.input.events.MouseXAxisEvent;
 import org.terasology.input.events.MouseYAxisEvent;
 import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.characters.CharacterHeldItemComponent;
 import org.terasology.logic.characters.CharacterMoveInputEvent;
 import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.MovementMode;
 import org.terasology.logic.characters.interactions.InteractionUtil;
 import org.terasology.logic.inventory.InventoryComponent;
-import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.AABB;
@@ -112,12 +112,8 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
         CharacterComponent characterComp = entity.getComponent(CharacterComponent.class);
         LocationComponent location = entity.getComponent(LocationComponent.class);
 
-
         processInput(entity, characterComp, characterMovementComponent);
         updateCamera(characterComp, characterMovementComponent, characterComp, location);
-
-        // Hand animation update
-        characterComp.handAnimation = Math.max(0, characterComp.handAnimation - 2.5f * delta);
 
         entity.saveComponent(characterComp);
     }
@@ -319,12 +315,12 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
 
     @ReceiveEvent(components = {CharacterComponent.class, InventoryComponent.class})
-    public void onUseItemButton(UseItemButton event, EntityRef entity, CharacterComponent characterComponent) {
+    public void onUseItemButton(UseItemButton event, EntityRef entity, CharacterHeldItemComponent characterHeldItemComponent) {
         if (!event.isDown() || time.getGameTimeInMs() - lastItemUse < 200) {
             return;
         }
 
-        EntityRef selectedItemEntity = InventoryUtils.getItemAt(entity, characterComponent.selectedItem);
+        EntityRef selectedItemEntity = characterHeldItemComponent.selectedItem;
         if (!selectedItemEntity.exists()) {
             return;
         }
@@ -332,8 +328,8 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
         localPlayer.activateOwnedEntityAsClient(selectedItemEntity);
 
         lastItemUse = time.getGameTimeInMs();
-        characterComponent.handAnimation = 0.5f;
-        entity.saveComponent(characterComponent);
+        characterHeldItemComponent.handAnimation = 0.5f;
+        entity.saveComponent(characterHeldItemComponent);
         event.consume();
     }
 

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -16,9 +16,7 @@
 
 package org.terasology.logic.players;
 
-import java.util.Iterator;
-import java.util.List;
-
+import com.google.common.collect.Lists;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
@@ -35,13 +33,11 @@ import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.health.DestroyEvent;
 import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.health.HealthComponent;
-import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.logic.players.event.RespawnRequestEvent;
-import org.terasology.logic.players.event.SelectedItemChangedEvent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -52,12 +48,13 @@ import org.terasology.network.events.ConnectedEvent;
 import org.terasology.network.events.DisconnectedEvent;
 import org.terasology.persistence.PlayerStore;
 import org.terasology.registry.In;
-import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.rendering.world.WorldRenderer;
+import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.generator.WorldGenerator;
 
-import com.google.common.collect.Lists;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  */
@@ -250,7 +247,6 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         updateRelevanceEntity(clientEntity, distance);
         client.character = playerCharacter;
         clientEntity.saveComponent(client);
-        playerCharacter.send(new SelectedItemChangedEvent(EntityRef.NULL, InventoryUtils.getItemAt(playerCharacter, 0)));
         playerCharacter.send(new OnPlayerSpawnedEvent());
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/hud/HudToolbar.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/hud/HudToolbar.java
@@ -17,8 +17,8 @@ package org.terasology.rendering.nui.layers.hud;
 
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.health.HealthComponent;
+import org.terasology.logic.inventory.SelectedInventorySlotComponent;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
@@ -91,8 +91,8 @@ public class HudToolbar extends CoreHudWidget {
 
         @Override
         public Boolean get() {
-            CharacterComponent component = localPlayer.getCharacterEntity().getComponent(CharacterComponent.class);
-            return component != null && component.selectedItem == slot;
+            SelectedInventorySlotComponent component = localPlayer.getCharacterEntity().getComponent(SelectedInventorySlotComponent.class);
+            return component != null && component.slot == slot;
         }
     }
 }

--- a/engine/src/main/resources/assets/prefabs/player/player.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/player.prefab
@@ -60,5 +60,9 @@
               0,0,0,0,0,0,0,0,0,0
             ]
     },
+    "SelectedInventorySlot": {
+    },
+    "CharacterHeldItem": {
+    },
     "Breather" : {}
 }


### PR DESCRIPTION
The main benefit of this is to start decoupling the inventory system from the other systems.  It adds a "held item" system that will help when adding new features like dual wielding and/or different inventory systems by encapsulating the logic from each system to its own.

There is no change in functionality with this.  I used this short list of things to do in order to test both on a local game and a remote game hosted by a headless server:
- drop item
- switch item in selected slot
- switch from item to null to item
- switch from item to item
- scrollwheel up and down
- use item
- use item continuously by holding button
- attack with item
- attack with item continuously by holding button
- pick up an item into selected empty slot