### PR TITLE
#2139 Added item impact events when hitting world

### DIFF
--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
@@ -29,7 +29,6 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.location.LocationResynchEvent;
 import org.terasology.math.geom.Quat4f;
@@ -41,14 +40,18 @@ import org.terasology.physics.HitResult;
 import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.physics.components.RigidBodyComponent;
 import org.terasology.physics.components.TriggerComponent;
-import org.terasology.physics.events.*;
+import org.terasology.physics.events.ChangeVelocityEvent;
+import org.terasology.physics.events.CollideEvent;
+import org.terasology.physics.events.ForceEvent;
+import org.terasology.physics.events.ImpulseEvent;
+import org.terasology.physics.events.PhysicsResynchEvent;
+import org.terasology.physics.events.ImpactEvent;
 import org.terasology.registry.In;
 import org.terasology.world.OnChangedBlock;
 import org.terasology.world.block.BlockComponent;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * The PhysicsSystem is a bridging class between the event system and the
@@ -167,7 +170,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
                 float fDistance = vDirection.length();
                 vDirection.normalize();
 
-                HitResult hitInfo = physics.rayTrace(vLocation, vDirection, fDistance * delta, StandardCollisionGroup.WORLD);
+                HitResult hitInfo = physics.rayTrace(vLocation, vDirection, fDistance * delta, StandardCollisionGroup.WORLD, StandardCollisionGroup.CHARACTER );
                 if (hitInfo.isHit()) {
                     entity.send(new ImpactEvent());
                 }

--- a/engine/src/main/java/org/terasology/physics/events/ImpactEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/ImpactEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.physics.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+/**
+ */
+public class ImpactEvent implements Event {
+}


### PR DESCRIPTION
Contains:

This PR fixes #2139 by making any item that hits the ground (hard enough to register) send an event that is then caught, processed and gives the item a set speed upwards which prevents it from tunneling. 

By doing so, I've seen improvements in framerate when using the railgun and had the comical effect of some blocks bouncing around before they settle. 

This also puts the building blocks down for creating the StickySystem for #1443 and _could_ help with #1697


How to test:

Throw any item from any height onto any piece of land. They will most likely not go through them.


Possible improvements I need feedback on:
- [ ] Consider giving the item a physical reaction by giving it a reduced speed on the vector opposite of the collision normal. I do still like how they bounce though :)
- [ ] Adjust the space items are thrown from by the player (when throwing items directly into a wall in front of the player, they are thrown from the same relative point to the player, which in this case is already inside the wall. This can be fixed by changing said position withing a max range of the direction the player is looking, but I'm not sure if we want that).
- [ ] Consider sending more information throught the event. (probably the other entity?)

