### PR TITLE
Improve performance by removing unnecessary locking.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -164,17 +164,16 @@ public final class ChunkMeshUpdateManager {
             ChunkMesh newMesh;
             ChunkView chunkView = worldProvider.getLocalView(c.getPosition());
             if (chunkView != null) {
+                /*
+                 * Important set dirty flag first, so that a concurrent modification of the chunk in the mean time we
+                 * will end up with a dirty chunk.
+                 */
                 c.setDirty(false);
-                chunkView.readLock();
-                try {
-                    if (chunkView.isValidView()) {
-                        newMesh = tessellator.generateMesh(chunkView, ChunkConstants.SIZE_Y, 0);
+                if (chunkView.isValidView()) {
+                    newMesh = tessellator.generateMesh(chunkView, ChunkConstants.SIZE_Y, 0);
 
-                        c.setPendingMesh(newMesh);
-                        ChunkMonitor.fireChunkTessellated(c.getPosition(), newMesh);
-                    }
-                } finally {
-                    chunkView.readUnlock();
+                    c.setPendingMesh(newMesh);
+                    ChunkMonitor.fireChunkTessellated(c.getPosition(), newMesh);
                 }
 
             }

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -220,30 +220,6 @@ public interface ChunkView {
      */
     void setDirtyAround(Region3i blockRegion);
 
-    /**
-     * Locks the chunk view, enabling write operations
-     */
-    void writeLock();
-
-    /**
-     * Unlocks the chunk view, disabling write operations
-     */
-    void writeUnlock();
-
-    /**
-     * Locks the chunk view, enabling write operations
-     */
-    void readLock();
-
-    /**
-     * Unlocks the chunk view, disabling write operations
-     */
-    void readUnlock();
-
-    /**
-     * @return Whether the chunk view is locked and hence whether write operations are allowed.
-     */
-    boolean isLocked();
 
     /**
      * @return Whether the chunk view is still valid - will be false if a chunk has been unloaded since the chunk

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -85,16 +85,6 @@ public interface CoreChunk {
 
     Region3i getRegion();
 
-    void writeLock();
-
-    void writeUnlock();
-
-    void readLock();
-
-    void readUnlock();
-
-    boolean isLocked();
-
     int getEstimatedMemoryConsumptionInBytes();
 
     ChunkBlockIterator getBlockIterator();

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -189,9 +189,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
-            chunk.writeLock();
             Block oldBlockType = chunk.setBlock(blockPos, type);
-            chunk.writeUnlock();
             if (oldBlockType != type) {
                 BlockChange oldChange = blockChanges.get(worldPos);
                 if (oldChange == null) {
@@ -227,9 +225,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             if (chunk != null) {
                 Block type = entry.getValue();
                 Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
-                chunk.writeLock();
                 Block oldBlockType = chunk.setBlock(blockPos, type);
-                chunk.writeUnlock();
                 if (oldBlockType != type) {
                     BlockChange oldChange = blockChanges.get(worldPos);
                     if (oldChange == null) {
@@ -286,16 +282,11 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
-            chunk.writeLock();
-            try {
-                Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
-                LiquidData liquidState = chunk.getLiquid(blockPos);
-                if (liquidState.equals(oldState)) {
-                    chunk.setLiquid(blockPos, newState);
-                    return true;
-                }
-            } finally {
-                chunk.writeUnlock();
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
+            LiquidData liquidState = chunk.getLiquid(blockPos);
+            if (liquidState.equals(oldState)) {
+                chunk.setLiquid(blockPos, newState);
+                return true;
             }
         }
         return false;
@@ -340,9 +331,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
-            chunk.writeLock();
             Biome oldBiomeType = chunk.setBiome(blockPos.x, blockPos.y, blockPos.z, biome);
-            chunk.writeUnlock();
             if (oldBiomeType != biome) {
                 BiomeChange oldChange = biomeChanges.get(worldPos);
                 if (oldChange == null) {

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightMerger.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightMerger.java
@@ -80,52 +80,38 @@ public class LightMerger<T> {
     private void merge(Chunk chunk) {
         Chunk[] localChunks = assembleLocalChunks(chunk);
         localChunks[CENTER_INDEX] = chunk;
-        for (Chunk localChunk : localChunks) {
-            if (localChunk != null) {
-                localChunk.writeLock();
-            }
-        }
-        try {
+        List<BatchPropagator> propagators = Lists.newArrayList();
+        propagators.add(new StandardBatchPropagator(new LightPropagationRules(), new LocalChunkView(localChunks, lightRules)));
+        PropagatorWorldView regenWorldView = new LocalChunkView(localChunks, sunlightRegenRules);
+        PropagationRules sunlightRules = new SunlightPropagationRules(regenWorldView);
+        PropagatorWorldView sunlightWorldView = new LocalChunkView(localChunks, sunlightRules);
+        BatchPropagator sunlightPropagator = new StandardBatchPropagator(sunlightRules, sunlightWorldView);
+        propagators.add(new SunlightRegenBatchPropagator(sunlightRegenRules, regenWorldView, sunlightPropagator, sunlightWorldView));
+        propagators.add(sunlightPropagator);
 
-            List<BatchPropagator> propagators = Lists.newArrayList();
-            propagators.add(new StandardBatchPropagator(new LightPropagationRules(), new LocalChunkView(localChunks, lightRules)));
-            PropagatorWorldView regenWorldView = new LocalChunkView(localChunks, sunlightRegenRules);
-            PropagationRules sunlightRules = new SunlightPropagationRules(regenWorldView);
-            PropagatorWorldView sunlightWorldView = new LocalChunkView(localChunks, sunlightRules);
-            BatchPropagator sunlightPropagator = new StandardBatchPropagator(sunlightRules, sunlightWorldView);
-            propagators.add(new SunlightRegenBatchPropagator(sunlightRegenRules, regenWorldView, sunlightPropagator, sunlightWorldView));
-            propagators.add(sunlightPropagator);
-
-            for (BatchPropagator propagator : propagators) {
-                // Propagate Inwards
-                for (Side side : Side.values()) {
-                    Vector3i adjChunkPos = side.getAdjacentPos(chunk.getPosition());
-                    LitChunk adjChunk = chunkProvider.getChunkUnready(adjChunkPos);
-                    if (adjChunk != null) {
-                        propagator.propagateBetween(adjChunk, chunk, side.reverse(), false);
-                    }
-                }
-
-                // Propagate Outwards
-                for (Side side : Side.values()) {
-                    Vector3i adjChunkPos = side.getAdjacentPos(chunk.getPosition());
-                    LitChunk adjChunk = chunkProvider.getChunk(adjChunkPos);
-                    if (adjChunk != null) {
-                        propagator.propagateBetween(chunk, adjChunk, side, true);
-                    }
+        for (BatchPropagator propagator : propagators) {
+            // Propagate Inwards
+            for (Side side : Side.values()) {
+                Vector3i adjChunkPos = side.getAdjacentPos(chunk.getPosition());
+                LitChunk adjChunk = chunkProvider.getChunkUnready(adjChunkPos);
+                if (adjChunk != null) {
+                    propagator.propagateBetween(adjChunk, chunk, side.reverse(), false);
                 }
             }
-            for (BatchPropagator propagator : propagators) {
-                propagator.process();
-            }
-            chunk.deflateSunlight();
-        } finally {
-            for (Chunk localChunk : localChunks) {
-                if (localChunk != null) {
-                    localChunk.writeUnlock();
+
+            // Propagate Outwards
+            for (Side side : Side.values()) {
+                Vector3i adjChunkPos = side.getAdjacentPos(chunk.getPosition());
+                LitChunk adjChunk = chunkProvider.getChunk(adjChunkPos);
+                if (adjChunk != null) {
+                    propagator.propagateBetween(chunk, adjChunk, side, true);
                 }
             }
         }
+        for (BatchPropagator propagator : propagators) {
+            propagator.process();
+        }
+        chunk.deflateSunlight();
     }
 
     private Chunk[] assembleLocalChunks(Chunk chunk) {


### PR DESCRIPTION
### Contains
A performance optimization, archived by removing uncessary locking.

In my test this made the setBlocks method of WorldProvider more than twice
as fast.

The locking used to be done mainly by the main thread. Besides the main thread the light merging thread and the chunk mesh building thread were also locking. One reason why it probably got locked was the disposal of the chunk. When a chunk was no logner needed, it got made unusable which could have potentially be a problem for the background threads that were still using it. This patch makes the chunk remain readable even when the chunk is no longer needed. For the garbage collector it makes no difference and we can that way dispose chunks without having to let the main thread wait for background threads which were still reading the chunk(which should improve performance at that point too).

A possible small disadvantage of the removed locking is that if you do a mass block placement, that you could theoretically see very shortly a state where some of the new block placements are done while other aren't. However this is mainly theoretically and should not be a problem during normal gameplay. Even if it is visible in some mass block replacement scenarios, I think most would prefer that glitch over a lag.

The performance benchmarks have been done via the benchmark screen from PR #2454:

Without this patch:

benchmark: WorldProvider.setBlocks
iteration:  200 / 200
last duration:  113.7 ms
min duration:  64.2 ms
median duration:  121.5 ms
avg duration:  122.1 ms
max duration:  216.3 ms

With this patch:

benchmark: WorldProvider.setBlocks
iteration:  200 / 200
last duration:  59.0 ms
min duration:  28.9 ms
median duration:  56.2 ms
avg duration:  56.7 ms
max duration:  112.1 ms

### How to test

Merge #2454 first. Then run the benchmarks once with and without with patch. The setBlocks benchmarks can be run by first calling "showScreen benchmarkScreen"  however it is by default not selected so you need to change the benchmark selection first before you start it.

### Outstanding before merging
I would like to give other developers a chance to comment on this and to give feedback. So I think we should wait a few days before we merge this. @immortius and @skaldarnar might be interested in this PR.