### PR TITLE
Fix null field deserialization crash + further possible crashes

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/BorderTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/BorderTypeHandler.java
@@ -49,7 +49,7 @@ public class BorderTypeHandler extends SimpleTypeHandler<Border> {
 
     @Override
     public Border deserialize(PersistedData data, DeserializationContext context) {
-        if (data.isValueMap()) {
+        if (!data.isNull() && data.isValueMap()) {
             PersistedDataMap map = data.getAsValueMap();
             return new Border(map.getAsInteger(LEFT_FIELD), map.getAsInteger(RIGHT_FIELD), map.getAsInteger(TOP_FIELD), map.getAsInteger(BOTTOM_FIELD));
         }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2fTypeHandler.java
@@ -48,7 +48,7 @@ public class Rect2fTypeHandler extends SimpleTypeHandler<Rect2f> {
 
     @Override
     public Rect2f deserialize(PersistedData data, DeserializationContext context) {
-        if (data.isValueMap()) {
+        if (!data.isNull() && data.isValueMap()) {
             PersistedDataMap map = data.getAsValueMap();
             Vector2f min = context.deserializeAs(map.get(MIN_FIELD), Vector2f.class);
             Vector2f size = context.deserializeAs(map.get(SIZE_FIELD), Vector2f.class);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Rect2iTypeHandler.java
@@ -49,7 +49,7 @@ public class Rect2iTypeHandler extends SimpleTypeHandler<Rect2i> {
 
     @Override
     public Rect2i deserialize(PersistedData data, DeserializationContext context) {
-        if (data.isValueMap()) {
+        if (!data.isNull() && data.isValueMap()) {
             PersistedDataMap map = data.getAsValueMap();
             Vector2i min = context.deserializeAs(map.get(MIN_FIELD), Vector2i.class);
             Vector2i size = context.deserializeAs(map.get(SIZE_FIELD), Vector2i.class);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Region3iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Region3iTypeHandler.java
@@ -49,7 +49,7 @@ public class Region3iTypeHandler extends SimpleTypeHandler<Region3i> {
 
     @Override
     public Region3i deserialize(PersistedData data, DeserializationContext context) {
-        if (data.isValueMap()) {
+        if (!data.isNull() && data.isValueMap()) {
             PersistedDataMap map = data.getAsValueMap();
             Vector3i min = context.deserializeAs(map.get(MIN_FIELD), Vector3i.class);
             Vector3i size = context.deserializeAs(map.get(SIZE_FIELD), Vector3i.class);


### PR DESCRIPTION
### Contains

* Fixes a remote client only NullPoinerException crash that happens when you clear a "wrong placement hint" of a structure template. The crash was caused by wrong deserialization of a `Region3i` field that got set to null.
* Fixes further potential crashes caused by the deserialization of `Rect2f`, `Rect2i` and `BorderTypeHandler` fields.

### How to test
1. Start a server with the Gooey's Quests module enabled
2. Connect to the server as client
3. Get yourself a structure template with placement conditions. e.g. via the command `giveItem dungeonEntranceViaMountain`.
4. Try to place it at an invalid location (where the placement preview shows a red region)
5. You should see an error message dialog. Confirm the dialog
6. A red region should still be visible. Right click once to clear it. There should be no crash.