### PR TITLE
Surface Depth Facet

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,6 +42,8 @@ import org.terasology.physics.shapes.SphereShapeComponent;
 import org.terasology.rendering.logic.MeshComponent;
 import org.terasology.world.WorldProvider;
 
+import java.util.Optional;
+
 /**
  * Creates new player instances.
  */
@@ -71,7 +73,7 @@ public class PlayerFactory {
         float entityHeight = getHeightOf(builder) + extraSpace;
 
         LocationComponent location = controller.getComponent(LocationComponent.class);
-        Vector3f spawnPosition = findSpawnPos(location.getWorldPosition(), entityHeight);
+        Vector3f spawnPosition = findSpawnPos(location.getWorldPosition(), entityHeight).get(); // TODO: Handle Optional being empty
         location.setWorldPosition(spawnPosition);
         controller.saveComponent(location);
 
@@ -129,20 +131,20 @@ public class PlayerFactory {
         return 1.0f;
     }
 
-    private Vector3f findSpawnPos(Vector3f targetPos, float entityHeight) {
+    private Optional<Vector3f> findSpawnPos(Vector3f targetPos, float entityHeight) {
         int targetBlockX = TeraMath.floorToInt(targetPos.x);
         int targetBlockY = TeraMath.floorToInt(targetPos.y);
         int targetBlockZ = TeraMath.floorToInt(targetPos.z);
         Vector2i center = new Vector2i(targetBlockX, targetBlockZ);
-        for (BaseVector2i pos : SpiralIterable.clockwise(center).maxRadius(3).scale(2).build()) {
+        for (BaseVector2i pos : SpiralIterable.clockwise(center).maxRadius(32).scale(2).build()) {
 
             Vector3i testPos = new Vector3i(pos.getX(), targetBlockY, pos.getY());
             Vector3i spawnPos = findOpenVerticalPosition(testPos, entityHeight);
             if (spawnPos != null) {
-                return new Vector3f(spawnPos.getX(), spawnPos.getY() + entityHeight, spawnPos.getZ());
+                return Optional.of(new Vector3f(spawnPos.getX(), spawnPos.getY() + entityHeight, spawnPos.getZ()));
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/generation/facets/SurfaceDepthFacet.java
+++ b/engine/src/main/java/org/terasology/world/generation/facets/SurfaceDepthFacet.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.generation.facets;
+
+import org.terasology.math.Region3i;
+import org.terasology.world.generation.Border3D;
+import org.terasology.world.generation.facets.base.BaseFieldFacet2D;
+
+/**
+ * Stores the surface depth limits.
+ * The surface depth limit (inclusive) is an optional bottom limit for the default world generator.
+ * No blocks below the surface depth limit are altered, and biomes are not set.
+ */
+public class SurfaceDepthFacet extends BaseFieldFacet2D {
+
+    public SurfaceDepthFacet(Region3i targetRegion, Border3D border) {
+        super(targetRegion, border);
+    }
+}

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -30,6 +30,7 @@ import org.terasology.world.generation.Region;
 import org.terasology.world.generation.WorldRasterizer;
 import org.terasology.world.generation.facets.DensityFacet;
 import org.terasology.world.generation.facets.SeaLevelFacet;
+import org.terasology.world.generation.facets.SurfaceDepthFacet;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.liquid.LiquidData;
 import org.terasology.world.liquid.LiquidType;
@@ -63,6 +64,7 @@ public class SolidRasterizer implements WorldRasterizer {
         LiquidData waterLiquid = new LiquidData(LiquidType.WATER, LiquidData.MAX_LIQUID_DEPTH);
         DensityFacet solidityFacet = chunkRegion.getFacet(DensityFacet.class);
         SurfaceHeightFacet surfaceFacet = chunkRegion.getFacet(SurfaceHeightFacet.class);
+        SurfaceDepthFacet surfaceDepthFacet = chunkRegion.getFacet(SurfaceDepthFacet.class);
         BiomeFacet biomeFacet = chunkRegion.getFacet(BiomeFacet.class);
         SeaLevelFacet seaLevelFacet = chunkRegion.getFacet(SeaLevelFacet.class);
         int seaLevel = seaLevelFacet.getSeaLevel();
@@ -70,10 +72,15 @@ public class SolidRasterizer implements WorldRasterizer {
         Vector2i pos2d = new Vector2i();
         for (Vector3i pos : ChunkConstants.CHUNK_REGION) {
             pos2d.set(pos.x, pos.z);
+            int posY = pos.y + chunk.getChunkWorldOffsetY();
+
+            if (surfaceDepthFacet != null && posY < surfaceDepthFacet.get(pos2d)) {
+                continue;
+            }
+
             Biome biome = biomeFacet.get(pos2d);
             chunk.setBiome(pos.x, pos.y, pos.z, biome);
 
-            int posY = pos.y + chunk.getChunkWorldOffsetY();
             float density = solidityFacet.get(pos);
 
             if (density >= 32) {


### PR DESCRIPTION
1. Added an optional surface depth facet that when added limits the default surface rasterizer from generating below the depth.

2. Made spawning point selection return a value even if no "good" spawn could be found, because it's better to at least spawn in the ground than crash the game.

Part of GCI task creating an Underworld.