### PR TITLE
Change how the inventory is opened and closed

### DIFF
--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
@@ -16,15 +16,12 @@
 package org.terasology.rendering.nui.layers.ingame.inventory;
 
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.input.BindButtonEvent;
-import org.terasology.input.binds.inventory.InventoryButton;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 
-/**
- */
+
 public class InventoryScreen extends CoreScreenLayer {
 
     @In
@@ -40,14 +37,6 @@ public class InventoryScreen extends CoreScreenLayer {
             }
         });
         inventory.setCellOffset(10);
-    }
-
-    @Override
-    public void onBindEvent(BindButtonEvent event) {
-        if (event instanceof InventoryButton && event.isDown()) {
-            getManager().closeScreen(this);
-            event.consume();
-        }
     }
 
     @Override


### PR DESCRIPTION
Currently, the inventory is opened via [`InventoryUIClientSystem`](https://github.com/MovingBlocks/Terasology/blob/develop/modules/Core/src/main/java/org/terasology/logic/inventory/InventoryUIClientSystem.java#L46) in `onToggleInventory`. For seemingly no reason it is closed in [`InventoryScreen`](https://github.com/MovingBlocks/Terasology/blob/develop/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java#L46) in `onBindEvent`.

The closing section in `InventoryScreen` appears to be redundant as when `onBindEvent` is removed the inventory opens and closes as normal. I am aware that I might simply be missing something which explains the logic behind this.

Also, removing `onBindEvent` also allows for other screens to be opened and closed alongside the inventory screen, as I've done in [my fork](http://github.com/jellysnake/Potions) with `potionStatusScreen` (See files [`PotionStatusScreen`](https://github.com/jellysnake/Potions/blob/master/src/main/java/org/terasology/potions/PotionStatusScreen.java) and [`PotionStatusUISystem`](https://github.com/jellysnake/Potions/blob/master/src/main/java/org/terasology/potions/PotionStatusUISystem.java))

(Also, I'm sorry if this is the wrong place for this, but I didn't think it fit on the forum)