### PR TITLE
Fix creation of FBO textures

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/assets/texture/TextureData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/TextureData.java
@@ -42,29 +42,28 @@ public class TextureData implements AssetData {
 
     public TextureData(int width, int height, ByteBuffer[] mipmaps, Texture.WrapMode wrapMode, Texture.FilterMode filterMode, Texture.Type type) {
         this(width, height, wrapMode, filterMode);
-        this.type = type;
 
+        if (mipmaps.length == 0) {
+            throw new IllegalArgumentException("Must supply at least one mipmap");
+        }
+
+        this.type = type;
         this.data = Arrays.copyOf(mipmaps, mipmaps.length);
 
-        if (data.length > 0) {
-            if (width <= 0 || height <= 0) {
-                throw new IllegalArgumentException("Width and height must be positive");
-            }
-            if (mipmaps.length == 0) {
-                throw new IllegalArgumentException("Must supply at least one mipmap");
-            }
-            if (mipmaps[0].limit() != width * height * BYTES_PER_PIXEL) {
-                throw new IllegalArgumentException("Texture data size incorrect, must be a set of RGBA values for each pixel (width * height)");
-            }
-            if (mipmaps.length > 1 && !(IntMath.isPowerOfTwo(width) && IntMath.isPowerOfTwo(height))) {
-                throw new IllegalArgumentException("Texture width, height and depth must be powers of 2 for mipmapping");
-            }
-            for (int i = 1; i < mipmaps.length; ++i) {
-                int mipWidth = width >> i;
-                int mipHeight = height >> i;
-                if (mipWidth * mipHeight * BYTES_PER_PIXEL != mipmaps[i].limit()) {
-                    throw new IllegalArgumentException("Mipmap has wrong dimensions");
-                }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Width and height must be positive");
+        }
+        if (mipmaps[0].limit() != width * height * BYTES_PER_PIXEL) {
+            throw new IllegalArgumentException("Texture data size incorrect, must be a set of RGBA values for each pixel (width * height)");
+        }
+        if (mipmaps.length > 1 && !(IntMath.isPowerOfTwo(width) && IntMath.isPowerOfTwo(height))) {
+            throw new IllegalArgumentException("Texture width, height and depth must be powers of 2 for mipmapping");
+        }
+        for (int i = 1; i < mipmaps.length; ++i) {
+            int mipWidth = width >> i;
+            int mipHeight = height >> i;
+            if (mipWidth * mipHeight * BYTES_PER_PIXEL != mipmaps[i].limit()) {
+                throw new IllegalArgumentException("Mipmap has wrong dimensions");
             }
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglFrameBufferObject.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglFrameBufferObject.java
@@ -79,7 +79,9 @@ public class LwjglFrameBufferObject implements FrameBufferObject {
     }
 
     private Texture generateTexture(ResourceUrn urn) {
-        TextureData data = new TextureData(size.x(), size.y(), new ByteBuffer[]{}, Texture.WrapMode.CLAMP, Texture.FilterMode.NEAREST);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(size.x() * size.y() * Integer.BYTES);
+        ByteBuffer[] mipmaps = new ByteBuffer[]{buffer};
+        TextureData data = new TextureData(size.x(), size.y(), mipmaps, Texture.WrapMode.CLAMP, Texture.FilterMode.NEAREST);
         return Assets.generateAsset(urn, data, Texture.class);
     }
 


### PR DESCRIPTION
Currently, the FBO texture was created without backing texture data. Some machines (graphics card drivers?) seem to auto-generate matching buffers while others don't.

The existing check in the constructor did not work, because it was bypassed by the `if` statement.

Fixes #2076 and https://github.com/Terasology/Minimap/issues/4.