### PR TITLE
Fix for Issue 2800

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/SimpleBlendMaterialsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/SimpleBlendMaterialsNode.java
@@ -19,6 +19,7 @@ import org.terasology.engine.ComponentSystemManager;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.registry.In;
+import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.stateChanges.BindFBO;
 import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
@@ -27,9 +28,11 @@ import org.terasology.rendering.dag.stateChanges.DisableDepthWriting;
 import org.terasology.rendering.dag.stateChanges.EnableBlending;
 import static org.terasology.rendering.opengl.DefaultDynamicFBOs.READ_ONLY_GBUFFER;
 
+import org.terasology.rendering.dag.stateChanges.LookThrough;
 import org.terasology.rendering.dag.stateChanges.SetBlendFunction;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
+import org.terasology.rendering.world.WorldRenderer;
 
 /**
  * An instance of this class renders and blends semi-transparent objects into the content of the existing g-buffer.
@@ -49,6 +52,9 @@ import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 public class SimpleBlendMaterialsNode extends AbstractNode {
 
     @In
+    private WorldRenderer worldRenderer;
+
+    @In
     private ComponentSystemManager componentSystemManager;
 
     @In
@@ -60,6 +66,9 @@ public class SimpleBlendMaterialsNode extends AbstractNode {
      */
     @Override
     public void initialise() {
+        Camera playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new LookThrough(playerCamera));
+
         addDesiredStateChange(new BindFBO(READ_ONLY_GBUFFER.getName(), displayResolutionDependentFBOs));
         addDesiredStateChange(new SetViewportToSizeOf(READ_ONLY_GBUFFER.getName(), displayResolutionDependentFBOs));
 


### PR DESCRIPTION
### Contains
Fixes #2800

### How to test
Break some bushes: a small cloud of rapidly disappearing particles/leaves should appear where the bush used to be - this is the normal behavior. 

The Bug detailed in 2800 had the particle appear in the lower portion of the field of view of the player, in a frame of coordinates seemingly unrelated to the visible world.

### Notes
This problem was due to the SimpleBlendMaterialsNode implicitly relying on other nodes to set the correct modelview and projection matrices. After the merging of PR #2794 nodes _must_ either add a StateChange to look through a specific camera or run their code assuming the projection and modelview matrices being identity matrices - opengl's default. 

As testing of #2794 didn't include semi-transparent objects, this problem was not noticed.