### PR TITLE
Fixed #1988 auto blocks in-game console

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/loader/AutoBlockProvider.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/AutoBlockProvider.java
@@ -60,7 +60,7 @@ public class AutoBlockProvider implements AssetDataProducer<BlockFamilyDefinitio
         assetManager.resolve(resourceName.toString(), BlockTile.class).stream()
                 .map(urn -> assetManager.getAsset(urn, BlockTile.class).get())
                 .filter(BlockTile::isAutoBlock)
-                .forEach(tile -> result.add(tile.getUrn().getResourceName()));
+                .forEach(tile -> result.add(tile.getUrn().getModuleName()));
         return result;
     }
 


### PR DESCRIPTION
### Contains

Fixes #1988 

### How to test
- Start a game
- Console command `giveBlock companion` (or any other auto block like dirt [BuilderSampleGameplay:Dirt] etc) should now give you the block! :smile:

### What I gathered
- with ` forEach(tile -> result.add(tile.getUrn().getResourceName()));` the result was "**companion**". However when this was passed back to the giveBlock method inside `BlockCommands.java` (Refer: [this](https://github.com/MovingBlocks/Terasology/blob/3252f9ec05241ac370430abdf2118b771a6d590e/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java#L277)), the matchingUris set from `Set<ResourceUrn> matchingUris = Assets.resolveAssetUri(uri, BlockFamilyDefinition.class);` now contained "Companion:companion". As pointed out by @Waterpicker.
- with ` forEach(tile -> result.add(tile.getUrn().getModuleName()));` instead, the result was "**core**". However when this was passed back to the giveBlock method inside `BlockCommands.java`, the matchingUris set from `Set<ResourceUrn> matchingUris = Assets.resolveAssetUri(uri, BlockFamilyDefinition.class);` now contained "core:companion".

Don't really know what's happening inside resolveAssetUri, but this one word change (which took a lot of detective work, phew!) fixes it! :laughing: 
