### PR TITLE
Made it so that right-clicking on an inventory cell with a stack of i…

### DIFF
--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryCell.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryCell.java
@@ -62,8 +62,14 @@ public class InventoryCell extends ItemCell {
                 }
             } else if (mouseButton == MouseInput.MOUSE_RIGHT) {
                 int stackSize = InventoryUtils.getStackCount(getTargetItem());
-                if (stackSize > 0) {
+                if (stackSize > 0 && getTransferItem().getClass() != getTargetItem().getClass()) {
                     giveAmount((stackSize + 1) / 2);
+                }
+                else {
+					int transferStackSize = InventoryUtils.getStackCount(getTransferItem());
+					if (transferStackSize > 0) {
+						takeAmount(1);
+					}
                 }
             }
             return true;


### PR DESCRIPTION
…tems selected places one element of that stack into the target cell (in response to Inventory related behavior on right-click #2295)

### Contains
This pull request addresses Issue #2295. In the message on Apr. 16, @Cervator points out that his request earlier in the issue - that right-clicking in an empty cell with an item selected should add one item from the stack to the target cell - was not implemented.

### How to test
In the base branch, if you grab a stack of an item and right-click in an empty cell, nothing happens. In my branch, it deposits one item into the cell.

I also confirmed that multiple right-clicks has the same behavior, and that the final item in the stack being placed results in the stack disappearing from the mouse cursor.