### PR TITLE
[Merge it! Merge it!] Rendering and the RenderingDebug configs now "subscribable", on a per-property basis.

### DIFF
--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -24,11 +24,57 @@ import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.utilities.subscribables.AbstractSubscribable;
 
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 
 /**
  */
 public class RenderingConfig extends AbstractSubscribable {
+
+    public static final String PIXEL_FORMAT = "PixelFormat";
+    public static final String WINDOW_POS_X = "WindowPosX";
+    public static final String WINDOW_POS_Y = "WindowPosY";
+    public static final String WINDOW_WIDTH = "WindowWidth";
+    public static final String WINDOW_HEIGHT = "WindowHeight";
+    public static final String FULLSCREEN = "FullScreen";
+    public static final String ANIMATED_MENU = "AnimatedMenu";
+    public static final String VIEW_DISTANCE = "viewDistance";
+    public static final String FLICKERING_LIGHT = "FlickeringLight";
+    public static final String ANIMATE_GRASS = "AnimateGrass";
+    public static final String ANIMATE_WATER = "AnimateWater";
+    public static final String DYNAMIC_SHADOWS = "DynamicShadows";
+    public static final String FIELD_OF_VIEW = "FieldOfView";
+    public static final String CAMERA_BOBBING = "CameraBobbing";
+    public static final String RENDER_PLACING_BOX = "RenderPlacingBox";
+    public static final String BLUR_INTENSITY = "BlurIntensity";
+    public static final String REFLECTIVE_WATER = "ReflectiveWater";
+    public static final String VIGNETTE = "Vignette";
+    public static final String MOTION_BLUR = "MotionBlur";
+    public static final String SSAO = "Ssao";
+    public static final String FILM_GRAIN = "FilmGrain";
+    public static final String OUTLINE = "Outline";
+    public static final String LIGHT_SHAFTS = "LightShafts";
+    public static final String EYE_ADAPTATION = "EyeAdaptation";
+    public static final String BLOOM = "Bloom";
+    public static final String OCULUS_VR_SUPPORT = "OculusVrSupport";
+    public static final String MAX_TEXTURE_ATLAS_RESOLUTION = "MaxTextureAtlasResolution";
+    public static final String MAX_CHUNKS_USED_FOR_SHADOW_MAPPING = "MaxChunksUsedForShadowMapping";
+    public static final String SHADOW_MAP_RESOLUTION = "ShadowMapResolution";
+    public static final String NORMAL_MAPPING = "NormalMapping";
+    public static final String PARALLAX_MAPPING = "ParallaxMapping";
+    public static final String DYNAMIC_SHADOWS_PCF_FILTERING = "DynamicShadowsPcfFiltering";
+    public static final String CLOUD_SHADOWS = "CloudShadows";
+    public static final String LOCAL_REFLECTIONS = "LocalReflections";
+    public static final String INSCATTERING = "Inscattering";
+    public static final String RENDER_NEAREST = "RenderNearest";
+    public static final String PARTICLE_EFFECT_LIMIT = "ParticleEffectLimit";
+    public static final String MESH_LIMIT = "MeshLimit";
+    public static final String V_SYNC = "VSync";
+    public static final String FRAME_LIMIT = "FrameLimit";
+    public static final String FBO_SCALE = "FboScale";
+    public static final String CLAMP_LIGHTING = "ClampLighting";
+    public static final String SCREENSHOT_SIZE = "screenshotSize";
+    public static final String SCREENSHOT_FORMAT = "ScreenshotFormat";
+    public static final String DUMP_SHADERS = "DumpShaders";
+    public static final String VOLUMETRIC_FOG = "VolumetricFog";
 
     private PixelFormat pixelFormat;
     private int windowPosX;
@@ -88,7 +134,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return pixelFormat;
     }
 
