### PR TITLE
Added gson to whitelist

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
+++ b/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
@@ -53,6 +53,7 @@ public final class ExternalApiWhitelist {
             .add("com.google.common.math")
             .add("com.google.common.primitives")
             .add("com.google.common.util.concurrent")
+            .add("com.google.gson")
             .add("gnu.trove")
             .add("gnu.trove.decorator")
             .add("gnu.trove.function")


### PR DESCRIPTION
This is linked to https://github.com/Terasology/Books/pull/14
The referenced PR makes a change to the Books module such that recipes (icon images) are now loaded dynamically. The book's page contains a mixture of text and recipes.
Such a page looks like this: 

> Following are some recipes <recipe **{\"blockIngredients\": 2, \"itemIngredients\": [\"WoodAndStone:stone\", \"WoodAndStone:stone\"], \"blockResult\": null, \"itemResult\": \"WoodAndStone:toolStone\", \"resultCount\": 1}**><l><l><l>Some More Text<l><l><recipe **{\"blockIngredients\": 2, \"itemIngredients\": [\"WoodAndStone:stone\", \"WoodAndStone:stone\"], \"blockResult\": null, \"itemResult\": \"WoodAndStone:toolStone\", \"resultCount\": 1}**>More Text

The recipe tags are extracted and the content is parsed as JSON. This is used to dynamically create new recipes (editable books).
Gson is required for this purpose of parsing and needs to be added to the whitelist.