### PR TITLE
whitelist a handful of rendering-related engine and library classes

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
+++ b/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
@@ -90,6 +90,10 @@ public final class ExternalApiWhitelist {
             .add(java.awt.datatransfer.UnsupportedFlavorException.class)
             .add(java.nio.ByteBuffer.class)
             .add(java.nio.IntBuffer.class)
+            .add(org.lwjgl.opengl.GL11.class)
+            .add(org.lwjgl.opengl.GL13.class)
+            .add(org.terasology.rendering.opengl.OpenGLUtils.class)
+            .add(org.terasology.rendering.world.WorldRenderer.class)
             .build();
 
     private ExternalApiWhitelist() {


### PR DESCRIPTION
### Contains

Whitelist entries for low-level rendering classes like `org.lwjgl.opengl.GL11`

### How to test

Just try to access one of the listed classes :)

My WIP HealthBars module requires this patch to run: https://github.com/kaen/HealthBars/blob/master/src/main/java/org/terasology/healthbars/HealthBarRenderSystem.java#L194

I looked for any previous discussion of whitelisting these classes and couldn't find any, hopefully there's not an obvious security-related reason for excluding them.