### PR TITLE
Fix NUIManager issues

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -349,10 +349,9 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     @Override
     public void popScreen() {
         if (!screens.isEmpty()) {
-            UIScreenLayer popped = screens.pop();
-            screenLookup.inverse().remove(popped);
-            popped.onClosed();
-            if (!popped.isLowerLayerVisible()) {
+            UIScreenLayer top = screens.peek();
+            closeScreen(top);
+            if (!top.isLowerLayerVisible()) {
                 UIScreenLayer current = screens.peek();
                 if (current != null) {
                     current.onShow();


### PR DESCRIPTION
### Contains
This fixes the issue mentioned in [JoshariasSurvival/#15](https://github.com/Terasology/JoshariasSurvival/issues/15) as well as [Books/#1](https://github.com/Terasology/Books/issues/1) related to how sometimes 2 `E` clicks are required to open an interaction screen if you close it with `Esc`. This is something that affects all interaction screens.

The problem seems to lie with how `popScreen` (called when `Esc` is pressed) is implemented in `NUIManager` as opposed to `closeScreen`. `popScreen` doesn't send a `ScreenLayerClosedEvent` to the client, leading to the some parts of the client still thinking that the interaction screen is open.

### How to test

- Open a chest, then close it with `Esc`
- The next E should open the chest again.

### Outstanding before merging

A somewhat related issue would be how interaction screens overlay the inventory (such as when you open the inventory and then open the chest screen). Whenever the interaction button is pressed, it closes any active interaction screens. However, since the inventory screen is pushed from the `NUIManager`, it is not affected. This is something that might occur with other screens as well.

I think a potential fix for this would be adding a `closeAllScreens` to `NUIManager` which would close all screens with `isLowerLayerVisible` set to true (this excludes screens like the hud) and then calling this before any interaction screen is shown in-game. This would essentially 'reset' the player's view before opening any interaction screens.

Let me know what you think and if it's alright, I will add it to this PR as well.
