### PR TITLE
Remove dependency on CoreRegistry from Skysphere

### DIFF
--- a/engine-tests/src/main/java/org/terasology/Environment.java
+++ b/engine-tests/src/main/java/org/terasology/Environment.java
@@ -80,6 +80,10 @@ public class Environment {
 
         setupComponentManager();
 
+        setupWorldProvider();
+
+        setupCelestialSystem();
+
         loadPrefabs();
     }
 
@@ -138,6 +142,14 @@ public class Environment {
     }
 
     protected void setupStorageManager() throws IOException {
+        // empty
+    }
+
+    protected void setupWorldProvider() {
+        // empty
+    }
+
+    protected void setupCelestialSystem() {
         // empty
     }
 

--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -90,6 +90,7 @@ import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.rendering.nui.skin.UISkinData;
 import org.terasology.testUtil.ModuleManagerFactory;
+import org.terasology.world.WorldProvider;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
@@ -110,6 +111,12 @@ import org.terasology.world.block.tiles.BlockTile;
 import org.terasology.world.block.tiles.NullWorldAtlas;
 import org.terasology.world.block.tiles.TileData;
 import org.terasology.world.block.tiles.WorldAtlas;
+import org.terasology.world.internal.WorldInfo;
+import org.terasology.world.sun.BasicCelestialModel;
+import org.terasology.world.sun.CelestialSystem;
+import org.terasology.world.sun.DefaultCelestialSystem;
+import org.terasology.world.time.WorldTime;
+import org.terasology.world.time.WorldTimeImpl;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -117,6 +124,7 @@ import java.nio.file.Path;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Setup a headless ( = no graphics ) environment.
@@ -126,6 +134,7 @@ import static org.mockito.Mockito.mock;
 public class HeadlessEnvironment extends Environment {
 
     private static final Logger logger = LoggerFactory.getLogger(HeadlessEnvironment.class);
+    protected static final WorldTime worldTime = new WorldTimeImpl();
 
     /**
      * Setup a headless ( = no graphics ) environment
@@ -299,6 +308,20 @@ public class HeadlessEnvironment extends Environment {
         ComponentSystemManager componentSystemManager = new ComponentSystemManager(context);
         componentSystemManager.initialise();
         context.put(ComponentSystemManager.class, componentSystemManager);
+    }
+
+    @Override
+    protected void setupWorldProvider() {
+        WorldProvider worldProvider = mock(WorldProvider.class);
+        when(worldProvider.getWorldInfo()).thenReturn(new WorldInfo());
+        when(worldProvider.getTime()).thenReturn(worldTime);
+        context.put(WorldProvider.class, worldProvider);
+    }
+
+    @Override
+    protected void setupCelestialSystem() {
+        DefaultCelestialSystem celestialSystem = new DefaultCelestialSystem(new BasicCelestialModel(), context);
+        context.put(CelestialSystem.class, celestialSystem);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -79,7 +79,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         context.get(ComponentSystemManager.class).register(celestialSystem);
 
         // Init. a new world
-        Skysphere skysphere = new Skysphere(celestialSystem);
+        Skysphere skysphere = new Skysphere(context);
         BackdropProvider backdropProvider = skysphere;
         BackdropRenderer backdropRenderer = skysphere;
         context.put(BackdropProvider.class, backdropProvider);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -79,7 +79,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         context.get(ComponentSystemManager.class).register(celestialSystem);
 
         // Init. a new world
-        Skysphere skysphere = new Skysphere();
+        Skysphere skysphere = new Skysphere(celestialSystem);
         BackdropProvider backdropProvider = skysphere;
         BackdropRenderer backdropRenderer = skysphere;
         context.put(BackdropProvider.class, backdropProvider);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -143,7 +143,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         context.put(CelestialSystem.class, celestialSystem);
         context.get(ComponentSystemManager.class).register(celestialSystem);
 
-        Skysphere skysphere = new Skysphere();
+        Skysphere skysphere = new Skysphere(celestialSystem);
         BackdropProvider backdropProvider = skysphere;
         BackdropRenderer backdropRenderer = skysphere;
         context.put(BackdropProvider.class, backdropProvider);

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -143,7 +143,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         context.put(CelestialSystem.class, celestialSystem);
         context.get(ComponentSystemManager.class).register(celestialSystem);
 
-        Skysphere skysphere = new Skysphere(celestialSystem);
+        Skysphere skysphere = new Skysphere(context);
         BackdropProvider backdropProvider = skysphere;
         BackdropRenderer backdropRenderer = skysphere;
         context.put(BackdropProvider.class, backdropProvider);

--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.backdrop;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Sphere;
+import org.terasology.context.Context;
 import org.terasology.utilities.Assets;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
@@ -49,8 +50,8 @@ public class Skysphere implements BackdropProvider, BackdropRenderer {
 
     private final CelestialSystem celSystem;
 
-    public Skysphere(CelestialSystem celestialSystem) {
-        celSystem = celestialSystem;
+    public Skysphere(Context context) {
+        celSystem = context.get(CelestialSystem.class);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -49,8 +49,8 @@ public class Skysphere implements BackdropProvider, BackdropRenderer {
 
     private final CelestialSystem celSystem;
 
-    public Skysphere() {
-        celSystem = CoreRegistry.get(CelestialSystem.class);
+    public Skysphere(CelestialSystem celestialSystem) {
+        celSystem = celestialSystem;
     }
 
     @Override


### PR DESCRIPTION
Remove dependency on CoreRegistry from Skysphere by passing in the CelestialSystem directly. 
I also added it to the HeadlessEnvironment, with a mock to WorldProvider, and a static WorldTime reference, so unit testing the day/night cycle in the future becomes possible

### How to test
* Run all the unit tests and verify nothing got broken by this change.
* Open up the game, and create a world
* Open up the game, and load a world