### PR TITLE
Bumped -Xmx from 1024m to 1536m in launch configs

### DIFF
--- a/config/gradle/ide.gradle
+++ b/config/gradle/ide.gradle
@@ -157,7 +157,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -220,7 +220,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir=terasology-2ndclient -noCrashReport"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -252,7 +252,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -284,7 +284,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport -noSplash"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -316,7 +316,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport -loadlastgame"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -348,7 +348,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport -noSaveGames"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -380,7 +380,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport -noSound"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -412,7 +412,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-headless -homedir=terasology-server"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
@@ -444,7 +444,7 @@ ext {
                 </pattern>
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.editor.TeraEd"/>
-              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1024m"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
               <option name="PROGRAM_PARAMETERS" value="-homedir"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>

--- a/facades/PC/launchScripts/run_linux.sh
+++ b/facades/PC/launchScripts/run_linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd "$(dirname "$0")"
-java -Xms128m -Xmx1024m -jar libs/Terasology.jar
+java -Xms128m -Xmx1536m -jar libs/Terasology.jar
 
 # Alternatively use our Launcher from: https://github.com/MovingBlocks/TerasologyLauncher/releases

--- a/facades/PC/launchScripts/run_macosx.command
+++ b/facades/PC/launchScripts/run_macosx.command
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd "$(dirname "$0")"
-java -Xms128m -Xmx1024m -jar libs/Terasology.jar
+java -Xms128m -Xmx1536m -jar libs/Terasology.jar
 
 # Alternatively use our Launcher from: https://github.com/MovingBlocks/TerasologyLauncher/releases
 

--- a/facades/PC/launchScriptsSrc/LauncherTeraEd.xml
+++ b/facades/PC/launchScriptsSrc/LauncherTeraEd.xml
@@ -25,6 +25,6 @@
     <jdkPreference>preferJre</jdkPreference>
     <runtimeBits>64/32</runtimeBits>
     <initialHeapSize>128</initialHeapSize>
-    <maxHeapSize>1024</maxHeapSize>
+    <maxHeapSize>1536</maxHeapSize>
   </jre>
 </launch4jConfig>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

This *mostly* addresses #2424.  The Windows launchers still need to be updated but I don't have a Windows machine to develop on.

### How to test

Run any of the launch configs in IntelliJ, I had to re-run 'gradlew idea' for it to show the updated parameters in the configuration window.

### Outstanding before merging

The IntelliJ, OSX, Linux and TeraEd launchers were updated.  The Windows
binaries were not. Re-run 'gradlew idea' to have the updated configs applied in
IntelliJ.