### PR TITLE
Null prefab crash fix

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/PrefabTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/PrefabTypeHandler.java
@@ -37,6 +37,9 @@ public class PrefabTypeHandler extends StringRepresentationTypeHandler<Prefab> {
 
     @Override
     public Prefab getFromString(String representation) {
+        if (representation == null) {
+            return null;
+        }
         return Assets.getPrefab(representation).orElse(null);
     }
 }


### PR DESCRIPTION
### Contains

A fix for a crash that occurred when a field of type Prefab got synchronized over network with value `null`.

### How to test

Not sure if this needs a test, but I had a crash after I placed a structure template on a server. The client would instantly crash upon joining.