### PR TITLE
Added disabled widgets to migTestScreen; fixed misc. issues

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MigTestScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MigTestScreen.java
@@ -16,16 +16,33 @@
 package org.terasology.rendering.nui.layers.mainMenu;
 
 import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UIDropdown;
+import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UIList;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class MigTestScreen extends CoreScreenLayer {
     @Override
     public void initialise() {
-        find("list1", UIList.class).setList(Arrays.asList("one", "two", "12345678901234567890"));
-        find("list2", UIList.class).setList(Arrays.asList("one", "two", "12345678901234567890"));
-        find("list3", UIList.class).setList(Arrays.asList("one", "two", "12345678901234567890"));
+        List<String> values = Arrays.asList("one", "two", "three", "12345678901234567890");
+        String selectedValue = values.get(1);
+
+        for (String id : new String[]{"dropdown1", "dropdown2", "dropdown3", "dropdown4"}) {
+            find(id, UIDropdown.class).setOptions(values);
+            find(id, UIDropdown.class).setSelection(selectedValue);
+        }
+
+        for (String id : new String[]{"dropdownScrollable1", "dropdownScrollable2", "dropdownScrollable3", "dropdownScrollable4"}) {
+            find(id, UIDropdownScrollable.class).setVisibleOptions(2);
+            find(id, UIDropdownScrollable.class).setOptions(values);
+            find(id, UIDropdownScrollable.class).setSelection(selectedValue);
+        }
+
+        for (String id : new String[]{"list1", "list2", "list3", "list4"}) {
+            find(id, UIList.class).setList(values);
+        }
     }
 
     @Override

--- a/engine/src/main/resources/assets/ui/migTestScreen.ui
+++ b/engine/src/main/resources/assets/ui/migTestScreen.ui
@@ -1,366 +1,464 @@
 {
-    "type" : "engine:migTestScreen",
-    "skin" : "engine:mainMenu",
-    "contents" : {
-        "type" : "migLayout",
-        "layoutConstraints" : "",
-        "colConstraints" : "[min][min][pref][grow]",
-        "rowConstraints" : "[min]",
-        "debug" : true,
-        "contents" : [
+    "type": "engine:migTestScreen",
+    "skin": "engine:mainMenu",
+    "contents": {
+        "type": "migLayout",
+        "layoutConstraints": "",
+        "colConstraints": "[min][pref][min][pref][grow]",
+        "rowConstraints": "[min]",
+        "debug": true,
+        "contents": [
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UILabel",
+                "id": "",
+                "text": "",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "min",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UILabel",
+                "id": "",
+                "text": "disabled",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "pref",
-                 "layoutInfo" : {
-                     "cc" : ""
-                 }
-            },
-            {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "grow",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UILabel",
+                "id": "",
+                "text": "min",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIButton",
-                "layoutInfo" : {
-                    "cc" : "newline"
+                "type": "UILabel",
+                "id": "",
+                "text": "pref",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UIButton",
-                "id" : "",
-                "text" : "A1",
-                "layoutInfo" : {
-                    "cc" : "w min, h min"
+                "type": "UILabel",
+                "id": "",
+                "text": "grow",
+                "layoutInfo": {
+                    "cc": "grow"
                 }
             },
             {
-                "type" : "UIButton",
-                "id" : "",
-                "text" : "A2",
-                 "layoutInfo" : {
-                     "cc" : ""
-                 }
-            },
-            {
-                "type" : "UIButton",
-                "id" : "",
-                "text" : "A3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UILabel",
+                "id": "",
+                "text": "UIButton",
+                "layoutInfo": {
+                    "cc": "newline"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UISlider",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
+                "type": "UIButton",
+                "id": "button1",
+                "text": "button1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
             },
             {
-                "type" : "UISlider",
-                "id" : "",
-                "text" : "B1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UISlider",
-                "id" : "",
-                "text" : "B2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UIButton",
+                "id": "button2",
+                "text": "button2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
                 }
             },
             {
-                "type" : "UISlider",
-                "id" : "",
-                "text" : "B3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UIButton",
+                "id": "button3",
+                "text": "button3",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIDoubleSlider",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
-            },
-            {
-                "type" : "UIDoubleSlider",
-                "id" : "",
-                "text" : "B1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UIDoubleSlider",
-                "id" : "",
-                "text" : "B2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UIButton",
+                "id": "button4",
+                "text": "button4",
+                "layoutInfo": {
+                    "cc": "grow"
                 }
             },
             {
-                "type" : "UIDoubleSlider",
-                "id" : "",
-                "text" : "B3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UILabel",
+                "id": "",
+                "text": "UISlider",
+                "layoutInfo": {
+                    "cc": "newline"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIText",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
+                "type": "UISlider",
+                "id": "slider1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
             },
             {
-                "type" : "UIText",
-                "id" : "",
-                "text" : "C1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UIText",
-                "id" : "",
-                "text" : "C2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UISlider",
+                "id": "slider2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
                 }
             },
             {
-                "type" : "UIText",
-                "id" : "",
-                "text" : "C3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UISlider",
+                "id": "slider3",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIDropdown",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
-            },
-            {
-                "type" : "UIDropdown",
-                "id" : "",
-                "text" : "D1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UIDropdown",
-                "id" : "",
-                "text" : "D2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UISlider",
+                "id": "slider4",
+                "layoutInfo": {
+                    "cc": "grow"
                 }
             },
             {
-                "type" : "UIDropdown",
-                "id" : "",
-                "text" : "D3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UILabel",
+                "id": "",
+                "text": "UIDoubleSlider",
+                "layoutInfo": {
+                    "cc": "newline"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UICheckbox",
-                "layoutInfo" : {
-                    "cc" : "newline"
+                "type": "UIDoubleSlider",
+                "id": "doubleSlider1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UIDoubleSlider",
+                "id": "doubleSlider2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
                 }
             },
             {
-                "type" : "UICheckbox",
-                "id" : "",
-                "text" : "E1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UICheckbox",
-                "id" : "",
-                "text" : "E2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UIDoubleSlider",
+                "id": "doubleSlider3",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UICheckbox",
-                "id" : "",
-                "text" : "E3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UIDoubleSlider",
+                "id": "doubleSlider4",
+                "layoutInfo": {
+                    "cc": "grow"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIList",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
-            },
-            {
-                "type" : "UIList",
-                "id" : "list1",
-                "text" : "F1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UIList",
-                "id" : "list2",
-                "text" : "F2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UILabel",
+                "id": "",
+                "text": "UIText",
+                "layoutInfo": {
+                    "cc": "newline"
                 }
             },
             {
-                "type" : "UIList",
-                "id" : "list3",
-                "text" : "F3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UIText",
+                "id": "text1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "readOnly": true
+            },
+            {
+                "type": "UIText",
+                "id": "text2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIBox",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
-            },
-            {
-                "type" : "UIBox",
-                "id" : "",
-                "text" : "G1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UIBox",
-                "id" : "",
-                "text" : "G2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UIText",
+                "id": "text3",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UIBox",
-                "id" : "",
-                "text" : "G3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UIText",
+                "id": "text4",
+                "layoutInfo": {
+                    "cc": "grow"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UIScrollbar",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
-            },
-            {
-                "type" : "UIScrollbar",
-                "id" : "",
-                "text" : "H1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UIScrollbar",
-                "id" : "",
-                "text" : "H2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UILabel",
+                "id": "",
+                "text": "UIDropdown",
+                "layoutInfo": {
+                    "cc": "newline"
                 }
             },
             {
-                "type" : "UIScrollbar",
-                "id" : "",
-                "text" : "H3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UIDropdown",
+                "id": "dropdown1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UIDropdown",
+                "id": "dropdown2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
                 }
             },
             {
-                "type" : "UILabel",
-                "id" : "",
-                "text" : "UISpace",
-                 "layoutInfo" : {
-                     "cc" : "newline"
-                 }
-            },
-            {
-                "type" : "UISpace",
-                "id" : "",
-                "text" : "H1",
-                 "layoutInfo" : {
-                     "cc" : "w min, h min"
-                 }
-            },
-            {
-                "type" : "UISpace",
-                "id" : "",
-                "text" : "H2",
-                "layoutInfo" : {
-                    "cc" : ""
+                "type": "UIDropdown",
+                "id": "dropdown3",
+                "layoutInfo": {
+                    "cc": ""
                 }
             },
             {
-                "type" : "UISpace",
-                "id" : "",
-                "text" : "H3",
-                "layoutInfo" : {
-                    "cc" : "grow"
+                "type": "UIDropdown",
+                "id": "dropdown4",
+                "layoutInfo": {
+                    "cc": "grow"
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "",
+                "text": "UIDropdownScrollable",
+                "layoutInfo": {
+                    "cc": "newline"
+                }
+            },
+            {
+                "type": "UIDropdownScrollable",
+                "id": "dropdownScrollable1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UIDropdownScrollable",
+                "id": "dropdownScrollable2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
+                }
+            },
+            {
+                "type": "UIDropdownScrollable",
+                "id": "dropdownScrollable3",
+                "layoutInfo": {
+                    "cc": ""
+                }
+            },
+            {
+                "type": "UIDropdownScrollable",
+                "id": "dropdownScrollable4",
+                "layoutInfo": {
+                    "cc": "grow"
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "",
+                "text": "UICheckbox",
+                "layoutInfo": {
+                    "cc": "newline"
+                }
+            },
+            {
+                "type": "UICheckbox",
+                "id": "checkbox1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UICheckbox",
+                "id": "checkbox2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
+                }
+            },
+            {
+                "type": "UICheckbox",
+                "id": "checkbox3",
+                "layoutInfo": {
+                    "cc": ""
+                }
+            },
+            {
+                "type": "UICheckbox",
+                "id": "checkbox4",
+                "layoutInfo": {
+                    "cc": "grow"
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "",
+                "text": "UIList",
+                "layoutInfo": {
+                    "cc": "newline"
+                }
+            },
+            {
+                "type": "UIList",
+                "id": "list1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UIList",
+                "id": "list2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
+                }
+            },
+            {
+                "type": "UIList",
+                "id": "list3",
+                "layoutInfo": {
+                    "cc": ""
+                }
+            },
+            {
+                "type": "UIList",
+                "id": "list4",
+                "layoutInfo": {
+                    "cc": "grow"
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "",
+                "text": "UIBox",
+                "layoutInfo": {
+                    "cc": "newline"
+                }
+            },
+            {
+                "type": "UIBox",
+                "id": "box1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UIBox",
+                "id": "box2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
+                }
+            },
+            {
+                "type": "UIBox",
+                "id": "box3",
+                "layoutInfo": {
+                    "cc": ""
+                }
+            },
+            {
+                "type": "UIBox",
+                "id": "box4",
+                "layoutInfo": {
+                    "cc": "grow"
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "",
+                "text": "UIScrollbar",
+                "layoutInfo": {
+                    "cc": "newline"
+                }
+            },
+            {
+                "type": "UIScrollbar",
+                "id": "scrollbar1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UIScrollbar",
+                "id": "scrollbar2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
+                }
+            },
+            {
+                "type": "UIScrollbar",
+                "id": "scrollbar3",
+                "layoutInfo": {
+                    "cc": ""
+                }
+            },
+            {
+                "type": "UIScrollbar",
+                "id": "scrollbar4",
+                "layoutInfo": {
+                    "cc": "grow"
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "",
+                "text": "UISpace",
+                "layoutInfo": {
+                    "cc": "newline"
+                }
+            },
+            {
+                "type": "UISpace",
+                "id": "space1",
+                "layoutInfo": {
+                    "cc": ""
+                },
+                "enabled": false
+            },
+            {
+                "type": "UISpace",
+                "id": "space2",
+                "layoutInfo": {
+                    "cc": "w min, h min"
+                }
+            },
+            {
+                "type": "UISpace",
+                "id": "space3",
+                "layoutInfo": {
+                    "cc": ""
+                }
+            },
+            {
+                "type": "UISpace",
+                "id": "space4",
+                "layoutInfo": {
+                    "cc": "grow"
                 }
             }
-
-       ]
+        ]
     }
 }


### PR DESCRIPTION
### Contains

Implements a TODO item from #2274 as suggested in @Cervator's [comment](https://github.com/MovingBlocks/Terasology/pull/2274#issuecomment-206097263) on the issue:

- Adds a column containing disabled widgets for the relevant row (`"readOnly": true` for UIText and `"enabled": false` elsewhere). Currently widget disabling is implemented for UIButton, UIText, UIDropdown, UIDropdownScrollable and UICheckbox - making the assumption that `enabled` will eventually become an `AbstractWidget` property as per #2275.
- Removes invalid text properties that were throwing logger warnings, replaces them with more meaningful identifiers.
- Adds UIDropdownScrollable and fills some of the other widgets with sample data.

### How to test

In the main menu open the console by pressing tilde, type in `showScreen migTestScreen`, play around with the widgets!

Reference screenshot:

![migTestScreen screenshot](http://i.imgur.com/yNVFhMS.jpg)
### Outstanding before merging

No outstanding issues.