### PR TITLE
[RFR] Introduces API for module developers to add graphical tweaks to their mods

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -25,6 +25,8 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.dag.RenderGraph;
+import org.terasology.rendering.dag.nodes.ShadowMapNode;
 import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.WorldRendererImpl;
@@ -68,6 +70,21 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     @Override
     public boolean renderLightComponent(LightComponent lightComponent, Vector3f lightWorldPosition, Material program, boolean geometryOnly) {
         return false;
+    }
+
+    @Override
+    public void setRenderGraph(RenderGraph renderGraph) {
+
+    }
+
+    @Override
+    public void setShadowMapNode(ShadowMapNode shadowNode) {
+
+    }
+
+    @Override
+    public void clear() {
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/ShaderManagerHeadless.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/ShaderManagerHeadless.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.engine.subsystem.headless.renderer;
 
+import org.terasology.assets.ResourceUrn;
 import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.shader.ShaderParameters;
 
 public class ShaderManagerHeadless implements ShaderManager {
 
@@ -25,6 +27,11 @@ public class ShaderManagerHeadless implements ShaderManager {
 
     @Override
     public void initShaders() {
+    }
+
+    @Override
+    public void loadShader(ResourceUrn shaderName, ShaderParameters shaderParameters) {
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/GraphicEffectsSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/GraphicEffectsSystem.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering;
+
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.module.sandbox.API;
+import org.terasology.registry.In;
+import org.terasology.registry.Share;
+import org.terasology.rendering.dag.RenderGraph;
+import org.terasology.rendering.dag.nodes.ShadowMapNode;
+import org.terasology.rendering.shader.ShaderParameters;
+import org.terasology.rendering.world.WorldRenderer;
+
+/**
+ * TODO: Add javadocs
+ */
+
+@API
+@RegisterSystem
+@Share(GraphicEffectsSystem.class)
+public class GraphicEffectsSystem extends BaseComponentSystem {
+
+    @In
+    private WorldRenderer worldRenderer;
+
+    @In
+    private ShaderManager shaderManager;
+
+    public void setRenderGraph(RenderGraph renderGraph) {
+        worldRenderer.setRenderGraph(renderGraph);
+    }
+
+    public void setShadowNode(ShadowMapNode shadowNode) {
+        worldRenderer.setShadowMapNode(shadowNode);
+    }
+
+    public void clear() {
+        worldRenderer.clear();
+    }
+
+    public void loadShader(ResourceUrn shaderName, ShaderParameters shaderParameters) {
+        shaderManager.loadShader(shaderName, shaderParameters);
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/ShaderManager.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManager.java
@@ -15,8 +15,10 @@
  */
 package org.terasology.rendering;
 
+import org.terasology.assets.ResourceUrn;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.shader.ShaderParameters;
 
 public interface ShaderManager {
 
@@ -29,6 +31,8 @@ public interface ShaderManager {
     Material getActiveMaterial();
 
     void recompileAllShaders();
+
+    void loadShader(ResourceUrn shaderName, ShaderParameters shaderParameters);
 
     /**
      * Enables the default shader program.

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -180,6 +180,17 @@ public class ShaderManagerLwjgl implements ShaderManager {
         return material;
     }
 
+    @Override
+    public void loadShader(ResourceUrn shaderName, ShaderParameters shaderParameters) {
+        Optional<? extends Shader> shader = Assets.getShader(shaderName.toString());
+        checkState(shader.isPresent(), "Failed to resolve %s", shaderName.toString());
+        shader.get().recompile();
+        GLSLMaterial material = (GLSLMaterial) Assets.generateAsset(new ResourceUrn(shaderName.getModuleName()
+                + ":prog." + shaderName.getResourceName()), new MaterialData(shader.get()), Material.class);
+        material.setShaderParameters(shaderParameters);
+        progamaticShaders.add(material);
+    }
+
     /**
      * Enables the default shader program.
      */

--- a/engine/src/main/java/org/terasology/rendering/assets/material/Material.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/material/Material.java
@@ -24,6 +24,7 @@ import org.terasology.math.geom.Matrix4f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
+import org.terasology.module.sandbox.API;
 import org.terasology.rendering.assets.shader.ShaderProgramFeature;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.cameras.Camera;
@@ -32,6 +33,7 @@ import java.nio.FloatBuffer;
 
 /**
  */
+@API
 public abstract class Material extends Asset<MaterialData> {
 
     protected Material(ResourceUrn urn, AssetType<?, MaterialData> assetType) {

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/package-info.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2016 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.shader;
-
-import org.terasology.module.sandbox.API;
-import org.terasology.rendering.assets.material.Material;
 
 /**
- * Interface for all shader parameters. Shader parameters can
- * be used to automatically set shader parameters when the
- * corresponding shader program gets activated.
- *
+ * TODO: Add javadocs
  */
-@API
-public interface ShaderParameters {
+@API package org.terasology.rendering.dag.nodes;
 
-    void initialParameters(Material material);
+import org.terasology.module.sandbox.API;
 
-    void applyParameters(Material material);
-}
+
+

--- a/engine/src/main/java/org/terasology/rendering/dag/package-info.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2016 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.shader;
-
-import org.terasology.module.sandbox.API;
-import org.terasology.rendering.assets.material.Material;
 
 /**
- * Interface for all shader parameters. Shader parameters can
- * be used to automatically set shader parameters when the
- * corresponding shader program gets activated.
- *
+ * TODO: Add javadocs
  */
-@API
-public interface ShaderParameters {
+@API package org.terasology.rendering.dag;
 
-    void initialParameters(Material material);
+import org.terasology.module.sandbox.API;
 
-    void applyParameters(Material material);
-}
+
+

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/package-info.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2016 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.shader;
-
-import org.terasology.module.sandbox.API;
-import org.terasology.rendering.assets.material.Material;
 
 /**
- * Interface for all shader parameters. Shader parameters can
- * be used to automatically set shader parameters when the
- * corresponding shader program gets activated.
- *
+ * TODO: Add javadocs
  */
-@API
-public interface ShaderParameters {
+@API package org.terasology.rendering.dag.stateChanges;
 
-    void initialParameters(Material material);
+import org.terasology.module.sandbox.API;
 
-    void applyParameters(Material material);
-}
+
+

--- a/engine/src/main/java/org/terasology/rendering/opengl/AbstractFBOsManager.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/AbstractFBOsManager.java
@@ -110,6 +110,17 @@ public abstract class AbstractFBOsManager implements BaseFBOsManager {
         }
     }
 
+    @Override
+    public void clear() {
+        for (FBO fbo : fboLookup.values()) {
+            fbo.dispose();
+        }
+        fboConfigs.clear();
+        fboLookup.clear();
+        fboUsageCountMap.clear();
+        fboManagerSubscribers.clear();
+    }
+
     /**
      * TODO: add javadoc
      *

--- a/engine/src/main/java/org/terasology/rendering/opengl/BaseFBOsManager.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/BaseFBOsManager.java
@@ -16,10 +16,12 @@
 package org.terasology.rendering.opengl;
 
 import org.terasology.assets.ResourceUrn;
+import org.terasology.module.sandbox.API;
 
 /**
  * TODO: Add javadocs
  */
+@API
 public interface BaseFBOsManager {
 
     boolean subscribe(FBOManagerSubscriber subscriber);
@@ -31,6 +33,8 @@ public interface BaseFBOsManager {
     FBO request(FBOConfig fboConfig);
 
     FBO get(ResourceUrn fboName);
+
+    void clear();
 
     boolean bindFboColorTexture(ResourceUrn fboName);
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/DefaultDynamicFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/DefaultDynamicFBOs.java
@@ -17,11 +17,13 @@ package org.terasology.rendering.opengl;
 
 import java.nio.ByteBuffer;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.module.sandbox.API;
 import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
 
 /**
  * TODO: Add javadocs
  */
+@API
 public enum DefaultDynamicFBOs {
     // TODO: investigate ways to make these nameless.
     // TODO: investigate how to remove special handling of default FBOs in state changes (especially BindFBO and SetViewportToSizeOf)

--- a/engine/src/main/java/org/terasology/rendering/opengl/OpenGLUtils.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/OpenGLUtils.java
@@ -17,7 +17,10 @@
 package org.terasology.rendering.opengl;
 
 import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import static org.lwjgl.opengl.GL13.glActiveTexture;
 import org.lwjgl.opengl.GL20;
 
 import java.nio.FloatBuffer;
@@ -29,10 +32,12 @@ import static org.lwjgl.opengl.EXTFramebufferObject.glBindFramebufferEXT;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL11.GL_MODELVIEW;
 import static org.lwjgl.opengl.GL11.glPopMatrix;
+import org.terasology.module.sandbox.API;
 
 /**
 
  */
+@API
 public final class OpenGLUtils {
     private static int displayListQuad = -1;
 
@@ -85,6 +90,10 @@ public final class OpenGLUtils {
         glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
     }
 
+
+    public static void selectActiveTexture(int texture) {
+        glActiveTexture(GL13.GL_TEXTURE0 + texture);
+    }
 
     /**
      * Once an FBO is bound, opengl commands will act on it, i.e. by drawing on it.
@@ -162,6 +171,10 @@ public final class OpenGLUtils {
     public static void renderFullscreenQuad(int x, int y, int viewportWidth, int viewportHeight) {
         glViewport(x, y, viewportWidth, viewportHeight);
         renderFullscreenQuad();
+    }
+
+    public static void renderFullScreenQuad() {
+        renderFullscreenQuad(0, 0, Display.getWidth(), Display.getHeight());
     }
 
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -75,6 +75,12 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager {
         return fbo;
     }
 
+    @Override
+    public void clear() {
+        super.clear();
+        generateDefaultFBOs();
+    }
+
     /**
      * Invoked before real-rendering starts
      * TODO: how about completely removing this, and make Display observable and this FBM as an observer

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/package-info.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2016 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.shader;
+
+
+@API package org.terasology.rendering.opengl.fbms;
 
 import org.terasology.module.sandbox.API;
-import org.terasology.rendering.assets.material.Material;
-
-/**
- * Interface for all shader parameters. Shader parameters can
- * be used to automatically set shader parameters when the
- * corresponding shader program gets activated.
- *
- */
-@API
-public interface ShaderParameters {
-
-    void initialParameters(Material material);
-
-    void applyParameters(Material material);
-}

--- a/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
+++ b/engine/src/main/java/org/terasology/rendering/shader/ShaderParametersBase.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.shader;
 
 import org.terasology.config.Config;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.module.sandbox.API;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
@@ -28,6 +29,7 @@ import org.terasology.world.WorldProvider;
  * Basic shader parameters for all shader program.
  *
  */
+@API
 public class ShaderParametersBase implements ShaderParameters {
 
     public ShaderParametersBase() {

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -19,6 +19,8 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.dag.RenderGraph;
+import org.terasology.rendering.dag.nodes.ShadowMapNode;
 import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
@@ -66,6 +68,12 @@ public interface WorldRenderer {
      * @param chunkPos a Vector3i providing the coordinates of the chunk that has just been unloaded.
      */
     void onChunkUnloaded(Vector3i chunkPos);
+
+    void setRenderGraph(RenderGraph renderGraph);
+
+    void setShadowMapNode(ShadowMapNode shadowNode);
+
+    void clear();
 
     /**
      * Lists the stages the rendering engine may go through on a given frame.

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -130,6 +130,7 @@ public final class WorldRendererImpl implements WorldRenderer {
     private ScreenGrabber screenGrabber;
     private List<RenderPipelineTask> renderPipelineTaskList;
     private ShadowMapNode shadowMapNode;
+    private RenderTaskListGenerator renderTaskListGenerator;
 
     private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
     private ShadowMapResolutionDependentFBOs shadowMapResolutionDependentFBOs;
@@ -258,10 +259,27 @@ public final class WorldRendererImpl implements WorldRenderer {
         renderGraph.addNode(blurPassesNode, "blurPassesNode");
         renderGraph.addNode(finalPostProcessingNode, "finalPostProcessingNode");
 
-        RenderTaskListGenerator renderTaskListGenerator = new RenderTaskListGenerator();
+        renderTaskListGenerator = new RenderTaskListGenerator();
         List<Node> orderedNodes = renderGraph.getNodesInTopologicalOrder();
-
         renderPipelineTaskList = renderTaskListGenerator.generateFrom(orderedNodes);
+    }
+
+    @Override
+    public void setShadowMapNode(ShadowMapNode shadowMapNode) {
+        this.shadowMapNode = shadowMapNode;
+    }
+
+    @Override
+    public void setRenderGraph(RenderGraph renderGraph) {
+        List<Node> orderedNodes = renderGraph.getNodesInTopologicalOrder();
+        renderPipelineTaskList = renderTaskListGenerator.generateFrom(orderedNodes);
+    }
+
+    @Override
+    public void clear() {
+        displayResolutionDependentFBOs.clear();
+        immutableFBOs.clear();
+        shadowMapResolutionDependentFBOs.clear();
     }
 
     @Override


### PR DESCRIPTION
### Contains

Enables module developers to add their own nodes/render graph to rendering engine. 
### How to test

Try to enable [the tutorial module](https://github.com/Terasology/TutorialGraphicTweaks) and run the game. Confirm that colours are inverted.
### Outstanding before merging

Which parts to expose to module developer is a good start. Because of the deadline, I might have wrongly put `@API` annotation to somer parts, that we don't want to. Better to discuss this with @msteiger and @emanuele3d .
