### PR TITLE
NUI editor binding tweak

### DIFF
--- a/docs/Playing.md
+++ b/docs/Playing.md
@@ -71,6 +71,7 @@ Note: Keys between the latest stable and latest develop build may differ.
 * [F2] - Toggle window focus and reveals a debug pane (only contains stuff if module(s) using it is enabled)
 * [F3] - Toggle debug mode and information
 * [F5] - Show behavior tree editor
+* [F10] - Show NUI editor
 * [F12] - Take screenshot (goes to /screenshots in game data dir)
 
 

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/NUIEditorButton.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/NUIEditorButton.java
@@ -22,6 +22,6 @@ import org.terasology.input.Keyboard;
 import org.terasology.input.RegisterBindButton;
 
 @RegisterBindButton(id = "nuiEditor", description = "${engine:menu#binding-nui-editor}", category = "nui")
-@DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.F6)
+@DefaultBinding(type = InputType.KEY, id = Keyboard.KeyId.F10)
 public class NUIEditorButton extends BindButtonEvent {
 }


### PR DESCRIPTION
### Contains

Changes the hotkey to trigger the NUI editor to F10 (was F6) and adds info about it to `docs\Playing.md`.

### How to test

Launch the game and press F10 to trigger the editor, then check Input Settings for binding details.

### Outstanding before merging

Nope!