### PR TITLE
Add button to launch the Crash Reporter from the pause menu

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -132,6 +132,9 @@ dependencies {
 
     // In addition to all the above the dev source set also needs to depend on what gets compiled in main
     devCompile sourceSets.main.output
+
+    // Dependency on CrashReporter
+    compile group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '4.0.0'
 }
 
 // Instructions for packaging a jar file for the engine

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
@@ -15,7 +15,9 @@
  */
 package org.terasology.rendering.nui.layers.ingame;
 
+import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.GameEngine;
+import org.terasology.engine.LoggingContext;
 import org.terasology.engine.modes.StateMainMenu;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.CoreScreenLayer;
@@ -31,6 +33,7 @@ public class PauseMenu extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "settings", widget -> getManager().pushScreen("settingsMenuScreen"));
         WidgetUtil.trySubscribe(this, "mainMenu", widget -> CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu()));
         WidgetUtil.trySubscribe(this, "exit", widget -> CoreRegistry.get(GameEngine.class).shutdown());
+        WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("Report an error."), LoggingContext.getLoggingPath()));
         WidgetUtil.trySubscribe(this, "devTools", widget -> getManager().pushScreen("devToolsMenuScreen"));
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
@@ -16,7 +16,9 @@
 
 package org.terasology.rendering.nui.layers.mainMenu;
 
+import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.GameEngine;
+import org.terasology.engine.LoggingContext;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
@@ -53,6 +55,7 @@ public class MainMenuScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "join", button -> triggerForwardAnimation(JoinGameScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "settings", button -> triggerForwardAnimation(SettingsMenuScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "exit", button -> engine.shutdown());
+        WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("Report an error."), LoggingContext.getLoggingPath()));
     }
 
     @Override

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -57,6 +57,7 @@
     "connecting-to": "connecting-to",
     "connection-failed": "connection-failed",
     "could-not-connect-to-server": "could-not-connect-to-server",
+    "crash-reporter": "crash-reporter",
     "create-game": "create-game",
     "create-game-title": "create-game-title",
     "create-preview": "create-preview",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -57,6 +57,7 @@
     "connecting-to": "Connecting to",
     "connection-failed": "Connection Failed!",
     "could-not-connect-to-server": "Could not connect to server",
+    "crash-reporter": "Crash Reporter",
     "create-game": "Create",
     "create-game-title": "Create Game",
     "create-preview": "Preview",

--- a/engine/src/main/resources/assets/ui/ingame/pauseMenu.ui
+++ b/engine/src/main/resources/assets/ui/ingame/pauseMenu.ui
@@ -68,6 +68,23 @@
                         "offset": 8
                     }
                 }
+            },
+            {
+                "type": "UIButton",
+                "id": "crashReporter",
+                "text": "${engine:menu#crash-reporter}",
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-bottom": {
+                        "offset": 8
+                    },
+                    "position-right": {
+                        "offset": 8,
+                        "target": "LEFT",
+                        "widget": "devTools"
+                    }
+                }
             }
         ]
     }

--- a/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
@@ -80,6 +80,21 @@
                         "text": "${engine:menu#exit-game}"
                     }
                 ]
+            },
+            {
+                "type": "UIButton",
+                "id": "crashReporter",
+                "text": "${engine:menu#crash-reporter}",
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-bottom": {
+                        "offset": 8
+                    },
+                    "position-right": {
+                        "offset": 8
+                    }
+                }
             }
         ]
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->
### Contains

Fixes #2577 

![screen shot 2016-10-30 at 8 38 15 pm](https://cloud.githubusercontent.com/assets/804197/19841359/fcc075ce-9ee0-11e6-90cf-69843a9aa9bb.png)
### How to test

Load up a game
Press **Esc** to open the pause menu
There is a new button which brings up the crash reporter with the current game log
### Outstanding before merging
- [x] Decide if the button should go anywhere else
- [ ] Decide what to do about Crash Reporter dependency issue (see comment on #2577)
