### PR TITLE
Added categories to leaf block template to make it breakable

### DIFF
--- a/modules/Core/assets/blocks/templates/leaf.block
+++ b/modules/Core/assets/blocks/templates/leaf.block
@@ -3,6 +3,7 @@
  */
 {
     "template" : true,
+    "categories" : ["wood", "leaf"],
     "attachmentAllowed" : false,
     "hardness" : 1,
     "colorSource" : "foliage_lut",

--- a/modules/Core/assets/prefabs/damageTypes/shovelDamage.prefab
+++ b/modules/Core/assets/prefabs/damageTypes/shovelDamage.prefab
@@ -1,6 +1,6 @@
 {
     "parent" : "physicalDamage",
     "blockDamageModifier" : {
-        "materialDamageMultiplier" : {"soil" : 2}
+        "materialDamageMultiplier" : {"leaf" : 1, "soil" : 2}
     }
 }

--- a/modules/Core/assets/prefabs/damageTypes/shovelTier2Damage.prefab
+++ b/modules/Core/assets/prefabs/damageTypes/shovelTier2Damage.prefab
@@ -1,6 +1,6 @@
 {
     "parent" : "physicalDamage",
     "blockDamageModifier" : {
-        "materialDamageMultiplier" : {"soil" : 2, "soil2" : 10}
+        "materialDamageMultiplier" : {"leaf" : 1, "soil" : 2, "soil2" : 10}
     }
 }

--- a/modules/Core/assets/prefabs/damageTypes/shovelTier3Damage.prefab
+++ b/modules/Core/assets/prefabs/damageTypes/shovelTier3Damage.prefab
@@ -1,6 +1,6 @@
 {
     "parent" : "physicalDamage",
     "blockDamageModifier" : {
-        "materialDamageMultiplier" : {"soil" : 2, "soil2" : 10, "soil3" : 10}
+        "materialDamageMultiplier" : {"leaf" : 1, "soil" : 2, "soil2" : 10, "soil3" : 10}
     }
 }


### PR DESCRIPTION
### Contains

Changed the leaf block template to add two default categories ("wood" and "leaf") to it. Also altered the shovel damage prefabs so that shovels can now damage leaves. Thus, leaves can now be broken using fists, axes, or shovels.

### How to test

Create a new world, and try destroying the leaves off of trees using unarmed combat, axes, and shovels.

### Credits

@Cervator for finding this bug in the first place.