### PR TITLE
Introducing FrameBuffersManager

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -40,7 +40,7 @@ import org.terasology.rendering.nui.asset.UIData;
 import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.layers.ingame.OnlinePlayersOverlay;
 import org.terasology.rendering.nui.layers.ingame.inventory.TransferItemCursor;
-import org.terasology.rendering.opengl.FrameBuffersManager;
+import org.terasology.rendering.opengl.PostProcessor;
 
 /**
  */
@@ -78,7 +78,7 @@ public class MenuControlSystem extends BaseComponentSystem {
     public void onKeyDown(KeyDownEvent event, EntityRef entity) {
         switch (event.getKey().getId()) {
             case Keyboard.KeyId.F12:
-                CoreRegistry.get(FrameBuffersManager.class).takeScreenshot();
+                CoreRegistry.get(PostProcessor.class).takeScreenshot();
                 CoreRegistry.get(AudioManager.class).playSound(Assets.getSound("engine:camera").get());
                 break;
             default:

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -40,7 +40,7 @@ import org.terasology.rendering.nui.asset.UIData;
 import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.layers.ingame.OnlinePlayersOverlay;
 import org.terasology.rendering.nui.layers.ingame.inventory.TransferItemCursor;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  */
@@ -78,7 +78,7 @@ public class MenuControlSystem extends BaseComponentSystem {
     public void onKeyDown(KeyDownEvent event, EntityRef entity) {
         switch (event.getKey().getId()) {
             case Keyboard.KeyId.F12:
-                CoreRegistry.get(LwjglRenderingProcess.class).takeScreenshot();
+                CoreRegistry.get(FrameBuffersManager.class).takeScreenshot();
                 CoreRegistry.get(AudioManager.class).playSound(Assets.getSound("engine:camera").get());
                 break;
             default:

--- a/engine/src/main/java/org/terasology/rendering/opengl/FrameBuffersManager.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/FrameBuffersManager.java
@@ -45,12 +45,11 @@ import static org.lwjgl.opengl.EXTFramebufferObject.glDeleteFramebuffersEXT;
 import static org.lwjgl.opengl.EXTFramebufferObject.glDeleteRenderbuffersEXT;
 
 /**
- * The Default Rendering Process class.
- *
+ * TODO: write javadoc
  */
-public class LwjglRenderingProcess {
+public class FrameBuffersManager {
 
-    private static final Logger logger = LoggerFactory.getLogger(LwjglRenderingProcess.class);
+    private static final Logger logger = LoggerFactory.getLogger(FrameBuffersManager.class);
 
     private PBO readBackPBOFront;
     private PBO readBackPBOBack;
@@ -70,7 +69,10 @@ public class LwjglRenderingProcess {
     private int overwriteRtWidth;
     private int overwriteRtHeight;
 
-    /* VARIOUS */
+    private String currentlyBoundFboName = "";
+    private FBO currentlyBoundFbo;
+    //private int currentlyBoundTextureId = -1;
+
     private boolean isTakingScreenshot;
 
     // Note: this assumes that the settings in the configs might change at runtime,
@@ -83,8 +85,9 @@ public class LwjglRenderingProcess {
     private GraphicState graphicState;
     private PostProcessor postProcessor;
 
-    public LwjglRenderingProcess() {
-
+    public FrameBuffersManager() {
+        // nothing to do here, everything happens at initialization time,
+        // after GraphicState and PostProcessors have been set.
     }
 
     public void initialize() {

--- a/engine/src/main/java/org/terasology/rendering/opengl/GraphicState.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GraphicState.java
@@ -45,17 +45,16 @@ import static org.lwjgl.opengl.GL20.glStencilOpSeparate;
  * method changes an unspecified default state while the second method reinstates it.
  *
  * A number of FBO references are kept up to date through the refreshDynamicFBOs() and
- * setSceneShadowMap() methods. At this stage the LwjglRenderingProcess class is tasked
+ * setSceneShadowMap() methods. At this stage the FrameBuffersManager class is tasked
  * with running these methods whenever its FBOs change.
  */
-// TODO: update comment when the BuffersManager comes online.
 public class GraphicState {
     // As this class pretty much always deals with OpenGL states, it did occur to me
     // that it might be better called OpenGLState or something along that line. I
     // eventually decided for GraphicState as it resides in the rendering.opengl
     // package anyway and rendering.opengl.OpenGLState felt cumbersome. --emanuele3d
 
-    private LwjglRenderingProcess renderingProcess;
+    private FrameBuffersManager buffersManager;
     private Dimensions fullScale;
     private Buffers buffers  = new Buffers();
 
@@ -68,14 +67,13 @@ public class GraphicState {
      * available) refreshDynamicFBOs() and setSceneShadowMap() are called and the associated internal
      * FBO references are initialized.
      *
-     * @param renderingProcess An instance of the LwjglRenderingProcess class, used to obtain references to its FBOs.
+     * @param buffersManager An instance of the FrameBuffersManager class, used to obtain references to its FBOs.
      */
-    public GraphicState(LwjglRenderingProcess renderingProcess) {
-        // a reference to the renderingProcess is not strictly necessary, as it is used only
+    public GraphicState(FrameBuffersManager buffersManager) {
+        // a reference to the frameBuffersManager is not strictly necessary, as it is used only
         // in refreshDynamicFBOs() and it could be passed as argument to it. We do it this
-        // way however to maintain similarity with the way the PostProcessor will work.
-        // TODO: update the comment above when the PostProcessor is in place.
-        this.renderingProcess = renderingProcess;
+        // way however to maintain similarity with the way the PostProcessor works.
+        this.buffersManager = buffersManager;
     }
 
     /**
@@ -87,25 +85,25 @@ public class GraphicState {
      * useful.
      */
     public void dispose() {
-        renderingProcess = null;
+        buffersManager = null;
         fullScale = null;
         buffers = null;
     }
 
     /**
      * Used to initialize and eventually refresh the internal references to FBOs primarily
-     * held by the LwjglRenderingProcess instance.
+     * held by the FrameBuffersManager instance.
      *
      * Instances of the GraphicState class cannot operate unless this method has been called
      * at least once, the FBOs retrieved through it not null. It then needs to be called again
-     * every time the LwjglRenderingProcess instance changes its FBOs. This occurs whenever
+     * every time the FrameBuffersManager instance changes its FBOs. This occurs whenever
      * the display resolution changes or when a screenshot is taken with a resolution that
      * is different from that of the display.
      */
     public void refreshDynamicFBOs() {
-        buffers.sceneOpaque               = renderingProcess.getFBO("sceneOpaque");
-        buffers.sceneReflectiveRefractive = renderingProcess.getFBO("sceneReflectiveRefractive");
-        buffers.sceneReflected            = renderingProcess.getFBO("sceneReflected");
+        buffers.sceneOpaque               = buffersManager.getFBO("sceneOpaque");
+        buffers.sceneReflectiveRefractive = buffersManager.getFBO("sceneReflectiveRefractive");
+        buffers.sceneReflected            = buffersManager.getFBO("sceneReflected");
         fullScale = buffers.sceneOpaque.dimensions();
     }
 
@@ -116,11 +114,11 @@ public class GraphicState {
     /**
      * Used to initialize and update the internal reference to the Shadow Map FBO.
      *
-     * Gets called every time the LwjglRenderingProcess instance changes the ShadowMap FBO.
+     * Gets called every time the FrameBuffersManager instance changes the ShadowMap FBO.
      * This will occur whenever the ShadowMap resolution is changed, i.e. via the rendering
      * settings.
      *
-     * @param newShadowMap
+     * @param newShadowMap the FBO containing the new shadow map buffer
      */
     public void setSceneShadowMap(FBO newShadowMap) {
         buffers.sceneShadowMap = newShadowMap;

--- a/engine/src/main/java/org/terasology/rendering/opengl/PostProcessor.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/PostProcessor.java
@@ -105,7 +105,7 @@ public class PostProcessor {
     private int displayListQuad = -1;
     private FBO.Dimensions fullScale;
 
-    private LwjglRenderingProcess renderingProcess;
+    private FrameBuffersManager buffersManager;
     private GraphicState graphicState;
     private Materials materials = new Materials();
     private Buffers buffers = new Buffers();
@@ -122,12 +122,11 @@ public class PostProcessor {
      * Method obtainStaticFBOs() must be called to initialize unchanging FBOs references.
      * Method refreshDynamicFBOs() must be called at least once to initialize all other FBOs references.
      *
-     * @param renderingProcess An LwjglRenderingProcess instance, required to obtain FBO references.
+     * @param buffersManager An FrameBuffersManager instance, required to obtain FBO references.
      * @param graphicState A GraphicState instance, providing opengl state-changing methods.
      */
-    // TODO: update javadoc when the rendering process becomes the FrameBuffersManager
-    public PostProcessor(LwjglRenderingProcess renderingProcess, GraphicState graphicState) {
-        this.renderingProcess = renderingProcess;
+    public PostProcessor(FrameBuffersManager buffersManager, GraphicState graphicState) {
+        this.buffersManager = buffersManager;
         this.graphicState = graphicState;
     }
 
@@ -168,7 +167,7 @@ public class PostProcessor {
     }
 
     /**
-     * Fetches a number of static FBOs from the RenderingProcess instance and initializes a number of
+     * Fetches a number of static FBOs from the FrameBuffersManager instance and initializes a number of
      * internal references with them. They are called "static" as they do not change over the lifetime
      * of a PostProcessor instance.
      *
@@ -179,17 +178,16 @@ public class PostProcessor {
      * downsampleSceneAndUpdateExposure() method relying on these FBOs. But this method is fully executed
      * only if eye adaptation is enabled: an NPE would be thrown only in that case.
      */
-    // TODO: update javadoc when the rendering process becomes the FrameBuffersManager
     public void obtainStaticFBOs() {
-        buffers.downSampledScene[4] = renderingProcess.getFBO("scene16");
-        buffers.downSampledScene[3] = renderingProcess.getFBO("scene8");
-        buffers.downSampledScene[2] = renderingProcess.getFBO("scene4");
-        buffers.downSampledScene[1] = renderingProcess.getFBO("scene2");
-        buffers.downSampledScene[0] = renderingProcess.getFBO("scene1");
+        buffers.downSampledScene[4] = buffersManager.getFBO("scene16");
+        buffers.downSampledScene[3] = buffersManager.getFBO("scene8");
+        buffers.downSampledScene[2] = buffersManager.getFBO("scene4");
+        buffers.downSampledScene[1] = buffersManager.getFBO("scene2");
+        buffers.downSampledScene[0] = buffersManager.getFBO("scene1");
     }
 
     /**
-     * Fetches a number of FBOs from the RenderingProcess instance and initializes or refreshes
+     * Fetches a number of FBOs from the FrameBuffersManager instance and initializes or refreshes
      * a number of internal references with them. These FBOs may become obsolete over the lifetime
      * of a PostProcessor instance and refreshing the internal references might be needed.
      * These FBOs are therefore referred to as "dynamic" FBOs.
@@ -199,39 +197,38 @@ public class PostProcessor {
      * every time the dynamic FBOs become obsolete and the internal references need to be
      * refreshed with new FBOs.
      */
-    // TODO: update javadoc when the rendering process becomes the FrameBuffersManager
     public void refreshDynamicFBOs() {
         // initial renderings
-        buffers.sceneOpaque         = renderingProcess.getFBO("sceneOpaque");
-        buffers.sceneOpaquePingPong = renderingProcess.getFBO("sceneOpaquePingPong");
+        buffers.sceneOpaque         = buffersManager.getFBO("sceneOpaque");
+        buffers.sceneOpaquePingPong = buffersManager.getFBO("sceneOpaquePingPong");
 
-        buffers.sceneSkyBand0   = renderingProcess.getFBO("sceneSkyBand0");
-        buffers.sceneSkyBand1   = renderingProcess.getFBO("sceneSkyBand1");
+        buffers.sceneSkyBand0   = buffersManager.getFBO("sceneSkyBand0");
+        buffers.sceneSkyBand1   = buffersManager.getFBO("sceneSkyBand1");
 
-        buffers.sceneReflectiveRefractive   = renderingProcess.getFBO("sceneReflectiveRefractive");
+        buffers.sceneReflectiveRefractive   = buffersManager.getFBO("sceneReflectiveRefractive");
         // sceneReflected, in case one wonders, is not used by the post-processor.
 
         // pre-post composite
-        buffers.outline         = renderingProcess.getFBO("outline");
-        buffers.ssao            = renderingProcess.getFBO("ssao");
-        buffers.ssaoBlurred     = renderingProcess.getFBO("ssaoBlurred");
+        buffers.outline         = buffersManager.getFBO("outline");
+        buffers.ssao            = buffersManager.getFBO("ssao");
+        buffers.ssaoBlurred     = buffersManager.getFBO("ssaoBlurred");
 
         // initial post-processing
-        buffers.lightShafts     = renderingProcess.getFBO("lightShafts");
-        buffers.initialPost     = renderingProcess.getFBO("initialPost");
-        buffers.sceneToneMapped = renderingProcess.getFBO("sceneToneMapped");
+        buffers.lightShafts     = buffersManager.getFBO("lightShafts");
+        buffers.initialPost     = buffersManager.getFBO("initialPost");
+        buffers.sceneToneMapped = buffersManager.getFBO("sceneToneMapped");
 
-        buffers.sceneHighPass   = renderingProcess.getFBO("sceneHighPass");
-        buffers.sceneBloom0     = renderingProcess.getFBO("sceneBloom0");
-        buffers.sceneBloom1     = renderingProcess.getFBO("sceneBloom1");
-        buffers.sceneBloom2     = renderingProcess.getFBO("sceneBloom2");
+        buffers.sceneHighPass   = buffersManager.getFBO("sceneHighPass");
+        buffers.sceneBloom0     = buffersManager.getFBO("sceneBloom0");
+        buffers.sceneBloom1     = buffersManager.getFBO("sceneBloom1");
+        buffers.sceneBloom2     = buffersManager.getFBO("sceneBloom2");
 
-        buffers.sceneBlur0     = renderingProcess.getFBO("sceneBlur0");
-        buffers.sceneBlur1     = renderingProcess.getFBO("sceneBlur1");
+        buffers.sceneBlur0     = buffersManager.getFBO("sceneBlur0");
+        buffers.sceneBlur1     = buffersManager.getFBO("sceneBlur1");
 
         // final post-processing
-        buffers.ocUndistorted   = renderingProcess.getFBO("ocUndistorted");
-        buffers.sceneFinal      = renderingProcess.getFBO("sceneFinal");
+        buffers.ocUndistorted   = buffersManager.getFBO("ocUndistorted");
+        buffers.sceneFinal      = buffersManager.getFBO("sceneFinal");
 
         fullScale = buffers.sceneOpaque.dimensions();
     }
@@ -242,8 +239,8 @@ public class PostProcessor {
      * refreshing the internal references to these FBOs.
      */
     public void refreshSceneOpaqueFBOs() {
-        buffers.sceneOpaque         = renderingProcess.getFBO("sceneOpaque");
-        buffers.sceneOpaquePingPong = renderingProcess.getFBO("sceneOpaquePingPong");
+        buffers.sceneOpaque         = buffersManager.getFBO("sceneOpaque");
+        buffers.sceneOpaquePingPong = buffersManager.getFBO("sceneOpaquePingPong");
     }
 
     /**
@@ -254,7 +251,7 @@ public class PostProcessor {
     // dispose support objects and it clearly marks the end of a PostProcessor
     // instance's lifecycle.
     public void dispose() {
-        renderingProcess = null;
+        buffersManager = null;
         graphicState = null;
         fullScale = null;
     }
@@ -333,7 +330,7 @@ public class PostProcessor {
         graphicState.bindDisplay();     // TODO: verify this is necessary
         setViewportToWholeDisplay();    // TODO: verify this is necessary
 
-        renderingProcess.swapSceneOpaqueFBOs();
+        buffersManager.swapSceneOpaqueFBOs();
         buffers.sceneOpaque.attachDepthBufferTo(buffers.sceneReflectiveRefractive);
     }
 
@@ -431,7 +428,7 @@ public class PostProcessor {
         graphicState.bindDisplay();     // TODO: verify this is necessary
         setViewportToWholeDisplay();    // TODO: verify this is necessary
 
-        renderingProcess.swapSceneOpaqueFBOs();
+        buffersManager.swapSceneOpaqueFBOs();
         buffers.sceneOpaque.attachDepthBufferTo(buffers.sceneReflectiveRefractive);
     }
 
@@ -524,11 +521,11 @@ public class PostProcessor {
 
             downsampleSceneInto1x1pixelsBuffer();
 
-            renderingProcess.getCurrentReadbackPBO().copyFromFBO(buffers.downSampledScene[0].fboId, 1, 1, GL12.GL_BGRA, GL11.GL_UNSIGNED_BYTE);
+            buffersManager.getCurrentReadbackPBO().copyFromFBO(buffers.downSampledScene[0].fboId, 1, 1, GL12.GL_BGRA, GL11.GL_UNSIGNED_BYTE);
 
-            renderingProcess.swapReadbackPBOs();
+            buffersManager.swapReadbackPBOs();
 
-            ByteBuffer pixels = renderingProcess.getCurrentReadbackPBO().readBackPixels();
+            ByteBuffer pixels = buffersManager.getCurrentReadbackPBO().readBackPixels();
 
             if (pixels.limit() < 3) {
                 logger.error("Failed to auto-update the exposure value.");
@@ -709,7 +706,7 @@ public class PostProcessor {
      * pattern to each, to match the optics in the OculusVR headset.
      *
      * Finally, it either sends the image to the display or, when taking a screenshot,
-     * instructs the rendering process to save it to a file. // TODO: update this sentence when the FrameBuffersManager becomes available.
+     * instructs the FrameBuffersManager to save it to a file.
      *
      * @param renderingStage Can be MONO, LEFT_EYE or RIGHT_EYE, and communicates to the method weather
      *                       it is dealing with a standard display or an OculusVR setup, and in the
@@ -738,7 +735,7 @@ public class PostProcessor {
 
     private void renderFinalMonoImage() {
 
-        if (renderingProcess.isNotTakingScreenshot()) {
+        if (buffersManager.isNotTakingScreenshot()) {
             graphicState.bindDisplay();
             renderFullscreenQuad(0, 0, Display.getWidth(), Display.getHeight());
 
@@ -748,7 +745,7 @@ public class PostProcessor {
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
             renderFullscreenQuad(0, 0, fullScale.width(), fullScale.height());
 
-            renderingProcess.saveScreenshot();
+            buffersManager.saveScreenshot();
             // when saving a screenshot we do not send the image to screen,
             // to avoid the brief one-frame flicker of the screenshot
 
@@ -761,7 +758,7 @@ public class PostProcessor {
     // TODO: have a flag to invert the eyes (Cross Eye 3D), as mentioned in
     // TODO: http://forum.terasology.org/threads/happy-coding.1018/#post-11264
     private void renderFinalStereoImage(WorldRenderer.WorldRenderingStage renderingStage) {
-        if (renderingProcess.isNotTakingScreenshot()) {
+        if (buffersManager.isNotTakingScreenshot()) {
             buffers.sceneFinal.bind();
         } else {
             buffers.ocUndistorted.bind();
@@ -778,14 +775,14 @@ public class PostProcessor {
                 // no glClear() here: the rendering for the second eye is being added besides the first eye's rendering
                 renderFullscreenQuad(fullScale.width() / 2 + 1, 0, fullScale.width() / 2, fullScale.height());
 
-                if (renderingProcess.isNotTakingScreenshot()) {
+                if (buffersManager.isNotTakingScreenshot()) {
                     graphicState.bindDisplay();
                     applyOculusDistortion(buffers.sceneFinal);
 
                 } else {
                     buffers.sceneFinal.bind();
                     applyOculusDistortion(buffers.ocUndistorted);
-                    renderingProcess.saveScreenshot();
+                    buffersManager.saveScreenshot();
                     // when saving a screenshot we do NOT send the image to screen,
                     // to avoid the brief flicker of the screenshot for one frame
                 }
@@ -804,7 +801,7 @@ public class PostProcessor {
         inputBuffer.bindTexture();
         materials.ocDistortion.setInt("texInputBuffer", texId, true);
 
-        if (renderingProcess.isNotTakingScreenshot()) {
+        if (buffersManager.isNotTakingScreenshot()) {
             updateOcShaderParametersForVP(0, 0, fullScale.width() / 2, fullScale.height(), WorldRenderer.WorldRenderingStage.LEFT_EYE);
             renderFullscreenQuad(0, 0, Display.getWidth(), Display.getHeight());
             updateOcShaderParametersForVP(fullScale.width() / 2 + 1, 0, fullScale.width() / 2, fullScale.height(), WorldRenderer.WorldRenderingStage.RIGHT_EYE);

--- a/engine/src/main/java/org/terasology/rendering/opengl/PostProcessor.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/PostProcessor.java
@@ -149,7 +149,7 @@ public class PostProcessor {
 
         // initial post-processing
         materials.lightShafts = getMaterial("engine:prog.lightshaft");   // TODO: rename shader to lightShafts
-        materials.initialPost = getMaterial("engine:prog.prePost");      // TODO: rename shader to initialPost
+        materials.initialPost = getMaterial("engine:prog.prePost");      // TODO: rename shader to scenePrePost
         materials.downSampler = getMaterial("engine:prog.down");         // TODO: rename shader to downSampler
         materials.highPass = getMaterial("engine:prog.highp");           // TODO: rename shader to highPass
         materials.blur = getMaterial("engine:prog.blur");
@@ -212,10 +212,10 @@ public class PostProcessor {
         buffers.outline         = buffersManager.getFBO("outline");
         buffers.ssao            = buffersManager.getFBO("ssao");
         buffers.ssaoBlurred     = buffersManager.getFBO("ssaoBlurred");
+        buffers.scenePrePost    = buffersManager.getFBO("scenePrePost");
 
         // initial post-processing
         buffers.lightShafts     = buffersManager.getFBO("lightShafts");
-        buffers.initialPost     = buffersManager.getFBO("initialPost");
         buffers.sceneToneMapped = buffersManager.getFBO("sceneToneMapped");
 
         buffers.sceneHighPass   = buffersManager.getFBO("sceneHighPass");
@@ -464,9 +464,9 @@ public class PostProcessor {
         materials.initialPost.enable();
 
         // TODO: verify what the inputs are
-        buffers.initialPost.bind(); // TODO: see if we could write this straight into sceneOpaque
+        buffers.scenePrePost.bind(); // TODO: see if we could write this straight into sceneOpaque
 
-        setViewportTo(buffers.initialPost.dimensions());
+        setViewportTo(buffers.scenePrePost.dimensions());
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
 
         renderFullscreenQuad();
@@ -495,7 +495,7 @@ public class PostProcessor {
 
             // TODO: move this block above, for consistency
             if (i == 4) {
-                buffers.initialPost.bindTexture();
+                buffers.scenePrePost.bindTexture();
             } else {
                 buffers.downSampledScene[i + 1].bindTexture();
             }
@@ -959,7 +959,7 @@ public class PostProcessor {
         public FBO outline;
         public FBO ssao;
         public FBO ssaoBlurred;
-        public FBO initialPost;
+        public FBO scenePrePost;
 
         // initial post-processing
         public FBO lightShafts;

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
@@ -24,7 +24,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.nui.properties.Range;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 import java.util.Optional;
 
@@ -90,7 +90,7 @@ public class ShaderParametersChunk extends ShaderParametersBase {
             return;
         }
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -112,10 +112,10 @@ public class ShaderParametersChunk extends ShaderParametersBase {
         glBindTexture(GL11.GL_TEXTURE_2D, effects.get().getId());
         program.setInt("textureEffects", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        renderingProcess.bindFboColorTexture("sceneReflected");
+        buffersManager.bindFboColorTexture("sceneReflected");
         program.setInt("textureWaterReflection", texId++, true);
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        renderingProcess.bindFboColorTexture("sceneOpaque");
+        buffersManager.bindFboColorTexture("sceneOpaque");
         program.setInt("texSceneOpaque", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -23,7 +23,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 
 /**
@@ -49,8 +49,8 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         int texId = 0;
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
-        FBO sceneOpaque = renderingProcess.getFBO("sceneOpaque");
+        FrameBuffersManager frameBuffersManager = CoreRegistry.get(FrameBuffersManager.class);
+        FBO sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -70,7 +70,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
             program.setInt("texSceneOpaqueLightBuffer", texId++, true);
         }
 
-        FBO sceneReflectiveRefractive = renderingProcess.getFBO("sceneReflectiveRefractive");
+        FBO sceneReflectiveRefractive = frameBuffersManager.getFBO("sceneReflectiveRefractive");
 
         if (sceneReflectiveRefractive != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -94,13 +94,13 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isSsao()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.bindFboColorTexture("ssaoBlurred");
+            frameBuffersManager.bindFboColorTexture("ssaoBlurred");
             program.setInt("texSsao", texId++, true);
         }
 
         if (CoreRegistry.get(Config.class).getRendering().isOutline()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.bindFboColorTexture("outline");
+            frameBuffersManager.bindFboColorTexture("outline");
             program.setInt("texEdges", texId++, true);
 
             program.setFloat("outlineDepthThreshold", outlineDepthThreshold, true);
@@ -109,7 +109,7 @@ public class ShaderParametersCombine extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isInscattering()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.bindFboColorTexture("sceneSkyBand1");
+            frameBuffersManager.bindFboColorTexture("sceneSkyBand1");
             program.setInt("texSceneSkyBand", texId++, true);
 
             Vector4f skyInscatteringSettingsFrag = new Vector4f();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
@@ -20,7 +20,7 @@ import org.terasology.config.Config;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 
 /**
@@ -37,53 +37,53 @@ public class ShaderParametersDebug extends ShaderParametersBase {
 
         int texId = 0;
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
 
         switch (config.getRendering().getDebug().getStage()) {
             case SHADOW_MAP:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboDepthTexture("sceneShadowMap");
+                buffersManager.bindFboDepthTexture("sceneShadowMap");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("sceneOpaque");
+                buffersManager.bindFboColorTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_NORMALS:
             case OPAQUE_SUNLIGHT:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboNormalsTexture("sceneOpaque");
+                buffersManager.bindFboNormalsTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_DEPTH:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboDepthTexture("sceneOpaque");
+                buffersManager.bindFboDepthTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case OPAQUE_LIGHT_BUFFER:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboLightBufferTexture("sceneOpaque");
+                buffersManager.bindFboLightBufferTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case TRANSPARENT_COLOR:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("sceneReflectiveRefractive");
+                buffersManager.bindFboColorTexture("sceneReflectiveRefractive");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SSAO:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("ssaoBlurred");
+                buffersManager.bindFboColorTexture("ssaoBlurred");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SOBEL:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("outline");
+                buffersManager.bindFboColorTexture("outline");
                 program.setInt("texDebug", texId++, true);
                 break;
             case BAKED_OCCLUSION:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("sceneOpaque");
+                buffersManager.bindFboColorTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case RECONSTRUCTED_POSITION:
@@ -93,27 +93,27 @@ public class ShaderParametersDebug extends ShaderParametersBase {
                 }
 
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboDepthTexture("sceneOpaque");
+                buffersManager.bindFboDepthTexture("sceneOpaque");
                 program.setInt("texDebug", texId++, true);
                 break;
             case BLOOM:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("sceneBloom2");
+                buffersManager.bindFboColorTexture("sceneBloom2");
                 program.setInt("texDebug", texId++, true);
                 break;
             case HIGH_PASS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("sceneHighPass");
+                buffersManager.bindFboColorTexture("sceneHighPass");
                 program.setInt("texDebug", texId++, true);
                 break;
             case SKY_BAND:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("sceneSkyBand1");
+                buffersManager.bindFboColorTexture("sceneSkyBand1");
                 program.setInt("texDebug", texId++, true);
                 break;
             case LIGHT_SHAFTS:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-                renderingProcess.bindFboColorTexture("lightShafts");
+                buffersManager.bindFboColorTexture("lightShafts");
                 program.setInt("texDebug", texId++, true);
                 break;
             default:

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -41,7 +41,7 @@ public class ShaderParametersHdr extends ShaderParametersBase {
         PostProcessor postProcessor = CoreRegistry.get(PostProcessor.class);
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
-        buffersManager.bindFboColorTexture("initialPost");
+        buffersManager.bindFboColorTexture("scenePrePost");
 
         program.setInt("texScene", 0, true);
         program.setFloat("exposure", postProcessor.getExposure() * exposureBias, true);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -19,7 +19,7 @@ import org.lwjgl.opengl.GL13;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.nui.properties.Range;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.opengl.PostProcessor;
 
 /**
@@ -37,11 +37,11 @@ public class ShaderParametersHdr extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
         PostProcessor postProcessor = CoreRegistry.get(PostProcessor.class);
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
-        renderingProcess.bindFboColorTexture("initialPost");
+        buffersManager.bindFboColorTexture("initialPost");
 
         program.setInt("texScene", 0, true);
         program.setFloat("exposure", postProcessor.getExposure() * exposureBias, true);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -25,7 +25,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 
 import static org.lwjgl.opengl.GL11.glBindTexture;
@@ -40,8 +40,8 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
-        FBO sceneOpaque = renderingProcess.getFBO("sceneOpaque");
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
+        FBO sceneOpaque = buffersManager.getFBO("sceneOpaque");
 
         int texId = 0;
         if (sceneOpaque != null) {
@@ -60,7 +60,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isDynamicShadows()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.bindFboDepthTexture("sceneShadowMap");
+            buffersManager.bindFboDepthTexture("sceneShadowMap");
             program.setInt("texSceneShadowMap", texId++, true);
 
             Camera lightCamera = CoreRegistry.get(WorldRenderer.class).getLightCamera();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -24,7 +24,7 @@ import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 
 /**
@@ -46,8 +46,8 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
-        FBO scene = renderingProcess.getFBO("sceneOpaque");
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
+        FBO scene = buffersManager.getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
@@ -18,7 +18,7 @@ package org.terasology.rendering.shader;
 import org.lwjgl.opengl.GL13;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  * Shader parameters for the Combine shader program.
@@ -32,7 +32,7 @@ public class ShaderParametersOcDistortion extends ShaderParametersBase {
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        CoreRegistry.get(LwjglRenderingProcess.class).bindFboColorTexture("sceneFinal");
+        CoreRegistry.get(FrameBuffersManager.class).bindFboColorTexture("sceneFinal");
         program.setInt("texSceneFinal", texId++, true);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -29,7 +29,7 @@ import org.terasology.rendering.assets.texture.TextureUtil;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -52,16 +52,16 @@ public class ShaderParametersPost extends ShaderParametersBase {
         super.applyParameters(program);
 
         CameraTargetSystem cameraTargetSystem = CoreRegistry.get(CameraTargetSystem.class);
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        renderingProcess.bindFboColorTexture("sceneToneMapped");
+        buffersManager.bindFboColorTexture("sceneToneMapped");
         program.setInt("texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().getBlurIntensity() != 0) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.getFBO("sceneBlur1").bindTexture();
+            buffersManager.getFBO("sceneBlur1").bindTexture();
             program.setInt("texBlur", texId++, true);
 
             if (cameraTargetSystem != null) {
@@ -77,7 +77,7 @@ public class ShaderParametersPost extends ShaderParametersBase {
             program.setInt("texColorGradingLut", texId++, true);
         }
 
-        FBO sceneCombined = renderingProcess.getFBO("sceneOpaque");
+        FBO sceneCombined = buffersManager.getFBO("sceneOpaque");
 
         if (sceneCombined != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
@@ -24,7 +24,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.nui.properties.Range;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 
 import java.util.Optional;
@@ -49,19 +49,19 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        LwjglRenderingProcess renderingProcess = CoreRegistry.get(LwjglRenderingProcess.class);
+        FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
 
         Vector3f tint = CoreRegistry.get(WorldRenderer.class).getTint();
         program.setFloat3("inLiquidTint", tint.x, tint.y, tint.z, true);
 
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        renderingProcess.bindFboColorTexture("sceneOpaque");
+        buffersManager.bindFboColorTexture("sceneOpaque");
         program.setInt("texScene", texId++, true);
 
         if (CoreRegistry.get(Config.class).getRendering().isBloom()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.bindFboColorTexture("sceneBloom2");
+            buffersManager.bindFboColorTexture("sceneBloom2");
             program.setInt("texBloom", texId++, true);
 
             program.setFloat("bloomFactor", bloomFactor, true);
@@ -71,7 +71,7 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
 
         if (CoreRegistry.get(Config.class).getRendering().isLightShafts()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-            renderingProcess.bindFboColorTexture("lightShafts");
+            buffersManager.bindFboColorTexture("lightShafts");
             program.setInt("texLightShafts", texId++, true);
         }
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -30,7 +30,7 @@ import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -91,7 +91,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        FBO scene = CoreRegistry.get(LwjglRenderingProcess.class).getFBO("sceneOpaque");
+        FBO scene = CoreRegistry.get(FrameBuffersManager.class).getFBO("sceneOpaque");
 
         int texId = 0;
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -20,7 +20,7 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  * Shader parameters for the Post-processing shader program.
@@ -37,7 +37,7 @@ public class ShaderParametersSobel extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
-        FBO scene = CoreRegistry.get(LwjglRenderingProcess.class).getFBO("sceneOpaque");
+        FBO scene = CoreRegistry.get(FrameBuffersManager.class).getFBO("sceneOpaque");
 
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -267,6 +267,8 @@ public final class WorldRendererImpl implements WorldRenderer {
             renderableWorld.update();
             renderableWorld.generateVBOs();
             secondsSinceLastFrame = 0;
+
+            buffersManager.preRenderUpdate();
         }
 
         if (currentRenderingStage != WorldRenderingStage.MONO) {
@@ -309,8 +311,6 @@ public final class WorldRendererImpl implements WorldRenderer {
         graphicState.disableWireframeIf(renderingDebugConfig.isWireframe());
 
         PerformanceMonitor.startActivity("Pre-post composite");
-        buffersManager.createOrUpdateFullscreenFbos();
-
 
         postProcessor.generateOutline();                      // into outline buffer
         postProcessor.generateAmbientOcclusionPasses();     // into ssao and ssaoBlurred buffers
@@ -323,7 +323,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         postProcessor.generateLightShafts();                // into lightShafts buffer
 
         // Initial Post-Processing: chromatic aberration, light shafts, 1/8th resolution bloom, vignette
-        postProcessor.initialPostProcessing();              // into initialPost buffer
+        postProcessor.initialPostProcessing();              // into scenePrePost buffer
 
         // Post-Processing proper: tone mapping, bloom and blur passes // TODO: verify if the order of operations around here is correct
         postProcessor.downsampleSceneAndUpdateExposure();   // downSampledScene buffer used only to update exposure value

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -48,7 +48,7 @@ import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.cameras.PerspectiveCamera;
 import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.opengl.GraphicState;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.opengl.PostProcessor;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.primitives.LightGeometryHelper;
@@ -109,7 +109,7 @@ public final class WorldRendererImpl implements WorldRenderer {
     private final RenderingConfig renderingConfig;
     private final RenderingDebugConfig renderingDebugConfig;
 
-    private LwjglRenderingProcess renderingProcess;
+    private FrameBuffersManager buffersManager;
     private GraphicState graphicState;
     private PostProcessor postProcessor;
 
@@ -155,16 +155,16 @@ public final class WorldRendererImpl implements WorldRenderer {
     }
 
     private void initRenderingSupport() {
-        renderingProcess = new LwjglRenderingProcess();
-        context.put(LwjglRenderingProcess.class, renderingProcess);
+        buffersManager = new FrameBuffersManager();
+        context.put(FrameBuffersManager.class, buffersManager);
 
-        graphicState = new GraphicState(renderingProcess);
-        postProcessor = new PostProcessor(renderingProcess, graphicState);
+        graphicState = new GraphicState(buffersManager);
+        postProcessor = new PostProcessor(buffersManager, graphicState);
         context.put(PostProcessor.class, postProcessor);
 
-        renderingProcess.setGraphicState(graphicState);
-        renderingProcess.setPostProcessor(postProcessor);
-        renderingProcess.initialize();
+        buffersManager.setGraphicState(graphicState);
+        buffersManager.setPostProcessor(postProcessor);
+        buffersManager.initialize();
 
         context.get(ShaderManager.class).initShaders();
         postProcessor.initializeMaterials();
@@ -309,7 +309,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         graphicState.disableWireframeIf(renderingDebugConfig.isWireframe());
 
         PerformanceMonitor.startActivity("Pre-post composite");
-        renderingProcess.createOrUpdateFullscreenFbos();
+        buffersManager.createOrUpdateFullscreenFbos();
 
 
         postProcessor.generateOutline();                      // into outline buffer

--- a/facades/TeraEd/src/main/java/org/terasology/editor/properties/SceneProperties.java
+++ b/facades/TeraEd/src/main/java/org/terasology/editor/properties/SceneProperties.java
@@ -22,7 +22,7 @@ import org.terasology.engine.modes.GameState;
 import org.terasology.engine.modes.StateIngame;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.backdrop.BackdropRenderer;
-import org.terasology.rendering.opengl.LwjglRenderingProcess;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 import java.util.List;
 
@@ -56,7 +56,8 @@ public class SceneProperties implements PropertyProvider {
         if (backdropRenderer != null) {
             result.addAll(new ReflectionProvider(backdropRenderer, ingameContext).getProperties());
         }
-        LwjglRenderingProcess renderingProcess = ingameContext.get(LwjglRenderingProcess.class);
+
+        FrameBuffersManager renderingProcess = ingameContext.get(FrameBuffersManager.class);
         if (renderingProcess != null) {
             result.addAll(new ReflectionProvider(renderingProcess, ingameContext).getProperties());
         }


### PR DESCRIPTION
With the work I did around six months ago, the class LwjglRenderingProcess had been progressively stripped of much of its functionality and classes such as the PostProcessor and GraphicState made their appearance.

This PR finally addresses what is left in the LwjglRenderingProcess class (FBO-related functionality) and refactors it into a FrameBuffersManager class.

The first [commit](https://github.com/MovingBlocks/Terasology/commit/ca92f309968a099f24c7649693de3c377ae9eb1d) simply deals with the immediate consequences of the renaming.
The second [commit](https://github.com/MovingBlocks/Terasology/commit/59e8d892aebbe8f0993a3d5ed3e0d0946651f48e) is where the "meat" is, as the newly renamed class is considerably refactored.
The third [commit](https://github.com/MovingBlocks/Terasology/commit/5f8db8fa341e32ebfc1721aa551ccfc529c4889e) mostly add javadocs, comments and TODOs, with some very minor refactoring alongside.

