### PR TITLE
[RFR] Adds SetViewportSizeOf StateChange 

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
@@ -28,6 +28,7 @@ import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.RenderableWorld;
@@ -49,6 +50,9 @@ public class ShadowMapNode extends AbstractNode {
     private static final String SCENE_SHADOW_MAP = "sceneShadowMap";
     private static final int SHADOW_FRUSTUM_BOUNDS = 500;
     public Camera shadowMapCamera = new OrthographicCamera(-SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, -SHADOW_FRUSTUM_BOUNDS);
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
 
     @In
     private RenderableWorld renderableWorld;
@@ -79,8 +83,8 @@ public class ShadowMapNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         renderableWorld.setShadowMapCamera(shadowMapCamera);
 
-        addDesiredStateChange(new BindFBO(SCENE_SHADOW_MAP));
-        addDesiredStateChange(new SetViewportSizeOf(SCENE_SHADOW_MAP));
+        addDesiredStateChange(new BindFBO(SCENE_SHADOW_MAP, frameBuffersManager));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_SHADOW_MAP, frameBuffersManager));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
@@ -28,7 +28,6 @@ import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
-import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.RenderableWorld;
@@ -47,7 +46,7 @@ import static org.lwjgl.opengl.GL11.glClear;
  * - https://docs.google.com/drawings/d/13I0GM9jDFlZv1vNrUPlQuBbaF86RPRNpVfn5q8Wj2lc/edit?usp=sharing
  */
 public class ShadowMapNode extends AbstractNode {
-    private static final String SHADOW_MAP_FBO_NAME = "sceneShadowMap";
+    private static final String SCENE_SHADOW_MAP = "sceneShadowMap";
     private static final int SHADOW_FRUSTUM_BOUNDS = 500;
     public Camera shadowMapCamera = new OrthographicCamera(-SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, -SHADOW_FRUSTUM_BOUNDS);
 
@@ -59,9 +58,6 @@ public class ShadowMapNode extends AbstractNode {
 
     @In
     private Config config;
-
-    @In
-    private FrameBuffersManager frameBuffersManager;
 
     @In
     private WorldRenderer worldRenderer;
@@ -83,8 +79,8 @@ public class ShadowMapNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         renderableWorld.setShadowMapCamera(shadowMapCamera);
 
-        addDesiredStateChange(new BindFBO(SHADOW_MAP_FBO_NAME, frameBuffersManager));
-        addDesiredStateChange(new SetViewportSizeOf(SHADOW_MAP_FBO_NAME, frameBuffersManager));
+        addDesiredStateChange(new BindFBO(SCENE_SHADOW_MAP));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_SHADOW_MAP));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -27,6 +27,7 @@ import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -42,6 +43,9 @@ import static org.lwjgl.opengl.GL11.glClear;
  */
 public class WorldReflectionNode extends AbstractNode {
     private static final String SCENE_REFLECTED_FBO = "sceneReflected";
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
 
     @In
     private RenderQueuesHelper renderQueues;
@@ -65,8 +69,8 @@ public class WorldReflectionNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         this.chunkShader = worldRenderer.getMaterial("engine:prog.chunk");
         this.playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new BindFBO(SCENE_REFLECTED_FBO));
