### PR TITLE
Quick fix for the visual artifact caused by DirectionalLightsNode

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/DirectionalLightsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/DirectionalLightsNode.java
@@ -66,7 +66,6 @@ public class DirectionalLightsNode implements Node {
     @Override
     public void initialise() {
         playerCamera = worldRenderer.getActiveCamera();
-        sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
         lightGeometryShader = worldRenderer.getMaterial("engine:prog.lightGeometryPass");
         lightBufferPass = worldRenderer.getMaterial("engine:prog.lightBufferPass");
         initMainDirectionalLight();
@@ -83,6 +82,7 @@ public class DirectionalLightsNode implements Node {
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/directionallights");
+        sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
         sceneOpaque.bind();
 
         Vector3f sunlightWorldPosition = new Vector3f(backdropProvider.getSunDirection(true));


### PR DESCRIPTION
### Contains

![out](https://cloud.githubusercontent.com/assets/136392/16592589/23317aa8-42ea-11e6-8c52-b1a972ebaca1.gif)

As title says, quick fix for the bug which was introduced in c301a69f4676f4a469c56ee126f0ff9966624b30. 

Probably fixes #2392.

### How to test

Load the game and try to resize the window.


_Side note: Sorry for this tiny bug, human errors 😞  Hopefully not caused any fatalities, hoping it was just a little frustration to fellow gamers._ 