### PR TITLE
[RFR] Added TODOs for future work on ShaderParameter classes

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
@@ -43,9 +43,11 @@ public class ShaderParametersBase implements ShaderParameters {
 
         program.setFloat("viewingDistance", CoreRegistry.get(Config.class).getRendering().getViewDistance().getChunkDistance().x * 8.0f, true);
 
+        // TODO: obtain once in superclass?
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
 
+        // TODO: move into BaseMaterial?
         if (worldRenderer != null && backdropProvider != null) {
             program.setFloat("daylight", backdropProvider.getDaylight(), true);
             program.setFloat("swimming", worldRenderer.isHeadUnderWater() ? 1.0f : 0.0f, true);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBlock.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBlock.java
@@ -37,15 +37,19 @@ public class ShaderParametersBlock extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: move in material or node, take advantage of texture.subscribeToDisposal()
         Texture terrainTex = Assets.getTexture("engine:terrain").get();
 
+        // TODO: review - unnecessary?
         if (terrainTex == null) {
             return;
         }
 
+        // TODO: move texture binding into the appropriate node(s) as state changes.
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
         glBindTexture(GL11.GL_TEXTURE_2D, terrainTex.getId());
 
+        // TODO: move into material
         program.setFloat3("colorOffset", 1.0f, 1.0f, 1.0f, true);
         program.setBoolean("textured", true, true);
         program.setFloat("alpha", 1.0f, true);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersChunk.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.shader;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
+import org.terasology.config.RenderingConfig;
 import org.terasology.utilities.Assets;
 import org.terasology.config.Config;
 import org.terasology.math.geom.Vector4f;
@@ -76,6 +77,7 @@ public class ShaderParametersChunk extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: move in material or node, take advantage of texture.subscribeToDisposal()
         Optional<Texture> terrain = Assets.getTexture("engine:terrain");
         Optional<Texture> terrainNormal = Assets.getTexture("engine:terrainNormal");
         Optional<Texture> terrainHeight = Assets.getTexture("engine:terrainHeight");
@@ -91,45 +93,59 @@ public class ShaderParametersChunk extends ShaderParametersBase {
         }
 
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
+        RenderingConfig renderingConfig = CoreRegistry.get(Config.class).getRendering();
 
+        // TODO move texture binding and setting into nodes
         int texId = 0;
+        // TODO: group these three lines in a method somewhere
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, terrain.get().getId());
         program.setInt("textureAtlas", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, water.get().getId());
         program.setInt("textureWater", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, lava.get().getId());
         program.setInt("textureLava", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, waterNormal.get().getId());
         program.setInt("textureWaterNormal", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, waterNormalAlt.get().getId());
         program.setInt("textureWaterNormalAlt", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         glBindTexture(GL11.GL_TEXTURE_2D, effects.get().getId());
         program.setInt("textureEffects", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffersManager.bindFboColorTexture("sceneReflected");
         program.setInt("textureWaterReflection", texId++, true);
+
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffersManager.bindFboColorTexture("sceneOpaque");
         program.setInt("texSceneOpaque", texId++, true);
 
-        if (CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {
+        // TODO: monitor the renderingConfig for changes rather than check every frame
+        if (renderingConfig.isNormalMapping()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             glBindTexture(GL11.GL_TEXTURE_2D, terrainNormal.get().getId());
             program.setInt("textureAtlasNormal", texId++, true);
 
-            if (CoreRegistry.get(Config.class).getRendering().isParallaxMapping()) {
+            if (renderingConfig.isParallaxMapping()) {
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 glBindTexture(GL11.GL_TEXTURE_2D, terrainHeight.get().getId());
                 program.setInt("textureAtlasHeight", texId++, true);
+
+                program.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
             }
         }
 
+        // TODO: move into Material?
         Vector4f lightingSettingsFrag = new Vector4f();
         lightingSettingsFrag.z = waterSpecExp;
         program.setFloat4("lightingSettingsFrag", lightingSettingsFrag, true);
@@ -145,7 +161,8 @@ public class ShaderParametersChunk extends ShaderParametersBase {
         alternativeWaterSettingsFrag.x = waterTint;
         program.setFloat4("alternativeWaterSettingsFrag", alternativeWaterSettingsFrag, true);
 
-        if (CoreRegistry.get(Config.class).getRendering().isAnimateWater()) {
+        // TODO: monitor the renderingConfig for changes rather than check every frame
+        if (renderingConfig.isAnimateWater()) {
             program.setFloat("waveIntensFalloff", waveIntensFalloff, true);
             program.setFloat("waveSizeFalloff", waveSizeFalloff, true);
             program.setFloat("waveSize", waveSize, true);
@@ -156,10 +173,5 @@ public class ShaderParametersChunk extends ShaderParametersBase {
             program.setFloat("waveOverallScale", waveOverallScale, true);
         }
 
-        if (CoreRegistry.get(Config.class).getRendering().isParallaxMapping()
-                && CoreRegistry.get(Config.class).getRendering().isNormalMapping()) {
-            program.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
-        }
     }
-
 }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersCombine.java
@@ -49,9 +49,11 @@ public class ShaderParametersCombine extends ShaderParametersBase {
         super.applyParameters(program);
 
         int texId = 0;
+        // TODO: obtain these objects once in superclass and add there monitoring functionality as needed?
         FrameBuffersManager frameBuffersManager = CoreRegistry.get(FrameBuffersManager.class);
         FBO sceneOpaque = frameBuffersManager.getFBO("sceneOpaque");
 
+        // TODO: move texture bindings to the appropriate nodes
         if (sceneOpaque != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindTexture();
@@ -81,10 +83,13 @@ public class ShaderParametersCombine extends ShaderParametersBase {
         RenderingConfig renderingConfig = CoreRegistry.get(Config.class).getRendering();
         Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
 
+        // TODO: review - unnecessary? Probably from a time when shaders were initialized
+        // TODO:          on application startup rather than renderer startup.
         if (renderingConfig == null || activeCamera == null) {
             return;
         }
 
+        // TODO: monitor the property subscribing to it
         if (renderingConfig.isLocalReflections()) {
             if (sceneReflectiveRefractive != null) {
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
@@ -96,12 +101,14 @@ public class ShaderParametersCombine extends ShaderParametersBase {
             program.setMatrix4("projMatrix", activeCamera.getProjectionMatrix(), true);
         }
 
+        // TODO: monitor the property subscribing to it
         if (renderingConfig.isSsao()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             frameBuffersManager.bindFboColorTexture("ssaoBlurred");
             program.setInt("texSsao", texId++, true);
         }
 
+        // TODO: monitor the property subscribing to it
         if (renderingConfig.isOutline()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             frameBuffersManager.bindFboColorTexture("outline");
@@ -111,11 +118,13 @@ public class ShaderParametersCombine extends ShaderParametersBase {
             program.setFloat("outlineThickness", outlineThickness, true);
         }
 
+        // TODO: monitor the property subscribing to it
         if (renderingConfig.isVolumetricFog()) {
             program.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
             //TODO: Other parameters and volumetric fog test case is needed
         }
 
+        // TODO: monitor the property subscribing to it
         if (renderingConfig.isInscattering()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             frameBuffersManager.bindFboColorTexture("sceneSkyBand1");

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDebug.java
@@ -39,6 +39,7 @@ public class ShaderParametersDebug extends ShaderParametersBase {
 
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
 
+        // TODO: review - might have to go into a debug node
         switch (config.getRendering().getDebug().getStage()) {
             case SHADOW_MAP:
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDefault.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersDefault.java
@@ -31,6 +31,7 @@ public class ShaderParametersDefault extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: verify this is still relevant
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
         glBindTexture(GL11.GL_TEXTURE_2D, 0);
     }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersHdr.java
@@ -40,9 +40,11 @@ public class ShaderParametersHdr extends ShaderParametersBase {
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
         PostProcessor postProcessor = CoreRegistry.get(PostProcessor.class);
 
+        // TODO: move into a node
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
         buffersManager.bindFboColorTexture("scenePrePost");
 
+        // TODO: move into a material?
         program.setInt("texScene", 0, true);
         // TODO: move to DownSampleSceneAndUpdateExposure
         program.setFloat("exposure", postProcessor.getExposure() * exposureBias, true);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightGeometryPass.java
@@ -40,11 +40,13 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: obtain once in the superclass and monitor from there?
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
         FBO sceneOpaque = buffersManager.getFBO("sceneOpaque");
 
         int texId = 0;
         if (sceneOpaque != null) {
+            // TODO: move content of this block into the node
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneOpaque.bindDepthTexture();
             program.setInt("texSceneOpaqueDepth", texId++, true);
@@ -58,7 +60,9 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
             program.setInt("texSceneOpaqueLightBuffer", texId++, true);
         }
 
+        // TODO: monitor property by subscribing to it
         if (CoreRegistry.get(Config.class).getRendering().isDynamicShadows()) {
+            // TODO: move into node
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             buffersManager.bindFboDepthTexture("sceneShadowMap");
             program.setInt("texSceneShadowMap", texId++, true);
@@ -67,6 +71,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
             Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
 
             if (lightCamera != null && activeCamera != null) {
+                // TODO: move into material?
                 program.setMatrix4("lightViewProjMatrix", lightCamera.getViewProjectionMatrix(), true);
                 program.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
 
@@ -76,6 +81,7 @@ public class ShaderParametersLightGeometryPass extends ShaderParametersBase {
             }
 
             if (CoreRegistry.get(Config.class).getRendering().isCloudShadows()) {
+                // TODO: move into node - make sure to obtain texture only once and subscribe to it
                 Texture clouds = Assets.getTexture("engine:perlinNoiseTileable").get();
 
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersLightShaft.java
@@ -46,11 +46,15 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: obtain once in superclass and monitor from there?
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
         FBO scene = buffersManager.getFBO("sceneOpaque");
 
         int texId = 0;
 
+        // TODO: - move into node
+        // TODO: - many null checks are happening in these shader parameter classes. I feel they are unnecessary
+        // TODO:   as those objects should never be null. If they are I'd be happy receiving an NPE and debugging as needed.
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             scene.bindTexture();
@@ -60,6 +64,7 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
             program.setInt("texDepth", texId++, true);
         }
 
+        // TODO: move into Material?
         program.setFloat("density", density, true);
         program.setFloat("exposure", exposure, true);
         program.setFloat("weight", weight, true);
@@ -68,7 +73,9 @@ public class ShaderParametersLightShaft extends ShaderParametersBase {
         WorldRenderer worldRenderer = CoreRegistry.get(WorldRenderer.class);
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
 
+        // TODO: eliminate null check?
         if (worldRenderer != null) {
+            // TODO: move into Material?
             Vector3f sunDirection = backdropProvider.getSunDirection(true);
 
             Camera activeCamera = worldRenderer.getActiveCamera();

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersOcDistortion.java
@@ -30,7 +30,10 @@ public class ShaderParametersOcDistortion extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: move into node
         int texId = 0;
+        // TODO: convert the next three lines in a public method somewhere.
+        // TODO: In the BaseMaterial class perhaps? Or an even more generic utility class?
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         CoreRegistry.get(FrameBuffersManager.class).bindFboColorTexture("sceneFinal");
         program.setInt("texSceneFinal", texId++, true);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPost.java
@@ -51,14 +51,17 @@ public class ShaderParametersPost extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: obtain these only once in superclass and monitor from there?
         CameraTargetSystem cameraTargetSystem = CoreRegistry.get(CameraTargetSystem.class);
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
 
+        // TODO: move into node
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         buffersManager.bindFboColorTexture("sceneToneMapped");
         program.setInt("texScene", texId++, true);
 
+        // TODO: monitor property rather than check every frame
         if (CoreRegistry.get(Config.class).getRendering().getBlurIntensity() != 0) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             buffersManager.getFBO("sceneBlur1").bindTexture();
@@ -69,9 +72,11 @@ public class ShaderParametersPost extends ShaderParametersBase {
             }
         }
 
+        // TODO: move to node - obtain only once and then subscribe to it
+        // TODO: take advantage of Texture.subscribeToDisposal(Runnable) to reobtain the asset only if necessary
         Texture colorGradingLut = Assets.getTexture("engine:colorGradingLut1").get();
 
-        if (colorGradingLut != null) {
+        if (colorGradingLut != null) { // TODO: review need for null check
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             glBindTexture(GL12.GL_TEXTURE_3D, colorGradingLut.getId());
             program.setInt("texColorGradingLut", texId++, true);
@@ -79,17 +84,23 @@ public class ShaderParametersPost extends ShaderParametersBase {
 
         FBO sceneCombined = buffersManager.getFBO("sceneOpaque");
 
-        if (sceneCombined != null) {
+        if (sceneCombined != null) { // TODO: review need for null check
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             sceneCombined.bindDepthTexture();
             program.setInt("texDepth", texId++, true);
 
+            // TODO: review - is this loading a noise texture every frame? And why is it not in the IF(grain) block?
+            // TODO:          and must it be monitored like a standard texture?
             ResourceUrn noiseTextureUri = TextureUtil.getTextureUriForWhiteNoise(1024, 0x1234, 0, 512);
             Texture filmGrainNoiseTexture = Assets.getTexture(noiseTextureUri).get();
 
+            // TODO: monitor property rather than check every frame
             if (CoreRegistry.get(Config.class).getRendering().isFilmGrain()) {
+                // TODO: move into node
                 GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
                 glBindTexture(GL11.GL_TEXTURE_2D, filmGrainNoiseTexture.getId());
+
+                // TODO: move into material?
                 program.setInt("texNoise", texId++, true);
                 program.setFloat("grainIntensity", filmGrainIntensity, true);
                 program.setFloat("noiseOffset", rand.nextFloat(), true);
@@ -99,8 +110,10 @@ public class ShaderParametersPost extends ShaderParametersBase {
             }
         }
 
+        // TODO: monitor property rather than check every frame
         Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
         if (activeCamera != null && CoreRegistry.get(Config.class).getRendering().isMotionBlur()) {
+            // TODO: move into material?
             program.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
             program.setMatrix4("prevViewProjMatrix", activeCamera.getPrevViewProjectionMatrix(), true);
         }

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersPrePost.java
@@ -51,10 +51,12 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: often used objects: perhaps to be obtained in BaseMaterial?
         FrameBuffersManager buffersManager = CoreRegistry.get(FrameBuffersManager.class);
         Camera activeCamera = CoreRegistry.get(WorldRenderer.class).getActiveCamera();
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
 
+        // TODO: move what follows into material and/or node
         Vector3f tint = worldProvider.getBlock(activeCamera.getPosition()).getTint();
         program.setFloat3("inLiquidTint", tint.x, tint.y, tint.z, true);
 
@@ -63,6 +65,7 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
         buffersManager.bindFboColorTexture("sceneOpaque");
         program.setInt("texScene", texId++, true);
 
+        // TODO: monitor config parameter by subscribing to it
         if (CoreRegistry.get(Config.class).getRendering().isBloom()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             buffersManager.bindFboColorTexture("sceneBloom2");
@@ -73,12 +76,14 @@ public class ShaderParametersPrePost extends ShaderParametersBase {
 
         program.setFloat2("aberrationOffset", aberrationOffsetX, aberrationOffsetY, true);
 
+        // TODO: monitor config parameter by subscribing to it
         if (CoreRegistry.get(Config.class).getRendering().isLightShafts()) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
             buffersManager.bindFboColorTexture("lightShafts");
             program.setInt("texLightShafts", texId++, true);
         }
 
+        // TODO: obtain once, monitor using Texture.subscribeToDisposal(Runnable)
         Optional<? extends Texture> vignetteTexture = Assets.getTexture("engine:vignette");
 
         if (vignetteTexture.isPresent()) {

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSSAO.java
@@ -95,6 +95,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
 
         int texId = 0;
 
+        // TODO: move to node
         if (scene != null) {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);
             scene.bindDepthTexture();
@@ -110,6 +111,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
         glBindTexture(GL11.GL_TEXTURE_2D, ssaoNoiseTexture.getId());
         program.setInt("texNoise", texId++, true);
 
+        // TODO: move to material?
         program.setFloat4("ssaoSettings", ssaoStrength, ssaoRad, 0.0f, 0.0f, true);
 
         if (CoreRegistry.get(WorldRenderer.class) != null) {
@@ -122,6 +124,7 @@ public class ShaderParametersSSAO extends ShaderParametersBase {
     }
 
     private Texture updateNoiseTexture() {
+        // TODO: take advantage of Texture.subscribeToDisposal(Runnable) to reobtain the asset only if necessary
         Optional<Texture> texture = CoreRegistry.get(AssetManager.class).getAsset("engine:ssaoNoise", Texture.class);
         if (!texture.isPresent()) {
             ByteBuffer noiseValues = BufferUtils.createByteBuffer(SSAO_NOISE_SIZE * SSAO_NOISE_SIZE * 4);

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSky.java
@@ -67,6 +67,8 @@ public class ShaderParametersSky extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: move to node and/or material?
+        // TODO: take advantage of Texture.subscribeToDisposal(Runnable) to reobtain the asset only if necessary
         int texId = 0;
         GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, Assets.getTexture("engine:sky90").get().getId());
@@ -78,6 +80,7 @@ public class ShaderParametersSky extends ShaderParametersBase {
         BackdropProvider backdropProvider = CoreRegistry.get(BackdropProvider.class);
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
 
+        // TODO: move the rest to material?
         if (worldProvider != null && backdropProvider != null) {
             program.setFloat("colorExp", backdropProvider.getColorExp(), true);
 

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersSobel.java
@@ -37,9 +37,13 @@ public class ShaderParametersSobel extends ShaderParametersBase {
     public void applyParameters(Material program) {
         super.applyParameters(program);
 
+        // TODO: obtain once in superclass? The superclass could then have the monitoring functionality.
         FBO scene = CoreRegistry.get(FrameBuffersManager.class).getFBO("sceneOpaque");
 
+        // TODO: move to node
         if (scene != null) {
+
+            // TODO: group these recurring three lines into a method binding a texture from disk or an FBO-bound buffer
             GL13.glActiveTexture(GL13.GL_TEXTURE0);
             scene.bindDepthTexture();
             program.setInt("texDepth", 0);


### PR DESCRIPTION
The code of ShaderParameter implementations will have to find its way into GLSLMaterial implementations or within the rendering engine's Node implementations. As the ShaderParameter implementations become empty, they will be removed.

This PR:
- provides no functional changes
- adds a large number of TODOs for future work
- in ShaderParametersChunk small code changes have been made to obtain the renderingConfig only once, add some empty lines and move a program.setFloat4 line to remove an otherwise unnecessary IF block.

I've ignored a large number of pre-existing CheckStyle warnings. We will deal with them as we move the ShaderParameter code into materials and nodes.