### PR TITLE
Implemented server MOTD (Message Of The Day)

### DIFF
--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -69,7 +69,7 @@ public class NetworkConfig {
         this.serverPort = serverPort;
     }
 
-    public String getServerMOTD(){
+    public String getServerMOTD() {
         return serverMOTD;
     }
 

--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -73,6 +73,10 @@ public class NetworkConfig {
         return serverMOTD;
     }
 
+    public void setServerMOTD(String serverMOTD) {
+        this.serverMOTD = serverMOTD;
+    }
+
     public void addServerInfo(ServerInfo serverInfo) {
         servers.add(serverInfo);
     }

--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -40,6 +40,11 @@ public class NetworkConfig {
     private int serverPort;
 
     /**
+     * The server's Message of The Day
+     */
+    private String serverMOTD;
+
+    /**
      * The master server URL
      */
     private String masterServer = "meta.terasology.org";
@@ -62,6 +67,10 @@ public class NetworkConfig {
 
     public void setServerPort(int serverPort) {
         this.serverPort = serverPort;
+    }
+
+    public String getServerMOTD(){
+        return serverMOTD;
     }
 
     public void addServerInfo(ServerInfo serverInfo) {

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -102,8 +102,9 @@ public class StateIngame implements GameState {
             }
         });
 
-        if (networkSystem.getMode() == NetworkMode.CLIENT)
+        if (networkSystem.getMode() == NetworkMode.CLIENT) {
             nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server MOTD", networkSystem.getServer().getInfo().getMOTD());
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -42,6 +42,7 @@ import org.terasology.persistence.StorageManager;
 import org.terasology.physics.engine.PhysicsEngine;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.rendering.world.WorldRenderer.RenderingStage;
 import org.terasology.world.chunks.ChunkProvider;
@@ -102,7 +103,7 @@ public class StateIngame implements GameState {
         });
 
         if (networkSystem.getMode() == NetworkMode.CLIENT)
-            System.out.println("SERVER MOTD: " + networkSystem.getServer().getInfo().getMOTD());
+            nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server MOTD", networkSystem.getServer().getInfo().getMOTD());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -103,7 +103,9 @@ public class StateIngame implements GameState {
         });
 
         if (networkSystem.getMode() == NetworkMode.CLIENT) {
-            nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server MOTD", networkSystem.getServer().getInfo().getMOTD());
+            String motd = networkSystem.getServer().getInfo().getMOTD();
+            if (motd != null && motd.length() != 0)
+                nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server MOTD", motd);
         }
     }
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -100,6 +100,9 @@ public class StateIngame implements GameState {
                 return !context.get(Config.class).getRendering().getDebug().isHudHidden();
             }
         });
