### PR TITLE
Use multiple stacks to give blocks. This closes #2607

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -327,17 +327,21 @@ public class BlockCommands extends BaseComponentSystem {
         if (quantity < 1) {
             return "Here, have these zero (0) blocks just like you wanted";
         }
+        //continue giving blocks until there are no more blocks to give
+        //TODO reference maxStackSize instead of explicitely subtracting 99
+        for(int quantityLeft = quantity; quantityLeft > 0; quantityLeft -= 99) {
+            EntityRef item = blockItemFactory.newInstance(blockFamily, quantityLeft > 99 ? 99 : quantityLeft);
+            if (!item.exists()) {
+                throw new IllegalArgumentException("Unknown block or item");
+            }
 
-        EntityRef item = blockItemFactory.newInstance(blockFamily, quantity);
-        if (!item.exists()) {
-            throw new IllegalArgumentException("Unknown block or item");
-        }
-        EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
+            EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
 
-        GiveItemEvent giveItemEvent = new GiveItemEvent(playerEntity);
-        item.send(giveItemEvent);
-        if (!giveItemEvent.isHandled()) {
-            item.destroy();
+            GiveItemEvent giveItemEvent = new GiveItemEvent(playerEntity);
+            item.send(giveItemEvent);
+            if (!giveItemEvent.isHandled()) {
+                item.destroy();
+            }
         }
 
         return "You received " + quantity + " blocks of " + blockFamily.getDisplayName();


### PR DESCRIPTION
### Contains
Makes the giveBlock command send multiple times, until quantity runs out. The command is limited to 99 blocks per stack, since that is the max stack size. Fixes #2607. 

### How to test

Press (F1) to bring up the console. Use the giveBlock command by typing give <item> <quantity>. Pull up the inventory with (i) to see if none of the stack sizes are above 99 and if the correct number of blocks were given.

### Outstanding before merging

Sorry I had to reopen this again. I accidentally closed it when I force pushed. To answer @portokaliu 's question, unless I change stackCount in ItemComponent to an integer or create another component to contain the number of blocks to give, then I can't use InventoryAuthoritySystem to send blocks more than 127. If there's another way to do it, then please let me know. I apologize for the late response; I've been a bit busy with finals.