### PR TITLE
Move the CrashReporter to the PC facade and make it possible to embed it into a Terasology workspace

### DIFF
--- a/config/gradle/utility.gradle
+++ b/config/gradle/utility.gradle
@@ -354,6 +354,11 @@ tasks.addRule("Pattern: fetchLib<ID>") { String taskName ->
                 case 'Index' :
                     githubHome = 'Terasology'
                     break;
+
+                case 'CrashReporter' :
+                    // Temporary for testing only
+                    branch = 'embeddedCR'
+                    break;
             }
 
             // Allow user to override the GitHub account to pull from. Supply with -PgithubAccount="TargetAccountName"

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -127,9 +127,6 @@ dependencies {
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     compile fileTree(dir: 'libs', include: '*.jar')
 
-    // TODO: These could be moved into facade
-    compile group: 'org.terasology', name: 'CrashReporter-terasology', version: '3.0.0'
-
     runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
     runtime group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.21'
 

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -16,7 +16,7 @@
 
 package org.terasology.engine;
 
-import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngineBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngineBuilder.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.engine;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 import com.google.common.base.Preconditions;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.engine.subsystem.common.TimeSubsystem;

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefabManager.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.entitySystem.prefab.internal;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Strings;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.context.Context;
 import org.terasology.entitySystem.Component;

--- a/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
+++ b/engine/src/main/java/org/terasology/logic/console/suggesters/ScreenSuggester.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.logic.console.suggesters;
 
-import com.google.api.client.util.Maps;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;

--- a/engine/src/main/java/org/terasology/rendering/animation/Rect2fAnimator.java
+++ b/engine/src/main/java/org/terasology/rendering/animation/Rect2fAnimator.java
@@ -17,9 +17,9 @@ package org.terasology.rendering.animation;
 
 import java.util.function.Consumer;
 
+import com.google.common.base.Preconditions;
 import org.terasology.math.geom.Rect2f;
 
-import com.google.api.client.util.Preconditions;
 
 /**
  * Interpolates rectangles

--- a/engine/src/main/java/org/terasology/rendering/animation/Rect2iAnimator.java
+++ b/engine/src/main/java/org/terasology/rendering/animation/Rect2iAnimator.java
@@ -17,9 +17,8 @@ package org.terasology.rendering.animation;
 
 import java.util.function.Consumer;
 
+import com.google.common.base.Preconditions;
 import org.terasology.math.geom.Rect2i;
-
-import com.google.api.client.util.Preconditions;
 
 /**
  * Interpolates rectangles

--- a/engine/src/main/java/org/terasology/rendering/animation/TimeModifiers.java
+++ b/engine/src/main/java/org/terasology/rendering/animation/TimeModifiers.java
@@ -16,9 +16,8 @@
 
 package org.terasology.rendering.animation;
 
+import com.google.common.base.Preconditions;
 import org.terasology.math.TeraMath;
-
-import com.google.api.client.util.Preconditions;
 
 /**
  * A collection of {@link TimeModifier} implementations

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -16,7 +16,7 @@
 
 package org.terasology.rendering.logic;
 
-import com.google.api.client.util.Maps;
+import com.google.common.collect.Maps;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;

--- a/engine/src/main/java/org/terasology/rendering/logic/RegionOutlineRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/RegionOutlineRenderer.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.rendering.logic;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.api.client.util.Maps;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.google.common.base.Preconditions;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
@@ -16,7 +16,7 @@
 package org.terasology.rendering.nui.layers.ingame.metrics;
 
 
-import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.registry.Share;

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/CardLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/CardLayout.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.rendering.nui.layouts;
 
-import com.google.api.client.util.Maps;
+import com.google.common.collect.Maps;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreLayout;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/data/html/basic/DefaultHTMLDocumentBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/data/html/basic/DefaultHTMLDocumentBuilder.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.rendering.nui.widgets.browser.data.html.basic;
 
-import com.google.api.client.util.Maps;
+import com.google.common.collect.Maps;
 import org.terasology.rendering.nui.widgets.browser.data.html.HTMLBlockBuilder;
 import org.terasology.rendering.nui.widgets.browser.data.html.HTMLDocument;
 import org.terasology.rendering.nui.widgets.browser.data.html.HTMLDocumentBuilder;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/data/html/basic/ParagraphBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/data/html/basic/ParagraphBuilder.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.rendering.nui.widgets.browser.data.html.basic;
 
-import com.google.api.client.util.Maps;
+import com.google.common.collect.Maps;
 import org.terasology.rendering.assets.font.Font;
 import org.terasology.rendering.nui.Color;
 import org.terasology.rendering.nui.widgets.browser.data.ParagraphData;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/models/Tree.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/models/Tree.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.rendering.nui.widgets.models;
 
-import com.google.api.client.util.Lists;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import java.util.ArrayDeque;
 import java.util.Collection;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/models/TreeModel.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/models/TreeModel.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.rendering.nui.widgets.models;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 
 import java.util.Iterator;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.rendering.world;
 
-import com.google.api.client.util.Lists;
+import com.google.common.collect.Lists;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.config.RenderingDebugConfig;

--- a/engine/src/main/java/org/terasology/utilities/Assets.java
+++ b/engine/src/main/java/org/terasology/utilities/Assets.java
@@ -16,7 +16,7 @@
 
 package org.terasology.utilities;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Strings;
 import com.google.common.base.Preconditions;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetData;

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
@@ -16,7 +16,7 @@
 
 package org.terasology.world.block.internal;
 
-import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionData.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionData.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.world.block.loader;
 
-import com.google.api.client.util.Maps;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.terasology.assets.AssetData;
 import org.terasology.module.sandbox.API;
 import org.terasology.world.block.family.BlockFamilyFactory;

--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -39,6 +39,24 @@ group = 'org.terasology.facades'
 
 dependencies {
     compile project(':engine')
+
+    // Dependency on CrashReporter, conditionally either from source or via binary
+    File wouldBeSrcPath = new File(rootDir, 'libs/CrashReporter')
+    println "Scanning for source CrashReporter at: " + wouldBeSrcPath.getAbsolutePath()
+
+    if (wouldBeSrcPath.exists()) {
+        println "*** Identified CrashReporter source, using that"
+        //compile ':libs:CrashReporter:cr-terasology'
+
+        def targetProject = findProject(':libs:CrashReporter:cr-terasology')
+        println "Found the project? " + targetProject
+        //compile targetProject
+
+        compile project(':libs:CrashReporter:cr-terasology')
+    } else {
+        println "*** Setting a CrashReporter binary dependency, not present as source"
+        compile group: 'org.terasology', name: 'CrashReporter-terasology', version: '3.0.0'
+    }
 }
 
 // Instructions for packaging a jar file for the PC facade

--- a/libs/subprojects.gradle
+++ b/libs/subprojects.gradle
@@ -9,6 +9,13 @@ new File(rootDir, 'libs').eachDir { possibleSubprojectDir ->
         def subprojectPath = ':' + subprojectName
         def subproject = project(subprojectPath)
         subproject.projectDir = possibleSubprojectDir
+
+        // Also look for a nested settings.gradle file in case of embedded libraries with their own sub projects
+        File settingsFile = new File(possibleSubprojectDir, "settings.gradle")
+        if (settingsFile.exists()) {
+            println "Library $subprojectName has a settings file so applying it expecting nested sub projects"
+            apply from: settingsFile
+        }
     } else {
         println "Library dir found without a build.gradle, not including $subprojectName in the Gradle project tree"
     }


### PR DESCRIPTION
Okay I'm officially on vacation/sabbatical woohoo! First stage is *only* till mid-July, but hoping by then to have another couple months lined up :-)

Dug into the idea of having the CrashReporter embedded in a Terasology workspace as a library entry (same approach could be applied to other stuff like Gestalt) and got it working after a bit, sure has been a while but I missed it!

This was in part for @mtjvankuik to make it easier to make changes to the CR then immediately test them via Terasology. Reference: #1120 + https://github.com/MovingBlocks/CrashReporter/issues/29

Pinging @msteiger and @rzats for some review as well, especially for how this might handle in Eclipse rather than IntelliJ. I believe you can already link to the CR in a big Eclipse workspace, but it takes some setup, while this hopefully should make it as simple as running a couple Gradle commands.

### Contains

Most the changes are specific to `.gradle` files, but I renamed the three sub-components in the CrashReporter to be less ambiguous (particularly "core" and "terasology") which means almost everything will show up as changed. So I thought I'd highlight the actual changes here to make it easier. Paths are relative to how they'll appear in a Terasology workspace with the CR embedded, but in reality naturally anything `libs/CrashReporter/...` is in the actual CR repo.

* `engine/build.gradle` - The dependency on CR has finally been moved from here to the PC facade. Apparently a transitive dependency on some Google stuff in the CR led to misdirected imports in a few places (like `Preconditions` being present with two different import paths) - fixed
* `facades/PC/build.gradle` - The CR dependency was moved here and made conditional to check for source vs binary. Can be done with a cleaner Gradle dependency substitution trick later, but that's for another PR
* `libs/subprojects.gradle` - Enhanced to consider the presence of a `settings.gradle` in a library, such as the one that for the CR hooks up *its* three sub-components (which this way works both embedded and standalone)
* `libs/CrashReporter/settings.gradle` - simplified sub-component naming and made the `include` paths conditional on whether the CR is embedded or standalone
* `libs/CrashReporter/build.gradle` - added `idea` plugin and tweaked the setting of `group` to work the same both embedded and standalone
* `libs/CrashReporter/cr-core/build.gradle` - no actual changes other than the different path (was "core" is now "cr-core")
* `libs/CrashReporter/cr-destsol/build.gradle` + `cr-terasology` version - renamed and updated to work at different levels in the Gradle project tree

The imports in various Terasology engine classes have been changed but nothing else. This shouldn't happen again as now engine no longer has access to the transitive dependencies of the CR with its alternative Google stuff (something about guava vs. an HTTP gadget). Sure confused the heck out of me for a little while!

### How to test

* Grab the embeddedCR branch for Terasology
* `gradlew fetchLibCrashReporter`
* `gradlew clean cleanIdea idea`
* Restart IntelliJ (should prompt you)
* Have a way to crash the game, I usually just use the Sample module's crash block (console `giveblock reallyCrashGameBlock` then place and `e` click it)
* Change something in the source version of the CR like the "editBeforeUpload" value in `MessagesBundle.properties` so you can verify you actually are using the embedded CR rather than the binary dependency
* Be sure to run with the CR enabled (non-default utility run config provided for IntelliJ - "Terasology PC (CR enabled)")
* Crash! Confirm that the CR pops up and that your change is present
* Close IntelliJ
* Delete `libs/CrashReporter`
* Run `gradlew clean cleanIdea idea` again
* Retest - you should now again be using the binary dependency

Since this messes with project structure some it may need some extra cleaning. Plain `gradlew idea` isn't necessarily enough.

### Outstanding before merging

- [x] Check on any misdirected imports across modules (I'm working in a mini workspace for Gradle without my usual full module setup)
- [x] Increment the CR version to 4.0.0, release it, and make sure its new Artifactory name matches the dependency in Terasology
- [x] Remove the hard link to the CR PR branch in the Terasology `utility.gradle` (just included for easy testing)
- [ ] Also check on Destination Sol - bump the version of the CR it uses (past v1.4) and make sure it has the updated name if changed.
- [x] Double check on import order (I edited some imports in-place and re-added others, so the order differs a bit) and other small stuff, maybe update the license header year etc

### Screenie!

![crash reporter_2016-06-28_23-08-23](https://cloud.githubusercontent.com/assets/1063833/16441068/21abf49c-3d95-11e6-9934-0241516490a8.png)
