### PR TITLE
Discussion: Make setBlocks update entities like setBlock - at huge performance cost !!!

### DIFF
--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -127,6 +127,23 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     }
 
     @Override
+    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
+        if (GameThread.isCurrentThread()) {
+            Map<Vector3i, Block> oldTypes = super.setBlocks(blocks);
+            for (Map.Entry<Vector3i, Block> entry: oldTypes.entrySet()) {
+                Vector3i pos = entry.getKey();
+                Block oldType = entry.getValue();
+                Block newType = blocks.get(pos);
+                EntityRef blockEntity = getBlockEntityAt(pos);
+                if (oldType != null) {
+                    updateBlockEntity(blockEntity, pos, oldType, newType, false, Collections.<Class<? extends Component>>emptySet());
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
     @SafeVarargs
     public final Block setBlockRetainComponent(Vector3i pos, Block type, Class<? extends Component>... components) {
         if (GameThread.isCurrentThread()) {


### PR DESCRIPTION
### Contains

This fixes an NullPointerEException when the following steps are done:
1. A chest gets placed
2. The chest gets overridden with air by a setBlocks call
3. A stone block gets placed at the location of the chest.

The exception had the following stacktrace:

```
java.lang.NullPointerException
    at org.terasology.world.internal.EntityAwareWorldProvider.updateBlockEntityComponents(EntityAwareWorldProvider.java:235)
    at org.terasology.world.internal.EntityAwareWorldProvider.updateBlockEntity(EntityAwareWorldProvider.java:151)
    at org.terasology.world.internal.EntityAwareWorldProvider.setBlock(EntityAwareWorldProvider.java:122)
    at org.terasology.world.internal.WorldProviderWrapper.setBlock(WorldProviderWrapper.java:52)
    at org.terasology.network.internal.ServerImpl.processBlockChanges(ServerImpl.java:304)
    at org.terasology.network.internal.ServerImpl.processMessages(ServerImpl.java:269)
    at org.terasology.network.internal.ServerImpl.update(ServerImpl.java:187)
    at org.terasology.network.internal.NetworkSystemImpl.update(NetworkSystemImpl.java:317)
    at org.terasology.engine.subsystem.common.NetworkSubsystem.preUpdate(NetworkSubsystem.java:46)
    at org.terasology.engine.TerasologyEngine.mainLoop(TerasologyEngine.java:406)
    at org.terasology.engine.TerasologyEngine.run(TerasologyEngine.java:368)
    at org.terasology.engine.Terasology.main(Terasology.java:152)
```

The crash happened for the clients only, as they knew temporary block entities without any component. I haven't fully investigated how they get to such an entity, but making setBlocks do the same block entity updating like setBlock fixed the issue.

However it comes at a huge performance cost, now setBlocks is even
slightly worse in performance then setBlock:

```
benchmark: WorldProvider.setBlock
iteration:  200 / 200
last duration:  945.6 ms
min duration:  822.1 ms
median duration:  912.6 ms
avg duration:  1073.4 ms
max duration:  4839.3 ms
```

```
benchmark: WorldProvider.setBlocks
iteration:  200 / 200
last duration:  5471.2 ms
min duration:  627.1 ms
median duration:  950.6 ms
avg duration:  1089.6 ms
max duration:  5471.2 ms
```

Without this PR, the placement performance is much better:

```
benchmark: WorldProvider.setBlocks
iteration:  200 / 200
last duration:  66.3 ms
min duration:  36.9 ms
median duration:  60.8 ms
avg duration:  73.7 ms
max duration:  1883.9 ms
```
### How to test
1. Start a headless server with the Gooey's Quest module.
2. Join the server as a client with cheat permissions (or get those permissions via permission key)
3. Cheat yourself a dungeonTownInn item
4. place it on a block
5. place it on a second block that is 1 block closer to you

Alternativlty you can also create a structure template that replaces a block with air and then use that template on a chest and then place afterwards a solid block where the chest has been.
### Outstanding before merging

I think we should discuss how much of the "a block must behave like an entity" behavior we actually need. Currently the block entities have special rulss in some places where they don't belong (e.g. entity manager) and block placement results in a lot of overhead.

Currently basically placing a block means that the entity that represents the block will be updated to have the new components. if there is no such entity, an entity will be silently be created. Then the entity will be updated, and when it is not an "force active" block then the entity will be silently be destroyed at  the next update cycle.

Changes to be discussed:
1.) Reintroduce life cycle events for block entities, to make them just normal entities without special rules. Reasoning: Remove special handling currently present in entity manager where it does not belong in my opinion. It also fixes a potential memory leak: Systems that watch for component activation/deactivation could then properly track block entities. Currently a system might detect the addition of a component to an entity and remembers the entity for further processing. When that entity gets silently removed the system will still remember that entity.
2.) OnChangedBlock event could be sent to the world entity, instead of the temporary block entities. That way we don't need to create block entities just for the events. When a block change happens at the location of an entity that entity could of course still be updated.
3.) Maybe we could turn  EntityAwareWorldProvider into a normal system, that just uses activation/deactivation of BlockComponents to track block entities. It could store the entities in a map from location to entity and when a OnchangedBlock event gets received on the world entity it could notify the entity at the given location.
4.) Remove the automatic creation, update and deletion of block entities. Block entities could be created/updated manually from whatever system needs it. e.g. the system of a item entity could create the block entity when a "force active" block gets placed. A low prio event handler could delete entities with BlockComponents when they receives a OnChangedBlock event. 

Pinging @immortius, @skaldarnar , @MarcinSc, @Josharias  as they might be interested in joining the discussion.
