### PR TITLE
Quick fix for #2329, disposes loaded assets for correct initialization

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.console.suggesters;
 
+import com.google.api.client.util.Maps;
 import com.google.common.collect.Sets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
@@ -23,7 +24,7 @@ import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
 import org.terasology.rendering.nui.UIScreenLayer;
 import org.terasology.rendering.nui.asset.UIElement;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -36,18 +37,21 @@ public final class ScreenSuggester implements CommandParameterSuggester<String> 
 
     @Override
     public Set<String> suggest(EntityRef sender, Object... resolvedParameters) {
-
-        HashMap<String, Set<ResourceUrn>> resourceMap = new HashMap<>();
+        Map<String, Set<ResourceUrn>> resourceMap = Maps.newHashMap();
         Set<String> suggestions = Sets.newHashSet();
 
         for (ResourceUrn resolvedParameter : assetManager.getAvailableAssets(UIElement.class)) {
             Optional<UIElement> element = assetManager.getAsset(resolvedParameter, UIElement.class);
             if (element.isPresent() && element.get().getRootWidget() instanceof UIScreenLayer) {
                 String resourceName = resolvedParameter.getResourceName().toString();
-                if (!resourceMap.containsKey(resourceName))
+                if (!resourceMap.containsKey(resourceName)) {
                     resourceMap.put(resourceName, Sets.newHashSet());
+                }
 
                 resourceMap.get(resourceName).add(resolvedParameter);
+            }
+            if (element.isPresent()) {
+                element.get().dispose();
             }
         }
 


### PR DESCRIPTION
### Contains

My auto-complete PR(#2266) seems like broke proper initialisation of UIScreenLayer. An example for reproducing as mentioned in  #2329, when `migTestScreen` is loaded with auto completion, exiting the screen with `ESC` throws an Exception.  

My previous PR used `AssetManager`'s `getAvailableAssets()` method for suggesting available UIScreenLayer's for `showScreen()`. What I missed at that time, ~~`getAvailableAssets()`~~ `getAsset(...)` method tries to  initialise the assets and when `showScreen()` method is invoked with auto completion and proper initialisation steps are not considered.  A quick fix in this PR disposes these loaded assets, therefore screens are correctly loaded. 


### How to test

For testing, loading `migTestScreen` with auto completion(writing `showScreen mig` and hitting `TAB` key) and exitting the screen by hitting `ESC` must suffice. 

### Outstanding before merging

- [ ] A method in AssetManager, that I might be missing for getting available assets without requiring disposal 


