### PR TITLE
Prompt new users to pick username

### DIFF
--- a/engine/src/main/java/org/terasology/config/PlayerConfig.java
+++ b/engine/src/main/java/org/terasology/config/PlayerConfig.java
@@ -37,6 +37,8 @@ public class PlayerConfig {
 
     private Float eyeHeight = DEFAULT_PLAYER_EYE_HEIGHT;
 
+    private boolean hasEnteredUsername;
+
     public String getName() {
         return name;
     }
@@ -71,17 +73,16 @@ public class PlayerConfig {
         }
     }
 
+    public boolean hasEnteredUsername() {
+        return hasEnteredUsername;
+    }
+
+    public void setHasEnteredUsername(boolean entered) {
+        this.hasEnteredUsername = entered;
+    }
+
     private static String defaultPlayerName() {
-        try {
-            String login = System.getProperty("user.name");
-            if (login != null && !login.isEmpty()) {
-                return login;
-            }
-        } catch (SecurityException e) {
-            // thrown by all Sandbox RIAs (Webstart, Applets)
-            e.getMessage(); // dummy method call to trick CheckStyle
-        }
-        return "Player_" + new FastRandom().nextInt(10000, 99999);
+        return "Player" + new FastRandom().nextInt(10000, 99999);
     }
 
     private Color defaultPlayerColor() {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/EnterUsernamePopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/EnterUsernamePopup.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.config.Config;
+import org.terasology.config.PlayerConfig;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.widgets.UIText;
+
+public class EnterUsernamePopup extends CoreScreenLayer {
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:enterUsernamePopup");
+
+    @In
+    private Config config;
+
+    private UIText username;
+    private PlayerConfig playerConfig;
+
+    @Override
+    public void initialise() {
+        playerConfig = config.getPlayer();
+
+        username = find("username", UIText.class);
+        username.setText(playerConfig.getName());
+
+        WidgetUtil.trySubscribe(this, "ok", button -> {
+            if (username != null && !username.getText().isEmpty()) {
+                playerConfig.setName(username.getText());
+                playerConfig.setHasEnteredUsername(true);
+                getManager().popScreen();
+            }
+        });
+
+        WidgetUtil.trySubscribe(this, "cancel", button -> {
+            playerConfig.setHasEnteredUsername(true);
+            getManager().popScreen();
+        });
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -152,6 +152,10 @@ public class JoinGameScreen extends CoreScreenLayer {
         super.onOpened();
 
         infoService = new ServerInfoService();
+
+        if (!config.getPlayer().hasEnteredUsername()) {
+            getManager().pushScreen(EnterUsernamePopup.ASSET_URI, EnterUsernamePopup.class);
+        }
     }
 
     @Override
@@ -317,7 +321,7 @@ public class JoinGameScreen extends CoreScreenLayer {
                 }
             });
             refreshButton.subscribe(button -> {
-               refresh();
+                refresh();
             });
         }
     }
