### PR TITLE
Fix inactive controller inputs being consumed

### DIFF
--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -394,6 +394,9 @@ public class InputSystem extends BaseComponentSystem {
     }
 
     private void processControllerInput(float delta) {
+        if(!display.hasFocus()){
+            return;
+        }
         for (ControllerAction action : controllers.getInputQueue()) {
             // TODO: send event to entity system
             boolean consumed = false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2554 and prevents controller input from being accepted when the game window isn't active.
Not actually sure how to run Checkstyle on the code, so unable to verify that currently...

### How to test

Run game with out change using a controller, test that controller works for the game, make the window inactive and then try to input on the controller(it will still put in inputs).

With change these inputs on the inactive window are not accepted and function as a mouse or keyboard input would.

With the window active the game still functions normally and consumes all inputs.
