### PR TITLE
Fix #2836

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/ResettableUIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/ResettableUIText.java
@@ -42,39 +42,12 @@ public class ResettableUIText extends UIText {
     @Override
     public void onDraw(Canvas canvas) {
         Rect2i clearButtonRegion = Rect2i.createFromMinAndSize(0, 0, 30, canvas.size().y);
-
-        if (text.get() == null) {
-            text.set("");
-        }
-        if (isShowingHintText) {
-            setCursorPosition(0);
-            if (!text.get().equals(hintText) && text.get().endsWith(hintText)) {
-                text.set(text.get().substring(0, text.get().length()-hintText.length()));
-                setCursorPosition(text.get().length());
-                isShowingHintText = false;
-            }
-        }
-        lastFont = canvas.getCurrentStyle().getFont();
         lastWidth = canvas.size().x - clearButtonRegion.size().x;
         if (isEnabled()) {
             canvas.addInteractionRegion(interactionListener, Rect2i.createFromMinAndMax(0, 0, canvas.size().x, canvas.size().y));
             canvas.addInteractionRegion(clearInteractionListener, Rect2i.createFromMinAndMax(canvas.size().x, 0, canvas.size().x +
                     clearButtonRegion.size().x, canvas.size().y));
         }
-        correctCursor();
-
-        int widthForDraw = (multiline) ? canvas.size().x - clearButtonRegion.size().x : lastFont.getWidth(getText());
-
-        try (SubRegion ignored = canvas.subRegion(canvas.getRegion(), true);
-             SubRegion ignored2 = canvas.subRegion(Rect2i.createFromMinAndSize(-offset, 0, widthForDraw + 1, Integer.MAX_VALUE), false)) {
-            canvas.drawText(text.get(), canvas.getRegion());
-            if (isFocused()) {
-                if (hasSelection()) {
-                    drawSelection(canvas);
-                } else {
-                    drawCursor(canvas);
-                }
-            }
-        }
+        drawAll(canvas, canvas.size().x - clearButtonRegion.size().x);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/ResettableUIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/ResettableUIText.java
@@ -46,6 +46,14 @@ public class ResettableUIText extends UIText {
         if (text.get() == null) {
             text.set("");
         }
+        if (isShowingHintText) {
+            setCursorPosition(0);
+            if (!text.get().equals(hintText) && text.get().endsWith(hintText)) {
+                text.set(text.get().substring(0, text.get().length()-hintText.length()));
+                setCursorPosition(text.get().length());
+                isShowingHintText = false;
+            }
+        }
         lastFont = canvas.getCurrentStyle().getFont();
         lastWidth = canvas.size().x - clearButtonRegion.size().x;
         if (isEnabled()) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -69,10 +69,10 @@ public class UIText extends CoreWidget {
 
     /* The placeholder hint text. */
     @LayoutConfig
-    protected String hintText = "";
+    private String hintText = "";
 
     /* Whether the box is currently showing the hint text. */
-    protected boolean isShowingHintText = true;
+    private boolean isShowingHintText = true;
 
     /** Whether the content needs to be displayed on multiple lines. */
     @LayoutConfig
@@ -184,6 +184,14 @@ public class UIText extends CoreWidget {
      */
     @Override
     public void onDraw(Canvas canvas) {
+        lastWidth = canvas.size().x;
+        if (isEnabled()) {
+            canvas.addInteractionRegion(interactionListener, canvas.getRegion());
+        }
+        drawAll(canvas, canvas.size().x);
+    }
+
+    protected void drawAll(Canvas canvas, int multilineWidth) {
         if (text.get() == null) {
             text.set("");
         }
@@ -194,20 +202,14 @@ public class UIText extends CoreWidget {
         if (isShowingHintText) {
             setCursorPosition(0);
             if (!text.get().equals(hintText) && text.get().endsWith(hintText)) {
-                text.set(text.get().substring(0, text.get().length()-hintText.length()));
+                text.set(text.get().substring(0, text.get().length() - hintText.length()));
                 setCursorPosition(text.get().length());
                 isShowingHintText = false;
             }
         }
         lastFont = canvas.getCurrentStyle().getFont();
-        lastWidth = canvas.size().x;
-        if (isEnabled()) {
-            canvas.addInteractionRegion(interactionListener, canvas.getRegion());
-        }
         correctCursor();
-
-        int widthForDraw = (multiline) ? canvas.size().x : lastFont.getWidth(getText());
-
+        int widthForDraw = (multiline) ? multilineWidth : lastFont.getWidth(getText());
         try (SubRegion ignored = canvas.subRegion(canvas.getRegion(), true);
              SubRegion ignored2 = canvas.subRegion(Rect2i.createFromMinAndSize(-offset, 0, widthForDraw + 1, Integer.MAX_VALUE), false)) {
             if (isShowingHintText && !readOnly) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -69,10 +69,10 @@ public class UIText extends CoreWidget {
 
     /* The placeholder hint text. */
     @LayoutConfig
-    private String hintText = "";
+    protected String hintText = "";
 
     /* Whether the box is currently showing the hint text. */
-    private boolean isShowingHintText = true;
+    protected boolean isShowingHintText = true;
 
     /** Whether the content needs to be displayed on multiple lines. */
     @LayoutConfig


### PR DESCRIPTION
### Contains

As described in issue #2836, the ResettableUIText widget was not reacting properly to some keyboard events (e.g. backspace) due to `isShowingHintText` in the parent class never being updated. This solves the issue by setting `isShowingHintText` in `ResettableUIText.draw(Canvas)` like it's done in `UIText.draw(Canvas)`.

### How to test

Typing the backspace key in the search/filter field in the Modules screen (from Create Game) now works correctly, while before it was not erasing any text.

### Notes

I'm not sure if this is the right way to fix the bug, considering I'm duplicating ~8 lines of code from a class to a child class and changing the visibility of a couple of fields in the superclass to make them accessible in the subclass. A more sophisticated fix could be splitting the code in the `UIText.onDraw` method in multiple smaller methods and overriding only the strictly necessary one in `ResettableUIText` but I'm not sure how it could be done in practice.