### PR TITLE
Add a bunch of modules to the lineup + bump libraries

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -38,6 +38,7 @@ Here's a list of modules bundled with the game by default (this line-up will cha
 * CoreSampleGameplay - gameplay front for Core - allows modules to depend on Core without the default starting inventory
 * [CustomOreGen](https://github.com/Terasology/CustomOreGen) - library containing an ore distribution algorithm based on [JRoush's CustomOreGen](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1282294-1-4-6-v2-custom-ore-generation-updated-jan-5th)
 * [DamagingBlocks](https://github.com/Terasology/DamagingBlocks) - allows blocks like lava to hurt the player
+* [Dialogs](https://github.com/Terasology/Dialogs) - supports opening dialogs for interactions with NPCs and such
 * [Durability](https://github.com/Terasology/Durability) - library module to support destructible items (wear and tear eventually breaks them)
 * [DynamicCities](https://github.com/Terasology/DynamicCities) - variant of Cities that places then grows cities dynamically over time 
 * [Economy](https://github.com/Terasology/Economy) - a module to simulate a basic supply & demand economy system
@@ -68,6 +69,7 @@ Here's a list of modules bundled with the game by default (this line-up will cha
 * [MarkovChains](https://github.com/Terasology/MarkovChains) - Library module with some pseudo random math stuff
 * [MasterOfOreon](https://github.com/Terasology/MasterOfOreon) - Master the Oreons, or others like them, from the throne-world of the Ancients! A menu command system, default show/hide key 'O'
 * [Maze](https://github.com/Terasology/Maze) - a maze generator. Right-click with the provided maze tool on one block then again on another and a maze will generate between the two points (in multiple layers if the area is tall enough)
+* [MedievalCities](https://github.com/Terasology/MedievalCities) - a set of building templates for a medieval era city
 * [Minerals](https://github.com/Terasology/Minerals) - a large collection of mineral blocks
 * [Miniion](https://github.com/Terasology/Miniion) - base creature control system, used by MasterOfOreon - old module that has gone through a few redesigns
 * [Minimap](https://github.com/Terasology/Minimap) - a basic minimap. Show/hide with `M` by default and zoom with numpad `-` and `+`
@@ -85,8 +87,9 @@ Here's a list of modules bundled with the game by default (this line-up will cha
 * [PolyWorld](https://github.com/Terasology/PolyWorld) - creates very neat island worlds based on the [map generating algorithm by Amit Patel of Red Blob Games](http://www-cs-students.stanford.edu/~amitp/game-programming/polygon-map-generation/)
 * [Portals](https://github.com/Terasology/Portals) - allows placement of portal blocks that'll spawn Oreons `giveBlock portal`
 * [PotentialEnergyDevices](https://github.com/Terasology/PotentialEnergyDevices) - A library for creating entities that build up potential energy
+* [Potions](https://github.com/Terasology/Potions) - contains a set of assorted potions the player can consume to gain various effects
 * [QuestExamples](https://github.com/Terasology/QuestExamples) - samples for developers to help create quests
-* ~~[Rails](https://github.com/Terasology/Rails) - railroads and trains! Press 'e' to start a caboose or enter a cart. Use the wrench to attach carts~~ (broken, waiting for author's return)
+* [Rails](https://github.com/Terasology/Rails) - railroads and trains! Press 'e' to start a caboose or enter a cart. Use the wrench to attach carts
 * [Sample](https://github.com/Terasology/Sample) - miscellaneous example content showcasing module usage
 * [Seasons](https://github.com/Terasology/Seasons) - adds seasons to the game
 * [ShatteredPlanes](https://github.com/Terasology/ShatteredPlanes) - a world generator focused on canyons, sky islands, and other somewhat radical terrain features
@@ -101,8 +104,13 @@ Here's a list of modules bundled with the game by default (this line-up will cha
 * [SubstanceMatters](https://github.com/Terasology/SubstanceMatters) - library for the definition and usage of materials in various contexts, such as tools with dynamic looks based on material
 * [Tasks](https://github.com/Terasology/Tasks) - allows for the definition of tasks/quests
 * [ThroughoutTheAges](https://github.com/Terasology/ThroughoutTheAges) - gameplay module for a large content series letting you slowly climb a tech tree to improve your available tools, foods, and so on
+* [TutorialAssetSystem](https://github.com/Terasology/TutorialAssetSystem) - a tutorial module covering our asset system, see also its [wiki](https://github.com/Terasology/TutorialAssetSystem/wiki)
+* [TutorialDynamicCities](https://github.com/Terasology/TutorialDynamicCities) - GSOC 2016 project tutorial / docs. Covers how dynamic cities function. [Shared wiki with DynamicCities](https://github.com/Terasology/DynamicCities/wiki)
+* [TutorialGraphicTweaks](https://github.com/Terasology/TutorialGraphicTweaks) - GSOC 2016 project tutorial / docs. Contains examples of how to modify rendering from a module
+* [TutorialNui](https://github.com/Terasology/TutorialNui) - GSOC 2016 project tutorial / docs. Includes details both on NUI itself as well as its editor in the [wiki](https://github.com/Terasology/TutorialNui/wiki)
 * [TutorialWorldGeneration](https://github.com/Terasology/TutorialWorldGeneration) - a world generation tutorial module, goes with a guide in its [wiki](https://github.com/Terasology/TutorialWorldGeneration/wiki)
 * [Valentines](https://github.com/Terasology/Valentines) - What is love? Gooey don't hurt me, don't hurt me, no more ... ♫
+* [WeatherManager](https://github.com/Terasology/WeatherManager) - simple weather foundation, tracks whether, maintains a single cloud layer, and so on 
 * [WildAnimals](https://github.com/Terasology/WildAnimals) - a module containing animals, initially a deer you can spawn in-world via console with `spawnPrefab deer` then watch wander idly
 * [WoodAndStone](https://github.com/Terasology/WoodAndStone) - big content module including "from scratch" crafting, starting with wood here
 * [Workstation](https://github.com/Terasology/Workstation) - workstations offer a way to use blocks in-world for advanced purposes


### PR DESCRIPTION
Normally I just slip new modules straight into `develop` from time to time when we get them, but this batch is huge and a bit unusual so I thought I'd PR them for discussion. There are also some I'm not sure we should add yet.

## New modules with doc updates in this PR

These are the ones I think we should add for sure and I just tested all of them:

* Dialogs - involved with both unreleased L&S work and the new dynamic cities tutorial. Might not be perfect yet (I can only sporadically get the dialogs to work in the city tutorial) but it has been outside the lineup long enough - it actually went out of date vs. the engine and I didn't notice since it wasn't in my mega-workspace (107 modules and counting!). You okay with that @msteiger?
* MedievalCities - new by @skaldarnar and makes awesome cities!
* Potions - fixed up by @xrtariq2594 and split out from Alchemy which in part had some pieces split out from TTA (I think?). Ancient version of the potions by bi0hax broke long ago, seemed fitting to regenerate it this way. Could be used by @flo to add potions to chests in GooeysQuests
* Rails - finally fixed in part by @SkySom then @pollend. Its master branch works about as well as I remember it from days of old (locos move, carts can be attached with some difficulty and move along, player can ride). Develop branch has the big rails and they work again but have no vehicles. @pollend is working on an overhaul of movement in an experimental branch. Ready for Metal Renegades @SuperSnark and @glasz? :D
* TutorialAssetSystem - added by @oniatus a while back and also just sort of sat there without being formally added. Separate note on all the tutorial modules below. I think it is ready.
* TutorialDynamicCities - GSOC 2016! Just tested out @CptCrispyCrunchy's work and its worlds look amazing. Few quirks here and there and depends on Dialogs with MedievalCities as an optional (I guess? Just worked!) - goes with the [DynamicCities wiki](https://github.com/Terasology/DynamicCities/wiki) for more docs
* TutorialGraphicTweaks - GSOC 2016! @tdgunes added a simple proof of concept example in there that goes with and depends on #2449. Needs a bit more work and maybe some documentation in its wiki down the road, but unsure when we should target that
* TutorialNui - GSOC 2016! @rzats added a [great wiki here](https://github.com/Terasology/TutorialNui/wiki) that covers both some NUI stuff in general and the editor he made. Actually doesn't have any code or assets in the module. More on that below.
* WeatherManager - surprisingly old module (last functional change by @LinusVanElswijk 1.5 years ago) that just never got shoved into the lineup. I think it is time. Since I happened to leave it in my mega-workspace it *did* get engine updates over the many months and actually seems to work perfectly (tracks weather states and generates + slowly moves a thin cloud layer). I think we pretty much had working rain in an earlier particle system effort (#2208) that could've been added here.

## So what's up with all the tutorial modules?

They aren't necessarily for players, more for modders - which is kind of awkward. But if we don't keep them in the lineup they'll likely get dusty, and they'll be less visible. Right now we really only have the "Omega" lineup and that's on me. All that stuff needs to be split out better and that's a big goal for my current sabbatical period. I need to figure that out but for now this is the easiest option. I might try to tweak the module descriptions to better indicate this.

## Extras

Other than the list above which have doc added on them in this PR there are a few more potential candidates for addition:

* Alchemy, Cooking, WorkstationCrafting - @xrtariq2594's inventions/extractions from TTA and bits of JS, sort of a benevolent Frankenstein mutant of the two. Could also consider them Neo-TTA or something. @xrtariq2594 do you think they're about ready for inclusion? Several of the other modules like them have been grabbed.
* FlightModeToggleButton, HUDToggleButtons - old inventions by @Josharias that likewise just never made it in the lineup despite seemingly working in the past. I haven't retested them and suspect they might have gone out of date since I don't have them locally :(
* SampleIntegrations - new module by meee - much like @tdgunes' example module for the new rendering stuff this one takes advantage of #2449 to add a shader in a module. This one adds a sort of rose colored glasses view of the world, making everything look more vibrant. Actually surprised how well it turned out. My goal was to begin a new sample module for more complex examples that involve dependencies on other modules. Still only exists locally in my workspace.

Outstanding before merge:

- [x] Tweak descriptions and maybe version numbers for some modules, especially the tutorial ones
- [x] Consider including some of the extras listed above
- [x] Actually update the Omega distro list in the Index repo
- [x] Sort the view tabs in Jenkins around appropriately between Modules and ModulesPending