### PR TITLE
Empty space input for chat/console handling

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.console.ui;
 
+import org.codehaus.plexus.util.StringUtils;
 import org.terasology.input.MouseInput;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.CoreMessageType;
@@ -73,9 +74,9 @@ public class ChatScreen extends CoreScreenLayer {
         getManager().setFocus(commandLine);
 
         commandLine.subscribe(widget -> {
-            String text = commandLine.getText().trim();
+            String text = commandLine.getText();
 
-            if (!text.isEmpty()) {
+            if (StringUtils.isNotBlank(text)) {
                 String command = "say";
                 List<String> params = Collections.singletonList(text);
 

--- a/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ChatScreen.java
@@ -73,7 +73,7 @@ public class ChatScreen extends CoreScreenLayer {
         getManager().setFocus(commandLine);
 
         commandLine.subscribe(widget -> {
-            String text = commandLine.getText();
+            String text = commandLine.getText().trim();
 
             if (!text.isEmpty()) {
                 String command = "say";
@@ -85,6 +85,10 @@ public class ChatScreen extends CoreScreenLayer {
                 scrollArea.moveToBottom();
                 MiniChatOverlay overlay = nuiManager.addOverlay("engine:minichatOverlay", MiniChatOverlay.class);
                 overlay.setVisible(true);
+                nuiManager.closeScreen(this);
+            }
+            else{
+                commandLine.setText("");
                 nuiManager.closeScreen(this);
             }
         });

--- a/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
@@ -73,8 +73,10 @@ public class ConsoleScreen extends CoreScreenLayer {
             }
         });
         commandLine.subscribe(widget -> {
-            console.execute(commandLine.getText(), localPlayer.getClientEntity());
-            commandLine.setText("");
+            String text = commandLine.getText().trim();
+            if(!text.isEmpty()) {
+                console.execute(text, localPlayer.getClientEntity());
+            }
             scrollArea.moveToBottom();
         });
 

--- a/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.console.ui;
 
+import org.codehaus.plexus.util.StringUtils;
 import org.terasology.input.MouseInput;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.Message;
@@ -73,8 +74,8 @@ public class ConsoleScreen extends CoreScreenLayer {
             }
         });
         commandLine.subscribe(widget -> {
-            String text = commandLine.getText().trim();
-            if(!text.isEmpty()) {
+            String text = commandLine.getText();
+            if(StringUtils.isNotBlank(text)) {
                 console.execute(text, localPlayer.getClientEntity());
             }
             scrollArea.moveToBottom();

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -354,7 +354,13 @@ public class UIText extends CoreWidget {
                         eventHandled = true;
                     }
                 }
-                if (event.getKeyCharacter() != 0 && lastFont.hasCharacter(event.getKeyCharacter())) {
+                if(event.getKey() == Keyboard.Key.ENTER || event.getKey() == Keyboard.Key.NUMPAD_ENTER){
+                    for (ActivateEventListener listener : activationListeners) {
+                        listener.onActivated(this);
+                    }
+                    eventHandled = true;
+                }
+                else if (event.getKeyCharacter() != 0 && lastFont.hasCharacter(event.getKeyCharacter())) {
                     String fullText = text.get();
                     String before = fullText.substring(0, Math.min(getCursorPosition(), selectionStart));
                     String after = fullText.substring(Math.max(getCursorPosition(), selectionStart));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes the problems addressed in #2834 

Inputting a string of empty spaces into either console or chat treats it as an empty message. (Does not send that message)
Inputting an empty message into console does nothing.
Inputting an empty message into chat closes the chat box.
Any messages are trimmed(white space before and after messages is removed)

### How to test

Open up chat, try sending an empty message.
Open up chat, try sending a message with only spaces in it.
Open up console, try sending an empty message.
Open up console, try sending a message with only empty spaces in it.

Check that console and chat both trim the message before it is sent.


### Outstanding before merging

Nothing that I know of!
