### PR TITLE
Fixes for item use cooldowns

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/events/OnItemUseEvent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/OnItemUseEvent.java
@@ -16,9 +16,11 @@
 package org.terasology.logic.characters.events;
 
 
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.Event;
+import org.terasology.entitySystem.event.AbstractConsumableEvent;
 
-public class OnItemUseEvent implements Event {
+/**
+ * Consuming this event means that the subsequent actions should cancel
+ */
+public class OnItemUseEvent extends AbstractConsumableEvent {
 
 }

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemComponent.java
@@ -86,5 +86,4 @@ public final class ItemComponent implements Component {
     public Prefab pickupPrefab;
 
     public int cooldownTime = 200;
-    public int baseCooldownTime = cooldownTime;
 }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -436,7 +436,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
     @ReceiveEvent(components = {CharacterComponent.class})
     public void onUseItemButton(UseItemButton event, EntityRef entity, CharacterHeldItemComponent characterHeldItemComponent) {
-        if (!event.isDown() || time.getGameTimeInMs() < characterHeldItemComponent.nextItemUseTime) {
+        if (!event.isDown()) {
             return;
         }
 
@@ -445,13 +445,14 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
             return;
         }
 
-        localPlayer.activateOwnedEntityAsClient(selectedItemEntity);
-        entity.send(new OnItemUseEvent());
 
-        // TODO: send this data back to the server so that other players can visualize this item use
-
-        entity.saveComponent(characterHeldItemComponent);
-        event.consume();
+        OnItemUseEvent onItemUseEvent = new OnItemUseEvent();
+        entity.send(onItemUseEvent);
+        if (!onItemUseEvent.isConsumed()) {
+            localPlayer.activateOwnedEntityAsClient(selectedItemEntity);
+            entity.saveComponent(characterHeldItemComponent);
+            event.consume();
+        }
     }
 
     private float calcBobbingOffset(float phaseOffset, float amplitude, float frequency) {


### PR DESCRIPTION
### Contains
- A fix to let items use just a single cooldowntime property on the ItemComponent.
- A improvement to the cooldown system that enforces validation on both the client and server side to see if an action is attempted while still cooling down.

As an implication of getting setting this data also on the server side,  this data will also be sent to other remote clients so that they can show other characters doing an action.
### How to test
- Use an item
- Attack with a weapon
- Attack with bare hand
- Press and hold attack to ensure no machine gun-ing happens

### Outstanding before merging
- [ ] There is a problem with single player which causes the authority to skip sending the activation event.