### PR TITLE
Reduce overbrightness in various parts of the system

### DIFF
--- a/engine/src/main/java/org/terasology/logic/inventory/ItemCommonSystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemCommonSystem.java
@@ -16,7 +16,6 @@
 
 package org.terasology.logic.inventory;
 
-import org.terasology.utilities.Assets;
 import org.terasology.entitySystem.MutableComponentContainer;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
@@ -24,10 +23,10 @@ import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.iconmesh.IconMeshFactory;
 import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.logic.MeshComponent;
+import org.terasology.utilities.Assets;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
 import org.terasology.world.block.family.BlockFamily;
@@ -104,12 +103,11 @@ public class ItemCommonSystem extends BaseComponentSystem {
             meshComponent.material = Assets.getMaterial("engine:terrain").get();
             meshComponent.translucent = blockFamily.getArchetypeBlock().isTranslucent();
 
-            if (blockFamily.getArchetypeBlock().getLuminance() > 0 && !entity.hasComponent(LightComponent.class)) {
+            int luminance = blockFamily.getArchetypeBlock().getLuminance();
+            if (luminance > 0 && !entity.hasComponent(LightComponent.class)) {
                 LightComponent lightComponent = entity.addComponent(new LightComponent());
-
-                Vector3f randColor = new Vector3f(rand.nextFloat(), rand.nextFloat(), rand.nextFloat());
-                lightComponent.lightColorDiffuse.set(randColor);
-                lightComponent.lightColorAmbient.set(randColor);
+                //scale the light back if it is a less bright block
+                lightComponent.lightAttenuationRange *= luminance / 15f;
             }
 
             entity.addOrSaveComponent(meshComponent);

--- a/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
@@ -15,13 +15,14 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.reflection.metadata.FieldMetadata;
 import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.Replicate;
 import org.terasology.network.ReplicationCheck;
+import org.terasology.reflection.metadata.FieldMetadata;
 
 /**
+ * Add this component to an entity for it to transmit light from its location.  By default the component is configured to act similarly to a placed torch block.
  */
 // TODO: Split into multiple components? Point, Directional?
 public final class LightComponent implements Component, ReplicationCheck {
@@ -43,14 +44,29 @@ public final class LightComponent implements Component, ReplicationCheck {
     @Replicate
     public float lightAmbientIntensity = 1.0f;
 
+    /**
+     * This helps control how focused the specular light is. A smaller number will make a wider cone of light. A larger number will make a narrower cone of light.
+     */
     @Replicate
-    public float lightSpecularPower = 1.0f;
+    public float lightSpecularPower = 100.0f;
+    /**
+     * Light attenuation range used in the calculation of how light fades from the light source as it gets farther away.  It is use in the following calculation:
+     * <p>
+     * attenuation = 1 / (lightDist/lightAttenuationRange + 1)^2
+     * <p>
+     * Where lightDist is how far the point in the world is from the light source.
+     */
     @Replicate
-    public float lightAttenuationRange = 16.0f;
+    public float lightAttenuationRange = 10.0f;
+    /**
+     * After light travels the lightAttenuationRange, linearly fade to 0 light over this falloff distance.
+     */
     @Replicate
     public float lightAttenuationFalloff = 1.25f;
 
-    // The rendering distance for light components (0.0f == Always render the light)
+    /**
+     * The rendering distance for light components (0.0f == Always render the light)
+     */
     @Replicate
     public float lightRenderingDistance;
 

--- a/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
@@ -40,7 +40,7 @@ public final class LightComponent implements Component, ReplicationCheck {
     @Replicate
     public float lightDiffuseIntensity = 1.0f;
     @Replicate
-    public float lightSpecularIntensity = 0.1f;
+    public float lightSpecularIntensity = 0.03f;
     @Replicate
     public float lightAmbientIntensity = 1.0f;
 
@@ -48,7 +48,7 @@ public final class LightComponent implements Component, ReplicationCheck {
      * This helps control how focused the specular light is. A smaller number will make a wider cone of light. A larger number will make a narrower cone of light.
      */
     @Replicate
-    public float lightSpecularPower = 100.0f;
+    public float lightSpecularPower = 80.0f;
     /**
      * Light attenuation range used in the calculation of how light fades from the light source as it gets farther away.  It is use in the following calculation:
      * <p>

--- a/engine/src/main/java/org/terasology/rendering/opengl/GraphicState.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GraphicState.java
@@ -26,9 +26,36 @@ import java.nio.IntBuffer;
 import static org.lwjgl.opengl.EXTFramebufferObject.GL_COLOR_ATTACHMENT0_EXT;
 import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_EXT;
 import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
-import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11.GL_ALWAYS;
+import static org.lwjgl.opengl.GL11.GL_BACK;
+import static org.lwjgl.opengl.GL11.GL_BLEND;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
+import static org.lwjgl.opengl.GL11.GL_DECR;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.GL_FILL;
+import static org.lwjgl.opengl.GL11.GL_FRONT;
+import static org.lwjgl.opengl.GL11.GL_FRONT_AND_BACK;
+import static org.lwjgl.opengl.GL11.GL_INCR;
+import static org.lwjgl.opengl.GL11.GL_KEEP;
 import static org.lwjgl.opengl.GL11.GL_LEQUAL;
+import static org.lwjgl.opengl.GL11.GL_LINE;
+import static org.lwjgl.opengl.GL11.GL_NOTEQUAL;
+import static org.lwjgl.opengl.GL11.GL_ONE;
+import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
+import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_COLOR;
+import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
+import static org.lwjgl.opengl.GL11.GL_STENCIL_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_STENCIL_TEST;
+import static org.lwjgl.opengl.GL11.glBlendFunc;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glCullFace;
+import static org.lwjgl.opengl.GL11.glDepthMask;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glStencilFunc;
+import static org.lwjgl.opengl.GL11.glViewport;
 import static org.lwjgl.opengl.GL20.glStencilOpSeparate;
 
 /**
@@ -318,7 +345,7 @@ public class GraphicState {
         glDisable(GL_DEPTH_TEST);
 
         glEnable(GL_BLEND);
-        glBlendFunc(GL_ONE, GL_ONE);
+        glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_COLOR);
 
         glEnable(GL_CULL_FACE);
         glCullFace(GL_FRONT);

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.rendering.world;
 
-import org.terasology.utilities.Assets;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.config.RenderingDebugConfig;
@@ -45,12 +44,13 @@ import org.terasology.rendering.cameras.OculusStereoCamera;
 import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.cameras.PerspectiveCamera;
 import org.terasology.rendering.logic.LightComponent;
-import org.terasology.rendering.opengl.GraphicState;
 import org.terasology.rendering.opengl.FrameBuffersManager;
+import org.terasology.rendering.opengl.GraphicState;
 import org.terasology.rendering.opengl.PostProcessor;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.primitives.LightGeometryHelper;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
+import org.terasology.utilities.Assets;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
@@ -169,11 +169,8 @@ public final class WorldRendererImpl implements WorldRenderer {
     // TODO: one day the main light (sun/moon) should be just another light in the scene.
     private void initMainDirectionalLight() {
         mainDirectionalLight.lightType = LightComponent.LightType.DIRECTIONAL;
-        mainDirectionalLight.lightColorAmbient = new Vector3f(1.0f, 1.0f, 1.0f);
-        mainDirectionalLight.lightColorDiffuse = new Vector3f(1.0f, 1.0f, 1.0f);
-        mainDirectionalLight.lightAmbientIntensity = 1.0f;
-        mainDirectionalLight.lightDiffuseIntensity = 2.0f;
-        mainDirectionalLight.lightSpecularIntensity = 0.0f;
+        mainDirectionalLight.lightAmbientIntensity = 0.75f;
+        mainDirectionalLight.lightDiffuseIntensity = 0.75f;
     }
 
     private void initRenderingSupport() {
@@ -576,7 +573,7 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         if (lightComponent.lightType == LightComponent.LightType.POINT) {
             if (!geometryOnly) {
-                program.setFloat4("lightExtendedProperties", lightComponent.lightAttenuationRange * 0.975f, lightComponent.lightAttenuationFalloff, 0.0f, 0.0f, true);
+                program.setFloat4("lightExtendedProperties", lightComponent.lightAttenuationRange, lightComponent.lightAttenuationFalloff, 0.0f, 0.0f, true);
             }
 
             LightGeometryHelper.renderSphereGeometry();

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -171,6 +171,8 @@ public final class WorldRendererImpl implements WorldRenderer {
         mainDirectionalLight.lightType = LightComponent.LightType.DIRECTIONAL;
         mainDirectionalLight.lightAmbientIntensity = 0.75f;
         mainDirectionalLight.lightDiffuseIntensity = 0.75f;
+        mainDirectionalLight.lightSpecularIntensity = 0.02f;
+        mainDirectionalLight.lightSpecularPower = 100f;
     }
 
     private void initRenderingSupport() {

--- a/engine/src/main/resources/assets/shaders/lightGeometryPass_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/lightGeometryPass_frag.glsl
@@ -126,7 +126,7 @@ void main() {
 
 #if defined (DYNAMIC_SHADOWS) && defined (FEATURE_LIGHT_DIRECTIONAL)
     // ensure that the shadow does not make the surface completely black
-    shadowTerm = clamp(shadowTerm, 0.25, 1.0);
+    shadowTerm = clamp(shadowTerm, 0.5, 1.0);
 
     lambTerm *= shadowTerm;
     specTerm *= shadowTerm;

--- a/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
+++ b/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
@@ -40,14 +40,8 @@ float calcLambLight(vec3 normal, vec3 lightVec) {
     return diffuse;
 }
 
-float calcSpecLight(vec3 normal, vec3 lightVec, vec3 eyeVec, float exp) {
-    vec3 halfWay = normalize(eyeVec+lightVec);
-    return pow(clamp(dot(halfWay, normal), 0.0, 1.0), exp);
-}
-
 float calcSpecLightNormalized(vec3 normal, vec3 lightVec, vec3 eyeVec, float exp) {
-    vec3 halfWay = normalize(eyeVec+lightVec);
-    return ((exp + 8.0) / PI_TIMES_8) * pow(clamp(dot(halfWay, normal), 0.0, 1.0), exp);
+    return pow(max(0.0, dot(-eyeVec, reflect(lightVec, normal))), exp);
 }
 
 vec4 linearToSrgb(vec4 color) {


### PR DESCRIPTION
### Contains

This fixes various parts of the lighting system.  Addressing issues with dropping multiple torches, oddness with specular light, and more usable attenuation values.  Screenshots to follow...

This does introduce something that needs addressing.  When a torch is held or dropped in the world,  it does not light itself.  This is probably an already existing issue present,  but made more obvious when I removed the light fading in and out when switching between torches and non torches.  Which brings me to something else that needs addressing,  items that are held need to be better shown in a multiplayer setting.  This will allow us to avoid putting lights on the character altogether.

### How to test

Drop lots of torches.  Hold torches.  Watch the sun/moon effect on the world.

### Outstanding before merging

- [x] ~~See if something easy can be done with dimming when walking in bright daylight.~~  I dont know how to fix this without causing more overbrightness.  Who lights a torch in daylight? ;)
- [x] Reduce overall specular light as everything is definitely too shiney