### PR TITLE
Added postWorldGeneration event / WorldGenerationSubscriberSystem

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -44,6 +44,7 @@ import org.terasology.engine.modes.loadProcesses.JoinServer;
 import org.terasology.engine.modes.loadProcesses.LoadEntities;
 import org.terasology.engine.modes.loadProcesses.LoadPrefabs;
 import org.terasology.engine.modes.loadProcesses.PostBeginSystems;
+import org.terasology.engine.modes.loadProcesses.PostWorldGenerationSystems;
 import org.terasology.engine.modes.loadProcesses.PreBeginSystems;
 import org.terasology.engine.modes.loadProcesses.PrepareWorld;
 import org.terasology.engine.modes.loadProcesses.ProcessBlockPrefabs;
@@ -167,6 +168,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new SetupRemotePlayer(context));
         loadProcesses.add(new AwaitCharacterSpawn(context));
         loadProcesses.add(new PrepareWorld(context));
+        loadProcesses.add(new PostWorldGenerationSystems(context));
     }
 
     private void initHost() {
@@ -209,6 +211,7 @@ public class StateLoading implements GameState {
             loadProcesses.add(new AwaitCharacterSpawn(context));
         }
         loadProcesses.add(new PrepareWorld(context));
+        loadProcesses.add(new PostWorldGenerationSystems(context));
     }
 
     private void popStep() {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PostWorldGenerationSystems.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/PostWorldGenerationSystems.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.modes.loadProcesses;
+
+import org.terasology.context.Context;
+import org.terasology.engine.ComponentSystemManager;
+import org.terasology.entitySystem.systems.ComponentSystem;
+import org.terasology.entitySystem.systems.WorldGenerationSubscriberSystem;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+
+/**
+ */
+public class PostWorldGenerationSystems extends StepBasedLoadProcess {
+
+    private final Context context;
+
+    private Iterator<WorldGenerationSubscriberSystem> componentSystems;
+
+    public PostWorldGenerationSystems(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Post-World Generation Systems";
+    }
+
+    @Override
+    public boolean step() {
+        if (componentSystems.hasNext()) {
+            componentSystems.next().postWorldGeneration();
+        }
+        return !componentSystems.hasNext();
+    }
+
+    @Override
+    public void begin() {
+        ComponentSystemManager csm = context.get(ComponentSystemManager.class);
+        LinkedList<WorldGenerationSubscriberSystem> systems = new LinkedList<>();
+        for (ComponentSystem system : csm.iterateAll()) {
+            if (system instanceof WorldGenerationSubscriberSystem) {
+                systems.add((WorldGenerationSubscriberSystem) system);
+            }
+        }
+        componentSystems = systems.iterator();
+    }
+
+    @Override
+    public int getExpectedCost() {
+        return 1;
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/systems/WorldGenerationSubscriberSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/WorldGenerationSubscriberSystem.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.systems;
+
+/**
+ * Interface for component systems that need events related to world generation.
+ */
+public interface WorldGenerationSubscriberSystem extends ComponentSystem {
+
+    /**
+     * Called right after the world is generated
+     */
+    void postWorldGeneration();
+
+}


### PR DESCRIPTION
Currently systems have no events that fire after world generation. I went and added one, postWorldGeneration(). 
More events related to worldgen can be added to the WorldGenerationSubscriberSystem.