### PR TITLE
Fixes #2174 - adds a useful error message in case of giveItem with an ambiguous item

### DIFF
--- a/modules/Core/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -16,6 +16,9 @@
 
 package org.terasology.logic.inventory;
 
+import com.google.common.base.Joiner;
+import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
@@ -30,6 +33,8 @@ import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.world.block.entity.BlockCommands;
 
+import java.util.Set;
+
 /**
  */
 @RegisterSystem
@@ -42,10 +47,10 @@ public class ItemCommands extends BaseComponentSystem {
     private InventoryManager inventoryManager;
 
     @In
-    private PrefabManager prefabManager;
+    private EntityManager entityManager;
 
     @In
-    private EntityManager entityManager;
+    private AssetManager assetManager;
 
     @Command(shortDescription = "Adds an item to your inventory", runOnServer = true,
             requiredPermission = PermissionManager.CHEAT_PERMISSION)
@@ -53,16 +58,30 @@ public class ItemCommands extends BaseComponentSystem {
             @Sender EntityRef client,
             @CommandParam("prefabId or blockName") String itemPrefabName,
             @CommandParam(value = "amount", required = false) Integer amount) {
-        Prefab prefab = prefabManager.getPrefab(itemPrefabName);
-        if (prefab != null && prefab.getComponent(ItemComponent.class) != null) {
-            EntityRef item = entityManager.create(prefab);
-            EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
-            if (!inventoryManager.giveItem(playerEntity, playerEntity, item)) {
-                item.destroy();
-            }
-            return "You received an item of " + prefab.getName();
-        } else {
-            return blockCommands.giveBlock(client, itemPrefabName, amount, null);
+        Set<ResourceUrn> matches = assetManager.resolve(itemPrefabName, Prefab.class);
+        switch(matches.size()) {
+            case 0:
+                return "Could not find any item matching \"" + itemPrefabName + "\"";
+            case 1:
+                Prefab prefab = assetManager.getAsset(matches.iterator().next(), Prefab.class).orElse(null);
+                if (prefab != null && prefab.getComponent(ItemComponent.class) != null) {
+                    EntityRef item = entityManager.create(prefab);
+                    EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
+                    if (!inventoryManager.giveItem(playerEntity, playerEntity, item)) {
+                        item.destroy();
+                    }
+                    return "You received an item of " + prefab.getName();
+                } else {
+                    return blockCommands.giveBlock(client, itemPrefabName, amount, null);
+                }
+            default:
+                StringBuilder builder = new StringBuilder();
+                builder.append("Requested item \"");
+                builder.append(itemPrefabName);
+                builder.append("\": matches ");
+                Joiner.on(" and ").appendTo(builder, matches);
+                builder.append(". Please fully specify one.");
+                return builder.toString();
         }
     }
 


### PR DESCRIPTION
### Contains

Fixes issue #2174 

### How to test

Using JoshariasSurvival, type into the console "giveItem axe". It will now list all items called "axe", instead of saying it couldn't find an item called "axe".

Type into the console "giveItem Stone" and it will still give you stone.

Type into the console "giveItem nothingWithThisNameExists" and it will tell you that no such item exists.

### Outstanding before merging

The wording on the details could be changed.