### PR TITLE
Initial inline editor implementation

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/treeView/GenericTreeTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/treeView/GenericTreeTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeConverterTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeConverterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;

--- a/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuBuilder.java
@@ -18,9 +18,7 @@ package org.terasology.rendering.nui.contextMenu;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.terasology.assets.management.AssetManager;
 import org.terasology.math.geom.Vector2i;
-import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.widgets.UpdateListener;
@@ -35,9 +33,6 @@ import java.util.function.Consumer;
  * Should be used in favor of manually creating the screen.
  */
 public class ContextMenuBuilder {
-    @In
-    private AssetManager assetManager;
-
     /**
      * A list of available consumer/object actions mapped to a string.
      */

--- a/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuBuilder.java
@@ -18,7 +18,9 @@ package org.terasology.rendering.nui.contextMenu;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.math.geom.Vector2i;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.widgets.UpdateListener;
@@ -33,6 +35,9 @@ import java.util.function.Consumer;
  * Should be used in favor of manually creating the screen.
  */
 public class ContextMenuBuilder {
+    @In
+    private AssetManager assetManager;
+
     /**
      * A list of available consumer/object actions mapped to a string.
      */
@@ -45,6 +50,10 @@ public class ContextMenuBuilder {
      * Listeners fired when the menu is closed.
      */
     private List<UpdateListener> closeListeners = Lists.newArrayList();
+    /**
+     *
+     */
+    private List<UpdateListener> screenClosedListeners = Lists.newArrayList();
 
     /**
      * Adds an action to the available options.
@@ -83,16 +92,19 @@ public class ContextMenuBuilder {
 
                     @Override
                     public void set(String value) {
-                        selectionListeners.forEach(UpdateListener::onAction);
-                        manager.closeScreen(ContextMenuScreen.ASSET_URI);
-
                         ConsumerObjectPair pair = options.get(value);
                         pair.getConsumer().accept(pair.getObject());
+                        selectionListeners.forEach(UpdateListener::onAction);
+                        manager.closeScreen(ContextMenuScreen.ASSET_URI);
                     }
                 });
 
         contextMenuScreen.subscribeClose(() -> {
             closeListeners.forEach(UpdateListener::onAction);
+        });
+
+        contextMenuScreen.subscribeScreenClosed(() -> {
+            screenClosedListeners.forEach(UpdateListener::onAction);
         });
     }
 
@@ -134,5 +146,15 @@ public class ContextMenuBuilder {
     public void unsubscribeClose(UpdateListener listener) {
         Preconditions.checkNotNull(listener);
         closeListeners.remove(listener);
+    }
+
+    public void subscribeScreenClosed(UpdateListener listener) {
+        Preconditions.checkNotNull(listener);
+        screenClosedListeners.add(listener);
+    }
+
+    public void unsubscribeScreenclosed(UpdateListener listener) {
+        Preconditions.checkNotNull(listener);
+        screenClosedListeners.remove(listener);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuScreen.java
@@ -51,6 +51,10 @@ public class ContextMenuScreen extends CoreScreenLayer {
      * Listeners fired when the menu is closed (without selecting an option).
      */
     private List<UpdateListener> closeListeners = Lists.newArrayList();
+    /**
+     *
+     */
+    private List<UpdateListener> screenClosedListeners = Lists.newArrayList();
 
     private InteractionListener mainListener = new BaseInteractionListener() {
         @Override
@@ -76,6 +80,12 @@ public class ContextMenuScreen extends CoreScreenLayer {
     @Override
     public void initialise() {
         menu = find("menu", UIList.class);
+        menu.setCanBeFocus(false);
+    }
+
+    @Override
+    public void onClosed() {
+        screenClosedListeners.forEach(UpdateListener::onAction);
     }
 
     @Override
@@ -105,5 +115,15 @@ public class ContextMenuScreen extends CoreScreenLayer {
     public void unsubscribeClose(UpdateListener listener) {
         Preconditions.checkNotNull(listener);
         closeListeners.remove(listener);
+    }
+
+    public void subscribeScreenClosed(UpdateListener listener) {
+        Preconditions.checkNotNull(listener);
+        screenClosedListeners.add(listener);
+    }
+
+    public void unsubscribeScreenClosed(UpdateListener listener) {
+        Preconditions.checkNotNull(listener);
+        screenClosedListeners.remove(listener);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/contextMenu/ContextMenuScreen.java
@@ -56,6 +56,7 @@ public class ContextMenuScreen extends CoreScreenLayer {
         @Override
         public boolean onMouseClick(NUIMouseClickEvent event) {
             // Close the context menu on click outside it.
+            closeListeners.forEach(UpdateListener::onAction);
             getManager().closeScreen(ASSET_URI);
 
             return false;
@@ -64,6 +65,7 @@ public class ContextMenuScreen extends CoreScreenLayer {
         @Override
         public boolean onMouseWheel(NUIMouseWheelEvent event) {
             // Close the context menu on mouse wheel scroll outside it.
+            closeListeners.forEach(UpdateListener::onAction);
             getManager().closeScreen(ASSET_URI);
 
             // Consume the event to prevent awkward rendering if the menu is within a scrollable widget.
@@ -81,11 +83,6 @@ public class ContextMenuScreen extends CoreScreenLayer {
         canvas.addInteractionRegion(mainListener);
         Rect2i region = Rect2i.createFromMinAndSize(menuPosition, canvas.calculatePreferredSize(menu));
         canvas.drawWidget(menu, region);
-    }
-
-    @Override
-    public void onClosed() {
-        closeListeners.forEach(UpdateListener::onAction);
     }
 
     public void setList(List list) {

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/NUIEditorScreen.java
@@ -49,9 +49,9 @@ import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UITextEntry;
 import org.terasology.rendering.nui.widgets.UITreeView;
-import org.terasology.rendering.nui.widgets.models.JsonTree;
-import org.terasology.rendering.nui.widgets.models.JsonTreeConverter;
-import org.terasology.rendering.nui.widgets.models.JsonTreeNode;
+import org.terasology.rendering.nui.widgets.treeView.JsonTree;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeConverter;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeNode;
 
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -478,10 +478,10 @@ public class NUIEditorScreen extends CoreScreenLayer {
         try {
             JsonElement element = JsonTreeConverter.deserialize(tree);
             widget = new UIFormat().load(element).getRootWidget();
+            selectedScreenContainer.setContent(widget);
         } catch (Exception e) {
-            widget = new UILabel(ExceptionUtils.getStackTrace(e));
+            selectedScreenContainer.setContent(new UILabel(ExceptionUtils.getStackTrace(e)));
         }
-        selectedScreenContainer.setContent(widget);
     }
 }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/NUIEditorScreen.java
@@ -117,6 +117,10 @@ public class NUIEditorScreen extends CoreScreenLayer {
      * The index of the currently displayed tree view model state.
      */
     private int editorHistoryPosition;
+    /**
+     *
+     */
+    private UITextEntry<JsonTree> inlineEditorEntry;
 
     @Override
     public void initialise() {
@@ -195,6 +199,23 @@ public class NUIEditorScreen extends CoreScreenLayer {
                 contextMenuBuilder.subscribeClose(() -> {
                     editorTreeView.setAlternativeWidget(null);
                     editorTreeView.setSelectedIndex(null);
+                });
+
+                contextMenuBuilder.subscribeScreenClosed(() -> {
+                    if (inlineEditorEntry != null) {
+                        getManager().setFocus(inlineEditorEntry);
+                        inlineEditorEntry.resetValue();
+
+                        if (type == JsonTreeValue.Type.KEY_VALUE_PAIR) {
+                            // Select the value string only. Account for the key quotes + colon.
+                            inlineEditorEntry.setCursorPosition(((JsonTree) node).getValue().getKey().length() + "\"\":".length(), true);
+                            inlineEditorEntry.setCursorPosition(inlineEditorEntry.getText().length(), false);
+                        } else {
+                            // Select the entire editor string.
+                            inlineEditorEntry.setCursorPosition(0, true);
+                            inlineEditorEntry.setCursorPosition(inlineEditorEntry.getText().length(), false);
+                        }
+                    }
                 });
 
                 contextMenuBuilder.show(getManager(), event.getMouse().getPosition());
@@ -341,7 +362,7 @@ public class NUIEditorScreen extends CoreScreenLayer {
 
 
     private void edit(JsonTree node, UITextEntry.Formatter<JsonTree> formatter, UITextEntry.Parser<JsonTree> parser) {
-        UITextEntry<JsonTree> inlineEditorEntry = new UITextEntry<>();
+        inlineEditorEntry = new UITextEntry<>();
         inlineEditorEntry.bindValue(new Binding<JsonTree>() {
             @Override
             public JsonTree get() {

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/WidgetSelectionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/WidgetSelectionScreen.java
@@ -29,8 +29,8 @@ import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UpdateListener;
-import org.terasology.rendering.nui.widgets.models.JsonTree;
-import org.terasology.rendering.nui.widgets.models.JsonTreeNode;
+import org.terasology.rendering.nui.widgets.treeView.JsonTree;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeNode;
 
 import java.util.Collections;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/WidgetSelectionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/WidgetSelectionScreen.java
@@ -30,7 +30,7 @@ import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UpdateListener;
 import org.terasology.rendering.nui.widgets.treeView.JsonTree;
-import org.terasology.rendering.nui.widgets.treeView.JsonTreeNode;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeValue;
 
 import java.util.Collections;
 import java.util.List;
@@ -44,9 +44,9 @@ public class WidgetSelectionScreen extends CoreScreenLayer {
      */
     private UIDropdownScrollable availableWidgets;
     /**
-     * The JsonTree a selected widget is to be added to.
+     * The {@link JsonTree} a selected widget is to be added to.
      */
-    private JsonTree item;
+    private JsonTree node;
     /**
      * The list of available UIWidget instances, excluding CoreScreenLayer overrides.
      */
@@ -77,17 +77,17 @@ public class WidgetSelectionScreen extends CoreScreenLayer {
 
             ClassMetadata metadata = widgets.get(selection);
 
-            JsonTree scaffolding = new JsonTree(new JsonTreeNode(null, null, JsonTreeNode.ElementType.OBJECT));
+            JsonTree scaffolding = new JsonTree(new JsonTreeValue(null, null, JsonTreeValue.Type.OBJECT));
 
             // Always add a "type" node with its' value being equal to the selected widget's type.
-            scaffolding.addChild(new JsonTreeNode("type", selection, JsonTreeNode.ElementType.KEY_VALUE_PAIR));
+            scaffolding.addChild(new JsonTreeValue("type", selection, JsonTreeValue.Type.KEY_VALUE_PAIR));
 
             // If the widget is an UILayout override, add a "contents" array node.
             if (UILayout.class.isAssignableFrom(metadata.getType())) {
-                scaffolding.addChild(new JsonTreeNode("contents", null, JsonTreeNode.ElementType.ARRAY));
+                scaffolding.addChild(new JsonTreeValue("contents", null, JsonTreeValue.Type.ARRAY));
             }
 
-            item.addChild(scaffolding);
+            node.addChild(scaffolding);
 
             closeListeners.forEach(UpdateListener::onAction);
             getManager().closeScreen(ASSET_URI);
@@ -105,8 +105,8 @@ public class WidgetSelectionScreen extends CoreScreenLayer {
         });
     }
 
-    public void setItem(JsonTree item) {
-        this.item = item;
+    public void setNode(JsonTree node) {
+        this.node = node;
     }
 
     public void subscribeClose(UpdateListener listener) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/TreeViewTestScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/TreeViewTestScreen.java
@@ -28,7 +28,7 @@ import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.widgets.UITreeView;
 import org.terasology.rendering.nui.widgets.treeView.JsonTree;
 import org.terasology.rendering.nui.widgets.treeView.JsonTreeConverter;
-import org.terasology.rendering.nui.widgets.treeView.JsonTreeNode;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeValue;
 import org.terasology.rendering.nui.widgets.treeView.Tree;
 
 import java.io.IOException;
@@ -60,7 +60,7 @@ public class TreeViewTestScreen extends CoreScreenLayer {
         JsonTree tree = JsonTreeConverter.serialize(new JsonParser().parse(content));
         Iterator it = tree.getDepthFirstIterator(false);
         while (it.hasNext()) {
-            ((Tree<JsonTreeNode>) it.next()).setExpanded(true);
+            ((Tree<JsonTreeValue>) it.next()).setExpanded(true);
         }
 
         for (String id : new String[]{"treeViewDisabled", "treeViewEnabled"}) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/TreeViewTestScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/TreeViewTestScreen.java
@@ -26,10 +26,10 @@ import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.widgets.UITreeView;
-import org.terasology.rendering.nui.widgets.models.JsonTree;
-import org.terasology.rendering.nui.widgets.models.JsonTreeConverter;
-import org.terasology.rendering.nui.widgets.models.JsonTreeNode;
-import org.terasology.rendering.nui.widgets.models.Tree;
+import org.terasology.rendering.nui.widgets.treeView.JsonTree;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeConverter;
+import org.terasology.rendering.nui.widgets.treeView.JsonTreeNode;
+import org.terasology.rendering.nui.widgets.treeView.Tree;
 
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 /**
  * A list widget.
+ *
  * @param <T> the list element type
  */
 public class UIList<T> extends CoreWidget {
@@ -47,7 +48,7 @@ public class UIList<T> extends CoreWidget {
     private Binding<T> selection = new DefaultBinding<>();
     private Binding<List<T>> list = new DefaultBinding<>(new ArrayList<>());
     private ItemRenderer<T> itemRenderer = new ToStringTextRenderer<>();
-
+    private Binding<Boolean> canBeFocus = new DefaultBinding<>(true);
 
     public UIList() {
 
@@ -101,6 +102,11 @@ public class UIList<T> extends CoreWidget {
     }
 
     @Override
+    public boolean canBeFocus() {
+        return canBeFocus.get();
+    }
+
+    @Override
     public Vector2i getPreferredContentSize(Canvas canvas, Vector2i areaHint) {
         canvas.setPart("item");
         Vector2i result = new Vector2i();
@@ -134,6 +140,10 @@ public class UIList<T> extends CoreWidget {
 
     public void setSelectable(boolean value) {
         selectable.set(value);
+    }
+
+    public void setCanBeFocus(boolean value) {
+        canBeFocus.set(value);
     }
 
     public void bindSelection(Binding<T> binding) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITextEntry.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITextEntry.java
@@ -45,7 +45,7 @@ public class UITextEntry<T> extends UIText {
     @Override
     public void onDraw(Canvas canvas) {
         if (!isFocused()) {
-            stringValue.set(formatter.toString(value.get()));
+            resetValue();
         }
         super.onDraw(canvas);
     }
@@ -62,6 +62,10 @@ public class UITextEntry<T> extends UIText {
             // ignore
             logger.debug("Failed to parse text value", e);
         }
+    }
+
+    public void resetValue() {
+        stringValue.set(formatter.toString(value.get()));
     }
 
     public void bindValue(Binding<T> binding) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITextEntry.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITextEntry.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  */
 public class UITextEntry<T> extends UIText {
     private static final Logger logger = LoggerFactory.getLogger(UITextEntry.class);
-    
+
     private Binding<T> value = new DefaultBinding<>();
     private Binding<String> stringValue = new DefaultBinding<>("");
     private Parser<T> parser;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
@@ -671,21 +671,21 @@ public class UITreeView<T> extends CoreWidget {
         /**
          * @return The top listener.
          */
-        public ItemTopListener getTopListener() {
+        ItemTopListener getTopListener() {
             return topListener;
         }
 
         /**
          * @return The central listener.
          */
-        public ItemCenterListener getCenterListener() {
+        ItemCenterListener getCenterListener() {
             return centerListener;
         }
 
         /**
          * @return The bottom listener.
          */
-        public ItemBottomListener getBottomListener() {
+        ItemBottomListener getBottomListener() {
             return bottomListener;
         }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
@@ -17,7 +17,6 @@ package org.terasology.rendering.nui.widgets;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.terasology.input.Keyboard;
 import org.terasology.input.MouseInput;
 import org.terasology.input.device.KeyboardDevice;
@@ -27,6 +26,7 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.Color;
 import org.terasology.rendering.nui.CoreWidget;
+import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
@@ -37,11 +37,12 @@ import org.terasology.rendering.nui.events.NUIMouseOverEvent;
 import org.terasology.rendering.nui.events.NUIMouseReleaseEvent;
 import org.terasology.rendering.nui.itemRendering.ItemRenderer;
 import org.terasology.rendering.nui.itemRendering.ToStringTextRenderer;
-import org.terasology.rendering.nui.widgets.models.Tree;
-import org.terasology.rendering.nui.widgets.models.TreeModel;
+import org.terasology.rendering.nui.widgets.treeView.Tree;
+import org.terasology.rendering.nui.widgets.treeView.TreeModel;
+import org.terasology.rendering.nui.widgets.treeView.TreeMouseClickListener;
+import org.terasology.rendering.nui.widgets.treeView.TreeViewState;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -50,7 +51,7 @@ import java.util.Objects;
  * @param <T> Type of objects stored in the underlying tree.
  */
 public class UITreeView<T> extends CoreWidget {
-    private enum MouseOverItemType {
+    public enum MouseOverItemType {
         TOP,
         CENTER,
         BOTTOM
@@ -69,35 +70,19 @@ public class UITreeView<T> extends CoreWidget {
     private static final String SELECTED_MODE = "selected";
 
     /**
-     * The indentation of one level in the tree.
+     * The horizontal indentation, in pixels, corresponding to one level in the tree.
      */
+    @LayoutConfig
     private Binding<Integer> itemIndent = new DefaultBinding<>(25);
     /**
      * The underlying tree model - a wrapper around a {@code Tree<T>}.
      */
     private Binding<TreeModel<T>> model = new DefaultBinding<>(new TreeModel<>());
     /**
-     * The index of the currently selected item, or null if no item is selected.
+     * The state of the tree - includes session-specific information about the currently selected node, copied node etc.
+     * See the documentation {@link TreeViewState} for information concerning specific state variables.
      */
-    private Binding<Integer> selectedIndex = new DefaultBinding<>();
-    /**
-     * The index of the item being drag&dropped, or null if no item is dragged.
-     */
-    private Binding<Integer> draggedItemIndex = new DefaultBinding<>();
-    /**
-     * The index of the item being moused over if another item is currently dragged.
-     * Null if no item is either dragged or moused over.
-     */
-    private Binding<Integer> mouseOverItemIndex = new DefaultBinding<>();
-    /**
-     * The index of the item being moused over if another item is currently dragged.
-     * Null if no item is either dragged or moused over.
-     */
-    private Binding<MouseOverItemType> mouseOverItemType = new DefaultBinding<>();
-    /**
-     * The item currently being copied, or null if no item has been copied.
-     */
-    private Binding<Tree<T>> clipboard = new DefaultBinding<>();
+    private TreeViewState<T> state = new TreeViewState<T>();
     /**
      * The value to be used when adding nodes to the tree.
      */
@@ -122,209 +107,6 @@ public class UITreeView<T> extends CoreWidget {
      * Tree view item click listeners.
      */
     private List<TreeMouseClickListener> itemListeners = Lists.newArrayList();
-    /**
-     *
-     */
-    private Map<Integer, UIWidget> alternativeWidgets = Maps.newHashMap();
-
-    private class ExpandButtonInteractionListener extends BaseInteractionListener {
-        private int index;
-
-        ExpandButtonInteractionListener(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public boolean onMouseClick(NUIMouseClickEvent event) {
-            if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
-                // Expand or contract and item on LMB - works even if the tree is disabled.
-                model.get().getItem(index).setExpanded(!model.get().getItem(index).isExpanded());
-
-                Tree<T> selectedItem = selectedIndex.get() != null ? model.get().getItem(selectedIndex.get()) : null;
-                model.get().resetItems();
-
-                // Update the index of the selected item.
-                if (selectedItem != null) {
-                    int newIndex = model.get().indexOf(selectedItem);
-                    if (newIndex == -1) {
-                        selectedIndex.set(null);
-                    } else {
-                        selectedIndex.set(newIndex);
-                    }
-                }
-                return true;
-            }
-            return false;
-        }
-    }
-
-    private class ItemTopListener extends BaseInteractionListener {
-        private int index;
-
-        ItemTopListener(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public boolean onMouseClick(NUIMouseClickEvent event) {
-            return onItemMouseClick(index, event);
-        }
-
-        @Override
-        public void onMouseDrag(NUIMouseDragEvent event) {
-            onItemMouseDrag(index);
-        }
-
-        @Override
-        public void onMouseOver(NUIMouseOverEvent event) {
-            super.onMouseOver(event);
-            if (draggedItemIndex.get() != null
-                    && !model.get().getItem(index).isRoot()
-                    && model.get().getItem(index).getParent().acceptsChild(model.get().getItem(draggedItemIndex.get()))) {
-                onItemMouseOver(index, MouseOverItemType.TOP);
-            }
-        }
-
-        @Override
-        public void onMouseRelease(NUIMouseReleaseEvent event) {
-            onItemMouseRelease(index);
-        }
-    }
-
-    private class ItemCenterListener extends BaseInteractionListener {
-        private int index;
-
-        ItemCenterListener(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public boolean onMouseClick(NUIMouseClickEvent event) {
-            return onItemMouseClick(index, event);
-        }
-
-        @Override
-        public void onMouseDrag(NUIMouseDragEvent event) {
-            onItemMouseDrag(index);
-        }
-
-        @Override
-        public void onMouseOver(NUIMouseOverEvent event) {
-            super.onMouseOver(event);
-            if (draggedItemIndex.get() != null
-                    && model.get().getItem(index).acceptsChild(model.get().getItem(draggedItemIndex.get()))) {
-                onItemMouseOver(index, MouseOverItemType.CENTER);
-            }
-        }
-
-        @Override
-        public void onMouseRelease(NUIMouseReleaseEvent event) {
-            onItemMouseRelease(index);
-        }
-    }
-
-    private class ItemBottomListener extends BaseInteractionListener {
-        private int index;
-
-        ItemBottomListener(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public boolean onMouseClick(NUIMouseClickEvent event) {
-            return onItemMouseClick(index, event);
-        }
-
-        @Override
-        public void onMouseDrag(NUIMouseDragEvent event) {
-            onItemMouseDrag(index);
-        }
-
-        @Override
-        public void onMouseOver(NUIMouseOverEvent event) {
-            super.onMouseOver(event);
-            if (draggedItemIndex.get() != null
-                    && !model.get().getItem(index).isRoot()
-                    && model.get().getItem(index).getParent().acceptsChild(model.get().getItem(draggedItemIndex.get()))) {
-                onItemMouseOver(index, MouseOverItemType.BOTTOM);
-            }
-        }
-
-        @Override
-        public void onMouseRelease(NUIMouseReleaseEvent event) {
-            onItemMouseRelease(index);
-        }
-    }
-
-    private boolean onItemMouseClick(int index, NUIMouseClickEvent event) {
-        for (TreeMouseClickListener listener : itemListeners) {
-            listener.onMouseClick(event, model.get().getItem(index));
-        }
-        if (isEnabled() && event.getMouseButton() == MouseInput.MOUSE_LEFT) {
-            // Select the item on LMB - deselect when selected again.
-            if (selectedIndex.get() != null && selectedIndex.get().equals(index)) {
-                selectedIndex.set(null);
-            } else {
-                selectedIndex.set(index);
-            }
-            clearAlternativeWidgets();
-            return true;
-        }
-        return false;
-    }
-
-    private void onItemMouseDrag(int index) {
-        draggedItemIndex.set(index);
-    }
-
-    private void onItemMouseOver(int index, MouseOverItemType type) {
-        // Set temporary index variables for the dragged/target items.
-        if (draggedItemIndex.get() != null) {
-            if (draggedItemIndex.get() != index) {
-                mouseOverItemIndex.set(index);
-                mouseOverItemType.set(type);
-            } else {
-                mouseOverItemIndex.set(null);
-                mouseOverItemType.set(null);
-            }
-        }
-    }
-
-    private void onItemMouseRelease(int index) {
-        if (draggedItemIndex.get() != null && mouseOverItemIndex.get() != null) {
-            Tree<T> child = model.get().getItem(draggedItemIndex.get());
-            Tree<T> parent = model.get().getItem(mouseOverItemIndex.get());
-
-            // Handle item drag&dropping.
-            if (mouseOverItemType.get() == MouseOverItemType.TOP) {
-                // Insert the dragged item before the target item (as a child of the same tree).
-                child.getParent().removeChild(child);
-                parent.getParent().addChild(parent.getParent().indexOf(parent), child);
-            } else if (mouseOverItemType.get() == MouseOverItemType.CENTER) {
-                // Insert the dragged item as a child of the target item.
-                child.getParent().removeChild(child);
-                parent.addChild(child);
-            } else {
-                // Insert the dragged item after the target item (as a child of the same tree).
-                child.getParent().removeChild(child);
-                parent.getParent().addChild(parent.getParent().indexOf(parent) + 1, child);
-            }
-
-            fireUpdateListeners();
-        }
-
-        // Reset the temporary index variables.
-        if (draggedItemIndex.get() != null) {
-            if (draggedItemIndex.get() != index) {
-                selectedIndex.set(null);
-            }
-            draggedItemIndex.set(null);
-        }
-        if (mouseOverItemIndex.get() != null) {
-            mouseOverItemIndex.set(null);
-            mouseOverItemType.set(null);
-        }
-    }
 
     public UITreeView() {
     }
@@ -344,6 +126,8 @@ public class UITreeView<T> extends CoreWidget {
             Tree<T> item = model.get().getItem(i);
             TreeViewListenerSet treeViewListenerSet = treeViewListenerSets.get(i);
             ExpandButtonInteractionListener buttonListener = expandListeners.get(i);
+
+            // Calculate the item height and overall region.
 
             int itemHeight = canvas.getCurrentStyle().getMargin()
                     .grow(itemRenderer.getPreferredSize(item.getValue(), canvas).addX(item.getDepth() * itemIndent.get()))
@@ -368,8 +152,10 @@ public class UITreeView<T> extends CoreWidget {
                 canvas.setPart(TREE_ITEM);
             }
 
-            if (alternativeWidgets.containsKey(i)) {
-                canvas.drawWidget(alternativeWidgets.get(i), itemRegion);
+            if (state.getAlternativeWidgets().containsKey(i)) {
+                //Draw an alternative widget in place of the item (with the same size).
+
+                canvas.drawWidget(state.getAlternativeWidgets().get(i), itemRegion);
                 currentHeight += itemHeight;
             } else {
                 // Draw the item itself.
@@ -379,8 +165,7 @@ public class UITreeView<T> extends CoreWidget {
                 currentHeight += itemHeight;
 
                 // Draw the item dragging hints if the current item is a drag&drop target.
-                if (mouseOverItemIndex.get() != null
-                        && mouseOverItemIndex.get() == i) {
+                if (state.getMouseOverItemIndex() != null && state.getMouseOverItemIndex() == i) {
                     drawDragHint(canvas, itemRegion);
                 }
             }
@@ -406,7 +191,7 @@ public class UITreeView<T> extends CoreWidget {
         }
         model.get().setEnumerateExpandedOnly(true);
 
-        // Account for the expand/contract button.
+        // Account for the expand/contract button!
         result.addX(itemIndent.get());
 
         return result;
@@ -434,11 +219,11 @@ public class UITreeView<T> extends CoreWidget {
                 return true;
             } else if (ctrlDown && id == Keyboard.KeyId.C) {
                 // Ctrl+C: copy a selected node.
-                copy(model.get().getItem(selectedIndex.get()));
+                copy(model.get().getItem(state.getSelectedIndex()));
                 return true;
             } else if (ctrlDown && id == Keyboard.KeyId.V) {
                 // Ctrl+V: paste the copied node as a child of the currently selected node.
-                paste(model.get().getItem(selectedIndex.get()));
+                paste(model.get().getItem(state.getSelectedIndex()));
                 return true;
             } else {
                 return false;
@@ -448,67 +233,57 @@ public class UITreeView<T> extends CoreWidget {
         return false;
     }
 
+    public void addAlternativeWidget(int index, UIWidget widget) {
+        state.getAlternativeWidgets().put(index, widget);
+    }
+
+    public void clearAlternativeWidgets() {
+        state.getAlternativeWidgets().clear();
+    }
+
     public void fireUpdateListeners() {
         clearAlternativeWidgets();
         updateListeners.forEach(UpdateListener::onAction);
     }
 
-    private void moveSelected(int keyId) {
-        if (selectedIndex.get() != null) {
-            Tree<T> selectedItem = model.get().getItem(selectedIndex.get());
-            Tree<T> parent = selectedItem.getParent();
-
-            if (!selectedItem.isRoot()) {
-                int itemIndex = parent.getIndex(selectedItem);
-
-                if (keyId == Keyboard.KeyId.UP && itemIndex > 0) {
-                    // Move the item up, unless it is the first item.
-                    parent.removeChild(selectedItem);
-                    parent.addChild(itemIndex - 1, selectedItem);
-                    model.get().resetItems();
-
-                    // Re-select the moved item.
-                    selectedIndex.set(model.get().indexOf(selectedItem));
-
-                    fireUpdateListeners();
-                } else if (keyId == Keyboard.KeyId.DOWN && itemIndex < parent.getChildren().size() - 1) {
-                    // Move the item down, unless it is the last item.
-                    parent.removeChild(selectedItem);
-                    parent.addChild(itemIndex + 1, selectedItem);
-                    model.get().resetItems();
-
-                    // Re-select the moved item.
-                    selectedIndex.set(model.get().indexOf(selectedItem));
-
-                    fireUpdateListeners();
-                }
-            }
-        }
-    }
-
-    private void removeSelected() {
-        model.get().removeItem(selectedIndex.get());
-        selectedIndex.set(null);
-
-        fireUpdateListeners();
-    }
-
-    private void addToSelected() {
-        model.get().getItem(selectedIndex.get()).addChild(defaultValue.get());
-
-        fireUpdateListeners();
-    }
-
     public void copy(Tree<T> item) {
-        clipboard.set(item.copy());
+        state.setClipboard(item.copy());
     }
 
     public void paste(Tree<T> item) {
-        if (clipboard.get() != null) {
-            item.addChild(clipboard.get());
+        if (state.getClipboard() != null) {
+            item.addChild(state.getClipboard());
 
             fireUpdateListeners();
         }
+    }
+
+    public TreeModel<T> getModel() {
+        return model.get();
+    }
+
+    public void setModel(Tree<T> root) {
+        setModel(new TreeModel<>(root));
+    }
+
+    public void setModel(TreeModel<T> newModel) {
+        model.set(newModel);
+        state.getAlternativeWidgets().clear();
+        state.setSelectedIndex(null);
+    }
+
+    public void setDefaultValue(T value) {
+        defaultValue.set(value);
+    }
+
+    public void subscribeTreeViewUpdate(UpdateListener listener) {
+        Preconditions.checkNotNull(listener);
+        updateListeners.add(listener);
+    }
+
+    public void subscribeItemMouseClick(TreeMouseClickListener listener) {
+        Preconditions.checkNotNull(listener);
+        itemListeners.add(listener);
     }
 
     private void setButtonMode(Canvas canvas, Tree<T> item, ExpandButtonInteractionListener listener) {
@@ -522,7 +297,7 @@ public class UITreeView<T> extends CoreWidget {
     private void setItemMode(Canvas canvas, Tree<T> item, TreeViewListenerSet listenerSet) {
         if (item.isSelected()) {
             canvas.setMode(SELECTED_MODE);
-        } else if (selectedIndex.get() != null && Objects.equals(item, model.get().getItem(selectedIndex.get()))) {
+        } else if (state.getSelectedIndex() != null && Objects.equals(item, model.get().getItem(state.getSelectedIndex()))) {
             canvas.setMode(ACTIVE_MODE);
         } else if (listenerSet.isMouseOver()) {
             canvas.setMode(isEnabled() ? HOVER_MODE : HOVER_DISABLED_MODE);
@@ -561,16 +336,16 @@ public class UITreeView<T> extends CoreWidget {
     }
 
     private void drawDragHint(Canvas canvas, Rect2i itemRegion) {
-        if (mouseOverItemType.get() == MouseOverItemType.TOP) {
+        if (state.getMouseOverItemType() == MouseOverItemType.TOP) {
             // Draw a line at the top of the item.
             canvas.drawLine(itemRegion.minX(), itemRegion.minY(), itemRegion.maxX(), itemRegion.minY(), Color.WHITE);
-        } else if (mouseOverItemType.get() == MouseOverItemType.CENTER) {
+        } else if (state.getMouseOverItemType() == MouseOverItemType.CENTER) {
             // Draw a border around the item.
             canvas.drawLine(itemRegion.minX(), itemRegion.minY(), itemRegion.maxX(), itemRegion.minY(), Color.WHITE);
             canvas.drawLine(itemRegion.maxX(), itemRegion.minY(), itemRegion.maxX(), itemRegion.maxY(), Color.WHITE);
             canvas.drawLine(itemRegion.minX(), itemRegion.minY(), itemRegion.minX(), itemRegion.maxY(), Color.WHITE);
             canvas.drawLine(itemRegion.minX(), itemRegion.maxY(), itemRegion.maxX(), itemRegion.maxY(), Color.WHITE);
-        } else if (mouseOverItemType.get() == MouseOverItemType.BOTTOM) {
+        } else { // MouseOverItemType.BOTTOM
             // Draw a line at the bottom of the item.
             canvas.drawLine(itemRegion.minX(), itemRegion.maxY(), itemRegion.maxX(), itemRegion.maxY(), Color.WHITE);
         }
@@ -586,12 +361,12 @@ public class UITreeView<T> extends CoreWidget {
         }
         if (!mouseOver) {
             // Reset the temporary index variables.
-            if (draggedItemIndex.get() != null) {
-                draggedItemIndex.set(null);
+            if (state.getDraggedItemIndex() != null) {
+                state.setDraggedItemIndex(null);
             }
-            if (mouseOverItemIndex.get() != null) {
-                mouseOverItemIndex.set(null);
-                mouseOverItemType.set(null);
+            if (state.getMouseOverItemIndex() != null) {
+                state.setMouseOverItemIndex(null);
+                state.setMouseOverItemType(null);
             }
         }
 
@@ -609,40 +384,251 @@ public class UITreeView<T> extends CoreWidget {
         }
     }
 
-    public TreeModel<T> getModel() {
-        return model.get();
+    private void moveSelected(int keyId) {
+        if (state.getSelectedIndex() != null) {
+            Tree<T> selectedItem = model.get().getItem(state.getSelectedIndex());
+            Tree<T> parent = selectedItem.getParent();
+
+            if (!selectedItem.isRoot()) {
+                int itemIndex = parent.getIndex(selectedItem);
+
+                if (keyId == Keyboard.KeyId.UP && itemIndex > 0) {
+                    // Move the item up, unless it is the first item.
+                    parent.removeChild(selectedItem);
+                    parent.addChild(itemIndex - 1, selectedItem);
+                    model.get().resetItems();
+
+                    // Re-select the moved item.
+                    state.setSelectedIndex(model.get().indexOf(selectedItem));
+
+                    fireUpdateListeners();
+                } else if (keyId == Keyboard.KeyId.DOWN && itemIndex < parent.getChildren().size() - 1) {
+                    // Move the item down, unless it is the last item.
+                    parent.removeChild(selectedItem);
+                    parent.addChild(itemIndex + 1, selectedItem);
+                    model.get().resetItems();
+
+                    // Re-select the moved item.
+                    state.setSelectedIndex(model.get().indexOf(selectedItem));
+
+                    fireUpdateListeners();
+                }
+            }
+        }
     }
 
-    public void setModel(Tree<T> root) {
-        setModel(new TreeModel<>(root));
+    private void removeSelected() {
+        if (state.getSelectedIndex() != null) {
+            model.get().removeItem(state.getSelectedIndex());
+            state.setSelectedIndex(null);
+
+            fireUpdateListeners();
+        }
     }
 
-    public void setModel(TreeModel<T> newModel) {
-        model.set(newModel);
-        alternativeWidgets.clear();
-        selectedIndex.set(null);
+    private void addToSelected() {
+        if (state.getSelectedIndex() != null) {
+            model.get().getItem(state.getSelectedIndex()).addChild(defaultValue.get());
+
+            fireUpdateListeners();
+        }
     }
 
-    public void setDefaultValue(T value) {
-        defaultValue.set(value);
+    private boolean onItemMouseClick(int index, NUIMouseClickEvent event) {
+        for (TreeMouseClickListener listener : itemListeners) {
+            listener.onMouseClick(event, model.get().getItem(index));
+        }
+        if (isEnabled() && event.getMouseButton() == MouseInput.MOUSE_LEFT) {
+            // Select the item on LMB - deselect when selected again.
+            if (state.getSelectedIndex() != null && state.getSelectedIndex() == index) {
+                state.setSelectedIndex(null);
+            } else {
+                state.setSelectedIndex(index);
+            }
+            clearAlternativeWidgets();
+            return true;
+        }
+        return false;
     }
 
-    public void subscribeTreeViewUpdate(UpdateListener listener) {
-        Preconditions.checkNotNull(listener);
-        updateListeners.add(listener);
+    private void onItemMouseDrag(int index) {
+        state.setDraggedItemIndex(index);
     }
 
-    public void subscribeItemMouseClick(TreeMouseClickListener listener) {
-        Preconditions.checkNotNull(listener);
-        itemListeners.add(listener);
+    private void onItemMouseOver(int index, MouseOverItemType type) {
+        // Set temporary index variables for the dragged/target items.
+        if (state.getDraggedItemIndex() != null) {
+            if (state.getDraggedItemIndex() != index) {
+                state.setMouseOverItemIndex(index);
+                state.setMouseOverItemType(type);
+            } else {
+                state.setMouseOverItemIndex(null);
+                state.setMouseOverItemType(null);
+            }
+        }
     }
 
-    public void addAlternativeWidget(int index, UIWidget widget) {
-        alternativeWidgets.put(index, widget);
+    private void onItemMouseRelease(int index) {
+        if (state.getDraggedItemIndex() != null && state.getMouseOverItemIndex() != null) {
+            Tree<T> child = model.get().getItem(state.getDraggedItemIndex());
+            Tree<T> parent = model.get().getItem(state.getMouseOverItemIndex());
+
+            // Handle item drag&dropping.
+            if (state.getMouseOverItemType() == MouseOverItemType.TOP) {
+                // Insert the dragged item before the target item (as a child of the same tree).
+                child.getParent().removeChild(child);
+                parent.getParent().addChild(parent.getParent().indexOf(parent), child);
+            } else if (state.getMouseOverItemType() == MouseOverItemType.CENTER) {
+                // Insert the dragged item as a child of the target item.
+                child.getParent().removeChild(child);
+                parent.addChild(child);
+            } else { // MouseOverItemType.BOTTOM
+                // Insert the dragged item after the target item (as a child of the same tree).
+                child.getParent().removeChild(child);
+                parent.getParent().addChild(parent.getParent().indexOf(parent) + 1, child);
+            }
+
+            fireUpdateListeners();
+        }
+
+        // Reset the temporary index variables.
+        if (state.getDraggedItemIndex() != null) {
+            state.setSelectedIndex(null);
+            state.setDraggedItemIndex(null);
+        }
+        if (state.getMouseOverItemIndex() != null) {
+            state.setMouseOverItemIndex(null);
+            state.setMouseOverItemType(null);
+        }
     }
 
-    public void clearAlternativeWidgets() {
-        alternativeWidgets.clear();
+    private class ExpandButtonInteractionListener extends BaseInteractionListener {
+        private int index;
+
+        ExpandButtonInteractionListener(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean onMouseClick(NUIMouseClickEvent event) {
+            if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
+                // Expand or contract and item on LMB - works even if the tree is disabled.
+                model.get().getItem(index).setExpanded(!model.get().getItem(index).isExpanded());
+
+                Tree<T> selectedItem = state.getSelectedIndex() != null ? model.get().getItem(state.getSelectedIndex()) : null;
+                model.get().resetItems();
+
+                // Update the index of the selected item.
+                if (selectedItem != null) {
+                    int newIndex = model.get().indexOf(selectedItem);
+                    if (newIndex == -1) {
+                        state.setSelectedIndex(null);
+                    } else {
+                        state.setSelectedIndex(newIndex);
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+
+    private class ItemTopListener extends BaseInteractionListener {
+        private int index;
+
+        ItemTopListener(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean onMouseClick(NUIMouseClickEvent event) {
+            return onItemMouseClick(index, event);
+        }
+
+        @Override
+        public void onMouseDrag(NUIMouseDragEvent event) {
+            onItemMouseDrag(index);
+        }
+
+        @Override
+        public void onMouseOver(NUIMouseOverEvent event) {
+            super.onMouseOver(event);
+            if (state.getDraggedItemIndex() != null
+                    && !model.get().getItem(index).isRoot()
+                    && model.get().getItem(index).getParent().acceptsChild(model.get().getItem(state.getDraggedItemIndex()))) {
+                onItemMouseOver(index, MouseOverItemType.TOP);
+            }
+        }
+
+        @Override
+        public void onMouseRelease(NUIMouseReleaseEvent event) {
+            onItemMouseRelease(index);
+        }
+    }
+
+    private class ItemCenterListener extends BaseInteractionListener {
+        private int index;
+
+        ItemCenterListener(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean onMouseClick(NUIMouseClickEvent event) {
+            return onItemMouseClick(index, event);
+        }
+
+        @Override
+        public void onMouseDrag(NUIMouseDragEvent event) {
+            onItemMouseDrag(index);
+        }
+
+        @Override
+        public void onMouseOver(NUIMouseOverEvent event) {
+            super.onMouseOver(event);
+            if (state.getDraggedItemIndex() != null
+                    && model.get().getItem(index).acceptsChild(model.get().getItem(state.getDraggedItemIndex()))) {
+                onItemMouseOver(index, MouseOverItemType.CENTER);
+            }
+        }
+
+        @Override
+        public void onMouseRelease(NUIMouseReleaseEvent event) {
+            onItemMouseRelease(index);
+        }
+    }
+
+    private class ItemBottomListener extends BaseInteractionListener {
+        private int index;
+
+        ItemBottomListener(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean onMouseClick(NUIMouseClickEvent event) {
+            return onItemMouseClick(index, event);
+        }
+
+        @Override
+        public void onMouseDrag(NUIMouseDragEvent event) {
+            onItemMouseDrag(index);
+        }
+
+        @Override
+        public void onMouseOver(NUIMouseOverEvent event) {
+            super.onMouseOver(event);
+            if (state.getDraggedItemIndex() != null
+                    && !model.get().getItem(index).isRoot()
+                    && model.get().getItem(index).getParent().acceptsChild(model.get().getItem(state.getDraggedItemIndex()))) {
+                onItemMouseOver(index, MouseOverItemType.BOTTOM);
+            }
+        }
+
+        @Override
+        public void onMouseRelease(NUIMouseReleaseEvent event) {
+            onItemMouseRelease(index);
+        }
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
@@ -69,7 +69,6 @@ public class UITreeView<T> extends CoreWidget {
     private static final String EXPAND_MODE = "expand";
     private static final String EXPAND_HOVER_MODE = "expand-hover";
     private static final String HOVER_DISABLED_MODE = "hover-disabled";
-    private static final String SELECTED_MODE = "selected";
 
     /**
      * The horizontal indentation, in pixels, corresponding to one level in the tree.
@@ -161,10 +160,11 @@ public class UITreeView<T> extends CoreWidget {
                 canvas.setPart(TREE_NODE);
             }
 
-            if (state.getAlternativeWidgets().containsKey(i)) {
+            if (state.getSelectedIndex() != null && state.getSelectedIndex() == i
+                    && state.getAlternativeWidget() != null) {
                 //Draw an alternative widget in place of the node (with the same size).
 
-                canvas.drawWidget(state.getAlternativeWidgets().get(i), nodeRegion);
+                canvas.drawWidget(state.getAlternativeWidget(), nodeRegion);
                 currentHeight += nodeHeight;
             } else {
                 // Draw the node itself.
@@ -247,16 +247,20 @@ public class UITreeView<T> extends CoreWidget {
         return false;
     }
 
-    public void addAlternativeWidget(int index, UIWidget widget) {
-        state.getAlternativeWidgets().put(index, widget);
+    public Integer getSelectedIndex() {
+        return state.getSelectedIndex();
     }
 
-    public void clearAlternativeWidgets() {
-        state.getAlternativeWidgets().clear();
+    public void setSelectedIndex(Integer index) {
+        state.setSelectedIndex(index);
+    }
+
+    public void setAlternativeWidget(UIWidget widget) {
+        state.setAlternativeWidget(widget);
     }
 
     public void fireUpdateListeners() {
-        clearAlternativeWidgets();
+        state.setAlternativeWidget(null);
         updateListeners.forEach(UpdateListener::onAction);
     }
 
@@ -282,12 +286,8 @@ public class UITreeView<T> extends CoreWidget {
 
     public void setModel(TreeModel<T> newModel) {
         model.set(newModel);
-        state.getAlternativeWidgets().clear();
+        state.setAlternativeWidget(null);
         state.setSelectedIndex(null);
-    }
-
-    public TreeViewState<T> getState() {
-        return state;
     }
 
     public void setDefaultValue(T value) {
@@ -323,9 +323,7 @@ public class UITreeView<T> extends CoreWidget {
     }
 
     private void setNodeMode(Canvas canvas, Tree<T> node, TreeViewListenerSet listenerSet) {
-        if (node.isSelected()) {
-            canvas.setMode(SELECTED_MODE);
-        } else if (state.getSelectedIndex() != null && Objects.equals(node, model.get().getNode(state.getSelectedIndex()))) {
+        if (state.getSelectedIndex() != null && Objects.equals(node, model.get().getNode(state.getSelectedIndex()))) {
             canvas.setMode(ACTIVE_MODE);
         } else if (listenerSet.isMouseOver()) {
             canvas.setMode(isEnabled() ? HOVER_MODE : HOVER_DISABLED_MODE);
@@ -473,7 +471,7 @@ public class UITreeView<T> extends CoreWidget {
             } else {
                 state.setSelectedIndex(index);
             }
-            clearAlternativeWidgets();
+            state.setAlternativeWidget(null);
             return true;
         }
         return false;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UITreeView.java
@@ -207,6 +207,13 @@ public class UITreeView<T> extends CoreWidget {
         return result;
     }
 
+    @Override
+    public void update(float delta) {
+        super.update(delta);
+        if (state.getAlternativeWidget() != null) {
+            state.getAlternativeWidget().update(delta);
+        }
+    }
 
     @Override
     public boolean onKeyEvent(NUIKeyEvent event) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/GenericTree.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/GenericTree.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 /**
  * A general purpose, data agnostic implementation of {@link Tree}.

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTree.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTree.java
@@ -18,49 +18,49 @@ package org.terasology.rendering.nui.widgets.treeView;
 /**
  * A tree representation of a JSON hierarchy, constructed from a {@link com.google.gson.JsonElement}.
  */
-public class JsonTree extends Tree<JsonTreeNode> {
-    public JsonTree(JsonTreeNode childValue) {
+public class JsonTree extends Tree<JsonTreeValue> {
+    public JsonTree(JsonTreeValue childValue) {
         this.setValue(childValue);
     }
 
     @Override
-    public boolean acceptsChild(Tree<JsonTreeNode> child) {
+    public boolean acceptsChild(Tree<JsonTreeValue> child) {
         if (!super.acceptsChild(child)) {
             return false;
         }
 
         // Only arrays or objects can have children.
-        if (getValue().getType() != JsonTreeNode.ElementType.ARRAY
-                && getValue().getType() != JsonTreeNode.ElementType.OBJECT) {
+        if (getValue().getType() != JsonTreeValue.Type.ARRAY
+                && getValue().getType() != JsonTreeValue.Type.OBJECT) {
             return false;
         }
 
         // Objects cannot have empty object children.
-        if (getValue().getType() == JsonTreeNode.ElementType.OBJECT
-                && child.getValue().getType() == JsonTreeNode.ElementType.OBJECT
+        if (getValue().getType() == JsonTreeValue.Type.OBJECT
+                && child.getValue().getType() == JsonTreeValue.Type.OBJECT
                 && child.getValue().getKey() == null) {
             return false;
         }
 
         // Only objects can have child key-value pairs.
-        if (getValue().getType() == JsonTreeNode.ElementType.ARRAY
-                && (child.getValue().getType() == JsonTreeNode.ElementType.KEY_VALUE_PAIR)) {
+        if (getValue().getType() == JsonTreeValue.Type.ARRAY
+                && (child.getValue().getType() == JsonTreeValue.Type.KEY_VALUE_PAIR)) {
             return false;
         }
         return true;
     }
 
     @Override
-    public void addChild(JsonTreeNode childValue) {
+    public void addChild(JsonTreeValue childValue) {
         this.addChild(new JsonTree(childValue));
     }
 
     @Override
-    public Tree<JsonTreeNode> copy() {
-        Tree<JsonTreeNode> copy = new JsonTree(this.value);
+    public Tree<JsonTreeValue> copy() {
+        Tree<JsonTreeValue> copy = new JsonTree(this.value);
         copy.setExpanded(this.isExpanded());
 
-        for (Tree<JsonTreeNode> child : this.children) {
+        for (Tree<JsonTreeValue> child : this.children) {
             copy.addChild(child.copy());
         }
         return copy;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTree.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTree.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 /**
  * A tree representation of a JSON hierarchy, constructed from a {@link com.google.gson.JsonElement}.

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeConverter.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeConverter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeConverter.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeConverter.java
@@ -47,33 +47,33 @@ public final class JsonTreeConverter {
         if (json.isJsonPrimitive()) {
             JsonPrimitive primitive = json.getAsJsonPrimitive();
             if (primitive.isBoolean()) {
-                return new JsonTree(new JsonTreeNode(name, json.getAsBoolean(),
-                        name != null ? JsonTreeNode.ElementType.KEY_VALUE_PAIR : JsonTreeNode.ElementType.VALUE));
+                return new JsonTree(new JsonTreeValue(name, json.getAsBoolean(),
+                        name != null ? JsonTreeValue.Type.KEY_VALUE_PAIR : JsonTreeValue.Type.VALUE));
             } else if (primitive.isNumber()) {
-                return new JsonTree(new JsonTreeNode(name, json.getAsNumber(),
-                        name != null ? JsonTreeNode.ElementType.KEY_VALUE_PAIR : JsonTreeNode.ElementType.VALUE));
+                return new JsonTree(new JsonTreeValue(name, json.getAsNumber(),
+                        name != null ? JsonTreeValue.Type.KEY_VALUE_PAIR : JsonTreeValue.Type.VALUE));
             } else if (primitive.isString()) {
-                return new JsonTree(new JsonTreeNode(name, json.getAsString(),
-                        name != null ? JsonTreeNode.ElementType.KEY_VALUE_PAIR : JsonTreeNode.ElementType.VALUE));
+                return new JsonTree(new JsonTreeValue(name, json.getAsString(),
+                        name != null ? JsonTreeValue.Type.KEY_VALUE_PAIR : JsonTreeValue.Type.VALUE));
             } else {
-                return new JsonTree(new JsonTreeNode(name, null, name != null ? JsonTreeNode.ElementType.KEY_VALUE_PAIR : JsonTreeNode.ElementType.VALUE));
+                return new JsonTree(new JsonTreeValue(name, null, name != null ? JsonTreeValue.Type.KEY_VALUE_PAIR : JsonTreeValue.Type.VALUE));
             }
         } else if (json.isJsonArray()) {
-            JsonTree tree = new JsonTree(new JsonTreeNode(name, null, JsonTreeNode.ElementType.ARRAY));
+            JsonTree tree = new JsonTree(new JsonTreeValue(name, null, JsonTreeValue.Type.ARRAY));
             JsonArray array = json.getAsJsonArray();
             for (int i = 0; i < array.size(); i++) {
                 tree.addChild(serialize(array.get(i)));
             }
             return tree;
         } else if (json.isJsonObject()) {
-            JsonTree tree = new JsonTree(new JsonTreeNode(name, null, JsonTreeNode.ElementType.OBJECT));
+            JsonTree tree = new JsonTree(new JsonTreeValue(name, null, JsonTreeValue.Type.OBJECT));
             JsonObject object = json.getAsJsonObject();
             for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
                 tree.addChild(serialize(entry.getKey(), entry.getValue()));
             }
             return tree;
         } else {
-            return new JsonTree(new JsonTreeNode(name, null, JsonTreeNode.ElementType.NULL));
+            return new JsonTree(new JsonTreeValue(name, null, JsonTreeValue.Type.NULL));
         }
     }
 
@@ -81,28 +81,28 @@ public final class JsonTreeConverter {
      * @param tree A tree hierarchy based on a {@link JsonElement}, created by the serialize() method.
      * @return The initial {@link JsonElement} reconstructed from the tree.
      */
-    public static JsonElement deserialize(Tree<JsonTreeNode> tree) {
-        JsonTreeNode node = tree.getValue();
-        if (node.getType() == JsonTreeNode.ElementType.KEY_VALUE_PAIR || node.getType() == JsonTreeNode.ElementType.VALUE) {
-            Object value = node.getValue();
-            if (value instanceof Boolean) {
-                return new JsonPrimitive((Boolean) value);
-            } else if (value instanceof Number) {
-                return new JsonPrimitive((Number) value);
-            } else if (value instanceof String) {
-                return new JsonPrimitive((String) value);
+    public static JsonElement deserialize(Tree<JsonTreeValue> tree) {
+        JsonTreeValue value = tree.getValue();
+        if (value.getType() == JsonTreeValue.Type.KEY_VALUE_PAIR || value.getType() == JsonTreeValue.Type.VALUE) {
+            Object primitive = value.getValue();
+            if (primitive instanceof Boolean) {
+                return new JsonPrimitive((Boolean) primitive);
+            } else if (primitive instanceof Number) {
+                return new JsonPrimitive((Number) primitive);
+            } else if (primitive instanceof String) {
+                return new JsonPrimitive((String) primitive);
             } else {
                 return JsonNull.INSTANCE;
             }
-        } else if (node.getType() == JsonTreeNode.ElementType.ARRAY) {
+        } else if (value.getType() == JsonTreeValue.Type.ARRAY) {
             JsonArray array = new JsonArray();
-            for (Tree<JsonTreeNode> child : tree.getChildren()) {
+            for (Tree<JsonTreeValue> child : tree.getChildren()) {
                 array.add(deserialize(child));
             }
             return array;
-        } else if (node.getType() == JsonTreeNode.ElementType.OBJECT) {
+        } else if (value.getType() == JsonTreeValue.Type.OBJECT) {
             JsonObject object = new JsonObject();
-            for (Tree<JsonTreeNode> child : tree.getChildren()) {
+            for (Tree<JsonTreeValue> child : tree.getChildren()) {
                 object.add(child.getValue().getKey(), deserialize(child));
             }
             return object;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeNode.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeNode.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import com.google.gson.JsonElement;
 

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeValue.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/JsonTreeValue.java
@@ -20,11 +20,11 @@ import com.google.gson.JsonElement;
 /**
  * The value type for the tree representation of a {@link JsonElement}.
  */
-public class JsonTreeNode {
+public class JsonTreeValue {
     /**
      * The type of the JSON node.
      */
-    public enum ElementType {
+    public enum Type {
         /**
          * Primitive data type (string, boolean, array).
          */
@@ -70,9 +70,9 @@ public class JsonTreeNode {
     /**
      * The type of the node.
      */
-    private ElementType type;
+    private Type type;
 
-    public JsonTreeNode(String key, Object value, ElementType type) {
+    public JsonTreeValue(String key, Object value, Type type) {
         this.key = key;
         this.value = value;
         this.type = type;
@@ -86,22 +86,22 @@ public class JsonTreeNode {
         return this.value;
     }
 
-    public ElementType getType() {
+    public Type getType() {
         return this.type;
     }
 
     @Override
     public String toString() {
-        if (type == ElementType.KEY_VALUE_PAIR) {
+        if (type == Type.KEY_VALUE_PAIR) {
             if (key != null && value != null) {
                 return key + ": " + value;
             }
             return key == null ? value.toString() : key;
-        } else if (type == ElementType.VALUE) {
+        } else if (type == Type.VALUE) {
             return value.toString();
-        } else if (type == ElementType.ARRAY) {
+        } else if (type == Type.ARRAY) {
             return key != null ? key : ARRAY_STRING;
-        } else if (type == ElementType.OBJECT) {
+        } else if (type == Type.OBJECT) {
             return key != null ? key : OBJECT_STRING;
         } else {
             return key != null ? key : NULL_STRING;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/Tree.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/Tree.java
@@ -45,10 +45,6 @@ public abstract class Tree<T> {
      */
     private boolean expanded;
     /**
-     * Whether the tree is selected, i.e. it is outlined within the user interface.
-     */
-    private boolean selected;
-    /**
      * The parent of this tree.
      */
     protected Tree<T> parent;
@@ -83,20 +79,6 @@ public abstract class Tree<T> {
      */
     public void setExpanded(boolean expanded) {
         this.expanded = expanded;
-    }
-
-    /**
-     * @return Whether the tree is selected.
-     */
-    public boolean isSelected() {
-        return selected;
-    }
-
-    /**
-     * @param selected The new selected state of this tree.
-     */
-    public void setSelected(boolean selected) {
-        this.selected = selected;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/Tree.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/Tree.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import com.google.api.client.util.Lists;
 import com.google.common.base.Preconditions;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeKeyEventListener.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeKeyEventListener.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.rendering.nui.widgets.treeView;
 
-import org.terasology.rendering.nui.events.NUIMouseClickEvent;
+import org.terasology.rendering.nui.events.NUIKeyEvent;
 
 @FunctionalInterface
-public interface TreeMouseClickListener {
-    void onMouseClick(NUIMouseClickEvent event, Tree node);
+public interface TreeKeyEventListener {
+    void onKeyEvent(NUIKeyEvent event);
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeModel.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeModel.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.models;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import com.google.api.client.util.Lists;
 

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeModel.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeModel.java
@@ -25,11 +25,11 @@ import java.util.List;
  */
 public class TreeModel<T> {
     /**
-     * A list of items, fetched from a {@code Tree} iterator.
+     * A list of nodes, fetched from a {@code Tree} iterator.
      */
-    private List<Tree<T>> items = Lists.newArrayList();
+    private List<Tree<T>> nodes = Lists.newArrayList();
     /**
-     * Whether the children of non-expanded items are excluded from the enumeration.
+     * Whether the children of non-expanded nodes are excluded from the enumeration.
      */
     private boolean enumerateExpandedOnly = true;
 
@@ -38,26 +38,26 @@ public class TreeModel<T> {
     }
 
     public TreeModel(Tree<T> root) {
-        this.resetItems(root);
+        this.resetNodes(root);
     }
 
     /**
-     * Reset the items in the tree.
+     * Reset the nodes in the tree.
      */
-    public void resetItems() {
-        this.resetItems(this.items.get(0).getRoot());
+    public void resetNodes() {
+        this.resetNodes(this.nodes.get(0).getRoot());
     }
 
     /**
-     * @param root The tree the list of items is to be fetched from.
+     * @param root The tree the list of nodes is to be fetched from.
      */
-    private void resetItems(Tree<T> root) {
-        this.items = Lists.newArrayList();
+    private void resetNodes(Tree<T> root) {
+        this.nodes = Lists.newArrayList();
 
         Iterator it = root.getDepthFirstIterator(enumerateExpandedOnly);
 
         while (it.hasNext()) {
-            this.items.add((Tree<T>) it.next());
+            this.nodes.add((Tree<T>) it.next());
         }
     }
 
@@ -65,32 +65,32 @@ public class TreeModel<T> {
      * @param index The index.
      * @return The item located at a given index.
      */
-    public Tree<T> getItem(int index) {
-        return this.items.get(index);
+    public Tree<T> getNode(int index) {
+        return this.nodes.get(index);
     }
 
     /**
-     * @param item The item.
-     * @return The index of the given item.
+     * @param node The node.
+     * @return The index of the given node.
      */
-    public int indexOf(Tree<T> item) {
-        return items.indexOf(item);
+    public int indexOf(Tree<T> node) {
+        return nodes.indexOf(node);
     }
 
     /**
-     * Removes the item located at a given index.
+     * Removes the node located at a given index.
      *
      * @param index The index.
      */
-    public void removeItem(int index) {
-        Tree<T> item = this.getItem(index);
+    public void removeNode(int index) {
+        Tree<T> item = this.getNode(index);
 
         // Never remove the root node.
         if (item.isRoot()) {
             return;
         }
 
-        Iterator it = this.items.get(0).getRoot().getDepthFirstIterator(enumerateExpandedOnly);
+        Iterator it = this.nodes.get(0).getRoot().getDepthFirstIterator(enumerateExpandedOnly);
 
         while (it.hasNext()) {
             Tree<T> next = (Tree<T>) it.next();
@@ -99,21 +99,21 @@ public class TreeModel<T> {
                 break;
             }
         }
-        this.resetItems(this.items.get(0).getRoot());
+        this.resetNodes(this.nodes.get(0).getRoot());
     }
 
     /**
-     * @return The amount of items in the tree.
+     * @return The amount of nodes in the tree.
      */
-    public int getItemCount() {
-        return this.items.size();
+    public int getNodeCount() {
+        return this.nodes.size();
     }
 
     /**
-     * @param enumerateExpandedOnly Whether the children of non-expanded items are excluded from the enumeration.
+     * @param enumerateExpandedOnly Whether the children of non-expanded nodes are excluded from the enumeration.
      */
     public void setEnumerateExpandedOnly(boolean enumerateExpandedOnly) {
         this.enumerateExpandedOnly = enumerateExpandedOnly;
-        this.resetItems();
+        this.resetNodes();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeMouseClickListener.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeMouseClickListener.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets;
+package org.terasology.rendering.nui.widgets.treeView;
 
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
-import org.terasology.rendering.nui.widgets.models.Tree;
 
 @FunctionalInterface
 public interface TreeMouseClickListener {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeViewState.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeViewState.java
@@ -15,42 +15,48 @@
  */
 package org.terasology.rendering.nui.widgets.treeView;
 
-import com.google.common.collect.Maps;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.widgets.UITreeView;
 
-import java.util.Map;
-
 public class TreeViewState<T> {
     /**
-     * The index of the currently selected node, or null if no node is selected.
+     * The index of the currently selected node.
+     * <p>
+     * {@code null} if no node is selected.
      */
     private Binding<Integer> selectedIndex = new DefaultBinding<>();
     /**
-     * The index of the node being drag&dropped, or null if no node is dragged.
+     * The index of the node being drag&dropped.
+     * <p>
+     * {@code null} if no node is dragged.
      */
     private Binding<Integer> draggedIndex = new DefaultBinding<>();
     /**
      * The index of the node being moused over if another node is currently dragged.
-     * Null if no node is either dragged or moused over.
+     * <p>
+     * {@code null} if no node is either dragged or moused over.
      */
     private Binding<Integer> mouseOverIndex = new DefaultBinding<>();
     /**
      * The index of the node being moused over if another node is currently dragged.
-     * Null if no node is either dragged or moused over.
+     * <p>
+     * {@code null} if no node is either dragged or moused over.
      */
     private Binding<UITreeView.MouseOverType> mouseOverType = new DefaultBinding<>();
     /**
-     * The node currently being copied, or null if no node has been copied.
+     * The node currently being copied.
+     * <p>
+     * {@code null} if no node has been copied.
      */
     private Binding<Tree<T>> clipboard = new DefaultBinding<>();
     /**
-     * A map containing an node index as key and the widget to be drawn in place of the
-     * specified node as value.
+     * The widget to be drawn in place of a selected item.
+     * <p>
+     * {@code null} if no alternative widget is to be drawn.
      */
-    private Map<Integer, UIWidget> alternativeWidgets = Maps.newHashMap();
+    private Binding<UIWidget> alternativeWidget = new DefaultBinding<>();
 
     public Integer getSelectedIndex() {
         return selectedIndex.get();
@@ -92,11 +98,11 @@ public class TreeViewState<T> {
         this.clipboard.set(clipboard);
     }
 
-    public Map<Integer, UIWidget> getAlternativeWidgets() {
-        return alternativeWidgets;
+    public UIWidget getAlternativeWidget() {
+        return alternativeWidget.get();
     }
 
-    public void setAlternativeWidgets(Map<Integer, UIWidget> alternativeWidgets) {
-        this.alternativeWidgets = alternativeWidgets;
+    public void setAlternativeWidget(UIWidget alternativeWidget) {
+        this.alternativeWidget.set(alternativeWidget);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeViewState.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeViewState.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.widgets.treeView;
+
+import com.google.common.collect.Maps;
+import org.terasology.rendering.nui.UIWidget;
+import org.terasology.rendering.nui.databinding.Binding;
+import org.terasology.rendering.nui.databinding.DefaultBinding;
+import org.terasology.rendering.nui.widgets.UITreeView;
+
+import java.util.Map;
+
+public class TreeViewState<T> {
+    /**
+     * The index of the currently selected item, or null if no item is selected.
+     */
+    private Binding<Integer> selectedIndex = new DefaultBinding<>();
+    /**
+     * The index of the item being drag&dropped, or null if no item is dragged.
+     */
+    private Binding<Integer> draggedItemIndex = new DefaultBinding<>();
+    /**
+     * The index of the item being moused over if another item is currently dragged.
+     * Null if no item is either dragged or moused over.
+     */
+    private Binding<Integer> mouseOverItemIndex = new DefaultBinding<>();
+    /**
+     * The index of the item being moused over if another item is currently dragged.
+     * Null if no item is either dragged or moused over.
+     */
+    private Binding<UITreeView.MouseOverItemType> mouseOverItemType = new DefaultBinding<>();
+    /**
+     * The item currently being copied, or null if no item has been copied.
+     */
+    private Binding<Tree<T>> clipboard = new DefaultBinding<>();
+    /**
+     * A map containing an item index as key and the widget to be drawn in place of the
+     * specified item as value.
+     */
+    private Map<Integer, UIWidget> alternativeWidgets = Maps.newHashMap();
+
+    public Integer getSelectedIndex() {
+        return selectedIndex.get();
+    }
+
+    public void setSelectedIndex(Integer selectedIndex) {
+        this.selectedIndex.set(selectedIndex);
+    }
+
+    public Integer getDraggedItemIndex() {
+        return draggedItemIndex.get();
+    }
+
+    public void setDraggedItemIndex(Integer draggedItemIndex) {
+        this.draggedItemIndex.set(draggedItemIndex);
+    }
+
+    public Integer getMouseOverItemIndex() {
+        return mouseOverItemIndex.get();
+    }
+
+    public void setMouseOverItemIndex(Integer mouseOverItemIndex) {
+        this.mouseOverItemIndex.set(mouseOverItemIndex);
+    }
+
+    public UITreeView.MouseOverItemType getMouseOverItemType() {
+        return mouseOverItemType.get();
+    }
+
+    public void setMouseOverItemType(UITreeView.MouseOverItemType mouseOverItemType) {
+        this.mouseOverItemType.set(mouseOverItemType);
+    }
+
+    public Tree<T> getClipboard() {
+        return clipboard.get();
+    }
+
+    public void setClipboard(Tree<T> clipboard) {
+        this.clipboard.set(clipboard);
+    }
+
+    public Map<Integer, UIWidget> getAlternativeWidgets() {
+        return alternativeWidgets;
+    }
+
+    public void setAlternativeWidgets(Map<Integer, UIWidget> alternativeWidgets) {
+        this.alternativeWidgets = alternativeWidgets;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeViewState.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/treeView/TreeViewState.java
@@ -25,30 +25,30 @@ import java.util.Map;
 
 public class TreeViewState<T> {
     /**
-     * The index of the currently selected item, or null if no item is selected.
+     * The index of the currently selected node, or null if no node is selected.
      */
     private Binding<Integer> selectedIndex = new DefaultBinding<>();
     /**
-     * The index of the item being drag&dropped, or null if no item is dragged.
+     * The index of the node being drag&dropped, or null if no node is dragged.
      */
-    private Binding<Integer> draggedItemIndex = new DefaultBinding<>();
+    private Binding<Integer> draggedIndex = new DefaultBinding<>();
     /**
-     * The index of the item being moused over if another item is currently dragged.
-     * Null if no item is either dragged or moused over.
+     * The index of the node being moused over if another node is currently dragged.
+     * Null if no node is either dragged or moused over.
      */
-    private Binding<Integer> mouseOverItemIndex = new DefaultBinding<>();
+    private Binding<Integer> mouseOverIndex = new DefaultBinding<>();
     /**
-     * The index of the item being moused over if another item is currently dragged.
-     * Null if no item is either dragged or moused over.
+     * The index of the node being moused over if another node is currently dragged.
+     * Null if no node is either dragged or moused over.
      */
-    private Binding<UITreeView.MouseOverItemType> mouseOverItemType = new DefaultBinding<>();
+    private Binding<UITreeView.MouseOverType> mouseOverType = new DefaultBinding<>();
     /**
-     * The item currently being copied, or null if no item has been copied.
+     * The node currently being copied, or null if no node has been copied.
      */
     private Binding<Tree<T>> clipboard = new DefaultBinding<>();
     /**
-     * A map containing an item index as key and the widget to be drawn in place of the
-     * specified item as value.
+     * A map containing an node index as key and the widget to be drawn in place of the
+     * specified node as value.
      */
     private Map<Integer, UIWidget> alternativeWidgets = Maps.newHashMap();
 
@@ -60,28 +60,28 @@ public class TreeViewState<T> {
         this.selectedIndex.set(selectedIndex);
     }
 
-    public Integer getDraggedItemIndex() {
-        return draggedItemIndex.get();
+    public Integer getDraggedIndex() {
+        return draggedIndex.get();
     }
 
-    public void setDraggedItemIndex(Integer draggedItemIndex) {
-        this.draggedItemIndex.set(draggedItemIndex);
+    public void setDraggedIndex(Integer draggedIndex) {
+        this.draggedIndex.set(draggedIndex);
     }
 
-    public Integer getMouseOverItemIndex() {
-        return mouseOverItemIndex.get();
+    public Integer getMouseOverIndex() {
+        return mouseOverIndex.get();
     }
 
-    public void setMouseOverItemIndex(Integer mouseOverItemIndex) {
-        this.mouseOverItemIndex.set(mouseOverItemIndex);
+    public void setMouseOverIndex(Integer mouseOverIndex) {
+        this.mouseOverIndex.set(mouseOverIndex);
     }
 
-    public UITreeView.MouseOverItemType getMouseOverItemType() {
-        return mouseOverItemType.get();
+    public UITreeView.MouseOverType getMouseOverType() {
+        return mouseOverType.get();
     }
 
-    public void setMouseOverItemType(UITreeView.MouseOverItemType mouseOverItemType) {
-        this.mouseOverItemType.set(mouseOverItemType);
+    public void setMouseOverType(UITreeView.MouseOverType mouseOverType) {
+        this.mouseOverType.set(mouseOverType);
     }
 
     public Tree<T> getClipboard() {

--- a/engine/src/main/java/org/terasology/world/viewer/color/ColorModels.java
+++ b/engine/src/main/java/org/terasology/world/viewer/color/ColorModels.java
@@ -19,7 +19,7 @@ package org.terasology.world.viewer.color;
 import java.awt.image.DirectColorModel;
 
 /**
- * A collection of constants for different color models.
+ * A collection of constants for different color treeView.
  */
 public final class ColorModels {
 

--- a/engine/src/main/resources/assets/skins/default.skin
+++ b/engine/src/main/resources/assets/skins/default.skin
@@ -552,9 +552,6 @@
                     },
                     "texture-scale-mode": "scale fit",
                     "modes": {
-                        "selected": {
-                            "background": "buttonDown"
-                        },
                         "hover": {
                             "background": "buttonOver"
                         },

--- a/engine/src/main/resources/assets/skins/default.skin
+++ b/engine/src/main/resources/assets/skins/default.skin
@@ -534,7 +534,7 @@
                         }
                     }
                 },
-                "tree-item": {
+                "tree-node": {
                     "text-align-horizontal": "left",
                     "text-align-vertical": "middle",
                     "background": "button",


### PR DESCRIPTION
### Contains

An implementation for rzats/gsoc-nui-editor#6.
- An option is added to replace a `UITreeView`'s node with an arbitrary widget that will be rendered in place of the node.
- It is used within `NUIEditorScreen` to replace a selected node with an inline `UITextEntry` editor using custom `Formatter`/`Parser` overrides to convert a `JsonTreeNode` to a JSON string and vice versa.

![editor-before](https://cloud.githubusercontent.com/assets/13783592/16714261/eb4ce282-46c5-11e6-8b58-b771e413bb2c.png)
![editor-after](https://cloud.githubusercontent.com/assets/13783592/16714262/ec2e880e-46c5-11e6-9730-37afdf252143.png)

### How to test

Right-click on a NUI editor node, select "Edit", make some changes!

### Outstanding before merging

- [x] Currently testing for different validation quirks (other than the basic `JsonSyntaxException` that can be thrown by `JsonParser`) and implementing validation accordingly.
- [x] Should handle `OBJECT`/`ARRAY` nodes (with slightly different `Parser`/`Formatter` logic).
- [x] Editor should also open on doubleclick/F2.