### PR TITLE
Show warning if running in 32-bit JVM on 64-bit system

### DIFF
--- a/engine/src/main/java/org/terasology/engine/NonNativeJVMDetector.java
+++ b/engine/src/main/java/org/terasology/engine/NonNativeJVMDetector.java
@@ -46,11 +46,10 @@ public final class NonNativeJVMDetector {
 
     private static boolean posixSystemIs64() throws IOException, InterruptedException {
         Process unameProc = new ProcessBuilder("uname", "-m").start();
-        BufferedReader unameStdout = new BufferedReader(new InputStreamReader(unameProc.getInputStream()));
         unameProc.waitFor();
-        boolean result = unameStdout.readLine().endsWith("64");
-        unameStdout.close();
-        return result;
+        try (BufferedReader unameStdout = new BufferedReader(new InputStreamReader(unameProc.getInputStream()))) {
+            return unameStdout.readLine().endsWith("64");
+        }
     }
 
     private static boolean jvmIs64() {

--- a/engine/src/main/java/org/terasology/engine/NonNativeJVMDetector.java
+++ b/engine/src/main/java/org/terasology/engine/NonNativeJVMDetector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+public final class NonNativeJVMDetector {
+
+    /**
+     * This is <code>true</code> if the engine is running in a 32-bit JVM on a 64-bit system.
+     */
+    public static final boolean JVM_ARCH_IS_NONNATIVE = jvmIsNotNative();
+
+    private NonNativeJVMDetector() {
+    }
+
+    private static boolean jvmIsNotNative() {
+        if (System.getProperty("os.name").contains("Windows")) {
+            //Windows sets the PROCESSOR_ARCHITEW6432 env variable for processes running under WOW64
+            //Source: https://blogs.msdn.microsoft.com/david.wang/2006/03/27/howto-detect-process-bitness/
+            return System.getenv("PROCESSOR_ARCHITEW6432") != null;
+        } else {
+            //Assuming we are on a POSIX-compliant system if we aren't on a Windows system
+            try {
+                return !jvmIs64() && posixSystemIs64();
+            } catch (Exception ex) {
+                return false;
+            }
+        }
+    }
+
+    private static boolean posixSystemIs64() throws IOException, InterruptedException {
+        Process unameProc = new ProcessBuilder("uname", "-m").start();
+        BufferedReader unameStdout = new BufferedReader(new InputStreamReader(unameProc.getInputStream()));
+        unameProc.waitFor();
+        boolean result = unameStdout.readLine().endsWith("64");
+        unameStdout.close();
+        return result;
+    }
+
+    private static boolean jvmIs64() {
+        return System.getProperty("os.arch").endsWith("64"); //match amd64, x86_64, etc
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -231,6 +231,9 @@ public class TerasologyEngine implements GameEngine {
         logger.info("OS: {}, arch: {}, version: {}", System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"));
         logger.info("Max. Memory: {} MiB", Runtime.getRuntime().maxMemory() / ONE_MEBIBYTE);
         logger.info("Processors: {}", Runtime.getRuntime().availableProcessors());
+        if (NonNativeJVMDetector.JVM_ARCH_IS_NONNATIVE) {
+            logger.warn("Running on a 32-bit JVM on a 64-bit system. This may limit performance.");
+        }
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
@@ -19,6 +19,7 @@ package org.terasology.rendering.nui.layers.mainMenu;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.LoggingContext;
+import org.terasology.engine.NonNativeJVMDetector;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
@@ -41,6 +42,9 @@ public class MainMenuScreen extends CoreScreenLayer {
 
         UILabel versionLabel = find("version", UILabel.class);
         versionLabel.setText(TerasologyVersion.getInstance().getHumanVersion());
+
+        UILabel jvmWarningLabel = find("nonNativeJvmWarning", UILabel.class);
+        jvmWarningLabel.setVisible(NonNativeJVMDetector.JVM_ARCH_IS_NONNATIVE);
 
         SelectGameScreen selectScreen = getManager().createScreen(SelectGameScreen.ASSET_URI, SelectGameScreen.class);
 

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -65,6 +65,7 @@
     "connection-failed": "connection-failed",
     "could-not-connect-to-server": "could-not-connect-to-server",
     "crash-reporter": "crash-reporter",
+    "non-native-jvm-warn": "non-native-jvm-warn",
     "credits": "credits",
     "create-game": "create-game",
     "create-game-title": "create-game-title",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -66,6 +66,7 @@
     "connection-failed": "Connection Failed!",
     "could-not-connect-to-server": "Could not connect to server",
     "crash-reporter": "Crash Reporter",
+    "non-native-jvm-warn": "WARNING: you are using a 32-bit JVM on a 64-bit system!\nUse a 64-bit Java installation for the best performance.",
     "credits": "Credits",
     "create-game": "Create",
     "create-game-title": "Create Game",

--- a/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
@@ -100,6 +100,23 @@
                         "offset": 8
                     }
                 }
+            },
+            {
+                "type": "UILabel",
+                "id": "nonNativeJvmWarning",
+                "family": "warning",
+                "text": "${engine:menu#non-native-jvm-warn}",
+                "visible": false,
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-bottom": {
+                        "offset": 8
+                    },
+                    "position-left": {
+                        "offset": 8
+                    }
+                }
             }
         ]
     }


### PR DESCRIPTION
Idea for this patch is from issue #2905.

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

If the game is running in a 32-bit JVM on a 64-bit system, a warning is shown in the console and on the main menu screen.
This can help users which get limited performance due to running in a 32-bit JVM when they could install a 64-bit one (thus native for their CPU).

This is not uncommon especially on Windows, I remember seeing people playing other Java games on x86 JVMs despite being on a 64-bit CPU and OS.

On Windows, this is checked by simply verifying if the [PROCESSOR_ARCHITEW6432](https://blogs.msdn.microsoft.com/david.wang/2006/03/27/howto-detect-process-bitness/) is set.
On POSIX OSs, the JVM architecture is read from the "os.arch" property and the real system architecture by reading the output of "uname -m".

### How to test

You need to be on a 64-bit CPU and OS, and have installed both a 64-bit JVM ("native") and a 32-bit one ("non-native"). Start the game on this branch with the 64-bit JVM (your usual run configuration) and everything should be as before. Now start Terasology with the 32-bit one - some examples of how to do it:
* in IntelliJ: create a new run configuration by duplicating the default one ("Terasology"); then, change the JRE path pointing it to the directory where the 32-bit one is installed (for example, on Windows should be something like `C:\Program Files (x86)\Java\jre1.8.0_121`), then run with this new configuration; if there are memory parameters you may need to remove or tweak them, for example during my tests the `-Xms256m -Xmx1536m` copied from the normal configuration didn't worked with the x86 JVM;
* from the command line: run `gradlew game` or `gradlew server` (with the second one you will obviously see the warning in the terminal only) with the JAVA_HOME env variable set to the 32-bit JVM home; for example on my Ubuntu 16.04 I did `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/ ./gradlew server`.

In this case, you should see the warning. On stdout, it's printed right after the system info (after `Processors`); on the main menu screen, it's shown in red in the bottom-left corner.
