### PR TITLE
fixed singlePlayer and multiPlayer screen disappearance after enabling Animated Menus option

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -122,6 +122,7 @@ public class SelectGameScreen extends CoreScreenLayer {
 
     @Override
     public void onOpened() {
+    	super.onOpened();
         if (loadingAsServer && !config.getPlayer().hasEnteredUsername()) {
             getManager().pushScreen(EnterUsernamePopup.ASSET_URI, EnterUsernamePopup.class);
         }


### PR DESCRIPTION
Fixes disappearance of buttons that should come after clicking Singleplayer and Host Game buttons in main menu.
#2762 partially fixed already in pr 2772 and completely fixed after this

### Contains

Fixes #2762 

### How to test

1. Enable animated menus in settings > video
2. go back to main screen
3. click Singleplayer or Host Game button
4. click Back
5. click any among the Singleplayer or Host Game button
