### PR TITLE
Made the graphics presets respect translation keys (requires user reset of config.cfg)

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/itemRendering/ToStringTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/itemRendering/ToStringTextRenderer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 package org.terasology.rendering.nui.itemRendering;
-
+import org.terasology.i18n.TranslationSystem;
 import java.util.Objects;
 
 /**
@@ -23,8 +23,22 @@ import java.util.Objects;
  */
 public class ToStringTextRenderer<T> extends StringTextRenderer<T> {
 
+    private TranslationSystem translationSystem;
+
+    public ToStringTextRenderer() { }
+
+    public ToStringTextRenderer(TranslationSystem translationSystemInput) {
+        translationSystem = translationSystemInput;
+    }
+
+
     @Override
     public String getString(T value) {
-        return Objects.toString(value);
+        if (translationSystem == null) {
+            return Objects.toString(value);
+        }
+        else {
+            return translationSystem.translate(Objects.toString(value));
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/CameraSetting.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/CameraSetting.java
@@ -18,9 +18,9 @@ package org.terasology.rendering.nui.layers.mainMenu.videoSettings;
 /**
  */
 public enum CameraSetting {
-    NORMAL("Normal", 1),
-    SMOOTH("Smooth", 5),
-    CINEMATIC("Cinematic", 60);
+    NORMAL("${engine:menu#camera-setting-normal}", 1),
+    SMOOTH("${engine:menu#camera-setting-smooth}", 5),
+    CINEMATIC("${engine:menu#camera-setting-cinematic}", 60);
 
     private String displayName;
     private int smoothingFrames;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/DynamicShadows.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/DynamicShadows.java
@@ -20,9 +20,9 @@ import org.terasology.config.RenderingConfig;
 /**
  */
 public enum DynamicShadows {
-    OFF("Off", false, false),
-    ON("On", true, false),
-    ON_PCF("On (PCF)", true, true);
+    OFF("${engine:menu#shadows-off}", false, false),
+    ON("${engine:menu#shadows-on}", true, false),
+    ON_PCF("${engine:menu#shadows-pcr}", true, true);
 
     private String displayName;
     private boolean shadow;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/Preset.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/Preset.java
@@ -20,7 +20,7 @@ import org.terasology.config.RenderingConfig;
 /**
  */
 public enum Preset {
-    MINIMAL("Minimal") {
+    MINIMAL("${engine:menu#video-preset-minimal}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setFlickeringLight(false);
@@ -36,7 +36,7 @@ public enum Preset {
             renderConfig.setNormalMapping(false);
         }
     },
-    LOW("Low") {
+    LOW("${engine:menu#video-preset-low}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setFlickeringLight(true);
@@ -52,7 +52,7 @@ public enum Preset {
             renderConfig.setCloudShadows(false);
         }
     },
-    MEDIUM("Medium") {
+    MEDIUM("${engine:menu#video-preset-medium}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setFlickeringLight(true);
@@ -68,7 +68,7 @@ public enum Preset {
             renderConfig.setCloudShadows(false);
         }
     },
-    HIGH("High") {
+    HIGH("${engine:menu#video-preset-high}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setFlickeringLight(true);
@@ -84,7 +84,7 @@ public enum Preset {
             renderConfig.setSsao(false);
         }
     },
-    ULTRA("Ultra") {
+    ULTRA("${engine:menu#video-preset-ultra}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setFlickeringLight(true);
@@ -101,7 +101,7 @@ public enum Preset {
 
         }
     },
-    CUSTOM("Custom") {
+    CUSTOM("${engine:menu#video-preset-custom}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotSize.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotSize.java
@@ -22,10 +22,10 @@ import org.terasology.math.TeraMath;
  */
 public enum ScreenshotSize {
 
-    DOUBLE_SIZE("Double Size", 2.0F),
-    NORMAL_SIZE("Normal Size", 1.0F),
-    HALF_SIZE("Half Size", 0.5F),
-    QUARTER_SIZE("Quarter Size", 0.25F),
+    DOUBLE_SIZE("${engine:menu#screenshot-size-double}", 2.0F),
+    NORMAL_SIZE("${engine:menu#screenshot-size-normal}", 1.0F),
+    HALF_SIZE("${engine:menu#screenshot-size-half}", 0.5F),
+    QUARTER_SIZE("${engine:menu#screenshot-size-quarter}", 0.25F),
     HD720("720p", 1280, 720),
     HD1080("1080p", 1920, 1080);
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -33,6 +33,7 @@ import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.BindHelper;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
+import org.terasology.rendering.nui.itemRendering.ToStringTextRenderer;
 import org.terasology.rendering.nui.widgets.UIDropdown;
 import org.terasology.rendering.nui.widgets.UISlider;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
@@ -72,24 +73,28 @@ public class VideoSettingsScreen extends CoreScreenLayer {
         setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
         UIDropdown<Preset> videoQuality = find("graphicsPreset", UIDropdown.class);
         if (videoQuality != null) {
+            videoQuality.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));
             videoQuality.setOptions(Lists.newArrayList(Preset.CUSTOM, Preset.MINIMAL, Preset.LOW, Preset.MEDIUM, Preset.HIGH, Preset.ULTRA));
             videoQuality.bindSelection(new PresetBinding(config.getRendering()));
         }
 
         UIDropdown<ViewDistance> viewDistance = find("viewDistance", UIDropdown.class);
         if (viewDistance != null) {
+            viewDistance.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));
             viewDistance.setOptions(Arrays.asList(ViewDistance.values()));
             viewDistance.bindSelection(BindHelper.bindBeanProperty("viewDistance", config.getRendering(), ViewDistance.class));
         }
 
         UIDropdown<WaterReflection> waterReflection = find("reflections", UIDropdown.class);
         if (waterReflection != null) {
+            waterReflection.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));
             waterReflection.setOptions(Lists.newArrayList(WaterReflection.SKY, WaterReflection.GLOBAL, WaterReflection.LOCAL));
             waterReflection.bindSelection(new WaterReflectionBinding(config.getRendering()));
         }
 
         UIDropdown<ScreenshotSize> screenshotSize = find("screenshotSize", UIDropdown.class);
         if (screenshotSize != null) {
+            screenshotSize.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));
             screenshotSize.setOptions(Arrays.asList(ScreenshotSize.values()));
             screenshotSize.bindSelection(BindHelper.bindBeanProperty("screenshotSize", config.getRendering(), ScreenshotSize.class));
         }
@@ -110,13 +115,13 @@ public class VideoSettingsScreen extends CoreScreenLayer {
                 public String getString(Integer value) {
                     switch (value) {
                         case 1:
-                            return "Some";
+                            return translationSystem.translate("${engine:menu#camera-blur-some}");
                         case 2:
-                            return "Normal";
+                            return translationSystem.translate("${engine:menu#camera-blur-normal}");
                         case 3:
-                            return "Max";
+                            return translationSystem.translate("${engine:menu#camera-blur-max}");
                         default:
-                            return "Off";
+                            return translationSystem.translate("${engine:menu#camera-blur-off}");
                     }
                 }
             });
@@ -124,6 +129,7 @@ public class VideoSettingsScreen extends CoreScreenLayer {
 
         UIDropdown<DynamicShadows> dynamicShadows = find("shadows", UIDropdown.class);
         if (dynamicShadows != null) {
+            dynamicShadows.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));
             dynamicShadows.setOptions(Arrays.asList(DynamicShadows.values()));
             dynamicShadows.bindSelection(new DynamicShadowsBinding(config.getRendering()));
         }
@@ -224,6 +230,7 @@ public class VideoSettingsScreen extends CoreScreenLayer {
 
         UIDropdown<CameraSetting> cameraSetting = find("camera", UIDropdown.class);
         if (cameraSetting != null) {
+            cameraSetting.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));
             cameraSetting.setOptions(Arrays.asList(CameraSetting.values()));
             cameraSetting.bindSelection(new CameraSettingBinding(config.getRendering()));
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/WaterReflection.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/WaterReflection.java
@@ -20,21 +20,21 @@ import org.terasology.config.RenderingConfig;
 /**
  */
 public enum WaterReflection {
-    SKY("Sky Only") {
+    SKY("${engine:menu#water-reflections-sky}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setReflectiveWater(false);
             renderConfig.setLocalReflections(false);
         }
     },
-    GLOBAL("Global") {
+    GLOBAL("${engine:menu#water-reflections-global}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setReflectiveWater(true);
             renderConfig.setLocalReflections(false);
         }
     },
-    LOCAL("SSR (EXPERIMENTAL)") {
+    LOCAL("${engine:menu#water-reflections-ssr}") {
         @Override
         public void apply(RenderingConfig renderConfig) {
             renderConfig.setReflectiveWater(false);

--- a/engine/src/main/java/org/terasology/rendering/world/viewDistance/ViewDistance.java
+++ b/engine/src/main/java/org/terasology/rendering/world/viewDistance/ViewDistance.java
@@ -24,13 +24,13 @@ import org.terasology.math.geom.Vector3i;
  */
 public enum ViewDistance {
 
-    LEGALLY_BLIND("Legally Blind", 0, new Vector3i(5, 5, 5)),
-    NEAR("Near", 1, new Vector3i(9, 7, 9)),
-    MODERATE("Moderate", 2, new Vector3i(13, 7, 13)),
-    FAR("Far", 3, new Vector3i(17, 7, 17)),
-    ULTRA("Ultra", 4, new Vector3i(25, 7, 25)),
-    MEGA("Mega", 5, new Vector3i(33, 7, 33)),
-    EXTREME("Extreme", 6, new Vector3i(63, 7, 63));
+    LEGALLY_BLIND("${engine:menu#view-distance-blind}", 0, new Vector3i(5, 5, 5)),
+    NEAR("${engine:menu#view-distance-near}", 1, new Vector3i(9, 7, 9)),
+    MODERATE("${engine:menu#view-distance-moderate}", 2, new Vector3i(13, 7, 13)),
+    FAR("${engine:menu#view-distance-far}", 3, new Vector3i(17, 7, 17)),
+    ULTRA("${engine:menu#view-distance-ultra}", 4, new Vector3i(25, 7, 25)),
+    MEGA("${engine:menu#view-distance-mega}", 5, new Vector3i(33, 7, 33)),
+    EXTREME("${engine:menu#view-distance-extreme}", 6, new Vector3i(63, 7, 63));
 
     private static TIntObjectMap<ViewDistance> indexLookup = new TIntObjectHashMap<>();
 

--- a/engine/src/main/resources/default.cfg
+++ b/engine/src/main/resources/default.cfg
@@ -24,7 +24,7 @@
     "windowWidth": 1152,
     "windowHeight": 720,
     "fullscreen": false,
-    "viewDistance": "moderate",
+    "viewDistance": "${engine:menu#view-distance-moderate}",
     "flickeringLight": true,
     "animateGrass": true,
     "animateWater": false,
@@ -60,10 +60,10 @@
     "clampLighting": false,
     "fboScale": 100,
     "dumpShaders": false,
-    "screenshotSize": "normal size",
+    "screenshotSize": "${engine:menu#screenshot-size-normal}",
     "screenshotFormat": "jpg",
     "cameraSettings": {
-      "cameraSetting": "normal"
+      "cameraSetting": "${engine:menu#camera-setting-normal}"
     },
     "debug": {
       "enabled": false,


### PR DESCRIPTION
### Contains

Fixes #2207. The presets menu now is translated according to the keys in menu_XX.lang.

I looked at this issue, and it appeared that the asignee had gotten busy and forgotten about it. I hope I'm not stepping on any toes.

### How to test

Before:
Go to Settings->Player and switch your language to "Deutsch (German)". Note that the first two entries remain "Custom" and "Minimal."

After:
Do the same thing. Note that the first two entries change to "Benutzerdefiniert" und "Einfach."

### Outstanding before merging

- [ ] Translations appear to be somewhat incomplete. That probably shouldn't stay in the way of this getting merged, though.