### PR TITLE
Faster skeleton mesh rendering via frustum culling

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessSkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessSkeletalMesh.java
@@ -18,6 +18,7 @@ package org.terasology.engine.subsystem.headless.assets;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.math.AABB;
 import org.terasology.rendering.assets.skeletalmesh.Bone;
 import org.terasology.rendering.assets.skeletalmesh.SkeletalMesh;
 import org.terasology.rendering.assets.skeletalmesh.SkeletalMeshData;
@@ -57,5 +58,10 @@ public class HeadlessSkeletalMesh extends SkeletalMesh {
     @Override
     public Bone getBone(String boneName) {
         return data.getBone(boneName);
+    }
+
+    @Override
+    public AABB getStaticAabb() {
+        return data.getStaticAABB();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimation.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimation.java
@@ -19,6 +19,7 @@ package org.terasology.rendering.assets.animation;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.math.AABB;
 import org.terasology.rendering.assets.skeletalmesh.SkeletalMesh;
 
 /**
@@ -40,4 +41,6 @@ public abstract class MeshAnimation extends Asset<MeshAnimationData> {
     public abstract String getBoneName(int index);
 
     public abstract float getTimePerFrame();
+
+    public abstract AABB getAabb();
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimationData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimationData.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import org.terasology.assets.AssetData;
+import org.terasology.math.AABB;
 
 import java.util.List;
 
@@ -32,14 +33,17 @@ public class MeshAnimationData implements AssetData {
     private TIntList boneParent;
     private List<MeshAnimationFrame> frames;
     private float timePerFrame;
+    private AABB aabb;
 
     /**
      * @param boneNames    The names of the bones this animation expects
      * @param boneParents  The indices of the parent of each bone in the boneNames list, NO_PARENT for no parent.
+     * @param aabb A bounding box that contains the object in all animation stops.
      * @param frames
      * @param timePerFrame
      */
-    public MeshAnimationData(List<String> boneNames, TIntList boneParents, List<MeshAnimationFrame> frames, float timePerFrame) {
+    public MeshAnimationData(List<String> boneNames, TIntList boneParents, List<MeshAnimationFrame> frames,
+                             float timePerFrame, AABB aabb) {
         if (boneNames.size() != boneParents.size()) {
             throw new IllegalArgumentException("Bone names and boneParent indices must align");
         }
@@ -47,6 +51,7 @@ public class MeshAnimationData implements AssetData {
         this.boneParent = new TIntArrayList(boneParents);
         this.frames = ImmutableList.copyOf(frames);
         this.timePerFrame = timePerFrame;
+        this.aabb = aabb;
     }
 
     public List<String> getBoneNames() {
@@ -63,5 +68,9 @@ public class MeshAnimationData implements AssetData {
 
     public float getTimePerFrame() {
         return timePerFrame;
+    }
+
+    public AABB getAabb() {
+        return aabb;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimationImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimationImpl.java
@@ -18,6 +18,7 @@ package org.terasology.rendering.assets.animation;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.math.AABB;
 import org.terasology.rendering.assets.skeletalmesh.Bone;
 import org.terasology.rendering.assets.skeletalmesh.SkeletalMesh;
 
@@ -74,6 +75,11 @@ public class MeshAnimationImpl extends MeshAnimation {
     }
 
     @Override
+    public AABB getAabb() {
+        return data.getAabb();
+    }
+
+    @Override
     protected void doReload(MeshAnimationData newData) {
         this.data = newData;
     }
@@ -82,4 +88,5 @@ public class MeshAnimationImpl extends MeshAnimation {
     protected Optional<? extends Asset<MeshAnimationData>> doCreateCopy(ResourceUrn copyUrn, AssetType<?, MeshAnimationData> parentAssetType) {
         return Optional.of(new MeshAnimationImpl(copyUrn, parentAssetType, data));
     }
+
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMesh.java
@@ -19,6 +19,7 @@ package org.terasology.rendering.assets.skeletalmesh;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.math.AABB;
 
 import java.util.Collection;
 
@@ -35,4 +36,10 @@ public abstract class SkeletalMesh extends Asset<SkeletalMeshData> {
     public abstract Collection<Bone> getBones();
 
     public abstract Bone getBone(String boneName);
+
+    /**
+     *
+     * @return the boundings of the mesh when it its not being animated.
+     */
+    public abstract AABB getStaticAabb();
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshData.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import org.terasology.assets.AssetData;
+import org.terasology.math.AABB;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
@@ -41,8 +42,10 @@ public class SkeletalMeshData implements AssetData {
     private TIntList vertexStartWeights = new TIntArrayList();
     private TIntList vertexWeightCounts = new TIntArrayList();
     private TIntList indices = new TIntArrayList();
+    private AABB staticAABB;
 
-    public SkeletalMeshData(List<Bone> bones, List<BoneWeight> weights, List<Vector2f> uvs, TIntList vertexStartWeights, TIntList vertexWeightCounts, TIntList indices) {
+    public SkeletalMeshData(List<Bone> bones, List<BoneWeight> weights, List<Vector2f> uvs, TIntList vertexStartWeights,
+                            TIntList vertexWeightCounts, TIntList indices, AABB staticAABB) {
         for (Bone bone : bones) {
             if (bone.getParent() == null) {
                 rootBone = bone;
@@ -55,9 +58,12 @@ public class SkeletalMeshData implements AssetData {
         this.vertexStartWeights.addAll(vertexStartWeights);
         this.vertexWeightCounts.addAll(vertexWeightCounts);
         this.indices.addAll(indices);
+        this.staticAABB = staticAABB;
 
         calculateNormals();
     }
+
+
 
     public Collection<Bone> getBones() {
         return bones;
@@ -136,6 +142,10 @@ public class SkeletalMeshData implements AssetData {
 
     public List<Vector2f> getUVs() {
         return uvs;
+    }
+
+    public AABB getStaticAABB() {
+        return staticAABB;
     }
 
     private void calculateNormals() {

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -132,8 +133,8 @@ public class MD5AnimationLoader extends AbstractAssetFileFormat<MeshAnimationDat
             frames.add(new MeshAnimationFrame(positions, rotations));
 
         }
-
-        return new MeshAnimationData(boneNames, boneParents, frames, timePerFrame);
+        AABB aabb = AABB.createEncompassing(Arrays.asList(md5.bounds));
+        return new MeshAnimationData(boneNames, boneParents, frames, timePerFrame, aabb);
     }
 
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/OpenGLSkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/OpenGLSkeletalMesh.java
@@ -25,6 +25,7 @@ import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.engine.GameThread;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
+import org.terasology.math.AABB;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
@@ -184,6 +185,11 @@ public class OpenGLSkeletalMesh extends SkeletalMesh {
     @Override
     public Bone getBone(String boneName) {
         return data.getBone(boneName);
+    }
+
+    @Override
+    public AABB getStaticAabb() {
+        return data.getStaticAABB();
     }
 
     private static class DisposalAction implements Runnable {


### PR DESCRIPTION
### Contains

Adds frustum culling to skeleton based meshes. 

This speeds up the game when there are a lot of skeleton meshes around that are currently not beeing looked at by the camera.

### How to test

Test with newest version of the WildAnimals addon, which contains deers that have correct bounding boxes.
