### PR TITLE
Added popup if a key has already been assigned to another action.

### DIFF
--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -30,6 +30,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+import org.lwjgl.Sys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
@@ -52,15 +53,11 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.ResolutionResult;
 import org.terasology.module.predicates.FromModule;
 import org.terasology.naming.Name;
+import org.terasology.registry.In;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * User binds configuration. This holds the key/mouse binding for Button Binds. They are sorted by package.
@@ -72,6 +69,18 @@ public final class BindsConfig {
     private ListMultimap<SimpleUri, Input> data = ArrayListMultimap.create();
 
     public BindsConfig() {
+    }
+
+    /**
+     * Returns true if an input has already been bound to another key
+     *
+     * @param newInput The input to check if it has been bound already
+     * @return True if newInput has been bound. False otherwise.
+     */
+    public boolean isBound(Input newInput) {
+        if(data.containsValue(newInput))
+            return true;
+        return false;
     }
 
     /**
@@ -105,6 +114,7 @@ public final class BindsConfig {
      * @param bindUri
      * @param inputs
      */
+
     public void setBinds(SimpleUri bindUri, Input... inputs) {
         setBinds(bindUri, Arrays.asList(inputs));
     }

--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -78,9 +78,7 @@ public final class BindsConfig {
      * @return True if newInput has been bound. False otherwise.
      */
     public boolean isBound(Input newInput) {
-        if(data.containsValue(newInput))
-            return true;
-        return false;
+        return data.containsValue(newInput);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -30,7 +30,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
-import org.lwjgl.Sys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
@@ -53,11 +52,16 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.ResolutionResult;
 import org.terasology.module.predicates.FromModule;
 import org.terasology.naming.Name;
-import org.terasology.registry.In;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.*;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.Collections;
 
 /**
  * User binds configuration. This holds the key/mouse binding for Button Binds. They are sorted by package.

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ChangeBindingPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ChangeBindingPopup.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.rendering.nui.layers.mainMenu.inputSettings;
 
+import org.lwjgl.Sys;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.BindsConfig;
 import org.terasology.config.Config;
+import org.terasology.config.InputConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
@@ -55,7 +57,7 @@ public class ChangeBindingPopup extends CoreScreenLayer {
 
     private UIInputBind bindButton;
 
-    private BindsConfig defaultBinds;
+    private BindsConfig defaultBinds, currBinds;
 
     @Override
     public void initialise() {
@@ -64,8 +66,16 @@ public class ChangeBindingPopup extends CoreScreenLayer {
         bindButton = find("new-binding", UIInputBind.class);
         WidgetUtil.trySubscribe(this, "remove", button -> bindButton.setNewInput(null));
         WidgetUtil.trySubscribe(this, "ok", button -> {
-            bindButton.saveInput();
-            getManager().popScreen();
+            Input newInput = bindButton.getNewInput();
+            currBinds = config.getInput().getBinds();
+            if(currBinds.isBound(newInput) && !newInput.equals(bindButton.getInput())) {
+                ConfirmChangePopup popup = getManager().pushScreen(ConfirmChangePopup.ASSET_URI, ConfirmChangePopup.class);
+                popup.setButtonData(bindButton);
+            }
+            else {
+                bindButton.saveInput();
+                getManager().popScreen();
+            }
         });
         WidgetUtil.trySubscribe(this, "cancel", button -> getManager().popScreen());
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ChangeBindingPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ChangeBindingPopup.java
@@ -15,11 +15,9 @@
  */
 package org.terasology.rendering.nui.layers.mainMenu.inputSettings;
 
-import org.lwjgl.Sys;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.BindsConfig;
 import org.terasology.config.Config;
-import org.terasology.config.InputConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
@@ -57,7 +55,8 @@ public class ChangeBindingPopup extends CoreScreenLayer {
 
     private UIInputBind bindButton;
 
-    private BindsConfig defaultBinds, currBinds;
+    private BindsConfig defaultBinds;
+    private BindsConfig currBinds;
 
     @Override
     public void initialise() {
@@ -68,11 +67,10 @@ public class ChangeBindingPopup extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "ok", button -> {
             Input newInput = bindButton.getNewInput();
             currBinds = config.getInput().getBinds();
-            if(currBinds.isBound(newInput) && !newInput.equals(bindButton.getInput())) {
+            if (currBinds.isBound(newInput) && !newInput.equals(bindButton.getInput())) {
                 ConfirmChangePopup popup = getManager().pushScreen(ConfirmChangePopup.ASSET_URI, ConfirmChangePopup.class);
                 popup.setButtonData(bindButton);
-            }
-            else {
+            } else {
                 bindButton.saveInput();
                 getManager().popScreen();
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ConfirmChangePopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ConfirmChangePopup.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.mainMenu.inputSettings;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.widgets.UILabel;
+
+public class ConfirmChangePopup extends CoreScreenLayer {
+
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:confirmChangePopup");
+
+    private UIInputBind bindButton;
+
+    @Override
+    public void initialise() {
+        WidgetUtil.trySubscribe(this, "ok", button -> {
+            bindButton.saveInput();
+            getManager().popScreen();
+            getManager().popScreen();
+        });
+        WidgetUtil.trySubscribe(this, "cancel", button -> getManager().popScreen());
+    }
+
+    public void setButtonData(UIInputBind bindButton) {
+        this.bindButton = bindButton;
+        String messageText = "Key " +  bindButton.getNewInput().getDisplayName() + " has already been assigned an action. Press ok to change anyway.";
+        find("title", UILabel.class).setText("Rebinding");
+        find("message", UILabel.class).setText(messageText);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ConfirmChangePopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ConfirmChangePopup.java
@@ -39,7 +39,6 @@ public class ConfirmChangePopup extends CoreScreenLayer {
     public void setButtonData(UIInputBind bindButton) {
         this.bindButton = bindButton;
         String messageText = "Key " +  bindButton.getNewInput().getDisplayName() + " has already been assigned an action. Press ok to change anyway.";
-        find("title", UILabel.class).setText("Rebinding");
         find("message", UILabel.class).setText(messageText);
     }
 

--- a/engine/src/main/resources/assets/ui/confirmChangePopup.ui
+++ b/engine/src/main/resources/assets/ui/confirmChangePopup.ui
@@ -19,8 +19,7 @@
                     "contents": [
                         {
                             "type": "UILabel",
-                            "text": "Title",
-                            "id": "title",
+                            "text": "Rebinding",
                             "family": "title"
                         },
                         {

--- a/engine/src/main/resources/assets/ui/confirmChangePopup.ui
+++ b/engine/src/main/resources/assets/ui/confirmChangePopup.ui
@@ -1,0 +1,70 @@
+{
+    "type": "confirmChangePopup",
+    "skin": "messageBox",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "UIBox",
+                "layoutInfo": {
+                    "width": 500,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-vertical-center": {}
+                },
+                "content": {
+                    "type": "ColumnLayout",
+                    "columns": 1,
+                    "verticalSpacing": 8,
+                    "contents": [
+                        {
+                            "type": "UILabel",
+                            "text": "Title",
+                            "id": "title",
+                            "family": "title"
+                        },
+                        {
+                            "type": "UISpace",
+                            "size": [
+                                1,
+                                16
+                            ]
+                        },
+                        {
+                            "type": "UILabel",
+                            "text": "Message",
+                            "id": "message"
+                        },
+                        {
+                            "type": "UISpace",
+                            "size": [
+                                1,
+                                16
+                            ]
+                        },
+                        {
+                            "type": "RowLayout",
+                            "horizontalSpacing": 4,
+                            "contents": [
+                                {
+                                    "type": "UIButton",
+                                    "text": "${engine:menu#dialog-ok}",
+                                    "id": "ok"
+                                },
+                                {
+                                    "type": "UIButton",
+                                    "text": "${engine:menu#dialog-cancel}",
+                                    "id": "cancel"
+                                }
+                            ],
+                            "layoutInfo": {
+                                "width": 200,
+                                "position-right": {}
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Added a fix for issue #2552 where if a key has already been mapped to another action, a popup is raised which asks the user to confirm the change. It opens a popup instead of flashing a red error message because I think that will look slightly out of style. 

### How to test

To test - 

- Open the Input section in the Settings screen.

- Click on button to map.

- Choose a key that has already been assigned for another task. (Say S when you're rebinding W)

- Select OK to continue with the rebinding or cancel to go back and reconsider.
