### PR TITLE
Add an exclusion list for unready languages to the player settings

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/settings/PlayerSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/settings/PlayerSettingsScreen.java
@@ -58,6 +58,12 @@ public class PlayerSettingsScreen extends CoreScreenLayer {
 
     private final List<Color> colors = CieCamColors.L65C65;
 
+    /**
+     * Remove language x from this languagesExcluded table when it is ready for testing
+     */
+    private final Locale[] languagesExcluded = {Locale.forLanguageTag("zh"), Locale.forLanguageTag("hi"),
+            Locale.forLanguageTag("ar"), Locale.forLanguageTag("ko"), Locale.forLanguageTag("fa")};
+
     private UIText nametext;
     private UISlider slider;
     private UISlider heightSlider;
@@ -135,6 +141,9 @@ public class PlayerSettingsScreen extends CoreScreenLayer {
             SimpleUri menuUri = new SimpleUri("engine:menu");
             TranslationProject menuProject = translationSystem.getProject(menuUri);
             List<Locale> locales = new ArrayList<>(menuProject.getAvailableLocales());
+            for (Locale languageExcluded : languagesExcluded) {
+                locales.remove(languageExcluded);
+            }
             Collections.sort(locales, ((Object o1, Object o2) -> (o1.toString().compareTo(o2.toString()))));
             language.setOptions(Lists.newArrayList(locales));
             language.setVisibleOptions(5); // Set maximum number of options visible for scrolling


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2781 

### How to test

- I've added Hindi #2733, Arabic #2769, Korean #2745, Farsi #2735, Chinese #2677 to the exclusion list.
- I've tested in Hindi and Chinese.
Before the change, Chinese appears in the list : 
![screen shot 2017-02-11 at 1 15 35 pm](https://cloud.githubusercontent.com/assets/17897358/22853732/0db1eba0-f05e-11e6-9634-a660257e7053.png)
After the change, Chinese disappeared : 
![screen shot 2017-02-11 at 1 14 23 pm](https://cloud.githubusercontent.com/assets/17897358/22853738/294d6768-f05e-11e6-8088-98bef8c1d6c3.png)



### Outstanding before merging

- [ ] I'm not sure about the best place to put documentation for contributors testing languages, for now I put it before the declaration of `languagesExcluded`
- [ ] We might have to consider the scenario : when a user's system language is an unready language  e.g. Chinese, when  this user start the game, there will be problems in menu text(as mentioned in #2777). We might need to add an exclusion list in an other class. Now I still don't find that class, please tell me if someone knows :-) 

