### PR TITLE
More work on Lighting Nodes

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -25,7 +25,6 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -60,11 +59,6 @@ public class HeadlessWorldRenderer implements WorldRenderer {
         LocalPlayerSystem localPlayerSystem = context.get(LocalPlayerSystem.class);
         localPlayerSystem.setPlayerCamera(noCamera);
         config = context.get(Config.class);
-    }
-
-    @Override
-    public boolean renderLightComponent(LightComponent lightComponent, Vector3f lightWorldPosition, Material program, boolean geometryOnly) {
-        return false;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
@@ -25,9 +25,7 @@ import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
 
-import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.*;
 import static org.terasology.rendering.opengl.DefaultDynamicFBOs.READ_ONLY_GBUFFER;
 import static org.terasology.rendering.opengl.DefaultDynamicFBOs.WRITE_ONLY_GBUFFER;
 import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
@@ -55,6 +53,13 @@ public class ApplyDeferredLightingNode extends AbstractNode {
         lightBufferPass = worldRenderer.getMaterial("engine:prog.lightBufferPass");
     }
 
+
+    /**
+     * Part of the deferred lighting technique, this method applies lighting through screen-space
+     * calculations to the previously flat-lit world rendering stored in the primary FBO.   // TODO: rename sceneOpaque* FBOs to primaryA/B
+     * <p>
+     * See http://en.wikipedia.org/wiki/Deferred_shading as a starting point.
+     */
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/applyDeferredLighting");

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.nodes;
+
+import org.lwjgl.opengl.GL13;
+import org.terasology.assets.ResourceUrn;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
+import org.terasology.rendering.world.WorldRenderer;
+
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.terasology.rendering.opengl.DefaultDynamicFBOs.READ_ONLY_GBUFFER;
+import static org.terasology.rendering.opengl.DefaultDynamicFBOs.WRITE_ONLY_GBUFFER;
+import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
+import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
+import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
+
+/**
+ * TODO
+ */
+public class ApplyDeferredLightingNode extends AbstractNode {
+    private static final ResourceUrn REFRACTIVE_REFLECTIVE = new ResourceUrn("engine:sceneReflectiveRefractive");
+
+    @In
+    private WorldRenderer worldRenderer;
+
+    @In
+    private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
+
+    private Material lightBufferPass;
+    private FBO sceneReflectiveRefractive;
+
+
+    @Override
+    public void initialise() {
+        lightBufferPass = worldRenderer.getMaterial("engine:prog.lightBufferPass");
+    }
+
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/applyDeferredLighting");
+
+        int texId = 0;
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindTexture();
+        lightBufferPass.setInt("texSceneOpaque", texId++, true);
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindDepthTexture();
+        lightBufferPass.setInt("texSceneOpaqueDepth", texId++, true);
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindNormalsTexture();
+        lightBufferPass.setInt("texSceneOpaqueNormals", texId++, true);
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindLightBufferTexture();
+        lightBufferPass.setInt("texSceneOpaqueLightBuffer", texId, true);
+
+        WRITE_ONLY_GBUFFER.bind();
+        WRITE_ONLY_GBUFFER.setRenderBufferMask(true, true, true);
+
+        setViewportToSizeOf(WRITE_ONLY_GBUFFER);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
+
+        renderFullscreenQuad();
+
+        bindDisplay();     // TODO: verify this is necessary
+        setViewportToSizeOf(READ_ONLY_GBUFFER); // TODO: verify this is necessary
+
+        sceneReflectiveRefractive = displayResolutionDependentFBOs.get(REFRACTIVE_REFLECTIVE);
+        displayResolutionDependentFBOs.swapReadWriteBuffers();
+        READ_ONLY_GBUFFER.attachDepthBufferTo(sceneReflectiveRefractive);
+
+        PerformanceMonitor.endActivity();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
@@ -21,38 +21,37 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.dag.AbstractNode;
-import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.dag.stateChanges.EnableMaterial;
+import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
-import org.terasology.rendering.world.WorldRenderer;
 
-import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.glClear;
 import static org.terasology.rendering.opengl.DefaultDynamicFBOs.READ_ONLY_GBUFFER;
 import static org.terasology.rendering.opengl.DefaultDynamicFBOs.WRITE_ONLY_GBUFFER;
-import static org.terasology.rendering.opengl.OpenGLUtils.bindDisplay;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
-import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
 
 /**
  * TODO
  */
 public class ApplyDeferredLightingNode extends AbstractNode {
     private static final ResourceUrn REFRACTIVE_REFLECTIVE = new ResourceUrn("engine:sceneReflectiveRefractive");
-
-    @In
-    private WorldRenderer worldRenderer;
+    private static final ResourceUrn DEFERRED_LIGHTING_MATERIAL = new ResourceUrn("engine:prog.lightBufferPass");
 
     @In
     private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
 
-    private Material lightBufferPass;
-    private FBO sceneReflectiveRefractive;
-
+    private Material deferredLightingMaterial;
 
     @Override
     public void initialise() {
-        lightBufferPass = worldRenderer.getMaterial("engine:prog.lightBufferPass");
-    }
 
+        addDesiredStateChange(new SetViewportToSizeOf(WRITE_ONLY_GBUFFER));
+
+        addDesiredStateChange(new EnableMaterial(DEFERRED_LIGHTING_MATERIAL.toString()));
+        deferredLightingMaterial = getMaterial(DEFERRED_LIGHTING_MATERIAL);
+    }
 
     /**
      * Part of the deferred lighting technique, this method applies lighting through screen-space
@@ -64,39 +63,38 @@ public class ApplyDeferredLightingNode extends AbstractNode {
     public void process() {
         PerformanceMonitor.startActivity("rendering/applyDeferredLighting");
 
-        int texId = 0;
+        setInputTextures();
 
-        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        READ_ONLY_GBUFFER.bindTexture();
-        lightBufferPass.setInt("texSceneOpaque", texId++, true);
-
-        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        READ_ONLY_GBUFFER.bindDepthTexture();
-        lightBufferPass.setInt("texSceneOpaqueDepth", texId++, true);
-
-        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        READ_ONLY_GBUFFER.bindNormalsTexture();
-        lightBufferPass.setInt("texSceneOpaqueNormals", texId++, true);
-
-        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
-        READ_ONLY_GBUFFER.bindLightBufferTexture();
-        lightBufferPass.setInt("texSceneOpaqueLightBuffer", texId, true);
-
-        WRITE_ONLY_GBUFFER.bind();
+        WRITE_ONLY_GBUFFER.bind(); // TODO: remove and replace with a state change
         WRITE_ONLY_GBUFFER.setRenderBufferMask(true, true, true);
-
-        setViewportToSizeOf(WRITE_ONLY_GBUFFER);
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: verify this is necessary
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // TODO: this is necessary - but why? Verify in the shader.
 
         renderFullscreenQuad();
 
-        bindDisplay();     // TODO: verify this is necessary
-        setViewportToSizeOf(READ_ONLY_GBUFFER); // TODO: verify this is necessary
-
-        sceneReflectiveRefractive = displayResolutionDependentFBOs.get(REFRACTIVE_REFLECTIVE);
         displayResolutionDependentFBOs.swapReadWriteBuffers();
-        READ_ONLY_GBUFFER.attachDepthBufferTo(sceneReflectiveRefractive);
+        READ_ONLY_GBUFFER.attachDepthBufferTo(displayResolutionDependentFBOs.get(REFRACTIVE_REFLECTIVE));
 
         PerformanceMonitor.endActivity();
+    }
+
+    private void setInputTextures() {
+        int texId = 0;
+
+        // TODO: turn into state changes
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindTexture();
+        deferredLightingMaterial.setInt("texSceneOpaque", texId++, true);
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindDepthTexture();
+        deferredLightingMaterial.setInt("texSceneOpaqueDepth", texId++, true);
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindNormalsTexture();
+        deferredLightingMaterial.setInt("texSceneOpaqueNormals", texId++, true);
+
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + texId);
+        READ_ONLY_GBUFFER.bindLightBufferTexture();
+        deferredLightingMaterial.setInt("texSceneOpaqueLightBuffer", texId, true);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ApplyDeferredLightingNode.java
@@ -66,6 +66,7 @@ public class ApplyDeferredLightingNode extends AbstractNode {
         addDesiredStateChange(new SetInputTexture(
                 textureSlot,   READ_ONLY_GBUFFER.getFbo().lightBufferTextureId,   DEFERRED_LIGHTING_MATERIAL, "texSceneOpaqueLightBuffer"));
     }
+
     /**
      * Part of the deferred lighting technique, this method applies lighting through screen-space
      * calculations to the previously flat-lit world rendering, stored in the READ_ONLY_GBUFFER.

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredMainLightNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredMainLightNode.java
@@ -37,9 +37,18 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 
 import org.terasology.rendering.world.WorldRenderer;
 
+// TODO: have this node and the shadowmap node handle multiple directional lights
+
 /**
- * TODO: Break this node into several nodes
- * TODO: For doing that worldRenderer.renderLightComponent must be eliminated somehow
+ * This class is integral to the deferred rendering process.
+ * It renders the main light (sun/moon) as a directional light, a type of light emitting parallel rays as is
+ * appropriate for astronomical light sources.
+ *
+ * This achieved by blending a single color into each pixel of the light accumulation buffer, the single
+ * color being dependent only on the angle between the camera and the light direction.
+ *
+ * Eventually the content of the light accumulation buffer is combined with other buffers to correctly
+ * light up the 3d scene.
  */
 public class DeferredMainLightNode extends AbstractNode {
     private static final ResourceUrn LIGHT_GEOMETRY_MATERIAL = new ResourceUrn("engine:prog.lightGeometryPass");
@@ -50,13 +59,15 @@ public class DeferredMainLightNode extends AbstractNode {
     @In
     private WorldRenderer worldRenderer;
 
-    // TODO: Review this? (What are we doing with a component not attached to an entity?)
     private LightComponent mainLightComponent = new LightComponent();
-
     private Camera playerCamera;
-
     private Material lightGeometryMaterial;
 
+    /**
+     * Initializes an instance of this node.
+     *
+     * This method -must- be called once for this node to be fully operational.
+     */
     @Override
     public void initialise() {
         playerCamera = worldRenderer.getActiveCamera();
@@ -80,6 +91,10 @@ public class DeferredMainLightNode extends AbstractNode {
         mainLightComponent.lightSpecularPower = 100f;
     }
 
+    /**
+     * Renders the main light (sun/moon) as a uniformly colored full-screen quad.
+     * This gets blended into the existing data stored in the light accumulation buffer.
+     */
     @Override
     public void process() {
         PerformanceMonitor.startActivity("rendering/mainLightGeometry");

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredMainLightNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredMainLightNode.java
@@ -44,7 +44,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.setViewportToSizeOf;
  * TODO: Break this node into several nodes
  * TODO: For doing that worldRenderer.renderLightComponent must be eliminated somehow
  */
-public class DirectionalLightsNode extends AbstractNode {
+public class DeferredMainLightNode extends AbstractNode {
     private static final ResourceUrn REFRACTIVE_REFLECTIVE = new ResourceUrn("engine:sceneReflectiveRefractive");
 
     @In
@@ -113,7 +113,7 @@ public class DirectionalLightsNode extends AbstractNode {
         READ_ONLY_GBUFFER.setRenderBufferMask(true, true, true);
         bindDisplay();
 
-        applyLightBufferPass();
+        //applyLightBufferPass();
         PerformanceMonitor.endActivity();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredPointLightsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredPointLightsNode.java
@@ -43,9 +43,6 @@ import static org.terasology.rendering.opengl.DefaultDynamicFBOs.READ_ONLY_GBUFF
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
 
-
-// TODO: rename class to PointLightsGeometryNode
-
 /**
  * Instances of this class are integral to the deferred rendering process.
  * They render point lights as spheres, into the light accumulation buffer

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTexture.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTexture.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.stateChanges;
+
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.dag.RenderPipelineTask;
+import org.terasology.rendering.dag.StateChange;
+import org.terasology.rendering.dag.tasks.SetInputTextureTask;
+
+import java.util.Objects;
+
+/**
+ * TODO
+ */
+public class SetInputTexture implements StateChange {
+
+    private final int textureSlot;
+    private final int textureId;
+    private final Material material;
+    private final String materialParameter;
+
+    private SetInputTexture defaultInstance;
+    private SetInputTextureTask task;
+
+    public SetInputTexture(int textureSlot, int textureId, Material material, String materialParameter) {
+        this.textureSlot = textureSlot;
+        this.textureId = textureId;
+        this.material = material;
+        this.materialParameter = materialParameter;
+    }
+
+    private SetInputTexture(int textureSlot, Material material, String materialParameter) {
+        this.textureSlot = textureSlot;
+        this.textureId = 0;
+        this.material = material;
+        this.materialParameter = materialParameter;
+
+        defaultInstance = this;
+    }
+
+    @Override
+    public RenderPipelineTask generateTask() {
+        if (task == null) {
+            task = new SetInputTextureTask(textureSlot, textureId, material, materialParameter);
+        }
+        return task;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(textureSlot, textureId, material, materialParameter);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return (other instanceof SetInputTexture)
+                && this.textureSlot == ((SetInputTexture) other).textureSlot
+                && this.textureId == ((SetInputTexture) other).textureId
+                && this.material == ((SetInputTexture) other).material
+                && this.materialParameter.equals(((SetInputTexture) other).materialParameter);
+    }
+
+    @Override
+    public StateChange getDefaultInstance() {
+        if (defaultInstance == null) {
+            defaultInstance = new SetInputTexture(textureSlot, material, materialParameter);
+        }
+        return defaultInstance;
+    }
+
+    @Override
+    public boolean isTheDefaultInstance() {
+        return this == defaultInstance;
+    }
+}
+

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTexture.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTexture.java
@@ -90,8 +90,7 @@ public class SetInputTexture implements StateChange {
                 && this.materialURN.equals(((SetInputTexture) other).materialURN)
                 && this.materialParameter.equals(((SetInputTexture) other).materialParameter);
     }
-
-
+    
     /**
      * Returns a StateChange instance useful to disconnect the given texture from its assigned texture slot.
      * Also disconnects the texture from the shader program.

--- a/engine/src/main/java/org/terasology/rendering/dag/tasks/SetInputTextureTask.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/tasks/SetInputTextureTask.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.tasks;
+
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.dag.RenderPipelineTask;
+
+import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
+import static org.lwjgl.opengl.GL11.glBindTexture;
+import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
+import static org.lwjgl.opengl.GL13.glActiveTexture;
+
+/**
+ * TODO
+ */
+public class SetInputTextureTask implements RenderPipelineTask {
+
+    private final int textureSlot;
+    private final int textureId;
+    private final Material material;
+    private final String materialParameter;
+
+    public SetInputTextureTask(int textureSlot, int textureId, Material material, String materialParameter) {
+        this.textureSlot = textureSlot;
+        this.textureId = textureId;
+        this.material = material;
+        this.materialParameter = materialParameter;
+    }
+
+    @Override
+    public void execute() {
+        glActiveTexture(GL_TEXTURE0 + textureSlot);
+        glBindTexture(GL_TEXTURE_2D, textureId);
+        material.setInt(materialParameter, textureSlot, true);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%30s: slot %s, texture %s, material %s, parameter %s", this.getClass().getSimpleName(),
+                textureSlot, textureId, material.getUrn().toString(), materialParameter);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/tasks/SetInputTextureTask.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/tasks/SetInputTextureTask.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.rendering.dag.tasks;
 
+import org.terasology.assets.ResourceUrn;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.dag.RenderPipelineTask;
 
@@ -22,9 +23,17 @@ import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
 import static org.lwjgl.opengl.GL11.glBindTexture;
 import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
 import static org.lwjgl.opengl.GL13.glActiveTexture;
+import static org.terasology.rendering.dag.AbstractNode.getMaterial;
 
 /**
- * TODO
+ * Instances of this class bind a texture to a texture unit. The integer identifying
+ * the texture unit is then passed to a shader program using the material/parameter
+ * pair provided on construction. See the source of the execute() method for the
+ * nitty gritty details.
+ *
+ * WARNING: RenderPipelineTasks are not meant for direct instantiation and manipulation.
+ * Modules or other parts of the engine should take advantage of them through classes
+ * inheriting from StateChange.
  */
 public class SetInputTextureTask implements RenderPipelineTask {
 
@@ -33,10 +42,10 @@ public class SetInputTextureTask implements RenderPipelineTask {
     private final Material material;
     private final String materialParameter;
 
-    public SetInputTextureTask(int textureSlot, int textureId, Material material, String materialParameter) {
+    public SetInputTextureTask(int textureSlot, int textureId, ResourceUrn materialURN, String materialParameter) {
         this.textureSlot = textureSlot;
         this.textureId = textureId;
-        this.material = material;
+        this.material = getMaterial(materialURN);
         this.materialParameter = materialParameter;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
@@ -50,6 +50,7 @@ public final class FBO {
     private static final boolean DEFAULT_LIGHT_BUFFER_MASK = true;
     private static final Logger logger = LoggerFactory.getLogger(FBO.class);
 
+    // TODO: make accessors for these
     public int fboId;
     public int colorBufferTextureId;
     public int depthStencilTextureId;

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -19,7 +19,6 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
-import org.terasology.rendering.logic.LightComponent;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 
 /**
@@ -37,10 +36,6 @@ public interface WorldRenderer {
     float BLOCK_LIGHT_POW = 0.96f;
     float BLOCK_LIGHT_SUN_POW = 0.96f;
     float BLOCK_INTENSITY_FACTOR = 0.7f;
-
-
-    // TODO: appropriate javadocs
-    boolean renderLightComponent(LightComponent lightComponent, Vector3f lightWorldPosition, Material program, boolean geometryOnly);
 
     float getSecondsSinceLastFrame();
 

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,7 +15,9 @@
  */
 package org.terasology.rendering.world;
 
+import org.terasology.rendering.dag.nodes.ApplyDeferredLightingNode;
 import org.terasology.rendering.dag.nodes.CopyImageToScreenNode;
+import org.terasology.rendering.dag.nodes.DeferredMainLightNode;
 import org.terasology.rendering.openvrprovider.OpenVRProvider;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
@@ -51,7 +53,6 @@ import org.terasology.rendering.dag.nodes.BufferClearingNode;
 import org.terasology.rendering.dag.nodes.AlphaRejectBlocksNode;
 import org.terasology.rendering.dag.nodes.OpaqueBlocksNode;
 import org.terasology.rendering.dag.nodes.RefractiveReflectiveBlocksNode;
-import org.terasology.rendering.dag.nodes.DirectionalLightsNode;
 import org.terasology.rendering.dag.nodes.DownSampleSceneAndUpdateExposureNode;
 import org.terasology.rendering.dag.nodes.FinalPostProcessingNode;
 import org.terasology.rendering.dag.nodes.CopyImageToHMDNode;
@@ -294,11 +295,16 @@ public final class WorldRendererImpl implements WorldRenderer {
         Node firstPersonViewNode = nodeFactory.createInstance(FirstPersonViewNode.class);
         renderGraph.addNode(firstPersonViewNode, "firstPersonViewNode");
 
+        // lighting
         Node deferredPointLightsNode = nodeFactory.createInstance(DeferredPointLightsNode.class);
         renderGraph.addNode(deferredPointLightsNode, "DeferredPointLightsNode");
 
         // TODO next!
-        Node directionalLightsNode = nodeFactory.createInstance(DirectionalLightsNode.class);
+        Node deferredMainLightNode = nodeFactory.createInstance(DeferredMainLightNode.class);
+        renderGraph.addNode(deferredMainLightNode, "deferredMainLightNode");
+
+        Node applyDeferredLightingNode = nodeFactory.createInstance(ApplyDeferredLightingNode.class);
+        renderGraph.addNode(applyDeferredLightingNode, "applyDeferredLightingNode");
 
         // END OF THE SECOND REFACTORING PASS TO SWITCH NODES TO THE NEW ARCHITECTURE - each PR moves this line down.
         // TODO: node instantiation and node addition to the graph should be handled as above, for easy deactivation of nodes during the debug.
@@ -323,7 +329,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         Node copyToVRFrameBufferNode = nodeFactory.createInstance(CopyImageToHMDNode.class);
         Node copyImageToScreenNode = nodeFactory.createInstance(CopyImageToScreenNode.class);
         
-        renderGraph.addNode(directionalLightsNode, "directionalLightsNode");
+
         renderGraph.addNode(chunksRefractiveReflectiveNode, "chunksRefractiveReflectiveNode");
         renderGraph.addNode(outlineNode, "outlineNode");
         renderGraph.addNode(ambientOcclusionPassesNode, "ambientOcclusionPassesNode");


### PR DESCRIPTION
### Contains
- existing DirectionalLightsNode has been split in DeferredMainLightNode and ApplyDeferredLightingNode. Both nodes now almost fully take advantage of the new architecture. [1]
- DeferredMainLightNode work done in commits 2 and 3 (eea3f7c and dc3d9cb).
- ApplyDeferredLightingNode work done in commits 4 and 5 (c377647 and 62affd8).
- Added classes SetInputTexture (StateChange) and SetInputTextureTask. [2]
- removed renderLightComponent method from WorldRenderer and WorldRendererImpl.

### How to test
- start Terasology
- create or load a game
- verify rendering of the 3d scene continues to work as expected

### Footnotes
[1] _Almost_ fully because there are a few things that are not yet in StateChanges but should, for example the binding of default FBOs
[2] StateChange subclass SetInputTexture is a good start as it makes texture inputs used by a shader very explicit. However, it seems to me that without some sort of orchestrating manager textures are bound to and unbound from the GPU's texture units without any criteria other than "I need this texture available now". I might write an issue about this: ideally frequently used textures are permanently bound to a specific texture unit on the GPU, while infrequently used textures share the remaining pool of texture units.