-    public static final String PIXEL_FORMAT = "PixelFormat";
     public void setPixelFormat(PixelFormat pixelFormat) {
         PixelFormat oldFormat = this.pixelFormat;
         this.pixelFormat = pixelFormat;
@@ -96,14 +141,13 @@ public class RenderingConfig extends AbstractSubscribable {
         // propertyChangeSupport fires only if oldObject != newObject.
         // This method could theoretically use a better equality check then. In practice
         // it's unlikely a new PixelFormat instance will ever be value-per-value identical
-        // to the previous one, -not- needing a change event firing.
+        // to the previous one.
     }
 
     public int getWindowPosX() {
         return windowPosX;
     }
 
-    public static final String WINDOW_POS_X = "WindowPosX";
     public void setWindowPosX(int windowPosX) {
         int oldValue = this.windowPosX;
         this.windowPosX = windowPosX;
@@ -114,7 +158,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return windowPosY;
     }
 
-    public static final String WINDOW_POS_Y = "WindowPosY";
     public void setWindowPosY(int windowPosY) {
         int oldValue = this.windowPosY;
         this.windowPosY = windowPosY;
@@ -125,16 +168,16 @@ public class RenderingConfig extends AbstractSubscribable {
         return windowWidth;
     }
 
-    public static final String WINDOW_WIDTH = "WindowWidth";
     public void setWindowWidth(int windowWidth) {
         int oldValue = this.windowWidth;
         this.windowWidth = windowWidth;
         propertyChangeSupport.firePropertyChange(WINDOW_WIDTH, oldValue, this.windowWidth);
     }
 
-    public int getWindowHeight() { return windowHeight; }
+    public int getWindowHeight() {
+        return windowHeight;
+    }
 
-    public static final String WINDOW_HEIGHT = "WindowHeight";
     public void setWindowHeight(int windowHeight) {
             int oldValue = this.windowHeight;
             this.windowHeight = windowHeight;
@@ -145,29 +188,30 @@ public class RenderingConfig extends AbstractSubscribable {
         return new DisplayMode(windowWidth, windowHeight);
     }
 
-    public boolean isFullscreen() { return fullscreen; }
+    public boolean isFullscreen() {
+        return fullscreen;
+    }
 
-    public static final String FULLSCREEN = "FullScreen";
     public void setFullscreen(boolean fullscreen) {
+        boolean oldValue = this.fullscreen;
         this.fullscreen = fullscreen;
-        propertyChangeSupport.firePropertyChange(FULLSCREEN, !this.fullscreen, this.fullscreen);
+        propertyChangeSupport.firePropertyChange(FULLSCREEN, oldValue, this.fullscreen);
     }
 
     public boolean isAnimatedMenu() {
         return animatedMenu;
     }
 
-    public static final String ANIMATED_MENU = "AnimatedMenu";
     public void setAnimatedMenu(boolean animatedMenu) {
+        boolean oldValue = this.animatedMenu;
         this.animatedMenu = animatedMenu;
-        propertyChangeSupport.firePropertyChange(ANIMATED_MENU, !this.animatedMenu, this.animatedMenu);
+        propertyChangeSupport.firePropertyChange(ANIMATED_MENU, oldValue, this.animatedMenu);
     }
 
     public ViewDistance getViewDistance() {
         return viewDistance;
     }
 
-    public static final String VIEW_DISTANCE = "viewDistance";
     /**
      * Sets the view distance and notifies the property change listeners registered via
      * {@link RenderingConfig#subscribe(PropertyChangeListener)} that listen for the property {@link #VIEW_DISTANCE}.
@@ -183,47 +227,46 @@ public class RenderingConfig extends AbstractSubscribable {
         return flickeringLight;
     }
 
-    public static final String FLICKERING_LIGHT = "FlickeringLight";
     public void setFlickeringLight(boolean flickeringLight) {
+        boolean oldValue = this.flickeringLight;
         this.flickeringLight = flickeringLight;
-        propertyChangeSupport.firePropertyChange(FLICKERING_LIGHT, !this.flickeringLight, this.flickeringLight);
+        propertyChangeSupport.firePropertyChange(FLICKERING_LIGHT, oldValue, this.flickeringLight);
     }
 
     public boolean isAnimateGrass() {
         return animateGrass;
     }
 
-    public static final String ANIMATE_GRASS = "AnimateGrass";
     public void setAnimateGrass(boolean animateGrass) {
+        boolean oldValue = this.animateGrass;
         this.animateGrass = animateGrass;
-        propertyChangeSupport.firePropertyChange(ANIMATE_GRASS, !this.animateGrass, this.animateGrass);
+        propertyChangeSupport.firePropertyChange(ANIMATE_GRASS, oldValue, this.animateGrass);
     }
 
     public boolean isAnimateWater() {
         return animateWater;
     }
 
-    public static final String ANIMATE_WATER = "AnimateWater";
     public void setAnimateWater(boolean animateWater) {
+        boolean oldValue = this.animateWater;
         this.animateWater = animateWater;
-        propertyChangeSupport.firePropertyChange(ANIMATE_WATER, !this.animateWater, this.animateWater);
+        propertyChangeSupport.firePropertyChange(ANIMATE_WATER, oldValue, this.animateWater);
     }
 
     public boolean isDynamicShadows() {
         return dynamicShadows;
     }
 
-    public static final String DYNAMIC_SHADOWS = "DynamicShadows";
     public void setDynamicShadows(boolean dynamicShadows) {
+        boolean oldValue = this.dynamicShadows;
         this.dynamicShadows = dynamicShadows;
-        propertyChangeSupport.firePropertyChange(DYNAMIC_SHADOWS, !this.dynamicShadows, this.dynamicShadows);
+        propertyChangeSupport.firePropertyChange(DYNAMIC_SHADOWS, oldValue, this.dynamicShadows);
     }
 
     public float getFieldOfView() {
         return fieldOfView;
     }
 
-    public static final String FIELD_OF_VIEW = "FieldOfView";
     public void setFieldOfView(float fieldOfView) {
         float oldFieldOfView = this.fieldOfView;
         this.fieldOfView = fieldOfView;
@@ -234,20 +277,20 @@ public class RenderingConfig extends AbstractSubscribable {
         return cameraBobbing;
     }
 
-    public static final String CAMERA_BOBBING = "CameraBobbing";
     public void setCameraBobbing(boolean cameraBobbing) {
+        boolean oldValue = this.cameraBobbing;
         this.cameraBobbing = cameraBobbing;
-        propertyChangeSupport.firePropertyChange(CAMERA_BOBBING, !this.cameraBobbing, this.cameraBobbing);
+        propertyChangeSupport.firePropertyChange(CAMERA_BOBBING, oldValue, this.cameraBobbing);
     }
 
     public boolean isRenderPlacingBox() {
         return renderPlacingBox;
     }
 
-    public static final String RENDER_PLACING_BOX = "RenderPlacingBox";
     public void setRenderPlacingBox(boolean renderPlacingBox) {
+        boolean oldValue = this.renderPlacingBox;
         this.renderPlacingBox = renderPlacingBox;
-        propertyChangeSupport.firePropertyChange(RENDER_PLACING_BOX, !this.renderPlacingBox, this.renderPlacingBox);
+        propertyChangeSupport.firePropertyChange(RENDER_PLACING_BOX, oldValue, this.renderPlacingBox);
     }
 
     public int getBlurRadius() {
@@ -258,7 +301,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return blurIntensity;
     }
 
-    public static final String BLUR_INTENSITY = "BlurIntensity";
     public void setBlurIntensity(int blurIntensity) {
         int oldIntensity = this.blurIntensity;
         this.blurIntensity = blurIntensity;
@@ -269,107 +311,106 @@ public class RenderingConfig extends AbstractSubscribable {
         return reflectiveWater;
     }
 
-    public static final String REFLECTIVE_WATER = "ReflectiveWater";
     public void setReflectiveWater(boolean reflectiveWater) {
+        boolean oldValue = this.reflectiveWater;
         this.reflectiveWater = reflectiveWater;
-        propertyChangeSupport.firePropertyChange(REFLECTIVE_WATER, !this.reflectiveWater, this.reflectiveWater);
+        propertyChangeSupport.firePropertyChange(REFLECTIVE_WATER, oldValue, this.reflectiveWater);
     }
 
     public boolean isVignette() {
         return vignette;
     }
 
-    public static final String VIGNETTE = "Vignette";
     public void setVignette(boolean vignette) {
+        boolean oldValue = this.vignette;
         this.vignette = vignette;
-        propertyChangeSupport.firePropertyChange(VIGNETTE, !this.vignette, this.vignette);
+        propertyChangeSupport.firePropertyChange(VIGNETTE, oldValue, this.vignette);
     }
 
     public boolean isMotionBlur() {
         return motionBlur && !isOculusVrSupport();
     }
 
-    public static final String MOTION_BLUR = "MotionBlur";
     public void setMotionBlur(boolean motionBlur) {
+        boolean oldValue = this.motionBlur;
         this.motionBlur = motionBlur;
-        propertyChangeSupport.firePropertyChange(MOTION_BLUR, !this.motionBlur, this.motionBlur);
+        propertyChangeSupport.firePropertyChange(MOTION_BLUR, oldValue, this.motionBlur);
     }
 
     public boolean isSsao() {
         return ssao;
     }
 
-    public static final String SSAO = "Ssao";
     public void setSsao(boolean ssao) {
+        boolean oldValue = this.ssao;
         this.ssao = ssao;
-        propertyChangeSupport.firePropertyChange(SSAO, !this.ssao, this.ssao);
+        propertyChangeSupport.firePropertyChange(SSAO, oldValue, this.ssao);
     }
 
     public boolean isFilmGrain() {
         return filmGrain;
     }
 
-    public static final String FILM_GRAIN = "FilmGrain";
     public void setFilmGrain(boolean filmGrain) {
+        boolean oldValue = this.filmGrain;
         this.filmGrain = filmGrain;
-        propertyChangeSupport.firePropertyChange(FILM_GRAIN, !this.filmGrain, this.filmGrain);
+        propertyChangeSupport.firePropertyChange(FILM_GRAIN, oldValue, this.filmGrain);
     }
 
     public boolean isOutline() {
         return outline;
     }
 
-    public static final String OUTLINE = "Outline";
     public void setOutline(boolean outline) {
+        boolean oldValue = this.outline;
         this.outline = outline;
-        propertyChangeSupport.firePropertyChange(OUTLINE, !this.outline, this.outline);
+        propertyChangeSupport.firePropertyChange(OUTLINE, oldValue, this.outline);
     }
 
     public boolean isLightShafts() {
         return lightShafts;
     }
 
-    public static final String LIGHT_SHAFTS = "LightShafts";
     public void setLightShafts(boolean lightShafts) {
+        boolean oldValue = this.lightShafts;
         this.lightShafts = lightShafts;
-        propertyChangeSupport.firePropertyChange(LIGHT_SHAFTS, !this.lightShafts, this.lightShafts);
+        propertyChangeSupport.firePropertyChange(LIGHT_SHAFTS, oldValue, this.lightShafts);
     }
 
     public boolean isEyeAdaptation() {
         return eyeAdaptation;
     }
 
-    public static final String EYE_ADAPTATION = "EyeAdaptation";
     public void setEyeAdaptation(boolean eyeAdaptation) {
+        boolean oldValue = this.eyeAdaptation;
         this.eyeAdaptation = eyeAdaptation;
-        propertyChangeSupport.firePropertyChange(EYE_ADAPTATION, !this.eyeAdaptation, this.eyeAdaptation);
+        propertyChangeSupport.firePropertyChange(EYE_ADAPTATION, oldValue, this.eyeAdaptation);
     }
 
     public boolean isBloom() {
         return bloom;
     }
 
-    public static final String BLOOM = "Bloom";
     public void setBloom(boolean bloom) {
+        boolean oldValue = this.bloom;
         this.bloom = bloom;
-        propertyChangeSupport.firePropertyChange(BLOOM, !this.bloom, this.bloom);
+        propertyChangeSupport.firePropertyChange(BLOOM, oldValue, this.bloom);
     }
 
     public boolean isOculusVrSupport() {
         return oculusVrSupport;
     }
 
-    public static final String OCULUS_VR_SUPPORT = "OculusVrSupport";
     public void setOculusVrSupport(boolean oculusVrSupport) {
-            this.oculusVrSupport = oculusVrSupport;
-            propertyChangeSupport.firePropertyChange(OCULUS_VR_SUPPORT, !this.oculusVrSupport, this.oculusVrSupport);
+        boolean oldValue = this.oculusVrSupport;
+        this.oculusVrSupport = oculusVrSupport;
+        propertyChangeSupport.firePropertyChange(OCULUS_VR_SUPPORT, oldValue, this.oculusVrSupport);
     }    
 
     public int getMaxTextureAtlasResolution() {
         return maxTextureAtlasResolution;
     }
 
-    public static final String MAX_TEXTURE_ATLAS_RESOLUTION = "MaxTextureAtlasResolution";
     public void setMaxTextureAtlasResolution(int maxTextureAtlasResolution) {
         int oldResolution = this.maxTextureAtlasResolution;
         this.maxTextureAtlasResolution = maxTextureAtlasResolution;
@@ -380,7 +421,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return maxChunksUsedForShadowMapping;
     }
 
-    public static final String MAX_CHUNKS_USED_FOR_SHADOW_MAPPING = "MaxChunksUsedForShadowMapping";
     public void setMaxChunksUsedForShadowMapping(int maxChunksUsedForShadowMapping) {
         int oldValue = this.maxChunksUsedForShadowMapping;
         this.maxChunksUsedForShadowMapping = maxChunksUsedForShadowMapping;
@@ -391,7 +431,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return shadowMapResolution;
     }
 
-    public static final String SHADOW_MAP_RESOLUTION = "ShadowMapResolution";
     public void setShadowMapResolution(int shadowMapResolution) {
         int oldResolution = this.shadowMapResolution;
         this.shadowMapResolution = shadowMapResolution;
@@ -401,76 +440,75 @@ public class RenderingConfig extends AbstractSubscribable {
         return normalMapping;
     }
 
-    public static final String NORMAL_MAPPING = "NormalMapping";
     public void setNormalMapping(boolean normalMapping) {
+        boolean oldValue = this.normalMapping;
         this.normalMapping = normalMapping;
-        propertyChangeSupport.firePropertyChange(NORMAL_MAPPING, !this.normalMapping, this.normalMapping);
+        propertyChangeSupport.firePropertyChange(NORMAL_MAPPING, oldValue, this.normalMapping);
     }
     
     public boolean isParallaxMapping() {
         return parallaxMapping;
     }
 
-    public static final String PARALLAX_MAPPING = "ParallaxMapping";
     public void setParallaxMapping(boolean parallaxMapping) {
+        boolean oldValue = this.parallaxMapping;
         this.parallaxMapping = parallaxMapping;
-        propertyChangeSupport.firePropertyChange(PARALLAX_MAPPING, !this.parallaxMapping, this.parallaxMapping);
+        propertyChangeSupport.firePropertyChange(PARALLAX_MAPPING, oldValue, this.parallaxMapping);
     }
 
     public boolean isDynamicShadowsPcfFiltering() {
         return dynamicShadowsPcfFiltering;
     }
 
-    public static final String DYNAMIC_SHADOWS_PCF_FILTERING = "DynamicShadowsPcfFiltering";
     public void setDynamicShadowsPcfFiltering(boolean dynamicShadowsPcfFiltering) {
+        boolean oldValue = this.dynamicShadowsPcfFiltering;
         this.dynamicShadowsPcfFiltering = dynamicShadowsPcfFiltering;
-        propertyChangeSupport.firePropertyChange(DYNAMIC_SHADOWS_PCF_FILTERING, !this.dynamicShadowsPcfFiltering, this.dynamicShadowsPcfFiltering);
+        propertyChangeSupport.firePropertyChange(DYNAMIC_SHADOWS_PCF_FILTERING, oldValue, this.dynamicShadowsPcfFiltering);
     }
 
     public boolean isCloudShadows() {
         return cloudShadows;
     }
 
-    public static final String CLOUD_SHADOWS = "CloudShadows";
     public void setCloudShadows(boolean cloudShadows) {
+        boolean oldValue = this.cloudShadows;
         this.cloudShadows = cloudShadows;
-        propertyChangeSupport.firePropertyChange(CLOUD_SHADOWS, !this.cloudShadows, this.cloudShadows);
+        propertyChangeSupport.firePropertyChange(CLOUD_SHADOWS, oldValue, this.cloudShadows);
     }
 
     public boolean isLocalReflections() {
         return this.localReflections;
     }
 
-    public static final String LOCAL_REFLECTIONS = "LocalReflections";
     public void setLocalReflections(boolean localReflections) {
+        boolean oldValue = this.localReflections;
         this.localReflections = localReflections;
-        propertyChangeSupport.firePropertyChange(LOCAL_REFLECTIONS, !this.localReflections, this.localReflections);
+        propertyChangeSupport.firePropertyChange(LOCAL_REFLECTIONS, oldValue, this.localReflections);
     }
 
     public boolean isInscattering() {
         return this.inscattering;
     }
 
-    public static final String INSCATTERING = "Inscattering";
     public void setInscattering(boolean inscattering) {
+        boolean oldValue = this.inscattering;
         this.inscattering = inscattering;
-        propertyChangeSupport.firePropertyChange(INSCATTERING, !this.inscattering, this.inscattering);
+        propertyChangeSupport.firePropertyChange(INSCATTERING, oldValue, this.inscattering);
     }
 
     public boolean isRenderNearest() {
         return renderNearest;
     }
 
-    public static final String RENDER_NEAREST = "RenderNearest";
     public void setRenderNearest(boolean renderNearest) {
+        boolean oldValue = this.renderNearest;
         this.renderNearest = renderNearest;
-        propertyChangeSupport.firePropertyChange(RENDER_NEAREST, !this.renderNearest, this.renderNearest);
+        propertyChangeSupport.firePropertyChange(RENDER_NEAREST, oldValue, this.renderNearest);
     }
     public int getParticleEffectLimit() {
         return particleEffectLimit;
     }
 
-    public static final String PARTICLE_EFFECT_LIMIT = "ParticleEffectLimit";
     public void setParticleEffectLimit(int particleEffectLimit) {
         int oldLimit = this.particleEffectLimit;
         this.particleEffectLimit = particleEffectLimit;
@@ -481,7 +519,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return meshLimit;
     }
 
-    public static final String MESH_LIMIT = "MeshLimit";
     public void setMeshLimit(int meshLimit) {
         int oldLimit = this.meshLimit;
         this.meshLimit = meshLimit;
@@ -491,10 +528,10 @@ public class RenderingConfig extends AbstractSubscribable {
         return this.vSync;
     }
 
-    public static final String V_SYNC = "VSync";
-    public void setVSync(boolean vSync) {
-        this.vSync = vSync;
-        propertyChangeSupport.firePropertyChange(V_SYNC, !this.vSync, this.vSync);
+    public void setVSync(boolean vsync) {
+        boolean oldValue = this.vSync;
+        this.vSync = vsync;
+        propertyChangeSupport.firePropertyChange(V_SYNC, oldValue, this.vSync);
     }
 
     public RenderingDebugConfig getDebug() {
@@ -505,7 +542,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return frameLimit;
     }
 
-    public static final String FRAME_LIMIT = "FrameLimit";
     public void setFrameLimit(int frameLimit) {
         int oldLimit = this.frameLimit;
         this.frameLimit = frameLimit;
@@ -516,7 +552,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return fboScale;
     }
 
-    public static final String FBO_SCALE = "FboScale";
     public void setFboScale(int fboScale) {
         int oldScale = this.fboScale;
         this.fboScale = fboScale;
@@ -527,17 +562,16 @@ public class RenderingConfig extends AbstractSubscribable {
         return clampLighting;
     }
 
-    public static final String CLAMP_LIGHTING = "ClampLighting";
     public void setClampLighting(boolean clampLighting) {
+        boolean oldValue = this.clampLighting;
         this.clampLighting = clampLighting;
-        propertyChangeSupport.firePropertyChange(CLAMP_LIGHTING, !this.clampLighting, this.clampLighting);
+        propertyChangeSupport.firePropertyChange(CLAMP_LIGHTING, oldValue, this.clampLighting);
     }
 
     public ScreenshotSize getScreenshotSize() {
         return screenshotSize;
     }
 
-    public static final String SCREENSHOT_SIZE = "screenshotSize";
     public void setScreenshotSize(ScreenshotSize screenshotSize) {
         ScreenshotSize oldSize = this.screenshotSize;
         this.screenshotSize = screenshotSize;
@@ -552,7 +586,6 @@ public class RenderingConfig extends AbstractSubscribable {
         return screenshotFormat;
     }
 
-    public static final String SCREENSHOT_FORMAT = "ScreenshotFormat";
     public void setScreenshotFormat(String screenshotFormat) {
 
         // propertyChangeSupport fires if oldFormat != newFormat which in the case of strings is always true.
@@ -569,20 +602,20 @@ public class RenderingConfig extends AbstractSubscribable {
         return dumpShaders;
     }
 
-    public static final String DUMP_SHADERS = "DumpShaders";
     public void setDumpShaders(boolean dumpShaders) {
+        boolean oldValue = this.dumpShaders;
         this.dumpShaders = dumpShaders;
-        propertyChangeSupport.firePropertyChange(DUMP_SHADERS, !this.dumpShaders, this.dumpShaders);
+        propertyChangeSupport.firePropertyChange(DUMP_SHADERS, oldValue, this.dumpShaders);
     }
     
     public boolean isVolumetricFog() {
         return volumetricFog;
     }
 
-    public static final String VOLUMETRIC_FOG = "VolumetricFog";
     public void setVolumetricFog(boolean volumetricFog) {
+        boolean oldValue = this.volumetricFog;
         this.volumetricFog = volumetricFog;
-        propertyChangeSupport.firePropertyChange(VOLUMETRIC_FOG, !this.volumetricFog, this.volumetricFog);
+        propertyChangeSupport.firePropertyChange(VOLUMETRIC_FOG, oldValue, this.volumetricFog);
     }
 
 }

--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -21,14 +21,14 @@ import org.lwjgl.opengl.PixelFormat;
 import org.terasology.rendering.cameras.PerspectiveCameraSettings;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.ScreenshotSize;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
+import org.terasology.utilities.subscribables.AbstractSubscribable;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
 /**
  */
-public class RenderingConfig {
-    public static final String VIEW_DISTANCE = "viewDistance";
+public class RenderingConfig extends AbstractSubscribable {
 
     private PixelFormat pixelFormat;
     private int windowPosX;
@@ -80,9 +80,6 @@ public class RenderingConfig {
 
     private RenderingDebugConfig debug = new RenderingDebugConfig();
 
-    private transient PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
-
-
     public PerspectiveCameraSettings getCameraSettings() {
         return cameraSettings;
     }
@@ -91,131 +88,166 @@ public class RenderingConfig {
         return pixelFormat;
     }
 
+    public static final String PIXEL_FORMAT = "PixelFormat";
     public void setPixelFormat(PixelFormat pixelFormat) {
+        PixelFormat oldFormat = this.pixelFormat;
         this.pixelFormat = pixelFormat;
+        propertyChangeSupport.firePropertyChange(PIXEL_FORMAT, oldFormat, this.pixelFormat);
+        // propertyChangeSupport fires only if oldObject != newObject.
+        // This method could theoretically use a better equality check then. In practice
+        // it's unlikely a new PixelFormat instance will ever be value-per-value identical
+        // to the previous one, -not- needing a change event firing.
     }
 
     public int getWindowPosX() {
         return windowPosX;
     }
 
-    public void setWindowPosX(int posX) {
-        this.windowPosX = posX;
+    public static final String WINDOW_POS_X = "WindowPosX";
+    public void setWindowPosX(int windowPosX) {
+        int oldValue = this.windowPosX;
+        this.windowPosX = windowPosX;
+        propertyChangeSupport.firePropertyChange(WINDOW_POS_X, oldValue, this.windowPosX);
     }
 
     public int getWindowPosY() {
         return windowPosY;
     }
 
-    public void setWindowPosY(int posY) {
-        this.windowPosY = posY;
+    public static final String WINDOW_POS_Y = "WindowPosY";
+    public void setWindowPosY(int windowPosY) {
+        int oldValue = this.windowPosY;
+        this.windowPosY = windowPosY;
+        propertyChangeSupport.firePropertyChange(WINDOW_POS_Y, oldValue, this.windowPosY);
     }
 
     public int getWindowWidth() {
         return windowWidth;
     }
 
+    public static final String WINDOW_WIDTH = "WindowWidth";
     public void setWindowWidth(int windowWidth) {
+        int oldValue = this.windowWidth;
         this.windowWidth = windowWidth;
+        propertyChangeSupport.firePropertyChange(WINDOW_WIDTH, oldValue, this.windowWidth);
     }
 
-    public int getWindowHeight() {
-        return windowHeight;
-    }
+    public int getWindowHeight() { return windowHeight; }
 
+    public static final String WINDOW_HEIGHT = "WindowHeight";
     public void setWindowHeight(int windowHeight) {
-        this.windowHeight = windowHeight;
+            int oldValue = this.windowHeight;
+            this.windowHeight = windowHeight;
+            propertyChangeSupport.firePropertyChange(WINDOW_HEIGHT, oldValue, this.windowHeight);
     }
 
     public DisplayMode getDisplayMode() {
         return new DisplayMode(windowWidth, windowHeight);
     }
 
-    public boolean isFullscreen() {
-        return fullscreen;
-    }
+    public boolean isFullscreen() { return fullscreen; }
 
+    public static final String FULLSCREEN = "FullScreen";
     public void setFullscreen(boolean fullscreen) {
         this.fullscreen = fullscreen;
+        propertyChangeSupport.firePropertyChange(FULLSCREEN, !this.fullscreen, this.fullscreen);
     }
 
     public boolean isAnimatedMenu() {
         return animatedMenu;
     }
 
+    public static final String ANIMATED_MENU = "AnimatedMenu";
     public void setAnimatedMenu(boolean animatedMenu) {
         this.animatedMenu = animatedMenu;
+        propertyChangeSupport.firePropertyChange(ANIMATED_MENU, !this.animatedMenu, this.animatedMenu);
     }
 
     public ViewDistance getViewDistance() {
         return viewDistance;
     }
 
+    public static final String VIEW_DISTANCE = "viewDistance";
     /**
      * Sets the view distance and notifies the property change listeners registered via
      * {@link RenderingConfig#subscribe(PropertyChangeListener)} that listen for the property {@link #VIEW_DISTANCE}.
      * @param viewDistance the new view distance
      */
     public void setViewDistance(ViewDistance viewDistance) {
-        ViewDistance oldValue = this.viewDistance;
+        ViewDistance oldDistance = this.viewDistance;
         this.viewDistance = viewDistance;
-        propertyChangeSupport.firePropertyChange(VIEW_DISTANCE, oldValue, viewDistance);
+        propertyChangeSupport.firePropertyChange(VIEW_DISTANCE, oldDistance, viewDistance);
     }
 
     public boolean isFlickeringLight() {
         return flickeringLight;
     }
 
+    public static final String FLICKERING_LIGHT = "FlickeringLight";
     public void setFlickeringLight(boolean flickeringLight) {
         this.flickeringLight = flickeringLight;
+        propertyChangeSupport.firePropertyChange(FLICKERING_LIGHT, !this.flickeringLight, this.flickeringLight);
     }
 
     public boolean isAnimateGrass() {
         return animateGrass;
     }
 
+    public static final String ANIMATE_GRASS = "AnimateGrass";
     public void setAnimateGrass(boolean animateGrass) {
         this.animateGrass = animateGrass;
+        propertyChangeSupport.firePropertyChange(ANIMATE_GRASS, !this.animateGrass, this.animateGrass);
     }
 
     public boolean isAnimateWater() {
         return animateWater;
     }
 
+    public static final String ANIMATE_WATER = "AnimateWater";
     public void setAnimateWater(boolean animateWater) {
         this.animateWater = animateWater;
+        propertyChangeSupport.firePropertyChange(ANIMATE_WATER, !this.animateWater, this.animateWater);
     }
 
     public boolean isDynamicShadows() {
         return dynamicShadows;
     }
 
+    public static final String DYNAMIC_SHADOWS = "DynamicShadows";
     public void setDynamicShadows(boolean dynamicShadows) {
         this.dynamicShadows = dynamicShadows;
+        propertyChangeSupport.firePropertyChange(DYNAMIC_SHADOWS, !this.dynamicShadows, this.dynamicShadows);
     }
 
     public float getFieldOfView() {
         return fieldOfView;
     }
 
+    public static final String FIELD_OF_VIEW = "FieldOfView";
     public void setFieldOfView(float fieldOfView) {
+        float oldFieldOfView = this.fieldOfView;
         this.fieldOfView = fieldOfView;
+        propertyChangeSupport.firePropertyChange(FIELD_OF_VIEW, oldFieldOfView, this.fieldOfView);
     }
 
     public boolean isCameraBobbing() {
         return cameraBobbing;
     }
 
+    public static final String CAMERA_BOBBING = "CameraBobbing";
     public void setCameraBobbing(boolean cameraBobbing) {
         this.cameraBobbing = cameraBobbing;
+        propertyChangeSupport.firePropertyChange(CAMERA_BOBBING, !this.cameraBobbing, this.cameraBobbing);
     }
 
     public boolean isRenderPlacingBox() {
         return renderPlacingBox;
     }
 
+    public static final String RENDER_PLACING_BOX = "RenderPlacingBox";
     public void setRenderPlacingBox(boolean renderPlacingBox) {
         this.renderPlacingBox = renderPlacingBox;
+        propertyChangeSupport.firePropertyChange(RENDER_PLACING_BOX, !this.renderPlacingBox, this.renderPlacingBox);
     }
 
     public int getBlurRadius() {
@@ -226,192 +258,243 @@ public class RenderingConfig {
         return blurIntensity;
     }
 
+    public static final String BLUR_INTENSITY = "BlurIntensity";
     public void setBlurIntensity(int blurIntensity) {
+        int oldIntensity = this.blurIntensity;
         this.blurIntensity = blurIntensity;
+        propertyChangeSupport.firePropertyChange(BLUR_INTENSITY, oldIntensity, this.blurIntensity);
     }
 
     public boolean isReflectiveWater() {
         return reflectiveWater;
     }
 
+    public static final String REFLECTIVE_WATER = "ReflectiveWater";
     public void setReflectiveWater(boolean reflectiveWater) {
         this.reflectiveWater = reflectiveWater;
+        propertyChangeSupport.firePropertyChange(REFLECTIVE_WATER, !this.reflectiveWater, this.reflectiveWater);
     }
 
     public boolean isVignette() {
         return vignette;
     }
 
+    public static final String VIGNETTE = "Vignette";
     public void setVignette(boolean vignette) {
         this.vignette = vignette;
+        propertyChangeSupport.firePropertyChange(VIGNETTE, !this.vignette, this.vignette);
     }
 
     public boolean isMotionBlur() {
         return motionBlur && !isOculusVrSupport();
     }
 
+    public static final String MOTION_BLUR = "MotionBlur";
     public void setMotionBlur(boolean motionBlur) {
         this.motionBlur = motionBlur;
+        propertyChangeSupport.firePropertyChange(MOTION_BLUR, !this.motionBlur, this.motionBlur);
     }
 
     public boolean isSsao() {
         return ssao;
     }
 
+    public static final String SSAO = "Ssao";
     public void setSsao(boolean ssao) {
         this.ssao = ssao;
+        propertyChangeSupport.firePropertyChange(SSAO, !this.ssao, this.ssao);
     }
 
     public boolean isFilmGrain() {
         return filmGrain;
     }
 
+    public static final String FILM_GRAIN = "FilmGrain";
     public void setFilmGrain(boolean filmGrain) {
         this.filmGrain = filmGrain;
+        propertyChangeSupport.firePropertyChange(FILM_GRAIN, !this.filmGrain, this.filmGrain);
     }
 
     public boolean isOutline() {
         return outline;
     }
 
+    public static final String OUTLINE = "Outline";
     public void setOutline(boolean outline) {
         this.outline = outline;
+        propertyChangeSupport.firePropertyChange(OUTLINE, !this.outline, this.outline);
     }
 
     public boolean isLightShafts() {
         return lightShafts;
     }
 
+    public static final String LIGHT_SHAFTS = "LightShafts";
     public void setLightShafts(boolean lightShafts) {
         this.lightShafts = lightShafts;
+        propertyChangeSupport.firePropertyChange(LIGHT_SHAFTS, !this.lightShafts, this.lightShafts);
     }
 
     public boolean isEyeAdaptation() {
         return eyeAdaptation;
     }
 
+    public static final String EYE_ADAPTATION = "EyeAdaptation";
     public void setEyeAdaptation(boolean eyeAdaptation) {
         this.eyeAdaptation = eyeAdaptation;
+        propertyChangeSupport.firePropertyChange(EYE_ADAPTATION, !this.eyeAdaptation, this.eyeAdaptation);
     }
 
     public boolean isBloom() {
         return bloom;
     }
 
+    public static final String BLOOM = "Bloom";
     public void setBloom(boolean bloom) {
         this.bloom = bloom;
+        propertyChangeSupport.firePropertyChange(BLOOM, !this.bloom, this.bloom);
     }
 
     public boolean isOculusVrSupport() {
         return oculusVrSupport;
     }
 
+    public static final String OCULUS_VR_SUPPORT = "OculusVrSupport";
     public void setOculusVrSupport(boolean oculusVrSupport) {
-        this.oculusVrSupport = oculusVrSupport;
-    }
+            this.oculusVrSupport = oculusVrSupport;
+            propertyChangeSupport.firePropertyChange(OCULUS_VR_SUPPORT, !this.oculusVrSupport, this.oculusVrSupport);
+    }    
 
     public int getMaxTextureAtlasResolution() {
         return maxTextureAtlasResolution;
     }
 
+    public static final String MAX_TEXTURE_ATLAS_RESOLUTION = "MaxTextureAtlasResolution";
     public void setMaxTextureAtlasResolution(int maxTextureAtlasResolution) {
+        int oldResolution = this.maxTextureAtlasResolution;
         this.maxTextureAtlasResolution = maxTextureAtlasResolution;
+        propertyChangeSupport.firePropertyChange(MAX_TEXTURE_ATLAS_RESOLUTION, oldResolution, this.maxTextureAtlasResolution);
     }
 
     public int getMaxChunksUsedForShadowMapping() {
         return maxChunksUsedForShadowMapping;
     }
 
+    public static final String MAX_CHUNKS_USED_FOR_SHADOW_MAPPING = "MaxChunksUsedForShadowMapping";
     public void setMaxChunksUsedForShadowMapping(int maxChunksUsedForShadowMapping) {
+        int oldValue = this.maxChunksUsedForShadowMapping;
         this.maxChunksUsedForShadowMapping = maxChunksUsedForShadowMapping;
+        propertyChangeSupport.firePropertyChange(MAX_CHUNKS_USED_FOR_SHADOW_MAPPING, oldValue, this.maxChunksUsedForShadowMapping);
     }
 
     public int getShadowMapResolution() {
         return shadowMapResolution;
     }
 
+    public static final String SHADOW_MAP_RESOLUTION = "ShadowMapResolution";
     public void setShadowMapResolution(int shadowMapResolution) {
+        int oldResolution = this.shadowMapResolution;
         this.shadowMapResolution = shadowMapResolution;
+        propertyChangeSupport.firePropertyChange(SHADOW_MAP_RESOLUTION, oldResolution, this.shadowMapResolution);
     }
-
     public boolean isNormalMapping() {
         return normalMapping;
     }
 
+    public static final String NORMAL_MAPPING = "NormalMapping";
     public void setNormalMapping(boolean normalMapping) {
         this.normalMapping = normalMapping;
+        propertyChangeSupport.firePropertyChange(NORMAL_MAPPING, !this.normalMapping, this.normalMapping);
     }
-
+    
     public boolean isParallaxMapping() {
         return parallaxMapping;
     }
 
+    public static final String PARALLAX_MAPPING = "ParallaxMapping";
     public void setParallaxMapping(boolean parallaxMapping) {
         this.parallaxMapping = parallaxMapping;
+        propertyChangeSupport.firePropertyChange(PARALLAX_MAPPING, !this.parallaxMapping, this.parallaxMapping);
     }
 
     public boolean isDynamicShadowsPcfFiltering() {
         return dynamicShadowsPcfFiltering;
     }
 
+    public static final String DYNAMIC_SHADOWS_PCF_FILTERING = "DynamicShadowsPcfFiltering";
     public void setDynamicShadowsPcfFiltering(boolean dynamicShadowsPcfFiltering) {
         this.dynamicShadowsPcfFiltering = dynamicShadowsPcfFiltering;
+        propertyChangeSupport.firePropertyChange(DYNAMIC_SHADOWS_PCF_FILTERING, !this.dynamicShadowsPcfFiltering, this.dynamicShadowsPcfFiltering);
     }
 
     public boolean isCloudShadows() {
         return cloudShadows;
     }
 
+    public static final String CLOUD_SHADOWS = "CloudShadows";
     public void setCloudShadows(boolean cloudShadows) {
         this.cloudShadows = cloudShadows;
+        propertyChangeSupport.firePropertyChange(CLOUD_SHADOWS, !this.cloudShadows, this.cloudShadows);
     }
 
     public boolean isLocalReflections() {
         return this.localReflections;
     }
 
+    public static final String LOCAL_REFLECTIONS = "LocalReflections";
     public void setLocalReflections(boolean localReflections) {
         this.localReflections = localReflections;
+        propertyChangeSupport.firePropertyChange(LOCAL_REFLECTIONS, !this.localReflections, this.localReflections);
     }
 
     public boolean isInscattering() {
         return this.inscattering;
     }
 
+    public static final String INSCATTERING = "Inscattering";
     public void setInscattering(boolean inscattering) {
         this.inscattering = inscattering;
+        propertyChangeSupport.firePropertyChange(INSCATTERING, !this.inscattering, this.inscattering);
     }
 
     public boolean isRenderNearest() {
         return renderNearest;
     }
 
+    public static final String RENDER_NEAREST = "RenderNearest";
     public void setRenderNearest(boolean renderNearest) {
         this.renderNearest = renderNearest;
+        propertyChangeSupport.firePropertyChange(RENDER_NEAREST, !this.renderNearest, this.renderNearest);
     }
-
     public int getParticleEffectLimit() {
         return particleEffectLimit;
     }
 
+    public static final String PARTICLE_EFFECT_LIMIT = "ParticleEffectLimit";
     public void setParticleEffectLimit(int particleEffectLimit) {
+        int oldLimit = this.particleEffectLimit;
         this.particleEffectLimit = particleEffectLimit;
+        propertyChangeSupport.firePropertyChange(PARTICLE_EFFECT_LIMIT, oldLimit, this.particleEffectLimit);
     }
 
     public int getMeshLimit() {
         return meshLimit;
     }
 
+    public static final String MESH_LIMIT = "MeshLimit";
     public void setMeshLimit(int meshLimit) {
+        int oldLimit = this.meshLimit;
         this.meshLimit = meshLimit;
+        propertyChangeSupport.firePropertyChange(MESH_LIMIT, oldLimit, this.meshLimit);
     }
-
     public boolean isVSync() {
         return this.vSync;
     }
 
-    public void setVSync(boolean value) {
-        this.vSync = value;
+    public static final String V_SYNC = "VSync";
+    public void setVSync(boolean vSync) {
+        this.vSync = vSync;
+        propertyChangeSupport.firePropertyChange(V_SYNC, !this.vSync, this.vSync);
     }
 
     public RenderingDebugConfig getDebug() {
@@ -422,66 +505,84 @@ public class RenderingConfig {
         return frameLimit;
     }
 
+    public static final String FRAME_LIMIT = "FrameLimit";
     public void setFrameLimit(int frameLimit) {
+        int oldLimit = this.frameLimit;
         this.frameLimit = frameLimit;
+        propertyChangeSupport.firePropertyChange(FRAME_LIMIT, oldLimit, this.frameLimit);
     }
 
     public int getFboScale() {
         return fboScale;
     }
 
+    public static final String FBO_SCALE = "FboScale";
     public void setFboScale(int fboScale) {
+        int oldScale = this.fboScale;
         this.fboScale = fboScale;
+        propertyChangeSupport.firePropertyChange(FBO_SCALE, oldScale, this.fboScale);
     }
 
     public boolean isClampLighting() {
         return clampLighting;
     }
 
+    public static final String CLAMP_LIGHTING = "ClampLighting";
     public void setClampLighting(boolean clampLighting) {
         this.clampLighting = clampLighting;
+        propertyChangeSupport.firePropertyChange(CLAMP_LIGHTING, !this.clampLighting, this.clampLighting);
     }
 
     public ScreenshotSize getScreenshotSize() {
         return screenshotSize;
     }
 
+    public static final String SCREENSHOT_SIZE = "screenshotSize";
     public void setScreenshotSize(ScreenshotSize screenshotSize) {
+        ScreenshotSize oldSize = this.screenshotSize;
         this.screenshotSize = screenshotSize;
+        propertyChangeSupport.firePropertyChange(SCREENSHOT_SIZE, oldSize, this.screenshotSize);
+        // propertyChangeSupport fires only if oldObject != newObject.
+        // This method could theoretically use a better equality check then. In practice
+        // it's unlikely a new ScreenshotSize instance will ever be value-per-value identical
+        // to the previous one, not requiring the event to be fired.
     }
 
     public String getScreenshotFormat() {
         return screenshotFormat;
     }
 
+    public static final String SCREENSHOT_FORMAT = "ScreenshotFormat";
     public void setScreenshotFormat(String screenshotFormat) {
-        this.screenshotFormat = screenshotFormat;
+
+        // propertyChangeSupport fires if oldFormat != newFormat which in the case of strings is always true.
+        // For this case we therefore use the equals method to prevent identical strings triggering the
+        // firing of the change event.
+        if (!this.screenshotFormat.equals(screenshotFormat)) {
+            String oldFormat = this.screenshotFormat;
+            this.screenshotFormat = screenshotFormat;
+            propertyChangeSupport.firePropertyChange(SCREENSHOT_FORMAT, oldFormat, this.screenshotFormat);
+        }
     }
 
     public boolean isDumpShaders() {
         return dumpShaders;
     }
 
+    public static final String DUMP_SHADERS = "DumpShaders";
     public void setDumpShaders(boolean dumpShaders) {
         this.dumpShaders = dumpShaders;
+        propertyChangeSupport.firePropertyChange(DUMP_SHADERS, !this.dumpShaders, this.dumpShaders);
     }
-
-    /**
-     * Subscribe a listener that gets nofified when a property cahnges..
-     */
-    public void subscribe(PropertyChangeListener changeListener) {
-        this.propertyChangeSupport.addPropertyChangeListener(changeListener);
-    }
-
-    public void unsubscribe(PropertyChangeListener changeListener) {
-        this.propertyChangeSupport.removePropertyChangeListener(changeListener);
-    }
-
+    
     public boolean isVolumetricFog() {
         return volumetricFog;
     }
 
+    public static final String VOLUMETRIC_FOG = "VolumetricFog";
     public void setVolumetricFog(boolean volumetricFog) {
         this.volumetricFog = volumetricFog;
+        propertyChangeSupport.firePropertyChange(VOLUMETRIC_FOG, !this.volumetricFog, this.volumetricFog);
     }
+
 }

--- a/engine/src/main/java/org/terasology/config/RenderingDebugConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingDebugConfig.java
@@ -56,6 +56,14 @@ public class RenderingDebugConfig extends AbstractSubscribable {
         }
     }
 
+    public static final String WIREFRAME = "wireframe";
+    public static final String ENABLED = "enabled";
+    public static final String STAGE = "stage";
+    public static final String FIRST_PERSON_ELEMENTS_HIDDEN = "FirstPersonElementsHidden";
+    public static final String HUD_HIDDEN = "hudHidden";
+    public static final String RENDER_CHUNK_BOUNDING_BOXES = "renderChunkBoundingBoxes";
+    public static final String RENDER_SKELETONS = "renderSkeletons";
+
     private boolean enabled;
     private DebugRenderingStage stage;
     private boolean firstPersonElementsHidden;
@@ -64,25 +72,24 @@ public class RenderingDebugConfig extends AbstractSubscribable {
     private boolean renderChunkBoundingBoxes;
     private boolean renderSkeletons;
 
-
     public boolean isWireframe() {
         return wireframe;
     }
 
-    public static final String WIREFRAME = "wireframe";
-    public void setWireframe(boolean Wireframe) {
-        this.wireframe = Wireframe;
-        propertyChangeSupport.firePropertyChange(WIREFRAME, !this.wireframe, this.wireframe);
+    public void setWireframe(boolean wireframe) {
+        boolean oldValue = this.wireframe;
+        this.wireframe = wireframe;
+        propertyChangeSupport.firePropertyChange(WIREFRAME, oldValue, this.wireframe);
     }
 
     public boolean isEnabled() {
         return enabled;
     }
 
-    public static final String ENABLED = "enabled";
     public void setEnabled(boolean enabled) {
+        boolean oldValue = this.enabled;
         this.enabled = enabled;
-        propertyChangeSupport.firePropertyChange(ENABLED, !this.enabled, this.enabled);
+        propertyChangeSupport.firePropertyChange(ENABLED, oldValue, this.enabled);
     }
 
     public void cycleStage() {
@@ -93,7 +100,6 @@ public class RenderingDebugConfig extends AbstractSubscribable {
         return stage;
     }
 
-    public static final String STAGE = "stage";
     public void setStage(DebugRenderingStage stage) {
         DebugRenderingStage oldStage = this.stage;
         this.stage = stage;
@@ -104,40 +110,40 @@ public class RenderingDebugConfig extends AbstractSubscribable {
         return firstPersonElementsHidden;
     }
 
-    public static final String FIRST_PERSON_ELEMENTS_HIDDEN = "FirstPersonElementsHidden";
-    public void setFirstPersonElementsHidden(boolean FirstPersonElementsHidden) {
-        this.firstPersonElementsHidden = FirstPersonElementsHidden;
-        propertyChangeSupport.firePropertyChange(FIRST_PERSON_ELEMENTS_HIDDEN, !this.firstPersonElementsHidden, this.firstPersonElementsHidden);
+    public void setFirstPersonElementsHidden(boolean firstPersonElementsHidden) {
+        boolean oldValue = this.firstPersonElementsHidden;
+        this.firstPersonElementsHidden = firstPersonElementsHidden;
+        propertyChangeSupport.firePropertyChange(FIRST_PERSON_ELEMENTS_HIDDEN, oldValue, this.firstPersonElementsHidden);
     }
 
     public boolean isHudHidden() {
         return hudHidden;
     }
 
-    public static final String HUD_HIDDEN = "hudHidden";
     public void setHudHidden(boolean hudHidden) {
+        boolean oldValue = this.hudHidden;
         this.hudHidden = hudHidden;
-        propertyChangeSupport.firePropertyChange(HUD_HIDDEN, !this.hudHidden, this.hudHidden);
+        propertyChangeSupport.firePropertyChange(HUD_HIDDEN, oldValue, this.hudHidden);
     }
 
     public boolean isRenderChunkBoundingBoxes() {
         return renderChunkBoundingBoxes;
     }
 
-    public static final String RENDER_CHUNK_BOUNDING_BOXES = "renderChunkBoundingBoxes";
     public void setRenderChunkBoundingBoxes(boolean renderChunkBoundingBoxes) {
+        boolean oldValue = this.renderChunkBoundingBoxes;
         this.renderChunkBoundingBoxes = renderChunkBoundingBoxes;
-        propertyChangeSupport.firePropertyChange(RENDER_CHUNK_BOUNDING_BOXES, !this.renderChunkBoundingBoxes, this.renderChunkBoundingBoxes);
+        propertyChangeSupport.firePropertyChange(RENDER_CHUNK_BOUNDING_BOXES, oldValue, this.renderChunkBoundingBoxes);
     }
 
     public boolean isRenderSkeletons() {
         return renderSkeletons;
     }
 
-    public static final String RENDER_SKELETONS = "renderSkeletons";
     public void setRenderSkeletons(boolean renderSkeletons) {
+        boolean oldValue = this.renderSkeletons;
         this.renderSkeletons = renderSkeletons;
-        propertyChangeSupport.firePropertyChange(RENDER_SKELETONS, !this.renderSkeletons, this.renderSkeletons);
+        propertyChangeSupport.firePropertyChange(RENDER_SKELETONS, oldValue, this.renderSkeletons);
     }
 
 }

--- a/engine/src/main/java/org/terasology/config/RenderingDebugConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingDebugConfig.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.config;
 
+import org.terasology.utilities.subscribables.AbstractSubscribable;
+
 /**
  */
-public class RenderingDebugConfig {
+public class RenderingDebugConfig extends AbstractSubscribable {
 
     public enum DebugRenderingStage {
         OPAQUE_COLOR(0, "DEBUG_STAGE_OPAQUE_COLOR"),
@@ -40,7 +42,7 @@ public class RenderingDebugConfig {
         private int index;
         private String defineName;
 
-        private DebugRenderingStage(int index, String defineName) {
+        DebugRenderingStage(int index, String defineName) {
             this.index = index;
             this.defineName = defineName;
         }
@@ -62,20 +64,25 @@ public class RenderingDebugConfig {
     private boolean renderChunkBoundingBoxes;
     private boolean renderSkeletons;
 
+
     public boolean isWireframe() {
         return wireframe;
     }
 
-    public void setWireframe(boolean wireframe) {
-        this.wireframe = wireframe;
+    public static final String WIREFRAME = "wireframe";
+    public void setWireframe(boolean Wireframe) {
+        this.wireframe = Wireframe;
+        propertyChangeSupport.firePropertyChange(WIREFRAME, !this.wireframe, this.wireframe);
     }
 
     public boolean isEnabled() {
         return enabled;
     }
 
+    public static final String ENABLED = "enabled";
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+        propertyChangeSupport.firePropertyChange(ENABLED, !this.enabled, this.enabled);
     }
 
     public void cycleStage() {
@@ -86,39 +93,51 @@ public class RenderingDebugConfig {
         return stage;
     }
 
+    public static final String STAGE = "stage";
     public void setStage(DebugRenderingStage stage) {
+        DebugRenderingStage oldStage = this.stage;
         this.stage = stage;
+        propertyChangeSupport.firePropertyChange(STAGE, oldStage, this.stage);
     }
 
     public boolean isFirstPersonElementsHidden() {
         return firstPersonElementsHidden;
     }
 
-    public void setFirstPersonElementsHidden(boolean firstPersonElementsHidden) {
-        this.firstPersonElementsHidden = firstPersonElementsHidden;
+    public static final String FIRST_PERSON_ELEMENTS_HIDDEN = "FirstPersonElementsHidden";
+    public void setFirstPersonElementsHidden(boolean FirstPersonElementsHidden) {
+        this.firstPersonElementsHidden = FirstPersonElementsHidden;
+        propertyChangeSupport.firePropertyChange(FIRST_PERSON_ELEMENTS_HIDDEN, !this.firstPersonElementsHidden, this.firstPersonElementsHidden);
     }
 
     public boolean isHudHidden() {
         return hudHidden;
     }
 
+    public static final String HUD_HIDDEN = "hudHidden";
     public void setHudHidden(boolean hudHidden) {
         this.hudHidden = hudHidden;
+        propertyChangeSupport.firePropertyChange(HUD_HIDDEN, !this.hudHidden, this.hudHidden);
     }
 
     public boolean isRenderChunkBoundingBoxes() {
         return renderChunkBoundingBoxes;
     }
 
+    public static final String RENDER_CHUNK_BOUNDING_BOXES = "renderChunkBoundingBoxes";
     public void setRenderChunkBoundingBoxes(boolean renderChunkBoundingBoxes) {
         this.renderChunkBoundingBoxes = renderChunkBoundingBoxes;
+        propertyChangeSupport.firePropertyChange(RENDER_CHUNK_BOUNDING_BOXES, !this.renderChunkBoundingBoxes, this.renderChunkBoundingBoxes);
     }
 
     public boolean isRenderSkeletons() {
         return renderSkeletons;
     }
 
+    public static final String RENDER_SKELETONS = "renderSkeletons";
     public void setRenderSkeletons(boolean renderSkeletons) {
         this.renderSkeletons = renderSkeletons;
+        propertyChangeSupport.firePropertyChange(RENDER_SKELETONS, !this.renderSkeletons, this.renderSkeletons);
     }
+
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotSize.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotSize.java
@@ -27,7 +27,8 @@ public enum ScreenshotSize {
     HALF_SIZE("Half Size", 0.5F),
     QUARTER_SIZE("Quarter Size", 0.25F),
     HD720("720p", 1280, 720),
-    HD1080("1080p", 1920, 1080);
+    HD1080("1080p", 1920, 1080),
+    UHD_1("4K UHD", 3840, 2160); // see: https://en.wikipedia.org/wiki/4K_resolution
 
     private final String displayName;
 
@@ -36,12 +37,12 @@ public enum ScreenshotSize {
     private int width;
     private int height;
 
-    private ScreenshotSize(String displayName, float multiplier) {
+    ScreenshotSize(String displayName, float multiplier) {
         this.displayName = displayName;
         this.multiplier = multiplier;
     }
 
-    private ScreenshotSize(String displayName, int width, int height) {
+    ScreenshotSize(String displayName, int width, int height) {
         this.displayName = displayName;
         this.width = width;
         this.height = height;

--- a/engine/src/main/java/org/terasology/utilities/subscribables/AbstractGeneralSubscribable.java
+++ b/engine/src/main/java/org/terasology/utilities/subscribables/AbstractGeneralSubscribable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.utilities.subscribables;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+/**
+ * {@inheritDoc}
+ */
+public class AbstractGeneralSubscribable implements GeneralSubscribable {
+
+    protected transient PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+    /**
+     * {@inheritDoc}
+     */
+    public void subscribe(PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.addPropertyChangeListener(changeListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void unsubscribe(PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.removePropertyChangeListener(changeListener);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/utilities/subscribables/AbstractSpecificSubscribable.java
+++ b/engine/src/main/java/org/terasology/utilities/subscribables/AbstractSpecificSubscribable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.utilities.subscribables;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+/**
+ * {@inheritDoc}
+ */
+public class AbstractSpecificSubscribable implements SpecificSubscribable {
+
+    protected transient PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+    /**
+     * {@inheritDoc}
+     */
+    public void subscribe(String propertyName, PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.addPropertyChangeListener(propertyName, changeListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void unsubscribe(String propertyName, PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.removePropertyChangeListener(propertyName, changeListener);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/utilities/subscribables/AbstractSubscribable.java
+++ b/engine/src/main/java/org/terasology/utilities/subscribables/AbstractSubscribable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.utilities.subscribables;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+/**
+ * {@inheritDoc}
+ */
+public abstract class AbstractSubscribable implements Subscribable {
+
+    protected transient PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+    /**
+     * {@inheritDoc}
+     */
+    public void subscribe(PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.addPropertyChangeListener(changeListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void unsubscribe(PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.removePropertyChangeListener(changeListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void subscribe(String propertyName, PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.addPropertyChangeListener(propertyName, changeListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void unsubscribe(String propertyName, PropertyChangeListener changeListener) {
+        this.propertyChangeSupport.removePropertyChangeListener(propertyName, changeListener);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/utilities/subscribables/GeneralSubscribable.java
+++ b/engine/src/main/java/org/terasology/utilities/subscribables/GeneralSubscribable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.utilities.subscribables;
+
+import java.beans.PropertyChangeListener;
+
+/**
+ * Originally created to provide Observable-like functionality to config classes,
+ * it can be used by any class that wishes to be monitored for any change in its properties.
+ */
+public interface GeneralSubscribable {
+
+    /**
+     * Subscribe a listener that gets notified when -any- property changes.
+     */
+    void subscribe(PropertyChangeListener changeListener);
+
+    /**
+     * Unsubscribe a listener that gets notified when -any- property changes.
+     */
+    void unsubscribe(PropertyChangeListener changeListener);
+
+}

--- a/engine/src/main/java/org/terasology/utilities/subscribables/SpecificSubscribable.java
+++ b/engine/src/main/java/org/terasology/utilities/subscribables/SpecificSubscribable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.utilities.subscribables;
+
+import java.beans.PropertyChangeListener;
+
+/**
+ * Originally created to provide Observable-like functionality to config classes,
+ * it can be used by any class that wishes to be monitored for change in specific properties.
+ */
+public interface SpecificSubscribable {
+
+    /**
+     * Subscribe a listener that gets notified when a -specific- property changes.
+     */
+    void subscribe(String propertyName, PropertyChangeListener changeListener);
+
+    /**
+     * Unsubscribe a listener that gets notified when a -specific- property changes.
+     */
+    void unsubscribe(String propertyName, PropertyChangeListener changeListener);
+
+}

--- a/engine/src/main/java/org/terasology/utilities/subscribables/Subscribable.java
+++ b/engine/src/main/java/org/terasology/utilities/subscribables/Subscribable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.utilities.subscribables;
+
+import java.beans.PropertyChangeListener;
+
+/**
+ * Originally created to provide Observable-like functionality to config classes,
+ * it can be used by any class that wishes to be monitored for both general and specific
+ * changes to its properties.
+ */
+public interface Subscribable extends GeneralSubscribable, SpecificSubscribable {}


### PR DESCRIPTION
- Added a number of "Subscribable" interfaces and abstract classes, allowing implementations to be monitored for general changes, specific changes or both.
- RenderingConfig and RenderingDebugConfig are now extending AbstractSubscribable. Should they extend AbstractSpecificSubscribable instead?
- Bonus Feature: added 4K UHD resolution among the possible Screenshot sizes.
- Eliminated 3 warnings related to private enum constructors - the "private" keyword is redundant in those circumstances.

**EDIT**: It should be noted that while individual parameters are, with this PR, monitorable, they are not yet monitored. This will come as @tdgunes work on the rendering engine proceeds.