### PR TITLE
Add Character back in to ray tests to allow PvP combat

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterSystem.java
@@ -16,6 +16,7 @@
 
 package org.terasology.logic.characters;
 
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
@@ -55,6 +56,7 @@ import org.terasology.registry.In;
  */
 @RegisterSystem
 public class CharacterSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+    public static final CollisionGroup[] DEFAULTPHYSICSFILTER = {StandardCollisionGroup.DEFAULT, StandardCollisionGroup.WORLD, StandardCollisionGroup.CHARACTER};
     private static final Logger logger = LoggerFactory.getLogger(CharacterSystem.class);
 
     @In
@@ -70,14 +72,6 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
     private InventoryManager inventoryManager;
 
     private PickupBuilder pickupBuilder;
-
-    /**
-     * TODO: Include the Character collision group
-     * Including the character collision group was removed because tracing from the character's gaze position would hit
-     * the initiating character instead of the ground when looking downwards.
-     */
-    private CollisionGroup[] filter = {StandardCollisionGroup.DEFAULT, StandardCollisionGroup.WORLD};
-
 
     @Override
     public void initialise() {
@@ -108,7 +102,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
         Vector3f direction = gazeLocation.getWorldDirection();
         Vector3f originPos = gazeLocation.getWorldPosition();
 
-        HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, filter);
+        HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
 
         if (result.isHit()) {
             int damage = 1;
@@ -211,7 +205,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
                 return false; // can happen if target existed on client
             }
 
-            HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, filter);
+            HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
             if (!result.isHit()) {
                 String msg = "Denied activation attempt by {} since at the authority there was nothing to activate at that place";
                 logger.info(msg, getPlayerNameFromCharacter(character));

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.logic.players;
 
+import com.google.common.collect.Sets;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.CharacterMovementComponent;
+import org.terasology.logic.characters.CharacterSystem;
 import org.terasology.logic.characters.events.ActivationPredicted;
 import org.terasology.logic.characters.events.ActivationRequest;
 import org.terasology.logic.location.LocationComponent;
@@ -25,10 +27,8 @@ import org.terasology.math.Direction;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
-import org.terasology.physics.CollisionGroup;
 import org.terasology.physics.HitResult;
 import org.terasology.physics.Physics;
-import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.registry.CoreRegistry;
 
 /**
@@ -37,10 +37,6 @@ public class LocalPlayer {
 
     private EntityRef clientEntity = EntityRef.NULL;
     private int nextActivationId;
-
-    // TODO use same as CharacterSystem?
-    private CollisionGroup[] filter = {StandardCollisionGroup.DEFAULT, StandardCollisionGroup.WORLD,
-            StandardCollisionGroup.CHARACTER};
 
     public LocalPlayer() {
     }
@@ -202,7 +198,7 @@ public class LocalPlayer {
         boolean ownedEntityUsage = usedOwnedEntity.exists();
         int activationId = nextActivationId++;
         Physics physics = CoreRegistry.get(Physics.class);
-        HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, filter);
+        HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), CharacterSystem.DEFAULTPHYSICSFILTER);
         boolean eventWithTarget = result.isHit();
         if (eventWithTarget) {
             EntityRef activatedObject = usedOwnedEntity.exists() ? usedOwnedEntity : result.getEntity();

--- a/engine/src/main/java/org/terasology/physics/Physics.java
+++ b/engine/src/main/java/org/terasology/physics/Physics.java
@@ -20,6 +20,7 @@ import org.terasology.math.AABB;
 import org.terasology.math.geom.Vector3f;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  */
@@ -35,6 +36,19 @@ public interface Physics {
      * @return A HitResult object that contains the info about the ray trace.
      */
     HitResult rayTrace(Vector3f from, Vector3f direction, float distance, CollisionGroup... collisionGroups);
+
+    /**
+     * Executes a rayTrace on the physics engine, excluding hitting entities specified
+     *
+     * @param from             Place to start tracing
+     * @param direction        Directing in which to trace
+     * @param distance         maximum distance to trace before giving up
+     * @param excludedEntities entities that should not be tested during the ray trace
+     * @param collisionGroups  the collision groups to collide with. Only if an
+     *                         object of any of these groups is hit it will be registered.
+     * @return A HitResult object that contains the info about the ray trace.
+     */
+    HitResult rayTrace(Vector3f from, Vector3f direction, float distance, Set<EntityRef> excludedEntities, CollisionGroup... collisionGroups);
 
     /**
      * Scans the given area for physics objects of the given groups and returns


### PR DESCRIPTION
Add Character back in to ray tests to allow PvP combat.  Be wary of Mr Barsack and his axe!

Add the ability to exclude entities from a physics ray test so that a player cannot hit or activate their own character.

This also fixes the problem of being not able to place blocks close to your feet because of the mismatched ray trace filters.  This problem is 
mentioned in https://github.com/MovingBlocks/Terasology/pull/2157.