### PR TITLE
Fixes #2489 - ESC now recompiles shaders while exiting video settings

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -23,6 +23,7 @@ import org.terasology.config.Config;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.i18n.TranslationSystem;
+import org.terasology.input.Keyboard;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
@@ -32,6 +33,7 @@ import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.BindHelper;
 import org.terasology.rendering.nui.databinding.Binding;
+import org.terasology.rendering.nui.events.NUIKeyEvent;
 import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
 import org.terasology.rendering.nui.itemRendering.ToStringTextRenderer;
 import org.terasology.rendering.nui.widgets.UIDropdown;
@@ -263,13 +265,25 @@ public class VideoSettingsScreen extends CoreScreenLayer {
         }
 
         WidgetUtil.trySubscribe(this, "close", button -> {
-            logger.info("Video Settings: {}", config.renderConfigAsJson(config.getRendering()));
-            // TODO: add a dirty flag that checks if recompiling is needed
-            CoreRegistry.get(ShaderManager.class).recompileAllShaders();
-            triggerBackAnimation();
+            saveSettings();
         });
     }
 
+
+    @Override
+    public boolean onKeyEvent(NUIKeyEvent event) {
+        if (event.isDown() && event.getKey() == Keyboard.Key.ESCAPE) {
+            saveSettings();
+        }
+        return false;
+    }
+
+    public void saveSettings() {
+        logger.info("Video Settings: {}", config.renderConfigAsJson(config.getRendering()));
+        // TODO: add a dirty flag that checks if recompiling is needed
+        CoreRegistry.get(ShaderManager.class).recompileAllShaders();
+        triggerBackAnimation();
+    }
     @Override
     public boolean isLowerLayerVisible() {
         return false;


### PR DESCRIPTION
### Contains
Fix for #2489: The ESC key now does exactly what the "back" button does i.e recompiles shaders etc.

### How to test
- Enter Setting -> Video, (either in-game or from outside)
- Hit ESC
- Check the logger
It should now show something like `VideoSettingsScreen - Video Settings: {"pixelFormat":24,"wind...`, which would earlier only arise after the back button was clicked.