### PR TITLE
Make it possible to add new biomes and still be compatible with CoreBiomes

### DIFF
--- a/engine/src/main/java/org/terasology/world/viewer/layers/NominalFacetLayer.java
+++ b/engine/src/main/java/org/terasology/world/viewer/layers/NominalFacetLayer.java
@@ -16,17 +16,17 @@
 
 package org.terasology.world.viewer.layers;
 
-import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
-import java.awt.image.DataBufferInt;
-import java.util.function.Function;
-
 import org.terasology.rendering.nui.Color;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.facets.base.ObjectFacet2D;
 import org.terasology.world.viewer.color.ColorBlender;
 import org.terasology.world.viewer.color.ColorBlenders;
 import org.terasology.world.viewer.color.ColorModels;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.DataBufferInt;
+import java.util.function.Function;
 
 /**
  * Provides info about an {@link ObjectFacet2D}.
@@ -56,8 +56,10 @@ public abstract class NominalFacetLayer<E> extends AbstractFacetLayer {
         for (int z = 0; z < height; z++) {
             for (int x = 0; x < width; x++) {
                 Color src = getColor(facet, x, z);
-                int blend = blender.get(src.rgba());
-                dataBuffer.setElem(z * width + x, blend);
+                if (src != null) {
+                    int blend = blender.get(src.rgba());
+                    dataBuffer.setElem(z * width + x, blend);
+                }
             }
         }
     }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facets/BiomeFacet.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facets/BiomeFacet.java
@@ -15,15 +15,15 @@
  */
 package org.terasology.core.world.generator.facets;
 
-import org.terasology.core.world.CoreBiome;
 import org.terasology.math.Region3i;
+import org.terasology.world.biomes.Biome;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.facets.base.BaseObjectFacet2D;
 
 /**
  */
