### PR TITLE
Add import statement order config file for Eclipse

### DIFF
--- a/config/eclipse/.importorder
+++ b/config/eclipse/.importorder
@@ -1,0 +1,6 @@
+#Organize Import Order
+#Mon Feb 29 21:48:22 EET 2016
+3=\#
+2=java
+1=javax
+0=


### PR DESCRIPTION
Fixes #2117.

_Note: since .importorder is a semantic extension, I've chosen not to name this file at all - looks clean and .gitignore-like. This may cause some awkward issues on Windows, though, so it's subject to change._

### Usage:

- In Eclipse, go to Window → Preferences → Java → Code Style → Organize Imports.

- Import the import order file, click Apply.

![screenshot of Organize Imports menu in Eclipse](http://i.imgur.com/ZTdzH7g.png)

- **[Recommended]** Switch to Editor → Save Actions, check Perform the selected actions on save and Organize imports.

![screenshot of Save Actions menu in Eclipse](http://i.imgur.com/1Gh88pL.png)