### PR TITLE
Fix #2030 Add hostname & server address as log file name on server play

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
@@ -33,6 +33,7 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.naming.NameVersion;
 import org.terasology.network.JoinStatus;
 import org.terasology.network.NetworkSystem;
+import org.terasology.network.Server;
 import org.terasology.network.ServerInfoMessage;
 import org.terasology.world.internal.WorldInfo;
 
@@ -80,8 +81,16 @@ public class JoinServer implements LoadProcess {
             }
             return false;
         } else if (joinStatus.getStatus() == JoinStatus.Status.COMPLETE) {
+            Server server = networkSystem.getServer();
             ServerInfoMessage serverInfo = networkSystem.getServer().getInfo();
-            gameManifest.setTitle(serverInfo.getGameName());
+
+            // If no GameName, use Server IP Address
+            if (serverInfo.getGameName().length() > 0) {
+                gameManifest.setTitle(serverInfo.getGameName());
+            } else {
+                gameManifest.setTitle(server.getRemoteAddress());
+            }
+
             for (WorldInfo worldInfo : serverInfo.getWorldInfoList()) {
                 gameManifest.addWorld(worldInfo);
             }

--- a/engine/src/main/java/org/terasology/network/Server.java
+++ b/engine/src/main/java/org/terasology/network/Server.java
@@ -27,6 +27,8 @@ public interface Server extends ChunkReadyListener {
 
     EntityRef getClientEntity();
 
+    String getRemoteAddress();
+
     ServerInfoMessage getInfo();
 
     void send(Event event, EntityRef target);

--- a/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
@@ -63,6 +63,8 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.internal.ChunkSerializer;
 import org.terasology.world.chunks.remoteChunkProvider.RemoteChunkProvider;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -130,6 +132,16 @@ public class ServerImpl implements Server {
     @Override
     public EntityRef getClientEntity() {
         return networkSystem.getEntity(clientEntityNetId);
+    }
+
+    @Override
+    public String getRemoteAddress() {
+        SocketAddress socketAddress = channel.getRemoteAddress();
+
+        // Cast to InetSocketAddress to retrieve remote address
+        InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
+
+        return inetSocketAddress.getHostName() + "-" + inetSocketAddress.getAddress().getHostAddress() + "-" + inetSocketAddress.getPort();
     }
 
     @Override


### PR DESCRIPTION
First, this fix check whether Game Name is present or not. If the game name is not present, then this fix look up for the Server hostname & address as log file name using existing SocketAddress.

The output forrmat log file name as follows:
Terasology-<hostname>-<IP>-<port>.log

Example:
Terasology-localhost-127.0.0.1-25777.log