### PR TITLE
Engine fixes: code formatter, unit tests, create game screen, config

### DIFF
--- a/config/eclipse/formatting.xml
+++ b/config/eclipse/formatting.xml
@@ -20,7 +20,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="8"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>

--- a/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
@@ -19,6 +19,7 @@ package org.terasology.world;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.ResourceUrn;
@@ -193,6 +194,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         assertTrue(checker.activateReceived);
     }
 
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testComponentsAddedAndActivatedWhenBlockChanged() {
         LifecycleEventChecker checker = new LifecycleEventChecker(entityManager.getEventSystem(), StringComponent.class);
@@ -205,6 +207,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
                 checker.receivedEvents);
     }
 
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testComponentsDeactivatedAndRemovedWhenBlockChanged() {
         worldProvider.setBlock(Vector3i.zero(), blockWithString);
@@ -219,6 +222,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
                 checker.receivedEvents);
     }
 
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testComponentsUpdatedWhenBlockChanged() {
         worldProvider.setBlock(Vector3i.zero(), blockWithString);
@@ -249,7 +253,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         assertTrue(blockEntity.isActive());
     }
 
-
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testEntityCeasesToBeTemporaryIfBlockChangedToKeepActive() {
         worldProvider.setBlock(Vector3i.zero(), keepActiveBlock);
@@ -406,7 +410,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         assertNotNull(entity.getComponent(IntegerComponent.class));
     }
 
-
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testBlockEntityPrefabCorrectlyAlteredOnChangeToDifferentPrefab() {
         worldProvider.setBlock(Vector3i.zero(), blockWithString);
@@ -415,6 +419,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         assertEquals(blockWithDifferentString.getPrefab().get().getUrn(), entity.getParentPrefab().getUrn());
     }
 
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testBlockEntityPrefabCorrectlyRemovedOnChangeToBlockWithNoPrefab() {
         worldProvider.setBlock(Vector3i.zero(), blockWithString);
@@ -423,6 +428,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         assertEquals(null, entity.getParentPrefab());
     }
 
+    @Ignore("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testBlockEntityPrefabCorrectlyAddedOnChangeToBlockWithPrefab() {
         worldProvider.setBlock(Vector3i.zero(), plainBlock);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -120,11 +120,6 @@ public class CreateGameScreen extends CoreScreenLayer {
             seed.setText(new FastRandom().nextString(32));
         }
 
-        final UILabel saveGamePath = find("saveGamePath", UILabel.class);
-        if(saveGamePath != null) {
-            saveGamePath.setText(PathManager.getInstance().getSavesPath().toAbsolutePath().toString());
-        }
-
         final UIDropdownScrollable<Module> gameplay = find("gameplay", UIDropdownScrollable.class);
         gameplay.setOptions(getGameplayModules());
         gameplay.setVisibleOptions(3);

--- a/engine/src/main/resources/assets/ui/menu/createGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/createGameScreen.ui
@@ -138,18 +138,6 @@
                         },
                         {
                             "type": "UILabel",
-                            "text": "${engine:menu#save-game-path}"
-                        },
-                        {
-                             "type": "UILabel",
-                             "id": "saveGamePath"
-                        },
-                        {
-                             "type": "UISpace",
-                             "size": [1, 16]
-                        },
-                        {
-                            "type": "UILabel",
                             "text": "${engine:menu#select-world-gen} (${engine:menu#select-world-gen-info}):"
                         },
                         {

--- a/engine/src/main/resources/default.cfg
+++ b/engine/src/main/resources/default.cfg
@@ -36,7 +36,7 @@
     "vignette": true,
     "motionBlur": true,
     "ssao": false,
-    "filmGrain": true,
+    "filmGrain": false,
     "outline": true,
     "lightShafts": true,
     "eyeAdaptation": true,


### PR DESCRIPTION
### Contains

Small fixes for various issues mentioned in IRC and elsewhere:

- Set the Eclipse (IDEA-compatible) code formatter to indent with 4 spaces, which is what our indentation is, instead of 8.
- Ignored the known failing unit tests (see #2625 and #2629) for now so that they don't potentially confuse GCI students.
- Removed the save game path from the Create Game screen, as it would otherwise break the interface on resolutions lower than 1366x768:

![a98ra0j](https://cloud.githubusercontent.com/assets/13783592/20860695/0037ca20-b987-11e6-8931-fd89c1682515.jpg)

- Set the Film Grain setting to false in the default config - it's been widely reported as an annoyance.

### How to test

Fairly self-explanatory:

- IDEA should use 4-space indentation when set to the Terasology formatter.
- No unit tests should fail.
- The Create Game screen should work fine on 1366x768.
- A new game install should have film grain off by default.

### Outstanding before merging

No outstanding issues!