### PR TITLE
Auto-include build.gradle from Core module

### DIFF
--- a/modules/subprojects.gradle
+++ b/modules/subprojects.gradle
@@ -3,13 +3,16 @@ new File(rootDir, 'modules').eachDir { possibleSubprojectDir ->
     def subprojectName = 'modules:' + possibleSubprojectDir.name
     //println "Gradle is reviewing module $subprojectName for inclusion as a sub-project"
     File buildFile = new File(possibleSubprojectDir, "build.gradle")
-    if (buildFile.exists()) {
-        println "Module $subprojectName has a build file so counting it complete and including it"
-        include subprojectName
-        def subprojectPath = ':' + subprojectName
-        def subproject = project(subprojectPath)
-        subproject.projectDir = possibleSubprojectDir
+    if (!buildFile.exists()) {
+        println "Module $subprojectName has no build file, adding build.gradle file from core and including it"
+        File replacementGradle = new File(rootDir, 'modules/Core/build.gradle')
+        File targetFile = new File(possibleSubprojectDir, "build.gradle")
+        targetFile << replacementGradle.text
     } else {
-        println "***** WARNING: Found a module without a build.gradle, corrupt dir? NOT including $subprojectName *****"
+        println "Module $subprojectName has a build file so counting it complete and including it"
     }
+    include subprojectName
+    def subprojectPath = ':' + subprojectName
+    def subproject = project(subprojectPath)
+    subproject.projectDir = possibleSubprojectDir
 }

--- a/modules/subprojects.gradle
+++ b/modules/subprojects.gradle
@@ -6,8 +6,7 @@ new File(rootDir, 'modules').eachDir { possibleSubprojectDir ->
     if (!buildFile.exists()) {
         println "Module $subprojectName has no build file, adding build.gradle file from core and including it"
         File replacementGradle = new File(rootDir, 'modules/Core/build.gradle')
-        File targetFile = new File(possibleSubprojectDir, "build.gradle")
-        targetFile << replacementGradle.text
+        buildFile << replacementGradle.text
     } else {
         println "Module $subprojectName has a build file so counting it complete and including it"
     }


### PR DESCRIPTION
### Contains

Auto includes the build.gradle from the core module if a module has no such file.
Makes working with own forks a bit less complicated :)

### How to test

Clone a module via git or delete the build.gradle, then run ./gradlew eclipse or idea. The module should be included in the build process and also have the build.gradle included.