### PR TITLE
Handle situations where the server misbehaves better

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/JoinServer.java
@@ -147,6 +147,7 @@ public class JoinServer implements LoadProcess {
         } else if (joinStatus.getStatus() == JoinStatus.Status.FAILED) {
             StateMainMenu mainMenu = new StateMainMenu("Failed to connect to server: " + joinStatus.getErrorMessage());
             context.get(GameEngine.class).changeState(mainMenu);
+            networkSystem.shutdown();
         }
         return false;
     }

--- a/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
+++ b/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
@@ -117,6 +117,9 @@ public class ClientConnectionHandler extends SimpleChannelUpstreamHandler {
 			} else if (message.hasModuleData()) {
 				receiveModule(ctx, message.getModuleData());
 			} else if (message.hasJoinComplete()) {
+				if (missingModules.size() > 0) {
+					logger.error("THe server did not send all of the modules that were needed before ending module transmission.");
+				}
 				completeJoin(ctx, message.getJoinComplete());
 			} else {
 				logger.error("Received unexpected message");

--- a/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
+++ b/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
@@ -137,7 +137,10 @@ public class ClientConnectionHandler extends SimpleChannelUpstreamHandler {
                 channelHandlerContext.getChannel().close();
             } else {
                 String sizeString = getSizeString(moduleDataHeader.getSize());
-                joinStatus.setCurrentActivity("Downloading " + moduleDataHeader.getId() + ":" + moduleDataHeader.getVersion() + " (" + sizeString + ")");
+                joinStatus.setCurrentActivity("Downloading " + moduleDataHeader.getId() + ":" + moduleDataHeader.getVersion() + " (" + sizeString + ","
+                		+ missingModules.size() + " modules remain)");
+                logger.info("Downloading " + moduleDataHeader.getId() + ":" + moduleDataHeader.getVersion() + " (" + sizeString + ","
+                		+ missingModules.size() + " modules remain)");
                 receivingModule = moduleDataHeader;
                 lengthReceived = 0;
                 try {

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -235,9 +235,6 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
                 return new JoinStatusImpl("Failed to connect to server - " + connectCheck.getCause().getMessage());
             } else {
                 allChannels.add(connectCheck.getChannel());
-                mode = NetworkMode.CLIENT;
-                nextNetworkTick = time.getRealTimeInMs();
-                logger.info("Connected to server");
                 ClientConnectionHandler connectionHandler = connectCheck.getChannel().getPipeline().get(ClientConnectionHandler.class);
                 if (connectionHandler == null) {
                     JoinStatusImpl status = new JoinStatusImpl();
@@ -892,6 +889,11 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     }
 
     void setServer(ServerImpl server) {
+    	if (server != null) {
+    		mode = NetworkMode.CLIENT;
+			nextNetworkTick = time.getRealTimeInMs();
+			logger.info("Connected to server");
+    	}
         this.server = server;
 
     }

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -250,10 +250,8 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
 
     @Override
     public void shutdown() {
-        if (mode != NetworkMode.NONE) {
-            allChannels.close().awaitUninterruptibly();
-            factory.releaseExternalResources();
-        }
+        allChannels.close().awaitUninterruptibly();
+        factory.releaseExternalResources();
         processPendingDisconnects();
         clientList.forEach(this::processRemovedClient);
         server = null;

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -889,11 +889,11 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     }
 
     void setServer(ServerImpl server) {
-    	if (server != null) {
-    		mode = NetworkMode.CLIENT;
-			nextNetworkTick = time.getRealTimeInMs();
-			logger.info("Connected to server");
-    	}
+        if (server != null) {
+            mode = NetworkMode.CLIENT;
+            nextNetworkTick = time.getRealTimeInMs();
+            logger.info("Connected to server");
+        }
         this.server = server;
 
     }


### PR DESCRIPTION
### Contains

In #2230, @Cervator requested several things. This PR is meant to address that issue.

 - I tested #1626 in many different ways on the local host and was unable to reproduce the error. I'm not sure if it was fixed since, or if it only affects WAN downloads.

 - When I went into the relevant sources I found that some information about the module downloads (the version, name, and size) was being sent to the loading screen. Maybe somebody got to this before me?

 - I did, however, add a similar statement to the log.

 - I also added the count of how many modules remain to the output string that is sent to the loading screen while a module is being downloaded.

 - Finally, and most significantly, I added a time out to the server info & module download process. If no packets are received from the server for 10 seconds, the client gives up and returns to the server menu. From what I can gather, this situation never happens during the connection process unless something goes wrong; I was unable to make the time out occur unless I artificially induced a delay on the server side, so I don't think this PR adds any bugs.

 - This required a small adjustment to NetworkSystemImpl.java. Before my change, if JoinStatus.FAILED was returned by ClientConnectionHandler.getJoinStatus(), the client would be left in a state where it could not connect to any servers until the entire program was restarted. After this change, it's possible to connect to another server after a connection fails.

 - Finally, I added an error message if the server fails to transfer a needed module to the client. A dev should know if they make a change that causes that situation.

The net total of all of these changes is that, if #1626 does happen again, the user will not have to restart their client, and will also have more meaningful error messages.

### How to test

At the top of ```sendModules()``` in ```ServerConnectionHandler.java```, you can put the following code:

```java
logger.info("purposefully waiting to simulate a bug.");
try {
  Thread.sleep(20000);
} catch (InterruptedException e1) {
  e1.printStackTrace();
}
```

Doing this will cause the server to stall for 20 seconds while trying to send a module. Trying this before and after my change will lead to different outcomes.

 - Before, the loading screen will hang indefinitely.
 - After, the loading screen will exit after 10 seconds with a meaningful error message ('Server stopped responding") and a more technical error will be printed to the log ("Server timeout threshold of 10000 ms exceeded.").
 - There are also log messages posted for each download, and more detail on the loading screen.

### Outstanding before merging

- [ ] Need to decide whether a cancel button is still necessary. The cancel button seems like it will be a bigger change and might disturb other stuff that I don't fully understand (in the startup sequence), so I decided to leave it out of this PR.