### PR TITLE
Remove UIInputBindButton from default.skin

### DIFF
--- a/engine/src/main/resources/assets/skins/default.skin
+++ b/engine/src/main/resources/assets/skins/default.skin
@@ -333,33 +333,6 @@
                 }
             }
         },
-        "UIInputBindButton": {
-            "text-align-horizontal": "center",
-            "text-align-vertical": "middle",
-            "background": "button",
-            "background-border": {
-                "top": 2,
-                "bottom": 2,
-                "left": 2,
-                "right": 2
-            },
-            "margin": {
-                "top": 6,
-                "bottom": 6,
-                "left": 4,
-                "right": 4
-            },
-            "texture-scale-mode": "scale fit",
-            "modes": {
-                "hover": {
-                    "background": "buttonOver"
-                },
-                "active": {
-                    "background": "buttonDown",
-                    "text-color": "FFFF00FF"
-                }
-            }
-        },
         "UICheckbox": {
             "background": "engine:checkbox",
             "fixed-width": 24,


### PR DESCRIPTION
Cleans up log output so it stops complaining about UIInputBindButton by removing UIInputBindButton from the default.skin file.

### Contains
Fixing #2145
Fixes UIInputBindButton being redundant. Detailed in: #2145

### How to test
Run the game and look at various log files for it complaining about UIInputBindButton
