### PR TITLE
Fixes IllegalStateException whenever LwjglGraphics.initDisplay() called when rendering.debug = true

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -245,12 +245,14 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                     ContextAttribs ctxAttribs = new ContextAttribs().withDebug(true);
                     Display.create(config.getPixelFormat(), ctxAttribs);
 
-                    GL43.glDebugMessageCallback(new KHRDebugCallback(new DebugCallback()));
-                } catch (LWJGLException | IllegalStateException e) {
-                    logger.warn("Unable to create an OpenGL debug context. Maybe your graphics card does not support it.", e);
-                    if (e.getClass().equals(IllegalStateException.class)) {
-                        Display.destroy();
+                    try {
+                        GL43.glDebugMessageCallback(new KHRDebugCallback(new DebugCallback()));
+                    } catch (IllegalStateException e) {
+                        logger.warn("Unable to specify DebugCallback to receive debugging messages from the GL.");
                     }
+
+                } catch (LWJGLException e) {
+                    logger.warn("Unable to create an OpenGL debug context. Maybe your graphics card does not support it.", e);
                     Display.create(config.getPixelFormat()); // Create a normal context instead
                 }
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MovingBlocks
+ * Copyright 2016 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,8 +246,11 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                     Display.create(config.getPixelFormat(), ctxAttribs);
 
                     GL43.glDebugMessageCallback(new KHRDebugCallback(new DebugCallback()));
-                } catch (LWJGLException e) {
+                } catch (LWJGLException | IllegalStateException e) {
                     logger.warn("Unable to create an OpenGL debug context. Maybe your graphics card does not support it.", e);
+                    if (e.getClass().equals(IllegalStateException.class)) {
+                        Display.destroy();
+                    }
                     Display.create(config.getPixelFormat()); // Create a normal context instead
                 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

As title states PR fixes `IllegalStateException` whenever `LwjglGraphics.initDisplay()` called if `config.cfg` has rendering.debug = true. Without this fix, running Terasology throws  `IllegalStateException` in Mac OS X 10.11.4:
```java
...
03:36:34.926 [main] INFO  o.t.e.subsystem.lwjgl.LwjglGraphics - Starting initialization of LWJGL
03:36:34.927 [main] INFO  o.t.e.subsystem.lwjgl.LwjglGraphics - Initial initialization complete
03:36:36.019 [main] INFO  o.t.e.subsystem.lwjgl.LwjglGraphics - Initializing display (if last line in log then likely the game crashed from an issue with your video card
03:36:36.287 [main] WARN  o.t.e.subsystem.lwjgl.LwjglGraphics - Unable to create an OpenGL debug context. Maybe your graphics card does not support it.
java.lang.IllegalStateException: Function is not supported
	at org.lwjgl.BufferChecks.checkFunctionAddress(BufferChecks.java:58)
	at org.lwjgl.opengl.GL43.glDebugMessageCallback(GL43.java:566)
	at org.terasology.engine.subsystem.lwjgl.LwjglGraphics.initDisplay(LwjglGraphics.java:249)
	at org.terasology.engine.subsystem.lwjgl.LwjglGraphics.postInitialise(LwjglGraphics.java:170)
	at org.terasology.engine.TerasologyEngine.postInitSubsystems(TerasologyEngine.java:261)
	at org.terasology.engine.TerasologyEngine.initialize(TerasologyEngine.java:196)
	at org.terasology.engine.TerasologyEngine.run(TerasologyEngine.java:362)
	at org.terasology.engine.Terasology.main(Terasology.java:150)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:144)
```

My renderer:
```
3:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - LWJGL: 2.9.3 / macosx
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - GL_VENDOR: NVIDIA Corporation
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - GL_RENDERER: NVIDIA GeForce GT 650M OpenGL Engine
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - GL_VERSION: 2.1 NVIDIA-10.10.5.2 310.42.25f01
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - SHADING_LANGUAGE VERSION: 1.20
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_color_buffer_float GL_ARB_depth_buffer_float GL_ARB_depth_clamp GL_ARB_depth_texture GL_ARB_draw_buffers GL_ARB_draw_elements_base_vertex GL_ARB_draw_instanced GL_ARB_fragment_program
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_fragment_program_shadow GL_ARB_fragment_shader GL_ARB_framebuffer_object GL_ARB_framebuffer_sRGB GL_ARB_half_float_pixel GL_ARB_half_float_vertex GL_ARB_imaging GL_ARB_instanced_arrays
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_multisample GL_ARB_multitexture GL_ARB_occlusion_query GL_ARB_pixel_buffer_object GL_ARB_point_parameters GL_ARB_point_sprite GL_ARB_provoking_vertex GL_ARB_seamless_cube_map
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_shader_objects GL_ARB_shader_texture_lod GL_ARB_shading_language_100 GL_ARB_shadow GL_ARB_sync GL_ARB_texture_border_clamp GL_ARB_texture_compression GL_ARB_texture_compression_rgtc
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_texture_cube_map GL_ARB_texture_env_add GL_ARB_texture_env_combine GL_ARB_texture_env_crossbar GL_ARB_texture_env_dot3 GL_ARB_texture_float GL_ARB_texture_mirrored_repeat GL_ARB_texture_non_power_of_two
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_texture_rectangle GL_ARB_texture_rg GL_ARB_transpose_matrix GL_ARB_vertex_array_bgra GL_ARB_vertex_blend GL_ARB_vertex_buffer_object GL_ARB_vertex_program GL_ARB_vertex_shader
03:36:36.364 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ARB_window_pos GL_EXT_abgr GL_EXT_bgra GL_EXT_bindable_uniform GL_EXT_blend_color GL_EXT_blend_equation_separate GL_EXT_blend_func_separate GL_EXT_blend_minmax
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_EXT_blend_subtract GL_EXT_clip_volume_hint GL_EXT_debug_label GL_EXT_debug_marker GL_EXT_depth_bounds_test GL_EXT_draw_buffers2 GL_EXT_draw_range_elements GL_EXT_fog_coord
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_EXT_framebuffer_blit GL_EXT_framebuffer_multisample GL_EXT_framebuffer_multisample_blit_scaled GL_EXT_framebuffer_object GL_EXT_framebuffer_sRGB GL_EXT_geometry_shader4 GL_EXT_gpu_program_parameters GL_EXT_gpu_shader4
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_EXT_multi_draw_arrays GL_EXT_packed_depth_stencil GL_EXT_packed_float GL_EXT_provoking_vertex GL_EXT_rescale_normal GL_EXT_secondary_color GL_EXT_separate_specular_color GL_EXT_shadow_funcs
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_EXT_stencil_two_side GL_EXT_stencil_wrap GL_EXT_texture_array GL_EXT_texture_compression_dxt1 GL_EXT_texture_compression_s3tc GL_EXT_texture_env_add GL_EXT_texture_filter_anisotropic GL_EXT_texture_integer
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_EXT_texture_lod_bias GL_EXT_texture_mirror_clamp GL_EXT_texture_rectangle GL_EXT_texture_shared_exponent GL_EXT_texture_sRGB GL_EXT_texture_sRGB_decode GL_EXT_timer_query GL_EXT_transform_feedback
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_EXT_vertex_array_bgra GL_APPLE_aux_depth_stencil GL_APPLE_client_storage GL_APPLE_element_array GL_APPLE_fence GL_APPLE_float_pixels GL_APPLE_flush_buffer_range GL_APPLE_flush_render
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_APPLE_object_purgeable GL_APPLE_packed_pixels GL_APPLE_pixel_buffer GL_APPLE_rgb_422 GL_APPLE_row_bytes GL_APPLE_specular_vector GL_APPLE_texture_range GL_APPLE_transform_hint
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_APPLE_vertex_array_object GL_APPLE_vertex_array_range GL_APPLE_vertex_point_size GL_APPLE_vertex_program_evaluators GL_APPLE_ycbcr_422 GL_ATI_separate_stencil GL_ATI_texture_env_combine3 GL_ATI_texture_float
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_ATI_texture_mirror_once GL_IBM_rasterpos_clip GL_NV_blend_square GL_NV_conditional_render GL_NV_depth_clamp GL_NV_fog_distance GL_NV_fragment_program_option GL_NV_fragment_program2
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_NV_light_max_exponent GL_NV_multisample_filter_hint GL_NV_point_sprite GL_NV_texgen_reflection GL_NV_texture_barrier GL_NV_vertex_program2_option GL_NV_vertex_program3 GL_SGIS_generate_mipmap
03:36:36.365 [main] INFO  o.t.rendering.ShaderManagerLwjgl - EXTENSIONS: GL_SGIS_texture_edge_clamp GL_SGIS_texture_lod
```

### How to test

Trying running the game with `rendering.debug = true` in config.cfg file without this PR confirming the bug and later trying PR checking if game is loaded without any exception.

### Outstanding before merging

- [x] ~~A possible way to not calling `Display.destroy()` once `IllegalStateException` is thrown?~~

