### PR TITLE
Reduce the log level for opengl notifications.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/DebugCallback.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/DebugCallback.java
@@ -63,7 +63,7 @@ class DebugCallback implements KHRDebugCallback.Handler {
                 break;
             default:
             case GL_DEBUG_SEVERITY_NOTIFICATION:
-                logger.info(logFormat, args);
+                logger.trace(logFormat, args);
                 break;
         }
     }


### PR DESCRIPTION
### Contains
Reduce the log level for opengl notifications.
 
Reasoning: It used to log a line about buffer usage whenever a buffer got used to draw a line of a UI widget.

The logged message looked like this:
```
    11:21:05.913 [main] INFO  OpenGL - [api] [other] Buffer detailed info:
    Buffer object 212 (bound to GL_ARRAY_BUFFER_ARB,
    usage hint is GL_STATIC_DRAW) will use VIDEO memory as the source for
    buffer object operations.
```

### How to test

Start the game, check the log file for the notifications above. May only occur on certain systems. I use a Geforce on a Linux system with Nvidia drivers.