### PR TITLE
Fix moon/sun cycles and nights being totally dark

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -537,18 +537,18 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     @Override
     public String getMetrics() {
-        String stringToReturn = "";
-        stringToReturn += renderableWorld.getMetrics();
-        stringToReturn += "Empty Mesh Chunks: ";
-        stringToReturn += statChunkMeshEmpty;
-        stringToReturn += "\n";
-        stringToReturn += "Unready Chunks: ";
-        stringToReturn += statChunkNotReady;
-        stringToReturn += "\n";
-        stringToReturn += "Rendered Triangles: ";
-        stringToReturn += statRenderedTriangles;
-        stringToReturn += "\n";
-        return stringToReturn;
+        StringBuilder stringToReturn = new StringBuilder("");
+        stringToReturn.append(renderableWorld.getMetrics());
+        stringToReturn.append("Empty Mesh Chunks: ");
+        stringToReturn.append(statChunkMeshEmpty);
+        stringToReturn.append("\n");
+        stringToReturn.append("Unready Chunks: ");
+        stringToReturn.append(statChunkNotReady);
+        stringToReturn.append("\n");
+        stringToReturn.append("Rendered Triangles: ");
+        stringToReturn.append(statRenderedTriangles);
+        stringToReturn.append("\n");
+        return stringToReturn.toString();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/sun/BasicCelestialModel.java
+++ b/engine/src/main/java/org/terasology/world/sun/BasicCelestialModel.java
@@ -29,9 +29,21 @@ public class BasicCelestialModel implements CelestialModel {
     private static final long DUSK_TIME = 3 * DAY_LENGTH / 4;
     private static final long MIDNIGHT_TIME = 0;
 
+    /**
+     * Return the direction of the sun based on the time of the day.<br />
+     * At days=0 midnight the direction of the sun will be -90 degrees, while at
+     * days=0.5 noon it will be +90 degrees.
+     * @param days the time of day
+     * @return the direction of the sun in radians in the range [-PI;PI]
+     */
     @Override
     public float getSunPosAngle(float days) {
-        return (float) (days * 2.0 * Math.PI - Math.PI);  // offset by 180 deg.;
+        double sunRad = (days%1.0) * 2.0 * Math.PI; // [0;2PI]
+        double shiftedBy90 = sunRad - Math.PI/2.0; // shift by -90 so midnight means moon is on top
+        if(shiftedBy90 > Math.PI) { // expected output is [-PI;PI]
+            return (float)(shiftedBy90 - 2.0*Math.PI);
+        }
+        return (float)shiftedBy90;
     }
 
     @Override


### PR DESCRIPTION
### Contains
Hopefully the position of the sun/moon and the light levels respective to the time of day now works correctly. Also now there is some dimmed light during the night, so the world is no longer totally black, see attached image.
![fullmoon](https://cloud.githubusercontent.com/assets/18668703/21085954/14e0479e-c018-11e6-8b54-2b3cec715faf.jpg)
Unfortunately the direction of shadows are sometimes in the wrong direction, and there are random groups of blocks which do not get illuminated in the night.

### How to test

Use the console with the following commands:
setWorldTime 0.0 -- Moon should be above, fairly lit night
setWorldTime 0.25 -- Moon and Sun not visible, almost total darkness
setWorldTime 0.5 -- Sun should be above, maximum visibility

OR if you use setTimeDilation 25.0 then you can watch as the moon/sun rises and sets.

### Outstanding before merging
- [x] Sun and Moon cycle based on time of day
- [x] No longer totally dark during the night
- [ ] Simplify calculations
- [ ] Colored light for the moon?
- [ ] Weird shadow directions/patches