### PR TITLE
TranslationSystem API & reload i18n module assets

### DIFF
--- a/engine/src/main/java/org/terasology/i18n/TranslationRefreshSystem.java
+++ b/engine/src/main/java/org/terasology/i18n/TranslationRefreshSystem.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.i18n;
+
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+
+//the translation system is only refreshed as EngineSubsystem but not when the module environment is loaded
+//this system allows the translation system to load the module assets
+@RegisterSystem
+public class TranslationRefreshSystem extends BaseComponentSystem {
+
+    @In
+    private TranslationSystem translationSystem;
+
+    @Override
+    public void initialise() {
+        translationSystem.refresh();
+    }
+}

--- a/engine/src/main/java/org/terasology/i18n/TranslationRefreshSystem.java
+++ b/engine/src/main/java/org/terasology/i18n/TranslationRefreshSystem.java
@@ -19,8 +19,10 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.registry.In;
 
-//the translation system is only refreshed as EngineSubsystem but not when the module environment is loaded
-//this system allows the translation system to load the module assets
+/**
+ * This system refreshes the translation system during the initialization, reloading the i18n files from the module environment.
+ * The translation system by it's own is not refreshed, as it is an EngineSubsystem.
+ */
 @RegisterSystem
 public class TranslationRefreshSystem extends BaseComponentSystem {
 
@@ -29,6 +31,7 @@ public class TranslationRefreshSystem extends BaseComponentSystem {
 
     @Override
     public void initialise() {
+        //TODO See https://github.com/MovingBlocks/Terasology/issues/2433 for further translation support.
         translationSystem.refresh();
     }
 }

--- a/engine/src/main/java/org/terasology/i18n/TranslationSystem.java
+++ b/engine/src/main/java/org/terasology/i18n/TranslationSystem.java
@@ -16,15 +16,17 @@
 
 package org.terasology.i18n;
 
+import org.terasology.engine.Uri;
+import org.terasology.module.sandbox.API;
+
 import java.util.Locale;
 import java.util.function.Consumer;
-
-import org.terasology.engine.Uri;
 
 /**
  * A translation system that consists of different projects. An i18n string can either
  * contain a project URI or be used directly in a project.
  */
+@API
 public interface TranslationSystem {
 
     /**


### PR DESCRIPTION
### Contains

Adds i18n support for modules

### How to test

Create a module `TestAndTryout` (or any other name, replace the translation key if so) with the following system:

```
@RegisterSystem
public class GreeterSystem extends BaseComponentSystem {

    private static final Logger logger = LoggerFactory.getLogger(GreeterSystem.class);

    @In
    private TranslationSystem translationSystem;

    @ReceiveEvent
    public void onPlayerSpawn(OnPlayerSpawnedEvent event, EntityRef player) {
        logger.info(translationSystem.translate("${TestAndTryout:greeter#greet}"));
    }
}
```

add to the module `assets/i18n` (create folder):

greeter.lang
```
{
   "greet": "greet"
}
```

greeter_en.lang
```
{
   "greet": "Hello new player."
}
```

greeter_de.lang
```
{
   "greet": "Hallo neuer Spieler."
}
```

- Without the PR the system will not load (system is not api)
- With the PR, start a game with the module and english language setting, output should be "Hello new player", then change language to german and start another game, output should now be "Hallo neuer Spieler".

### Outstanding before merging

The refresh system feels a bit "hacky" but i found no better place in the I18nSubsystem to register for the game to be started. I would be fine to merge it the way it is though.