### PR TITLE
Fix #2087 by not generating block entities again as they also get loa…

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -250,12 +250,6 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
                 updateAdjacentChunksReadyFieldOf(chunk);
                 updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
 
-                if (!readyChunkInfo.isNewChunk()) {
-                    PerformanceMonitor.startActivity("Generating Block Entities");
-                    generateBlockEntities(chunk);
-                    PerformanceMonitor.endActivity();
-                }
-
                 if (readyChunkInfo.isNewChunk()) {
                     PerformanceMonitor.startActivity("Generating queued Entities");
                     readyChunkInfo.getEntities().forEach(this::generateQueuedEntities);
@@ -495,16 +489,6 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
         }
         lightMerger.beginMerge(chunk, readyChunkInfo);
         return true;
-    }
-
-    // Generates all non-temporary block entities
-    private void generateBlockEntities(Chunk chunk) {
-        ChunkBlockIterator i = chunk.getBlockIterator();
-        while (i.next()) {
-            if (i.getBlock().isKeepActive()) {
-                registry.getBlockEntityAt(i.getBlockPos());
-            }
-        }
     }
 
     void gatherBlockPositionsForDeactivate(Chunk chunk) {


### PR DESCRIPTION
### Contains

Fix #2087 by not generating block entities again as they also get loaded from the save game.

### How to test

Please test loading of modules with active blocks like chests.

@MarcinSc  please test if this fix your issue and check if your active blocks work properly

@Cervator please test a few module for side effects

@immortius since this patch bluntly removes code, I would like to have your review.

Techinical steps to reproduce the bug and verify later on that it is fixed:

1. Create a system that listens for the activation of a custom component with @ForceBlockActive :
```
@ForceBlockActive
public class ActivationTestComponent implements Component {
}

@RegisterSystem(RegisterMode.AUTHORITY)
public class ActivationTestSystem extends BaseComponentSystem {

    private static final Logger logger = LoggerFactory.getLogger(ActivationTestSystem.class);


    @ReceiveEvent(components = {ActivationTestComponent.class})
    public void onTestComponentActivation(OnActivatedComponent event, EntityRef entity) {
        if (entity.hasComponent(BlockTypeComponent.class)) {
            logger.info("activated block type");
        } else {
            logger.info("activated entity");
        }
    }

    @ReceiveEvent(components = {ActivationTestComponent.class})
    public void onTestComponentDeactivation(BeforeDeactivateComponent event, EntityRef entity) {
        if (entity.hasComponent(BlockTypeComponent.class)) {
            logger.info("block block type");
        } else {
            logger.info("deactivated block type");
        }
    }
}
```
2. Add the component to a block prefab like chest.prefab
3. Start a game and get a instance of the block. e.g. "giveItem chest"
4. Place the block
5. quit (and thus save)
6. load the game and check look out for the line "activated entity". It should be there only once.


### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [x] Testing
- [ ] Review by Immortius

