### PR TITLE
Rearranged gitignore, minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,12 @@ Icon
 .DS_Store
 .DS_Store?
 .Spotlight-V100
+.DocumentRevisions-V100
+.TemporaryItems
 .Trashes
+.dbfseventsd
+.fseventsd
+.VolumeIcon.icns
 
 #Ignore Windows
 ehthumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,22 @@
 !.gitignore
 !.github
 
+# Ignore subdirs with their own Git roots. PC Facade and Core module are bundled with the main repo.
+extensions
+/facades/*
+!/facades/PC
+!/facades/TeraEd
+!/facades/subprojects.gradle
+/modules/*
+!/modules/Core
+!/modules/CoreSampleGameplay
+!/modules/BuilderSampleGameplay
+!/modules/subprojects.gradle
+/meta/*
+!/meta/subprojects.gradle
+/libs/*
+!/libs/subprojects.gradle
+
 # Ignore Gradle, including local override properties (template file available under /templates)
 build/
 gradle.properties
@@ -39,6 +55,10 @@ facades/PC/Terasology.launch
 
 #Ignore OSX
 Icon
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
 
 #Ignore Windows
 ehthumbs.db
@@ -64,25 +84,5 @@ entityDump.txt
 /natives/
 config/metrics/
 
-# Ignore subdirs with their own Git roots. PC Facade and Core module are bundled with the main repo.
-extensions
-/facades/*
-!/facades/PC
-!/facades/TeraEd
-!/facades/subprojects.gradle
-/modules/*
-!/modules/Core
-!/modules/CoreSampleGameplay
-!/modules/BuilderSampleGameplay
-!/modules/subprojects.gradle
-/meta/*
-!/meta/subprojects.gradle
-/libs/*
-!/libs/subprojects.gradle
 
 # Ignore weird stuff that might be obsolete
-.DS_Store
-.DS_Store?
-.Spotlight-V100
-.Trashes
-

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -20,7 +20,13 @@ import com.google.api.client.repackaged.com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.AssetFactory;
@@ -77,14 +83,6 @@ import org.terasology.world.block.sounds.BlockSoundsData;
 import org.terasology.world.block.tiles.BlockTile;
 import org.terasology.world.block.tiles.TileData;
 
-import java.util.Collection;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
-
 /**
  * <p>
  * This GameEngine implementation is the heart of Terasology.
@@ -114,7 +112,7 @@ public class TerasologyEngine implements GameEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(TerasologyEngine.class);
 
-    private static final int ONE_MEBIBYTE = 1024 * 1024;
+    private static final int ONE_MEBIBYTE = 1048576; // 1024 * 1024;
 
     private GameState currentState;
     private GameState pendingState;

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -20,13 +20,7 @@ import com.google.api.client.repackaged.com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.AssetFactory;
@@ -82,6 +76,14 @@ import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.block.sounds.BlockSoundsData;
 import org.terasology.world.block.tiles.BlockTile;
 import org.terasology.world.block.tiles.TileData;
+
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 
 /**
  * <p>

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
@@ -26,6 +26,10 @@ import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TFloatArrayList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.list.array.TLongArrayList;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import org.terasology.persistence.typeHandling.DeserializationException;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
@@ -38,11 +42,6 @@ import org.terasology.persistence.typeHandling.inMemory.PersistedLong;
 import org.terasology.persistence.typeHandling.inMemory.PersistedMap;
 import org.terasology.persistence.typeHandling.inMemory.PersistedString;
 import org.terasology.protobuf.EntityData;
-
-import java.nio.ByteBuffer;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  */
@@ -82,7 +81,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number");
+            throw new ClassCastException("Data is not a number" + data.toString());
         }
     }
 
@@ -99,7 +98,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number");
+            throw new ClassCastException("Data is not a number" + data.toString());
         }
     }
 
@@ -116,7 +115,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number");
+            throw new ClassCastException("Data is not a number" + data.toString());
         }
     }
 
@@ -133,7 +132,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number");
+            throw new ClassCastException("Data is not a number" + data.toString());
         }
     }
 
@@ -144,7 +143,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getBooleanCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a boolean");
+            throw new ClassCastException("Data is not a boolean" + data.toString());
         }
     }
 
