### PR TITLE
Major change to DelayedActionSystem.

### DIFF
--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -70,7 +70,7 @@ public abstract class TerasologyTestingEnvironment {
 
     private EngineEntityManager engineEntityManager;
     private ComponentSystemManager componentSystemManager;
-    private EngineTime mockTime;
+    protected EngineTime mockTime;
 
     @BeforeClass
     public static void setupEnvironment() throws Exception {

--- a/engine-tests/src/test/java/org/terasology/logic/delay/ArbritaryDelayActionComponent.java
+++ b/engine-tests/src/test/java/org/terasology/logic/delay/ArbritaryDelayActionComponent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.delay;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+
+public class ArbritaryDelayActionComponent implements Component {
+    public int value = 1;
+}

--- a/engine-tests/src/test/java/org/terasology/logic/delay/DelayedActionSystemTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/delay/DelayedActionSystemTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.delay;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.terasology.TerasologyTestingEnvironment;
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.CoreRegistryTest;
+import org.terasology.registry.In;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DelayedActionSystemTest extends TerasologyTestingEnvironment {
+    private DelayedActionSystem delayedActionSystem;
+    private List<Integer> vals; // Use this for ordering the expected values.
+
+    @In
+    private Time time;
+
+    long nextFakeEntityId = 1;
+    int lookingForId = 0; // Use this for ordering the time events. 0 is earliest.
+
+    @Before
+    @Override
+    public void setup() throws Exception{
+        super.setup();
+
+        delayedActionSystem = new DelayedActionSystem();
+        nextFakeEntityId = 1;
+        lookingForId = 0;
+
+        time = mockTime;
+        delayedActionSystem.setTime(mockTime);
+    }
+
+    private EntityRef createFakeEntityWith(ArbritaryDelayActionComponent arbritaryDelayActionComp) {
+        EntityRef entRef = mock(EntityRef.class);
+        when(entRef.getComponent(ArbritaryDelayActionComponent.class)).thenReturn(arbritaryDelayActionComp);
+        when(entRef.exists()).thenReturn(true);
+        when(entRef.getId()).thenReturn(nextFakeEntityId++);
+        return entRef;
+    }
+
+    @Test
+    public void test1DelayedAction() {
+        ArbritaryDelayActionComponent a1 = new ArbritaryDelayActionComponent();
+        a1.value = 3;
+
+        vals = new ArrayList<Integer>(Arrays.asList(3));
+
+        long currentTime = time.getGameTimeInMs();
+
+
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a1),
+                "Blah Blah", ((currentTime + 1000) - currentTime));
+        nextFakeEntityId++;
+    }
+
+    @Test
+    public void test2DelayedActionsInChronoOrder() {
+        ArbritaryDelayActionComponent a1 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a2 = new ArbritaryDelayActionComponent();
+
+        a1.value = 3;
+        a2.value = 2;
+
+        vals = new ArrayList<Integer>(Arrays.asList(3, 2));
+
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a1),
+                "First", (time.getGameTimeInMs() + 1000) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a2),
+                "Second", (time.getGameTimeInMs() + 1500) - time.getGameTimeInMs());
+    }
+
+    @Test
+    public void test2DelayedActionsInReverseChronoOrder() {
+        ArbritaryDelayActionComponent a1 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a2 = new ArbritaryDelayActionComponent();
+
+        a1.value = 5;
+        a2.value = 8;
+
+        vals = new ArrayList<Integer>(Arrays.asList(5, 8));
+
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a2),
+                "Second", (time.getGameTimeInMs() + 1500) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a1),
+                "First", (time.getGameTimeInMs() + 1000) - time.getGameTimeInMs());
+    }
+
+    @Test
+    public void testMultipleDelayedActionsInChronoOrder() {
+        ArbritaryDelayActionComponent a1 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a2 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a3 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a4 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a5 = new ArbritaryDelayActionComponent();
+
+        a1.value = 13;
+        a2.value = 22;
+        a3.value = 10;
+        a4.value = 50;
+        a5.value = 1;
+
+        vals = new ArrayList<Integer>(Arrays.asList(13, 22, 10, 50, 1));
+
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a1),
+                "First", (time.getGameTimeInMs() + 1000) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a2),
+                "Second", (time.getGameTimeInMs() + 1500) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a3),
+                "Third", (time.getGameTimeInMs() + 2000) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a4),
+                "Fourth", (time.getGameTimeInMs() + 2500) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a5),
+                "Fifth", (time.getGameTimeInMs() + 3000) - time.getGameTimeInMs());
+    }
+
+    @Test
+    public void testMultipleDelayedActionsInRandomOrder() {
+        ArbritaryDelayActionComponent a3 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a5 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a2 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a1 = new ArbritaryDelayActionComponent();
+        ArbritaryDelayActionComponent a4 = new ArbritaryDelayActionComponent();
+
+        a1.value = 100;
+        a2.value = 200;
+        a3.value = 314;
+        a4.value = 12;
+        a5.value = 51;
+
+        vals = new ArrayList<Integer>(Arrays.asList(100, 200, 314, 12, 51));
+
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a3),
+                "Third", (time.getGameTimeInMs() + 2000) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a5),
+                "Fifth", (time.getGameTimeInMs() + 3000) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a2),
+                "Second", (time.getGameTimeInMs() + 1500) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a1),
+                "First", (time.getGameTimeInMs() + 1000) - time.getGameTimeInMs());
+        delayedActionSystem.addDelayedAction(createFakeEntityWith(a4),
+                "Fourth", (time.getGameTimeInMs() + 2500) - time.getGameTimeInMs());
+    }
+
+    @ReceiveEvent
+    public void finishWaiting(DelayedActionTriggeredEvent event, EntityRef entity, ArbritaryDelayActionComponent arbritaryDelayActionComp) {
+        assertEquals(vals.get(lookingForId).intValue(), arbritaryDelayActionComp.value);
+        lookingForId++;
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/logic/delay/DelayedActionSystemTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/delay/DelayedActionSystemTest.java
@@ -40,7 +40,6 @@ public class DelayedActionSystemTest extends TerasologyTestingEnvironment {
     private DelayedActionSystem delayedActionSystem;
     private List<Integer> vals; // Use this for ordering the expected values.
 
-    @In
     private Time time;
 
     long nextFakeEntityId = 1;
@@ -74,11 +73,8 @@ public class DelayedActionSystemTest extends TerasologyTestingEnvironment {
 
         vals = new ArrayList<Integer>(Arrays.asList(3));
 
-        long currentTime = time.getGameTimeInMs();
-
-
         delayedActionSystem.addDelayedAction(createFakeEntityWith(a1),
-                "Blah Blah", ((currentTime + 1000) - currentTime));
+                "Blah Blah", ((time.getGameTimeInMs() + 1000) - time.getGameTimeInMs()));
         nextFakeEntityId++;
     }
 

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
@@ -47,7 +47,7 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
     private SortedSetMultimap<Long, EntityRef> periodicOperationsSortedByTime = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
 
     // ONLY use this for testing. DO NOT use this during regular usage.
-    public void setTime(Time t)
+    void setTime(Time t)
     {
         time = t;
     }
@@ -83,7 +83,7 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
             }
 
             for (String actionId : actionIds) {
-                 delayedEntity.send(new DelayedActionTriggeredEvent(actionId));
+                delayedEntity.send(new DelayedActionTriggeredEvent(actionId));
             }
         });
     }

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
@@ -46,6 +46,12 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
     private SortedSetMultimap<Long, EntityRef> delayedOperationsSortedByTime = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
     private SortedSetMultimap<Long, EntityRef> periodicOperationsSortedByTime = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
 
