### PR TITLE
languages sorted in player settings menu

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/settings/PlayerSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/settings/PlayerSettingsScreen.java
@@ -45,6 +45,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Collections;
 
 /**
  */
@@ -112,6 +113,7 @@ public class PlayerSettingsScreen extends CoreScreenLayer {
             SimpleUri menuUri = new SimpleUri("engine:menu");
             TranslationProject menuProject = translationSystem.getProject(menuUri);
             List<Locale> locales = new ArrayList<>(menuProject.getAvailableLocales());
+            Collections.sort(locales, ((Object o1, Object o2) -> (o1.toString().compareTo(o2.toString()))));
             language.setOptions(Lists.newArrayList(locales));
             language.setVisibleOptions(5); // Set maximum number of options visible for scrolling
             language.setOptionRenderer(new LocaleRenderer(translationSystem));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes  #2350 Sort entries in the language dropdown under player settings

### How to test

Start Terasology. Go to settings -> player -> language. All languages should be sorted alphabetically instead of unordered.

### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [ ] Need to consider use case x
- [ ] Still have to adjust the wiki doc
- [ ] Will need translation work

