### PR TITLE
Drop 1 item from inventory on right click in drop region.

### DIFF
--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/hud/DropItemRegion.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/hud/DropItemRegion.java
@@ -42,14 +42,17 @@ public class DropItemRegion extends CoreHudWidget {
         @Override
         public boolean onMouseClick(NUIMouseClickEvent event) {
             MouseInput mouseButton = event.getMouseButton();
-            if (mouseButton == MouseInput.MOUSE_LEFT) {
+            if (mouseButton == MouseInput.MOUSE_LEFT || mouseButton == MouseInput.MOUSE_RIGHT) {
                 EntityRef playerEntity = localPlayer.getCharacterEntity();
                 EntityRef movingItem = playerEntity.getComponent(CharacterComponent.class).movingItem;
                 EntityRef item  = InventoryUtils.getItemAt(movingItem, 0);
                 if (!item.exists()) {
                     return true;
                 }
-                int count = InventoryUtils.getStackCount(item);
+                int count = 1;
+                if (mouseButton == MouseInput.MOUSE_LEFT) {
+                    count = InventoryUtils.getStackCount(item);     //Drop complete stack with left click
+                }
 
                 Vector3f position = localPlayer.getViewPosition();
                 Vector3f direction = localPlayer.getViewDirection();


### PR DESCRIPTION
Fixes #2295 

Adds dropping of 1 item when user presses right click while holding a stack of item on the drop region around inventory grid.