### PR TITLE
Fixes #2342 Module Filters impacting WorldGen list

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -177,8 +177,8 @@ public class CreateGameScreen extends CoreScreenLayer {
                 @Override
                 public List<WorldGeneratorInfo> get() {
                     // grab all the module names and their dependencies
+                    // This grabs modules from `config.getDefaultModSelection()` which is updated in SelectModulesScreen
                     Set<Name> enabledModuleNames = getAllEnabledModuleNames().stream().collect(Collectors.toSet());
-
                     List<WorldGeneratorInfo> result = Lists.newArrayList();
                     for (WorldGeneratorInfo option : worldGeneratorManager.getWorldGenerators()) {
                         if (enabledModuleNames.contains(option.getUri().getModuleName())) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectModulesScreen.java
@@ -547,9 +547,12 @@ public class SelectModulesScreen extends CoreScreenLayer {
 
     @Override
     public void onClosed() {
+        // moduleConfig passes the module collection to the Create Game Screen.
         ModuleConfig moduleConfig = config.getDefaultModSelection();
         moduleConfig.clear();
-        sortedModules.stream().filter(info -> info.isSelected() && info.isExplicitSelection()).forEach(info ->
+        // Fetch all the selected/activated modules using allSortedModules
+        // instead of fetching only selected/activated modules from filtered collection of modules using sortedModules
+        allSortedModules.stream().filter(info -> info.isSelected() && info.isExplicitSelection()).forEach(info ->
                 moduleConfig.addModule(info.getMetadata().getId()));
         SimpleUri defaultGenerator = config.getWorldGeneration().getDefaultGenerator();
         ModuleSelectionInfo info = modulesLookup.get(defaultGenerator.getModuleName());


### PR DESCRIPTION
### Contains

Fixes #2342

### How to test

- Open Singleplayer -> Create
- Check "Choose World Generator" list. (Should contain atleast "Builder Sample World")
- Go to Modules, enter "Filter" text as gibberish.
- Hit ESC or Back button
- Check "Choose World Generator" list.
- Filter text gibberish no longer impacts World Generator list. (Was earlier being generated from filtered module list. Now being generated from all modules list.)
- Note: Deactivating activated modules also works now. As compared to @kartikey0303's fix
