### PR TITLE
Added engine version and build number to log directories

### DIFF
--- a/engine/src/main/java/org/terasology/engine/LoggingContext.java
+++ b/engine/src/main/java/org/terasology/engine/LoggingContext.java
@@ -18,6 +18,7 @@ package org.terasology.engine;
 
 import org.slf4j.MDC;
 import org.terasology.engine.modes.GameState;
+import org.terasology.version.TerasologyVersion;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -71,8 +72,15 @@ public final class LoggingContext {
     }
 
     public static void initialize(Path logFileFolder) {
-        String timestamp = TIMESTAMP_FORMAT.format(new Date());
-        loggingPath = logFileFolder.resolve(timestamp).normalize();
+        TerasologyVersion terasologyVersion = TerasologyVersion.getInstance();
+        String logFileDir = TIMESTAMP_FORMAT.format(new Date());
+        if (!terasologyVersion.getengineVersion().trim().equals("")) {
+            logFileDir += "_" + terasologyVersion.getengineVersion();
+        }
+        if (!terasologyVersion.getBuildNumber().trim().equals("")) {
+            logFileDir += "_" + terasologyVersion.getBuildNumber();
+        }
+        loggingPath = logFileFolder.resolve(logFileDir).normalize();
         String pathString = loggingPath.toString();
         System.setProperty(LOG_FILE_FOLDER, pathString);
 

--- a/engine/src/main/java/org/terasology/engine/LoggingContext.java
+++ b/engine/src/main/java/org/terasology/engine/LoggingContext.java
@@ -74,10 +74,10 @@ public final class LoggingContext {
     public static void initialize(Path logFileFolder) {
         TerasologyVersion terasologyVersion = TerasologyVersion.getInstance();
         String logFileDir = TIMESTAMP_FORMAT.format(new Date());
-        if (!terasologyVersion.getengineVersion().trim().equals("")) {
+        if (!terasologyVersion.getengineVersion().equals("")) {
             logFileDir += "_" + terasologyVersion.getengineVersion();
         }
-        if (!terasologyVersion.getBuildNumber().trim().equals("")) {
+        if (!terasologyVersion.getBuildNumber().equals("")) {
             logFileDir += "_" + terasologyVersion.getBuildNumber();
         }
         loggingPath = logFileFolder.resolve(logFileDir).normalize();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

Simple fix for #2592 - Appends engine version and build number to log directory if they exist, separated by "_".

Tested working with `versionInfo.properties` and Crash Reporter.
