### PR TITLE
Add config option to override log level

### DIFF
--- a/engine-tests/src/test/resources/logback.xml
+++ b/engine-tests/src/test/resources/logback.xml
@@ -10,11 +10,11 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="${logOverrideLevel:-debug}">
     <appender-ref ref="CONSOLE" />
   </root>
 
-  <logger name="org.terasology" level="INFO" />
-  <logger name="org.reflections.Reflections" level="WARN" />
+  <logger name="org.terasology" level="${logOverrideLevel:-info}" />
+  <logger name="org.reflections.Reflections" level="${logOverrideLevel:-warn}" />
 
 </configuration>

--- a/facades/PC/src/main/resources/logback.xml
+++ b/facades/PC/src/main/resources/logback.xml
@@ -40,12 +40,12 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="${logOverrideLevel:-debug}">
     <appender-ref ref="SIFT" />
     <appender-ref ref="CONSOLE" />
   </root>
 
-  <logger name="org.terasology" level="INFO" />
-  <logger name="org.reflections.Reflections" level="WARN" />
+  <logger name="org.terasology" level="${logOverrideLevel:-info}" />
+  <logger name="org.reflections.Reflections" level="${logOverrideLevel:-warn}" />
 
 </configuration>

--- a/facades/TeraEd/src/main/resources/logback.xml
+++ b/facades/TeraEd/src/main/resources/logback.xml
@@ -16,11 +16,11 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="${logOverrideLevel:-debug}">
     <appender-ref ref="CONSOLE" />
   </root>
 
-  <logger name="org.terasology" level="INFO" />
-  <logger name="org.reflections.Reflections" level="WARN" />
+  <logger name="org.terasology" level="${logOverrideLevel:-info}" />
+  <logger name="org.reflections.Reflections" level="${logOverrideLevel:-warn}" />
 
 </configuration>


### PR DESCRIPTION
### Contains

A supplement to the fixes for MovingBlocks/TerasologyLauncher#349 and MovingBlocks/TerasologyLauncher#350, should be merged along with MovingBlocks/TerasologyLauncher#351

### How to test

Whenever MovingBlocks/TerasologyLauncher#351 is merged, try modifying log levels in the launcher and then check out the game logs. This PR is what makes Logback actually accept the new levels in the game.