### PR TITLE
Allow modification of jump speed using events

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/AffectJumpForceEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/AffectJumpForceEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.characters;
+
+import org.terasology.entitySystem.event.AbstractValueModifiableEvent;
+
+public class AffectJumpForceEvent extends AbstractValueModifiableEvent {
+    public AffectJumpForceEvent(float baseValue) {
+        super(baseValue);
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.logic.characters;
 
-import java.math.RoundingMode;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -38,6 +36,8 @@ import org.terasology.physics.engine.SweepCallback;
 import org.terasology.physics.events.MovedEvent;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
+
+import java.math.RoundingMode;
 
 /**
  * Calculates character movement using a physics-engine provided CharacterCollider.
@@ -648,7 +648,9 @@ public class KinematicCharacterMover implements CharacterMover {
             // Jumping is only possible, if the entity is standing on ground
             if (input.isJumpRequested()) {
                 state.setGrounded(false);
-                endVelocity.y += movementComp.jumpSpeed;
+                AffectJumpForceEvent affectJumpForceEvent = new AffectJumpForceEvent(movementComp.jumpSpeed);
+                entity.send(affectJumpForceEvent);
+                endVelocity.y += affectJumpForceEvent.getResultValue();
                 if (input.isFirstRun()) {
                     entity.send(new JumpEvent());
                 }


### PR DESCRIPTION
### Contains

An event that allows modifying the character's jump speed based off some other factors.  This could be used for things like:
1. Training a jumping skill (this is what I personally plan on doing)
2. Wearing springy boots
3. Drinking a super jumping potion

### How to test

This change should not affect current jumping behavior but allow extension.  After this is merged,  I have a jumping skill that will be added to ManualLaborEventualSkills.