### PR TITLE
Fix silent UITreeView error when no item is selected

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
@@ -342,14 +342,16 @@ public class UITreeView<T> extends CoreWidget {
                 // Expand or contract and item on RMB - works even if the tree is disabled.
                 model.get().getItem(index).setExpanded(!model.get().getItem(index).isExpanded());
 
-                Tree<T> selectedItem = model.get().getItem(selectedIndex.get());
+                Tree<T> selectedItem = selectedIndex.get() != null ? model.get().getItem(selectedIndex.get()) : null;
                 model.get().resetItems();
 
-                int newIndex = model.get().indexOf(selectedItem);
-                if (newIndex == -1) {
-                    selectedIndex.set(null);
-                } else {
-                    selectedIndex.set(newIndex);
+                if (selectedItem != null) {
+                    int newIndex = model.get().indexOf(selectedItem);
+                    if (newIndex == -1) {
+                        selectedIndex.set(null);
+                    } else {
+                        selectedIndex.set(newIndex);
+                    }
                 }
                 return true;
             } else if (isEnabled()) {


### PR DESCRIPTION
### Contains

A quick fix for an issue with #2338: when a `UITreeView` item is expanded/contracted with no item having been selected, a silent NPE is thrown. This doesn't cause any issues with the component (apart from the performance loss associated with throwing/logging exceptions?) but is still unintended.