### PR TITLE
Moving SimpleBlendMaterialsNode from post rendering to world generation

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -281,6 +281,9 @@ public final class WorldRendererImpl implements WorldRenderer {
         Node overlaysNode = nodeFactory.createInstance(OverlaysNode.class);
         renderGraph.addNode(overlaysNode, "overlaysNode");
 
+        Node simpleBlendMaterialsNode = nodeFactory.createInstance(SimpleBlendMaterialsNode.class);
+        renderGraph.addNode(simpleBlendMaterialsNode, "simpleBlendMaterialsNode");
+
         // TODO: remove this, including associated method in the RenderSystem interface
         Node firstPersonViewNode = nodeFactory.createInstance(FirstPersonViewNode.class);
         renderGraph.addNode(firstPersonViewNode, "firstPersonViewNode");
@@ -313,9 +316,6 @@ public final class WorldRendererImpl implements WorldRenderer {
         // and then it's 2D post-processing all the way to the image shown on the display.
         Node prePostCompositeNode = nodeFactory.createInstance(PrePostCompositeNode.class);
         renderGraph.addNode(prePostCompositeNode, "prePostCompositeNode");
-
-        Node simpleBlendMaterialsNode = nodeFactory.createInstance(SimpleBlendMaterialsNode.class);
-        renderGraph.addNode(simpleBlendMaterialsNode, "simpleBlendMaterialsNode");
 
         // Post-Processing proper: tone mapping, light shafts, bloom and blur passes
         Node lightShaftsNode = nodeFactory.createInstance(LightShaftsNode.class);


### PR DESCRIPTION
SimpleBlendMaterialsNode renders semi-transparent objects, therefore its appropriate for it to be under world-generation section. It partially fixes issue #2804  

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains
Moved SimpleBlendMaterialsNode, to world-generation section (above deferred lighting section) in initRederGraph() function of WorldRendererImpl class.

### Arguments 
- As I mentioned , it renders semi-transparent objects.

- Putting this node after deferred lighting nodes meant semi-transparent objects were being flatly lit.

- Putting this node before deferred lighting nodes gives this node a flatly lit world to blend from but deferred lighting nodes also enable blending, so I think that incorporates  the later lighting effects.

- This node shares the same render code as opaque objects, except the fact that GL_Blend is active.

### Outstanding issues

- [ ] blending against sky, still lit up the objects
- [ ] depth issue with water blocks, objects seem to be rendering behind them(chunksRefractiveReflectiveNode)