### PR TITLE
Override config

### DIFF
--- a/docs/Playing.md
+++ b/docs/Playing.md
@@ -35,6 +35,40 @@ With *server* rights you can terminate the server gracefully via `shutdownServer
 
 Finally to get modules configured for a headless server you either have to manually edit in a list of modules to the `defaultModSelection` section, and `defaultGenerator` for your chosen world, then delete the `saves` dir for the server and restart it. Start a single player world and look at the `config.cfg` that generates for hints.
 
+It is also possible to provide a configuration file which overrides the default configuration on startup. This file can be passed using the `-overrideDefaultConfig=<pathToFile>`. Settings from this file will be copied to the generated `config.cfg`. After that changes in the `config.cfg` have priority, so further modifications in the override file will not modify the server values. It not required to pass an entire configuration file. A typical example would be:
+
+```
+{
+  "defaultModSelection": {
+    "modules": [
+      "MyModule"
+    ],
+    "defaultGameplayModuleName": "MyModule"
+  },
+  "worldGeneration": {
+    "worldTitle": "World Title",
+    "defaultSeed": "custom seed for the server",
+    "defaultGenerator": "MyModule:MyWorldgen"
+  },
+  "moduleConfigs": {},
+  "network": {
+    "servers": [
+      {
+        "name": "localhost",
+        "address": "localhost",
+        "port": 25777,
+        "active": true
+      }
+    ],
+    "upstreamBandwidth": 1024,
+    "serverPort": 25777,
+    "masterServer": "meta.terasology.org"
+  }
+}
+```
+
+To set the gameplay module, the world generator and some basic server settings.
+
 If you include the "CheatsForAll" module in config for a server then you can bypass a lot of the admin setup as every player will be able to use `cheat` commands, like `giveBlock` - however, keep in mind then everybody can cheat, this is really more for testing :-)
 
 Alternatively you can run from source and supply parameters for game configuration. For instance here is how you would launch with ThroughoutTheAges active, our most complete setting. Keep in mind the module list may change any day, check in the game client what modules highlight with TTA selected to confirm.

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -347,9 +347,7 @@ public final class Terasology {
             System.out.println((recognized ? "Recognized" : "Invalid") + " argument: " + arg);
         }
 
-        try
-
-        {
+        try {
             if (homePath != null) {
                 PathManager.getInstance().useOverrideHomePath(homePath);
             } else {

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,6 +17,7 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import org.terasology.config.Config;
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.modes.StateLoading;
@@ -101,6 +102,7 @@ public final class Terasology {
     private static final String NO_SOUND = "-noSound";
     private static final String NO_SPLASH = "-noSplash";
     private static final String SERVER_PORT = "-serverPort=";
+    private static final String OVERRIDE_DEFAULT_CONFIG = "-overrideDefaultConfig=";
 
     private static boolean isHeadless;
     private static boolean crashReportEnabled = true;
@@ -170,7 +172,7 @@ public final class Terasology {
 
         SplashScreenBuilder builder = new SplashScreenBuilder();
 
-        String[] imgFiles = new String[] {
+        String[] imgFiles = new String[]{
                 "splash_1.png",
                 "splash_2.png",
                 "splash_3.png",
@@ -178,7 +180,7 @@ public final class Terasology {
                 "splash_5.png"
         };
 
-        Point[] imgOffsets = new Point[] {
+        Point[] imgOffsets = new Point[]{
                 new Point(0, 0),
                 new Point(150, 0),
                 new Point(300, 0),
@@ -186,7 +188,7 @@ public final class Terasology {
                 new Point(630, 0)
         };
 
-        EngineStatus[] trigger = new EngineStatus[] {
+        EngineStatus[] trigger = new EngineStatus[]{
                 TerasologyEngineStatus.PREPARING_SUBSYSTEMS,
                 TerasologyEngineStatus.INITIALIZING_MODULE_MANAGER,
                 TerasologyEngineStatus.INITIALIZING_ASSET_TYPES,
@@ -283,6 +285,8 @@ public final class Terasology {
         System.out.println();
         System.out.println("To change the port the server is hosted on use the " + SERVER_PORT + " launch argument.");
         System.out.println();
+        System.out.println("To override the default generated config (useful for headless server) use the " + OVERRIDE_DEFAULT_CONFIG + " launch argument");
+        System.out.println();
         System.out.println("Examples:");
         System.out.println();
         System.out.println("    Use the current directory as the home directory:");
@@ -320,6 +324,8 @@ public final class Terasology {
             } else if (arg.equals(START_HEADLESS)) {
                 isHeadless = true;
                 crashReportEnabled = false;
+                splashEnabled = false;
+                soundEnabled = false;
             } else if (arg.equals(NO_SAVE_GAMES)) {
                 System.setProperty(SystemConfig.SAVED_GAMES_ENABLED_PROPERTY, "false");
             } else if (arg.equals(NO_CRASH_REPORT)) {
@@ -332,6 +338,8 @@ public final class Terasology {
                 loadLastGame = true;
             } else if (arg.startsWith(SERVER_PORT)) {
                 System.setProperty(ConfigurationSubsystem.SERVER_PORT_PROPERTY, arg.substring(SERVER_PORT.length()));
+            } else if (arg.startsWith(OVERRIDE_DEFAULT_CONFIG)) {
+                System.setProperty(Config.PROPERTY_OVERRIDE_DEFAULT_CONFIG, arg.substring(OVERRIDE_DEFAULT_CONFIG.length()));
             } else {
                 recognized = false;
             }
@@ -339,7 +347,9 @@ public final class Terasology {
             System.out.println((recognized ? "Recognized" : "Invalid") + " argument: " + arg);
         }
 
-        try {
+        try
+
+        {
             if (homePath != null) {
                 PathManager.getInstance().useOverrideHomePath(homePath);
             } else {
@@ -351,7 +361,6 @@ public final class Terasology {
             System.exit(0);
         }
     }
-
 
     private static void populateSubsystems(TerasologyEngineBuilder builder) {
         if (isHeadless) {

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -172,7 +172,7 @@ public final class Terasology {
 
         SplashScreenBuilder builder = new SplashScreenBuilder();
 
-        String[] imgFiles = new String[]{
+        String[] imgFiles = new String[] {
                 "splash_1.png",
                 "splash_2.png",
                 "splash_3.png",
@@ -180,7 +180,7 @@ public final class Terasology {
                 "splash_5.png"
         };
 
-        Point[] imgOffsets = new Point[]{
+        Point[] imgOffsets = new Point[] {
                 new Point(0, 0),
                 new Point(150, 0),
                 new Point(300, 0),
@@ -188,7 +188,7 @@ public final class Terasology {
                 new Point(630, 0)
         };
 
-        EngineStatus[] trigger = new EngineStatus[]{
+        EngineStatus[] trigger = new EngineStatus[] {
                 TerasologyEngineStatus.PREPARING_SUBSYSTEMS,
                 TerasologyEngineStatus.INITIALIZING_MODULE_MANAGER,
                 TerasologyEngineStatus.INITIALIZING_ASSET_TYPES,

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -251,6 +251,7 @@ public final class Terasology {
                 NO_SAVE_GAMES,
                 NO_SOUND,
                 NO_SPLASH,
+                OVERRIDE_DEFAULT_CONFIG + "<path>",
                 SERVER_PORT + "<port>");
 
         StringBuilder optText = new StringBuilder();
@@ -325,7 +326,6 @@ public final class Terasology {
                 isHeadless = true;
                 crashReportEnabled = false;
                 splashEnabled = false;
-                soundEnabled = false;
             } else if (arg.equals(NO_SAVE_GAMES)) {
                 System.setProperty(SystemConfig.SAVED_GAMES_ENABLED_PROPERTY, "false");
             } else if (arg.equals(NO_CRASH_REPORT)) {


### PR DESCRIPTION
### Contains

See [this post](http://forum.terasology.org/threads/multiplayer-server-management.1583/#post-13835) for a detailed description.

In short, it adds a run parameter `-overrideDefaultConfig=` to the PC facade.
The override config goes between the default config and the user config and gives the option to predefine settings for a headless server.

### How to test

Create a file `override.cfg` with the following content:
```
{
  "defaultModSelection": {
    "modules": [
      "MyModule"
    ],
    "defaultGameplayModuleName": "MyModule"
  },
  "worldGeneration": {
    "worldTitle": "World Title",
    "defaultSeed": "custom seed for the server",
    "defaultGenerator": "MyModule:MyWorldgen"
  },
  "moduleConfigs": {},
  "network": {
    "servers": [
      {
        "name": "localhost",
        "address": "localhost",
        "port": 25777,
        "active": true
      }
    ],
    "upstreamBandwidth": 1024,
    "serverPort": 25777,
    "masterServer": "meta.terasology.org"
  }
}
```

Start the pc facade with `-overrideDefaultConfig=override.cfg -headless`. Verfiy that the generated config.cfg contains the modifications from the override.cfg.
Further changes to the config.cfg should not be overriden by the override.cfg (user changes have always priority) 

Secondly, the change wires the splashEnabled and soundEnabled to the headless option.
Disabling the splash when already passed the headless option is very unintuitive. Not sure if the sound was active (mybe implicit) but now the flag is set properly.

### Outstanding before merging

Maybe checkstyle? :smile:  Good old Eclipse formatting.