### PR TITLE
Fix StringTextIconRenderer icon overlapping issue

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/itemRendering/StringTextIconRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/itemRendering/StringTextIconRenderer.java
@@ -37,7 +37,7 @@ public abstract class StringTextIconRenderer<T> extends AbstractItemRenderer<T> 
     private final int marginRight;
 
     protected StringTextIconRenderer() {
-        this(true, 5, 5, 5, 10);
+        this(false, 5, 5, 5, 10);
     }
 
     protected StringTextIconRenderer(boolean wrap, int marginTop, int marginBottom, int marginLeft, int marginRight) {
@@ -66,25 +66,28 @@ public abstract class StringTextIconRenderer<T> extends AbstractItemRenderer<T> 
         // Drawing the text, adjusting for icon width
         String text = getString(value);
         int iconWidth = marginLeft + texture.getWidth() + marginRight;
+        Rect2i textRegion =  Rect2i.createFromMinAndSize(iconWidth, 0, canvas.getRegion().width() - iconWidth, canvas.getRegion().height());
 
         if (wrap) {
-            canvas.drawText(text, Rect2i.createFromMinAndSize(iconWidth, 0, canvas.getRegion().width() - iconWidth, canvas.getRegion().height()));
+            canvas.drawText(text, textRegion);
         } else {
-            int width = canvas.size().x - iconWidth;
+            int maxTextWidth = canvas.size().x - iconWidth;
             Font font = canvas.getCurrentStyle().getFont();
-            if (font.getWidth(text) <= width) {
-                canvas.drawText(text);
+
+            // If text does not horizontally fit within the canvas, shrink it
+            if (font.getWidth(text) <= maxTextWidth) {
+                canvas.drawText(text, textRegion);
             } else {
                 String shortText = "...";
                 StringBuilder sb = new StringBuilder(text);
                 while (sb.length() > 0) {
                     shortText = sb.toString() + "...";
-                    if (font.getWidth(shortText) <= width) {
+                    if (font.getWidth(shortText) <= maxTextWidth) {
                         break;
                     }
                     sb.setLength(sb.length() - 1);
                 }
-                canvas.drawText(shortText, Rect2i.createFromMinAndSize(iconWidth, 0, canvas.getRegion().width() - iconWidth, canvas.getRegion().height()));
+                canvas.drawText(shortText, textRegion);
             }
         }
     }


### PR DESCRIPTION
### Contains

Fixes a bug in the StringTextIconRenderer as described in [a comment](https://github.com/MovingBlocks/Terasology/pull/2270#issuecomment-204645493) on #2270: icons overlap with text when text wrapping is disabled. (This was caused by the renderer not adjusting for icon width when the text being rendered doesn't need to be shortened - see [line 76 in the original file](https://github.com/MovingBlocks/Terasology/blob/98f37a55886b6431aeba85d04f4618adcc37a494/engine/src/main/java/org/terasology/rendering/nui/itemRendering/StringTextIconRenderer.java#L76))

### How to test

Launch the game and go to _Settings → Player → Language_; test if any icons overlap with locale text.

### Outstanding before merging

No outstanding issues.