### PR TITLE
Improved detection for penetrable blocks. Also added range check for …

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -209,6 +209,9 @@ public class BulletPhysics implements PhysicsEngine {
     @Override
     public HitResult rayTrace(org.terasology.math.geom.Vector3f from1, org.terasology.math.geom.Vector3f direction, float distance, Set<EntityRef> excludedEntities,
             CollisionGroup... collisionGroups) {
+        if (excludedEntities == null) {
+            return rayTrace(from1, direction,distance,collisionGroups);
+        }
         Vector3f to = new Vector3f(VecMath.to(direction));
         Vector3f from = VecMath.to(from1);
         to.scale(distance);

--- a/engine/src/main/java/org/terasology/physics/events/ImpactEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/ImpactEvent.java
@@ -13,12 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.terasology.physics.events;
 
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.network.BroadcastEvent;
 
 /**
  */
+@BroadcastEvent
 public class ImpactEvent implements Event {
+    private Vector3f impactPoint;
+    private Vector3f impactNormal;
+    private Vector3f impactSpeed;
+    private float travelDistance;
+
+    protected ImpactEvent() {
+    }
+
+    public ImpactEvent(Vector3f impactPoint, Vector3f impactNormal, Vector3f impactSpeed, float travelDistance) {
+        this.impactPoint = impactPoint;
+        this.impactNormal = impactNormal;
+        this.impactSpeed = impactSpeed;
+        this.travelDistance = travelDistance;
+    }
+
+    public Vector3f getImpactPoint() {
+        return impactPoint;
+    }
+
+    public Vector3f getImpactNormal() {
+        return impactNormal;
+    }
+
+    public Vector3f getImpactSpeed() {
+        return impactSpeed;
+    }
+
+    public float getTravelDistance(){
+        return travelDistance;
+    }
 }

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/CharacterInventorySystem.java
@@ -17,6 +17,9 @@
 package org.terasology.logic.inventory;
 
 import org.terasology.logic.characters.events.DeathEvent;
+import org.terasology.physics.HitResult;
+import org.terasology.physics.Physics;
+import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.utilities.Assets;
 import org.terasology.audio.events.PlaySoundForOwnerEvent;
 import org.terasology.engine.Time;
@@ -68,6 +71,9 @@ public class CharacterInventorySystem extends BaseComponentSystem {
 
     @In
     private EntityManager entityManager;
+
+    @In
+    private Physics physics;
 
     private long lastInteraction;
     private long lastTimeThrowInteraction;
@@ -179,10 +185,16 @@ public class CharacterInventorySystem extends BaseComponentSystem {
             Vector3f position = localPlayer.getViewPosition();
             Vector3f direction = localPlayer.getViewDirection();
 
-            Vector3f newPosition = new Vector3f(position.x + direction.x * 1.5f,
-                    position.y + direction.y * 1.5f,
-                    position.z + direction.z * 1.5f
-            );
+            Vector3f maxAllowedDistanceInDirection = direction.mul(1.5f);
+            HitResult hitResult = physics.rayTrace(position,direction,1.5f, StandardCollisionGroup.CHARACTER, StandardCollisionGroup.WORLD);
+            if (hitResult.isHit())
+            {
+                Vector3f possibleNewPosition = hitResult.getHitPoint();
+                maxAllowedDistanceInDirection = possibleNewPosition.sub(position);
+            }
+
+            Vector3f newPosition = position;
+            newPosition.add(maxAllowedDistanceInDirection.mul(0.9f));
 
             //send DropItemRequest
             Vector3f impulseVector = new Vector3f(direction);


### PR DESCRIPTION
Contains:
    Second attempt at repairing the tunneling issue #2139 that items might have when traveling at high speed. It's an addition to #2533

This particular fix contains the addition of checking for penetrable blocks and ignoring them whilst checking further blocks for possible collisions ( in case the item has a speed of more than 1 Block / dT )

The collision event now returns a lot more relevant information that can be used by various systems in case the collision is needed (like the StickySystem) and adds a default reaction to the direction of impact to impose a relevant movement and position.

The range at which items are dropped is now considered. Dropping items while looking at a block will now be possible without the item being released inside said block.

How to test:
    Try throwing items of different shapes at different speeds towards surfaces and see a weird reaction they can have, but almost no tunneling.

To consider (and some needed) before merging:
- [x] Verify why the reaction vector has a low value
- [ ] See why items sometimes still do pass through blocks
- [ ] Change dropping items so that they also consider penetrable blocks
- [ ] See what can be done about releasing items close to blocks ( creating and imposing movement on an item during event processing will make it first move to the next position (because physics follow event processing) and only then checking if future blocks will have an effect on it (in the next event processing loop)
