### PR TITLE
[Discussion] Block placement renovation

### DIFF
--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -19,7 +19,6 @@ package org.terasology.testUtil;
 import com.google.common.collect.Maps;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
@@ -103,22 +102,18 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     }
 
     @Override
-    public Block setBlock(Vector3i pos, Block type) {
-        Block old = blocks.put(pos, type);
-        if (old == null) {
-            return air;
-        }
-        return old;
+    public boolean setBlock(Vector3i pos, Block type, EntityRef instigator) {
+        //TODO: send check permission event?
+        blocks.put(pos, type);
+        return true;
     }
 
     @Override
-    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocksToPlace) {
-        Map<Vector3i, Block> result = new HashMap<>(blocks.size());
+    public boolean setBlocks(Map<Vector3i, Block> blocksToPlace) {
         for (Map.Entry<Vector3i, Block> entry : blocksToPlace.entrySet()) {
-            Block b = setBlock(entry.getKey(), entry.getValue());
-            result.put(entry.getKey(), b);
+            blocks.put(entry.getKey(), entry.getValue());
         }
-        return result;
+        return true;
     }
 
     @Override

--- a/engine-tests/src/test/java/org/terasology/math/Region3iTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/Region3iTest.java
@@ -17,12 +17,13 @@
 package org.terasology.math;
 
 import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 import org.terasology.math.geom.Vector3i;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -76,6 +77,31 @@ public class Region3iTest {
                 new Vector3i(-2, 4, 0), new Vector3i(-2, 107, -16), new Vector3i(4, 4, -16), new Vector3i(-2, 4, -16));
         for (int i = 0; i < vec1.size(); ++i) {
             assertEquals(expectedRegion, Region3i.createBounded(vec1.get(i), vec2.get(i)));
+        }
+    }
+
+    @Test
+    public void testCreateBoundingBox() {
+        List<List<Vector3i>> vec = Arrays.asList(
+                Collections.emptyList(),
+                Collections.singletonList(new Vector3i(-2, 4, -16)),
+                Arrays.asList(new Vector3i(-2, 4, -16), new Vector3i(4, 4, -16), new Vector3i(-2, 107, -16), new Vector3i(-2, 4, 0),
+                        new Vector3i(4, 107, -16), new Vector3i(4, 4, 0), new Vector3i(-2, 107, 0), new Vector3i(4, 107, 0))
+        );
+
+
+        List<Region3i> expectedRegions = Arrays.asList(
+                Region3i.EMPTY,
+                Region3i.createFromMinMax(new Vector3i(-2, 4, -16), new Vector3i(-2, 4, -16)),
+                Region3i.createFromMinMax(new Vector3i(-2, 4, -16), new Vector3i(4, 107, 0))
+        );
+
+        for (int i = 0; i < vec.size(); i++) {
+            Region3i region = Region3i.createBoundingBox(vec.get(i));
+            assertEquals(expectedRegions.get(i), region);
+            for (Vector3i pos : vec.get(i)) {
+                assertTrue(region.encompasses(pos));
+            }
         }
     }
 

--- a/engine/src/main/java/org/terasology/math/Region3i.java
+++ b/engine/src/main/java/org/terasology/math/Region3i.java
@@ -16,16 +16,15 @@
 
 package org.terasology.math;
 
+import java.util.Collection;
+import java.util.Iterator;
 import org.terasology.math.geom.BaseVector3f;
 import org.terasology.math.geom.BaseVector3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 
