### PR TITLE
Do not edit attributes with no value; option to add layoutInfo

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/editor/ContextMenuUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/editor/ContextMenuUtilsTest.java
@@ -90,6 +90,6 @@ public class ContextMenuUtilsTest extends TerasologyTestingEnvironment {
     }
 
     private Class getNodeType(JsonTree node) {
-        return NUIEditorNodeUtils.getNodeInfo(node, context.get(NUIManager.class));
+        return NUIEditorNodeUtils.getNodeInfo(node, context.get(NUIManager.class)).getNodeClass();
     }
 }

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/editor/ContextMenuUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/editor/ContextMenuUtilsTest.java
@@ -90,6 +90,6 @@ public class ContextMenuUtilsTest extends TerasologyTestingEnvironment {
     }
 
     private Class getNodeType(JsonTree node) {
-        return NUIEditorNodeUtils.getNodeClass(node, context.get(NUIManager.class));
+        return NUIEditorNodeUtils.getNodeInfo(node, context.get(NUIManager.class));
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUIEditorScreen.java
@@ -188,13 +188,16 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
                 nuiEditorMenuTreeBuilder.putConsumer(NUIEditorMenuTreeBuilder.OPTION_DELETE, getEditor()::deleteNode);
                 nuiEditorMenuTreeBuilder.putConsumer(NUIEditorMenuTreeBuilder.OPTION_ADD_WIDGET, this::addWidget);
                 nuiEditorMenuTreeBuilder.subscribeAddContextMenu(n -> {
-                    editor.fireUpdateListeners();
+                    getEditor().fireUpdateListeners();
 
                     // Automatically edit a node that's been added.
-                    editor.getModel().getNode(editor.getSelectedIndex()).setExpanded(true);
-                    editor.getModel().resetNodes();
-                    editor.setSelectedIndex(editor.getModel().indexOf(n));
-                    editNode(n);
+                    if (n.getValue().getType() == JsonTreeValue.Type.KEY_VALUE_PAIR) {
+                        getEditor().getModel().getNode(getEditor().getSelectedIndex()).setExpanded(true);
+
+                        getEditor().getModel().resetNodes();
+                        getEditor().setSelectedIndex(getEditor().getModel().indexOf(n));
+                        editNode(n);
+                    }
                 });
                 return nuiEditorMenuTreeBuilder.createPrimaryContextMenu(node);
             });
@@ -365,7 +368,7 @@ public final class NUIEditorScreen extends AbstractEditorScreen {
         Class nodeClass = null;
 
         try {
-            Class parentClass = NUIEditorNodeUtils.getNodeClass((JsonTree) node.getParent(), getManager());
+            Class parentClass = NUIEditorNodeUtils.getNodeInfo((JsonTree) node.getParent(), getManager()).getNodeClass();
 
             if (parentClass != null) {
                 nodeClass = parentClass.getDeclaredField(node.getValue().getKey()).getType();

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/layers/NUISkinEditorScreen.java
@@ -218,10 +218,13 @@ public final class NUISkinEditorScreen extends AbstractEditorScreen {
                     getEditor().fireUpdateListeners();
 
                     // Automatically edit a node that's been added.
-                    getEditor().getModel().getNode(getEditor().getSelectedIndex()).setExpanded(true);
-                    getEditor().getModel().resetNodes();
-                    getEditor().setSelectedIndex(getEditor().getModel().indexOf(n));
-                    editNode(n);
+                    if (n.getValue().getType() == JsonTreeValue.Type.KEY_VALUE_PAIR) {
+                        getEditor().getModel().getNode(getEditor().getSelectedIndex()).setExpanded(true);
+
+                        getEditor().getModel().resetNodes();
+                        getEditor().setSelectedIndex(getEditor().getModel().indexOf(n));
+                        editNode(n);
+                    }
                 });
                 return nuiEditorMenuTreeBuilder.createPrimarySkinContextMenu(node);
             });


### PR DESCRIPTION
### Contains

Two small NUI editor tweaks based on Slack feedback and personal usage.

- Attributes without a value are no longer automatically edited as they are added.
- A `layoutInfo` node can now be added to nodes located inside a layout.

### How to test

- Create a new screen in the NUI editor. Try adding a few attributes to the `layoutInfo` node (e.g. `position-left`) and verify that they aren't automatically edited.
- Delete the `layoutInfo` node. Verify that it can be added again.

### Outstanding before merging

No outstanding issues.