### PR TITLE
Close all screens on E click

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
@@ -114,6 +114,7 @@ public class InteractionSystem extends BaseComponentSystem {
         }
         ClientComponent controller = characterComponent.controller.getComponent(ClientComponent.class);
         if (controller != null && controller.local) {
+            nuiManager.closeAllScreens();
             nuiManager.pushScreen(interactionScreenComponent.screen);
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
@@ -53,6 +53,8 @@ public interface NUIManager extends ComponentSystem, FocusManager {
     @Deprecated
     void closeScreen(UIElement element);
 
+    void closeAllScreens();
+
     void toggleScreen(String screenUri);
 
     void toggleScreen(ResourceUrn screenUri);
@@ -126,4 +128,5 @@ public interface NUIManager extends ComponentSystem, FocusManager {
     void setForceReleasingMouse(boolean value);
 
     void invalidate();
+
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -60,6 +60,7 @@ import org.terasology.rendering.nui.layers.hud.HUDScreenLayer;
 
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
@@ -206,6 +207,15 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     @Override
     public void closeScreen(UIElement element) {
         closeScreen(element.getUrn());
+    }
+
+    @Override
+    public void closeAllScreens() {
+        for (UIScreenLayer screen: screens) {
+            if (screen.isLowerLayerVisible()) {
+                closeScreen(screen);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

As mentioned in #2703, this closes all screens with `isLowerLayerVisible` set to true before showing any interaction screens.

### How to test

Open the inventory and then open a chest. The inventory screen should close before the chest screen appears.
