### PR TITLE
Added ladder "roping" functionality.

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -88,9 +88,25 @@ public class BlockItemSystem extends BaseComponentSystem {
         }
         Vector3i targetBlock = blockComponent.getPosition();
         Vector3i placementPos = new Vector3i(targetBlock);
+        Vector3i climbablePlacementPos = new Vector3i(targetBlock);
+
         placementPos.add(surfaceSide.getVector3i());
 
         Block block = type.getBlockForPlacement(worldProvider, blockEntityRegistry, placementPos, surfaceSide, secondaryDirection);
+
+        if (blockComponent.getBlock().isClimbable()) {
+            while (blockComponent.getBlock().getBlockFamily().getURI() == block.getBlockFamily().getURI()) {
+                climbablePlacementPos.add(Vector3i.down());
+                block = worldProvider.getBlock(climbablePlacementPos);
+            }
+            if (block.isReplacementAllowed()) {
+                PlaceBlocks placeBlocks = new PlaceBlocks(climbablePlacementPos, blockComponent.getBlock(), event.getInstigator());
+                worldProvider.getWorldEntity().send(placeBlocks);
+                event.getInstigator().send(new PlaySoundEvent(Assets.getSound("engine:PlaceBlock").get(), 0.5f));
+                event.consume();
+            }
+            return;
+        }
 
         if (canPlaceBlock(block, targetBlock, placementPos)) {
             // TODO: Fix this for changes.


### PR DESCRIPTION
Contains:
Functionality of "roping" ladders. Now when trying to place a ladder while looking at a ladder (of the same block family), you will be placing the new block at the bottom of however many ladders down the current one goes. No more getting stuck on flying islands for you :D

This would be a good start towards fixing #2553, if not overdoing some parts of it.

There's currently no special condition for what type of ladder is used, but any property or component can be checked so I'm open to ideas on that side. 

The only "downside", if it can be called that, is that now you cannot place ladders while looking at other same type ladders if there's no space below the one you're looking at (as opposed to putting a ladder block relative to whatever block you're pointing at.

How to test:

Get yourself some ladders, get stuck in a castle with said ladders and proceed to being ladder Rapunzel.

A tl;dr for what changes could be considered:
- [ ] Ladders only try to place below the current one, not at the end of the stack.
- [ ] Only ladders that have a certain component or property should be handled this way
- [ ] Consider moving this to a possible module.
- [x] Ask for what I'm missing