-        addDesiredStateChange(new SetViewportSizeOf(SCENE_REFLECTED_FBO));
+        addDesiredStateChange(new BindFBO(SCENE_REFLECTED_FBO, frameBuffersManager));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_REFLECTED_FBO, frameBuffersManager));
 
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -26,7 +26,7 @@ import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
-import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
@@ -35,8 +35,6 @@ import org.terasology.rendering.world.WorldRendererImpl;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
-import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
-import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
 
 /**
  * Diagram of this node can be viewed from:
@@ -44,6 +42,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
  * - https://docs.google.com/drawings/d/1Iz7MA8Y5q7yjxxcgZW-0antv5kgx6NYkvoInielbwGU/edit?usp=sharing
  */
 public class WorldReflectionNode extends AbstractNode {
+    private static final String REFLECTED_FBO_NAME = "sceneReflected";
 
     @In
     private FrameBuffersManager frameBuffersManager;
@@ -63,24 +62,22 @@ public class WorldReflectionNode extends AbstractNode {
     private Camera playerCamera;
     private Material chunkShader;
     private RenderingConfig renderingConfig;
-    private FBO sceneReflected;
-    private FBO sceneOpaque;
+
 
     @Override
     public void initialise() {
         this.renderingConfig = config.getRendering();
         this.chunkShader = worldRenderer.getMaterial("engine:prog.chunk");
         this.playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new BindFBO("sceneReflected", frameBuffersManager));
+        addDesiredStateChange(new BindFBO(REFLECTED_FBO_NAME, frameBuffersManager));
+        addDesiredStateChange(new SetViewportSizeOf(REFLECTED_FBO_NAME, frameBuffersManager));
+
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/worldReflection");
-        sceneReflected = frameBuffersManager.getFBO("sceneReflected");
-        sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
-        setViewportToSizeOf(sceneReflected); // TODO: add setViewportSizeOf state change and remove this line
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         GL11.glCullFace(GL11.GL_FRONT);
         playerCamera.setReflected(true);
@@ -101,8 +98,7 @@ public class WorldReflectionNode extends AbstractNode {
         playerCamera.setReflected(false);
 
         GL11.glCullFace(GL11.GL_BACK);
-        bindDisplay(); // TODO: remove since its reset by default BindFBO state change
-        setViewportToSizeOf(sceneOpaque); // TODO: add setViewportSizeOf state change and remove this line
+
 
         PerformanceMonitor.endActivity();
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -27,7 +27,6 @@ import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
-import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -42,10 +41,7 @@ import static org.lwjgl.opengl.GL11.glClear;
  * - https://docs.google.com/drawings/d/1Iz7MA8Y5q7yjxxcgZW-0antv5kgx6NYkvoInielbwGU/edit?usp=sharing
  */
 public class WorldReflectionNode extends AbstractNode {
-    private static final String REFLECTED_FBO_NAME = "sceneReflected";
-
-    @In
-    private FrameBuffersManager frameBuffersManager;
+    private static final String SCENE_REFLECTED_FBO = "sceneReflected";
 
     @In
     private RenderQueuesHelper renderQueues;
@@ -69,8 +65,8 @@ public class WorldReflectionNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         this.chunkShader = worldRenderer.getMaterial("engine:prog.chunk");
         this.playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new BindFBO(REFLECTED_FBO_NAME, frameBuffersManager));
-        addDesiredStateChange(new SetViewportSizeOf(REFLECTED_FBO_NAME, frameBuffersManager));
+        addDesiredStateChange(new BindFBO(SCENE_REFLECTED_FBO));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_REFLECTED_FBO));
 
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
@@ -19,7 +19,7 @@ import org.terasology.rendering.dag.FBOManagerSubscriber;
 import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.BindFBOTask;
-import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  * TODO: Add javadocs
@@ -30,15 +30,17 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     private static final String DEFAULT_FRAME_BUFFER_NAME = "display";
     private static BindFBO defaultInstance = new BindFBO();
     private String fboName;
+    private FrameBuffersManager frameBuffersManager;
     private int fboId;
     private BindFBOTask task;
 
-    public BindFBO(String fboName) {
+    public BindFBO(String fboName, FrameBuffersManager frameBuffersManager) {
         this.fboName = fboName;
+        this.frameBuffersManager = frameBuffersManager;
         fboId = frameBuffersManager.getFBO(fboName).fboId;
     }
 
-    private BindFBO() {
+    public BindFBO() {
         this.fboName = DEFAULT_FRAME_BUFFER_NAME;
         fboId = DEFAULT_FRAME_BUFFER_ID;
     }
@@ -46,6 +48,11 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     @Override
     public StateChange getDefaultInstance() {
         return defaultInstance;
+    }
+
+
+    public static void setDefaultInstance(BindFBO defaultInstance) {
+        BindFBO.defaultInstance = defaultInstance;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
@@ -19,7 +19,7 @@ import org.terasology.rendering.dag.FBOManagerSubscriber;
 import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.BindFBOTask;
-import org.terasology.rendering.opengl.FrameBuffersManager;
+import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
 
 /**
  * TODO: Add javadocs
@@ -32,11 +32,9 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     private String fboName;
     private int fboId;
     private BindFBOTask task;
-    private FrameBuffersManager frameBuffersManager;
 
-    public BindFBO(String fboName, FrameBuffersManager frameBuffersManager) {
+    public BindFBO(String fboName) {
         this.fboName = fboName;
-        this.frameBuffersManager = frameBuffersManager;
         fboId = frameBuffersManager.getFBO(fboName).fboId;
     }
 
@@ -74,7 +72,7 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     @Override
     public boolean isEqualTo(StateChange stateChange) {
         if (stateChange instanceof BindFBO) {
-            return this.fboName.equals(((BindFBO) stateChange).fboName);
+            return this.fboName.equals(((BindFBO) stateChange).getFboName());
         }
         return false;
     }
@@ -88,5 +86,9 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     @Override
     public String toString() { // TODO: used for logging purposes at the moment, investigate different methods
         return String.format("%21s: %s(%s)", this.getClass().getSimpleName(), fboName, fboId);
+    }
+
+    public String getFboName() {
+        return fboName;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
@@ -20,27 +20,37 @@ import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.SetViewportSizeOfTask;
 import org.terasology.rendering.opengl.FBO;
-import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  * TODO: Add javadocs
  */
 public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChange {
     private static final String DEFAULT_FBO = "sceneOpaque";
-    private static SetViewportSizeOf defaultInstance = new SetViewportSizeOf(DEFAULT_FBO);
+    private static SetViewportSizeOf defaultInstance;
     private SetViewportSizeOfTask task;
 
     private FBO fbo;
     private String fboName;
+    private FrameBuffersManager frameBuffersManager;
 
-    public SetViewportSizeOf(String fboName) {
+    public SetViewportSizeOf(String fboName, FrameBuffersManager frameBuffersManager) {
         this.fboName = fboName;
+        this.frameBuffersManager = frameBuffersManager;
         fbo = frameBuffersManager.getFBO(fboName);
+    }
+
+    public SetViewportSizeOf(FrameBuffersManager frameBuffersManager) {
+        this(DEFAULT_FBO, frameBuffersManager);
     }
 
     @Override
     public StateChange getDefaultInstance() {
         return defaultInstance;
+    }
+
+    public static void setDefaultInstance(SetViewportSizeOf defaultInstance) {
+        SetViewportSizeOf.defaultInstance = defaultInstance;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
@@ -20,37 +20,26 @@ import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.SetViewportSizeOfTask;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.FrameBuffersManager;
+import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
 
 /**
  * TODO: Add javadocs
  */
 public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChange {
-    private static final String DEFAULT_FBO_NAME = "sceneOpaque";
-    private static SetViewportSizeOf defaultInstance = new SetViewportSizeOf();
+    private static final String DEFAULT_FBO = "sceneOpaque";
+    private static SetViewportSizeOf defaultInstance = new SetViewportSizeOf(DEFAULT_FBO);
     private SetViewportSizeOfTask task;
 
     private FBO fbo;
     private String fboName;
-    private FrameBuffersManager frameBuffersManager;
 
-    public SetViewportSizeOf(String fboName, FrameBuffersManager frameBuffersManager) {
+    public SetViewportSizeOf(String fboName) {
         this.fboName = fboName;
-        this.frameBuffersManager = frameBuffersManager;
         fbo = frameBuffersManager.getFBO(fboName);
-    }
-
-    public SetViewportSizeOf() {
-        this.fboName = DEFAULT_FBO_NAME;
     }
 
     @Override
     public StateChange getDefaultInstance() {
-        // TODO: a very dirty approach :(, however defaultInstance requires a frameBuffer instance, any suggestions?
-        if (defaultInstance.frameBuffersManager == null) {
-            defaultInstance.frameBuffersManager = frameBuffersManager;
-            defaultInstance.fbo = frameBuffersManager.getFBO(DEFAULT_FBO_NAME);
-        }
         return defaultInstance;
     }
 
@@ -69,7 +58,7 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
     @Override
     public boolean isEqualTo(StateChange stateChange) {
         if (stateChange instanceof SetViewportSizeOf) {
-            return this.fboName.equals(((SetViewportSizeOf) stateChange).fboName);
+            return this.fboName.equals(((SetViewportSizeOf) stateChange).getFboName());
         }
         return false;
     }
@@ -88,5 +77,9 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
     @Override
     public String toString() { // TODO: used for logging purposes at the moment, investigate different methods
         return String.format("%21s: %s(%sx%s)", this.getClass().getSimpleName(), fboName, fbo.width(), fbo.height());
+    }
+
+    public String getFboName() {
+        return fboName;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
@@ -38,11 +38,6 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
         this.fboName = fboName;
         this.frameBuffersManager = frameBuffersManager;
         fbo = frameBuffersManager.getFBO(fboName);
-        // TODO: a very dirty approach :(, however defaultInstance requires a frameBuffer instance, any suggestions?
-        if (defaultInstance.frameBuffersManager == null) {
-            defaultInstance.frameBuffersManager = frameBuffersManager;
-            defaultInstance.fbo = frameBuffersManager.getFBO(DEFAULT_FBO_NAME);
-        }
     }
 
     public SetViewportSizeOf() {
@@ -51,6 +46,11 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
 
     @Override
     public StateChange getDefaultInstance() {
+        // TODO: a very dirty approach :(, however defaultInstance requires a frameBuffer instance, any suggestions?
+        if (defaultInstance.frameBuffersManager == null) {
+            defaultInstance.frameBuffersManager = frameBuffersManager;
+            defaultInstance.fbo = frameBuffersManager.getFBO(DEFAULT_FBO_NAME);
+        }
         return defaultInstance;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
@@ -23,7 +23,9 @@ import org.terasology.rendering.dag.tasks.SetWireframeTask;
  * TODO: Add javadocs
  */
 public final class SetWireframe implements StateChange {
-    private static SetWireframe defaultInstance = new SetWireframe(false);
+    private static final boolean DEFAULT_VALUE = false;
+
+    private static SetWireframe defaultInstance;
     private static SetWireframeTask enablingTask;
     private static SetWireframeTask disablingTask;
 
@@ -33,9 +35,19 @@ public final class SetWireframe implements StateChange {
         this.enabled = enabled;
     }
 
+    public SetWireframe() {
+        this(DEFAULT_VALUE);
+    }
+
+
     @Override
     public StateChange getDefaultInstance() {
         return defaultInstance;
+    }
+
+
+    public static void setDefaultInstance(SetWireframe defaultInstance) {
+        SetWireframe.defaultInstance = defaultInstance;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/tasks/SetViewportSizeOfTask.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/tasks/SetViewportSizeOfTask.java
@@ -15,34 +15,35 @@
  */
 package org.terasology.rendering.dag.tasks;
 
-import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_EXT;
-import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
+import static org.lwjgl.opengl.GL11.glViewport;
 import org.terasology.rendering.dag.RenderPipelineTask;
 
 /**
  * TODO: Add javadocs
  */
-public final class BindFBOTask implements RenderPipelineTask {
-
-    private int fboId;
+public class SetViewportSizeOfTask implements RenderPipelineTask {
+    private int width;
+    private int height;
     private String fboName;
 
-    public BindFBOTask(int fboId, String fboName) {
-        this.fboId = fboId;
+    public SetViewportSizeOfTask(String fboName, int width, int height) {
         this.fboName = fboName;
+        this.width = width;
+        this.height = height;
+    }
+
+    public void setDimensions(int w, int h) {
+        this.width = w;
+        this.height = h;
     }
 
     @Override
     public void execute() {
-        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fboId);
-    }
-
-    public void setFboId(int fboId) {
-        this.fboId = fboId;
+        glViewport(0, 0, width, height);
     }
 
     @Override
     public String toString() {
-        return String.format("%21s: %s(%s)", this.getClass().getSimpleName(), fboName, fboId);
+        return String.format("%21s: %s(%sx%s)", this.getClass().getSimpleName(), fboName, width, height);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -16,7 +16,6 @@
 package org.terasology.rendering.world;
 
 import java.util.List;
-import com.google.api.client.util.Lists;
 import org.lwjgl.opengl.GL11;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
@@ -95,6 +94,8 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  *
  */
 public final class WorldRendererImpl implements WorldRenderer {
+    public static FrameBuffersManager frameBuffersManager;
+
     private boolean isFirstRenderingStageForCurrentFrame;
     private final RenderQueuesHelper renderQueues;
     private final Context context;
@@ -125,7 +126,6 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private final RenderingConfig renderingConfig;
     private final RenderingDebugConfig renderingDebugConfig;
-    private FrameBuffersManager buffersManager;
     private PostProcessor postProcessor;
     private List<RenderPipelineTask> renderPipelineTaskList;
     private ShadowMapNode shadowMapNode;
@@ -174,14 +174,14 @@ public final class WorldRendererImpl implements WorldRenderer {
     }
 
     private void initRenderingSupport() {
-        buffersManager = new FrameBuffersManager();
-        context.put(FrameBuffersManager.class, buffersManager);
+        frameBuffersManager = new FrameBuffersManager();
+        context.put(FrameBuffersManager.class, frameBuffersManager);
 
-        postProcessor = new PostProcessor(buffersManager);
+        postProcessor = new PostProcessor(frameBuffersManager);
         context.put(PostProcessor.class, postProcessor);
 
-        buffersManager.setPostProcessor(postProcessor);
-        buffersManager.initialize();
+        frameBuffersManager.setPostProcessor(postProcessor);
+        frameBuffersManager.initialize();
 
         shaderManager.initShaders();
         initMaterials();
@@ -315,7 +315,7 @@ public final class WorldRendererImpl implements WorldRenderer {
             renderableWorld.generateVBOs();
             secondsSinceLastFrame = 0;
 
-            buffersManager.preRenderUpdate();
+            frameBuffersManager.preRenderUpdate();
 
             millisecondsSinceRenderingStart += secondsSinceLastFrame * 1000;  // updates the variable animations are based on.
         }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -64,6 +64,9 @@ import org.terasology.rendering.dag.nodes.SimpleBlendMaterialsNode;
 import org.terasology.rendering.dag.nodes.SkyBandsNode;
 import org.terasology.rendering.dag.nodes.ToneMappingNode;
 import org.terasology.rendering.dag.nodes.WorldReflectionNode;
+import org.terasology.rendering.dag.stateChanges.BindFBO;
+import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.opengl.PostProcessor;
@@ -94,8 +97,6 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  *
  */
 public final class WorldRendererImpl implements WorldRenderer {
-    public static FrameBuffersManager frameBuffersManager;
-
     private boolean isFirstRenderingStageForCurrentFrame;
     private final RenderQueuesHelper renderQueues;
     private final Context context;
@@ -126,6 +127,7 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private final RenderingConfig renderingConfig;
     private final RenderingDebugConfig renderingDebugConfig;
+    private FrameBuffersManager frameBuffersManager;
     private PostProcessor postProcessor;
     private List<RenderPipelineTask> renderPipelineTaskList;
     private ShadowMapNode shadowMapNode;
@@ -250,9 +252,18 @@ public final class WorldRendererImpl implements WorldRenderer {
         renderGraph.addNode(blurPassesNode, "blurPassesNode");
         renderGraph.addNode(finalPostProcessingNode, "finalPostProcessingNode");
 
+        initDefaultStateChanges();
+
         List<Node> orderedNodes = renderGraph.getNodesInTopologicalOrder();
         RenderTaskListGenerator generator = new RenderTaskListGenerator();
         renderPipelineTaskList = generator.generateFrom(orderedNodes);
+    }
+
+    private void initDefaultStateChanges() {
+        SetViewportSizeOf.setDefaultInstance(new SetViewportSizeOf(frameBuffersManager));
+        BindFBO.setDefaultInstance(new BindFBO());
+        SetWireframe.setDefaultInstance(new SetWireframe());
+
     }
 
     @Override


### PR DESCRIPTION
### Contains

As title mentions, adds a state change for [_All obvious State Changes implemented_](https://github.com/tdgunes/Terasology/issues/10)

### How to test

Check the log for any difference with given one below and any weirdness on shadow mapping and reflections. (Testing window resizing would be great!)

```
19:15:32.747 [main] INFO  o.t.r.dag.RenderTaskListGenerator - -- Task List --
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator - SetViewportSizeOfTask: sceneShadowMap(1024x1024)
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator -           BindFBOTask: sceneShadowMap(26)
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator - NodeTask: ShadowMapNode
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator - SetViewportSizeOfTask: sceneReflected(576x360)
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator -           BindFBOTask: sceneReflected(11)
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator - NodeTask: WorldReflectionNode
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator - SetViewportSizeOfTask: sceneOpaque(1152x720)
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator -           BindFBOTask: display(0)
19:15:32.748 [main] INFO  o.t.r.dag.RenderTaskListGenerator - NodeTask: BackdropNode
```

### Outstanding before merging

- [x] Any suggestions on resolving the dirty approach in stateChanges/SetViewportSizeOf.java, line 51? 

More state changes are coming! 