### PR TITLE
[OK to merge] Support for disabled UI elements

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UICheckbox.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UICheckbox.java
@@ -21,6 +21,7 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
 import org.terasology.rendering.nui.InteractionListener;
+import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
@@ -29,6 +30,10 @@ import org.terasology.rendering.nui.events.NUIMouseClickEvent;
  */
 public class UICheckbox extends CoreWidget {
     public static final String HOVER_ACTIVE_MODE = "hover-active";
+    public static final String DISABLED_MODE = "disabled";
+
+    @LayoutConfig
+    private Binding<Boolean> enabled = new DefaultBinding<>(Boolean.TRUE);
 
     private Binding<Boolean> active = new DefaultBinding<>(false);
 
@@ -36,7 +41,7 @@ public class UICheckbox extends CoreWidget {
 
         @Override
         public boolean onMouseClick(NUIMouseClickEvent event) {
-            if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
+            if (enabled.get() && event.getMouseButton() == MouseInput.MOUSE_LEFT) {
                 active.set(!active.get());
                 return true;
             }
@@ -59,7 +64,9 @@ public class UICheckbox extends CoreWidget {
 
     @Override
     public String getMode() {
-        if (interactionListener.isMouseOver()) {
+        if (!enabled.get()) {
+            return DISABLED_MODE;
+        } else if (interactionListener.isMouseOver()) {
             if (active.get()) {
                 return HOVER_ACTIVE_MODE;
             }
@@ -76,6 +83,14 @@ public class UICheckbox extends CoreWidget {
 
     public void setChecked(boolean checked) {
         active.set(checked);
+    }
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
     }
 
     public void bindChecked(Binding<Boolean> binding) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
@@ -24,6 +24,7 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
 import org.terasology.rendering.nui.InteractionListener;
+import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.SubRegion;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
@@ -39,20 +40,27 @@ import java.util.List;
 public class UIDropdown<T> extends CoreWidget {
     private static final String LIST = "list";
     private static final String LIST_ITEM = "list-item";
+    public static final String DISABLED_MODE = "disabled";
+
+    @LayoutConfig
+    private Binding<Boolean> enabled = new DefaultBinding<>(Boolean.TRUE);
 
     private Binding<List<T>> options = new DefaultBinding<>(new ArrayList<>());
     private Binding<T> selection = new DefaultBinding<>();
     private InteractionListener mainListener = new BaseInteractionListener() {
         @Override
         public boolean onMouseClick(NUIMouseClickEvent event) {
-            opened = !opened;
-            optionListeners.clear();
-            if (opened) {
-                for (int i = 0; i < getOptions().size(); ++i) {
-                    optionListeners.add(new ItemListener(i));
+            if (enabled.get()) {
+                opened = !opened;
+                optionListeners.clear();
+                if (opened) {
+                    for (int i = 0; i < getOptions().size(); ++i) {
+                        optionListeners.add(new ItemListener(i));
+                    }
                 }
+                return true;
             }
-            return true;
+            return false;
         }
     };
     private List<InteractionListener> optionListeners = Lists.newArrayList();
@@ -120,7 +128,9 @@ public class UIDropdown<T> extends CoreWidget {
 
     @Override
     public String getMode() {
-        if (opened) {
+        if (!enabled.get()) {
+            return DISABLED_MODE;
+        } else if (opened) {
             return ACTIVE_MODE;
         }
         return DEFAULT_MODE;
@@ -154,6 +164,14 @@ public class UIDropdown<T> extends CoreWidget {
 
     public void setSelection(T value) {
         selection.set(value);
+    }
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
     }
 
     public void setOptionRenderer(ItemRenderer<T> itemRenderer) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
@@ -23,6 +23,7 @@ import org.terasology.rendering.assets.font.Font;
 import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.InteractionListener;
+import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.SubRegion;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
@@ -39,6 +40,10 @@ import java.util.List;
 public class UIDropdownScrollable<T> extends UIDropdown<T> {
     private static final String LIST = "list";
     private static final String LIST_ITEM = "list-item";
+    public static final String DISABLED_MODE = "disabled";
+
+    @LayoutConfig
+    private Binding<Boolean> enabled = new DefaultBinding<>(Boolean.TRUE);
 
     private UIScrollbar verticalBar = new UIScrollbar(true);
     private int visibleOptionsNum = 5;
@@ -48,21 +53,27 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
     private InteractionListener mainListener = new BaseInteractionListener() {
         @Override
         public boolean onMouseClick(NUIMouseClickEvent event) {
-            opened = !opened;
-            optionListeners.clear();
-            if (opened) {
-                for (int i = 0; i < getOptions().size(); ++i) {
-                    optionListeners.add(new ItemListener(i));
+            if (enabled.get()) {
+                opened = !opened;
+                optionListeners.clear();
+                if (opened) {
+                    for (int i = 0; i < getOptions().size(); ++i) {
+                        optionListeners.add(new ItemListener(i));
+                    }
                 }
+                return true;
             }
-            return true;
+            return false;
         }
 
         @Override
         public boolean onMouseWheel(NUIMouseWheelEvent event) {
-            int scrollMultiplier = 0 - verticalBar.getRange() / getOptions().size();
-            verticalBar.setValue(verticalBar.getValue() + event.getWheelTurns() * scrollMultiplier);
-            return true;
+            if (enabled.get()) {
+                int scrollMultiplier = 0 - verticalBar.getRange() / getOptions().size();
+                verticalBar.setValue(verticalBar.getValue() + event.getWheelTurns() * scrollMultiplier);
+                return true;
+            }
+            return false;
         }
     };
     private List<InteractionListener> optionListeners = Lists.newArrayList();
@@ -233,6 +244,14 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
 
     public void setSelection(T value) {
         selection.set(value);
+    }
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
     }
 
     public void setOptionRenderer(ItemRenderer<T> itemRenderer) {

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -350,7 +350,8 @@
                                 },
                                 {
                                  "type": "UICheckbox",
-                                 "id": "volumetricFog"
+                                 "id": "volumetricFog",
+                                 "enabled": false
                                 }
                             ]
                         },


### PR DESCRIPTION
### Contains

Implementation for #2268. Adds a disabled state for UICheckbox, UIDropdown and UIDropdownScrollable - this should cover all of NUI's interactable widgets. _(UIButton can already be disabled via `"enabled": false`, while UIText can be set to readonly via `"readOnly": true`)_

### How to test

Interact with the Volumetric Fog checkbox (as per #2246).

### Outstanding before merging

No outstanding issues.

### Future improvements

- [ ] Add a skin for a disabled UIDropdown[Scrollable]. Should be fairly straightforward - just change the selected option's text color, as with the button.
- [ ] Add a skin for a disabled UICheckbox. Slightly harder to implement as it will require creating greyed-out variants of [checkbox.png](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/resources/assets/textures/ui/checkbox.png) and [checkboxChecked.png](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/resources/assets/textures/ui/checkboxChecked.png).
- [ ] Create a sample *.ui file containing a bunch of disabled items.