### PR TITLE
remove temporary Vector3i allocations in getBlock

### DIFF
--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -61,6 +61,16 @@ public final class ChunkMath {
         return (z >> chunkPowerZ);
     }
 
+    public static int calcChunkPosX(int x) {
+        return calcChunkPosX(x, ChunkConstants.CHUNK_POWER.x);
+    }
+    public static int calcChunkPosY(int y) {
+        return calcChunkPosY(y, ChunkConstants.CHUNK_POWER.y);
+    }
+    public static int calcChunkPosZ(int z) {
+        return calcChunkPosZ(z, ChunkConstants.CHUNK_POWER.z);
+    }
+
     public static Vector3i calcChunkPos(Vector3i pos, Vector3i chunkPower) {
         return calcChunkPos(pos.x, pos.y, pos.z, chunkPower);
     }
@@ -130,6 +140,18 @@ public final class ChunkMath {
      */
     public static int calcBlockPosZ(int blockZ, int chunkPosFilterZ) {
         return blockZ & chunkPosFilterZ;
+    }
+
+    public static int calcBlockPosX(int blockX) {
+        return calcBlockPosX(blockX, ChunkConstants.INNER_CHUNK_POS_FILTER.x);
+    }
+
+    public static int calcBlockPosY(int blockY) {
+        return calcBlockPosY(blockY, ChunkConstants.INNER_CHUNK_POS_FILTER.y);
+    }
+
+    public static int calcBlockPosZ(int blockZ) {
+        return calcBlockPosZ(blockZ, ChunkConstants.INNER_CHUNK_POS_FILTER.z);
     }
 
     public static Vector3i calcBlockPos(Vector3i worldPos) {

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -85,7 +85,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         }
 
         int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getBlock(ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
+        return chunks[chunkIndex].getBlock(ChunkMath.calcBlockPosX(blockX, chunkFilterSize.x), ChunkMath.calcBlockPosY(blockY, chunkFilterSize.y), ChunkMath.calcBlockPosZ(blockZ, chunkFilterSize.z));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -323,11 +323,9 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
     @Override
     public Block getBlock(int x, int y, int z) {
-        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
-        CoreChunk chunk = chunkProvider.getChunk(chunkPos);
+        CoreChunk chunk = chunkProvider.getChunk(ChunkMath.calcChunkPosX(x), ChunkMath.calcChunkPosY(y), ChunkMath.calcChunkPosZ(z));
         if (chunk != null) {
-            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
-            return chunk.getBlock(blockPos);
+            return chunk.getBlock(ChunkMath.calcBlockPosX(x), ChunkMath.calcBlockPosY(y), ChunkMath.calcBlockPosZ(z));
         }
         return unloadedBlock;
     }


### PR DESCRIPTION
### Contains

Some low-hanging optimization fruit for anything that calls `getBlock` in a tight loop (pathfinders or anything that analyzes the map).

### How to test

Call `getBlock` a lot and look at a profiler :)

The most obvious change is in allocations per second. I measured 2Ma/s before the patch, about 250Ka/s after. Also notice that GC stalls are much less frequent and that Eden heap space fills much less quickly :)

I wouldn't normally worry about object allocations but obviously the numbers are huge. After this change, `getBlock` can use CPU registers all the way until it indexes the massive data array behind it. Without it, we have to stop, find some space on the heap, create some object metadata, copy the values to far-away memory, recurse, unwrap the object (again going to far-away heap memory) and then finally index the array. In short, the actually runtime of `getBlocks` is improved a lot by this. There are some other call sites with similar issues that I will address in future PRs.

YourKit performance summary before:
![performance before](https://cloud.githubusercontent.com/assets/8729027/18293102/a897150e-7445-11e6-85c4-0bc45578140e.png)

summary after:
![performance after](https://cloud.githubusercontent.com/assets/8729027/18293115/bdabab44-7445-11e6-86c0-8b0f5c477161.png)


