### PR TITLE
Suppress all warnings in auto-generated source code

### DIFF
--- a/engine/src/main/java/org/terasology/protobuf/ChunksProtobuf.java
+++ b/engine/src/main/java/org/terasology/protobuf/ChunksProtobuf.java
@@ -3,6 +3,7 @@
 
 package org.terasology.protobuf;
 
+@SuppressWarnings("all")
 public final class ChunksProtobuf {
   private ChunksProtobuf() {}
   public static void registerAllExtensions(

--- a/engine/src/main/java/org/terasology/protobuf/EntityData.java
+++ b/engine/src/main/java/org/terasology/protobuf/EntityData.java
@@ -3,6 +3,7 @@
 
 package org.terasology.protobuf;
 
+@SuppressWarnings("all")
 public final class EntityData {
   private EntityData() {}
   public static void registerAllExtensions(

--- a/engine/src/main/java/org/terasology/protobuf/NetData.java
+++ b/engine/src/main/java/org/terasology/protobuf/NetData.java
@@ -3,6 +3,7 @@
 
 package org.terasology.protobuf;
 
+@SuppressWarnings("all")
 public final class NetData {
   private NetData() {}
   public static void registerAllExtensions(


### PR DESCRIPTION
This reduces the total amount of compiler warnings by ~300, but will be overwritten when the protobuf code changes.

In the long run we should consider generating a compiled JAR file instead. This would also significantly simplify the CheckStyle config setup.
