### PR TITLE
Fixes issue #2508, excess scrolling in module list

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
@@ -61,11 +61,11 @@ public class UIList<T> extends CoreWidget {
     @Override
     public void onDraw(Canvas canvas) {
         updateItemListeners();
+        canvas.setPart("item");
 
         boolean enabled = isEnabled();
         Border margin = canvas.getCurrentStyle().getMargin();
 
-        canvas.setPart("item");
         int yOffset = 0;
         for (int i = 0; i < list.get().size(); ++i) {
             T item = list.get().get(i);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2508 

### How to test

Start the game
Create a new game
Click Modules
Once the module list loads completely, scroll to the bottom.  There should no longer be excess space.

### Outstanding before merging


This was a regression introduced by 8c07c4e14.  The list items were rendering
without the correct margins but the margins were still being included when
calculating the size of the scrollable area, resulting in excess space at the
end of the list.