### PR TITLE
Fix sound issues when in multiplayer

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/tree/PlaySoundNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/PlaySoundNode.java
@@ -18,9 +18,8 @@ package org.terasology.logic.behavior.tree;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.audio.AudioEndListener;
-import org.terasology.audio.AudioManager;
 import org.terasology.audio.StaticSound;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.properties.OneOf;
 import org.terasology.rendering.nui.properties.Range;
@@ -49,8 +48,6 @@ public class PlaySoundNode extends Node {
 
     public static class PlaySoundTask extends Task implements AudioEndListener {
         @In
-        private AudioManager audioManager;
-        @In
         private AssetManager assetManager;
         private boolean playing;
         private boolean finished;
@@ -65,12 +62,7 @@ public class PlaySoundNode extends Node {
             if (uri != null) {
                 Optional<StaticSound> snd = assetManager.getAsset(uri, StaticSound.class);
                 if (snd.isPresent()) {
-                    if (actor().hasLocation()) {
-                        Vector3f worldPosition = actor().location().getWorldPosition();
-                        audioManager.playSound(snd.get(), worldPosition, getNode().volume, AudioManager.PRIORITY_NORMAL, this);
-                    } else {
-                        audioManager.playSound(snd.get(), new Vector3f(), getNode().volume, AudioManager.PRIORITY_NORMAL, this);
-                    }
+                    actor().minion().send(new PlaySoundEvent(snd.get(), getNode().volume));
                     playing = true;
                 }
             }

--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEffectComponent.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEffectComponent.java
@@ -16,14 +16,13 @@
 package org.terasology.logic.particles;
 
 import com.google.common.collect.Lists;
-
+import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
+import org.terasology.network.Replicate;
 import org.terasology.reflection.MappedContainer;
-import org.terasology.entitySystem.Component;
 import org.terasology.rendering.assets.texture.Texture;
-import org.terasology.world.block.family.BlockFamily;
 
 import java.util.List;
 
@@ -36,30 +35,46 @@ public final class BlockParticleEffectComponent implements Component {
         ADD
     }
 
+    @Replicate
     // Can be null for non-block particles
-    public BlockFamily blockType;
+    public String blockType;
     // If no texture is specified, the default block texture atlas is used
+    @Replicate
     public Texture texture;
 
+    @Replicate
     public int spawnCount = 16;
+    @Replicate
     public boolean destroyEntityOnCompletion;
+    @Replicate
     public Vector4f color = new Vector4f(1.0f, 1.0f, 1.0f, 1.0f);
+    @Replicate
     public ParticleBlendMode blendMode = ParticleBlendMode.OPAQUE;
 
     // Initial conditions
+    @Replicate
     public Vector3f spawnRange = new Vector3f();
+    @Replicate
     public Vector3f initialVelocityRange = new Vector3f();
+    @Replicate
     public float minSize = 0.1f;
+    @Replicate
     public float maxSize = 1.0f;
+    @Replicate
     public float minLifespan;
+    @Replicate
     public float maxLifespan = 1.0f;
-
+    @Replicate
     public boolean randBlockTexDisplacement;
+    @Replicate
     public Vector2f randBlockTexDisplacementScale = new Vector2f(0.25f, 0.25f);
 
     // Lifetime conditions
+    @Replicate
     public Vector3f targetVelocity = new Vector3f();
+    @Replicate
     public Vector3f acceleration = new Vector3f();
+    @Replicate
     public boolean collideWithBlocks;
 
     public List<Particle> particles = Lists.newArrayList();

--- a/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/particles/BlockParticleEmitterSystem.java
@@ -46,6 +46,7 @@ import org.terasology.utilities.random.Random;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.biomes.Biome;
 import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.tiles.WorldAtlas;
 
@@ -98,6 +99,9 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
     @In
     private Config config;
 
+    @In
+    private BlockManager blockManager;
+
     private Random random = new FastRandom();
     private NearestSortingList sorter = new NearestSortingList();
     private int displayList;
@@ -141,8 +145,6 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
 
             if (particleEffect.particles.size() == 0 && particleEffect.destroyEntityOnCompletion) {
                 entity.destroy();
-            } else {
-                entity.saveComponent(particleEffect);
             }
         }
     }
@@ -174,7 +176,7 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
             final float tileSize = worldAtlas.getRelativeTileSize();
             p.texSize.set(tileSize, tileSize);
 
-            Block b = particleEffect.blockType.getArchetypeBlock();
+            Block b = blockManager.getBlock(particleEffect.blockType).getBlockFamily().getArchetypeBlock();
             p.texOffset.set(b.getPrimaryAppearance().getTextureAtlasPos(BlockPart.FRONT));
 
             if (particleEffect.randBlockTexDisplacement) {
@@ -299,7 +301,7 @@ public class BlockParticleEmitterSystem extends BaseComponentSystem implements U
 
             float light = worldRenderer.getRenderingLightValueAt(new Vector3f(worldPos.x + particle.position.x,
                     worldPos.y + particle.position.y, worldPos.z + particle.position.z));
-            renderParticle(particle, particleEffect.blockType.getArchetypeBlock(), biome, light);
+            renderParticle(particle, blockManager.getBlock(particleEffect.blockType).getBlockFamily().getArchetypeBlock(), biome, light);
             glPopMatrix();
         }
         glPopMatrix();

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -103,7 +103,7 @@ public class BlockItemSystem extends BaseComponentSystem {
                     event.consume();
                 }
             }
