### PR TITLE
Fixed issue with untranslated text

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -379,7 +379,7 @@ public class JoinGameScreen extends CoreScreenLayer {
             downloadLabel.bindText(new ReadOnlyBinding<String>() {
                 @Override
                 public String get() {
-                    return downloader.getStatus();
+                    return translationSystem.translate(downloader.getStatus());
                 }
             });
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ServerListDownloader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ServerListDownloader.java
@@ -51,6 +51,8 @@ class ServerListDownloader {
     private final String serverAddress;
 
     /**
+     * The i18n key corresponding to the current status of the downloader
+     *
      * "volatile" ensures the visibility of updates across different threads
      */
     private volatile String status;
@@ -76,7 +78,7 @@ class ServerListDownloader {
     }
 
     /**
-     * @return the current status
+     * @return the i18n key corresponding to the current status of the downloader
      */
     public String getStatus() {
         return status;


### PR DESCRIPTION
### Contains

Closes #2698 with a very simple one line fix 🙂 

Just an issue with the text being untranslated. It does seem a bit unintuitive that the translation is done in JoinGameScreen.java instead of ServerListDownloader.java but I went with this since the TranslationSystem object cannot be instantiated in ServerListDownloader.

### How to test

Open the Join Game screen. Verify that the translated text is shown.