### PR TITLE
[RFR] Finalize SetWireframe StateChange

### DIFF
--- a/engine/src/main/java/org/terasology/config/RenderingDebugConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingDebugConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2016 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,16 @@
  */
 package org.terasology.config;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.rendering.world.WorldRendererImpl;
 import org.terasology.utilities.subscribables.AbstractSubscribable;
 
 /**
  */
-public class RenderingDebugConfig extends AbstractSubscribable {
-
+public class RenderingDebugConfig extends AbstractSubscribable implements PropertyChangeListener {
     public enum DebugRenderingStage {
         OPAQUE_COLOR(0, "DEBUG_STAGE_OPAQUE_COLOR"),
         TRANSPARENT_COLOR(1, "DEBUG_STAGE_TRANSPARENT_COLOR"),
@@ -63,6 +67,7 @@ public class RenderingDebugConfig extends AbstractSubscribable {
     public static final String HUD_HIDDEN = "hudHidden";
     public static final String RENDER_CHUNK_BOUNDING_BOXES = "renderChunkBoundingBoxes";
     public static final String RENDER_SKELETONS = "renderSkeletons";
+    private static final Logger logger = LoggerFactory.getLogger(WorldRendererImpl.class);
 
     private boolean enabled;
     private DebugRenderingStage stage;
@@ -71,6 +76,10 @@ public class RenderingDebugConfig extends AbstractSubscribable {
     private boolean wireframe;
     private boolean renderChunkBoundingBoxes;
     private boolean renderSkeletons;
+
+    public RenderingDebugConfig() {
+        subscribe(this);
+    }
 
     public boolean isWireframe() {
         return wireframe;
@@ -146,4 +155,8 @@ public class RenderingDebugConfig extends AbstractSubscribable {
         propertyChangeSupport.firePropertyChange(RENDER_SKELETONS, oldValue, this.renderSkeletons);
     }
 
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        logger.info("Set {} property to {}. ", evt.getPropertyName().toUpperCase(), evt.getNewValue()); // for debugging purposes
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
@@ -15,7 +15,10 @@
  */
 package org.terasology.rendering.dag;
 
+import com.google.api.client.util.Lists;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,13 +27,24 @@ import java.util.Set;
 public abstract class AbstractNode implements Node {
     private Set<StateChange> desiredStateChanges;
     private NodeTask task;
+    private RenderTaskListGenerator taskListGenerator;
+    private List<Range<Integer>> rangeList;
 
     protected AbstractNode() {
         desiredStateChanges = Sets.newLinkedHashSet();
+        rangeList = Lists.newArrayList();
     }
 
     protected boolean addDesiredStateChange(StateChange stateChange) {
         return desiredStateChanges.add(stateChange);
+    }
+
+    protected boolean removeDesiredStateChange(StateChange stateChange) {
+        return desiredStateChanges.remove(stateChange);
+    }
+
+    protected void refreshTaskList() {
+        taskListGenerator.refresh();
     }
 
     public Set<StateChange> getDesiredStateChanges() {
@@ -47,5 +61,9 @@ public abstract class AbstractNode implements Node {
     @Override
     public String toString() {
         return this.getClass().getSimpleName();
+    }
+
+    public void setTaskListGenerator(RenderTaskListGenerator taskListGenerator) {
+        this.taskListGenerator = taskListGenerator;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/Node.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/Node.java
@@ -31,4 +31,6 @@ public interface Node {
     Set<StateChange> getDesiredStateChanges();
 
     RenderPipelineTask generateTask();
+
+    void setTaskListGenerator(RenderTaskListGenerator taskListGenerator);
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/RenderTaskListGenerator.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/RenderTaskListGenerator.java
@@ -35,11 +35,14 @@ public final class RenderTaskListGenerator {
         intermediateList = Lists.newArrayList();
     }
 
+    public List<RenderPipelineTask> regenerate() {
+        generateTaskList();
+        return taskList;
+    }
+
     public List<RenderPipelineTask> generateFrom(List<Node> orderedNodes) {
         generateIntermediateList(orderedNodes);
-        logList("-- Intermediate List --", intermediateList); // TODO: remove in the future or turn it into debug
         generateTaskList();
-        logList("-- Task List --", taskList); // TODO: remove in the future or turn it into debug
         return taskList;
     }
 
@@ -77,7 +80,7 @@ public final class RenderTaskListGenerator {
                             // defensive programming here: the check is probably unnecessary as for every default
                             // instance of a state change subType there should be a non-default one already in the
                             // persistentStateChangeS map, falling within cases handled below.
-                            taskList.add(stateChange.generateTask());
+                            addTask(stateChange.generateTask());
                             persistentStateChanges.put(stateChange.getClass(), stateChange);
 
                         } // else {
@@ -87,12 +90,12 @@ public final class RenderTaskListGenerator {
                     } else {
                         if (stateChange.isTheDefaultInstance()) { // I know, I'm a sucker for almost plain-english code
                             // non redundant default state change, eliminates subType entry in the map, to keep map small
-                            taskList.add(stateChange.generateTask());
+                            addTask(stateChange.generateTask());
                             persistentStateChanges.remove(stateChange.getClass());
 
                         } else if (!stateChange.isEqualTo(persistentStateChange)) { // another new method, just for readability
                             // non-redundant state change of the same subType but different value, becomes new map entry
-                            taskList.add(stateChange.generateTask());
+                            addTask(stateChange.generateTask());
                             persistentStateChanges.put(stateChange.getClass(), stateChange);
 
                         } // else {
@@ -105,11 +108,10 @@ public final class RenderTaskListGenerator {
                 }
 
                 intranodesStateChanges.clear();
-                taskList.add(((Node) object).generateTask());
+                addTask(((Node) object).generateTask());
             }
         }
-
-
+        logList("-- Task List --", taskList); // TODO: remove in the future or turn it into debug
     }
 
     private void generateIntermediateList(List<Node> orderedNodes) {
@@ -121,6 +123,13 @@ public final class RenderTaskListGenerator {
             for (StateChange stateChange : node.getDesiredStateChanges()) {
                 intermediateList.add(stateChange.getDefaultInstance());
             }
+        }
+        logList("-- Intermediate List --", intermediateList); // TODO: remove in the future or turn it into debug
+    }
+
+    private void addTask(RenderPipelineTask task) {
+        if (task != null) {
+            taskList.add(task);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/WireframeCapableNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/WireframeCapableNode.java
@@ -25,7 +25,7 @@ import org.terasology.rendering.dag.stateChanges.SetWireframe;
 /**
  * TODO: Add javadocs
  */
-public abstract class WireframeNode extends AbstractNode implements PropertyChangeListener {
+public abstract class WireframeCapableNode extends AbstractNode implements PropertyChangeListener {
     @In
     protected Config config;
     protected RenderingDebugConfig renderingDebugConfig;

--- a/engine/src/main/java/org/terasology/rendering/dag/WireframeNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/WireframeNode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import org.terasology.config.Config;
+import org.terasology.config.RenderingDebugConfig;
+import org.terasology.registry.In;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
+
+/**
+ * TODO: Add javadocs
+ */
+public abstract class WireframeNode extends AbstractNode implements PropertyChangeListener {
+    @In
+    protected Config config;
+    protected RenderingDebugConfig renderingDebugConfig;
+
+    private SetWireframe wireframeStateChange;
+
+    @Override
+    public void initialise() {
+        wireframeStateChange = new SetWireframe(true);
+
+        renderingDebugConfig = config.getRendering().getDebug();
+        renderingDebugConfig.subscribe(RenderingDebugConfig.WIREFRAME, this);
+
+        if (renderingDebugConfig.isWireframe()) {
+            addDesiredStateChange(wireframeStateChange);
+        }
+    }
+
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (renderingDebugConfig.isWireframe()) {
+            addDesiredStateChange(wireframeStateChange);
+        } else {
+            removeDesiredStateChange(wireframeStateChange);
+        }
+        refreshTaskList();
+    }
+
+
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropNode.java
@@ -15,13 +15,12 @@
  */
 package org.terasology.rendering.dag.nodes;
 
-import org.terasology.config.Config;
-import org.terasology.config.RenderingDebugConfig;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
@@ -30,17 +29,12 @@ import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_STENCIL_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
 
 /**
  * TODO: Diagram of this node
  */
 public class BackdropNode extends AbstractNode {
-
-    @In
-    private Config config;
 
     @In
     private BackdropRenderer backdropRenderer;
@@ -51,22 +45,19 @@ public class BackdropNode extends AbstractNode {
     @In
     private FrameBuffersManager frameBuffersManager;
 
-    private RenderingDebugConfig renderingDebugConfig;
     private Camera playerCamera;
     private FBO sceneOpaque;
     private FBO sceneReflectiveRefractive;
 
     @Override
     public void initialise() {
-        renderingDebugConfig = config.getRendering().getDebug();
         playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/backdrop");
-        enableWireframeIf(renderingDebugConfig.isWireframe());
-
         sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
         initialClearing();
@@ -86,7 +77,6 @@ public class BackdropNode extends AbstractNode {
         setRenderBufferMask(sceneOpaque, true, false, false);
         backdropRenderer.render(playerCamera);
 
-        disableWireframeIf(renderingDebugConfig.isWireframe());
         PerformanceMonitor.endActivity();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropNode.java
@@ -19,7 +19,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
@@ -33,7 +33,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
 /**
  * TODO: Diagram of this node
  */
-public class BackdropNode extends WireframeNode {
+public class BackdropNode extends WireframeCapableNode {
 
     @In
     private BackdropRenderer backdropRenderer;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropNode.java
@@ -19,8 +19,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
@@ -34,7 +33,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
 /**
  * TODO: Diagram of this node
  */
-public class BackdropNode extends AbstractNode {
+public class BackdropNode extends WireframeNode {
 
     @In
     private BackdropRenderer backdropRenderer;
@@ -51,8 +50,8 @@ public class BackdropNode extends AbstractNode {
 
     @Override
     public void initialise() {
+        super.initialise();
         playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksAlphaRejectNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksAlphaRejectNode.java
@@ -15,28 +15,22 @@
  */
 package org.terasology.rendering.dag.nodes;
 
-import org.terasology.config.Config;
-import org.terasology.config.RenderingDebugConfig;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.rendering.world.WorldRendererImpl;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 
 /**
  * TODO: Diagram of this node
  * Alpha reject is used for semi-transparent billboards, which in turn are used for ground plants.
  */
 public class ChunksAlphaRejectNode extends AbstractNode {
-
-    @In
-    private Config config;
 
     @In
     private ComponentSystemManager componentSystemManager;
@@ -48,24 +42,19 @@ public class ChunksAlphaRejectNode extends AbstractNode {
     private RenderQueuesHelper renderQueues;
 
     private Camera playerCamera;
-    private RenderingDebugConfig renderingDebugConfig;
 
     @Override
     public void initialise() {
-        renderingDebugConfig = config.getRendering().getDebug();
         playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/chunksAlphaReject");
-        enableWireframeIf(renderingDebugConfig.isWireframe());
-
         worldRenderer.renderChunks(renderQueues.chunksAlphaReject,
                 ChunkMesh.RenderPhase.ALPHA_REJECT, playerCamera,
                 WorldRendererImpl.ChunkRenderMode.DEFAULT);
-
-        disableWireframeIf(renderingDebugConfig.isWireframe());
         PerformanceMonitor.endActivity();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksAlphaRejectNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksAlphaRejectNode.java
@@ -19,7 +19,7 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -29,7 +29,7 @@ import org.terasology.rendering.world.WorldRendererImpl;
  * TODO: Diagram of this node
  * Alpha reject is used for semi-transparent billboards, which in turn are used for ground plants.
  */
-public class ChunksAlphaRejectNode extends WireframeNode {
+public class ChunksAlphaRejectNode extends WireframeCapableNode {
 
     @In
     private ComponentSystemManager componentSystemManager;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksAlphaRejectNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksAlphaRejectNode.java
@@ -19,8 +19,7 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -30,7 +29,7 @@ import org.terasology.rendering.world.WorldRendererImpl;
  * TODO: Diagram of this node
  * Alpha reject is used for semi-transparent billboards, which in turn are used for ground plants.
  */
-public class ChunksAlphaRejectNode extends AbstractNode {
+public class ChunksAlphaRejectNode extends WireframeNode {
 
     @In
     private ComponentSystemManager componentSystemManager;
@@ -45,8 +44,8 @@ public class ChunksAlphaRejectNode extends AbstractNode {
 
     @Override
     public void initialise() {
+        super.initialise();
         playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksOpaqueNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksOpaqueNode.java
@@ -19,8 +19,7 @@ package org.terasology.rendering.dag.nodes;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -29,7 +28,7 @@ import org.terasology.rendering.world.WorldRendererImpl;
 /**
  * TODO: Diagram of this node
  */
-public class ChunksOpaqueNode extends AbstractNode {
+public class ChunksOpaqueNode extends WireframeNode {
 
     @In
     private WorldRenderer worldRenderer;
@@ -41,8 +40,8 @@ public class ChunksOpaqueNode extends AbstractNode {
 
     @Override
     public void initialise() {
+        super.initialise();
         playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksOpaqueNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksOpaqueNode.java
@@ -15,18 +15,16 @@
  */
 package org.terasology.rendering.dag.nodes;
 
-import org.terasology.config.Config;
-import org.terasology.config.RenderingDebugConfig;
+
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.rendering.world.WorldRendererImpl;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 
 /**
  * TODO: Diagram of this node
@@ -34,34 +32,26 @@ import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 public class ChunksOpaqueNode extends AbstractNode {
 
     @In
-    private Config config;
-
-    @In
     private WorldRenderer worldRenderer;
 
     @In
     private RenderQueuesHelper renderQueues;
 
-    private RenderingDebugConfig renderingDebugConfig;
     private Camera playerCamera;
 
     @Override
     public void initialise() {
-        renderingDebugConfig = config.getRendering().getDebug();
         playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/chunksOpaque");
-        enableWireframeIf(renderingDebugConfig.isWireframe());
-
         worldRenderer.renderChunks(renderQueues.chunksOpaque,
                 ChunkMesh.RenderPhase.OPAQUE,
                 playerCamera,
                 WorldRendererImpl.ChunkRenderMode.DEFAULT);
-
-        disableWireframeIf(renderingDebugConfig.isWireframe());
         PerformanceMonitor.endActivity();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksOpaqueNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ChunksOpaqueNode.java
@@ -19,7 +19,7 @@ package org.terasology.rendering.dag.nodes;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -28,7 +28,7 @@ import org.terasology.rendering.world.WorldRendererImpl;
 /**
  * TODO: Diagram of this node
  */
-public class ChunksOpaqueNode extends WireframeNode {
+public class ChunksOpaqueNode extends WireframeCapableNode {
 
     @In
     private WorldRenderer worldRenderer;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FirstPersonViewNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FirstPersonViewNode.java
@@ -21,14 +21,14 @@ import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 import org.terasology.rendering.world.WorldRenderer;
 import static org.lwjgl.opengl.GL11.GL_LEQUAL;
 
 /**
  * TODO: Diagram of this node
  */
-public class FirstPersonViewNode extends WireframeNode {
+public class FirstPersonViewNode extends WireframeCapableNode {
 
     @In
     private WorldRenderer worldRenderer;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FirstPersonViewNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FirstPersonViewNode.java
@@ -16,25 +16,19 @@
 package org.terasology.rendering.dag.nodes;
 
 import org.lwjgl.opengl.GL11;
-import org.terasology.config.Config;
-import org.terasology.config.RenderingDebugConfig;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 import org.terasology.rendering.world.WorldRenderer;
 import static org.lwjgl.opengl.GL11.GL_LEQUAL;
 
 /**
  * TODO: Diagram of this node
  */
-public class FirstPersonViewNode extends AbstractNode {
-
-    @In
-    private Config config;
+public class FirstPersonViewNode extends WireframeNode {
 
     @In
     private WorldRenderer worldRenderer;
@@ -42,14 +36,13 @@ public class FirstPersonViewNode extends AbstractNode {
     @In
     private ComponentSystemManager componentSystemManager;
 
-    private RenderingDebugConfig renderingDebugConfig;
     private Camera playerCamera;
 
     @Override
     public void initialise() {
+        super.initialise();
         renderingDebugConfig = config.getRendering().getDebug();
         playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FirstPersonViewNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FirstPersonViewNode.java
@@ -24,10 +24,9 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.world.WorldRenderer;
 import static org.lwjgl.opengl.GL11.GL_LEQUAL;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 
 /**
  * TODO: Diagram of this node
@@ -50,13 +49,13 @@ public class FirstPersonViewNode extends AbstractNode {
     public void initialise() {
         renderingDebugConfig = config.getRendering().getDebug();
         playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         if (!renderingDebugConfig.isFirstPersonElementsHidden()) {
             PerformanceMonitor.startActivity("rendering/firstPersonView");
-            enableWireframeIf(renderingDebugConfig.isWireframe());
 
             /**
              * Sets the state to render the First Person View.
@@ -83,7 +82,6 @@ public class FirstPersonViewNode extends AbstractNode {
             GL11.glDepthFunc(GL_LEQUAL);
             GL11.glPopMatrix();
 
-            disableWireframeIf(renderingDebugConfig.isWireframe());
             PerformanceMonitor.endActivity();
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ObjectsOpaqueNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ObjectsOpaqueNode.java
@@ -19,12 +19,12 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 
 /**
  * TODO: Diagram of this node
  */
-public class ObjectsOpaqueNode extends WireframeNode {
+public class ObjectsOpaqueNode extends WireframeCapableNode {
 
     @In
     private ComponentSystemManager componentSystemManager;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ObjectsOpaqueNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ObjectsOpaqueNode.java
@@ -19,21 +19,19 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 
 /**
  * TODO: Diagram of this node
  */
-public class ObjectsOpaqueNode extends AbstractNode {
+public class ObjectsOpaqueNode extends WireframeNode {
 
     @In
     private ComponentSystemManager componentSystemManager;
 
-
     @Override
     public void initialise() {
-        addDesiredStateChange(new SetWireframe(true));
+        super.initialise();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ObjectsOpaqueNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ObjectsOpaqueNode.java
@@ -15,43 +15,35 @@
  */
 package org.terasology.rendering.dag.nodes;
 
-import org.terasology.config.Config;
-import org.terasology.config.RenderingDebugConfig;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.dag.AbstractNode;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 
 /**
  * TODO: Diagram of this node
  */
 public class ObjectsOpaqueNode extends AbstractNode {
-    @In
-    private Config config;
 
     @In
     private ComponentSystemManager componentSystemManager;
 
-    private RenderingDebugConfig renderingDebugConfig;
 
     @Override
     public void initialise() {
-        renderingDebugConfig = config.getRendering().getDebug();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/objectsOpaque");
-        enableWireframeIf(renderingDebugConfig.isWireframe());
 
         for (RenderSystem renderer : componentSystemManager.iterateRenderSubscribers()) {
             renderer.renderOpaque();
         }
 
-        disableWireframeIf(renderingDebugConfig.isWireframe());
         PerformanceMonitor.endActivity();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
@@ -19,20 +19,19 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 
 /**
  * TODO: Diagram of this node
  */
-public class OverlaysNode extends AbstractNode {
+public class OverlaysNode extends WireframeNode {
 
     @In
     private ComponentSystemManager componentSystemManager;
 
     @Override
     public void initialise() {
-        addDesiredStateChange(new SetWireframe(true));
+        super.initialise();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
@@ -19,12 +19,12 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 
 /**
  * TODO: Diagram of this node
  */
-public class OverlaysNode extends WireframeNode {
+public class OverlaysNode extends WireframeCapableNode {
 
     @In
     private ComponentSystemManager componentSystemManager;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
@@ -15,15 +15,12 @@
  */
 package org.terasology.rendering.dag.nodes;
 
-import org.terasology.config.Config;
-import org.terasology.config.RenderingDebugConfig;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.dag.AbstractNode;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 
 /**
  * TODO: Diagram of this node
@@ -31,28 +28,21 @@ import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 public class OverlaysNode extends AbstractNode {
 
     @In
-    private Config config;
-
-    @In
     private ComponentSystemManager componentSystemManager;
-
-    private RenderingDebugConfig renderingDebugConfig;
 
     @Override
     public void initialise() {
-        renderingDebugConfig = config.getRendering().getDebug();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/overlays");
-        enableWireframeIf(renderingDebugConfig.isWireframe());
 
         for (RenderSystem renderer : componentSystemManager.iterateRenderSubscribers()) {
             renderer.renderOverlay();
         }
 
-        disableWireframeIf(renderingDebugConfig.isWireframe());
         PerformanceMonitor.endActivity();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
@@ -28,6 +28,7 @@ import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.RenderableWorld;
@@ -49,6 +50,9 @@ public class ShadowMapNode extends AbstractNode {
     private static final String SCENE_SHADOW_MAP = "sceneShadowMap";
     private static final int SHADOW_FRUSTUM_BOUNDS = 500;
     public Camera shadowMapCamera = new OrthographicCamera(-SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, -SHADOW_FRUSTUM_BOUNDS);
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
 
     @In
     private RenderableWorld renderableWorld;
@@ -79,8 +83,8 @@ public class ShadowMapNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         renderableWorld.setShadowMapCamera(shadowMapCamera);
 
-        addDesiredStateChange(new BindFBO(SCENE_SHADOW_MAP));
-        addDesiredStateChange(new SetViewportSizeOf(SCENE_SHADOW_MAP));
+        addDesiredStateChange(new BindFBO(SCENE_SHADOW_MAP, frameBuffersManager));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_SHADOW_MAP, frameBuffersManager));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
@@ -28,7 +28,6 @@ import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
-import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.RenderableWorld;
@@ -47,7 +46,7 @@ import static org.lwjgl.opengl.GL11.glClear;
  * - https://docs.google.com/drawings/d/13I0GM9jDFlZv1vNrUPlQuBbaF86RPRNpVfn5q8Wj2lc/edit?usp=sharing
  */
 public class ShadowMapNode extends AbstractNode {
-    private static final String SHADOW_MAP_FBO_NAME = "sceneShadowMap";
+    private static final String SCENE_SHADOW_MAP = "sceneShadowMap";
     private static final int SHADOW_FRUSTUM_BOUNDS = 500;
     public Camera shadowMapCamera = new OrthographicCamera(-SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, -SHADOW_FRUSTUM_BOUNDS);
 
@@ -59,9 +58,6 @@ public class ShadowMapNode extends AbstractNode {
 
     @In
     private Config config;
-
-    @In
-    private FrameBuffersManager frameBuffersManager;
 
     @In
     private WorldRenderer worldRenderer;
@@ -83,8 +79,8 @@ public class ShadowMapNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         renderableWorld.setShadowMapCamera(shadowMapCamera);
 
-        addDesiredStateChange(new BindFBO(SHADOW_MAP_FBO_NAME, frameBuffersManager));
-        addDesiredStateChange(new SetViewportSizeOf(SHADOW_MAP_FBO_NAME, frameBuffersManager));
+        addDesiredStateChange(new BindFBO(SCENE_SHADOW_MAP));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_SHADOW_MAP));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/SkyBandsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/SkyBandsNode.java
@@ -20,7 +20,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.WireframeNode;
+import org.terasology.rendering.dag.WireframeCapableNode;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
@@ -36,7 +36,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
  * TODO: Diagram of this node
  * TODO: Separate this node into multiple SkyBandNode's
  */
-public class SkyBandsNode extends WireframeNode {
+public class SkyBandsNode extends WireframeCapableNode {
 
     @In
     private WorldRenderer worldRenderer;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/SkyBandsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/SkyBandsNode.java
@@ -17,12 +17,12 @@ package org.terasology.rendering.dag.nodes;
 
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
-import org.terasology.config.RenderingDebugConfig;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
@@ -31,8 +31,6 @@ import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
 import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
-import static org.terasology.rendering.opengl.OpenGLUtils.disableWireframeIf;
-import static org.terasology.rendering.opengl.OpenGLUtils.enableWireframeIf;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
 
@@ -55,21 +53,19 @@ public class SkyBandsNode extends AbstractNode {
     private Material blurShader;
     private FBO sceneOpaque;
     private FBO sceneSkyBand0;
-    private RenderingDebugConfig renderingDebugConfig;
     private Camera playerCamera;
 
     @Override
     public void initialise() {
         renderingConfig = config.getRendering();
-        renderingDebugConfig = renderingConfig.getDebug();
         blurShader = worldRenderer.getMaterial("engine:prog.blur");
         playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/skyBands");
-        enableWireframeIf(renderingDebugConfig.isWireframe());
 
         sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
@@ -85,7 +81,7 @@ public class SkyBandsNode extends AbstractNode {
         sceneOpaque.bind();
 
         playerCamera.lookThrough();
-        disableWireframeIf(renderingDebugConfig.isWireframe());
+
         PerformanceMonitor.endActivity();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/SkyBandsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/SkyBandsNode.java
@@ -15,14 +15,12 @@
  */
 package org.terasology.rendering.dag.nodes;
 
-import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.dag.stateChanges.SetWireframe;
+import org.terasology.rendering.dag.WireframeNode;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.world.WorldRenderer;
@@ -38,10 +36,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setRenderBufferMask;
  * TODO: Diagram of this node
  * TODO: Separate this node into multiple SkyBandNode's
  */
-public class SkyBandsNode extends AbstractNode {
-
-    @In
-    private Config config;
+public class SkyBandsNode extends WireframeNode {
 
     @In
     private WorldRenderer worldRenderer;
@@ -57,10 +52,10 @@ public class SkyBandsNode extends AbstractNode {
 
     @Override
     public void initialise() {
+        super.initialise();
         renderingConfig = config.getRendering();
         blurShader = worldRenderer.getMaterial("engine:prog.blur");
         playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new SetWireframe(true));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -27,6 +27,7 @@ import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -42,6 +43,9 @@ import static org.lwjgl.opengl.GL11.glClear;
  */
 public class WorldReflectionNode extends AbstractNode {
     private static final String SCENE_REFLECTED_FBO = "sceneReflected";
+
+    @In
+    private FrameBuffersManager frameBuffersManager;
 
     @In
     private RenderQueuesHelper renderQueues;
@@ -65,8 +69,8 @@ public class WorldReflectionNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         this.chunkShader = worldRenderer.getMaterial("engine:prog.chunk");
         this.playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new BindFBO(SCENE_REFLECTED_FBO));
-        addDesiredStateChange(new SetViewportSizeOf(SCENE_REFLECTED_FBO));
+        addDesiredStateChange(new BindFBO(SCENE_REFLECTED_FBO, frameBuffersManager));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_REFLECTED_FBO, frameBuffersManager));
 
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -26,7 +26,7 @@ import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
-import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
@@ -35,8 +35,6 @@ import org.terasology.rendering.world.WorldRendererImpl;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
-import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
-import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
 
 /**
  * Diagram of this node can be viewed from:
@@ -44,6 +42,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
  * - https://docs.google.com/drawings/d/1Iz7MA8Y5q7yjxxcgZW-0antv5kgx6NYkvoInielbwGU/edit?usp=sharing
  */
 public class WorldReflectionNode extends AbstractNode {
+    private static final String REFLECTED_FBO_NAME = "sceneReflected";
 
     @In
     private FrameBuffersManager frameBuffersManager;
@@ -63,24 +62,22 @@ public class WorldReflectionNode extends AbstractNode {
     private Camera playerCamera;
     private Material chunkShader;
     private RenderingConfig renderingConfig;
-    private FBO sceneReflected;
-    private FBO sceneOpaque;
+
 
     @Override
     public void initialise() {
         this.renderingConfig = config.getRendering();
         this.chunkShader = worldRenderer.getMaterial("engine:prog.chunk");
         this.playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new BindFBO("sceneReflected", frameBuffersManager));
+        addDesiredStateChange(new BindFBO(REFLECTED_FBO_NAME, frameBuffersManager));
+        addDesiredStateChange(new SetViewportSizeOf(REFLECTED_FBO_NAME, frameBuffersManager));
+
     }
 
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/worldReflection");
-        sceneReflected = frameBuffersManager.getFBO("sceneReflected");
-        sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
-        setViewportToSizeOf(sceneReflected); // TODO: add setViewportSizeOf state change and remove this line
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         GL11.glCullFace(GL11.GL_FRONT);
         playerCamera.setReflected(true);
@@ -101,8 +98,7 @@ public class WorldReflectionNode extends AbstractNode {
         playerCamera.setReflected(false);
 
         GL11.glCullFace(GL11.GL_BACK);
-        bindDisplay(); // TODO: remove since its reset by default BindFBO state change
-        setViewportToSizeOf(sceneOpaque); // TODO: add setViewportSizeOf state change and remove this line
+
 
         PerformanceMonitor.endActivity();
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -27,7 +27,6 @@ import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
-import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.WorldRenderer;
@@ -42,10 +41,7 @@ import static org.lwjgl.opengl.GL11.glClear;
  * - https://docs.google.com/drawings/d/1Iz7MA8Y5q7yjxxcgZW-0antv5kgx6NYkvoInielbwGU/edit?usp=sharing
  */
 public class WorldReflectionNode extends AbstractNode {
-    private static final String REFLECTED_FBO_NAME = "sceneReflected";
-
-    @In
-    private FrameBuffersManager frameBuffersManager;
+    private static final String SCENE_REFLECTED_FBO = "sceneReflected";
 
     @In
     private RenderQueuesHelper renderQueues;
@@ -69,8 +65,8 @@ public class WorldReflectionNode extends AbstractNode {
         this.renderingConfig = config.getRendering();
         this.chunkShader = worldRenderer.getMaterial("engine:prog.chunk");
         this.playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new BindFBO(REFLECTED_FBO_NAME, frameBuffersManager));
-        addDesiredStateChange(new SetViewportSizeOf(REFLECTED_FBO_NAME, frameBuffersManager));
+        addDesiredStateChange(new BindFBO(SCENE_REFLECTED_FBO));
+        addDesiredStateChange(new SetViewportSizeOf(SCENE_REFLECTED_FBO));
 
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
@@ -19,7 +19,7 @@ import org.terasology.rendering.dag.FBOManagerSubscriber;
 import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.BindFBOTask;
-import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  * TODO: Add javadocs
@@ -30,15 +30,17 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     private static final String DEFAULT_FRAME_BUFFER_NAME = "display";
     private static BindFBO defaultInstance = new BindFBO();
     private String fboName;
+    private FrameBuffersManager frameBuffersManager;
     private int fboId;
     private BindFBOTask task;
 
-    public BindFBO(String fboName) {
+    public BindFBO(String fboName, FrameBuffersManager frameBuffersManager) {
         this.fboName = fboName;
+        this.frameBuffersManager = frameBuffersManager;
         fboId = frameBuffersManager.getFBO(fboName).fboId;
     }
 
-    private BindFBO() {
+    public BindFBO() {
         this.fboName = DEFAULT_FRAME_BUFFER_NAME;
         fboId = DEFAULT_FRAME_BUFFER_ID;
     }
@@ -46,6 +48,11 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     @Override
     public StateChange getDefaultInstance() {
         return defaultInstance;
+    }
+
+
+    public static void setDefaultInstance(BindFBO defaultInstance) {
+        BindFBO.defaultInstance = defaultInstance;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
@@ -19,7 +19,7 @@ import org.terasology.rendering.dag.FBOManagerSubscriber;
 import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.BindFBOTask;
-import org.terasology.rendering.opengl.FrameBuffersManager;
+import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
 
 /**
  * TODO: Add javadocs
@@ -32,11 +32,9 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     private String fboName;
     private int fboId;
     private BindFBOTask task;
-    private FrameBuffersManager frameBuffersManager;
 
-    public BindFBO(String fboName, FrameBuffersManager frameBuffersManager) {
+    public BindFBO(String fboName) {
         this.fboName = fboName;
-        this.frameBuffersManager = frameBuffersManager;
         fboId = frameBuffersManager.getFBO(fboName).fboId;
     }
 
@@ -74,7 +72,7 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     @Override
     public boolean isEqualTo(StateChange stateChange) {
         if (stateChange instanceof BindFBO) {
-            return this.fboName.equals(((BindFBO) stateChange).fboName);
+            return this.fboName.equals(((BindFBO) stateChange).getFboName());
         }
         return false;
     }
@@ -88,5 +86,9 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
     @Override
     public String toString() { // TODO: used for logging purposes at the moment, investigate different methods
         return String.format("%21s: %s(%s)", this.getClass().getSimpleName(), fboName, fboId);
+    }
+
+    public String getFboName() {
+        return fboName;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
@@ -20,27 +20,37 @@ import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.SetViewportSizeOfTask;
 import org.terasology.rendering.opengl.FBO;
-import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
+import org.terasology.rendering.opengl.FrameBuffersManager;
 
 /**
  * TODO: Add javadocs
  */
 public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChange {
     private static final String DEFAULT_FBO = "sceneOpaque";
-    private static SetViewportSizeOf defaultInstance = new SetViewportSizeOf(DEFAULT_FBO);
+    private static SetViewportSizeOf defaultInstance;
     private SetViewportSizeOfTask task;
 
     private FBO fbo;
     private String fboName;
+    private FrameBuffersManager frameBuffersManager;
 
-    public SetViewportSizeOf(String fboName) {
+    public SetViewportSizeOf(String fboName, FrameBuffersManager frameBuffersManager) {
         this.fboName = fboName;
+        this.frameBuffersManager = frameBuffersManager;
         fbo = frameBuffersManager.getFBO(fboName);
+    }
+
+    public SetViewportSizeOf(FrameBuffersManager frameBuffersManager) {
+        this(DEFAULT_FBO, frameBuffersManager);
     }
 
     @Override
     public StateChange getDefaultInstance() {
         return defaultInstance;
+    }
+
+    public static void setDefaultInstance(SetViewportSizeOf defaultInstance) {
+        SetViewportSizeOf.defaultInstance = defaultInstance;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
@@ -20,37 +20,26 @@ import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.tasks.SetViewportSizeOfTask;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.FrameBuffersManager;
+import static org.terasology.rendering.world.WorldRendererImpl.frameBuffersManager;
 
 /**
  * TODO: Add javadocs
  */
 public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChange {
-    private static final String DEFAULT_FBO_NAME = "sceneOpaque";
-    private static SetViewportSizeOf defaultInstance = new SetViewportSizeOf();
+    private static final String DEFAULT_FBO = "sceneOpaque";
+    private static SetViewportSizeOf defaultInstance = new SetViewportSizeOf(DEFAULT_FBO);
     private SetViewportSizeOfTask task;
 
     private FBO fbo;
     private String fboName;
-    private FrameBuffersManager frameBuffersManager;
 
-    public SetViewportSizeOf(String fboName, FrameBuffersManager frameBuffersManager) {
+    public SetViewportSizeOf(String fboName) {
         this.fboName = fboName;
-        this.frameBuffersManager = frameBuffersManager;
         fbo = frameBuffersManager.getFBO(fboName);
-    }
-
-    public SetViewportSizeOf() {
-        this.fboName = DEFAULT_FBO_NAME;
     }
 
     @Override
     public StateChange getDefaultInstance() {
-        // TODO: a very dirty approach :(, however defaultInstance requires a frameBuffer instance, any suggestions?
-        if (defaultInstance.frameBuffersManager == null) {
-            defaultInstance.frameBuffersManager = frameBuffersManager;
-            defaultInstance.fbo = frameBuffersManager.getFBO(DEFAULT_FBO_NAME);
-        }
         return defaultInstance;
     }
 
@@ -69,7 +58,7 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
     @Override
     public boolean isEqualTo(StateChange stateChange) {
         if (stateChange instanceof SetViewportSizeOf) {
-            return this.fboName.equals(((SetViewportSizeOf) stateChange).fboName);
+            return this.fboName.equals(((SetViewportSizeOf) stateChange).getFboName());
         }
         return false;
     }
@@ -88,5 +77,9 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
     @Override
     public String toString() { // TODO: used for logging purposes at the moment, investigate different methods
         return String.format("%21s: %s(%sx%s)", this.getClass().getSimpleName(), fboName, fbo.width(), fbo.height());
+    }
+
+    public String getFboName() {
+        return fboName;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportSizeOf.java
@@ -38,11 +38,6 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
         this.fboName = fboName;
         this.frameBuffersManager = frameBuffersManager;
         fbo = frameBuffersManager.getFBO(fboName);
-        // TODO: a very dirty approach :(, however defaultInstance requires a frameBuffer instance, any suggestions?
-        if (defaultInstance.frameBuffersManager == null) {
-            defaultInstance.frameBuffersManager = frameBuffersManager;
-            defaultInstance.fbo = frameBuffersManager.getFBO(DEFAULT_FBO_NAME);
-        }
     }
 
     public SetViewportSizeOf() {
@@ -51,6 +46,11 @@ public final class SetViewportSizeOf implements FBOManagerSubscriber, StateChang
 
     @Override
     public StateChange getDefaultInstance() {
+        // TODO: a very dirty approach :(, however defaultInstance requires a frameBuffer instance, any suggestions?
+        if (defaultInstance.frameBuffersManager == null) {
+            defaultInstance.frameBuffersManager = frameBuffersManager;
+            defaultInstance.fbo = frameBuffersManager.getFBO(DEFAULT_FBO_NAME);
+        }
         return defaultInstance;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
@@ -61,7 +61,7 @@ public final class SetWireframe implements StateChange {
             if (disablingTask == null) {
                 disablingTask = new SetWireframeTask(false);
             }
-            return enablingTask;
+            return disablingTask;
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
@@ -23,7 +23,9 @@ import org.terasology.rendering.dag.tasks.SetWireframeTask;
  * TODO: Add javadocs
  */
 public final class SetWireframe implements StateChange {
-    private static SetWireframe defaultInstance = new SetWireframe(false);
+    private static final boolean DEFAULT_VALUE = false;
+
+    private static SetWireframe defaultInstance;
     private static SetWireframeTask enablingTask;
     private static SetWireframeTask disablingTask;
 
@@ -33,9 +35,19 @@ public final class SetWireframe implements StateChange {
         this.enabled = enabled;
     }
 
+    public SetWireframe() {
+        this(DEFAULT_VALUE);
+    }
+
+
     @Override
     public StateChange getDefaultInstance() {
         return defaultInstance;
+    }
+
+
+    public static void setDefaultInstance(SetWireframe defaultInstance) {
+        SetWireframe.defaultInstance = defaultInstance;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/tasks/SetViewportSizeOfTask.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/tasks/SetViewportSizeOfTask.java
@@ -15,34 +15,35 @@
  */
 package org.terasology.rendering.dag.tasks;
 
-import static org.lwjgl.opengl.EXTFramebufferObject.GL_FRAMEBUFFER_EXT;
-import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
+import static org.lwjgl.opengl.GL11.glViewport;
 import org.terasology.rendering.dag.RenderPipelineTask;
 
 /**
  * TODO: Add javadocs
  */
-public final class BindFBOTask implements RenderPipelineTask {
-
-    private int fboId;
+public class SetViewportSizeOfTask implements RenderPipelineTask {
+    private int width;
+    private int height;
     private String fboName;
 
-    public BindFBOTask(int fboId, String fboName) {
-        this.fboId = fboId;
+    public SetViewportSizeOfTask(String fboName, int width, int height) {
         this.fboName = fboName;
+        this.width = width;
+        this.height = height;
+    }
+
+    public void setDimensions(int w, int h) {
+        this.width = w;
+        this.height = h;
     }
 
     @Override
     public void execute() {
-        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fboId);
-    }
-
-    public void setFboId(int fboId) {
-        this.fboId = fboId;
+        glViewport(0, 0, width, height);
     }
 
     @Override
     public String toString() {
-        return String.format("%21s: %s(%s)", this.getClass().getSimpleName(), fboName, fboId);
+        return String.format("%21s: %s(%sx%s)", this.getClass().getSimpleName(), fboName, width, height);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,12 +15,8 @@
  */
 package org.terasology.rendering.world;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.List;
 import org.lwjgl.opengl.GL11;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.config.RenderingDebugConfig;
@@ -100,8 +96,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  * - a RenderableWorld instance, providing acceleration structures caching blocks requiring different rendering treatments<br/>
  *
  */
-public final class WorldRendererImpl implements WorldRenderer, PropertyChangeListener {
-    private static final Logger logger = LoggerFactory.getLogger(WorldRendererImpl.class);
+public final class WorldRendererImpl implements WorldRenderer {
     private boolean isFirstRenderingStageForCurrentFrame;
     private final RenderQueuesHelper renderQueues;
     private final Context context;
@@ -159,7 +154,6 @@ public final class WorldRendererImpl implements WorldRenderer, PropertyChangeLis
         this.backdropProvider = context.get(BackdropProvider.class);
         this.renderingConfig = context.get(Config.class).getRendering();
         this.renderingDebugConfig = renderingConfig.getDebug();
-        this.renderingDebugConfig.subscribe(this); // subscribed to all properties
         this.shaderManager = context.get(ShaderManager.class);
 
         if (renderingConfig.isOculusVrSupport()) {
@@ -620,11 +614,6 @@ public final class WorldRendererImpl implements WorldRenderer, PropertyChangeLis
     public Camera getLightCamera() {
         //FIXME: remove this method
         return shadowMapNode.shadowMapCamera;
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        logger.info("Set {} property to {}. ", evt.getPropertyName().toUpperCase(), evt.getNewValue()); // for debugging purposes
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -16,7 +16,6 @@
 package org.terasology.rendering.world;
 
 import java.util.List;
-import com.google.api.client.util.Lists;
 import org.lwjgl.opengl.GL11;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
@@ -95,6 +94,8 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  *
  */
 public final class WorldRendererImpl implements WorldRenderer {
+    public static FrameBuffersManager frameBuffersManager;
+
     private boolean isFirstRenderingStageForCurrentFrame;
     private final RenderQueuesHelper renderQueues;
     private final Context context;
@@ -125,7 +126,6 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private final RenderingConfig renderingConfig;
     private final RenderingDebugConfig renderingDebugConfig;
-    private FrameBuffersManager buffersManager;
     private PostProcessor postProcessor;
     private List<RenderPipelineTask> renderPipelineTaskList;
     private ShadowMapNode shadowMapNode;
@@ -174,14 +174,14 @@ public final class WorldRendererImpl implements WorldRenderer {
     }
 
     private void initRenderingSupport() {
-        buffersManager = new FrameBuffersManager();
-        context.put(FrameBuffersManager.class, buffersManager);
+        frameBuffersManager = new FrameBuffersManager();
+        context.put(FrameBuffersManager.class, frameBuffersManager);
 
-        postProcessor = new PostProcessor(buffersManager);
+        postProcessor = new PostProcessor(frameBuffersManager);
         context.put(PostProcessor.class, postProcessor);
 
-        buffersManager.setPostProcessor(postProcessor);
-        buffersManager.initialize();
+        frameBuffersManager.setPostProcessor(postProcessor);
+        frameBuffersManager.initialize();
 
         shaderManager.initShaders();
         initMaterials();
@@ -315,7 +315,7 @@ public final class WorldRendererImpl implements WorldRenderer {
             renderableWorld.generateVBOs();
             secondsSinceLastFrame = 0;
 
-            buffersManager.preRenderUpdate();
+            frameBuffersManager.preRenderUpdate();
 
             millisecondsSinceRenderingStart += secondsSinceLastFrame * 1000;  // updates the variable animations are based on.
         }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -64,6 +64,9 @@ import org.terasology.rendering.dag.nodes.SimpleBlendMaterialsNode;
 import org.terasology.rendering.dag.nodes.SkyBandsNode;
 import org.terasology.rendering.dag.nodes.ToneMappingNode;
 import org.terasology.rendering.dag.nodes.WorldReflectionNode;
+import org.terasology.rendering.dag.stateChanges.BindFBO;
+import org.terasology.rendering.dag.stateChanges.SetViewportSizeOf;
+import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.opengl.FrameBuffersManager;
 import org.terasology.rendering.opengl.PostProcessor;
@@ -94,8 +97,6 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  *
  */
 public final class WorldRendererImpl implements WorldRenderer {
-    public static FrameBuffersManager frameBuffersManager;
-
     private boolean isFirstRenderingStageForCurrentFrame;
     private final RenderQueuesHelper renderQueues;
     private final Context context;
@@ -126,6 +127,7 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private final RenderingConfig renderingConfig;
     private final RenderingDebugConfig renderingDebugConfig;
+    private FrameBuffersManager frameBuffersManager;
     private PostProcessor postProcessor;
     private List<RenderPipelineTask> renderPipelineTaskList;
     private ShadowMapNode shadowMapNode;
@@ -250,9 +252,18 @@ public final class WorldRendererImpl implements WorldRenderer {
         renderGraph.addNode(blurPassesNode, "blurPassesNode");
         renderGraph.addNode(finalPostProcessingNode, "finalPostProcessingNode");
 
+        initDefaultStateChanges();
+
         List<Node> orderedNodes = renderGraph.getNodesInTopologicalOrder();
         RenderTaskListGenerator generator = new RenderTaskListGenerator();
         renderPipelineTaskList = generator.generateFrom(orderedNodes);
+    }
+
+    private void initDefaultStateChanges() {
+        SetViewportSizeOf.setDefaultInstance(new SetViewportSizeOf(frameBuffersManager));
+        BindFBO.setDefaultInstance(new BindFBO());
+        SetWireframe.setDefaultInstance(new SetWireframe());
+
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

As title mentions, finalizes a Wireframe state change for [_All obvious State Changes implemented_](https://github.com/tdgunes/Terasology/issues/10)

### How to test

By checking the log and observing wireframe debug mode. 

FYI:  _Debug mode is toggled by F3 key and wireframe with F9._

An example screenshot when wireframe is enabled:

<img width="1264" alt="screen shot 2016-07-27 at 04 31 00" src="https://cloud.githubusercontent.com/assets/136392/17161081/f8381e22-53b2-11e6-814a-b8e78a47e5ed.png">

Eliminations must be seen in the log:

![demonstration](https://cloud.githubusercontent.com/assets/136392/17161036/997c89a4-53b2-11e6-8ec1-435b25152fa0.png)

### Important note:

This PR also includes setViewportSizeOf PR. Please just focus on last commit.