### PR TITLE
Fix dvorak command

### DIFF
--- a/engine/src/main/java/org/terasology/input/internal/BindCommands.java
+++ b/engine/src/main/java/org/terasology/input/internal/BindCommands.java
@@ -61,9 +61,9 @@ public class BindCommands extends BaseComponentSystem {
             requiredPermission = PermissionManager.NO_PERMISSION)
     public String dvorak() {
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.COMMA, new SimpleUri("engine:forwards"));
-        inputSystem.linkBindButtonToKey(Keyboard.KeyId.A, new SimpleUri("engine:right"));
+        inputSystem.linkBindButtonToKey(Keyboard.KeyId.A, new SimpleUri("engine:left"));
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.O, new SimpleUri("engine:backwards"));
-        inputSystem.linkBindButtonToKey(Keyboard.KeyId.E, new SimpleUri("engine:left"));
+        inputSystem.linkBindButtonToKey(Keyboard.KeyId.E, new SimpleUri("engine:right"));
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.C, new SimpleUri("engine:inventory"));
         inputSystem.linkBindButtonToKey(Keyboard.KeyId.PERIOD, new SimpleUri("engine:useItem"));
 


### PR DESCRIPTION
Dvorak command had left and right inverted. This simple fix swaps them back to be the correct way around.

### Contains

Fix dvorak command (left and right were inverted)

### How to test

Set keyboard to be a dvorak layout. Open up a game world, and run the dvorak command. The movement should have the same keys as a normal qwerty keyboard.