### PR TITLE
NUI editor autosave

### DIFF
--- a/engine/src/main/java/org/terasology/config/NUIEditorConfig.java
+++ b/engine/src/main/java/org/terasology/config/NUIEditorConfig.java
@@ -22,6 +22,7 @@ import java.util.Locale;
  */
 public class NUIEditorConfig {
     private boolean disableIcons;
+    private boolean disableAutosave;
     private Locale alternativeLocale;
 
     public boolean isDisableIcons() {
@@ -38,5 +39,13 @@ public class NUIEditorConfig {
 
     public void setAlternativeLocale(Locale alternativeLocale) {
         this.alternativeLocale = alternativeLocale;
+    }
+
+    public boolean isDisableAutosave() {
+        return disableAutosave;
+    }
+
+    public void setDisableAutosave(boolean disableAutosave) {
+        this.disableAutosave = disableAutosave;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/AbstractEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/AbstractEditorScreen.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.input.Keyboard;
 import org.terasology.input.device.KeyboardDevice;
+import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.editor.systems.AbstractEditorSystem;
 import org.terasology.rendering.nui.events.NUIKeyEvent;
@@ -68,6 +69,10 @@ public abstract class AbstractEditorScreen extends CoreScreenLayer {
      * Whether unsaved changes in the editor are present.
      */
     private boolean unsavedChangesPresent;
+    /**
+     * Whether the autosave has been loaded.
+     */
+    private boolean autosaveLoaded;
 
     /**
      * Selects the current asset to be edited.
@@ -111,6 +116,15 @@ public abstract class AbstractEditorScreen extends CoreScreenLayer {
      * @return The path to the backup autosave file.
      */
     protected abstract Path getAutosaveFile();
+
+    @Override
+    public void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        if (!autosaveLoaded) {
+            loadAutosave();
+            autosaveLoaded = true;
+        }
+    }
 
     @Override
     public boolean onKeyEvent(NUIKeyEvent event) {
@@ -228,7 +242,7 @@ public abstract class AbstractEditorScreen extends CoreScreenLayer {
     /**
      * Resets the editor based on the state of the autosave file.
      */
-    protected void readAutosave() {
+    protected void loadAutosave() {
         try (JsonReader reader = new JsonReader(new InputStreamReader(Files.newInputStream(getAutosaveFile())))) {
             reader.setLenient(true);
             String content = new JsonParser().parse(reader).toString();

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/AbstractEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/AbstractEditorScreen.java
@@ -120,6 +120,10 @@ public abstract class AbstractEditorScreen extends CoreScreenLayer {
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
+
+        // If the autosave is loaded in initialise(), the preview widget is updated before interface component
+        // sizes are set, which breaks the editor's layout.
+        // Therefore, the autosave is loaded after the first onDraw() call.
         if (!autosaveLoaded) {
             loadAutosave();
             autosaveLoaded = true;

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
@@ -30,6 +30,7 @@ import org.terasology.assets.management.AssetManager;
 import org.terasology.config.Config;
 import org.terasology.config.NUIEditorConfig;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.paths.PathManager;
 import org.terasology.module.PathModule;
 import org.terasology.naming.Name;
 import org.terasology.registry.In;
@@ -183,6 +184,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
                 resetPreviewWidget();
                 updateConfig();
                 setUnsavedChangesPresent(true);
+                updateAutosave();
             });
 
             editor.setContextMenuTreeProducer(node -> {
@@ -242,6 +244,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
 
             if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
                 saveToFile(fileChooser.getSelectedFile());
+                deleteAutosave();
             }
 
             // Reload the look and feel.
@@ -260,6 +263,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
         });
         override.subscribe(button -> {
             saveToFile(selectedAssetPath);
+            deleteAutosave();
         });
 
         // Set the handlers for the editor buttons.
@@ -272,6 +276,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
         WidgetUtil.trySubscribe(this, "close", button -> nuiEditorSystem.toggleEditor());
 
         updateConfig();
+        readAutosave();
     }
 
     /**
@@ -448,5 +453,13 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
             getEditor().setSelectedIndex(getEditor().getModel().indexOf(widget.getChildWithKey("id")));
             editNode(widget.getChildWithKey("id"));
         });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Path getAutosaveFile() {
+        return PathManager.getInstance().getHomePath().resolve("nuiEditorAutosave.json");
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
@@ -124,7 +124,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
      */
     private String selectedAsset;
     /**
-     *
+     * The path to the currently selected asset. Null if no path exists.
      */
     private Path selectedAssetPath;
     /**
@@ -355,6 +355,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
     protected void updateConfig() {
         NUIEditorConfig nuiEditorConfig = config.getNuiEditor();
 
+        setDisableAutosave(nuiEditorConfig.isDisableAutosave());
         // Update the editor's item renderer.
         getEditor().setItemRenderer(nuiEditorConfig.isDisableIcons()
             ? new ToStringTextRenderer<>() : new NUIEditorItemRenderer(getEditor().getModel()));
@@ -460,5 +461,25 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
     @Override
     protected Path getAutosaveFile() {
         return PathManager.getInstance().getHomePath().resolve("nuiEditorAutosave.json");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getSelectedAsset() {
+        return selectedAsset;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setSelectedAsset(String selectedAsset) {
+        this.selectedAsset = selectedAsset;
+
+        // Also prevent the asset being reset.
+        this.selectedAssetPending = selectedAsset;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
@@ -25,14 +25,12 @@ import org.codehaus.plexus.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.exceptions.InvalidUrnException;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.config.Config;
 import org.terasology.config.NUIEditorConfig;
-import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
-import org.terasology.module.PathModule;
-import org.terasology.naming.Name;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.WidgetUtil;
@@ -104,12 +102,6 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
     private Config config;
 
     /**
-     * Used to get the {@link Path} of an asset.
-     */
-    @In
-    private ModuleManager moduleManager;
-
-    /**
      * Used to toggle the editor screen on ESCAPE.
      */
     @In
@@ -124,13 +116,13 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
      */
     private String selectedAsset;
     /**
-     * The path to the currently selected asset. Null if no path exists.
-     */
-    private Path selectedAssetPath;
-    /**
      * The Urn of the asset that will be selected after a response to a user prompt.
      */
     private String selectedAssetPending;
+    /**
+     * The path to the currently selected asset. Null if no path for the asset exists.
+     */
+    private Path selectedAssetPath;
     /**
      * The widget used as an inline node editor.
      */
@@ -292,19 +284,6 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
             }
 
             AssetDataFile source = element.getSource();
-
-            List<String> path = source.getPath();
-            Name moduleName = new Name(path.get(0));
-            if (moduleManager.getEnvironment().get(moduleName) instanceof PathModule) {
-                path.add(source.getFilename());
-                String[] pathArray = path.toArray(new String[path.size()]);
-
-                // Copy all the elements after the first to a separate array for getPath().
-                String first = pathArray[0];
-                String[] more = Arrays.copyOfRange(pathArray, 1, pathArray.length);
-                selectedAssetPath = moduleManager.getEnvironment().getFileSystem().getPath(first, more);
-            }
-
             String content = null;
             try (JsonReader reader = new JsonReader(new InputStreamReader(source.openStream(), Charsets.UTF_8))) {
                 reader.setLenient(true);
@@ -321,6 +300,9 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void resetStateInternal(JsonTree node) {
         getEditor().setTreeViewModel(node, true);
@@ -329,6 +311,11 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
         getEditor().clearHistory();
         updateConfig();
         selectedAsset = selectedAssetPending;
+        try {
+            ResourceUrn urn = new ResourceUrn(selectedAsset);
+            setSelectedAssetPath(urn);
+        } catch (InvalidUrnException ignored) {
+        }
     }
 
     /**
@@ -481,5 +468,23 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
 
         // Also prevent the asset being reset.
         this.selectedAssetPending = selectedAsset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setSelectedAssetPath(ResourceUrn urn) {
+        boolean isLoaded = assetManager.isLoaded(urn, UIElement.class);
+        Optional<UIElement> asset = assetManager.getAsset(urn, UIElement.class);
+        if (asset.isPresent()) {
+            UIElement element = asset.get();
+            if (!isLoaded) {
+                asset.get().dispose();
+            }
+
+            AssetDataFile source = element.getSource();
+            selectedAssetPath = getPath(source);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
@@ -276,7 +276,6 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
         WidgetUtil.trySubscribe(this, "close", button -> nuiEditorSystem.toggleEditor());
 
         updateConfig();
-        readAutosave();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorSettingsScreen.java
@@ -50,6 +50,7 @@ public class NUIEditorSettingsScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        WidgetUtil.tryBindCheckbox(this, "disableAutosave", BindHelper.bindBeanProperty("disableAutosave", config.getNuiEditor(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "disableIcons", BindHelper.bindBeanProperty("disableIcons", config.getNuiEditor(), Boolean.TYPE));
         WidgetUtil.trySubscribe(this, "close", button -> getManager().closeScreen(ASSET_URI));
 

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
@@ -25,14 +25,12 @@ import org.codehaus.plexus.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.exceptions.InvalidUrnException;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.config.Config;
 import org.terasology.config.NUIEditorConfig;
-import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
-import org.terasology.module.PathModule;
-import org.terasology.naming.Name;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.WidgetUtil;
@@ -97,24 +95,23 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
      */
     @In
     private AssetManager assetManager;
+
     /**
      * Used to read from and write to {@link NUIEditorConfig}
      */
     @In
     private Config config;
-    /**
-     * Used to get the {@link Path} of an asset.
-     */
-    @In
-    private ModuleManager moduleManager;
+
     /**
      * Used to toggle the editor screen on ESCAPE.
      */
     @In
     private NUISkinEditorSystem nuiSkinEditorSystem;
 
+    /**
+     * The box used to preview a NUI screen with a skin modified by the editor.
+     */
     private UIBox selectedScreenBox;
-
     /**
      * A dropdown containing available asset identifiers.
      */
@@ -128,7 +125,7 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
      */
     private String selectedAssetPending;
     /**
-     * The path to the currently selected asset. Null if no path exists.
+     * The path to the currently selected asset. Null if no path for the asset exists.
      */
     private Path selectedAssetPath;
     /**
@@ -320,20 +317,8 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
             if (!isLoaded) {
                 asset.get().dispose();
             }
+
             AssetDataFile source = skin.getSource();
-
-            List<String> path = source.getPath();
-            Name moduleName = new Name(path.get(0));
-            if (moduleManager.getEnvironment().get(moduleName) instanceof PathModule) {
-                path.add(source.getFilename());
-                String[] pathArray = path.toArray(new String[path.size()]);
-
-                // Copy all the elements after the first to a separate array for getPath().
-                String first = pathArray[0];
-                String[] more = Arrays.copyOfRange(pathArray, 1, pathArray.length);
-                selectedAssetPath = moduleManager.getEnvironment().getFileSystem().getPath(first, more);
-            }
-
             String content = null;
             try (JsonReader reader = new JsonReader(new InputStreamReader(source.openStream(), Charsets.UTF_8))) {
                 reader.setLenient(true);
@@ -350,6 +335,9 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void resetStateInternal(JsonTree node) {
         getEditor().setTreeViewModel(node, true);
@@ -358,6 +346,11 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
         getEditor().clearHistory();
         updateConfig();
         selectedAsset = selectedAssetPending;
+        try {
+            ResourceUrn urn = new ResourceUrn(selectedAsset);
+            setSelectedAssetPath(urn);
+        } catch (InvalidUrnException ignored) {
+        }
     }
 
     /**
@@ -507,5 +500,23 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
 
         // Also prevent the asset being reset.
         this.selectedAssetPending = selectedAsset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setSelectedAssetPath(ResourceUrn urn) {
+        boolean isLoaded = assetManager.isLoaded(urn, UISkin.class);
+        Optional<UISkin> asset = assetManager.getAsset(urn, UISkin.class);
+        if (asset.isPresent()) {
+            UISkin skin = asset.get();
+            if (!isLoaded) {
+                asset.get().dispose();
+            }
+
+            AssetDataFile source = skin.getSource();
+            selectedAssetPath = getPath(source);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
@@ -128,7 +128,7 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
      */
     private String selectedAssetPending;
     /**
-     *
+     * The path to the currently selected asset. Null if no path exists.
      */
     private Path selectedAssetPath;
     /**
@@ -410,6 +410,8 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
     protected void updateConfig() {
         NUIEditorConfig nuiEditorConfig = config.getNuiEditor();
 
+        setDisableAutosave(nuiEditorConfig.isDisableAutosave());
+
         // Update the editor's item renderer.
         getEditor().setItemRenderer(nuiEditorConfig.isDisableIcons()
             ? new ToStringTextRenderer<>() : new NUIEditorItemRenderer(getEditor().getModel()));
@@ -480,8 +482,30 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
         });
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Path getAutosaveFile() {
         return PathManager.getInstance().getHomePath().resolve("nuiSkinEditorAutosave.json");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getSelectedAsset() {
+        return selectedAsset;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setSelectedAsset(String selectedAsset) {
+        this.selectedAsset = selectedAsset;
+
+        // Also prevent the asset being reset.
+        this.selectedAssetPending = selectedAsset;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
@@ -306,7 +306,6 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
         WidgetUtil.trySubscribe(this, "close", button -> nuiSkinEditorSystem.toggleEditor());
 
         updateConfig();
-        readAutosave();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
@@ -30,6 +30,7 @@ import org.terasology.assets.management.AssetManager;
 import org.terasology.config.Config;
 import org.terasology.config.NUIEditorConfig;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.paths.PathManager;
 import org.terasology.module.PathModule;
 import org.terasology.naming.Name;
 import org.terasology.registry.In;
@@ -235,6 +236,7 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
                 resetPreviewWidget();
                 updateConfig();
                 setUnsavedChangesPresent(true);
+                updateAutosave();
             });
         }
 
@@ -273,6 +275,7 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
 
             if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
                 saveToFile(fileChooser.getSelectedFile());
+                deleteAutosave();
             }
 
             // Reload the look and feel.
@@ -290,6 +293,7 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
         });
         override.subscribe(button -> {
             saveToFile(selectedAssetPath);
+            deleteAutosave();
         });
 
         // Set the handlers for the editor buttons.
@@ -302,6 +306,7 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
         WidgetUtil.trySubscribe(this, "close", button -> nuiSkinEditorSystem.toggleEditor());
 
         updateConfig();
+        readAutosave();
     }
 
     /**
@@ -474,5 +479,10 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
             widget.setExpanded(true);
             getEditor().fireUpdateListeners();
         });
+    }
+
+    @Override
+    protected Path getAutosaveFile() {
+        return PathManager.getInstance().getHomePath().resolve("nuiSkinEditorAutosave.json");
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/utils/NUIEditorNodeUtils.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/utils/NUIEditorNodeUtils.java
@@ -38,8 +38,9 @@ import java.util.Set;
 
 @SuppressWarnings("unchecked")
 public final class NUIEditorNodeUtils {
-    private static final String SAMPLE_LABEL_TEXT = "Welcome to the Terasology NUI editor!\r\n" + "TODO: add tiny " +
-        "tutorial, keybinds etc.";
+    private static final String SAMPLE_LABEL_TEXT = "Welcome to the Terasology NUI editor!\r\n" +
+        "Visit https://github.com/Terasology/TutorialNui/wiki for a quick overview of the editor,\r\n" +
+        "as well as the NUI framework itself.";
 
     private NUIEditorNodeUtils() {
     }

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -129,6 +129,7 @@
     "nui-editor-alternative-locale": "nui-editor-alternative-locale",
     "nui-editor-close": "nui-editor-close",
     "nui-editor-copy": "nui-editor-copy",
+    "nui-editor-disable-autosave": "nui-editor-disable-autosave",
     "nui-editor-disable-icons": "nui-editor-disable-icons",
     "nui-editor-override": "nui-editor-override",
     "nui-editor-paste": "nui-editor-paste",

--- a/engine/src/main/resources/assets/i18n/menu_cs.lang
+++ b/engine/src/main/resources/assets/i18n/menu_cs.lang
@@ -109,6 +109,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_de.lang
+++ b/engine/src/main/resources/assets/i18n/menu_de.lang
@@ -109,6 +109,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -129,6 +129,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_es.lang
+++ b/engine/src/main/resources/assets/i18n/menu_es.lang
@@ -107,6 +107,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_fr.lang
+++ b/engine/src/main/resources/assets/i18n/menu_fr.lang
@@ -107,6 +107,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_gl.lang
+++ b/engine/src/main/resources/assets/i18n/menu_gl.lang
@@ -108,6 +108,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_it.lang
+++ b/engine/src/main/resources/assets/i18n/menu_it.lang
@@ -123,6 +123,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_ja.lang
+++ b/engine/src/main/resources/assets/i18n/menu_ja.lang
@@ -108,6 +108,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_pl.lang
+++ b/engine/src/main/resources/assets/i18n/menu_pl.lang
@@ -99,6 +99,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_pt.lang
+++ b/engine/src/main/resources/assets/i18n/menu_pt.lang
@@ -127,6 +127,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_ro.lang
+++ b/engine/src/main/resources/assets/i18n/menu_ro.lang
@@ -109,6 +109,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_ru.lang
+++ b/engine/src/main/resources/assets/i18n/menu_ru.lang
@@ -129,6 +129,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_sv.lang
+++ b/engine/src/main/resources/assets/i18n/menu_sv.lang
@@ -107,6 +107,7 @@
     "nui-editor-alternative-locale": "Preview widget locale",
     "nui-editor-close": "Close",
     "nui-editor-copy": "Copy",
+    "nui-editor-disable-autosave": "Disable autosave",
     "nui-editor-disable-icons": "Disable tree view icons",
     "nui-editor-override": "Save",
     "nui-editor-paste": "Paste",

--- a/engine/src/main/resources/assets/i18n/menu_uk.lang
+++ b/engine/src/main/resources/assets/i18n/menu_uk.lang
@@ -109,6 +109,7 @@
     "nui-editor-alternative-locale": "Мова попереднього перегляду",
     "nui-editor-close": "Закрити",
     "nui-editor-copy": "Копіювати",
+    "nui-editor-disable-autosave": "Відключити автозберігання",
     "nui-editor-disable-icons": "Відключити іконки",
     "nui-editor-override": "Зберегти",
     "nui-editor-paste": "Вставити",

--- a/engine/src/main/resources/assets/ui/editor/nuiEditorSettingsScreen.ui
+++ b/engine/src/main/resources/assets/ui/editor/nuiEditorSettingsScreen.ui
@@ -49,6 +49,20 @@
                             "contents": [
                                 {
                                     "type": "UILabel",
+                                    "text": "${engine:menu#nui-editor-disable-autosave}"
+                                },
+                                {
+                                    "type": "UICheckbox",
+                                    "id": "disableAutosave"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "RowLayout",
+                            "horizontalSpacing": 8,
+                            "contents": [
+                                {
+                                    "type": "UILabel",
                                     "text": "${engine:menu#nui-editor-alternative-locale}"
                                 },
                                 {


### PR DESCRIPTION
### Contains

Implements autosaving for the NUI editor, as per https://github.com/MovingBlocks/Terasology/pull/2438#issuecomment-241214770.

### How to test

Open the NUI (skin/screen) editor, edit, Alt+F4 without saving changes, restart the game and open the same editor again.

### Outstanding before merging

No outstanding issues.