### PR TITLE
[RFM] Added CharacterImpulseEvent

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterImpulseEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterImpulseEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.characters;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Vector3f;
+
+public class CharacterImpulseEvent implements Event {
+    Vector3f direction;
+
+    public CharacterImpulseEvent(Vector3f direction) {
+        this.direction = direction;
+    }
+
+    public Vector3f getDirection() {
+        return direction;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterStateEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterStateEvent.java
@@ -98,6 +98,10 @@ public class CharacterStateEvent extends NetworkEvent {
         return velocity;
     }
 
+    public void setVelocity(Vector3f velocity) {
+        this.velocity.set(velocity);
+    }
+
     public void setTime(long time) {
         this.time = time;
     }

--- a/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
@@ -145,6 +145,20 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
 
     }
 
+    @ReceiveEvent(components = {CharacterMovementComponent.class, LocationComponent.class})
+    public void onImpulse(CharacterImpulseEvent event, EntityRef entity) {
+        Vector3f impulse = event.getDirection();
+
+        CircularBuffer<CharacterStateEvent> stateBuffer = characterStates.get(entity);
+        CharacterStateEvent lastState = stateBuffer.getLast();
+        CharacterStateEvent newState = new CharacterStateEvent(lastState);
+        newState.setVelocity(impulse.add(newState.getVelocity()));
+        newState.setTime(time.getGameTimeInMs());
+        newState.setMode(MovementMode.WALKING);
+        stateBuffer.add(newState);
+        characterMovementSystemUtility.setToState(entity, newState);
+    }
+
     private CharacterStateEvent createInitialState(EntityRef entity) {
         LocationComponent location = entity.getComponent(LocationComponent.class);
         return new CharacterStateEvent(time.getGameTimeInMs(), 0, location.getWorldPosition(), location.getWorldRotation(), new Vector3f(), 0, 0, MovementMode.WALKING, false);

--- a/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
@@ -154,7 +154,7 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
         CharacterStateEvent newState = new CharacterStateEvent(lastState);
         newState.setVelocity(impulse.add(newState.getVelocity()));
         newState.setTime(time.getGameTimeInMs());
-        newState.setMode(MovementMode.WALKING);
+        newState.setGrounded(false);
         stateBuffer.add(newState);
         characterMovementSystemUtility.setToState(entity, newState);
     }

--- a/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
+++ b/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.debug;
 
+import org.terasology.logic.characters.CharacterImpulseEvent;
 import org.terasology.utilities.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -78,6 +79,14 @@ public class MovementDebugCommands extends BaseComponentSystem {
         ClientComponent clientComp = sender.getComponent(ClientComponent.class);
         clientComp.character.send(new CharacterTeleportEvent(new Vector3f(x, y, z)));
         return "Teleporting  to " + x + " " + y + " " + z;
+    }
+
+    @Command(value  = "pushCharacter", shortDescription = "Pushes you in the direction (x, y, z)", runOnServer = true)
+    public String pushCharacterCommand(@Sender EntityRef sender,
+                              @CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z) {
+        ClientComponent clientComponent = sender.getComponent(ClientComponent.class);
+        clientComponent.character.send(new CharacterImpulseEvent(new Vector3f(x, y, z)));
+        return "Pushing character with " + x + " " + y + " " + z;
     }
 
     @Command(shortDescription = "Set jump speed", runOnServer = true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

This PR adds a new `CharacterImpulseEvent` to change the player's movement. 

It allows to apply a forced movement, e.g., to push the player back or give a thrust forward. This does not require additional movement, in contrast to the boosted stats for running or jumping.

### Outstanding before merging

I'd like to have some feedback on this :) There are some outstanding positions I want to address before merging. 

- [x] add a debug command to "push" the player (required for testing)
- [x] investigate player movement - vertical velocity changes have no influence. 

I tried to give the player a "hard hit", throwing him backwards a bit (i.e., up a little and to the back). However, the only effect I could notice was the force backwards. Vertical velocity seems to be only in affect when jumping. Probably this is related to the `MovementMode`.