### PR TITLE
# Fixes issue 2608

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
@@ -79,8 +79,11 @@ public abstract class AbstractNode implements Node {
         desiredStateResets.remove(stateChange.getDefaultInstance());
     }
 
+    // TODO: to be refactored - nodes should request a refresh but this should be pending until the end of the frame
     protected void refreshTaskList() {
-        taskListGenerator.refresh();
+        if (taskListGenerator != null) {
+            taskListGenerator.refresh();
+        }
     }
 
     public Set<StateChange> getDesiredStateChanges() {


### PR DESCRIPTION
### Contains
Fixes #2608. See commit description for some more notes.

### How to test
- run Terasology
- load a game
- F3 for debug mode
- F9 for wireframe mode
- exit Terasology while in wireframe mode
- restart Terasology
- reload a Game: wireframe should still be active and no crash should occur.

By the way, perhaps it would be nice to apply a "BugFix" label to this PR. Unless we want to assume that a PR with a "Bug" label is a bugfix rather than a PR willingly introducing a bug. :smile: 

