### PR TITLE
Trying to add drag drop of items from inventory

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -46,6 +46,7 @@ public class MenuControlSystem extends BaseComponentSystem {
 
     @Override
     public void initialise() {
+        nuiManager.getHUD().addHUDElement("dropItemRegion");  //Ensure the drop region is behind the toolbar
         nuiManager.getHUD().addHUDElement("toolbar");
     }
 

--- a/modules/Core/assets/skins/dropItemRegionDefault.skin
+++ b/modules/Core/assets/skins/dropItemRegionDefault.skin
@@ -1,0 +1,5 @@
+{
+    "inherit" : "default",
+    "elements" : {
+    }
+}

--- a/modules/Core/assets/ui/hud/dropItemRegion.ui
+++ b/modules/Core/assets/ui/hud/dropItemRegion.ui
@@ -1,0 +1,10 @@
+{
+  "type": "DropItemRegion",
+  "skin": "dropItemRegionDefault",
+  "contents": {
+        "type" : "relativeLayout",
+        "id" : "mainOverlay",
+        "contents" : [
+        ]
+  }
+}

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
@@ -105,11 +105,12 @@ public class CharacterInventorySystem extends BaseComponentSystem {
             return;
         }
 
-        // remove a single item from the stack
+        int count = event.getCount();
+        // remove 'count' items from the stack
         EntityRef pickupItem = event.getItem();
         EntityRef owner = pickupItem.getOwner();
         if (owner.hasComponent(InventoryComponent.class)) {
-            final EntityRef removedItem = inventoryManager.removeItem(owner, EntityRef.NULL, pickupItem, false, 1);
+            final EntityRef removedItem = inventoryManager.removeItem(owner, EntityRef.NULL, pickupItem, false, count);
             if (removedItem != null) {
                 pickupItem = removedItem;
             }

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/events/DropItemRequest.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/events/DropItemRequest.java
@@ -32,15 +32,22 @@ public class DropItemRequest implements Event {
     private EntityRef inventory = EntityRef.NULL;
     private Vector3f impulse;
     private Vector3f newPosition;
+    private int count;
 
     protected DropItemRequest() {
     }
 
-    public DropItemRequest(EntityRef usedItem, EntityRef inventoryEntity, Vector3f impulse, Vector3f newPosition) {
+    public DropItemRequest(EntityRef usedItem, EntityRef inventoryEntity, Vector3f impulse, Vector3f newPosition, int count) {
         this.item = usedItem;
         this.inventory = inventoryEntity;
         this.impulse = impulse;
         this.newPosition = newPosition;
+        this.count = count;
+    }
+
+    public DropItemRequest(EntityRef usedItem, EntityRef inventoryEntity, Vector3f impulse, Vector3f newPosition)
+    {
+        this(usedItem, inventoryEntity, impulse, newPosition, 1);
     }
 
     public EntityRef getItem() {
@@ -57,5 +64,9 @@ public class DropItemRequest implements Event {
 
     public Vector3f getImpulse() {
         return impulse;
+    }
+
+    public int getCount() {
+        return count;
     }
 }

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/hud/DropItemRegion.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/hud/DropItemRegion.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.hud;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.input.MouseInput;
+import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.inventory.InventoryUtils;
+import org.terasology.logic.inventory.events.DropItemRequest;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.BaseInteractionListener;
+import org.terasology.rendering.nui.Canvas;
+import org.terasology.rendering.nui.InteractionListener;
+import org.terasology.rendering.nui.events.NUIMouseClickEvent;
+
+/**
+ * A region/layer around the inventory grid to allow players to get rid of extra items
+ * and have free inventory slots by dropping them onto this layer.
+ *
+ */
+public class DropItemRegion extends CoreHudWidget {
+
+    @In
+    private LocalPlayer localPlayer;
+
+    private InteractionListener interactionListener = new BaseInteractionListener() {
+        @Override
+        public boolean onMouseClick(NUIMouseClickEvent event) {
+            MouseInput mouseButton = event.getMouseButton();
+            if (mouseButton == MouseInput.MOUSE_LEFT) {
+                EntityRef playerEntity = localPlayer.getCharacterEntity();
+                EntityRef movingItem = playerEntity.getComponent(CharacterComponent.class).movingItem;
+                EntityRef item  = InventoryUtils.getItemAt(movingItem, 0);
+                if (!item.exists()) {
+                    return true;
+                }
+                int count = InventoryUtils.getStackCount(item);
+
+                Vector3f position = localPlayer.getViewPosition();
+                Vector3f direction = localPlayer.getViewDirection();
+                Vector3f newPosition = new Vector3f(position.x + direction.x * 1.5f,
+                        position.y + direction.y * 1.5f,
+                        position.z + direction.z * 1.5f
+                );
+                //send DropItemRequest
+                Vector3f impulseVector = new Vector3f(direction);
+                playerEntity.send(new DropItemRequest(item, playerEntity,
+                        impulseVector,
+                        newPosition,
+                        count));
+                return true;
+            }
+            return false;
+        }
+    };
+
+    @Override
+    public void initialise() {
+    }
+
+    @Override
+    public void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        canvas.addInteractionRegion(interactionListener);
+    }
+}

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryGrid.java
@@ -19,16 +19,20 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.input.MouseInput;
 import org.terasology.logic.inventory.InventoryUtils;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
+import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
+import org.terasology.rendering.nui.InteractionListener;
 import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+import org.terasology.rendering.nui.events.NUIMouseClickEvent;
 
 import java.util.Iterator;
 import java.util.List;
@@ -46,6 +50,17 @@ public class InventoryGrid extends CoreWidget {
 
     private List<InventoryCell> cells = Lists.newArrayList();
     private Binding<EntityRef> targetEntity = new DefaultBinding<>(EntityRef.NULL);
+
+    private InteractionListener interactionListener = new BaseInteractionListener() {
+        @Override
+        public boolean onMouseClick(NUIMouseClickEvent event) {
+            MouseInput mouseButton = event.getMouseButton();
+            if (mouseButton == MouseInput.MOUSE_LEFT) {
+                return true;
+            }
+            return false;
+        }
+    };
 
     @Override
     public void update(float delta) {
@@ -83,6 +98,8 @@ public class InventoryGrid extends CoreWidget {
         if (cellSize.getX() == 0 || cellSize.getY() == 0) {
             return;
         }
+        canvas.addInteractionRegion(interactionListener);
+
         int horizontalCells = Math.max(1, Math.min(maxHorizontalCells, canvas.size().getX() / cellSize.getX()));
         for (int i = 0; i < numSlots && i < cells.size(); ++i) {
             int horizPos = i % horizontalCells;


### PR DESCRIPTION
Fixing #2218 
.
I added an interaction region on all sides of the InventoryGrid, so the cells are put in the center of the screen (the offset is calculated by giving half of width left after drawing the cells).
There are 4 rectangular regions which need to be targetted. I have added all 4 with appropriate names.

I just tried to immitate the existing functionality of right click.. So the code is adapted version of [onUseItemButton](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java#L348) from ```LocalPlayerSystem```
.
I Expected that if I drag an item out of the inventory cells (on the inventory screen) and drop it on empty area around the grid then it would get dropped on the terrain. I saw that on right click I could put items on the terrain. So, I used its code.
.
But instead what happens is actually (i think) similar to if I press left click while inventory screen is not opened. i.e, the player tries to destroy the block which is just ahead (pointed to).
.
I tried to debug it checking for the function calls and yes all the lines are being executed as required. The problem that I think (as @flo mentioned) is that I couldn't understand the parameters which are passed to [onUseItemButton](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java#L348) and hence duplicated it in a wrong way.
.
.
I will now try to add the overlay as suggested.