### PR TITLE
Fix headless server build

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -45,7 +45,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     private WorldProvider worldProvider;
     private ChunkProvider chunkProvider;
 
-    private Camera noCamera = new NullCamera();
+    private Camera noCamera = new NullCamera(null, null);
 
     /* CHUNKS */
     private boolean pendingChunks;

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/NullCamera.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/NullCamera.java
@@ -15,9 +15,15 @@
  */
 package org.terasology.engine.subsystem.headless.renderer;
 
-import org.terasology.rendering.cameras.Camera;
+import org.terasology.config.RenderingConfig;
+import org.terasology.rendering.cameras.SubmersibleCamera;
+import org.terasology.world.WorldProvider;
 
-public final class NullCamera extends Camera {
+public final class NullCamera extends SubmersibleCamera {
+    public NullCamera(WorldProvider worldProvider, RenderingConfig renderingConfig) {
+        super(worldProvider, renderingConfig);
+    }
+
     @Override
     public void updateMatrices(float fov) {
     }


### PR DESCRIPTION
This pull request fixes the server build (the regression was likely caused by https://github.com/MovingBlocks/Terasology/pull/2803). It does not seem to affect the client noticeably (tested with a local client and server).

## How to test

`./gradlew jar server` used to cause a build error, now it works.

Pinging @fabriond about this, since this fix is a bit hacky.
