### PR TITLE
Minor logging tweaks.

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PrefabFormat.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PrefabFormat.java
@@ -16,6 +16,8 @@
 package org.terasology.entitySystem.prefab.internal;
 
 import com.google.common.base.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
@@ -34,6 +36,7 @@ import java.util.List;
 /**
  */
 public class PrefabFormat extends AbstractAssetFileFormat<PrefabData> {
+    private static final Logger logger = LoggerFactory.getLogger(PrefabFormat.class);
 
     private ComponentLibrary componentLibrary;
     private TypeSerializationLibrary typeSerializationLibrary;
@@ -49,6 +52,7 @@ public class PrefabFormat extends AbstractAssetFileFormat<PrefabData> {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputs.get(0).openStream(), Charsets.UTF_8))) {
             EntityData.Prefab prefabData = EntityDataJSONFormat.readPrefab(reader);
             if (prefabData != null) {
+                logger.debug("Attempting to deserialize prefab {} with inputs {}", resourceUrn, inputs);
                 PrefabSerializer serializer = new PrefabSerializer(componentLibrary, typeSerializationLibrary);
                 return serializer.deserialize(prefabData);
             } else {

--- a/facades/PC/src/main/resources/logback.xml
+++ b/facades/PC/src/main/resources/logback.xml
@@ -46,6 +46,7 @@
   </root>
 
   <logger name="org.terasology" level="${logOverrideLevel:-info}" />
-  <logger name="org.reflections.Reflections" level="${logOverrideLevel:-warn}" />
+  <logger name="org.terasology.entitySystem.prefab.internal.PrefabFormat" level="${logOverrideLevel:-debug}" />
+  <logger name="org.reflections.Reflections" level="${logOverrideLevel:-error}" />
 
 </configuration>


### PR DESCRIPTION
Makes it a little easier to find misbehaving prefabs. Used it to fix up Signalling and clean up the now-outdated color definitions in Pathfinding. Adjusted default logging config to allow this one piece of debug logging, which does make the logs a bit chattier, but then I disallowed the pointless "given scan urls are empty. set urls in the configuration" log spam so it sort of balances out.

Couple examples now allowing easier connecting of deeper issues like deserialization problems with the exact prefab that caused it:

```
16:08:42.848 [main] DEBUG o.t.e.prefab.internal.PrefabFormat - Attempting to deserialize prefab PlantPack:Squash with inputs [/PlantPack/assets/prefabs/crop/Squash.prefab]
16:08:42.848 [main] ERROR o.t.p.serializers.PrefabSerializer - Prefab contains unknown component 'ChangingBlocks'
...
16:30:17.232 [main] DEBUG o.t.e.prefab.internal.PrefabFormat - Attempting to deserialize prefab NameGenerator:floweringPlantsFamilies with inputs [/NameGenerator/assets/prefabs/floweringPlantsFamilies.prefab]
16:30:17.235 [main] DEBUG o.t.e.prefab.internal.PrefabFormat - Attempting to deserialize prefab Pathfinding:finishWork with inputs [/Pathfinding/assets/prefabs/behaviorNodes/finishWork.prefab]
16:30:17.236 [main] ERROR o.t.p.typeHandling.Serializer - Unable to deserialize field 'textColor' from 'double: 0.0
double: 0.0
double: 0.0
```

Edit: Dunno if this logging should just be info level, or if the similar logging registering blocks etc should be debug instead of info. I guess since it only happens on init it might be fine as info.