### PR TITLE
CopyImageToHMDNode Constructor Rework

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/CopyImageToHMDNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/CopyImageToHMDNode.java
@@ -62,18 +62,18 @@ public class CopyImageToHMDNode extends ConditionDependentNode implements FBOMan
     public CopyImageToHMDNode(Context context) {
         super(context);
 
-        worldRenderer = context.get(WorldRenderer.class);
-
         vrProvider = context.get(OpenVRProvider.class);
         requiresCondition(() -> (context.get(Config.class).getRendering().isVrSupport() && vrProvider.isInitialized()));
 
-        displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
-        requiresFBO(new FBOConfig(LEFT_EYE_FBO, FULL_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
-        requiresFBO(new FBOConfig(RIGHT_EYE_FBO, FULL_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
-        update(); // Cheeky way to initialise finalFbo, leftEyeFbo, rightEyeFbo
-        displayResolutionDependentFBOs.subscribe(this);
+        if (this.isEnabled()) {
+            worldRenderer = context.get(WorldRenderer.class);
 
-        if (vrProvider != null) {
+            displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
+            requiresFBO(new FBOConfig(LEFT_EYE_FBO, FULL_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
+            requiresFBO(new FBOConfig(RIGHT_EYE_FBO, FULL_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
+            update(); // Cheeky way to initialise finalFbo, leftEyeFbo, rightEyeFbo
+            displayResolutionDependentFBOs.subscribe(this);
+
             vrProvider.texType[0].handle = leftEyeFbo.colorBufferTextureId;
             vrProvider.texType[0].eColorSpace = JOpenVRLibrary.EColorSpace.EColorSpace_ColorSpace_Gamma;
             vrProvider.texType[0].eType = JOpenVRLibrary.EGraphicsAPIConvention.EGraphicsAPIConvention_API_OpenGL;
@@ -82,9 +82,9 @@ public class CopyImageToHMDNode extends ConditionDependentNode implements FBOMan
             vrProvider.texType[1].eColorSpace = JOpenVRLibrary.EColorSpace.EColorSpace_ColorSpace_Gamma;
             vrProvider.texType[1].eType = JOpenVRLibrary.EGraphicsAPIConvention.EGraphicsAPIConvention_API_OpenGL;
             vrProvider.texType[1].write();
-        }
 
-        addDesiredStateChange(new EnableMaterial(DEFAULT_TEXTURED_MATERIAL));
+            addDesiredStateChange(new EnableMaterial(DEFAULT_TEXTURED_MATERIAL));
+        }
     }
 
     /**


### PR DESCRIPTION
This PR prevents the creation of 2 unnecessary buffers for most casual players, the leftEye FBO and the rightEye FBO, which are used for HMD (Head Mounted Displays (VR)).

~~However, this PR is probably not complete, as we might want to consider re-working the ConditionDependentNodes. Currently, ConditionDependentNode::checkConditions() returns true if the state of Node was toggled, and false otherwise. Do we really need a return value, since we can just query it with Node.isEnabled() in the calling function (which returns the enabled state, which might be of more interest than toggleState, depending on the particular case)?~~

Pinging @indianajohn and @emanuele3d for review.