### PR TITLE
Fixes issue #2452, tooltips flicker when forced under the mouse

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
@@ -44,6 +44,7 @@ public class UIList<T> extends CoreWidget {
     private final List<ItemInteractionListener> itemListeners = Lists.newArrayList();
     private final List<ItemActivateEventListener<T>> activateListeners = Lists.newArrayList();
     private final List<ItemSelectEventListener<T>> selectionListeners = Lists.newArrayList();
+    private Binding<Boolean> interactive = new DefaultBinding<>(true);
     private Binding<Boolean> selectable = new DefaultBinding<>(true);
     private Binding<T> selection = new DefaultBinding<>();
     private Binding<List<T>> list = new DefaultBinding<>(new ArrayList<>());
@@ -80,7 +81,9 @@ public class UIList<T> extends CoreWidget {
                 } else {
                     canvas.setMode(DEFAULT_MODE);
                 }
-                canvas.addInteractionRegion(listener, itemRenderer.getTooltip(item), itemRegion);
+                if (isInteractive()) {
+                    canvas.addInteractionRegion(listener, itemRenderer.getTooltip(item), itemRegion);
+                }
             } else {
                 canvas.setMode(DISABLED_MODE);
             }
@@ -134,9 +137,13 @@ public class UIList<T> extends CoreWidget {
         selectable = binding;
     }
 
+    public boolean isInteractive() { return interactive.get(); }
+
     public boolean isSelectable() {
         return selectable.get();
     }
+
+    public void setInteractive(boolean value) { interactive.set(value); }
 
     public void setSelectable(boolean value) {
         selectable.set(value);

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemIcon.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/ItemIcon.java
@@ -58,6 +58,7 @@ public class ItemIcon extends CoreWidget {
 
     public ItemIcon() {
         tooltip = new UIList<>();
+        tooltip.setInteractive(false);
         tooltip.setSelectable(false);
         final UISkin defaultSkin = Assets.getSkin("core:itemTooltip").get();
         tooltip.setSkin(defaultSkin);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->
### Contains

Fixes #2452 
### How to test

Load up the game with the potions module
Give yourself a double jump potion
Place the item in the lower-right inventory slot
Mouse over the item, the tooltip should not flicker or "vibrate" even when the mouse is on top of it
### Outstanding before merging

This scenario can occur when a tooltip is unable to render in the preferred
location due to the screen boundaries, for instance if an item with a really
long tooltip is placed in the lower-right most inventory slot.  Because UILists
define InteractionRegions around their contents by default and tooltips are
rendered last, they are seen as the new top-most interactive element on the
following game tick.  This causes an immediate reset of the tooltip timer due
to the top-most region changing, and the process repeats.  This has been fixed
by preventing tooltips from defining interaction regions through a new optional
flag in UIList that sets whether the list is interactive or not.
