### PR TITLE
Make it possible to use more icon types for UI elements like tree views.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/itemRendering/StringTextIconRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/itemRendering/StringTextIconRenderer.java
@@ -18,7 +18,7 @@ package org.terasology.rendering.nui.itemRendering;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.rendering.assets.font.Font;
-import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.TextLineBuilder;
 
@@ -49,7 +49,7 @@ public abstract class StringTextIconRenderer<T> extends AbstractItemRenderer<T> 
     @Override
     public void draw(T value, Canvas canvas) {
         // Drawing the icon
-        Texture texture = getTexture(value);
+        TextureRegion texture = getTexture(value);
 
         if (texture != null) {
             if (marginTop + texture.getHeight() + marginBottom > canvas.size().y) {
@@ -82,7 +82,7 @@ public abstract class StringTextIconRenderer<T> extends AbstractItemRenderer<T> 
         Font font = canvas.getCurrentStyle().getFont();
         String text = getString(value);
 
-        Texture texture = getTexture(value);
+        TextureRegion texture = getTexture(value);
         if (texture == null) {
             List<String> lines = TextLineBuilder.getLines(font, text, canvas.size().x);
             return font.getSize(lines);
@@ -95,5 +95,5 @@ public abstract class StringTextIconRenderer<T> extends AbstractItemRenderer<T> 
 
     public abstract String getString(T value);
 
-    public abstract Texture getTexture(T value);
+    public abstract TextureRegion getTexture(T value);
 }


### PR DESCRIPTION
### Contains

A change that makes it possible to use atlas icon URLs like `engine:items#whiteRecipe` with the `StringTextIconRenderer`. The latter can for example be used by a TreeView to render its icons.

Note that this change should not break anything since the TextureRegion is a interface implemented by the class Texture: Thus a StringTextIconRenderer sub class is still allowed to return a Texture and does not need to be adjusted.

### How to test

No test needed, it should be enough that it compiles.