### PR TITLE
[RFR] Add Pre-Post Composite Nodes

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/AmbientOcclusionPassesNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/AmbientOcclusionPassesNode.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag;
+
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FrameBuffersManager;
+import org.terasology.rendering.world.WorldRenderer;
+
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
+import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
+import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
+
+/**
+ * TODO: Add diagram of this node
+ */
+public class AmbientOcclusionPassesNode implements Node {
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
+
+    @In
+    private WorldRenderer worldRenderer;
+
+    @In
+    private Config config;
+
+    private RenderingConfig renderingConfig;
+    private FBO sceneOpaque;
+    private FBO ssaoBlurredFBO;
+    private FBO ssaoFBO;
+    private Material ssaoShader;
+    private Material ssaoBlurredShader;
+
+    @Override
+    public void initialise() {
+        renderingConfig = config.getRendering();
+        ssaoShader = worldRenderer.getMaterial("engine:prog.ssao");
+        ssaoBlurredShader = worldRenderer.getMaterial("engine:prog.ssaoBlur");
+    }
+
+    /**
+     * If Ambient Occlusion is enabled in the render settings, this method generates and
+     * stores the necessary images into their own FBOs. The stored images are eventually
+     * combined with others.
+     * <p>
+     * For further information on Ambient Occlusion see: http://en.wikipedia.org/wiki/Ambient_occlusion
+     */
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/ambientocclusionpasses");
+        if (renderingConfig.isSsao()) {
+            // TODO: consider moving these into initialise without breaking existing implementation
+            sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
+            ssaoBlurredFBO = frameBuffersManager.getFBO("ssaoBlurred");
+            ssaoFBO = frameBuffersManager.getFBO("ssao");
+
+            generateSSAO();
+            generateBlurredSSAO();
+        }
+        PerformanceMonitor.endActivity();
+    }
+
+
+    private void generateSSAO() {
+        ssaoShader.enable();
+        ssaoShader.setFloat2("texelSize", 1.0f / ssaoFBO.width(), 1.0f / ssaoFBO.height(), true);
+        ssaoShader.setFloat2("noiseTexelSize", 1.0f / 4.0f, 1.0f / 4.0f, true);
+
+        // TODO: verify if some textures should be bound here
+        ssaoFBO.bind();
+
+        setViewportToSizeOf(ssaoFBO);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
+
+        renderFullscreenQuad();
+
+        bindDisplay(); // TODO: verify this is necessary
+        setViewportToSizeOf(sceneOpaque); // TODO: verify this is necessary
+    }
+
+    private void generateBlurredSSAO() {
+        ssaoBlurredShader.enable();
+        ssaoBlurredShader.setFloat2("texelSize", 1.0f / ssaoBlurredFBO.width(), 1.0f / ssaoBlurredFBO.height(), true);
+
+        ssaoFBO.bindTexture(); // TODO: verify this is the only input
+
+        ssaoBlurredFBO.bind();
+
+        setViewportToSizeOf(ssaoBlurredFBO);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
+
+        renderFullscreenQuad();
+
+        bindDisplay(); // TODO: verify this is necessary
+        setViewportToSizeOf(sceneOpaque); // TODO: verify this is necessary
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/AmbientOcclusionPassesNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/AmbientOcclusionPassesNode.java
@@ -68,8 +68,8 @@ public class AmbientOcclusionPassesNode implements Node {
      */
     @Override
     public void process() {
-        PerformanceMonitor.startActivity("rendering/ambientocclusionpasses");
         if (renderingConfig.isSsao()) {
+            PerformanceMonitor.startActivity("rendering/ambientocclusionpasses");
             // TODO: consider moving these into initialise without breaking existing implementation
             sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
             ssaoBlurredFBO = frameBuffersManager.getFBO("ssaoBlurred");
@@ -77,8 +77,8 @@ public class AmbientOcclusionPassesNode implements Node {
 
             generateSSAO();
             generateBlurredSSAO();
+            PerformanceMonitor.endActivity();
         }
-        PerformanceMonitor.endActivity();
     }
 
 

--- a/engine/src/main/java/org/terasology/rendering/dag/OutlineNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/OutlineNode.java
@@ -69,8 +69,8 @@ public class OutlineNode implements Node {
      */
     @Override
     public void process() {
-        PerformanceMonitor.startActivity("rendering/outline");
         if (renderingConfig.isOutline()) {
+            PerformanceMonitor.startActivity("rendering/outline");
             outlineFBO = frameBuffersManager.getFBO("outline");
             sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
@@ -86,7 +86,7 @@ public class OutlineNode implements Node {
 
             bindDisplay();  // TODO: verify this is necessary
             setViewportToSizeOf(sceneOpaque); // TODO: verify this is necessary
+            PerformanceMonitor.endActivity();
         }
-        PerformanceMonitor.endActivity();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/OutlineNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/OutlineNode.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag;
+
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FrameBuffersManager;
+import org.terasology.rendering.world.WorldRenderer;
+
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
+import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
+import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
+
+/**
+ * TODO: Add diagram of this node
+ */
+public class OutlineNode implements Node {
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
+
+    @In
+    private WorldRenderer worldRenderer;
+
+    @In
+    private Config config;
+
+    private RenderingConfig renderingConfig;
+    private Material outline;
+    private FBO outlineFBO;
+    private FBO sceneOpaque;
+
+    @Override
+    public void initialise() {
+        renderingConfig = config.getRendering();
+        outline = worldRenderer.getMaterial("engine:prog.sobel");
+    }
+
+    /**
+     * Enabled by the "outline" option in the render settings, this method generates
+     * landscape/objects outlines and stores them into a buffer in its own FBO. The
+     * stored image is eventually combined with others.
+     * <p>
+     * The outlines visually separate a given object (including the landscape) or parts of it
+     * from sufficiently distant objects it overlaps. It is effectively a depth-based edge
+     * detection technique and internally uses a Sobel operator.
+     * <p>
+     * For further information see: http://en.wikipedia.org/wiki/Sobel_operator
+     */
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/outline");
+        if (renderingConfig.isOutline()) {
+            outlineFBO = frameBuffersManager.getFBO("outline");
+            sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
+
+            outline.enable();
+
+            // TODO: verify inputs: shouldn't there be a texture binding here?
+            outlineFBO.bind();
+
+            setViewportToSizeOf(outlineFBO);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
+
+            renderFullscreenQuad();
+
+            bindDisplay();  // TODO: verify this is necessary
+            setViewportToSizeOf(sceneOpaque); // TODO: verify this is necessary
+        }
+        PerformanceMonitor.endActivity();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/PrePostCompositeNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/PrePostCompositeNode.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag;
+
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FrameBuffersManager;
+import org.terasology.rendering.world.WorldRenderer;
+
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
+import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
+import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
+
+/**
+ * TODO: Add diagram of this node
+ */
+public class PrePostCompositeNode implements Node {
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
+
+    @In
+    private WorldRenderer worldRenderer;
+
+    private Material prePostComposite;
+
+    @Override
+    public void initialise() {
+        prePostComposite = worldRenderer.getMaterial("engine:prog.combine");
+    }
+
+    /**
+     * Adds outlines and ambient occlusion to the rendering obtained so far stored in the primary FBO.
+     * Stores the resulting output back into the primary buffer.
+     */
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/prepostcomposite");
+        prePostComposite.enable();
+        FBO sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
+        FBO sceneOpaquePingPong = frameBuffersManager.getFBO("sceneOpaquePingPong");
+        FBO sceneReflectiveRefractive = frameBuffersManager.getFBO("sceneReflectiveRefractive");
+
+        // TODO: verify if there should be bound textures here.
+        sceneOpaquePingPong.bind();
+
+        setViewportToSizeOf(sceneOpaquePingPong);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
+
+        renderFullscreenQuad();
+
+        bindDisplay();     // TODO: verify this is necessary
+        setViewportToSizeOf(sceneOpaque);    // TODO: verify this is necessary
+
+        frameBuffersManager.swapSceneOpaqueFBOs();
+        sceneOpaque.attachDepthBufferTo(sceneReflectiveRefractive);
+        PerformanceMonitor.endActivity();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/SimpleBlendMaterialsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/SimpleBlendMaterialsNode.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag;
+
+import org.lwjgl.opengl.GL11;
+import org.terasology.engine.ComponentSystemManager;
+import org.terasology.entitySystem.systems.RenderSystem;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.registry.In;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FrameBuffersManager;
+
+import static org.lwjgl.opengl.GL11.GL_BLEND;
+import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
+import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
+import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
+import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
+
+/**
+ * TODO: Add diagram of this node
+ */
+public class SimpleBlendMaterialsNode implements Node {
+
+    @In
+    private ComponentSystemManager componentSystemManager;
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
+
+    private FBO sceneOpaque;
+
+    @Override
+    public void initialise() {
+
+    }
+
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/simpleblendmaterials");
+        sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
+        preRenderSetupSimpleBlendMaterials();
+
+        for (RenderSystem renderer : componentSystemManager.iterateRenderSubscribers()) {
+            renderer.renderAlphaBlend();
+        }
+
+        postRenderCleanupSimpleBlendMaterials();
+        PerformanceMonitor.endActivity();
+    }
+
+    /**
+     * Sets the state for the rendering of objects or portions of objects having some degree of transparency.
+     * <p>
+     * Generally speaking objects drawn with this state will have their color blended with the background
+     * color, depending on their opacity. I.e. a 25% opaque foreground object will provide 25% of its
+     * color while the background will provide the remaining 75%. The sum of the two RGBA vectors gets
+     * written onto the output buffer.
+     * <p>
+     * Important note: this method disables writing to the Depth Buffer. This is why filters relying on
+     * depth information (i.e. DoF) have problems with transparent objects: the depth of their pixels is
+     * found to be that of the background. This is an unresolved (unresolv-able?) issue that would only
+     * be reversed, not eliminated, by re-enabling writing to the Depth Buffer.
+     */
+    private void preRenderSetupSimpleBlendMaterials() {
+        sceneOpaque.bind();
+        setRenderBufferMask(sceneOpaque, true, true, true);
+
+        GL11.glEnable(GL_BLEND);
+        GL11.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // (*)
+        GL11.glDepthMask(false);
+
+        // (*) In this context SRC is Foreground. This effectively says:
+        // Resulting RGB = ForegroundRGB * ForegroundAlpha + BackgroundRGB * (1 - ForegroundAlpha)
+        // Which might still look complicated, but it's actually the most typical alpha-driven composite.
+        // A neat tool to play with this settings can be found here: http://www.andersriggelsen.dk/glblendfunc.php
+    }
+
+    /**
+     * Resets the state after the rendering of semi-opaque/semi-transparent objects.
+     * <p>
+     * See preRenderSetupSimpleBlendMaterials() for additional information.
+     */
+    private void postRenderCleanupSimpleBlendMaterials() {
+        GL11.glDisable(GL_BLEND);
+        GL11.glDepthMask(true);
+
+        setRenderBufferMask(sceneOpaque, true, true, true); // TODO: review - this might be redundant.
+        bindDisplay();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/opengl/GraphicState.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GraphicState.java
@@ -17,38 +17,6 @@ package org.terasology.rendering.opengl;
 
 import org.lwjgl.opengl.GL11;
 import org.terasology.math.geom.Vector3f;
-import static org.lwjgl.opengl.GL11.GL_ALWAYS;
-import static org.lwjgl.opengl.GL11.GL_BACK;
-import static org.lwjgl.opengl.GL11.GL_BLEND;
-import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
-import static org.lwjgl.opengl.GL11.GL_DECR;
-import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.GL_FILL;
-import static org.lwjgl.opengl.GL11.GL_FRONT;
-import static org.lwjgl.opengl.GL11.GL_FRONT_AND_BACK;
-import static org.lwjgl.opengl.GL11.GL_INCR;
-import static org.lwjgl.opengl.GL11.GL_KEEP;
-import static org.lwjgl.opengl.GL11.GL_LEQUAL;
-import static org.lwjgl.opengl.GL11.GL_LINE;
-import static org.lwjgl.opengl.GL11.GL_NOTEQUAL;
-import static org.lwjgl.opengl.GL11.GL_ONE;
-import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
-import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_COLOR;
-import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
-import static org.lwjgl.opengl.GL11.GL_STENCIL_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_STENCIL_TEST;
-import static org.lwjgl.opengl.GL11.glBlendFunc;
-import static org.lwjgl.opengl.GL11.glClear;
-import static org.lwjgl.opengl.GL11.glCullFace;
-import static org.lwjgl.opengl.GL11.glDepthMask;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glStencilFunc;
-import static org.lwjgl.opengl.GL20.glStencilOpSeparate;
-import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
-import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
 
 /**
  * The GraphicState class aggregates a number of methods setting the OpenGL state
@@ -137,57 +105,6 @@ public class GraphicState {
      */
     public void setSceneShadowMap(FBO newShadowMap) {
         buffers.sceneShadowMap = newShadowMap;
-    }
-
-    /**
-     * Disables wireframe rendering. Used together with enableWireFrameIf().
-     *
-     * @param wireframeIsEnabledInRenderingDebugConfig If True disables wireframe rendering. False, does nothing.
-     */
-    public void disableWireframeIf(boolean wireframeIsEnabledInRenderingDebugConfig) {
-        if (wireframeIsEnabledInRenderingDebugConfig) {
-            GL11.glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-        }
-    }
-
-    /**
-     * Sets the state for the rendering of objects or portions of objects having some degree of transparency.
-     *
-     * Generally speaking objects drawn with this state will have their color blended with the background
-     * color, depending on their opacity. I.e. a 25% opaque foreground object will provide 25% of its
-     * color while the background will provide the remaining 75%. The sum of the two RGBA vectors gets
-     * written onto the output buffer.
-     *
-     * Important note: this method disables writing to the Depth Buffer. This is why filters relying on
-     * depth information (i.e. DoF) have problems with transparent objects: the depth of their pixels is
-     * found to be that of the background. This is an unresolved (unresolv-able?) issue that would only
-     * be reversed, not eliminated, by re-enabling writing to the Depth Buffer.
-     */
-    public void preRenderSetupSimpleBlendMaterials() {
-        buffers.sceneOpaque.bind();
-        setRenderBufferMask(buffers.sceneOpaque, true, true, true);
-
-        GL11.glEnable(GL_BLEND);
-        GL11.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // (*)
-        GL11.glDepthMask(false);
-
-        // (*) In this context SRC is Foreground. This effectively says:
-        // Resulting RGB = ForegroundRGB * ForegroundAlpha + BackgroundRGB * (1 - ForegroundAlpha)
-        // Which might still look complicated, but it's actually the most typical alpha-driven composite.
-        // A neat tool to play with this settings can be found here: http://www.andersriggelsen.dk/glblendfunc.php
-    }
-
-    /**
-     * Resets the state after the rendering of semi-opaque/semi-transparent objects.
-     *
-     * See preRenderSetupSimpleBlendMaterials() for additional information.
-     */
-    public void postRenderCleanupSimpleBlendMaterials() {
-        GL11.glDisable(GL_BLEND);
-        GL11.glDepthMask(true);
-
-        setRenderBufferMask(buffers.sceneOpaque, true, true, true); // TODO: review - this might be redundant.
-        bindDisplay();
     }
 
     /**


### PR DESCRIPTION
### Contains

Four new nodes for DAG (Directed Acyclic Graph), wrapping tasks that are related with Pre-Post Composition.

* AmbientOcclusionPassesNode
* OutlineNode
* PrePostCompositeNode
* SimpleBlendMaterialsNode

### How to test

Check if there are any weirdness related to rendering of transparent(with some degree, blended with background) objects, [Ambient Occlusion](https://en.wikipedia.org/wiki/Ambient_occlusion#/media/File:Show_how_3D_real_time_ambient_occlusion_works_2013-11-23_10-45.jpeg) and [outline](http://en.wikipedia.org/wiki/Sobel_operator) option.