### PR TITLE
Fix camera linking to a respawned character.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -188,11 +188,13 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
         // get the first person mount point and rotate it away from the camera
         CharacterHeldItemComponent characterHeldItemComponent = localPlayer.getCharacterEntity().getComponent(CharacterHeldItemComponent.class);
         FirstPersonHeldItemMountPointComponent mountPointComponent = localPlayer.getCameraEntity().getComponent(FirstPersonHeldItemMountPointComponent.class);
-        LocationComponent locationComponent = mountPointComponent.mountPointEntity.getComponent(LocationComponent.class);
+        if (characterHeldItemComponent == null
+                || mountPointComponent == null) {
+            return;
+        }
 
-        if (characterHeldItemComponent == null ||
-                mountPointComponent == null ||
-                locationComponent == null) {
+        LocationComponent locationComponent = mountPointComponent.mountPointEntity.getComponent(LocationComponent.class);
+        if (locationComponent == null) {
             return;
         }
 


### PR DESCRIPTION
Rethought the way the events for this work.  This separates the mounting from the resetting of the camera a bit better.  Where a camera reset actually recreates the client side camera entity,  which naturally tiggers a mount.  Also,  force a camera reset when the character respawns.