### PR TITLE
Fixes all resizing issues

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/CopyImageToScreenNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/CopyImageToScreenNode.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.rendering.dag.nodes;
 
+import org.lwjgl.opengl.Display;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.rendering.dag.ConditionDependentNode;
 import org.terasology.config.Config;
@@ -27,6 +28,8 @@ import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FBOManagerSubscriber;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
+
+import static org.lwjgl.opengl.GL11.glViewport;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 import static org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs.FINAL_BUFFER;
 import static org.terasology.rendering.world.WorldRenderer.RenderingStage.LEFT_EYE;
@@ -45,6 +48,8 @@ public class CopyImageToScreenNode extends ConditionDependentNode implements FBO
     private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
 
     private FBO sceneFinalFbo;
+    private int displayWidth;
+    private int displayHeight;
 
     @Override
     public void initialise() {
@@ -60,6 +65,7 @@ public class CopyImageToScreenNode extends ConditionDependentNode implements FBO
     public void process() {
         PerformanceMonitor.startActivity("rendering/copyImageToScreen");
         sceneFinalFbo.bindTexture(); // TODO: Convert to a StateChange
+        glViewport(0, 0, displayWidth, displayHeight); // TODO: Convert to a StateChange
         renderFullscreenQuad();
         PerformanceMonitor.endActivity();
     }
@@ -67,5 +73,7 @@ public class CopyImageToScreenNode extends ConditionDependentNode implements FBO
     @Override
     public void update() {
         sceneFinalFbo = displayResolutionDependentFBOs.get(FINAL_BUFFER);
+        displayWidth = Display.getWidth();
+        displayHeight = Display.getHeight();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/CopyImageToScreenNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/CopyImageToScreenNode.java
@@ -65,7 +65,10 @@ public class CopyImageToScreenNode extends ConditionDependentNode implements FBO
     public void process() {
         PerformanceMonitor.startActivity("rendering/copyImageToScreen");
         sceneFinalFbo.bindTexture(); // TODO: Convert to a StateChange
-        glViewport(0, 0, displayWidth, displayHeight); // TODO: Convert to a StateChange
+        // The way things are set-up right now, we can have FBOs that are not the same size as the display (if scale != 100%).
+        // However, when drawing the final image to the screen, we always want the viewport to match the size of display,
+        // and not that of some FBO. Hence, we are manually setting the viewport via glViewport over here.
+        glViewport(0, 0, displayWidth, displayHeight);
         renderFullscreenQuad();
         PerformanceMonitor.endActivity();
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportToSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportToSizeOf.java
@@ -96,9 +96,8 @@ public final class SetViewportToSizeOf implements FBOManagerSubscriber, StateCha
         return fboManager.get(fboName);
     }
 
-    public static void ResetDefaultInstance() {
-        // TODO: Make this a method of StateChange, and override it here.
-        // TODO: Maybe rename this to dispose() ?
+    public static void disposeDefaultInstance() {
+        // TODO: Make a generic dispose() method for StateChange, and override it here.
         defaultInstance = null;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportToSizeOf.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/stateChanges/SetViewportToSizeOf.java
@@ -96,6 +96,12 @@ public final class SetViewportToSizeOf implements FBOManagerSubscriber, StateCha
         return fboManager.get(fboName);
     }
 
+    public static void ResetDefaultInstance() {
+        // TODO: Make this a method of StateChange, and override it here.
+        // TODO: Maybe rename this to dispose() ?
+        defaultInstance = null;
+    }
+
     private final class SetViewportToSizeOfTask implements RenderPipelineTask {
         private int width;
         private int height;

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -118,4 +118,8 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager {
         fboLookup.put(WRITEONLY_GBUFFER, fbo);
         notifySubscribers();
     }
+
+    public FBO.Dimensions getFullScale() {
+        return fullScale;
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -118,8 +118,4 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager {
         fboLookup.put(WRITEONLY_GBUFFER, fbo);
         notifySubscribers();
     }
-
-    public FBO.Dimensions getFullScale() {
-        return fullScale;
-    }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -551,8 +551,8 @@ public final class WorldRendererImpl implements WorldRenderer {
         renderableWorld.dispose();
         worldProvider.dispose();
         // TODO: Shift this to a better place, after a RenderGraph class has been implemented.
-        // TODO: Call ResetDefaultInstance() for every StateChange after it is a method of StateChange.
-        SetViewportToSizeOf.ResetDefaultInstance();
+        // TODO: Call disposeDefaultInstance() for every StateChange after it is a method of StateChange.
+        SetViewportToSizeOf.disposeDefaultInstance();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -551,8 +551,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         renderableWorld.dispose();
         worldProvider.dispose();
         // TODO: Shift this to a better place, after a RenderGraph class has been implemented.
-        // TODO: Call disposeDefaultInstance() for every StateChange after it is a method of StateChange.
-        SetViewportToSizeOf.disposeDefaultInstance();
+            SetViewportToSizeOf.disposeDefaultInstance();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -29,6 +29,7 @@ import org.terasology.rendering.dag.nodes.DownSamplerForExposureNode;
 import org.terasology.rendering.dag.nodes.HighPassNode;
 import org.terasology.rendering.dag.nodes.LateBlurNode;
 import org.terasology.rendering.dag.nodes.UpdateExposureNode;
+import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.openvrprovider.OpenVRProvider;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
@@ -549,6 +550,9 @@ public final class WorldRendererImpl implements WorldRenderer {
     public void dispose() {
         renderableWorld.dispose();
         worldProvider.dispose();
+        // TODO: Shift this to a better place, after a RenderGraph class has been implemented.
+        // TODO: Call ResetDefaultInstance() for every StateChange after it is a method of StateChange.
+        SetViewportToSizeOf.ResetDefaultInstance();
     }
 
     @Override


### PR DESCRIPTION
Contains fixes for the remaining resizing issues.

Existing Problem 1: When you start a game, exit to the main menu and start the game again, resizing will become corrupt and any resizing (maybe even no resizing) that you do will lead to problems.
Cause and Solution: The reason behind that is a static defaultInstance object of class SetViewportToSizeof, and this PR resets that object to null when disposing the RenderGraph.

Existing Problem 2: When playing with scale set to anything other than 100%, the game would not render to entire screen, and would draw only to a small part if scale < 100%, or outside bounds if scale > 100%.
Cause and Solution: This was caused because setViewportToSizeOf used an FBO to obtain the size, but since scale was not 100%, size of FBO was not same as size of Display. This PR fixes that by forcing last Node to set viewport to size of Display (there is still scope for improvement).