### PR TITLE
Check entity relevance for rendering

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -18,6 +18,9 @@ package org.terasology.rendering.logic;
 import com.bulletphysics.linearmath.Transform;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import java.nio.FloatBuffer;
+import java.util.Arrays;
+import java.util.Set;
 import org.lwjgl.BufferUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,10 +49,6 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.opengl.OpenGLMesh;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
-
-import java.nio.FloatBuffer;
-import java.util.Arrays;
-import java.util.Set;
 
 /**
  * TODO: This should be made generic (no explicit shader or mesh) and ported directly into WorldRenderer? Later note: some GelCube functionality moved to a module
@@ -192,8 +191,7 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
                     MeshComponent meshComp = entity.getComponent(MeshComponent.class);
                     LocationComponent location = entity.getComponent(LocationComponent.class);
 
-                    if (isHidden(entity, meshComp) || location == null || meshComp.mesh == null
-                            || !worldProvider.isBlockRelevant(location.getWorldPosition())) {
+                    if (isHidden(entity, meshComp) || location == null || meshComp.mesh == null || !isRelevant(entity, location.getWorldPosition())) {
                         continue;
                     }
                     if (meshComp.mesh.isDisposed()) {
@@ -242,6 +240,21 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
                 }
             }
         }
+    }
+
+    /**
+     * Checks whether the entity at the given position is relevant.
+     * <p>
+     * The entity is at the given position is relevant if
+     * a) the entity itself is always relevant, or
+     * b) if the block at the position is relevant.
+     *
+     * @param entity   the entity to check for relevance
+     * @param position the position the entity is located
+     * @return true if the entity itself or the block at the given position are relevant, false otherwise.
+     */
+    private boolean isRelevant(EntityRef entity, Vector3f position) {
+        return entity.isAlwaysRelevant() || worldProvider.isBlockRelevant(position);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -245,16 +245,16 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
     /**
      * Checks whether the entity at the given position is relevant.
      * <p>
-     * The entity is at the given position is relevant if
+     * The entity at the given position is relevant if
      * a) the entity itself is always relevant, or
-     * b) if the block at the position is relevant.
+     * b) the block at the position is relevant.
      *
      * @param entity   the entity to check for relevance
-     * @param position the position the entity is located
+     * @param position the world position the entity is located
      * @return true if the entity itself or the block at the given position are relevant, false otherwise.
      */
     private boolean isRelevant(EntityRef entity, Vector3f position) {
-        return entity.isAlwaysRelevant() || worldProvider.isBlockRelevant(position);
+        return worldProvider.isBlockRelevant(position) || entity.isAlwaysRelevant();
     }
 
     @Override


### PR DESCRIPTION
Solves #2412.

As stated in the linked issue, I was looking for a way to always render an entity's mesh, given that the entity is always relevant. Therefore, I changed the render check to include the relevance of the entity.

With this change, an entity that holds `MeshComponent` and `LocationComponent` with `alwaysRelevant` being `false` is handled like before, i.e., the mesh is only renderd when the chunk around it is loaded. 
Setting `alwaysRelevant` to `true` will cause the mesh to be rendered at the given location, regardless whether the chunk around is loaded or not. 

Pinging @immortius @flo @msteiger @Josharias @emanuele3d for quick review.