### PR TITLE
Item pickup delay

### DIFF
--- a/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
@@ -80,10 +80,6 @@ public final class ItemComponent implements Component {
      */
     public int baseDamage = 1;
 
-    public long timeToPickUp = 0;
-
-    public long pickUpTime = 0;
-
     //TODO: move this to a separate component alongside the health system
     public Prefab damageType;
 

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
@@ -80,6 +80,10 @@ public final class ItemComponent implements Component {
      */
     public int baseDamage = 1;
 
+    public long timeToPickUp = 0;
+
+    public long pickUpTime = 0;
+
     //TODO: move this to a separate component alongside the health system
     public Prefab damageType;
 

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
@@ -68,14 +68,14 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onBumpGiveItemToEntity(CollideEvent event, EntityRef entity, PickupComponent pickupComponent) {
-        ItemComponent itemComponent = entity.getComponent(ItemComponent.class);
-        if (itemComponent != null) {
-            if (itemComponent.pickUpTime + itemComponent.timeToPickUp < time.getGameTimeInMs()) {
-                GiveItemEvent giveItemEvent = new GiveItemEvent(event.getOtherEntity());
-                entity.send(giveItemEvent);
+        if (pickupComponent.timeDropped + pickupComponent.timeToPickUp < time.getGameTimeInMs()) {
+            GiveItemEvent giveItemEvent = new GiveItemEvent(event.getOtherEntity());
+            entity.send(giveItemEvent);
 
-                if (giveItemEvent.isHandled()) {
-                    // remove all the components added from the pickup prefab
+            if (giveItemEvent.isHandled()) {
+                // remove all the components added from the pickup prefab
+                ItemComponent itemComponent = entity.getComponent(ItemComponent.class);
+                if (itemComponent != null) {
                     for (Component component : itemComponent.pickupPrefab.iterateComponents()) {
                         entity.removeComponent(component.getClass());
                     }

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
@@ -17,6 +17,7 @@
 package org.terasology.logic.inventory;
 
 import com.bulletphysics.collision.shapes.BoxShape;
+import org.terasology.engine.Time;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
@@ -46,6 +47,9 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
     @In
     private EntitySystemLibrary library;
 
+    @In
+    private Time time;
+
     @ReceiveEvent
     public void onDropItemEvent(DropItemEvent event, EntityRef itemEntity, ItemComponent itemComponent) {
         for (Component component : itemComponent.pickupPrefab.iterateComponents()) {
@@ -64,15 +68,17 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onBumpGiveItemToEntity(CollideEvent event, EntityRef entity, PickupComponent pickupComponent) {
-        GiveItemEvent giveItemEvent = new GiveItemEvent(event.getOtherEntity());
-        entity.send(giveItemEvent);
+        ItemComponent itemComponent = entity.getComponent(ItemComponent.class);
+        if (itemComponent != null) {
+            if (itemComponent.pickUpTime + itemComponent.timeToPickUp < time.getGameTimeInMs()) {
+                GiveItemEvent giveItemEvent = new GiveItemEvent(event.getOtherEntity());
+                entity.send(giveItemEvent);
 
-        if (giveItemEvent.isHandled()) {
-            // remove all the components added from the pickup prefab
-            ItemComponent itemComponent = entity.getComponent(ItemComponent.class);
-            if (itemComponent != null) {
-                for (Component component : itemComponent.pickupPrefab.iterateComponents()) {
-                    entity.removeComponent(component.getClass());
+                if (giveItemEvent.isHandled()) {
+                    // remove all the components added from the pickup prefab
+                    for (Component component : itemComponent.pickupPrefab.iterateComponents()) {
+                        entity.removeComponent(component.getClass());
+                    }
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/logic/inventory/PickupComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/PickupComponent.java
@@ -20,4 +20,7 @@ import org.terasology.entitySystem.Component;
 
 
 public class PickupComponent implements Component {
+    public long timeToPickUp = 0;
+
+    public long timeDropped = 0;
 }

--- a/engine/src/main/resources/assets/prefabs/itemPickup.prefab
+++ b/engine/src/main/resources/assets/prefabs/itemPickup.prefab
@@ -3,6 +3,8 @@
         "scale" : 0.3
     },
     "Pickup": {
+        "timeToPickUp": 2000,
+        "timeDropped": 0
     },
     "Lifespan": {
         "lifespan": 30

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
@@ -119,7 +119,6 @@ public class CharacterInventorySystem extends BaseComponentSystem {
         if (pickupItem.hasComponent(PickupComponent.class))
         {
             PickupComponent pickupComponent = pickupItem.getComponent(PickupComponent.class);
-            pickupComponent.timeToPickUp = 2000;
             pickupComponent.timeDropped = time.getGameTimeInMs();
             pickupItem.saveComponent(pickupComponent);
         }

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
@@ -114,12 +114,16 @@ public class CharacterInventorySystem extends BaseComponentSystem {
             }
         }
 
-        ItemComponent itemComponent = pickupItem.getComponent(ItemComponent.class);
-        itemComponent.timeToPickUp = 2000;
-        itemComponent.pickUpTime = time.getGameTimeInMs();
-        pickupItem.saveComponent(itemComponent);
-
         pickupItem.send(new DropItemEvent(event.getNewPosition()));
+
+        if (pickupItem.hasComponent(PickupComponent.class))
+        {
+            PickupComponent pickupComponent = pickupItem.getComponent(PickupComponent.class);
+            pickupComponent.timeToPickUp = 2000;
+            pickupComponent.timeDropped = time.getGameTimeInMs();
+            pickupItem.saveComponent(pickupComponent);
+        }
+
         pickupItem.send(new ImpulseEvent(event.getImpulse()));
     }
 

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
@@ -114,6 +114,11 @@ public class CharacterInventorySystem extends BaseComponentSystem {
             }
         }
 
+        ItemComponent itemComponent = pickupItem.getComponent(ItemComponent.class);
+        itemComponent.timeToPickUp = 2000;
+        itemComponent.pickUpTime = time.getGameTimeInMs();
+        pickupItem.saveComponent(itemComponent);
+
         pickupItem.send(new DropItemEvent(event.getNewPosition()));
         pickupItem.send(new ImpulseEvent(event.getImpulse()));
     }


### PR DESCRIPTION
This PR adds item pickup time capabilities for the game. This has been discussed in PR #2289, and this is what I reduced it to.

I added _timeToPickUp_ to represent the time needed to pass from when the item was dropped and _pickUpTime_ as the time from when the counter starts.

I added the value changes in onDropItemRequest because I only wanted the **player's** item dropping to be affected by this change. Of course, any other drop item event listeners will be able to change the time needed to pick up the item by just getting the component, changing the two values, and saving.

I found this necessary because dropping items relatively below you or close enough to you would result in them being picked up by the character. This way, a player can throw items at his feed with no issues.

To test, get an item and throw it near your character. You shouldn't be able to pick it up for 2 seconds. On the other hand, items dropped from breaking blocks should be pickable instantly.

This can be only a beginning for the way item ownership and sharing items would work. Players will be able to throw items that they din't want to throw and stand on top of them so that nobody could take them until the pickup timer runs out

The only issue I have is the way I changed onBumpGiveItemToEntity. I'm not exactly sure what exactly was going on before (it looked like the item was given to the player even if there would be no itemComponent in it, which would be weird (for me at least)