@@ -153,7 +152,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         if (data.hasBytes()) {
             return data.getBytes().toByteArray();
         } else if (!isNull()) {
-            throw new DeserializationException("Data is not bytes");
+            throw new DeserializationException("Data is not bytes" + data.toString());
         } else {
             return new byte[0];
         }
@@ -164,7 +163,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         if (data.hasBytes()) {
             return data.getBytes().asReadOnlyByteBuffer();
         } else if (!isNull()) {
-            throw new DeserializationException("Data is not bytes");
+            throw new DeserializationException("Data is not bytes" + data.toString());
         } else {
             return ByteBuffer.wrap(new byte[0]);
         }
@@ -175,7 +174,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         if (isArray()) {
             return this;
         }
-        throw new IllegalStateException("Data is not an array");
+        throw new IllegalStateException("Data is not an array: " + data.toString());
     }
 
     @Override
@@ -186,7 +185,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
                 result.put(data.getNameValue(i).getName(), new ProtobufPersistedData(data.getNameValue(i).getValue()));
             }
         } else if (!isNull()) {
-            throw new IllegalStateException("Data is not a value map");
+            throw new IllegalStateException("Data is not a value map" + data.toString());
         }
         return new PersistedMap(result);
     }
@@ -391,7 +390,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getNameValueCount() > 0) {
             result.add(new ProtobufPersistedData(data));
         } else if (data.hasBytes()) {
-            throw new IllegalStateException("Data is not an array");
+            throw new IllegalStateException("Data is not an array: " + data.toString());
         }
         return result;
     }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
@@ -26,7 +26,6 @@ import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TFloatArrayList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.list.array.TLongArrayList;
-
 import org.terasology.persistence.typeHandling.DeserializationException;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
@@ -63,7 +63,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getStringCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else if (!isNull()) {
-            throw new ClassCastException("Data is not a String");
+            throw new ClassCastException("Data is not a String: " + data.toString());
         }
         return null;
     }
@@ -81,7 +81,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number" + data.toString());
+            throw new ClassCastException("Data is not a number: " + data.toString());
         }
     }
 
@@ -98,7 +98,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number" + data.toString());
+            throw new ClassCastException("Data is not a number: " + data.toString());
         }
     }
 
@@ -115,7 +115,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number" + data.toString());
+            throw new ClassCastException("Data is not a number: " + data.toString());
         }
     }
 
@@ -132,7 +132,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getDoubleCount() + data.getFloatCount() + data.getIntegerCount() + data.getLongCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a number" + data.toString());
+            throw new ClassCastException("Data is not a number: " + data.toString());
         }
     }
 
@@ -143,7 +143,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getBooleanCount() > 1) {
             throw new IllegalStateException("Data is an array of size != 1");
         } else {
-            throw new ClassCastException("Data is not a boolean" + data.toString());
+            throw new ClassCastException("Data is not a boolean: " + data.toString());
         }
     }
 
@@ -152,7 +152,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         if (data.hasBytes()) {
             return data.getBytes().toByteArray();
         } else if (!isNull()) {
-            throw new DeserializationException("Data is not bytes" + data.toString());
+            throw new DeserializationException("Data is not bytes: " + data.toString());
         } else {
             return new byte[0];
         }
@@ -163,7 +163,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         if (data.hasBytes()) {
             return data.getBytes().asReadOnlyByteBuffer();
         } else if (!isNull()) {
-            throw new DeserializationException("Data is not bytes" + data.toString());
+            throw new DeserializationException("Data is not bytes: " + data.toString());
         } else {
             return ByteBuffer.wrap(new byte[0]);
         }
@@ -185,7 +185,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
                 result.put(data.getNameValue(i).getName(), new ProtobufPersistedData(data.getNameValue(i).getValue()));
             }
         } else if (!isNull()) {
-            throw new IllegalStateException("Data is not a value map" + data.toString());
+            throw new IllegalStateException("Data is not a value map: " + data.toString());
         }
         return new PersistedMap(result);
     }
