### PR TITLE
Support transparent FBOs

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/opengl/LwjglFrameBufferObject.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/LwjglFrameBufferObject.java
@@ -63,13 +63,6 @@ public class LwjglFrameBufferObject implements FrameBufferObject {
             throw new IllegalStateException("Something went wrong with framebuffer! " + result);
         }
 
-        // clear and fill with full alpha
-        FloatBuffer buffer = BufferUtils.createFloatBuffer(16);
-        GL11.glGetFloat(GL11.GL_COLOR_CLEAR_VALUE, buffer);
-        GL11.glClearColor(0f, 0f, 0f, 1f);
-        GL11.glClear(GL11.GL_COLOR_BUFFER_BIT);
-        GL11.glClearColor(buffer.get(), buffer.get(), buffer.get(), buffer.get());  // reset
-
         GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);
     }
 
@@ -97,9 +90,6 @@ public class LwjglFrameBufferObject implements FrameBufferObject {
         glOrtho(0, Display.getWidth(), Display.getHeight(), 0, 0, 2048f);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
-
-        // reset color mask
-        GL11.glColorMask(true, true, true, true);
     }
 
     @Override
@@ -117,8 +107,5 @@ public class LwjglFrameBufferObject implements FrameBufferObject {
         glOrtho(0, size.x(), size.y(), 0, 0, 2048f);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
-
-        // disable writing alpha values so that blending semi-transparent billboards works as expected
-        GL11.glColorMask(true, true, true, false);
     }
 }


### PR DESCRIPTION
Setting the background to full alpha for FBOs is not necessary. This avoids state changes is also less code. 

Can be tested with [MiniMap](https://github.com/Terasology/Minimap).