### PR TITLE
Fixing JS

### DIFF
--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -190,7 +190,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     public EntityRef getBlockEntityAt(Vector3i blockPosition) {
         if (GameThread.isCurrentThread()) {
             EntityRef blockEntity = getExistingBlockEntityAt(blockPosition);
-            if (!blockEntity.exists() && isBlockRelevant(blockPosition.x, blockPosition.y, blockPosition.z)) {
+            if ( (!blockEntity.exists() || !blockEntity.hasComponent(NetworkComponent.class)) && isBlockRelevant(blockPosition.x, blockPosition.y, blockPosition.z)) {
                 Block block = getBlock(blockPosition.x, blockPosition.y, blockPosition.z);
                 blockEntity = createBlockEntity(blockPosition, block);
             }


### PR DESCRIPTION
This should fix  #2594 .
The issue was that the client told the server to create an entity he never created locally. For some reason (TBA), the created block doesn't exist for the host player but exists for the client player after it's seen in the world.

Seeing as any network component was created only if the entity the player was looking at (this as well may prove a problem and shouldn't be relied on, since currently the network component isn't created on block placement) doesn't exist, the client never considered it a networked entity, thus it had none of the proper components. As the systems relied on the block having these components, it caused a crash when trying to access null values.

As of this change, any block existence check will create the block if it doesn't have a network component. This might have the side-effect of creating network components for some blocks that don't need them, but I'm not entirely sure about that side of things. (still in testing :) )

How to test:
Place any machine block, or pretty much anything that should have a widget, as a client while the host isn't looking at said block. No crash == no problem.

Outstanding before merging:
- I've only tried it on my system with 2 players and I had 2 servers that worked pretty wonky (probably due to the 1.5gb limit. After increasing the limit I had no more problems)
- It might deserve further testing before fully merging. My personal ones were conclusive, but it's just one system 

