### PR TITLE
Cancel velocity on teleport

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/DeferredMomentumComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/DeferredMomentumComponent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.characters;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+public final class DeferredMomentumComponent implements Component {
+    private Vector3f velocity = new Vector3f();
+
+    public Vector3f getVelocity() {
+        return velocity;
+    }
+
+    public void setVelocity(Vector3f newVelocity) {
+        velocity.set(newVelocity);
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
@@ -147,7 +147,7 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
         // stores the old character momentum so that it might be re-applied after the teleport event
         DeferredMomentumComponent deferredMomentum = new DeferredMomentumComponent();
         deferredMomentum.setVelocity(lastState.getVelocity());
-        entity.saveComponent(new DeferredMomentumComponent());
+        entity.saveComponent(deferredMomentum);
 
         stateBuffer.add(newState);
         characterMovementSystemUtility.setToState(entity, newState);

--- a/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
@@ -140,6 +140,7 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
         CharacterStateEvent lastState = stateBuffer.getLast();
         CharacterStateEvent newState = new CharacterStateEvent(lastState);
         newState.setPosition(new Vector3f(event.getTargetPosition()));
+        newState.setVelocity(Vector3f.zero());
         newState.setTime(time.getGameTimeInMs());
         stateBuffer.add(newState);
         characterMovementSystemUtility.setToState(entity, newState);

--- a/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
@@ -139,12 +139,18 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
         CircularBuffer<CharacterStateEvent> stateBuffer = characterStates.get(entity);
         CharacterStateEvent lastState = stateBuffer.getLast();
         CharacterStateEvent newState = new CharacterStateEvent(lastState);
+
         newState.setPosition(new Vector3f(event.getTargetPosition()));
         newState.setVelocity(Vector3f.zero());
         newState.setTime(time.getGameTimeInMs());
+
+        // stores the old character momentum so that it might be re-applied after the teleport event
+        DeferredMomentumComponent deferredMomentum = new DeferredMomentumComponent();
+        deferredMomentum.setVelocity(lastState.getVelocity());
+        entity.saveComponent(new DeferredMomentumComponent());
+
         stateBuffer.add(newState);
         characterMovementSystemUtility.setToState(entity, newState);
-
     }
 
     @ReceiveEvent(components = {CharacterMovementComponent.class, LocationComponent.class, AliveCharacterComponent.class})


### PR DESCRIPTION
This is a small fix up for discussion. Currently, the teleport command will maintain the player's velocity. This fix will cancel the current velocity to zero.

On the one hand, maintaining velocity might be desired for a portal, where the player walks in and out. However, in the current implementation teleporting is a "normal" movement action with a (possible) huge delta in position. Thus, it is hard for system acting on player movement to identify a teleport.  

See https://github.com/Terasology/LightAndShadow/pull/52

I don't know if we could/should link the movement to a TeleportEvent of sorts so that systems can correctly identify the source of movement.

Discussion welcome: @krishnarb3 @msteiger