### PR TITLE
Rendering engine: refactored 2 nodes + new node type

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -327,7 +327,7 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                 "If that fails you might need to use a different GPU (graphics card). Sorry!\n";
     }
 
-    public void initOpenGLParams() {
+    public static void initOpenGLParams() {
         glEnable(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
         glEnable(GL_NORMALIZE);

--- a/engine/src/main/java/org/terasology/rendering/backdrop/BackdropProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/BackdropProvider.java
@@ -38,8 +38,6 @@ public interface BackdropProvider {
 
     float getSunPositionAngle();
 
-    Vector3f getQuantizedSunDirection(float stepSize);
-
     Vector3f getSunDirection(boolean moonlightFlip);
 
 }

--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -124,19 +124,6 @@ public class Skysphere implements BackdropProvider, BackdropRenderer {
     }
 
     @Override
-    public Vector3f getQuantizedSunDirection(float stepSize) {
-        float sunAngle = (float) Math.floor(getSunPositionAngle() * stepSize) / stepSize + 0.0001f;
-        Vector3f sunDirection = new Vector3f(0.0f, (float) Math.cos(sunAngle), (float) Math.sin(sunAngle));
-
-        // Moonlight flip
-        if (sunDirection.y < 0.0f) {
-            sunDirection.scale(-1.0f);
-        }
-
-        return sunDirection;
-    }
-
-    @Override
     public Vector3f getSunDirection(boolean moonlightFlip) {
         float sunAngle = getSunPositionAngle() + 0.0001f;
         Vector3f sunDirection = new Vector3f(0.0f, (float) Math.cos(sunAngle), (float) Math.sin(sunAngle));

--- a/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
@@ -40,6 +40,8 @@ public abstract class AbstractNode implements Node {
     private RenderTaskListGenerator taskListGenerator; // TODO: investigate ways to remove nodes influence on taskList
     private boolean enabled = true;
 
+    public void initialise(Object initialData) { } // added here to avoid adding it to all other nodes.
+
     protected FBO requiresFBO(FBOConfig fboConfig, BaseFBOsManager frameBuffersManager) {
         ResourceUrn fboName = fboConfig.getName();
 

--- a/engine/src/main/java/org/terasology/rendering/dag/ConditionDependentNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/ConditionDependentNode.java
@@ -32,17 +32,28 @@ public abstract class ConditionDependentNode extends AbstractNode implements Pro
         checkConditions(); // TODO: better to remove this in near feature
     }
 
-    private void checkConditions() {
-        boolean areSatisfied = true;
+    private boolean checkConditions() {
+        boolean conditionsAreSatisfied = true;
         for (Supplier<Boolean> condition : conditions) {
-            areSatisfied = areSatisfied && condition.get();
+            conditionsAreSatisfied = conditionsAreSatisfied && condition.get();
         }
-        setEnabled(areSatisfied);
+
+        if (conditionsAreSatisfied != isEnabled()) {
+            setEnabled(conditionsAreSatisfied);
+            // enabling/disabling here means we cannot enable/disable nodes directly:
+            // we must always go through the settings.
+            return true;
+        } else {
+            return false;
+        }
+
     }
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        checkConditions();
-        refreshTaskList(); // TODO: Think about `pending` mode for the nodes, for not refreshing task list more than once
+        boolean conditionsChanged = checkConditions();
+        if (conditionsChanged) {
+            refreshTaskList(); // TODO: Think about `pending` mode for the nodes, for not refreshing task list more than once
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/Node.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/Node.java
@@ -26,6 +26,8 @@ public interface Node {
 
     void initialise();
 
+    void initialise(Object initialData);
+
     void process();
 
     // TODO: invoked when Node is removed from RenderGraph

--- a/engine/src/main/java/org/terasology/rendering/dag/NodeFactory.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/NodeFactory.java
@@ -37,4 +37,13 @@ public class NodeFactory {
         node.initialise();
         return type.cast(node);
     }
+
+    public <T extends Node> T createInstance(Class<T> type, Object initializationData) {
+        // Attempt constructor-based injection first
+        T node = InjectionHelper.createWithConstructorInjection(type, context);
+        // Then fill @In fields
+        InjectionHelper.inject(node, context);
+        node.initialise(initializationData);
+        return type.cast(node);
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropReflectionNode.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.nodes;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.util.glu.Sphere;
+import org.terasology.assets.ResourceUrn;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.registry.In;
+import org.terasology.rendering.backdrop.BackdropRenderer;
+import org.terasology.rendering.cameras.Camera;
+import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.BindFBO;
+import org.terasology.rendering.dag.stateChanges.EnableFaceCulling;
+import org.terasology.rendering.dag.stateChanges.EnableMaterial;
+import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FBOConfig;
+import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
+import org.terasology.rendering.world.WorldRenderer;
+
+import static org.lwjgl.opengl.GL11.*;
+import static org.terasology.rendering.opengl.ScalingFactors.HALF_SCALE;
+
+/**
+ * An instance of this class is responsible for rendering a reflected backdrop (usually the sky) into the
+ * "engine:sceneReflected" buffer. The content of the buffer is later used to render the reflections
+ * on the water surface.
+ *
+ * This class could potentially be used also for other reflecting surfaces, i.e. metal, but it only works
+ * for horizontal surfaces.
+ *
+ * Instances of this class are not dependent on the Video Settings or any other conditions. They can be disabled
+ * by using method Node.setEnabled(boolean) or by removing the instance from the Render Graph.
+ *
+ */
+public class BackdropReflectionNode extends AbstractNode {
+
+    public static final ResourceUrn REFLECTED = new ResourceUrn("engine:sceneReflected");
+    public static final int RADIUS = 1024;
+    public static final int SLICES = 16;
+    public static final int STACKS = 128;
+
+    @In
+    private WorldRenderer worldRenderer;
+
+    @In
+    private BackdropRenderer backdropRenderer;
+
+    @In
+    private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
+
+    private Camera playerCamera;
+    private int skySphere = -1;
+
+    /**
+     * Node initialization.
+     *
+     * Internally requires the "engine:sceneReflected" buffer, stored in the (display) resolution-dependent FBO manager.
+     * This is a default, half-scale buffer inclusive of a depth buffer FBO. See FBOConfig and ScalingFactors for details
+     * on possible FBO configurations.
+     *
+     * This method also requests the material using the "sky" shaders (vertex, fragment) to be enabled.
+     */
+    @Override
+    public void initialise() {
+        this.playerCamera = worldRenderer.getActiveCamera();
+        initSkysphere();
+
+        requiresFBO(new FBOConfig(REFLECTED, HALF_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
+        addDesiredStateChange(new BindFBO(REFLECTED, displayResolutionDependentFBOs));
+        addDesiredStateChange(new SetViewportToSizeOf(REFLECTED, displayResolutionDependentFBOs));
+        addDesiredStateChange(new EnableFaceCulling());
+        addDesiredStateChange(new EnableMaterial("engine:prog.sky"));
+    }
+
+    /**
+     * Renders the sky, reflected, into the buffers attached to the "engine:sceneReflected" FBO. It is used later,
+     * to render horizontal reflective surfaces, i.e. water.
+     *
+     * Notice that this method clears the FBO, both its color and depth attachments. Earlier nodes using the
+     * same buffers beware.
+     */
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/reflectedBackdropNode");
+
+        playerCamera.setReflected(true);
+        playerCamera.lookThroughNormalized(); // we don't want the reflected scene to be bobbing or moving with the player
+
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        // Ideally we'd set a DisableDepthMask state change to avoid the glDepthMask calls, below.
+        // However, the glClear call above must be executed while writing to the depth buffer is enabled.
+        // Having a state change that clears the buffer before the depth mask is disabled is problematic
+        // as a glClear operation is effectively a render rather than a state change and does not have a
+        // "default" to reset to.
+        // I therefore opted for keeping the glDepthMask statements in process(), until glClear statements
+        // will go in their own ClearingNode class
+
+        glDepthMask(false);
+        glCallList(skySphere); // Draws the skysphere
+        glDepthMask(true); // this re-establish the default: writing to the depth buffer is enabled.
+
+        // TODO: initially avoid the next line by having a LookThroughNormalized state change
+        // TODO: eventually, when cameras are components, this node would simply use a different camera.
+        playerCamera.lookThrough();
+        playerCamera.setReflected(false);
+
+        PerformanceMonitor.endActivity();
+    }
+
+    private void initSkysphere() {
+        Sphere sphere = new Sphere();
+        sphere.setTextureFlag(true);
+
+        skySphere = glGenLists(1);
+
+        glNewList(skySphere, GL11.GL_COMPILE);
+            sphere.draw(RADIUS, SLICES, STACKS);
+        glEndList();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BackdropReflectionNode.java
@@ -24,6 +24,7 @@ import org.terasology.rendering.backdrop.BackdropRenderer;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
+import org.terasology.rendering.dag.stateChanges.DisableDepthMask;
 import org.terasology.rendering.dag.stateChanges.EnableFaceCulling;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
@@ -84,6 +85,7 @@ public class BackdropReflectionNode extends AbstractNode {
         addDesiredStateChange(new BindFBO(REFLECTED, displayResolutionDependentFBOs));
         addDesiredStateChange(new SetViewportToSizeOf(REFLECTED, displayResolutionDependentFBOs));
         addDesiredStateChange(new EnableFaceCulling());
+        addDesiredStateChange(new DisableDepthMask());
         addDesiredStateChange(new EnableMaterial("engine:prog.sky"));
     }
 
@@ -101,19 +103,7 @@ public class BackdropReflectionNode extends AbstractNode {
         playerCamera.setReflected(true);
         playerCamera.lookThroughNormalized(); // we don't want the reflected scene to be bobbing or moving with the player
 
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-        // Ideally we'd set a DisableDepthMask state change to avoid the glDepthMask calls, below.
-        // However, the glClear call above must be executed while writing to the depth buffer is enabled.
-        // Having a state change that clears the buffer before the depth mask is disabled is problematic
-        // as a glClear operation is effectively a render rather than a state change and does not have a
-        // "default" to reset to.
-        // I therefore opted for keeping the glDepthMask statements in process(), until glClear statements
-        // will go in their own ClearingNode class
-
-        glDepthMask(false);
         glCallList(skySphere); // Draws the skysphere
-        glDepthMask(true); // this re-establish the default: writing to the depth buffer is enabled.
 
         // TODO: initially avoid the next line by having a LookThroughNormalized state change
         // TODO: eventually, when cameras are components, this node would simply use a different camera.

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BufferClearingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BufferClearingNode.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.nodes;
+
+import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.stateChanges.BindFBO;
+import org.terasology.rendering.opengl.BaseFBOsManager;
+import org.terasology.rendering.opengl.FBOConfig;
+
+import static org.lwjgl.opengl.GL11.glClear;
+
+/**
+ * Instances of this node clear specific buffers attached to an FBOs, in accordance to a clearing mask.
+ * Normally this means that all the pixels in the buffers selected by the mask are reset to a default value.
+ *
+ * Notice that the node is fully initialised and ready to use only after calling the initialise(Object object) method.
+ *
+ * This class could be inherited by a more specific class that sets the default values, via (yet to be written)
+ * state changes.
+ */
+public class BufferClearingNode extends AbstractNode {
+
+    private int clearingMask;
+
+    /**
+     * Throws a RuntimeException if invoked. Use initialise(Object data) instead.
+     */
+    public void initialise() {
+        throw new RuntimeException("Please do not use initialise(). For this class use initialise(Object initialData) instead.");
+    }
+
+    /**
+     * Initialises the node by requesting the creation (if necessary) of the FBO implied in the RequiredData object
+     * passed as argument and by requesting for this FBO to be bound by the time process() gets executed. Also
+     * stores the clearing mask contained in the RequiredData object, for later use.
+     *
+     * @param initializationData an instance of BufferClearingNode.RequiredData, containing an FBOConfig, an FBO manager
+     *                           and a clearing mask needed by this type of nodes to operate. See contained RequireData class.
+     * @throws IllegalArgumentException if the object is not an instance of BufferClearingNode.RequiredData.
+     */
+    @Override
+    public void initialise(Object initializationData) {
+
+        if (initializationData instanceof RequiredData) {
+            RequiredData requiredData = (RequiredData) initializationData;
+
+            requiresFBO(requiredData.getFboConfig(), requiredData.getFboManager());
+            addDesiredStateChange(new BindFBO(requiredData.getFboConfig().getName(), requiredData.getFboManager()));
+            this.clearingMask = requiredData.getClearingMask();
+
+        } else {
+            throw new IllegalArgumentException("Object provided is not an instance of BufferClearingNode.RequiredData");
+        }
+    }
+
+    /**
+     * Clears the buffers selected by the mask provided in setRequiredObjects, with default values.
+     *
+     * This method is executed within a NodeTask in the Render Tasklist.
+     */
+    @Override
+    public void process() {
+        glClear(clearingMask);
+    }
+
+    /**
+     * A simple class validating and eventually providing appropriate data for
+     * the method BufferClearingNode.initialise(Object object) method.
+     */
+    public static class RequiredData {
+        FBOConfig fboConfig;
+        BaseFBOsManager fboManager;
+        int clearingMask;
+
+        /**
+         * Validates the arguments and returns an object containing the data required by BufferClearingNodes,
+         * to be provided to the initialise(Object object) method.
+         *
+         * @param fboConfig an FBOConfig object characterizing the FBO to act upon, if necessary prompting its creation.
+         * @param fboManager an instance implementing the BaseFBOsManager interface, used to retrieve and bind the FBO.
+         * @param clearingMask a glClear(int)-compatible mask, selecting which FBO-attached buffers to clear,
+         *                     i.e. "GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT". This argument can't be zero.
+         *                     Non GL_*_BIT values will be accepted but might eventually generate an opengl error.
+         * @throws IllegalArgumentException if fboConfig, fboManager are null and if clearingMask is zero.
+         */
+        public RequiredData(FBOConfig fboConfig, BaseFBOsManager fboManager, int clearingMask) {
+
+            boolean argumentsAreValid = validateArguments(fboConfig, fboManager, clearingMask);
+            if (argumentsAreValid) {
+
+                this.fboConfig = fboConfig;
+                this.fboManager = fboManager;
+                this.clearingMask = clearingMask;
+
+            } else {
+                throw new IllegalArgumentException("Illegal argument(s): see the log for details.");
+            }
+        }
+
+        private boolean validateArguments(FBOConfig anFboConfig, BaseFBOsManager anFboManager, int aClearingMask) {
+            boolean argumentsAreValid = true;
+
+            if (anFboConfig == null) {
+                argumentsAreValid = false;
+                logger.warn("Illegal argument: fboConfig shouldn't be null.");
+            }
+
+            if (anFboManager == null) {
+                argumentsAreValid = false;
+                logger.warn("Illegal argument: fboManager shouldn't be null.");
+            }
+
+            if (aClearingMask == 0) {
+                argumentsAreValid = false;
+                logger.warn("Illegal argument: clearingMask can't be 0.");
+            }
+
+            return argumentsAreValid;
+        }
+
+        /**
+         * @return the FBOConfig instance validated and stored on construction.
+         */
+        public FBOConfig getFboConfig() {
+            return this.fboConfig;
+        }
+
+        /**
+         * @return the FBO manager instance validated and stored on construction.
+         */
+        public BaseFBOsManager getFboManager() {
+            return this.fboManager;
+        }
+
+        /**
+         * @return the clearing mask integer validated and stored on construction.
+         */
+        public int getClearingMask() {
+            return this.clearingMask;
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
@@ -22,12 +22,12 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
-import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.OrthographicCamera;
-import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.ConditionDependentNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
+import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FBOConfig;
@@ -37,21 +37,30 @@ import org.terasology.rendering.world.RenderQueuesHelper;
 import org.terasology.rendering.world.RenderableWorld;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.rendering.world.WorldRendererImpl;
-import org.lwjgl.opengl.GL11;
-import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
+
+import java.beans.PropertyChangeEvent;
+
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.glClear;
 
 
 /**
+ * This node class generates a shadow map used by the lighting step to determine what's in sight of
+ * the main light (sun, moon) and what isn't, allowing the display of shadows cast from said light.
+ * TODO: generalize to handle more than one light.
+ *
+ * Instances of this class:
+ * - are enabled and disabled depending on the shadow setting in the rendering config.
+ * - in VR mode regenerate the shadow map only once per frame rather than once per-eye.
+ *
  * Diagram of this node can be viewed from:
  * TODO: move diagram to the wiki when this part of the code is stable
  * - https://docs.google.com/drawings/d/13I0GM9jDFlZv1vNrUPlQuBbaF86RPRNpVfn5q8Wj2lc/edit?usp=sharing
  */
-public class ShadowMapNode extends AbstractNode {
+public class ShadowMapNode extends ConditionDependentNode {
     public static final ResourceUrn SHADOW_MAP = new ResourceUrn("engine:sceneShadowMap");
     private static final int SHADOW_FRUSTUM_BOUNDS = 500;
+    private static final float STEP_SIZE = 50f;
     public Camera shadowMapCamera = new OrthographicCamera(-SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, SHADOW_FRUSTUM_BOUNDS, -SHADOW_FRUSTUM_BOUNDS);
 
     @In
@@ -72,86 +81,113 @@ public class ShadowMapNode extends AbstractNode {
     @In
     private ShadowMapResolutionDependentFBOs shadowMapResolutionDependentFBOs;
 
-    private Material shadowMapShader;
     private RenderingConfig renderingConfig;
     private Camera playerCamera;
     private float texelSize;
-    private float stepSize;
-
 
     @Override
     public void initialise() {
         this.playerCamera = worldRenderer.getActiveCamera();
-        this.shadowMapShader = worldRenderer.getMaterial("engine:prog.shadowMap");
         this.renderingConfig = config.getRendering();
         renderableWorld.setShadowMapCamera(shadowMapCamera);
 
         requiresFBO(new FBOConfig(SHADOW_MAP, FBO.Type.NO_COLOR).useDepthBuffer(), shadowMapResolutionDependentFBOs);
 
-        // TODO: fix them
+        texelSize = 1.0f / renderingConfig.getShadowMapResolution() * 2.0f;
+        renderingConfig.subscribe(RenderingConfig.SHADOW_MAP_RESOLUTION, this);
+
+        requiresCondition(() -> renderingConfig.isDynamicShadows());
+        renderingConfig.subscribe(RenderingConfig.DYNAMIC_SHADOWS, this);
+
         addDesiredStateChange(new BindFBO(SHADOW_MAP, shadowMapResolutionDependentFBOs));
         addDesiredStateChange(new SetViewportToSizeOf(SHADOW_MAP, shadowMapResolutionDependentFBOs));
+        addDesiredStateChange(new EnableMaterial("engine:prog.shadowMap"));
+    }
+
+    private float calculateTexelSize(int shadowMapResolution) {
+        return 1.0f / shadowMapResolution * 2.0f; // the 2.0 multiplier is currently a mystery.
+    }
+
+    /**
+     * Handle changes to the following rendering config properties:
+     *
+     * - DYNAMIC_SHADOWS
+     * - SHADOW_MAP_RESOLUTION
+     *
+     * It assumes the event gets fired only if one of the property has actually changed.
+     *
+     * @param event a PropertyChangeEvent instance, carrying information regarding
+     *              what property changed, its old value and its new value.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent event) {
+        if (event.getPropertyName().equals(RenderingConfig.DYNAMIC_SHADOWS)) {
+            super.propertyChange(event);
+        } else if (event.getPropertyName().equals(RenderingConfig.SHADOW_MAP_RESOLUTION)) {
+            int shadowMapResolution = (int) event.getNewValue();
+            texelSize = calculateTexelSize(shadowMapResolution);
+        }
     }
 
     @Override
     public void process() {
         positionShadowMapCamera();
 
-        // TODO: find an elegant way to fetch isFirstRenderingStageForCurrentFrame
-        // TODO: check these conditions before adding this node inside the DAG, removing this condition completely from process()
-        if (renderingConfig.isDynamicShadows() && worldRenderer.isFirstRenderingStageForCurrentFrame()) {
+        // TODO: remove this IF statement when VR is handled via parallel nodes, one per eye.
+        if (worldRenderer.isFirstRenderingStageForCurrentFrame()) {
             PerformanceMonitor.startActivity("rendering/shadowMap");
 
-            // preRenderSetupSceneShadowMap
-            // TODO: verify the need to clear color buffer
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            GL11.glDisable(GL_CULL_FACE);
-
-            // render
             shadowMapCamera.lookThrough();
 
-            shadowMapShader.enable();
+            glClear(GL_DEPTH_BUFFER_BIT); // the shadowmap is a depth-only FBO
+
             // FIXME: storing chunksOpaqueShadow or a mechanism for requesting a chunk queue for nodes which calls renderChunks method?
             worldRenderer.renderChunks(renderQueues.chunksOpaqueShadow, ChunkMesh.RenderPhase.OPAQUE, shadowMapCamera, WorldRendererImpl.ChunkRenderMode.SHADOW_MAP);
-            playerCamera.lookThrough(); //FIXME: not strictly needed: just defensive programming here.
-
-            // postRenderCleanupSceneShadowMap
-            GL11.glEnable(GL_CULL_FACE);
-
+            playerCamera.lookThrough(); //TODO: camera setting need to go into a state change: enable camera, back to default camera
 
             PerformanceMonitor.endActivity();
         }
     }
 
     private void positionShadowMapCamera() {
-        // Shadows are rendered around the player so...
-        Vector3f lightPosition = new Vector3f(playerCamera.getPosition().x, 0.0f, playerCamera.getPosition().z);
+        // We begin by setting our light coordinates at the player coordinates, ignoring the player's altitude altitude
+        Vector3f mainLightPosition = new Vector3f(playerCamera.getPosition().x, 0.0f, playerCamera.getPosition().z); // world-space coordinates
 
-        // Project the shadowMapCamera position to light space and make sure it is only moved in texel steps (avoids flickering when moving the shadowMapCamera)
-        texelSize = 1.0f / renderingConfig.getShadowMapResolution();
-        texelSize *= 2.0f;
+        // The shadow projected onto the ground must move in in light-space texel-steps, to avoid causing flickering.
+        // That's why we first convert it to the previous frame's light-space coordinates and then back to world-space.
+        shadowMapCamera.getViewProjectionMatrix().transformPoint(mainLightPosition); // to light-space
+        mainLightPosition.set(TeraMath.fastFloor(mainLightPosition.x / texelSize) * texelSize, 0.0f,
+                              TeraMath.fastFloor(mainLightPosition.z / texelSize) * texelSize);
+        shadowMapCamera.getInverseViewProjectionMatrix().transformPoint(mainLightPosition); // back to world-space
 
-        shadowMapCamera.getViewProjectionMatrix().transformPoint(lightPosition);
-        lightPosition.set(TeraMath.fastFloor(lightPosition.x / texelSize) * texelSize, 0.0f, TeraMath.fastFloor(lightPosition.z / texelSize) * texelSize);
-        shadowMapCamera.getInverseViewProjectionMatrix().transformPoint(lightPosition);
+        // This is what causes the shadow map to change infrequently, to prevent flickering.
+        // Notice that this is different from what is done above, which is about spatial steps
+        // and is related to the player's position and texels.
+        Vector3f quantizedMainLightDirection = getQuantizedMainLightDirection(STEP_SIZE);
 
-        // ... we position our new shadowMapCamera at the position of the player and move it
-        // quite a bit into the direction of the sun (our main light).
+        // The shadow map camera is placed away from the player, in the direction of the main light.
+        Vector3f offsetFromPlayer = new Vector3f(quantizedMainLightDirection);
+        offsetFromPlayer.scale(256.0f + 64.0f); // these hardcoded numbers are another mystery.
+        mainLightPosition.add(offsetFromPlayer);
+        shadowMapCamera.getPosition().set(mainLightPosition);
 
-        // Make sure the sun does not move too often since it causes massive shadow flickering (from hell to the max)!
-        stepSize = 50f;
-        Vector3f sunDirection = backdropProvider.getQuantizedSunDirection(stepSize);
+        // Finally, we adjust the shadow map camera to look toward the player
+        Vector3f fromLightToPlayerDirection = new Vector3f(quantizedMainLightDirection);
+        fromLightToPlayerDirection.scale(-1.0f);
+        shadowMapCamera.getViewingDirection().set(fromLightToPlayerDirection);
 
-        Vector3f sunPosition = new Vector3f(sunDirection);
-        sunPosition.scale(256.0f + 64.0f);
-        lightPosition.add(sunPosition);
-        shadowMapCamera.getPosition().set(lightPosition);
-
-        // and adjust it to look from the sun direction into the direction of our player
-        Vector3f negSunDirection = new Vector3f(sunDirection);
-        negSunDirection.scale(-1.0f);
-
-        shadowMapCamera.getViewingDirection().set(negSunDirection);
         shadowMapCamera.update(worldRenderer.getSecondsSinceLastFrame());
+    }
+
+    private Vector3f getQuantizedMainLightDirection(float stepSize) {
+        float mainLightAngle = (float) Math.floor(backdropProvider.getSunPositionAngle() * stepSize) / stepSize + 0.0001f;
+        Vector3f mainLightDirection = new Vector3f(0.0f, (float) Math.cos(mainLightAngle), (float) Math.sin(mainLightAngle));
+
+        // When the sun goes under the horizon we flip the vector, to provide the moon direction, and viceversa.
+        if (mainLightDirection.y < 0.0f) {
+            mainLightDirection.scale(-1.0f);
+        }
+
+        return mainLightDirection;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/tasks/DisableMaterialTask.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/tasks/DisableMaterialTask.java
@@ -15,7 +15,8 @@
  */
 package org.terasology.rendering.dag.tasks;
 
-import static org.lwjgl.opengl.GL20.glUseProgram;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.dag.RenderPipelineTask;
 
 /**
@@ -23,9 +24,11 @@ import org.terasology.rendering.dag.RenderPipelineTask;
  */
 public final class DisableMaterialTask implements RenderPipelineTask {
 
+    private ShaderManager shaderManager = CoreRegistry.get(ShaderManager.class);
+
     @Override
     public void execute() {
-        glUseProgram(0);
+        shaderManager.disableShader();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/ShadowMapResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/ShadowMapResolutionDependentFBOs.java
@@ -46,7 +46,7 @@ public class ShadowMapResolutionDependentFBOs extends AbstractFBOsManager implem
         FBO fbo;
         ResourceUrn fboName = fboConfig.getName();
         if (fboConfigs.containsKey(fboName)) {
-            if (!config.equals(fboConfigs.get(fboName))) {
+            if (!fboConfig.equals(fboConfigs.get(fboName))) {
                 throw new IllegalArgumentException("Requested FBO is already available with different configuration");
             }
             fbo = fboLookup.get(fboConfig.getName());


### PR DESCRIPTION
**[EDIT] the latest commit fixes the bug and makes this PR, further feedback notwithstanding, ready for merge.**

### Contains
* Refactored ShadowMapNode to fully take advantage of the new architecture
* Refactored WorldReflectionNode by extracting a new BackdropReflectionNode class from it, both taking advantage of the new architecture.
* [EDIT] Refactored BackdropNode to partially take advantage of the new architecture.
* Added and using a new BufferClearingNode class
* Added a new NodeFactory.createInstance(Class<T>, Object) method to allow passing initial data to the new Node.initialise(Object) method.
* [EDIT] <s>Changed FBOConfig class to hold information about the fbo manager to be associated with a given FBO.</s> - removed: will be reintroduced in a separate PR. 

### How to test

* Start Terasology
* Create/Load a game
* try changing Video Settings / Shadows
* try changing Video Settings / Water Reflections
* everything should look unchanged

### Outstanding before merging - [EDIT] OBSOLETE: the bug has been fixed.
At this stage this PR and in particular commit e737750e introduce a bug: when the Water Reflections are set to "Sky Only" the sky goes grey. This is probably due to the interactions between the old rendering engine architecture and the new one, as some nodes are still using the old architecture.

I intend to fix this bug before we merge this. However, most if not all the changes already visible in this PR are likely to be left untouched by the debugging process and I thought we could start the review process already.


