### PR TITLE
Fix reloading of assets on shutdown

### DIFF
--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -435,7 +435,7 @@ public class TerasologyEngine implements GameEngine {
         changeStatus(StandardGameStatus.SHUTTING_DOWN);
 
         if (currentState != null) {
-            currentState.dispose();
+            currentState.dispose(true);
             currentState = null;
         }
 

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -153,11 +153,6 @@ public final class EnvironmentSwitchHandler {
     }
 
 
-    public void handleSwitchToEmptyEnivronment(Context context) {
-        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
-        cheapAssetManagerUpdate(context, environment);
-    }
-
     private void unregisterPrefabFormats(ModuleAwareAssetTypeManager assetTypeManager) {
         if (registeredPrefabFormat != null) {
             assetTypeManager.removeCoreFormat(Prefab.class, registeredPrefabFormat);

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -153,6 +153,11 @@ public final class EnvironmentSwitchHandler {
     }
 
 
+    public void handleSwitchToEmptyEnivronment(Context context) {
+        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
+        cheapAssetManagerUpdate(context, environment);
+    }
+
     private void unregisterPrefabFormats(ModuleAwareAssetTypeManager assetTypeManager) {
         if (registeredPrefabFormat != null) {
             assetTypeManager.removeCoreFormat(Prefab.class, registeredPrefabFormat);

--- a/engine/src/main/java/org/terasology/engine/modes/GameState.java
+++ b/engine/src/main/java/org/terasology/engine/modes/GameState.java
@@ -31,7 +31,11 @@ public interface GameState {
 
     void init(GameEngine engine);
 
-    void dispose();
+    void dispose(boolean shuttingDown);
+
+    default void dispose() {
+        dispose(false);
+    }
 
     void handleInput(float delta);
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -143,6 +143,7 @@ public class StateIngame implements GameState {
 
         ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
         context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
+        context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnivronment(context);
         if (oldEnvironment != null) {
             oldEnvironment.close();
         }

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -143,7 +143,6 @@ public class StateIngame implements GameState {
 
         ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
         context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
-        context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnivronment(context);
         if (oldEnvironment != null) {
             oldEnvironment.close();
         }

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -110,7 +110,7 @@ public class StateIngame implements GameState {
     }
 
     @Override
-    public void dispose() {
+    public void dispose(boolean shuttingDown) {
         ChunkProvider chunkProvider = context.get(ChunkProvider.class);
         chunkProvider.dispose();
 
@@ -143,7 +143,9 @@ public class StateIngame implements GameState {
 
         ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
         context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
-        context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnivronment(context);
+        if (!shuttingDown) {
+            context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnivronment(context);
+        }
         if (oldEnvironment != null) {
             oldEnvironment.close();
         }

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -224,7 +224,7 @@ public class StateLoading implements GameState {
     }
 
     @Override
-    public void dispose() {
+    public void dispose(boolean shuttingDown) {
         EngineTime time = (EngineTime) context.get(Time.class);
         time.setPaused(false);
     }

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -125,7 +125,7 @@ public class StateMainMenu implements GameState {
     }
 
     @Override
-    public void dispose() {
+    public void dispose(boolean shuttingDown) {
         eventSystem.process();
 
         componentSystemManager.shutdown();

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -145,7 +145,7 @@ public class StateHeadlessSetup implements GameState {
     }
 
     @Override
-    public void dispose() {
+    public void dispose(boolean shuttingDown) {
         eventSystem.process();
 
         componentSystemManager.shutdown();


### PR DESCRIPTION
This PR removes a redundant call to the function `cheapAssetManagerUpdate` on shutdown, which causes a reload of assets during shutdown.

How to test: Run the game, do something (or don't) and ensure that you get no weirdness when quitting the game.

Pinging @immortius for review.