### PR TITLE
More avoiding dividing by zero in the inventory grid

### DIFF
--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -83,7 +83,7 @@ public class InventoryGrid extends CoreWidget {
         if (cellSize.getX() == 0 || cellSize.getY() == 0) {
             return;
         }
-        int horizontalCells = Math.min(maxHorizontalCells, canvas.size().getX() / cellSize.getX());
+        int horizontalCells = Math.max(1, Math.min(maxHorizontalCells, canvas.size().getX() / cellSize.getX()));
         for (int i = 0; i < numSlots && i < cells.size(); ++i) {
             int horizPos = i % horizontalCells;
             int vertPos = i / horizontalCells;


### PR DESCRIPTION
### Contains

Fixes another issue like #2212 after applying #2227 which makes the item icons bigger than the canvas.  In this divide by zero problem,  the canvas is smaller than the inventory item and so it rounds down horizontalCells to 0,  causing another divide by zero problem.  This will make it still draw the item even though it may not fit correctly.

### How to test

After opening a wooden workbench (hit two side by side logs on the top) and getting some craftable items (and able to see the results thanks to #2227), it would crash at this point.