### PR TITLE
Fix issue with periodic action

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -234,14 +234,15 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
     @ReceiveEvent
     public void onAutoMove(PeriodicActionTriggeredEvent event, EntityRef entity) {
-        if (event.getActionId().equals(AUTO_MOVE_ID) && isAutoMove) {
-            ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
-            Vector3f viewDir = entity.getComponent(LocationComponent.class).getWorldDirection();
-            clientComponent.character.send(new CharacterImpulseEvent(viewDir.mul(8f)));
-        } else if (!isAutoMove) {
-
-            // If isAutoMove turns false, cancel the action.
-            delayManager.cancelPeriodicAction(entity, AUTO_MOVE_ID);
+        if (event.getActionId().equals(AUTO_MOVE_ID)) {
+            if (isAutoMove) {
+                ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
+                Vector3f viewDir = entity.getComponent(LocationComponent.class).getWorldDirection();
+                clientComponent.character.send(new CharacterImpulseEvent(viewDir.mul(8f)));
+            } else if (!isAutoMove) {
+                // If isAutoMove turns false, cancel the action.
+                delayManager.cancelPeriodicAction(entity, AUTO_MOVE_ID);
+            }
         }
     }
 

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
@@ -16,15 +16,12 @@
 package org.terasology.rendering.nui.layers.ingame.inventory;
 
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.input.BindButtonEvent;
-import org.terasology.input.binds.inventory.InventoryButton;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 
-/**
- */
+
 public class InventoryScreen extends CoreScreenLayer {
 
     @In
@@ -40,14 +37,6 @@ public class InventoryScreen extends CoreScreenLayer {
             }
         });
         inventory.setCellOffset(10);
-    }
-
-    @Override
-    public void onBindEvent(BindButtonEvent event) {
-        if (event instanceof InventoryButton && event.isDown()) {
-            getManager().closeScreen(this);
-            event.consume();
-        }
     }
 
     @Override


### PR DESCRIPTION
Fix NPE error when attempting to use `delayManager` and `periodicAction` due to an instance of not checking the `actionId` before attempting to remove the `periodicAction`.
