### PR TITLE
Ignore out of bounds exception in NearestSortingList, Closes #2742

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/logic/NearestSortingList.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/NearestSortingList.java
@@ -40,7 +40,7 @@ import java.util.TimerTask;
  * sorting of the entities. This class only tries to keep the elements sorted,
  * but does not guarantee it.
  * <br><br>
- * It it therefor use full for graphics purposes, to keep track of the nearest
+ * It it therefore use full for graphics purposes, to keep track of the nearest
  * entities to draw.
  *
  */
@@ -99,11 +99,12 @@ public class NearestSortingList implements Iterable<EntityRef> {
      * from this container.
      *
      * @param e The entity to add. Must have a LocationComponent or an
-     *          IlligalArgumentException is thrown.
+     *          IllegalArgumentException is thrown.
      */
     public synchronized void add(EntityRef e) {
         if (e.getComponent(LocationComponent.class) == null) {
             logger.warn("Adding entity without LocationComponent to container that sorts on location. Entity: {}", e);
+            throw new IllegalArgumentException("Entity has no LocationComponent");
         }
         //new entities are inserted to make sure that new entities are drawn first.
         //Since it is likely the players wants to see new entities over existing ones
@@ -239,9 +240,9 @@ public class NearestSortingList implements Iterable<EntityRef> {
     public synchronized void initialiseAndPause(Camera origin) {
         if (sortingTask != null || timer != null) {
             logger.error("Mis-usages of initialise detected! Initialising again"
-                    + " before stopping the sorting process. Sorting is "
-                    + "stopped now, but it should be done by the user of "
-                    + "this class.");
+                         + " before stopping the sorting process. Sorting is "
+                         + "stopped now, but it should be done by the user of "
+                         + "this class.");
             stop();
         }
         sortingTask = new SortTask(origin);
@@ -259,9 +260,9 @@ public class NearestSortingList implements Iterable<EntityRef> {
     public synchronized void initialise(Camera origin, long period, long initialDelay) {
         if (sortingTask != null || timer != null) {
             logger.error("Mis-usages of initialise detected! Initialising again"
-                    + " before stopping the sorting process. Sorting is "
-                    + "stopped now, but it should be done by the user of "
-                    + "this class.");
+                         + " before stopping the sorting process. Sorting is "
+                         + "stopped now, but it should be done by the user of "
+                         + "this class.");
             stop();
         }
         sortPeriod = period;
@@ -450,6 +451,14 @@ public class NearestSortingList implements Iterable<EntityRef> {
                 Collections.sort(newEnts, comparator);
             } catch (IllegalArgumentException ex) {
                 logger.warn("Entities destroyed during sorting process. Sorting is skipped this round.");
+                clearQueue();
+                return;
+            } catch (ArrayIndexOutOfBoundsException e) {
+                // see https://github.com/MovingBlocks/Terasology/issues/2742
+                // This happens when the component lookup used for sorting is async with the game thread, 
+                // e.g. when a large amount of entities is destroyed or created in a short timespan.
+                // as long as this occurs rarely, it can be ignored.
+                logger.warn("Something went wrong during sorting process. Sorting is skipped this round.");
                 clearQueue();
                 return;
             }


### PR DESCRIPTION
### Contains

Possible fix for #2742.
Destroyed entities were not visible in the sorting thread, causing the lookup to fail.

### How to test

Start with core gameplay and use the large railgun while walking forward/diagonal downwards and collect the destroyed blocks (should lag a lot, make sure to assign enough memory. ~2,5GB worked for me).
Without the PR, you should get the exception from https://github.com/MovingBlocks/Terasology/issues/2742#issuecomment-271735663 after some time.
With the PR, you should get a log message like `10:15:08.759 [Timer-1] WARN  o.t.r.logic.NearestSortingList - Entities destroyed during sorting process. Sorting is skipped this round.` at a similar time.

### Outstanding before merging

We should discuss if the `ComponentTable` has to be thread safe in the first place, before merging.
If the entire environment is expected to work only in the main thread, this may lower the overall performance and we could just swallow the exception in the sorting code.
