### PR TITLE
Allow rigid bodies to settle and sleep - time for more explosions!

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/CreateWorldEntity.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/CreateWorldEntity.java
@@ -22,6 +22,7 @@ import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.network.NetworkComponent;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.generator.WorldConfigurator;
@@ -71,6 +72,9 @@ public class CreateWorldEntity extends SingleStepLoadProcess {
         } else {
             EntityRef worldEntity = entityManager.create();
             worldEntity.addComponent(new WorldComponent());
+            NetworkComponent networkComponent = new NetworkComponent();
+            networkComponent.replicateMode = NetworkComponent.ReplicateMode.ALWAYS;
+            worldEntity.addComponent(networkComponent);
             worldRenderer.getChunkProvider().setWorldEntity(worldEntity);
 
             // transfer all world generation parameters from Config to WorldEntity

--- a/engine/src/main/java/org/terasology/logic/common/lifespan/LifespanComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/lifespan/LifespanComponent.java
@@ -27,6 +27,8 @@ public class LifespanComponent implements Component {
     // Lifespan in seconds
     @Replicate
     public float lifespan = 5;
+    @Replicate
+    public long deathTime;
 
     public LifespanComponent() {
     }

--- a/engine/src/main/java/org/terasology/logic/location/Location.java
+++ b/engine/src/main/java/org/terasology/logic/location/Location.java
@@ -20,6 +20,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
@@ -118,5 +119,12 @@ public class Location extends BaseComponentSystem {
             }
             childIterator.remove();
         }
+    }
+
+    @ReceiveEvent(netFilter = RegisterMode.REMOTE_CLIENT)
+    public void onResyncLocation(LocationResynchEvent event, EntityRef entityRef, LocationComponent locationComponent) {
+        locationComponent.setWorldPosition(event.getPosition());
+        locationComponent.setWorldRotation(event.getRotation());
+        entityRef.saveComponent(locationComponent);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/location/LocationResynchEvent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationResynchEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.location;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.network.BroadcastEvent;
+
+@BroadcastEvent
+public class LocationResynchEvent implements Event {
+    public Vector3f position;
+    public Quat4f rotation;
+
+    public LocationResynchEvent() {
+    }
+
+    public LocationResynchEvent(Vector3f position, Quat4f rotation) {
+        this.position = position;
+        this.rotation = rotation;
+    }
+
+    public Vector3f getPosition() {
+        return position;
+    }
+
+    public Quat4f getRotation() {
+        return rotation;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/time/TimeAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/time/TimeAuthoritySystem.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.time;
+
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.console.commandSystem.annotations.Command;
+import org.terasology.logic.permission.PermissionManager;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+
+@RegisterSystem
+public class TimeAuthoritySystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+    private static final float TARGET_DELTA = 0.05f;
+    private static final long CHECK_AUTOMATIC_TIME_DILATION_MS = 500;
+
+
+    @In
+    WorldProvider worldProvider;
+    @In
+    private Time time;
+
+    private float lastGameTimeDilationValue;
+    //TODO: persist this across server restarts
+    private boolean enableAutomaticTimeDilation;
+    private long lastCheckedAutomaticTimeDilation;
+
+    @Override
+    public void initialise() {
+        lastGameTimeDilationValue = time.getGameTimeDilation();
+    }
+
+    @Override
+    public void update(float delta) {
+        if (enableAutomaticTimeDilation && lastCheckedAutomaticTimeDilation < time.getRealTimeInMs()) {
+            lastCheckedAutomaticTimeDilation = time.getRealTimeInMs() + CHECK_AUTOMATIC_TIME_DILATION_MS;
+            // attempt to maintain the target delta by slowing down time in general.
+            float newGameTimeDilation = Math.max(0.1f, Math.min(1f, TARGET_DELTA / time.getGameDelta()));
+            float deltaGameTimeDilation = newGameTimeDilation - time.getGameTimeDilation();
+            // change time dilation in 0.1 increments up or down
+            if (deltaGameTimeDilation > 0.1f) {
+                time.setGameTimeDilation(time.getGameTimeDilation() + 0.1f);
+            } else if (deltaGameTimeDilation < -0.1f) {
+                time.setGameTimeDilation(time.getGameTimeDilation() - 0.1f);
+            }
+        }
+
+        // send a resynch event if the authority values has changed
+        if (lastGameTimeDilationValue != time.getGameTimeDilation()) {
+            lastGameTimeDilationValue = time.getGameTimeDilation();
+            worldProvider.getWorldEntity().send(new TimeResynchEvent(lastGameTimeDilationValue));
+        }
+    }
+
+    @Command(shortDescription = "Toggle automatic time dilation", requiredPermission = PermissionManager.SERVER_MANAGEMENT_PERMISSION, runOnServer = true)
+    public String toggleAutoTimeDilation() {
+        enableAutomaticTimeDilation = !enableAutomaticTimeDilation;
+        if (enableAutomaticTimeDilation) {
+            return "Automatic Time Dilation enabled";
+        } else {
+
+            return "Automatic Time Dilation disabled";
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/time/TimeClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/time/TimeClientSystem.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.time;
+
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class TimeClientSystem extends BaseComponentSystem {
+    @In
+    private Time time;
+
+    @ReceiveEvent(netFilter = RegisterMode.REMOTE_CLIENT)
+    public void resynchTime(TimeResynchEvent event, EntityRef entityRef) {
+        time.setGameTimeDilation(event.getGameTimeDilation());
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/time/TimeResynchEvent.java
+++ b/engine/src/main/java/org/terasology/logic/time/TimeResynchEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.time;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.BroadcastEvent;
+
+@BroadcastEvent
+public class TimeResynchEvent implements Event {
+    private float gameTimeDilation;
+
+    public TimeResynchEvent() {
+    }
+
+    public TimeResynchEvent(float gameTimeDilation) {
+        this.gameTimeDilation = gameTimeDilation;
+    }
+
+    public float getGameTimeDilation() {
+        return gameTimeDilation;
+    }
+}

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -279,6 +279,10 @@ public class BulletPhysics implements PhysicsEngine {
         BulletRigidBody rigidBody = entityRigidBodies.remove(entity);
         if (rigidBody != null) {
             removeRigidBody(rigidBody);
+            // wake up this entities neighbors
+            float[] radius = new float[1];
+            rigidBody.rb.getCollisionShape().getBoundingSphere(new Vector3f(), radius);
+            awakenArea(rigidBody.getLocation(new org.terasology.math.geom.Vector3f()), radius[0]);
             return true;
         } else {
             logger.warn("Deleting non existing rigidBody from physics engine?! Entity: {}", entity);
@@ -304,16 +308,11 @@ public class BulletPhysics implements PhysicsEngine {
                 removeRigidBody(rigidBody);
                 newRigidBody(entity);
             } else {
-                if (!rigidBody.rb.getAngularFactor().equals(rb.angularFactor)) {
-                    rigidBody.rb.setAngularFactor(VecMath.to(rb.angularFactor));
-                }
-                if (!rigidBody.rb.getLinearFactor().equals(rb.linearFactor)) {
-                    rigidBody.rb.setLinearFactor(VecMath.to(rb.linearFactor));
-                }
+                rigidBody.rb.setAngularFactor(VecMath.to(rb.angularFactor));
+                rigidBody.rb.setLinearFactor(VecMath.to(rb.linearFactor));
                 rigidBody.rb.setFriction(rb.friction);
             }
 
-            updateKinematicSettings(entity.getComponent(RigidBodyComponent.class), rigidBody);
             return true;
         } else {
             /*

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -95,7 +95,6 @@ import java.util.Set;
 
 /**
  * Physics engine implementation using TeraBullet (a customised version of JBullet)
- *
  */
 public class BulletPhysics implements PhysicsEngine {
 

--- a/engine/src/main/java/org/terasology/physics/bullet/EntityMotionState.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/EntityMotionState.java
@@ -18,7 +18,6 @@ package org.terasology.physics.bullet;
 
 import com.bulletphysics.linearmath.MotionState;
 import com.bulletphysics.linearmath.Transform;
-
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.VecMath;
@@ -56,13 +55,8 @@ public class EntityMotionState extends MotionState {
     public void setWorldTransform(Transform transform) {
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         if (loc != null) {
-            javax.vecmath.Quat4f rot = new javax.vecmath.Quat4f();
-            transform.getRotation(rot);
-            if (!transform.origin.equals(VecMath.to(loc.getWorldPosition())) || !rot.equals(VecMath.to(loc.getWorldRotation()))) {
-                loc.setWorldPosition(VecMath.from(transform.origin));
-                loc.setWorldRotation(VecMath.from(transform.getRotation(new javax.vecmath.Quat4f())));
-                entity.saveComponent(loc);
-            }
+            loc.setWorldPosition(VecMath.from(transform.origin));
+            loc.setWorldRotation(VecMath.from(transform.getRotation(new javax.vecmath.Quat4f())));
         }
     }
 

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
@@ -147,9 +147,12 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
             EntityRef entity = iter.next();
             RigidBodyComponent comp = entity.getComponent(RigidBodyComponent.class);
             RigidBody body = physics.getRigidBody(entity);
-            body.getLinearVelocity(comp.velocity);
-            body.getAngularVelocity(comp.angularVelocity);
-            entity.saveComponent(comp);
+
+            if (body.isActive()) {
+                body.getLinearVelocity(comp.velocity);
+                body.getAngularVelocity(comp.angularVelocity);
+                entity.saveComponent(comp);
+            }
         }
 
         if (networkSystem.getMode().isServer() && time.getGameTimeInMs() - TIME_BETWEEN_NETSYNCS > lastNetsync) {

--- a/engine/src/main/java/org/terasology/physics/events/PhysicsResynchEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/PhysicsResynchEvent.java
@@ -17,7 +17,6 @@
 package org.terasology.physics.events;
 
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.BroadcastEvent;
 
@@ -25,33 +24,15 @@ import org.terasology.network.BroadcastEvent;
  */
 @BroadcastEvent
 public class PhysicsResynchEvent implements Event {
-    private Vector3f position = new Vector3f();
-    private Quat4f rotation = new Quat4f();
     private Vector3f velocity = new Vector3f();
     private Vector3f angularVelocity = new Vector3f();
 
     protected PhysicsResynchEvent() {
     }
 
-    public PhysicsResynchEvent(Vector3f position, Quat4f rotation, Vector3f velocity, Vector3f angularVelocity) {
-        this.position.set(position);
-        this.rotation.set(rotation);
+    public PhysicsResynchEvent(Vector3f velocity, Vector3f angularVelocity) {
         this.velocity.set(velocity);
         this.angularVelocity.set(angularVelocity);
-    }
-
-    /**
-     * @return The position of the physics entity when this event is sent. Copy to use.
-     */
-    public Vector3f getPosition() {
-        return position;
-    }
-
-    /**
-     * @return The rotation of the physics entity when this event is sent. Copy to use.
-     */
-    public Quat4f getRotation() {
-        return rotation;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
@@ -135,9 +135,10 @@ public class DebugOverlay extends CoreScreenLayer {
                         Biome biome = worldProvider.getBiome(blockPos);
                         biomeId = CoreRegistry.get(BiomeManager.class).getBiomeId(biome);
                     }
-                    return String.format("total vus: %s | worldTime: %.3f | biome: %s",
+                    return String.format("total vus: %s | worldTime: %.3f | tiDi: %.1f |  biome: %s",
                             ChunkTessellator.getVertexArrayUpdateCount(),
                             worldProvider.getTime().getDays() - 0.0005f,    // use floor instead of rounding up
+                            time.getGameTimeDilation(),
                             biomeId);
                 }
             });


### PR DESCRIPTION
When rigid bodies are removed,  an area around them is woken up so that bodies resting on top can fall.  This allows large amounts of rigid bodies in the world without actively calculating physics on them (like say from the railgun).  The falling bodies problem was solved before by always setting the bodies to an active state, now it only activates a region around the removed body.

You will see framerates improve a couple seconds after a number of railgun hits.  Previous to this change it would drop the framerate down really low until the entities were removed entirely by the LifespanComponent.