### PR TITLE
Fix bug #2213, result of crafting recipe is displayed in crafting window

### DIFF
--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemIcon.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemIcon.java
@@ -84,6 +84,12 @@ public class ItemIcon extends CoreWidget {
 
     @Override
     public Vector2i getPreferredContentSize(Canvas canvas, Vector2i sizeHint) {
+        if (icon != null) {
+            TextureRegion texture = icon.get();
+            if  (texture != null) {
+                return texture.size();
+            }
+        }
         return new Vector2i();
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes bug #2213 

ItemIcon always returned (0,0) for its preferred size, which is what the craft bench relied upon to render it. I chose to return the size of the texture instead, I'm not sure if this is the best approach to fixing it, but it fixes the recipe display perfectly.

An alternative fix would be to edit CraftRecipeWidget to not rely on calculatePreferredSize, and provide its own size.

### How to test

Obtain items for TTA crafting, eg destroy enough dirt to get stones. Press 'g' to open crafting window, you will see the result of the recipe displayed correctly.

### Outstanding before merging

ItemIcon is used all over the place, I am also unsure if it was set to return the 0 vector for a specific reason, or if it was a mistake.