-            event.getInstigator().send(new PlaySoundEvent(event.getInstigator(), Assets.getSound("engine:PlaceBlock").get(), 0.5f));
+            event.getInstigator().send(new PlaySoundEvent(Assets.getSound("engine:PlaceBlock").get(), 0.5f));
         } else {
             event.consume();
         }

--- a/engine/src/main/resources/assets/prefabs/particleEffects/defaultBlockParticles.prefab
+++ b/engine/src/main/resources/assets/prefabs/particleEffects/defaultBlockParticles.prefab
@@ -8,10 +8,11 @@
         "minSize" : 0.05,
         "maxSize" : 0.1,
         "minLifespan" : 1,
-        "maxLifespan" : 1.5;
+        "maxLifespan": 1.5,
         "targetVelocity" : [0, -5, 0],
         "acceleration" : [2, 2, 2],
         "collideWithBlocks" : true,
         "randBlockTexDisplacement" : true
-    }
+    },
+    "network": {}
 }

--- a/engine/src/main/resources/assets/prefabs/particleEffects/dustEffect.prefab
+++ b/engine/src/main/resources/assets/prefabs/particleEffects/dustEffect.prefab
@@ -1,19 +1,41 @@
 {
     "location" : {},
     "blockParticleEffect" : {
-        "spawnCount" : 64,
-        "initialVelocityRange" : [4, 4, 4],
-        "spawnRange" : [0.3, 0.3, 0.3],
-        "destroyEntityOnCompletion" : true,
-        "minSize" : 0.25,
-        "maxSize" : 1,
-        "minLifespan" : 1,
-        "maxLifespan" : 1.5,
-        "targetVelocity" : [0, 2, 0],
-        "acceleration" : [2, 2, 2],
-        "collideWithBlocks" : true,
-        "texture" : "engine:fx_smoke",
-        "blendMode" : "ADD",
-        "color" : [0.847, 0.78, 0.62, 0.5]
-    }
+        "spawnCount": 64,
+        "initialVelocityRange": [
+            4,
+            4,
+            4
+        ],
+        "spawnRange": [
+            0.3,
+            0.3,
+            0.3
+        ],
+        "destroyEntityOnCompletion": true,
+        "minSize": 0.25,
+        "maxSize": 1,
+        "minLifespan": 1,
+        "maxLifespan": 1.5,
+        "targetVelocity": [
+            0,
+            2,
+            0
+        ],
+        "acceleration": [
+            2,
+            2,
+            2
+        ],
+        "collideWithBlocks": true,
+        "texture": "engine:fx_smoke",
+        "blendMode": "ADD",
+        "color": [
+            0.847,
+            0.78,
+            0.62,
+            0.5
+        ]
+    },
+    "Network": {}
 }

--- a/engine/src/main/resources/assets/prefabs/particleEffects/smokeExplosion.prefab
+++ b/engine/src/main/resources/assets/prefabs/particleEffects/smokeExplosion.prefab
@@ -15,5 +15,6 @@
         "texture" : "engine:fx_smoke",
         "blendMode" : "ADD",
         "color" : [0.847, 0.78, 0.62, 0.5]
-    }
+    },
+    "network": {}
 }

--- a/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.asset.Assets;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.StaticSound;
+import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -143,8 +144,7 @@ public class DoorSystem extends BaseComponentSystem {
             newDoorComp.openSide = attachSide.reverse();
             newDoorComp.isOpen = false;
             newDoor.saveComponent(newDoorComp);
-            newDoor.removeComponent(ItemComponent.class);
-            audioManager.playSound(Assets.getSound("engine:PlaceBlock").get(), 0.5f);
+            newDoor.send(new PlaySoundEvent(Assets.getSound("engine:PlaceBlock").get(), 0.5f));
             logger.info("Closed Side: {}", newDoorComp.closedSide);
             logger.info("Open Side: {}", newDoorComp.openSide);
         }
@@ -190,8 +190,7 @@ public class DoorSystem extends BaseComponentSystem {
         worldProvider.setBlock(regionComp.region.max(), topBlock);
         StaticSound sound = (door.isOpen) ? door.closeSound : door.openSound;
         if (sound != null) {
-            LocationComponent loc = entity.getComponent(LocationComponent.class);
-            audioManager.playSound(sound, loc.getWorldPosition(), 10, 1);
+            entity.send(new PlaySoundEvent(sound, 1f));
         }
 
         door.isOpen = !door.isOpen;


### PR DESCRIPTION
This solves hopefully all of the sound issues in multiplayer (fixes #715) and some issues with sound placement (#663).  There are two strategies to sound that are important to note:

1. Playing sounds on a common system (where the same code runs on remote client and authority)
  - Use the PlaySoundEvent event that takes in the EntityRef of the owner.  Events that trigger playing a sound need need to specify the instigator entity that caused the sound so that when the authority broadcasts the sound to all players,  it will skip repeating the sound on the owning client.
  - Accessing the audio system directly is generally a bad idea.
2. Playing sounds on the authority
  - Use the PlaySoundEvent without an owner EntityRef.  That way it will broadcast to everyone including the client that caused the sound.

Also, this PR functionally fixes the particle effects on remote clients by replicating the particle entities across the wire.  This is probably not the most efficient way to do this,  but it is functional.  Ideally in the future we may want to allow clients to scale back the particles so that lesser computers can get ok performance.