### PR TITLE
Do not load assets when suggesting screens

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
@@ -21,13 +21,15 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
-import org.terasology.rendering.nui.UIScreenLayer;
 import org.terasology.rendering.nui.asset.UIElement;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Suggest screen names. When only one screen resource exists for the entire set of loaded modules,
+ * the name alone suffices. Otherwise, the module name must be prepended.
+ */
 public final class ScreenSuggester implements CommandParameterSuggester<String> {
     private final AssetManager assetManager;
 
@@ -41,18 +43,12 @@ public final class ScreenSuggester implements CommandParameterSuggester<String> 
         Set<String> suggestions = Sets.newHashSet();
 
         for (ResourceUrn resolvedParameter : assetManager.getAvailableAssets(UIElement.class)) {
-            Optional<UIElement> element = assetManager.getAsset(resolvedParameter, UIElement.class);
-            if (element.isPresent() && element.get().getRootWidget() instanceof UIScreenLayer) {
-                String resourceName = resolvedParameter.getResourceName().toString();
-                if (!resourceMap.containsKey(resourceName)) {
-                    resourceMap.put(resourceName, Sets.newHashSet());
-                }
+            String resourceName = resolvedParameter.getResourceName().toString();
+            if (!resourceMap.containsKey(resourceName)) {
+                resourceMap.put(resourceName, Sets.newHashSet());
+            }
 
-                resourceMap.get(resourceName).add(resolvedParameter);
-            }
-            if (element.isPresent()) {
-                element.get().dispose();
-            }
+            resourceMap.get(resourceName).add(resolvedParameter);
         }
 
         for (String key : resourceMap.keySet()) {

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.console.suggesters;
 
+import com.google.api.client.util.Maps;
 import com.google.common.collect.Sets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
@@ -23,7 +24,7 @@ import org.terasology.logic.console.commandSystem.CommandParameterSuggester;
 import org.terasology.rendering.nui.UIScreenLayer;
 import org.terasology.rendering.nui.asset.UIElement;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -36,18 +37,21 @@ public final class ScreenSuggester implements CommandParameterSuggester<String> 
 
     @Override
     public Set<String> suggest(EntityRef sender, Object... resolvedParameters) {
-
-        HashMap<String, Set<ResourceUrn>> resourceMap = new HashMap<>();
+        Map<String, Set<ResourceUrn>> resourceMap = Maps.newHashMap();
         Set<String> suggestions = Sets.newHashSet();
 
         for (ResourceUrn resolvedParameter : assetManager.getAvailableAssets(UIElement.class)) {
             Optional<UIElement> element = assetManager.getAsset(resolvedParameter, UIElement.class);
             if (element.isPresent() && element.get().getRootWidget() instanceof UIScreenLayer) {
                 String resourceName = resolvedParameter.getResourceName().toString();
-                if (!resourceMap.containsKey(resourceName))
+                if (!resourceMap.containsKey(resourceName)) {
                     resourceMap.put(resourceName, Sets.newHashSet());
+                }
 
                 resourceMap.get(resourceName).add(resolvedParameter);
+            }
+            if (element.isPresent()) {
+                element.get().dispose();
             }
         }
 


### PR DESCRIPTION
Currently, every screen that is suggested is loaded into memory and tested if the root widget implements `UIScreenLayer`. I removed the test to avoid unnecessary loading and to avoid creating duplicates. It will suggest other UIElements as well - I think that there are none though.

Fixes #2329, supersedes #2339