+
+        if (networkSystem.getMode() == NetworkMode.CLIENT)
+            System.out.println("SERVER MOTD: " + networkSystem.getServer().getInfo().getMOTD());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/network/ServerInfoMessage.java
+++ b/engine/src/main/java/org/terasology/network/ServerInfoMessage.java
@@ -33,6 +33,8 @@ public interface ServerInfoMessage {
      */
     String getGameName();
 
+    String getMOTD();
+
     List<WorldInfo> getWorldInfoList();
 
     /**

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -180,6 +180,7 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
                 Channel listenChannel = bootstrap.bind(new InetSocketAddress(port));
                 allChannels.add(listenChannel);
                 logger.info("Started server on port {}", port);
+                logger.info("Server MOTD is \"{}\"", config.getServerMOTD());
 
                 // enumerate all network interfaces that listen
                 Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -819,6 +820,7 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     NetData.ServerInfoMessage getServerInfoMessage() {
         NetData.ServerInfoMessage.Builder serverInfoMessageBuilder = NetData.ServerInfoMessage.newBuilder();
         serverInfoMessageBuilder.setTime(time.getGameTimeInMs());
+        serverInfoMessageBuilder.setMOTD(config.getServerMOTD());
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
         if (worldProvider != null) {
             NetData.WorldInfo.Builder worldInfoBuilder = NetData.WorldInfo.newBuilder();

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -180,7 +180,10 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
                 Channel listenChannel = bootstrap.bind(new InetSocketAddress(port));
                 allChannels.add(listenChannel);
                 logger.info("Started server on port {}", port);
-                logger.info("Server MOTD is \"{}\"", config.getServerMOTD());
+                if (config.getServerMOTD() != null)
+                    logger.info("Server MOTD is \"{}\"", config.getServerMOTD());
+                else
+                    logger.info("No server MOTD is defined");
 
                 // enumerate all network interfaces that listen
                 Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -820,7 +823,8 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     NetData.ServerInfoMessage getServerInfoMessage() {
         NetData.ServerInfoMessage.Builder serverInfoMessageBuilder = NetData.ServerInfoMessage.newBuilder();
         serverInfoMessageBuilder.setTime(time.getGameTimeInMs());
-        serverInfoMessageBuilder.setMOTD(config.getServerMOTD());
+        if (config.getServerMOTD() != null)
+            serverInfoMessageBuilder.setMOTD(config.getServerMOTD());
         WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
         if (worldProvider != null) {
             NetData.WorldInfo.Builder worldInfoBuilder = NetData.WorldInfo.newBuilder();

--- a/engine/src/main/java/org/terasology/network/internal/ServerInfoMessageImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerInfoMessageImpl.java
@@ -53,6 +53,11 @@ class ServerInfoMessageImpl implements ServerInfoMessage {
     }
 
     @Override
+    public String getMOTD() {
+        return info.getMOTD();
+    }
+
+    @Override
     public List<WorldInfo> getWorldInfoList() {
         List<WorldInfo> result = Lists.newArrayList();
 

--- a/engine/src/main/java/org/terasology/protobuf/EntityData.java
+++ b/engine/src/main/java/org/terasology/protobuf/EntityData.java
@@ -3,7 +3,6 @@
 
 package org.terasology.protobuf;
 
-@SuppressWarnings("all")
 public final class EntityData {
   private EntityData() {}
   public static void registerAllExtensions(

--- a/engine/src/main/java/org/terasology/protobuf/NetData.java
+++ b/engine/src/main/java/org/terasology/protobuf/NetData.java
@@ -3,7 +3,6 @@
 
 package org.terasology.protobuf;
 
-@SuppressWarnings("all")
 public final class NetData {
   private NetData() {}
   public static void registerAllExtensions(
@@ -14869,6 +14868,20 @@ public final class NetData {
      * <code>optional float reflectionHeight = 18;</code>
      */
     float getReflectionHeight();
+
+    /**
+     * <code>optional string MOTD = 19;</code>
+     */
+    boolean hasMOTD();
+    /**
+     * <code>optional string MOTD = 19;</code>
+     */
+    java.lang.String getMOTD();
+    /**
+     * <code>optional string MOTD = 19;</code>
+     */
+    com.google.protobuf.ByteString
+        getMOTDBytes();
   }
   /**
    * Protobuf type {@code ServerInfoMessage}
@@ -15074,6 +15087,12 @@ public final class NetData {
             case 149: {
               bitField0_ |= 0x00000008;
               reflectionHeight_ = input.readFloat();
+              break;
+            }
+            case 154: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              mOTD_ = bs;
               break;
             }
           }
@@ -15588,6 +15607,48 @@ public final class NetData {
       return reflectionHeight_;
     }
 
+    public static final int MOTD_FIELD_NUMBER = 19;
+    private java.lang.Object mOTD_;
+    /**
+     * <code>optional string MOTD = 19;</code>
+     */
+    public boolean hasMOTD() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional string MOTD = 19;</code>
+     */
+    public java.lang.String getMOTD() {
+      java.lang.Object ref = mOTD_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          mOTD_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string MOTD = 19;</code>
+     */
+    public com.google.protobuf.ByteString
+        getMOTDBytes() {
+      java.lang.Object ref = mOTD_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        mOTD_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private void initFields() {
       module_ = java.util.Collections.emptyList();
       blockId_ = java.util.Collections.emptyList();
@@ -15604,6 +15665,7 @@ public final class NetData {
       gameName_ = "";
       time_ = 0L;
       reflectionHeight_ = 0F;
+      mOTD_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -15705,6 +15767,9 @@ public final class NetData {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeFloat(18, reflectionHeight_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeBytes(19, getMOTDBytes());
       }
       extensionWriter.writeUntil(536870912, output);
       getUnknownFields().writeTo(output);
@@ -15825,6 +15890,10 @@ public final class NetData {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeFloatSize(18, reflectionHeight_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(19, getMOTDBytes());
       }
       size += extensionsSerializedSize();
       size += getUnknownFields().getSerializedSize();
@@ -15995,6 +16064,8 @@ public final class NetData {
         bitField0_ = (bitField0_ & ~0x00002000);
         reflectionHeight_ = 0F;
         bitField0_ = (bitField0_ & ~0x00004000);
+        mOTD_ = "";
+        bitField0_ = (bitField0_ & ~0x00008000);
         return this;
       }
 
@@ -16110,6 +16181,10 @@ public final class NetData {
           to_bitField0_ |= 0x00000008;
         }
         result.reflectionHeight_ = reflectionHeight_;
+        if (((from_bitField0_ & 0x00008000) == 0x00008000)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.mOTD_ = mOTD_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -16315,6 +16390,11 @@ public final class NetData {
         }
         if (other.hasReflectionHeight()) {
           setReflectionHeight(other.getReflectionHeight());
+        }
+        if (other.hasMOTD()) {
+          bitField0_ |= 0x00008000;
+          mOTD_ = other.mOTD_;
+          onChanged();
         }
         this.mergeExtensionFields(other);
         this.mergeUnknownFields(other.getUnknownFields());
@@ -18114,6 +18194,82 @@ public final class NetData {
       public Builder clearReflectionHeight() {
         bitField0_ = (bitField0_ & ~0x00004000);
         reflectionHeight_ = 0F;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object mOTD_ = "";
+      /**
+       * <code>optional string MOTD = 19;</code>
+       */
+      public boolean hasMOTD() {
+        return ((bitField0_ & 0x00008000) == 0x00008000);
+      }
+      /**
+       * <code>optional string MOTD = 19;</code>
+       */
+      public java.lang.String getMOTD() {
+        java.lang.Object ref = mOTD_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            mOTD_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string MOTD = 19;</code>
+       */
+      public com.google.protobuf.ByteString
+          getMOTDBytes() {
+        java.lang.Object ref = mOTD_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          mOTD_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string MOTD = 19;</code>
+       */
+      public Builder setMOTD(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00008000;
+        mOTD_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string MOTD = 19;</code>
+       */
+      public Builder clearMOTD() {
+        bitField0_ = (bitField0_ & ~0x00008000);
+        mOTD_ = getDefaultInstance().getMOTD();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string MOTD = 19;</code>
+       */
+      public Builder setMOTDBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00008000;
+        mOTD_ = value;
         onChanged();
         return this;
       }
@@ -25230,7 +25386,7 @@ public final class NetData {
       "\022\031\n\021viewDistanceLevel\030\003 \001(\021\022\025\n\005color\030\004 \001" +
       "(\0132\006.Color*\t\010\210\'\020\200\200\200\200\002\"\025\n\005Color\022\014\n\004rgba\030\001" +
       " \001(\r\"2\n\023JoinCompleteMessage\022\020\n\010clientId\030" +
-      "\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"\206\003\n\021ServerInfoMessage\022\033",
+      "\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"\224\003\n\021ServerInfoMessage\022\033",
       "\n\006module\030\001 \003(\0132\013.ModuleInfo\022\023\n\007blockId\030\002" +
       " \003(\021B\002\020\001\022\021\n\tblockName\030\003 \003(\t\022%\n\tcomponent" +
       "\030\004 \003(\0132\022.SerializationInfo\022!\n\005event\030\005 \003(" +
@@ -25239,28 +25395,28 @@ public final class NetData {
       "ily\030\010 \003(\t\022\035\n\tworldInfo\030\t \003(\0132\n.WorldInfo" +
       "\022\030\n\014biomeShortId\030\n \003(\021B\002\020\001\022\017\n\007biomeId\030\013 " +
       "\003(\t\022\017\n\007version\030\017 \001(\t\022\020\n\010gameName\030\020 \001(\t\022\014" +
-      "\n\004time\030\021 \001(\003\022\030\n\020reflectionHeight\030\022 \001(\002*\t" +
-      "\010\210\'\020\200\200\200\200\002\"3\n\tWorldInfo\022\r\n\005title\030\001 \001(\t\022\014\n",
-      "\004time\030\002 \001(\003*\t\010\210\'\020\200\200\200\200\002\"]\n\021SerializationI" +
-      "nfo\022\014\n\004name\030\001 \001(\t\022\n\n\002id\030\002 \001(\005\022\021\n\tfieldNa" +
-      "me\030\003 \003(\t\022\020\n\010fieldIds\030\004 \001(\014*\t\010\210\'\020\200\200\200\200\002\"@\n" +
-      "\nModuleInfo\022\020\n\010moduleId\030\001 \001(\t\022\025\n\rmoduleV" +
-      "ersion\030\002 \001(\t*\t\010\210\'\020\200\200\200\200\002\",\n\rModuleRequest" +
-      "\022\020\n\010moduleId\030\001 \001(\t*\t\010\210\'\020\200\200\200\200\002\"W\n\020ModuleD" +
-      "ataHeader\022\n\n\002id\030\001 \001(\t\022\017\n\007version\030\002 \001(\t\022\014" +
-      "\n\004size\030\003 \001(\003\022\r\n\005error\030\017 \001(\t*\t\010\210\'\020\200\200\200\200\002\"\'" +
-      "\n\nModuleData\022\016\n\006module\030\001 \001(\014*\t\010\210\'\020\200\200\200\200\002\"" +
-      "-\n\017ModuleSendError\022\017\n\007message\030\001 \001(\t*\t\010\210\'",
-      "\020\200\200\200\200\002\"`\n\023CreateEntityMessage\022\035\n\006entity\030" +
-      "\001 \001(\0132\r.PackedEntity\022\037\n\010blockPos\030\002 \001(\0132\r" +
-      ".Vector3iData*\t\010\210\'\020\200\200\200\200\002\"N\n\023UpdateEntity" +
-      "Message\022\035\n\006entity\030\001 \001(\0132\r.PackedEntity\022\r" +
-      "\n\005netId\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/\n\023RemoveEntity" +
-      "Message\022\r\n\005netId\030\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"i\n\014Eve" +
-      "ntMessage\022\020\n\010targetId\030\001 \001(\005\022\025\n\005event\030\002 \001" +
-      "(\0132\006.Event\022%\n\016targetBlockPos\030\003 \001(\0132\r.Vec" +
-      "tor3iData*\t\010\210\'\020\200\200\200\200\002B$\n\027org.terasology.p" +
-      "rotobufB\007NetDataH\001"
+      "\n\004time\030\021 \001(\003\022\030\n\020reflectionHeight\030\022 \001(\002\022\014" +
+      "\n\004MOTD\030\023 \001(\t*\t\010\210\'\020\200\200\200\200\002\"3\n\tWorldInfo\022\r\n\005",
+      "title\030\001 \001(\t\022\014\n\004time\030\002 \001(\003*\t\010\210\'\020\200\200\200\200\002\"]\n\021" +
+      "SerializationInfo\022\014\n\004name\030\001 \001(\t\022\n\n\002id\030\002 " +
+      "\001(\005\022\021\n\tfieldName\030\003 \003(\t\022\020\n\010fieldIds\030\004 \001(\014" +
+      "*\t\010\210\'\020\200\200\200\200\002\"@\n\nModuleInfo\022\020\n\010moduleId\030\001 " +
+      "\001(\t\022\025\n\rmoduleVersion\030\002 \001(\t*\t\010\210\'\020\200\200\200\200\002\",\n" +
+      "\rModuleRequest\022\020\n\010moduleId\030\001 \001(\t*\t\010\210\'\020\200\200" +
+      "\200\200\002\"W\n\020ModuleDataHeader\022\n\n\002id\030\001 \001(\t\022\017\n\007v" +
+      "ersion\030\002 \001(\t\022\014\n\004size\030\003 \001(\003\022\r\n\005error\030\017 \001(" +
+      "\t*\t\010\210\'\020\200\200\200\200\002\"\'\n\nModuleData\022\016\n\006module\030\001 \001" +
+      "(\014*\t\010\210\'\020\200\200\200\200\002\"-\n\017ModuleSendError\022\017\n\007mess",
+      "age\030\001 \001(\t*\t\010\210\'\020\200\200\200\200\002\"`\n\023CreateEntityMess" +
+      "age\022\035\n\006entity\030\001 \001(\0132\r.PackedEntity\022\037\n\010bl" +
+      "ockPos\030\002 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002\"N" +
+      "\n\023UpdateEntityMessage\022\035\n\006entity\030\001 \001(\0132\r." +
+      "PackedEntity\022\r\n\005netId\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/" +
+      "\n\023RemoveEntityMessage\022\r\n\005netId\030\001 \001(\005*\t\010\210" +
+      "\'\020\200\200\200\200\002\"i\n\014EventMessage\022\020\n\010targetId\030\001 \001(" +
+      "\005\022\025\n\005event\030\002 \001(\0132\006.Event\022%\n\016targetBlockP" +
+      "os\030\003 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002B$\n\027or" +
+      "g.terasology.protobufB\007NetDataH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -25376,7 +25532,7 @@ public final class NetData {
     internal_static_ServerInfoMessage_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_ServerInfoMessage_descriptor,
-        new java.lang.String[] { "Module", "BlockId", "BlockName", "Component", "Event", "AssetId", "AssetUri", "RegisterBlockFamily", "WorldInfo", "BiomeShortId", "BiomeId", "Version", "GameName", "Time", "ReflectionHeight", });
+        new java.lang.String[] { "Module", "BlockId", "BlockName", "Component", "Event", "AssetId", "AssetUri", "RegisterBlockFamily", "WorldInfo", "BiomeShortId", "BiomeId", "Version", "GameName", "Time", "ReflectionHeight", "MOTD", });
     internal_static_WorldInfo_descriptor =
       getDescriptor().getMessageTypes().get(17);
     internal_static_WorldInfo_fieldAccessorTable = new

--- a/engine/src/main/protobuf/NetMessage.proto
+++ b/engine/src/main/protobuf/NetMessage.proto
@@ -151,6 +151,7 @@ message ServerInfoMessage {
     optional string gameName = 16;
     optional int64 time = 17;
     optional float reflectionHeight = 18;
+    optional string MOTD = 19;
 
     extensions 5000 to max;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Implemented server MOTD (Message Of The Day) as suggested in #2855 (no html/markdown formatting for now).

### How to test

Spin up a server (for example launch with `-headless -homedir=server-dir`) to create a configuration. Wait for the server to finish the initialization and start listening on network interfaces, then stop it. Now, open the `config.cfg` in the server's home directory (`server-dir` in the example), go in the `network` section and add a `serverMOTD` field, for example:
```
...
    "serverPort": 25777,
    "serverMOTD": "Hi, I'm the server's MOTD! (change it as you like)",
    "masterServer": "meta.terasology.org"
...
```
Now start the server again, start a client and join the server (`localhost` if on the same machine). As soon as you get to the `StateInGame` state (the loading screen finishes) you'll see a message dialog with the MOTD.

### Outstanding before merging

Again as in my previous PR, I'm not sure if it's the right way of implementing this feature, any kind of improvement suggestion is obviously welcome. In particular, I modified the protobuf message schema `NetMessage.proto` and recompiled it to java with the appropriate gradle task, and the output is included in the commits (`NetData.java` and `EntityData.java`). I'm not sure why these generated files are checked in into git despite the fact they can built automatically.