@@ -348,12 +352,12 @@ public class JoinGameScreen extends CoreScreenLayer {
         if (edit != null) {
             edit.bindEnabled(localSelectedServerOnly);
             edit.subscribe(button -> {
-              AddServerPopup popup = getManager().pushScreen(AddServerPopup.ASSET_URI, AddServerPopup.class);
-              ServerInfo info = visibleList.getSelection();
-              popup.setServerInfo(info);
+                AddServerPopup popup = getManager().pushScreen(AddServerPopup.ASSET_URI, AddServerPopup.class);
+                ServerInfo info = visibleList.getSelection();
+                popup.setServerInfo(info);
 
-              // editing invalidates the currently known info, so query it again
-              popup.onSuccess(item -> extInfo.put(item, infoService.requestInfo(item.getAddress(), item.getPort())));
+                // editing invalidates the currently known info, so query it again
+                popup.onSuccess(item -> extInfo.put(item, infoService.requestInfo(item.getAddress(), item.getPort())));
             });
         }
 
@@ -415,9 +419,9 @@ public class JoinGameScreen extends CoreScreenLayer {
     public boolean onKeyEvent(NUIKeyEvent event) {
         if (event.isDown() && event.getKey() == Keyboard.Key.R) {
             refresh();
-            }
-            return false;
         }
+        return false;
+    }
 
     public void refresh() {
         ServerInfo i = visibleList.getSelection();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -73,10 +73,10 @@ public class SelectGameScreen extends CoreScreenLayer {
         }
 
         final UILabel saveGamePath = find("saveGamePath", UILabel.class);
-        if(saveGamePath != null) {
+        if (saveGamePath != null) {
             saveGamePath.setText(
                     translationSystem.translate("${engine:menu#save-game-path} ") +
-                    PathManager.getInstance().getSavesPath().toAbsolutePath().toString());
+                            PathManager.getInstance().getSavesPath().toAbsolutePath().toString());
         }
 
         final UIList<GameInfo> gameList = find("gameList", UIList.class);
@@ -118,6 +118,13 @@ public class SelectGameScreen extends CoreScreenLayer {
     @Override
     public boolean isLowerLayerVisible() {
         return false;
+    }
+
+    @Override
+    public void onOpened() {
+        if (loadingAsServer && !config.getPlayer().hasEnteredUsername()) {
+            getManager().pushScreen(EnterUsernamePopup.ASSET_URI, EnterUsernamePopup.class);
+        }
     }
 
     private void loadGame(GameInfo item) {

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -78,6 +78,7 @@
     "downloading-server-list": "downloading-server-list",
     "edit-server": "edit-server",
     "edit-server-title": "edit-server-title",
+    "enter-username-message": "enter-username-message",
     "enum-editor-prompt": "enum-editor-prompt",
     "enum-editor-title": "enum-editor-title",
     "error-downloading-server-list": "error-downloading-server-list",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -79,6 +79,7 @@
     "drop-item": "Drop Item",
     "edit-server": "Edit",
     "edit-server-title": "Add/Edit Server",
+    "enter-username-message": "Hello and welcome to Terasology's multiplayer!\nWould you like to use a non-default username?",
     "enum-editor-prompt": "Select a value for the node:",
     "enum-editor-title": "Enum Node Editor",
     "error-downloading-server-list": "Error downloading server list!",

--- a/engine/src/main/resources/assets/ui/enterUsernamePopup.ui
+++ b/engine/src/main/resources/assets/ui/enterUsernamePopup.ui
@@ -1,0 +1,68 @@
+{
+    "type": "enterUsernamePopup",
+    "skin": "popup",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "UIBox",
+                "skin": "solid",
+                "layoutInfo": {
+                    "width": 400,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-vertical-center": {}
+                },
+                "content": {
+                    "type": "ColumnLayout",
+                    "columns": 1,
+                    "verticalSpacing": 8,
+                    "contents": [
+                        {
+                            "type": "UILabel",
+                            "text": "${engine:menu#enter-username-message}"
+                        },
+                        {
+                            "type": "UISpace",
+                            "size": [1, 8]
+                        },
+                        {
+                            "type": "UIText",
+                            "text": "",
+                            "id": "username"
+                        },
+                        {
+                            "type": "UISpace",
+                            "size": [1, 8]
+                        },
+                        {
+                            "type": "RowLayout",
+                            "id": "actionsRow",
+                            "horizontalSpacing": 8,
+                            "contents": [
+                                {
+                                    "type": "UIButton",
+                                    "text": "${engine:menu#dialog-ok}",
+                                    "id": "ok"
+                                },
+                                {
+                                    "type": "UIButton",
+                                    "text": "${engine:menu#dialog-cancel}",
+                                    "id": "cancel"
+                                }
+                            ],
+                            "layoutInfo": {
+                                "height": 32,
+                                "position-horizontal-center": {},
+                                "position-bottom": {
+                                    "target": "BOTTOM",
+                                    "offset": 48
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

New players now always get assigned a generic username (Player#####) when they first run the game instead of the system username. Seems the code for this already existed so all I did was remove the part about the system username 🙂 

When accessing the Host Game or Join Game Screen for the first time, users will be prompted to choose a non-default username. They will only be prompted once.

![](http://i.imgur.com/piEA77E.png)

![](http://i.imgur.com/aeBvSBM.png)

### How to test

- Delete your config.cfg before loading up Terasology
- You will be assigned a generic username when the game first starts (you can check this in Player Settings)
- You will be prompted to change your username when you first access either the Join Game or Host Game screen
- 'Ok' sets the username, 'Cancel' does nothing
- You will not be prompted anymore after the first time.

### Outstanding before merging

None