+    // ONLY use this for testing. DO NOT use this during regular usage.
+    public void setTime(Time t)
+    {
+        time = t;
+    }
+
     @Override
     public void update(float delta) {
         final long currentWorldTime = time.getGameTimeInMs();

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
@@ -77,7 +77,7 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
             }
 
             for (String actionId : actionIds) {
-                delayedEntity.send(new DelayedActionTriggeredEvent(actionId));
+                 delayedEntity.send(new DelayedActionTriggeredEvent(actionId));
             }
         });
     }
@@ -145,6 +145,11 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
                 delayedOperationsSortedByTime.remove(oldWakeUp, entity);
                 delayedOperationsSortedByTime.put(newWakeUp, entity);
             }
+            // Even if the oldWakeUp time is greater than or equal to the new one, the next action should still be added
+            // to the delayedOperationsSortedByTime mapping.
+            else {
+                delayedOperationsSortedByTime.put(scheduleTime, entity);
+            }
         } else {
             delayedActionComponent = new DelayedActionComponent();
             delayedActionComponent.addActionId(actionId, scheduleTime);
@@ -165,6 +170,11 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
             if (oldWakeUp < newWakeUp) {
                 periodicOperationsSortedByTime.remove(oldWakeUp, entity);
                 periodicOperationsSortedByTime.put(newWakeUp, entity);
+            }
+            // Even if the oldWakeUp time is greater than or equal to the new one, the next action should still be added
+            // to the delayedOperationsSortedByTime mapping.
+            else {
+                periodicOperationsSortedByTime.put(scheduleTime, entity);
             }
         } else {
             periodicActionComponent = new PeriodicActionComponent();


### PR DESCRIPTION
### Contains

Minor yet important alteration to how the delayedActionComponent and PeriodicActionComponent are checked in the addDelayedAction and addPeriodicAction methods. 

In short, even if the old earliest operation wakeup time of the "...OperationsSortedByTime" is not less than the new earliest operation wakeup time, the new action should still be added to delayedOperationsSortedByTime/periodicOperationsSortedByTime. This will allow the event to be fired off when it's duration expires.

### How to test

Call addDelayedAction with various delay values, and see if the approraite events are sent out at the correct time. 

### Outstanding before merging

- [x] Need to consider all uses of addDelayedAction/addPeriodicAction in the engine.
- [ ] Need to consider uses of addDelayedAction/addPeriodicAction in other modules..
- [x] Need to perform unit testing.