-public class BiomeFacet extends BaseObjectFacet2D<CoreBiome> {
+public class BiomeFacet extends BaseObjectFacet2D<Biome> {
     public BiomeFacet(Region3i targetRegion, Border3D border) {
-        super(targetRegion, border, CoreBiome.class);
+        super(targetRegion, border, Biome.class);
     }
 }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -21,6 +21,7 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.world.biomes.Biome;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.ChunkConstants;
@@ -69,7 +70,7 @@ public class SolidRasterizer implements WorldRasterizer {
         Vector2i pos2d = new Vector2i();
         for (Vector3i pos : ChunkConstants.CHUNK_REGION) {
             pos2d.set(pos.x, pos.z);
-            CoreBiome biome = biomeFacet.get(pos2d);
+            Biome biome = biomeFacet.get(pos2d);
             chunk.setBiome(pos.x, pos.y, pos.z, biome);
 
             int posY = pos.y + chunk.getChunkWorldOffsetY();
@@ -93,51 +94,53 @@ public class SolidRasterizer implements WorldRasterizer {
         }
     }
 
-    private Block getSurfaceBlock(int depth, int height, CoreBiome type, int seaLevel) {
-        switch (type) {
-            case FOREST:
-            case PLAINS:
-            case MOUNTAINS:
-                // Beach
-                if (depth == 0 && height > seaLevel && height < seaLevel + 96) {
-                    return grass;
-                } else if (depth == 0 && height >= seaLevel + 96) {
-                    return snow;
-                } else if (depth > 32) {
-                    return stone;
-                } else {
-                    return dirt;
-                }
-            case SNOW:
-                if (depth == 0 && height > seaLevel) {
-                    // Snow on top
-                    return snow;
-                } else if (depth > 32) {
-                    // Stone
-                    return stone;
-                } else {
-                    // Dirt
-                    return dirt;
-                }
-            case DESERT:
-                if (depth > 8) {
-                    // Stone
-                    return stone;
-                } else {
-                    return sand;
-                }
-            case OCEAN:
-                if (depth == 0) {
-                    return sand;
-                } else {
-                    return stone;
-                }
-            case BEACH:
-                if (depth < 3) {
-                    return sand;
-                } else {
-                    return stone;
-                }
+    private Block getSurfaceBlock(int depth, int height, Biome type, int seaLevel) {
+        if (type instanceof CoreBiome) {
+            switch ((CoreBiome) type) {
+                case FOREST:
+                case PLAINS:
+                case MOUNTAINS:
+                    // Beach
+                    if (depth == 0 && height > seaLevel && height < seaLevel + 96) {
+                        return grass;
+                    } else if (depth == 0 && height >= seaLevel + 96) {
+                        return snow;
+                    } else if (depth > 32) {
+                        return stone;
+                    } else {
+                        return dirt;
+                    }
+                case SNOW:
+                    if (depth == 0 && height > seaLevel) {
+                        // Snow on top
+                        return snow;
+                    } else if (depth > 32) {
+                        // Stone
+                        return stone;
+                    } else {
+                        // Dirt
+                        return dirt;
+                    }
+                case DESERT:
+                    if (depth > 8) {
+                        // Stone
+                        return stone;
+                    } else {
+                        return sand;
+                    }
+                case OCEAN:
+                    if (depth == 0) {
+                        return sand;
+                    } else {
+                        return stone;
+                    }
+                case BEACH:
+                    if (depth < 3) {
+                        return sand;
+                    } else {
+                        return stone;
+                    }
+            }
         }
         return dirt;
     }

--- a/modules/Core/src/main/java/org/terasology/core/world/viewer/layers/CoreBiomeColors.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/viewer/layers/CoreBiomeColors.java
@@ -16,19 +16,18 @@
 
 package org.terasology.core.world.viewer.layers;
 
-import java.util.Map;
-import java.util.function.Function;
-
+import com.google.common.collect.Maps;
 import org.terasology.core.world.CoreBiome;
 import org.terasology.rendering.nui.Color;
 import org.terasology.world.biomes.Biome;
 
-import com.google.common.collect.Maps;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
- * TODO Type description
+ * Maps the core biomes to colors
  */
-public class CoreBiomeColors implements Function<CoreBiome, Color> {
+public class CoreBiomeColors implements Function<Biome, Color> {
 
     private final Map<Biome, Color> biomeColors = Maps.newHashMap();
 
@@ -43,7 +42,7 @@ public class CoreBiomeColors implements Function<CoreBiome, Color> {
     }
 
     @Override
-    public Color apply(CoreBiome biome) {
+    public Color apply(Biome biome) {
         Color color = biomeColors.get(biome);
         return color;
     }

--- a/modules/Core/src/main/java/org/terasology/core/world/viewer/layers/CoreBiomeFacetLayer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/viewer/layers/CoreBiomeFacetLayer.java
@@ -18,6 +18,7 @@ package org.terasology.core.world.viewer.layers;
 
 import org.terasology.core.world.CoreBiome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
+import org.terasology.world.biomes.Biome;
 import org.terasology.world.viewer.layers.NominalFacetLayer;
 import org.terasology.world.viewer.layers.Renders;
 import org.terasology.world.viewer.layers.ZOrder;
@@ -26,7 +27,7 @@ import org.terasology.world.viewer.layers.ZOrder;
  * Maps {@link CoreBiome} facet to corresponding colors.
  */
 @Renders(value = BiomeFacet.class, order = ZOrder.BIOME)
-public class CoreBiomeFacetLayer extends NominalFacetLayer<CoreBiome> {
+public class CoreBiomeFacetLayer extends NominalFacetLayer<Biome> {
 
     public CoreBiomeFacetLayer() {
         super(BiomeFacet.class, new CoreBiomeColors());


### PR DESCRIPTION
### Contains

This allows modules to extend the biomes in external world generators and maintain compatibility with existing plugin world generation.  This was a problem with using JoshariasSurvival with ShatteredPlanes because the foragable food generation required Core's BiomeFacet.  

With this,  ShatteredPlanes can use the built in Facet mechanisms for biomes and add additional biomes of its own.

### How to test

Core perlin world generation still generates flora according to biome.  The world preview still colors correctly to biome.

### Outstanding before merging