@@ -254,7 +254,7 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
         } else if (data.getStringCount() > 0) {
             return new PersistedString(data.getString(index));
         } else if (data.hasBytes()) {
-            throw new IllegalStateException("Data is not an array");
+            throw new IllegalStateException("Data is not an array: " + data.toString());
         }
         throw new IndexOutOfBoundsException(index + " exceeds size of array data");
     }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/protobuf/ProtobufPersistedData.java
@@ -26,10 +26,7 @@ import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TFloatArrayList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.list.array.TLongArrayList;
-import java.nio.ByteBuffer;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+
 import org.terasology.persistence.typeHandling.DeserializationException;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
@@ -42,6 +39,11 @@ import org.terasology.persistence.typeHandling.inMemory.PersistedLong;
 import org.terasology.persistence.typeHandling.inMemory.PersistedMap;
 import org.terasology.persistence.typeHandling.inMemory.PersistedString;
 import org.terasology.protobuf.EntityData;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  */

--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -81,11 +81,33 @@ task game(type:JavaExec) {
     classpath project(':engine').configurations.runtime
 }
 
+task debug(type:JavaExec) {
+    description = "Run 'Terasology' to play the game as a standard PC application (in debug mode)"
+
+    // Dependencies: natives + all modules & the PC facade itself (which will trigger the engine)
+    dependsOn rootProject.extractNatives
+    dependsOn rootProject.moduleClasses
+    dependsOn classes
+
+    // Run arguments
+    jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044"]
+    main = mainClassName
+    workingDir = rootDir
+    String[] runArgs = ["-homedir"]
+    args runArgs
+
+    // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
+    classpath sourceSets.main.output.classesDir
+    classpath sourceSets.main.output.resourcesDir
+    classpath project(':engine').sourceSets.main.output.classesDir
+    classpath project(':engine').configurations.runtime
+}
+
 // By delaying this task to doLast (the << bit) we don't get the headless server dir set up unless actually wanting it
 // TODO: This is not the Gradle Way. Needs more declared output-fu to determine up-to-date instead of the if
 task setupServerConfig() << {
     description "Parses parameters passed via Gradle and writes them to the local run-from-source server dir's config.cfg"
-    
+
     def json = new JsonBuilder()
 
     def serverRoot = rootProject.file(localServerDataPath);

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -47,6 +47,7 @@ import org.terasology.splash.overlay.ImageOverlay;
 import org.terasology.splash.overlay.RectOverlay;
 import org.terasology.splash.overlay.TextOverlay;
 import org.terasology.splash.overlay.TriggerImageOverlay;
+
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 import java.awt.Rectangle;

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,14 +17,7 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import java.awt.GraphicsEnvironment;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
+
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.modes.StateLoading;
@@ -55,6 +48,15 @@ import org.terasology.splash.overlay.ImageOverlay;
 import org.terasology.splash.overlay.RectOverlay;
 import org.terasology.splash.overlay.TextOverlay;
 import org.terasology.splash.overlay.TriggerImageOverlay;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * Class providing the main() method for launching Terasology as a PC app.

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,7 +17,6 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.modes.StateLoading;
@@ -48,7 +47,6 @@ import org.terasology.splash.overlay.ImageOverlay;
 import org.terasology.splash.overlay.RectOverlay;
 import org.terasology.splash.overlay.TextOverlay;
 import org.terasology.splash.overlay.TriggerImageOverlay;
-
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 import java.awt.Rectangle;

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,6 +17,14 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.modes.StateLoading;
@@ -47,15 +55,6 @@ import org.terasology.splash.overlay.ImageOverlay;
 import org.terasology.splash.overlay.RectOverlay;
 import org.terasology.splash.overlay.TextOverlay;
 import org.terasology.splash.overlay.TriggerImageOverlay;
-
-import java.awt.GraphicsEnvironment;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
 
 /**
  * Class providing the main() method for launching Terasology as a PC app.


### PR DESCRIPTION
`.gitignore` - rearranged so ignored files stay ignored, added new Mac-specific ignores for things introduced in Mavericks, Yosemite, and El Capitan

`TerasologyEngine.java` - 1MB is `1048576` bytes, so we should just use that number instead.

`ProtobufPersistedData.java` - added a few things to (hopefully) aid in debugging

`facades/PC/build.gradle` - added "debug" task, same as "game" task but starts the JVM in debug mode (useful for IDEs)

It all passed in checkstyle.