### PR TITLE
[Review/Discussion] Set multiple blocks at once using WorldProvider

### DIFF
--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -17,6 +17,10 @@
 package org.terasology.testUtil;
 
 import com.google.common.collect.Maps;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -29,10 +33,6 @@ import org.terasology.world.internal.WorldProviderCore;
 import org.terasology.world.liquid.LiquidData;
 import org.terasology.world.time.WorldTime;
 import org.terasology.world.time.WorldTimeImpl;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  */
@@ -109,6 +109,16 @@ public class WorldProviderCoreStub implements WorldProviderCore {
             return air;
         }
         return old;
+    }
+
+    @Override
+    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocksToPlace) {
+        Map<Vector3i, Block> result = new HashMap<>(blocks.size());
+        for (Map.Entry<Vector3i, Block> entry : blocksToPlace.entrySet()) {
+            Block b = setBlock(entry.getKey(), entry.getValue());
+            result.put(entry.getKey(), b);
+        }
+        return result;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/entity/placement/BlockPlacingSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/placement/BlockPlacingSystem.java
@@ -21,13 +21,9 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.block.Block;
-
-import java.util.Map;
 
 /**
  */
@@ -38,8 +34,6 @@ public class BlockPlacingSystem extends BaseComponentSystem {
 
     @ReceiveEvent(components = {WorldComponent.class}, priority = EventPriority.PRIORITY_TRIVIAL)
     public void placeBlockInWorld(PlaceBlocks event, EntityRef world) {
-        for (Map.Entry<Vector3i, Block> blockEntry : event.getBlocks().entrySet()) {
-            worldProvider.setBlock(blockEntry.getKey(), blockEntry.getValue());
-        }
+        worldProvider.setBlocks(event.getBlocks());
     }
 }

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -16,6 +16,8 @@
 
 package org.terasology.world.internal;
 
+import java.util.Collection;
+import java.util.Map;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -24,8 +26,6 @@ import org.terasology.world.biomes.Biome;
 import org.terasology.world.block.Block;
 import org.terasology.world.liquid.LiquidData;
 import org.terasology.world.time.WorldTime;
-
-import java.util.Collection;
 
 /**
  */
@@ -95,6 +95,11 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     @Override
     public Block setBlock(Vector3i pos, Block type) {
         return base.setBlock(pos, type);
+    }
+
+    @Override
+    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
+        return base.setBlocks(blocks);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.world.internal;
 
+import java.util.Collection;
+import java.util.Map;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -24,11 +26,8 @@ import org.terasology.world.block.Block;
 import org.terasology.world.liquid.LiquidData;
 import org.terasology.world.time.WorldTime;
 
-import java.util.Collection;
-
 /**
  * Provides the basic interface for all world providers.
- *
  */
 public interface WorldProviderCore {
 
@@ -103,6 +102,17 @@ public interface WorldProviderCore {
      * @return The previous block type. Null if the change failed (because the necessary chunk was not loaded)
      */
     Block setBlock(Vector3i pos, Block type);
+
+    /**
+     * Places all given blocks of specific types at their corresponding positions
+     * </p>
+     * Chunks are
+     *
+     * @param blocks A mapping from world position to change to the type of block to set
+     * @return A mapping from world position to previous block type.
+     * The value of a map entry is Null if the change failed (because the necessary chunk was not loaded)
+     */
+    Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks);
 
     /**
      * Changes the biome at the given position.

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -21,6 +21,13 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityManager;
@@ -56,11 +63,6 @@ import org.terasology.world.propagation.light.SunlightRegenWorldView;
 import org.terasology.world.propagation.light.SunlightWorldView;
 import org.terasology.world.time.WorldTime;
 import org.terasology.world.time.WorldTimeImpl;
-
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  */
@@ -209,6 +211,54 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
         }
         return null;
+    }
+
+    @Override
+    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
+        Set<RenderableChunk> dirtiedChunks = new HashSet<>();
+        Set<BlockChange> changedBlocks = new HashSet<>();
+        Map<Vector3i, Block> result = new HashMap<>(blocks.size());
+
+        for (Map.Entry<Vector3i, Block> entry : blocks.entrySet()) {
+            Vector3i worldPos = entry.getKey();
+            Vector3i chunkPos = ChunkMath.calcChunkPos(worldPos);
+            CoreChunk chunk = chunkProvider.getChunk(chunkPos);
+
+            if (chunk != null) {
+                Block type = entry.getValue();
+                Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
+                chunk.writeLock();
+                Block oldBlockType = chunk.setBlock(blockPos, type);
+                chunk.writeUnlock();
+                if (oldBlockType != type) {
+                    BlockChange oldChange = blockChanges.get(worldPos);
+                    if (oldChange == null) {
+                        blockChanges.put(worldPos, new BlockChange(worldPos, oldBlockType, type));
+                    } else {
+                        oldChange.setTo(type);
+                    }
+                    for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
+                        RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+                        if (dirtiedChunk != null) {
+                            dirtiedChunks.add(dirtiedChunk);
+                        }
+                    }
+                    changedBlocks.add(new BlockChange(worldPos, oldBlockType, type));
+                }
+                result.put(worldPos, oldBlockType);
+            } else {
+                result.put(worldPos, null);
+            }
+        }
+
+        for (RenderableChunk chunk : dirtiedChunks) {
+            chunk.setDirty(true);
+        }
+        for (BlockChange change : changedBlocks) {
+            notifyBlockChanged(change.getPosition(), change.getTo(), change.getFrom());
+        }
+
+        return result;
     }
 
     private void notifyBlockChanged(Vector3i pos, Block type, Block oldType) {


### PR DESCRIPTION
- added `setBlocks(Map<Vec3i, Block>)` to WorldProviderCore
- chunks are dirtied after all blocks are placed
- finally notifications for each changed block are send
- adjusted BlockPlacingSystem to take advantage of `setBlocks`

- - -

I tested this with structure templates (generating a PlaceBlocks event from the regions to fill) and the BlockBufferSystem of DynamicCities. I did not notice any crashes, and the overall time of placing blocks is reduced as each affected chunk is only re-calculated once after all blocks are set.

Does anybody see a problem in this implementation. Anything I forgot to take care of? I was wondering if the implemenation should make sure that the map is not too big (either restrict by API/contract or paritioning the blocksToPlace and run several iterations). Would it make sense to order by chunks and finish one chunk after the other?

Pinging @immortius @flo @Josharias @msteiger for feedback.
