### PR TITLE
Fix multi unbinding problem

### DIFF
--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -82,7 +82,7 @@ public final class BindsConfig {
      * @return True if newInput has been bound. False otherwise.
      */
     public boolean isBound(Input newInput) {
-        return data.containsValue(newInput);
+        return data.containsValue(newInput) && newInput != null;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/config/BindsConfig.java
+++ b/engine/src/main/java/org/terasology/config/BindsConfig.java
@@ -82,7 +82,7 @@ public final class BindsConfig {
      * @return True if newInput has been bound. False otherwise.
      */
     public boolean isBound(Input newInput) {
-        return data.containsValue(newInput) && newInput != null;
+        return newInput != null && data.containsValue(newInput) ;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2831 

There was a problem with checking if a bind input was bound and two inputs are both null, 
Could be solved a few different ways, but I figured the most plausible would be that no matter what null is never registered as bound to other inputs(even if it technically is).

### How to test

Unbind 1 key, try unbinding a second(and a third and a fourth if you don't trust it) and it will now allow you to unbind these keys. 

Test in game that they are properly unbound and then rebind and see that they still work when rebound(the fix doesn't break the input binding system)

### Outstanding before merging

Double check that this is how we want to deal with unbinding keys and setting their input values to null.

There are a few different ways this could be done, this is just one of them.
