### PR TITLE
Fix bug #2154

### DIFF
--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -87,7 +87,7 @@ public class TargetSystem {
         target = newTarget;
 
         LocationComponent location = target.getComponent(LocationComponent.class);
-        if(location != null && targetBlockPos != null) {
+        if (location != null && targetBlockPos != null) {
             location.setLocalPosition(targetBlockPos.toVector3f());
         }
 

--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -19,6 +19,7 @@ package org.terasology.input.cameraTarget;
 import java.util.Arrays;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.CollisionGroup;
@@ -66,21 +67,30 @@ public class TargetSystem {
         }
 
         HitResult hitInfo = physics.rayTrace(pos, dir, maxDist, filter);
-
         EntityRef newTarget = hitInfo.getEntity();
 
-        if (target.equals(newTarget)) {
-            return false;
-        }
-
         if (hitInfo.isWorldHit()) {
+            if (targetBlockPos != null) {
+                if (targetBlockPos.equals(hitInfo.getBlockPosition())) {
+                    return false;
+                }
+            }
             targetBlockPos = hitInfo.getBlockPosition();
         } else {
+            if (target.equals(newTarget)) {
+                return false;
+            }
             targetBlockPos = null;
         }
 
         prevTarget = target;
         target = newTarget;
+
+        LocationComponent location = target.getComponent(LocationComponent.class);
+        if(location != null && targetBlockPos != null) {
+            location.setLocalPosition(targetBlockPos.toVector3f());
+        }
+
         return true;
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -124,6 +124,10 @@ public class BlockItemSystem extends BaseComponentSystem {
             return false;
         }
 
+        if (block.getBlockFamily().equals(adjBlock.getBlockFamily())) {
+            return false;
+        }
+
         // Prevent players from placing blocks inside their bounding boxes
         if (!block.isPenetrable()) {
             Physics physics = CoreRegistry.get(Physics.class);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2154 

The target returned came from the entity associated with the block, which for all elements of a multi-block object would give a location in the same place. This modifies the target to set the LocationComponent to targetBlockPos

### How to test

Reproduce: In Throughout The Ages break apart enough branches and dirt to make a crude axe hammer (craft with g) then chop some tree trunk blocks, place two adjacent, right click either top with the axe, tadaa you get a two block work station. 

Hover over the station, see that the selection grid appears in correct place for all blocks at all times.
