### PR TITLE
Fix first letter in chatbox moving player

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -360,6 +360,7 @@ public class UIText extends CoreWidget {
                     String after = fullText.substring(Math.max(getCursorPosition(), selectionStart));
                     setText(before + event.getKeyCharacter() + after);
                     setCursorPosition(Math.min(getCursorPosition(), selectionStart) + 1);
+                    eventHandled = true;
                 }
             } else {
                 String fullText = text.get();


### PR DESCRIPTION
Fix part of issue #2833 (Various isses with movement inputs persisting
through the chatbox) where the first letter typed into an empty chatbox was
causing the player to move.

This was caused by the event falling through to the normal event system,
because a path was not marked with eventHandled = true.

Note: there are still parts of #2833 that this doesn't fix, but might be related.

### Contains

Fixes part of #2833

### How to test

Open up a chatbox, making sure it is empty. Type a movement command (e.g. 'w'), and observe what happens.

Before the patch, the character typed would go into the chatbox, but the player would move, even though the chat box is open. After the patch, the character typed just goes into the chatbox, and doesn't make the player move.