### PR TITLE
Whitelist many stream classes

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
+++ b/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
@@ -90,6 +90,25 @@ public final class ExternalApiWhitelist {
             .add(java.awt.datatransfer.UnsupportedFlavorException.class)
             .add(java.nio.ByteBuffer.class)
             .add(java.nio.IntBuffer.class)
+            .add(java.io.DataInput.class)
+            .add(java.io.DataOutput.class)
+            .add(java.io.EOFException.class)
+            .add(java.io.UTFDataFormatException.class)
+            /* All sorts of input streams */
+            .add(java.io.InputStream.class)
+            .add(java.io.ByteArrayInputStream.class)
+            .add(java.io.FilterInputStream.class)
+            .add(java.io.PipedInputStream.class)
+            .add(java.io.BufferedInputStream.class)
+            .add(java.io.DataInputStream.class)
+            .add(java.io.PushbackInputStream.class)
+            /* All sorts of output streams */
+            .add(java.io.OutputStream.class)
+            .add(java.io.ByteArrayOutputStream.class)
+            .add(java.io.FilterOutputStream.class)
+            .add(java.io.PipedOutputStream.class)
+            .add(java.io.BufferedOutputStream.class)
+            .add(java.io.DataOutputStream.class)
             .build();
 
     private ExternalApiWhitelist() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Adds many InputStream/OutputStream-related classes to the whitelist.

The classes whitelisted in this PR are safe and cannot open files.

This makes way for a potential Virtual FS API, and adds support for many libraries which use InputStream and OutputStream.

### How to test

No idea. Custom asset formats maybe?