### PR TITLE
Utility: Include a template override.cfg for use by default in headless launched via IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,10 @@ extensions
 /libs/*
 !/libs/subprojects.gradle
 
-# Ignore Gradle, including local override properties (template file available under /templates)
+# Ignore Gradle and some transient project config files (template versions available under /templates)
 build/
-gradle.properties
+/gradle.properties
+/override.cfg
 
 # Ignore IntelliJ - could use "/**/*.iml" to catch all .iml files, but that requires a somewhat recent Git version
 /out/

--- a/build.gradle
+++ b/build.gradle
@@ -187,8 +187,21 @@ task protobufCompileLinux(type:Exec) {
 // General IDE customization                                                                                         //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+task copyInMissingTemplates {
+    description = "Copies in placeholders from the /templates dir to project root if not present yet"
+    File gradlePropsFile = new File(rootDir, 'gradle.properties')
+    File OverrideCfgFile = new File(rootDir, 'override.cfg')
+    if (!gradlePropsFile.exists()) {
+        new File(rootDir, 'gradle.properties') << new File(templatesDir, 'gradle.properties').text
+    }
+    if (!OverrideCfgFile.exists()) {
+        new File(rootDir, 'override.cfg') << new File(templatesDir, 'override.cfg').text
+    }
+}
+
 // Make sure the IDE prep includes extraction of natives
 ideaModule.dependsOn extractNatives
+ideaModule.dependsOn copyInMissingTemplates
 
 // For IntelliJ add a bunch of excluded directories
 idea {

--- a/config/gradle/ide.gradle
+++ b/config/gradle/ide.gradle
@@ -242,6 +242,38 @@ ext {
             </configuration>
         '''))
 
+        // Run config for a *third* client in its own data dir (for more extensive multiplayer testing)
+        runManager.append(new XmlParser().parseText('''
+            <configuration default="false" name="TerasologyPC (3rd client)" type="Application" factoryName="Application">
+              <extension name="coverage" enabled="false" merge="false" runner="idea">
+                <pattern>
+                  <option name="PATTERN" value="org.terasology.engine.*"/>
+                  <option name="ENABLED" value="true"/>
+                </pattern>
+              </extension>
+              <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
+              <option name="PROGRAM_PARAMETERS" value="-homedir=terasology-3rdclient -noCrashReport"/>
+              <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
+              <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
+              <option name="ALTERNATIVE_JRE_PATH" value=""/>
+              <option name="ENABLE_SWING_INSPECTOR" value="false"/>
+              <option name="ENV_VARIABLES"/>
+              <option name="PASS_PARENT_ENVS" value="true"/>
+              <module name="PC"/>
+              <envs/>
+              <RunnerSettings RunnerId="Debug">
+                <option name="DEBUG_PORT" value=""/>
+                <option name="TRANSPORT" value="0"/>
+                <option name="LOCAL" value="true"/>
+              </RunnerSettings>
+              <RunnerSettings RunnerId="Run"/>
+              <ConfigurationWrapper RunnerId="Debug"/>
+              <ConfigurationWrapper RunnerId="Run"/>
+              <method/>
+            </configuration>
+        '''))
+
         // Run config that includes the Crash Reporter
         runManager.append(new XmlParser().parseText('''
             <configuration default="false" name="TerasologyPC (CR enabled)" type="Application" factoryName="Application">
@@ -413,7 +445,7 @@ ext {
               </extension>
               <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
               <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m"/>
-              <option name="PROGRAM_PARAMETERS" value="-headless -homedir=terasology-server"/>
+              <option name="PROGRAM_PARAMETERS" value="-headless -homedir=terasology-server -overrideDefaultConfig=override.cfg"/>
               <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
               <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
               <option name="ALTERNATIVE_JRE_PATH" value=""/>

--- a/templates/gradle.properties
+++ b/templates/gradle.properties
@@ -1,4 +1,4 @@
-# These settings can speed up the execution of Gradle
+# These settings can speed up the execution of Gradle (and some may be on by default anyway in newer Gradle versions)
 org.gradle.daemon=true
 org.gradle.parallel = true
 org.gradle.configureondemand=true

--- a/templates/override.cfg
+++ b/templates/override.cfg
@@ -1,0 +1,11 @@
+{
+  "defaultModSelection": {
+    "modules": [
+      "CoreSampleGameplay"
+    ],
+    "defaultGameplayModuleName": "CoreSampleGameplay"
+  },
+  "worldGeneration": {
+    "defaultGenerator": "Core:facetedperlin"
+  }
+}


### PR DESCRIPTION
This is a tiny developer convenience PR.
- Contains an `override.cfg` file under `/templates` that'll get copied to the project root on `gradlew idea` - an easy way to get a tiny config file prepared for a server run
- The existing `gradle.properties` under `/templates` will now also get copied to the project root automatically, allowing convenient access to a bunch of Gradle config (turns on the Gradle Daemon and some other stuff by default - which is becoming default in Gradle 3 anyway)
- The headless server run config in IntelliJ will now use the `override.cfg` mentioned above by default (if it isn't present the game falls back on default config - no crash)
- There is a 3rd game client run config in IntelliJ so you can easily run _three_ separate game clients (and a headless server!) for deeper multiplayer testing (like having one player teleport two others - handy for testing #2536 by @portokaliu / Anthodeus!)

I've personally had a `gradle.properties` in my project root dir for ages (since I have all kinds of project secrets in there!) and left a placeholder under `/templates` but it isn't obvious that it is there nor what you can do with it (make Gradle do its thing faster or retrieve/publish things to different GitHub orgs / Artifactories). So this helps expose that better.

@qwc might also be interested in this as I got the idea of a placeholder `override.cfg` from his tinkering with the Docker game server image. While this PR doesn't package the `override.cfg` in the game zip yet that could be done and even customized further if needed. Right now the template just matches current defaults (run CoreSampleGameplay with faceted Perlin) and is _only_ activated on headless server launch via IntelliJ

Like the `gradle.properties` I hope having a placeholder `override.cfg` will encourage using it more for developing, as it is _so much easier_ just adding a few modules to it then recreate a server over and over without having to modify `terasology-server/config.cfg` and then lose it each reset unless you carefully avoid deleting it.

For testing:
- Run `gradlew idea` without `override.cfg` or `gradle.properties` in the root dir, make sure they get copied in from `/templates`
- Make sure altered versions of the files in the project root do not get overwritten
- Make sure a server launched via the headless run config in IntelliJ respects custom modules added to `override.cfg`
- Make sure a server launches with _defaults_ without `override.cfg` present in project root (don't want it to crash if it doesn't find a file despite being told to look for one)

@qwc let me know what you think and if it would help to bundle a placeholder `override.cfg` (with something specific configured?) in the game zip. It likely would at least help me when preparing a server to upload somewhere and configure manually.
