### PR TITLE
Value comparison instead of reference comparison in StateChange.isDefaultInstance

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/dag/SetName.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/dag/SetName.java
@@ -53,7 +53,7 @@ public class SetName implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/BindFBO.java
@@ -63,7 +63,7 @@ public final class BindFBO implements FBOManagerSubscriber, StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/DisableDepthMask.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/DisableDepthMask.java
@@ -56,7 +56,7 @@ public final class DisableDepthMask implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/DisableDepthTest.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/DisableDepthTest.java
@@ -73,7 +73,7 @@ public final class DisableDepthTest extends SetStateParameter {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableBlending.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableBlending.java
@@ -76,7 +76,7 @@ public final class EnableBlending extends SetStateParameter {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableFaceCulling.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableFaceCulling.java
@@ -76,7 +76,7 @@ public final class EnableFaceCulling extends SetStateParameter {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableMaterial.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableMaterial.java
@@ -71,7 +71,7 @@ public final class EnableMaterial implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     private static Material getMaterial(String assetId) {

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableStencilTest.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/EnableStencilTest.java
@@ -70,7 +70,7 @@ public final class EnableStencilTest extends SetStateParameter {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetBlendFunction.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetBlendFunction.java
@@ -101,7 +101,7 @@ public class SetBlendFunction implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetDepthFunction.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetDepthFunction.java
@@ -89,7 +89,7 @@ public class SetDepthFunction implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTexture.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTexture.java
@@ -108,7 +108,7 @@ public class SetInputTexture implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTextureFromFBO.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetInputTextureFromFBO.java
@@ -136,7 +136,7 @@ public class SetInputTextureFromFBO implements StateChange, FBOManagerSubscriber
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     private int fetchTextureId() {

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportToSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportToSizeOf.java
@@ -75,7 +75,7 @@ public final class SetViewportToSizeOf implements FBOManagerSubscriber, StateCha
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetWireframe.java
@@ -70,7 +70,7 @@ public final class SetWireframe implements StateChange {
 
     @Override
     public boolean isTheDefaultInstance() {
-        return this == defaultInstance;
+        return this.equals(defaultInstance);
     }
 
     @Override


### PR DESCRIPTION
### Contains
Fixes #2706. Instead of the existing reference based comparison, all `StateChange.isDefaultInstance` implementations now make use of value based comparison by calling the `equals` method instead.

### How to test
- Run the game, load a world.
- Check the logs for the render task list. Note the difference in number of generated tasks (114 from 123).

### How it works
All implementations of the `isDefaultInstance` method used reference comparisons using the equality operator (`this == defaultInstance`). This is modified to call the overridden `equals` method instead (`this.equals(defaultInstance)`).