### PR TITLE
Fixes #2265

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -218,13 +218,30 @@ public class BlockCommands extends BaseComponentSystem {
                 throw new IllegalArgumentException("No block found for '" + uri + "'");
             }
         } else if (matchingUris.isEmpty()) {
-            throw new IllegalArgumentException("No block found for '" + uri + "'");
+        	return suggestItemIfAvailable(uri);
         } else {
             StringBuilder builder = new StringBuilder();
             builder.append("Non-unique block name, possible matches: ");
             Joiner.on(", ").appendTo(builder, matchingUris);
             return builder.toString();
         }
+    }
+    
+    /**
+     * Tells players that their request matched no blocks, and directs them to giveItem if an item matches.
+     * 
+     * @param uri the URI to use to look for an item
+     */
+    private String suggestItemIfAvailable(String uri){
+    	Set<ResourceUrn> matchingItems = assetManager.resolve(uri, Prefab.class);
+    	StringBuilder result = new StringBuilder();
+    	result.append("No block found for "+uri);
+    	if(matchingItems.size() != 0){
+    		result.append(". ");
+    		result.append("Item matches found, use 'giveItem' to request one: ");
+    		Joiner.on(", ").appendTo(result, matchingItems);
+    	}
+    	return result.toString();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2265

### How to test

In the command system: `giveBlock pickaxe` results in a suggestion to use `giveItem`, and `giveBlock NothingWithThisNameExists` results in a message telling the player that no such block exists.

### Outstanding before merging

Do we want to move to a unified `give` that gives either blocks or items? At the moment, `giveBlock` and `giveItem` overlap a lot.