### PR TITLE
Fix issue where chat overlay would overrun screen

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
@@ -33,8 +33,10 @@ import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * The chat console widget
@@ -91,14 +93,9 @@ public class ChatScreen extends CoreScreenLayer {
         history.bindText(new ReadOnlyBinding<String>() {
             @Override
             public String get() {
-                StringBuilder messageList = new StringBuilder();
-                for (Iterator<Message> it = console.getMessages(CoreMessageType.CHAT, CoreMessageType.NOTIFICATION).iterator(); it.hasNext();) {
-                    messageList.append(it.next().getMessage());
-                    if (it.hasNext()) {
-                        messageList.append(Console.NEW_LINE);
-                    }
-                }
-                return messageList.toString();
+                Iterable<Message> messageIterable = console.getMessages(CoreMessageType.CHAT, CoreMessageType.NOTIFICATION);
+                Stream<Message> messageStream = StreamSupport.stream(messageIterable.spliterator(), false);
+                return messageStream.map(Message::getMessage).collect(Collectors.joining(Console.NEW_LINE));
             }
         });
     }

--- a/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
@@ -33,6 +33,7 @@ import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -91,9 +92,11 @@ public class ChatScreen extends CoreScreenLayer {
             @Override
             public String get() {
                 StringBuilder messageList = new StringBuilder();
-                for (Message msg : console.getMessages(CoreMessageType.CHAT, CoreMessageType.NOTIFICATION)) {
-                    messageList.append(msg.getMessage());
-                    messageList.append(Console.NEW_LINE);
+                for (Iterator<Message> it = console.getMessages(CoreMessageType.CHAT, CoreMessageType.NOTIFICATION).iterator(); it.hasNext();) {
+                    messageList.append(it.next().getMessage());
+                    if (it.hasNext()) {
+                        messageList.append(Console.NEW_LINE);
+                    }
                 }
                 return messageList.toString();
             }

--- a/engine/src/main/java/org/terasology/logic/console/ui/MiniChatOverlay.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/MiniChatOverlay.java
@@ -16,6 +16,7 @@
 package org.terasology.logic.console.ui;
 
 import com.google.common.collect.Iterables;
+import org.codehaus.plexus.util.StringUtils;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.CoreMessageType;
 import org.terasology.logic.console.Message;
@@ -41,6 +42,8 @@ public class MiniChatOverlay extends CoreScreenLayer {
     private static final float TIME_FADE = 0.3f;
 
     private static final int MAX_MESSAGES = 6;
+
+    private static final int MAX_CHAR_PER_MSG = 250;
 
     private enum State {
         FADE_IN,
@@ -71,7 +74,7 @@ public class MiniChatOverlay extends CoreScreenLayer {
 
                 for (Message msg : msgs) {
                     if (count > size - MAX_MESSAGES) {
-                        messageHistory.append(msg.getMessage());
+                        messageHistory.append(StringUtils.abbreviate(msg.getMessage(), MAX_CHAR_PER_MSG));
                         if (count < size) {
                             messageHistory.append(Console.NEW_LINE);
                         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

This is a followup PR to #2667, closing #2376. It fixes the issue mentioned where part of the mini chat overlay would overrun the screen if the messages sent contain too many characters. 

The length of each message in the mini chat overlay is now limited to 250 characters, which the player can view in full by opening the active chat overlay (T by default). This also removes an extra newline in the active chat overlay.

### How to test

Paste a string containing more than 250 characters into chat. It should be truncated and the last few characters replaced with a ellipsis.

Mini chat overlay:
![](http://i.imgur.com/W9CSl2m.png)

Active chat overlay: 
![](http://i.imgur.com/bzONjdE.png)

### Outstanding before merging

None!

