### PR TITLE
Fix issue when menu is scrolled down.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
@@ -98,11 +98,11 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
             Border itemMargin = canvas.getCurrentStyle().getMargin();
 
             // Limit number of visible options
-            int optionsSize = options.get().size() <= visibleOptionsNum ? options.get().size() : visibleOptionsNum;
+            float optionsSize = options.get().size() <= visibleOptionsNum ? options.get().size() : (visibleOptionsNum + 0.5f);
 
             // Calculate total options height
             int itemHeight = itemMargin.getTotalHeight() + font.getLineHeight();
-            int height = itemHeight * optionsSize + canvas.getCurrentStyle().getBackgroundBorder().getTotalHeight();
+            int height = (int) (itemHeight * optionsSize + canvas.getCurrentStyle().getBackgroundBorder().getTotalHeight());
             canvas.addInteractionRegion(mainListener, Rect2i.createFromMinAndSize(0, 0, canvas.size().x, canvas.size().y + height));
 
             // Dropdown Background Frame
@@ -158,6 +158,10 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
         // Draw Scrollbar
         Rect2i scrollbarRegion = Rect2i.createFromMinAndSize(scrollbarXPos, scrollbarYPos, scrollbarWidth, scrollbarHeight);
         canvas.drawWidget(verticalBar, scrollbarRegion);
+
+        // Set the range of Scrollbar
+        float maxVertBarDesired = itemHeight * (optionListeners.size() - visibleOptionsNum - 0.5f) + itemMargin.getBottom();
+        verticalBar.setRange((int)maxVertBarDesired);
 
         for (int i = 0; i < optionListeners.size(); ++i) {
             readItemMouseOver(canvas, i);


### PR DESCRIPTION
Fixes #2185
Currently it just ignores the scroll value beyond a certain limit. So, no actual scroll happens after the vertical bar is scrolled a certain amount of pixels.
A better approach maybe to divide the net scroll amount of vertical bar according to the number of element (by linear weighing). This would allow actual scroll till the end of the bar.
If the second approach would be preferred, please let me know. I'll edit it.
.
 This is my first PR to Terasology, so just submitted it in a bit of excitement, sorry if I missed some coding standard followed in this project.