### PR TITLE
Make bulkGiveItem and bulkGiveBlock check for non-positive quantity

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -233,6 +233,11 @@ public class BlockCommands extends BaseComponentSystem {
             @CommandParam("searched") String searched,
             @CommandParam(value = "quantity", required = false) Integer quantityParam,
             @CommandParam(value = "shapeName", required = false) String shapeUriParam) {
+
+        if (quantityParam != null && quantityParam < 1) {
+            return "Here, have these zero (0) blocks just like you wanted";
+        }
+
         String searchLowercase = searched.toLowerCase();
         List<String> blocks = findBlockMatches(searchLowercase);
         String result = "Found " + blocks.size() + " block matches when searching for '" + searched + "'.";

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -233,7 +233,6 @@ public class BlockCommands extends BaseComponentSystem {
             @CommandParam("searched") String searched,
             @CommandParam(value = "quantity", required = false) Integer quantityParam,
             @CommandParam(value = "shapeName", required = false) String shapeUriParam) {
-        int quantity = quantityParam != null ? quantityParam : 16;
         String searchLowercase = searched.toLowerCase();
         List<String> blocks = findBlockMatches(searchLowercase);
         String result = "Found " + blocks.size() + " block matches when searching for '" + searched + "'.";

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -148,6 +148,11 @@ public class ItemCommands extends BaseComponentSystem {
             @Sender EntityRef sender,
             @CommandParam("searched") String searched,
             @CommandParam(value = "quantity", required = false) Integer quantityParam) {
+
+        if (quantityParam != null && quantityParam < 1) {
+            return "Here, have these zero (0) items just like you wanted";
+        }
+
         List<String> items = Lists.newArrayList();
         for (String item : listItems(null).split("\n")) {
             if(item.contains(searched.toLowerCase())) {


### PR DESCRIPTION
### Contains

Apply change requested by @xrtariq2594 in  #2842 (making bulkGiveItem print a sarcastic message if you give it a quantity of zero or below).

It also changes bulkGiveBlock to do the same thing, so it only prints out one sarcastic message, rather than searching through the list of blocks and printing out one message for each of them.

And a minor change removing one unnecessary line.

### How to test

Call the bulkGiveItem and bulkGiveBlock commands with a quantity of 0, and observe that you get a sarcastic message, and no blocks or items.