### PR TITLE
Fix quantity-based giving of items #2835

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -296,18 +296,20 @@ public class BlockCommands extends BaseComponentSystem {
             @CommandParam("blockName") String uri,
             @CommandParam(value = "quantity", required = false) Integer quantityParam,
             @CommandParam(value = "shapeName", required = false) String shapeUriParam) {
-        int quantity = quantityParam != null ? quantityParam : 16;
         Set<ResourceUrn> matchingUris = Assets.resolveAssetUri(uri, BlockFamilyDefinition.class);
+
+        BlockFamily blockFamily = null;
+
         if (matchingUris.size() == 1) {
             Optional<BlockFamilyDefinition> def = Assets.get(matchingUris.iterator().next(), BlockFamilyDefinition.class);
             if (def.isPresent()) {
                 if (def.get().isFreeform()) {
                     if (shapeUriParam == null) {
-                        return giveBlock(blockManager.getBlockFamily(new BlockUri(def.get().getUrn(), new ResourceUrn("engine:cube"))), quantity, sender);
+                        blockFamily = blockManager.getBlockFamily(new BlockUri(def.get().getUrn(), new ResourceUrn("engine:cube")));
                     } else {
                         Set<ResourceUrn> resolvedShapeUris = Assets.resolveAssetUri(shapeUriParam, BlockShape.class);
                         if (resolvedShapeUris.isEmpty()) {
-                            return  "Found block. No shape found for '" + shapeUriParam + "'";
+                            return "Found block. No shape found for '" + shapeUriParam + "'";
                         } else if (resolvedShapeUris.size() > 1) {
                             StringBuilder builder = new StringBuilder();
                             builder.append("Found block. Non-unique shape name, possible matches: ");
@@ -321,12 +323,23 @@ public class BlockCommands extends BaseComponentSystem {
 
                             return builder.toString();
                         }
-                        return giveBlock(blockManager.getBlockFamily(new BlockUri(def.get().getUrn(), resolvedShapeUris.iterator().next())), quantity, sender);
+                        blockFamily = blockManager.getBlockFamily(new BlockUri(def.get().getUrn(), resolvedShapeUris.iterator().next()));
                     }
                 } else {
-                    return giveBlock(blockManager.getBlockFamily(new BlockUri(def.get().getUrn())), quantity, sender);
+                    blockFamily = blockManager.getBlockFamily(new BlockUri(def.get().getUrn()));
                 }
             }
+
+            if (blockFamily == null) {
+                //Should never be reached
+                return "Block not found";
+            }
+
+            int defaultQuantity = blockFamily.getArchetypeBlock().isStackable() ? 16 : 1;
+            int quantity = quantityParam != null ? quantityParam : defaultQuantity;
+
+            return giveBlock(blockFamily, quantity, sender);
+
         } else if (matchingUris.size() > 1) {
             StringBuilder builder = new StringBuilder();
             builder.append("Non-unique block name, possible matches: ");

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -347,20 +347,22 @@ public class BlockCommands extends BaseComponentSystem {
         if (quantity < 1) {
             return "Here, have these zero (0) blocks just like you wanted";
         }
-        //continue giving blocks until there are no more blocks to give
-        //TODO reference maxStackSize instead of explicitly subtracting 99 and introduce an upper bound? 10 million lags ..
-        for (int quantityLeft = quantity; quantityLeft > 0; quantityLeft -= 99) {
-            EntityRef item = blockItemFactory.newInstance(blockFamily, quantityLeft > 99 ? 99 : quantityLeft);
+
+        EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
+
+        for (int quantityLeft = quantity; quantityLeft > 0; quantityLeft--) {
+            EntityRef item = blockItemFactory.newInstance(blockFamily, 1);
             if (!item.exists()) {
                 throw new IllegalArgumentException("Unknown block or item");
             }
 
-            EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
-
             GiveItemEvent giveItemEvent = new GiveItemEvent(playerEntity);
             item.send(giveItemEvent);
+
             if (!giveItemEvent.isHandled()) {
                 item.destroy();
+                quantity -= quantityLeft;
+                break;
             }
         }
 

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -70,10 +70,15 @@ public class ItemCommands extends BaseComponentSystem {
         if (matches.size() == 1) {
             Prefab prefab = assetManager.getAsset(matches.iterator().next(), Prefab.class).orElse(null);
             if (prefab != null && prefab.getComponent(ItemComponent.class) != null) {
-                EntityRef item = entityManager.create(prefab);
                 EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
-                if (!inventoryManager.giveItem(playerEntity, playerEntity, item)) { //TODO Give specified quantity of item (int itemAmount)
-                    item.destroy();
+
+                for (int quantityLeft = itemAmount; quantityLeft > 0; quantityLeft--) {
+                    EntityRef item = entityManager.create(prefab);
+                    if (!inventoryManager.giveItem(playerEntity, playerEntity, item)) {
+                        item.destroy();
+                        itemAmount -= quantityLeft;
+                        break;
+                    }
                 }
 
                 return "You received "


### PR DESCRIPTION
### Contains

Fix most of #2835 (everything apart from the bulkGiveItem command), including the lag on large numbers of items introduced in #2678.

### How to test

Run the command "give axe 1000", and observe that your inventory is filled with axes, and the command window reported the number of axes actually given.

Run the command "give dirt 10000000" and observe that the game no longer lags, but the command executes successfully, and reports the number of dirt blocks given.

### Outstanding before merging

This way of giving multiple items/blocks is a much more robust solution than the previous one, but it does it by giving them one at a time, rather than a stack at a time. I'm not sure if that's an issue, but it might be worthwhile to test giving a full inventory of items on a remote server, to make sure it's not too slow.

Also, the default number of items given is always 1; I'm not sure if you want this to be 16 as well. I tried to change it, and found about 4 different ways to get the stack size of an item, but they all returned the same for stackable and unstackable items, so I'm not sure how to determine whether or not an item is stackable.