-import java.util.Iterator;
-
 /**
  * Describes an axis-aligned bounded space in 3D integer.
- *
  */
 public final class Region3i implements Iterable<Vector3i> {
     public static final Region3i EMPTY = new Region3i();
@@ -102,6 +101,28 @@ public final class Region3i implements Iterable<Vector3i> {
         return createFromMinMax(min, max);
     }
 
+    /**
+     * Creates a {@link Region3i} that describes the bounding box for the given positions.
+     * <p>
+     * The bounding box of a set of positions is the smallest region such that the region encompasses all those points.
+     * The bounding box for the empty set is the empty region.
+     *
+     * @param positions a (possibly empty) list of positions
+     * @return the smallest region encompassing all given positions.
+     */
+    public static Region3i createBoundingBox(Collection<Vector3i> positions) {
+        if (positions.isEmpty()) {
+            return Region3i.EMPTY;
+        }
+        Vector3i min = Vector3i.one().mul(Integer.MAX_VALUE);
+        Vector3i max = Vector3i.one().mul(Integer.MIN_VALUE);
+        positions.forEach(pos -> {
+            min.min(pos);
+            max.max(pos);
+        });
+        return createFromMinMax(min, max);
+    }
+
     public boolean isEmpty() {
         return size.x + size.y + size().z == 0;
     }
@@ -168,9 +189,11 @@ public final class Region3i implements Iterable<Vector3i> {
     }
 
     /**
-     * @param other
-     * @return The region that is encompassed by both this and other. If they
-     * do not overlap then the empty region is returned
+     * Creates a new {@link Region3i} for the region encompassed by both this and other.
+     * If the two regions do not overlap the empty region is returned.
+     *
+     * @param other the region to intersect
+     * @return the region that is encompassed by both this and other, the empty region if they do not overlap
      */
     public Region3i intersect(Region3i other) {
         Vector3i intersectMin = min();
@@ -182,8 +205,10 @@ public final class Region3i implements Iterable<Vector3i> {
     }
 
     /**
-     * @param other
-     * @return An iterator over the positions in this region that aren't in other
+     * Returns an {@link Iterator} over the positions of this region that are not encompassed by other.
+     *
+     * @param other the region to subtract
+     * @return an iterator over the positions in this region that aren't in other
      */
     public Iterator<Vector3i> subtract(Region3i other) {
         return new SubtractiveIterator(other);
@@ -192,8 +217,8 @@ public final class Region3i implements Iterable<Vector3i> {
     /**
      * Creates a new region that is the same as this region but expanded in all directions by the given amount
      *
-     * @param amount
-     * @return A new region
+     * @param amount amount to expand in all directions
+     * @return the original region expanded in all directions by amount
      */
     public Region3i expand(int amount) {
         Vector3i expandedMin = min();
@@ -231,8 +256,10 @@ public final class Region3i implements Iterable<Vector3i> {
     }
 
     /**
-     * @param offset
-     * @return A copy of the region offset by the given value
+     * Creates a new region from this moved by the given offset.
+     *
+     * @param offset the offset to move this region
+     * @return a copy of this region that is offset by the given value
      */
     public Region3i move(BaseVector3i offset) {
         Vector3i newMin = min();
@@ -241,20 +268,32 @@ public final class Region3i implements Iterable<Vector3i> {
     }
 
     /**
-     * @param pos
-     * @return Whether this region includes pos
+     * Checks whether this region encompasses the given position.
+     *
+     * @param pos the position to check
+     * @return whether this region includes pos
      */
     public boolean encompasses(BaseVector3i pos) {
         return encompasses(pos.getX(), pos.getY(), pos.getZ());
     }
 
+    /**
+     * Checks whether this region encompasses the position given by (x, y, z).
+     *
+     * @param x position on the x-axis
+     * @param y position on the y-axis
+     * @param z position on the z-axis
+     * @return whether this region includes position (x, y, z)
+     */
     public boolean encompasses(int x, int y, int z) {
         return (x >= min.x) && (y >= min.y) && (z >= min.z) && (x < min.x + size.x) && (y < min.y + size.y) && (z < min.z + size.z);
     }
 
     /**
-     * @param pos
-     * @return The nearest position within the region to the given pos.
+     * Returns the point of this region that is closest to the given position.
+     *
+     * @param pos the position to check
+     * @return the nearest position within the region to the given pos
      */
     public Vector3i getNearestPointTo(BaseVector3i pos) {
         Vector3i result = new Vector3i(pos);

--- a/engine/src/main/java/org/terasology/world/block/entity/placement/CheckPlacementPermissionEvent.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/placement/CheckPlacementPermissionEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block.entity.placement;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.AbstractConsumableEvent;
+import org.terasology.math.Region3i;
+import org.terasology.math.geom.Vector3i;
+
+/**
+ * An event to verify the placement of blocks within the given region(s).
+ * <p>
+ * The event is send when a block placement should be performed. Any system can veto the placement by consuming this event.
+ */
+public class CheckPlacementPermissionEvent extends AbstractConsumableEvent {
+    private EntityRef instigator;
+    private List<Region3i> placementRegions;
+
+    public CheckPlacementPermissionEvent(Region3i placementRegion) {
+        this(Collections.singletonList(placementRegion), EntityRef.NULL);
+    }
+
+    public CheckPlacementPermissionEvent(Region3i placementRegion, EntityRef instigator) {
+        this(Collections.singletonList(placementRegion), instigator);
+    }
+
+    public CheckPlacementPermissionEvent(List<Region3i> placementRegions, EntityRef instigator) {
+        this.instigator = instigator;
+        this.placementRegions = placementRegions;
+    }
+
+    public CheckPlacementPermissionEvent(List<Region3i> placementRegions) {
+        this(placementRegions, EntityRef.NULL);
+    }
+
+    public CheckPlacementPermissionEvent(Vector3i pos) {
+        this(Region3i.createFromCenterExtents(pos, 1), EntityRef.NULL);
+    }
+
+    public CheckPlacementPermissionEvent(Vector3i pos, EntityRef instigator) {
+        this(Region3i.createFromCenterExtents(pos, 1), instigator);
+    }
+
+    /**
+     * The instigator of the block placement request.
+     *
+     * @return the instigating entity of the block placement
+     */
+    public EntityRef getInstigator() {
+        return instigator;
+    }
+
+    /**
+     * The regions affected by the block placement.
+     * <p>
+     * The block placements will happen inside the given regions. Any block encompassed by the regions might be affected by the block placement.
+     *
+     * @return a list of affected regions
+     */
+    public List<Region3i> getPlacementRegions() {
+        return ImmutableList.copyOf(placementRegions);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -93,13 +93,13 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     }
 
     @Override
-    public Block setBlock(Vector3i pos, Block type) {
-        return base.setBlock(pos, type);
+    public boolean setBlock(Vector3i pos, Block type, EntityRef instigator) {
+        return base.setBlock(pos, type, instigator);
     }
 
     @Override
-    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
-        return base.setBlocks(blocks);
+    public boolean setBlocks(Map<Vector3i, Block> blocks, EntityRef instigator) {
+        return base.setBlocks(blocks, instigator);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -16,6 +16,9 @@
 
 package org.terasology.world.internal;
 
+import java.math.RoundingMode;
+import java.util.Collection;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -23,9 +26,6 @@ import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.liquid.LiquidData;
-
-import java.math.RoundingMode;
-import java.util.Collection;
 
 /**
  */
@@ -48,8 +48,8 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
-    public Block setBlock(Vector3i pos, Block type) {
-        return core.setBlock(pos, type);
+    public boolean setBlock(Vector3i pos, Block type, EntityRef instigator) {
+        return core.setBlock(pos, type, instigator);
     }
 
     @Override


### PR DESCRIPTION
### Contains

A renovation of the block placement process. 

Based on a discussion with @flo and @MarcinSc this PR should be used to discuss possible changes to the block placement process. The main questions/criteria addressed are:
- Block placement should be vetoable by systems (prevent placement/destruction of blocks). Therefore, the CheckPlacementPermissionEvent is added. The event is sent whenever a block placement via setBlocks is requested. 
- Keep the performance impact low. Per default, the bounding box for multi block placement is used for the permission check. TODO: implement placementRegions

Related topics: 
- https://github.com/MovingBlocks/Terasology/issues/1694 : cosumable PlaceBlocks event to allow vetoing of block placements.
### Outstanding before merging

A lot of discussion and testing. I'm shifting things around in my head an may come up with some alternative suggestions how to handle this. 

I appreciate any feedback! Probably also interested in the topic: @Cervator @immortius @msteiger 
- [ ] implement placement regions
- [ ] add boolean flag to permission event to allow early consumption with positive result (e.g., an authority system might allow all placement instigated by some server entity)
- [ ] deprecate PlaceBlocks and adapt usages to new process.
- [ ] update/add documentation to wiki
- [ ] discuss API and behavior of `setBlocks`
