### PR TITLE
UITreeView scrollbar fixes

### DIFF
--- a/engine/src/main/resources/assets/skins/treeViewTestScreen.skin
+++ b/engine/src/main/resources/assets/skins/treeViewTestScreen.skin
@@ -1,11 +1,6 @@
 {
     "inherit": "engine:mainMenu",
     "elements": {
-        "UIBox": {
-            "background": "",
-            "background-border": {},
-            "margin": {}
-        },
         "ScrollableArea": {
             "background": "",
             "background-border": {}

--- a/engine/src/main/resources/assets/ui/nuiEditorScreen.ui
+++ b/engine/src/main/resources/assets/ui/nuiEditorScreen.ui
@@ -50,8 +50,13 @@
                 ]
             },
             {
-                "type": "UITreeView",
-                "id": "editor",
+                "type": "ScrollableArea",
+                "content": {
+                    "type": "UITreeView",
+                    "id": "editor"
+                },
+                "verticalScrollbar": true,
+                "horizontalScrollbar": true,
                 "layoutInfo": {
                     "cc": "cell 0 1"
                 }

--- a/engine/src/main/resources/assets/ui/treeViewTestScreen.ui
+++ b/engine/src/main/resources/assets/ui/treeViewTestScreen.ui
@@ -1,11 +1,11 @@
 {
     "type": "engine:treeViewTestScreen",
-    "skin": "engine:mainMenu",
+    "skin": "engine:treeViewTestScreen",
     "contents": {
         "type": "migLayout",
         "layoutConstraints": "",
         "colConstraints": "[min][pref][pref]",
-        "rowConstraints": "[min]",
+        "rowConstraints": "[min][min]",
         "debug": true,
         "contents": [
             {
@@ -41,18 +41,24 @@
                 }
             },
             {
-                "type": "UITreeView",
-                "id": "treeViewDisabled",
-                "layoutInfo": {
-                    "cc": ""
-                },
-                "enabled": false
+                "type": "ScrollableArea",
+                "content": {
+                    "type": "UITreeView",
+                    "id": "treeViewDisabled",
+                    "layoutInfo": {
+                        "cc": ""
+                    },
+                    "enabled": false
+                }
             },
             {
-                "type": "UITreeView",
-                "id": "treeViewEnabled",
-                "layoutInfo": {
-                    "cc": ""
+                "type": "ScrollableArea",
+                "content": {
+                    "type": "UITreeView",
+                    "id": "treeViewEnabled",
+                    "layoutInfo": {
+                        "cc": ""
+                    }
                 }
             }
         ]


### PR DESCRIPTION
### Contains

Removes `UITreeView`'s native vertical scrollbar in favor of wrapping the element within a `ScrollableArea` to provide scrolling functionality. Wraps the existing `UITreeView` elements (in `nuiEditorScreen`/`treeViewTestScreen`) within a `ScrollableArea`.

![UITreeView scrollbars](https://cloud.githubusercontent.com/assets/13783592/16362027/5d2d2bee-3bab-11e6-8d36-293132208407.png)

### How to test

Press F6 to activate the NUI editor, test the scrollbars with different asset files.

### Outstanding before merging

No outstanding issues.