### PR TITLE
Fixes Oddities surrounding maintaining momentum after hitting a ceiling

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -673,7 +673,13 @@ public class KinematicCharacterMover implements CharacterMover {
             }
         } else {
             if (moveResult.isTopHit() && endVelocity.y > 0) {
-                endVelocity.y = -0.5f * endVelocity.y;
+                if (input.isFirstRun()) {
+                    Vector3f hitVelocity = new Vector3f(state.getVelocity());
+                    hitVelocity.y += (distanceMoved.y / moveDelta.y) * (endVelocity.y - state.getVelocity().y);
+                    logger.debug("Hit at " + hitVelocity);
+                    entity.send(new VerticalCollisionEvent(state.getPosition(), hitVelocity));
+                }
+                endVelocity.y = -0.0f * endVelocity.y;
             }
 
             // Jump again in mid-air only if a jump was requested and there are jumps remaining.
@@ -698,10 +704,14 @@ public class KinematicCharacterMover implements CharacterMover {
 
             state.setGrounded(false);
         }
-        state.getVelocity().set(endVelocity);
         if (input.isFirstRun() && moveResult.isHorizontalHit()) {
-            entity.send(new HorizontalCollisionEvent(state.getPosition(), state.getVelocity()));
+              Vector3f hitVelocity = new Vector3f(state.getVelocity());
+              hitVelocity.x += (distanceMoved.x / moveDelta.x) * (endVelocity.x - state.getVelocity().x);
+              hitVelocity.z += (distanceMoved.z / moveDelta.z) * (endVelocity.z - state.getVelocity().z);
+              logger.debug("Hit at " + hitVelocity);
+              entity.send(new HorizontalCollisionEvent(state.getPosition(), hitVelocity));
         }
+        state.getVelocity().set(endVelocity);
         if (state.isGrounded() || movementComp.mode == MovementMode.SWIMMING || movementComp.mode == MovementMode.DIVING) {
             state.setFootstepDelta(
                     state.getFootstepDelta() + distanceMoved.length() / movementComp.distanceBetweenFootsteps);

--- a/engine/src/main/java/org/terasology/physics/engine/SweepCallback.java
+++ b/engine/src/main/java/org/terasology/physics/engine/SweepCallback.java
@@ -34,14 +34,14 @@ public interface SweepCallback {
     float calculateAverageSlope(float originalSlope, float checkingOffset);
 
     /**
-     * Returns where the closest hit took place.
+     * Returns the normal of the surface that has been hit in the closest hit.
      *
      * @return
      */
     Vector3f getHitNormalWorld();
 
     /**
-     * Returns the normal of the surface that has been hit in the closest hit.
+     * Returns where the closest hit took place.
      *
      * @return
      */

--- a/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -225,9 +225,10 @@ public class HealthAuthoritySystem extends BaseComponentSystem implements Update
     @ReceiveEvent(components = {HealthComponent.class})
     public void onLand(VerticalCollisionEvent event, EntityRef entity) {
         HealthComponent health = entity.getComponent(HealthComponent.class);
+        float speed = Math.abs(event.getVelocity().y);
 
-        if (event.getVelocity().y < 0 && -event.getVelocity().y > health.fallingDamageSpeedThreshold) {
-            int damage = (int) ((-event.getVelocity().y - health.fallingDamageSpeedThreshold) * health.excessSpeedDamageMultiplier);
+        if (speed > health.fallingDamageSpeedThreshold) {
+            int damage = (int) ((speed - health.fallingDamageSpeedThreshold) * health.excessSpeedDamageMultiplier);
             if (damage > 0) {
                 checkDamage(entity, damage, EngineDamageTypes.PHYSICAL.get(), EntityRef.NULL, EntityRef.NULL);
             }

--- a/modules/Core/src/main/java/org/terasology/logic/health/HealthComponent.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/HealthComponent.java
@@ -34,7 +34,7 @@ public final class HealthComponent implements Component {
     @Replicate
     public float fallingDamageSpeedThreshold = 20;
     @Replicate
-    public float horizontalDamageSpeedThreshold = 100;
+    public float horizontalDamageSpeedThreshold = 20;
     @Replicate
     public float excessSpeedDamageMultiplier = 10f;
 


### PR DESCRIPTION
###Contains

Fixes PR #2821 
Makes velocity of character = 0 when the character hits a ceiling. The gravity than does the rest.
Character takes damage if he/she hits the ceiling above allowable speed limit.
Made crashing speed generation more consistent and better than previously(Does not guarantee if player will take damage upon horizontal collision but is certainly better and consistent than the previous one)

###How to test

Run the game. Go under a low ceiling environment eg. under a tree.
Enable hjump.
Jump and die due to hitting on ground at a speed as if falling from a mountain.