### PR TITLE
Fix auto move cancel action when not triggered

### DIFF
--- a/engine/src/main/java/org/terasology/logic/delay/PeriodicActionComponent.java
+++ b/engine/src/main/java/org/terasology/logic/delay/PeriodicActionComponent.java
@@ -43,7 +43,7 @@ public final class PeriodicActionComponent implements Component {
     }
 
     public void removeScheduledActionId(String actionId) {
-        final long removedWakeUp = actionIdsWakeUp.remove(actionId);
+        final Long removedWakeUp = actionIdsWakeUp.remove(actionId);
         actionIdsPeriod.remove(actionId);
         if (removedWakeUp == lowestWakeUp) {
             lowestWakeUp = findSmallestWakeUp();

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -236,14 +236,15 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
     @ReceiveEvent
     public void onAutoMove(PeriodicActionTriggeredEvent event, EntityRef entity) {
-        if (event.getActionId().equals(AUTO_MOVE_ID) && isAutoMove) {
-            ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
-            Vector3f viewDir = entity.getComponent(LocationComponent.class).getWorldDirection();
-            clientComponent.character.send(new CharacterImpulseEvent(viewDir.mul(8f)));
-        } else if (!isAutoMove) {
-
-            // If isAutoMove turns false, cancel the action.
-            delayManager.cancelPeriodicAction(entity, AUTO_MOVE_ID);
+        if (event.getActionId().equals(AUTO_MOVE_ID)) {
+            if (isAutoMove) {
+                ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
+                Vector3f viewDir = entity.getComponent(LocationComponent.class).getWorldDirection();
+                clientComponent.character.send(new CharacterImpulseEvent(viewDir.mul(8f)));
+            } else {
+                // If isAutoMove turns false, cancel the action.
+                delayManager.cancelPeriodicAction(entity, AUTO_MOVE_ID);
+            }
         }
     }
 
@@ -381,8 +382,8 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
     @ReceiveEvent(components = {ClientComponent.class}, priority = EventPriority.PRIORITY_NORMAL)
     public void onAutoMoveMode(AutoMoveButton event, EntityRef entity) {
-        if(event.isDown()) {
-            if(!isAutoMove) {
+        if (event.isDown()) {
+            if (!isAutoMove) {
                 startAutoMove(entity);
             } else {
                 stopAutoMove();


### PR DESCRIPTION
### Contains

Short follow up to #2557.
The current implementation will cancel the periodic action each time **any** periodic action is triggered.
The PeriodicActionComponent is not null safe on removal (note the null -> long autoboxing), which causes periodic NPEs.

### How to test

Enable any module that triggers periodic action, like the portals module (place one portal block in the world, then watch the log).