### PR TITLE
Handle zero division in InventoryGrid

### DIFF
--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -103,7 +103,7 @@ public class InventoryGrid extends CoreWidget {
                 int verticalCells = ((numSlots - 1) / horizontalCells) + 1;
                 return new Vector2i(horizontalCells * cellSize.x, verticalCells * cellSize.y);
             } catch (ArithmeticException e) {
-                logger.warn("Attempted zero division - possible issue in layout definition", e);
+                logger.warn("Attempted zero division - possible issue in layout definition");
             }
         }
         return Vector2i.zero();

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -51,6 +51,11 @@ public class InventoryGrid extends CoreWidget {
     private List<InventoryCell> cells = Lists.newArrayList();
     private Binding<EntityRef> targetEntity = new DefaultBinding<>(EntityRef.NULL);
 
+    /**
+     * Used to limit the number of zero division log warnings to one per instance
+     */
+    private Boolean zeroDivisionNotified = false;
+    
     @Override
     public void update(float delta) {
         super.update(delta);
@@ -103,7 +108,10 @@ public class InventoryGrid extends CoreWidget {
                 int verticalCells = ((numSlots - 1) / horizontalCells) + 1;
                 return new Vector2i(horizontalCells * cellSize.x, verticalCells * cellSize.y);
             } catch (ArithmeticException e) {
-                logger.warn("Attempted zero division - possible issue in layout definition");
+                if (!zeroDivisionNotified) {
+                    logger.warn("Attempted zero division - possible issue in layout definition", e);
+                    zeroDivisionNotified = true;
+                }
             }
         }
         return Vector2i.zero();

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -18,6 +18,8 @@ package org.terasology.rendering.nui.layers.ingame.inventory;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.math.geom.Rect2i;
@@ -43,6 +45,8 @@ public class InventoryGrid extends CoreWidget {
     private Binding<Integer> cellOffset = new DefaultBinding<>(0);
     @LayoutConfig
     private Binding<Integer> maxCellCount = new DefaultBinding<>(Integer.MAX_VALUE);
+
+    private static final Logger logger = LoggerFactory.getLogger(InventoryGrid.class);
 
     private List<InventoryCell> cells = Lists.newArrayList();
     private Binding<EntityRef> targetEntity = new DefaultBinding<>(EntityRef.NULL);
@@ -78,11 +82,13 @@ public class InventoryGrid extends CoreWidget {
         int numSlots = getNumSlots();
         if (numSlots != 0 && !cells.isEmpty()) {
             Vector2i cellSize = canvas.calculatePreferredSize(cells.get(0));
-            int horizontalCells = Math.min(maxHorizontalCells, canvas.size().getX() / cellSize.getX());
-            for (int i = 0; i < numSlots && i < cells.size(); ++i) {
-                int horizPos = i % horizontalCells;
-                int vertPos = i / horizontalCells;
-                canvas.drawWidget(cells.get(i), Rect2i.createFromMinAndSize(horizPos * cellSize.x, vertPos * cellSize.y, cellSize.x, cellSize.y));
+            if (cellSize.getX() != 0 && canvas.size().getX() != 0) {
+                int horizontalCells = Math.min(maxHorizontalCells, canvas.size().getX() / cellSize.getX());
+                for (int i = 0; i < numSlots && i < cells.size(); ++i) {
+                    int horizPos = i % horizontalCells;
+                    int vertPos = i / horizontalCells;
+                    canvas.drawWidget(cells.get(i), Rect2i.createFromMinAndSize(horizPos * cellSize.x, vertPos * cellSize.y, cellSize.x, cellSize.y));
+                }
             }
         }
     }
@@ -92,9 +98,13 @@ public class InventoryGrid extends CoreWidget {
         int numSlots = getNumSlots();
         if (numSlots != 0 && !cells.isEmpty()) {
             Vector2i cellSize = canvas.calculatePreferredSize(cells.get(0));
-            int horizontalCells = Math.min(Math.min(maxHorizontalCells, numSlots), sizeHint.getX() / cellSize.getX());
-            int verticalCells = ((numSlots - 1) / horizontalCells) + 1;
-            return new Vector2i(horizontalCells * cellSize.x, verticalCells * cellSize.y);
+            try {
+                int horizontalCells = Math.min(Math.min(maxHorizontalCells, numSlots), sizeHint.getX() / cellSize.getX());
+                int verticalCells = ((numSlots - 1) / horizontalCells) + 1;
+                return new Vector2i(horizontalCells * cellSize.x, verticalCells * cellSize.y);
+            } catch (ArithmeticException e) {
+                logger.warn("Attempted zero division - possible issue in layout definition", e);
+            }
         }
         return Vector2i.zero();
     }
@@ -126,7 +136,6 @@ public class InventoryGrid extends CoreWidget {
     }
 
     /**
-     *
      * @deprecated Use bindTargetEntity to assign a read only binding that is a getter
      */
     @Deprecated


### PR DESCRIPTION
### Contains

Fixes #2212 - adds a catch block and warning-level log entry to `getPreferredContentSize()` & a precondition to `onDraw()` - logging here would be non-viable (think of the logspam!)

### How to test

Try playing TTA depending on a version of WoodAndStone that doesn't have Terasology/WoodAndStone#43 merged in?
This should be a fairly straightforward fix either way.

### Notes

These are the only methods that can cause a zero-division error within Core layouts.