### PR TITLE
Nullify damage events while in god mode (fixes #652)

### DIFF
--- a/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -19,6 +19,8 @@ import gnu.trove.iterator.TFloatIterator;
 import gnu.trove.iterator.TIntIterator;
 import gnu.trove.list.TFloatList;
 import gnu.trove.list.TIntList;
+import org.terasology.logic.characters.CharacterMovementComponent;
+import org.terasology.logic.characters.MovementMode;
 import org.terasology.utilities.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.audio.StaticSound;
@@ -168,7 +170,12 @@ public class HealthAuthoritySystem extends BaseComponentSystem implements Update
 
     private void doDamage(EntityRef entity, int damageAmount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
         HealthComponent health = entity.getComponent(HealthComponent.class);
-        if (health != null) {
+        CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
+        bool ghost = false;
+        if (characterMovementComponent != null) {
+            ghost = (characterMovementComponent.mode == MovementMode.GHOSTING);
+        }
+        if ((health != null) && !ghost) {
             int damagedAmount = health.currentHealth - Math.max(health.currentHealth - damageAmount, 0);
             health.currentHealth -= damagedAmount;
             health.nextRegenTick = time.getGameTimeInMs() + TeraMath.floorToInt(health.waitBeforeRegen * 1000);

--- a/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -171,7 +171,7 @@ public class HealthAuthoritySystem extends BaseComponentSystem implements Update
     private void doDamage(EntityRef entity, int damageAmount, Prefab damageType, EntityRef instigator, EntityRef directCause) {
         HealthComponent health = entity.getComponent(HealthComponent.class);
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
-        bool ghost = false;
+        boolean ghost = false;
         if (characterMovementComponent != null) {
             ghost = (characterMovementComponent.mode == MovementMode.GHOSTING);
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Nullify damage events while in god mode (fixes #652)

### How to test

-Activate "Breathing" module
-Begin play (either new or saved)
-Use pickaxe on blocks, verify they can still be destroyed and picked up
-Find deep water, go swimming
-Verify you begin to lose health after being underwater for the standard period of time
-Surface, enter ghost mode ('F1' then type "ghost")
-Dive back in
-Verify that the oxygen meter goes down, but no health is lost.

### Outstanding before merging

I'm new to this project, and just assumed that god mode and ghosting were synonymous, since I couldn't find any references to "god mode" in the code. If I got this wrong, hey, sorry.

