### PR TITLE
Reduce the amount of openGL noise in world rendering

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/assets/material/BaseMaterial.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/material/BaseMaterial.java
@@ -202,9 +202,9 @@ public abstract class BaseMaterial extends Material {
 
     @Override
     public void setCamera(Camera camera) {
-        setMatrix4("viewMatrix", camera.getViewMatrix());
-        setMatrix4("projMatrix", camera.getProjectionMatrix());
-        setMatrix4("viewProjMatrix", camera.getViewProjectionMatrix());
-        setMatrix4("invProjMatrix", camera.getInverseProjectionMatrix());
+        setMatrix4("viewMatrix", camera.getViewMatrix(), true);
+        setMatrix4("projMatrix", camera.getProjectionMatrix(), true);
+        setMatrix4("viewProjMatrix", camera.getViewProjectionMatrix(), true);
+        setMatrix4("invProjMatrix", camera.getInverseProjectionMatrix(), true);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -181,9 +181,9 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
             if (material.isRenderable()) {
                 OpenGLMesh lastMesh = null;
                 material.enable();
-                material.setFloat("sunlight", 1.0f);
-                material.setFloat("blockLight", 1.0f);
-                material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+                material.setFloat("sunlight", 1.0f, true);
+                material.setFloat("blockLight", 1.0f, true);
+                material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix(), true);
                 material.bindTextures();
 
                 Set<EntityRef> entities = meshByMaterial.get(material);
@@ -226,7 +226,7 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
                         MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
                         MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
 
-                        material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+                        material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix(), true);
                         material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
                         material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/PostProcessor.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/PostProcessor.java
@@ -21,7 +21,6 @@ import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL13;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.utilities.Assets;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.config.RenderingDebugConfig;
@@ -35,6 +34,7 @@ import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.oculusVr.OculusVrHelper;
 import org.terasology.rendering.world.WorldRenderer.RenderingStage;
+import org.terasology.utilities.Assets;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -47,7 +47,26 @@ import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_MODELVIEW;
+import static org.lwjgl.opengl.GL11.GL_PROJECTION;
+import static org.lwjgl.opengl.GL11.GL_QUADS;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glCallList;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glColor4f;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glEndList;
+import static org.lwjgl.opengl.GL11.glGenLists;
+import static org.lwjgl.opengl.GL11.glLoadIdentity;
+import static org.lwjgl.opengl.GL11.glMatrixMode;
+import static org.lwjgl.opengl.GL11.glNewList;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glTexCoord2d;
+import static org.lwjgl.opengl.GL11.glVertex3i;
+import static org.lwjgl.opengl.GL11.glViewport;
 
 /**
  * The term "Post Processing" is in analogy to what occurs in the world of Photography:
@@ -320,15 +339,15 @@ public class PostProcessor {
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffers.sceneOpaque.bindTexture();
-        materials.lightBufferPass.setInt("texSceneOpaque", texId++);
+        materials.lightBufferPass.setInt("texSceneOpaque", texId++, true);
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffers.sceneOpaque.bindDepthTexture();
-        materials.lightBufferPass.setInt("texSceneOpaqueDepth", texId++);
+        materials.lightBufferPass.setInt("texSceneOpaqueDepth", texId++, true);
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffers.sceneOpaque.bindNormalsTexture();
-        materials.lightBufferPass.setInt("texSceneOpaqueNormals", texId++);
+        materials.lightBufferPass.setInt("texSceneOpaqueNormals", texId++, true);
 
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffers.sceneOpaque.bindLightBufferTexture();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
@@ -41,7 +41,7 @@ public class ShaderParametersBase implements ShaderParameters {
     @Override
     public void applyParameters(Material program) {
 
-        program.setFloat("viewingDistance", CoreRegistry.get(Config.class).getRendering().getViewDistance().getChunkDistance().x * 8.0f);
+        program.setFloat("viewingDistance", CoreRegistry.get(Config.class).getRendering().getViewDistance().getChunkDistance().x * 8.0f, true);
 
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
@@ -68,7 +68,7 @@ public class ShaderParametersBase implements ShaderParameters {
 
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
         if (worldProvider != null) {
-            program.setFloat("time", worldProvider.getTime().getDays());
+            program.setFloat("time", worldProvider.getTime().getDays(), true);
         }
     }
 }


### PR DESCRIPTION
Applying a shader uniforms to not just "currentOnly" causes lots of openGL state changes because it has to enable all the other shaders individually,  set the value across the board,  then reload the original shader.  This starts to be a more prominent problem when each chunk does this multiple times in a frame.

With these changes,  I boosted my average FPS by 10+ and "mega" view distance became playable (over 20fps).

In measuring the amount of openGL calls,  I used gDEBugger and observed the difference in "OGL calls/frame".  The amount of OGL calls reduced by over 50%.

### Contains

- Reduction of openGL calls by only using "currentOnly = true" when setting shader uniform values in world rendering.  (NUI rendering is another issue.  But it does not seem to affect FPS like world rendering)
- Reduction of openGL calls by only enabling the shader once per set of chunks being rendered with ```renderChunk(...)``` (it now takes in the whole queue instead of one at a time).

### How to test

Run game, make sure all rendered stuff still renders correctly.

### Outstanding before merging

- [x] Test on another graphics card other than my own.
