### PR TITLE
First attempt for api test

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -49,5 +49,6 @@ dependencies {
     compile group: 'junit', name: 'junit', version: '4.12'
     compile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     compile group: 'org.jboss.shrinkwrap', name: 'shrinkwrap-depchain-java7', version: '1.1.3'
+    compile group: 'org.evosuite', name:'evosuite-standalone-runtime', version: '1.0.4'
 }
 

--- a/engine-tests/src/api-tests/java/org/terasology/engine/ComponentFieldUriTest.java
+++ b/engine-tests/src/api-tests/java/org/terasology/engine/ComponentFieldUriTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.evosuite.runtime.EvoAssertions.*;
+import org.terasology.naming.Name;
+import org.terasology.testUtil.ApiTestsParams;
+import org.terasology.testUtil.ApiTestsUtils;
+import org.terasology.testUtil.MethodSignature;
+
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ComponentFieldUriTest {
+
+    private static Class<ComponentFieldUri> cl;
+
+    private static Set<MethodSignature> registeredMethods;
+
+    private static Set<MethodSignature> registeredConstructors;
+
+    @BeforeClass
+    public static void setupClass() {
+        cl = ComponentFieldUri.class;
+        registeredMethods = ApiTestsUtils.getModifiableSet(ApiTestsParams.ObjectClassMethods);
+        registeredMethods.add(new MethodSignature("getObjectName", null,Modifier.PUBLIC,Name.class,null));
+        registeredMethods.add(new MethodSignature("getModuleName",null,Modifier.PUBLIC,Name.class,null));
+        registeredMethods.add(new MethodSignature("getComponentUri",null,Modifier.PUBLIC,SimpleUri.class,null));
+        registeredMethods.add(new MethodSignature("getFieldName", null,Modifier.PUBLIC,String.class,null));
+        registeredMethods.add(new MethodSignature("isValid",null,Modifier.PUBLIC,boolean.class,null));
+
+        registeredConstructors = new HashSet<>();
+        registeredConstructors.add(new MethodSignature("ComponentFieldUri",new Class[]{SimpleUri.class,String.class},Modifier.PUBLIC,null));
+        registeredConstructors.add(new MethodSignature("ComponentFieldUri",new Class[]{String.class},Modifier.PUBLIC,null));
+    }
+
+    @Test
+    public void majorIncreaseTest() {
+        ApiTestsUtils.compareConstructors(cl,registeredConstructors);
+        ApiTestsUtils.compareMethods(cl,registeredMethods);
+    }
+
+    @Test
+    public void minorIncreaseTest() {
+        ApiTestsUtils.compareConstructorsNum(cl,registeredConstructors);
+        ApiTestsUtils.compareMethodsNum(cl,registeredMethods);
+
+    }
+
+    @Test(timeout = 4000)
+    public void constructorTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = null;
+        try {
+            componentFieldUri0 = new ComponentFieldUri((String) null);
+            fail("Expecting exception: NullPointerException");
+
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void objectNameTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("");
+        Name name0 = componentFieldUri0.getObjectName();
+        assertEquals("", name0.toString());
+    }
+
+    @Test(timeout = 4000)
+    public void objectNameTest2()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "f`");
+        // Undeclared exception!
+        try {
+            componentFieldUri0.getObjectName();
+            fail("Expecting exception: NullPointerException");
+
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void isValidTest1()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("29N.~L;", "29N.~L;");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, (String) null);
+        componentFieldUri0.getObjectName();
+        assertFalse(componentFieldUri0.isValid());
+    }
+
+    @Test(timeout = 4000)
+    public void isValidTest2()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "p");
+        // Undeclared exception!
+        try {
+            componentFieldUri0.isValid();
+            fail("Expecting exception: NullPointerException");
+
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void isValidTest3()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("29N.~L;", "29N.~L;");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, (String) null);
+        boolean boolean0 = componentFieldUri0.isValid();
+        assertFalse(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void moduleNameTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("7bgvD4");
+        Name name0 = componentFieldUri0.getModuleName();
+        assertEquals("", name0.toString());
+    }
+
+    @Test(timeout = 4000)
+    public void moduleNameTest2()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "H0D)v=YM~g]");
+        // Undeclared exception!
+        try {
+            componentFieldUri0.getModuleName();
+            fail("Expecting exception: NullPointerException");
+
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void moduleNameTest3()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("29N.~L;", "29N.~L;");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, (String) null);
+        componentFieldUri0.getModuleName();
+        assertFalse(componentFieldUri0.isValid());
+    }
+
+    @Test(timeout = 4000)
+    public void fieldNameTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "p");
+        String string0 = componentFieldUri0.getFieldName();
+        assertEquals("p", string0);
+    }
+
+    @Test(timeout = 4000)
+    public void fieldNameTest2()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("", "");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, "");
+        String string0 = componentFieldUri0.getFieldName();
+        assertEquals("", string0);
+    }
+
+    @Test(timeout = 4000)
+    public void fieldNameTest3()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("org.terasology.naming.Name", "org.terasology.naming.Name");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, "org.terasology.naming.Name");
+        componentFieldUri0.hashCode();
+        assertEquals("org.terasology.naming.Name", componentFieldUri0.getFieldName());
+    }
+
+    @Test(timeout = 4000)
+    public void fieldNameTest4()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "$,,8|` ZR");
+        componentFieldUri0.getComponentUri();
+        assertEquals("$,,8|` ZR", componentFieldUri0.getFieldName());
+    }
+
+    @Test(timeout = 4000)
+    public void componentUriTest1()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("org.terasology.naming.Name", "org.terasology.naming.Name");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, "org.terasology.naming.Name");
+        componentFieldUri0.getComponentUri();
+        assertEquals("org.terasology.naming.Name", componentFieldUri0.getFieldName());
+    }
+
+    @Test(timeout = 4000)
+    public void componentUriTest2()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("");
+        SimpleUri simpleUri0 = componentFieldUri0.getComponentUri();
+        assertFalse(simpleUri0.isValid());
+    }
+
+    @Test(timeout = 4000)
+    public void toStringTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "N.sd6<;I6rqW%;<@%0");
+        // Undeclared exception!
+        try {
+            componentFieldUri0.toString();
+            fail("Expecting exception: NullPointerException");
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void toStringTest2()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("cX>?els)NUnN", "cX>?els)NUnN");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, "cX>?els)NUnN");
+        String string0 = componentFieldUri0.toString();
+        assertEquals("cX>?els)NUnN:cX>?els)NUnN.cX>?els)NUnN", string0);
+    }
+
+    @Test(timeout = 4000)
+    public void toStringTest3()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("");
+        String string0 = componentFieldUri0.toString();
+        assertEquals("", string0);
+    }
+
+    @Test(timeout = 4000)
+    public void hashCodeTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, "");
+        // Undeclared exception!
+        try {
+            componentFieldUri0.hashCode();
+            fail("Expecting exception: NullPointerException");
+
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void hashCodeTest2()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("7bgvD4");
+        componentFieldUri0.hashCode();
+    }
+
+    @Test(timeout = 4000)
+    public void isValidFieldNameTest1()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("po]&Kw14VaG.a#JgS");
+        boolean boolean0 = componentFieldUri0.isValid();
+        assertEquals("a#JgS", componentFieldUri0.getFieldName());
+        assertFalse(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void isValidFieldNameTest2()  throws Throwable {
+        SimpleUri simpleUri0 = new SimpleUri("org.terasology.naming.Name", "org.terasology.naming.Name");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, "org.terasology.naming.Name");
+        boolean boolean0 = componentFieldUri0.isValid();
+        assertEquals("org.terasology.naming.Name", componentFieldUri0.getFieldName());
+        assertTrue(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void isValidFieldNameTest3()  throws Throwable {
+        SimpleUri simpleUri0 = new SimpleUri("29N.~L;", "29N.~L;");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, (String) null);
+        String string0 = componentFieldUri0.getFieldName();
+        assertNull(string0);
+        assertFalse(componentFieldUri0.isValid());
+    }
+
+    @Test(timeout = 4000)
+    public void equalsTest1()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("cX>?els)NUnN", "cX>?els)NUnN");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, "cX>?els)NUnN");
+        ComponentFieldUri componentFieldUri1 = new ComponentFieldUri("cX>?els)NUnN");
+        boolean boolean0 = componentFieldUri1.equals(componentFieldUri0);
+        assertEquals("cX>?els)NUnN", componentFieldUri0.getFieldName());
+        assertFalse(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void equalsTest2()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("(:HV;FAyy>9# F");
+        ComponentFieldUri componentFieldUri1 = new ComponentFieldUri(".");
+        boolean boolean0 = componentFieldUri0.equals(componentFieldUri1);
+        assertTrue(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void equalsTest3()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri("7bgvD4");
+        boolean boolean0 = componentFieldUri0.equals("7bgvD4");
+        assertFalse(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void equalsTest4()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, (String) null);
+        ComponentFieldUri componentFieldUri1 = new ComponentFieldUri(".");
+        // Undeclared exception!
+        try {
+            componentFieldUri0.equals(componentFieldUri1);
+            fail("Expecting exception: NullPointerException");
+
+        } catch(NullPointerException e) {
+            //
+            // no message in exception (getMessage() returned null)
+            //
+            verifyException("org.terasology.engine.ComponentFieldUri", e);
+        }
+    }
+
+    @Test(timeout = 4000)
+    public void equalsTest5()  throws Throwable  {
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri((SimpleUri) null, (String) null);
+        boolean boolean0 = componentFieldUri0.equals(componentFieldUri0);
+        assertTrue(boolean0);
+    }
+
+    @Test(timeout = 4000)
+    public void equalsTest6()  throws Throwable  {
+        SimpleUri simpleUri0 = new SimpleUri("29N.~L;", "29N.~L;");
+        ComponentFieldUri componentFieldUri0 = new ComponentFieldUri(simpleUri0, (String) null);
+        boolean boolean0 = componentFieldUri0.equals((Object) null);
+        assertFalse(boolean0);
+        assertFalse(componentFieldUri0.isValid());
+    }
+}

--- a/engine-tests/src/api-tests/java/org/terasology/testUtil/ApiTestsParams.java
+++ b/engine-tests/src/api-tests/java/org/terasology/testUtil/ApiTestsParams.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.testUtil;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+/**
+ * Some parameters for API test.
+ * It includes the method signature for common classes.
+ */
+public class ApiTestsParams {
+
+    /**
+     * All public methods in Object class.
+     */
+    public static final Set<MethodSignature> ObjectClassMethods = new ImmutableSet.Builder<MethodSignature>()
+            .add(new MethodSignature("equals", new Class[] {Object.class},Modifier.PUBLIC,boolean.class,null))
+            .add(new MethodSignature("toString",null,Modifier.PUBLIC,String.class,null))
+            .add(new MethodSignature("hashCode",null,Modifier.PUBLIC,int.class,null))
+            .add(new MethodSignature("wait",new Class[]{long.class,int.class},Modifier.PUBLIC|Modifier.FINAL,void.class,new Class[]{InterruptedException.class}))
+            .add(new MethodSignature("wait", new Class[]{long.class},Modifier.PUBLIC|Modifier.FINAL|Modifier.NATIVE,void.class,new Class[]{InterruptedException.class}))
+            .add(new MethodSignature("wait", null,Modifier.PUBLIC|Modifier.FINAL, void.class, new Class[]{InterruptedException.class}))
+            .add(new MethodSignature("getClass",null,Modifier.PUBLIC|Modifier.FINAL|Modifier.NATIVE, Class.class,null))
+            .add(new MethodSignature("notify",null,Modifier.PUBLIC|Modifier.FINAL|Modifier.NATIVE,void.class,null))
+            .add(new MethodSignature("notifyAll",null,Modifier.PUBLIC|Modifier.FINAL|Modifier.NATIVE,void.class,null))
+            .build();
+}

--- a/engine-tests/src/api-tests/java/org/terasology/testUtil/ApiTestsUtils.java
+++ b/engine-tests/src/api-tests/java/org/terasology/testUtil/ApiTestsUtils.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.testUtil;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Some static methods used for API test.
+ */
+public class ApiTestsUtils {
+
+    /**
+     * Compare method signatures between all public methods in an API class and the methods registered in the API test.
+     * @param cl The API class
+     * @param registeredMethods All public methods registered in the API test
+     */
+    public static void compareMethods(Class cl, Set<MethodSignature> registeredMethods) {
+
+        for (MethodSignature registeredMethod : registeredMethods) {
+            String registeredName = registeredMethod.getName();
+            Class[] registeredParams = registeredMethod.getParameterTypes();
+            try {
+                Method currentMethod = cl.getMethod(registeredName,registeredParams);
+                int currentModifiers = currentMethod.getModifiers();
+                assertEquals(String.format("Major increase required: method %s changed modifiers from %s to %s",registeredMethod.getName(),Modifier.toString(registeredMethod.getModifiers()),Modifier.toString(currentModifiers)), registeredMethod.getModifiers(),currentModifiers);
+
+                Class currentReturnType = currentMethod.getReturnType();
+                assertEquals(String.format("Major increase required: method %s changed return type from %s to %s",registeredMethod.getName(), registeredMethod.getReturnType().toString(),currentReturnType.toString()), registeredMethod.getReturnType(), currentReturnType);
+
+                Class[] currentExceptionTypes = currentMethod.getExceptionTypes();
+                assertArrayEquals(String.format("Major increase required: method %s changed exception types from %s to %s", registeredMethod.getName(), Arrays.toString(registeredMethod.getExceptionTypes()), Arrays.toString(currentExceptionTypes)), registeredMethod.getExceptionTypes(),currentExceptionTypes);
+            } catch (NoSuchMethodException e) {
+                fail(String.format("Major increase required: method %s with parameter types %s has been deleted or changed parameters", registeredMethod, Arrays.toString(registeredParams)));
+            }
+        }
+    }
+
+    /**
+     * Print all public methods in a class.
+     * It's used to see all the public methods in a class.
+     * @param cl the target class
+     */
+    public static void printPublicMethod(Class cl) {
+        Method[] methods = cl.getMethods();
+        for (Method method : methods) {
+            System.out.println(method.toString());
+        }
+    }
+
+    /**
+     * Compare the number of public methods and the number of the methods registered in the API test.
+     * It's used to detect whether a new public method is addede to an API class.
+     * @param cl The API class
+     * @param registeredMethods All public methods registered in the API test
+     */
+    public static void compareMethodsNum(Class cl, Set<MethodSignature> registeredMethods) {
+        int currentMethodsNum = cl.getMethods().length;
+        if (currentMethodsNum < registeredMethods.size()) {
+            fail("Major increase required: there is a method being removed, see more details in majorIncreaseTest");
+        }
+        else if (currentMethodsNum > registeredMethods.size()) {
+            for (Method currentMethod : cl.getMethods()) {
+                MethodSignature currentSignature = new MethodSignature(currentMethod);
+                assertTrue(String.format("Minor increase required: new method %s with parameter types %s added", currentSignature.getName(),Arrays.toString(currentSignature.getParameterTypes())), registeredMethods.contains(currentSignature));
+            }
+        }
+    }
+
+    /**
+     * Print all constructors of a class.
+     * It's used to see all constructors of a class
+     * @param cl the target class
+     */
+    public static void printConstructors(Class cl) {
+        Constructor[] constructors = cl.getConstructors();
+        for (Constructor constructor : constructors) {
+            System.out.println(constructor.toString());
+        }
+    }
+
+    /**
+     * Compare the signatures between all public constructors and registered constructors in the API test.
+     * @param cl The API class
+     * @param registeredConstructors All registered constructors of an API class
+     */
+    public static void compareConstructors(Class cl, Set<MethodSignature> registeredConstructors) {
+
+        for (MethodSignature registeredConstroctor : registeredConstructors) {
+            String registeredName = registeredConstroctor.getName();
+            Class[] registeredParams = registeredConstroctor.getParameterTypes();
+            try {
+                Constructor currentMethod = cl.getConstructor(registeredParams);
+                int currentModifiers = currentMethod.getModifiers();
+                assertEquals(String.format("Major increase required: the constructor changed modifiers from %s to %s",Modifier.toString(registeredConstroctor.getModifiers()),Modifier.toString(currentModifiers)), registeredConstroctor.getModifiers(),currentModifiers);
+
+                Class[] currentExceptionTypes = currentMethod.getExceptionTypes();
+                assertArrayEquals(String.format("Major increase required: the constructor changed exception types from %s to %s", Arrays.toString(registeredConstroctor.getExceptionTypes()), Arrays.toString(currentExceptionTypes)), registeredConstroctor.getExceptionTypes(),currentExceptionTypes);
+            } catch (NoSuchMethodException e) {
+                fail(String.format("Major increase required: the constructor with parameter types %s has been deleted or changed parameters", Arrays.toString(registeredParams)));
+            }
+        }
+    }
+
+    /**
+     * Compare the number of constructors and the number of the constructors registered in the API test.
+     * @param cl The API class
+     * @param registeredConstructors All registered constructors of an API class
+     */
+    public static void compareConstructorsNum(Class cl, Set<MethodSignature> registeredConstructors) {
+        int currentMethodsNum = cl.getConstructors().length;
+        if (currentMethodsNum < registeredConstructors.size()) {
+            fail("Major increase required: there is a constructor being removed, see details in major IncreaseTest");
+        }
+        else if (currentMethodsNum > registeredConstructors.size()) {
+            for (Constructor currentConstructor : cl.getConstructors()) {
+                MethodSignature currentSignature = new MethodSignature(currentConstructor);
+                assertTrue(String.format("Minor increase required: new constructor with parameter types %s added", Arrays.toString(currentSignature.getParameterTypes())), registeredConstructors.contains(currentSignature));
+            }
+        }
+    }
+
+    /**
+     * Get a modifiable set from an ImmutableSet.
+     * @param set the ImmutableSet
+     * @return A HashSet contains all contents of the ImmutableSet
+     */
+    public static Set<MethodSignature> getModifiableSet(Set<MethodSignature> set) {
+        Set<MethodSignature> modifiableSet = new HashSet<>();
+        for (MethodSignature methodSignature : set) {
+            modifiableSet.add(methodSignature);
+        }
+        return modifiableSet;
+    }
+}

--- a/engine-tests/src/api-tests/java/org/terasology/testUtil/MethodSignature.java
+++ b/engine-tests/src/api-tests/java/org/terasology/testUtil/MethodSignature.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.testUtil;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * MethodSignature is the signature for a method (or a constructor) including method name, modifiers, parameters, return type and exceptions.
+ * Note: methodSignatures are considered to be equal if two methodSignatures has the same name and the same parameter types.
+ */
+public class MethodSignature {
+
+    private String name;
+
+    private int modifiers;
+
+    private Class<?>[] parameterTypes;
+
+    private Class<?> returnType;
+
+    private Class<?>[] exceptionTypes;
+
+    /**
+     * Register a MethodSignature object for a method.
+     * It's used to register a MethodSignature for a API method in API test.
+     * @param name name of the method
+     * @param parameterTypes parameter types of this method
+     * @param modifiers the modifiers of the method
+     * @param returnType return type of this method
+     * @param exceptionTypes exception types of the method
+     */
+    public MethodSignature(String name, Class<?>[] parameterTypes, int modifiers, Class<?> returnType, Class<?>[] exceptionTypes) {
+        this.name = name;
+        this.returnType = returnType;
+        this.modifiers = modifiers;
+        this.parameterTypes = parameterTypes == null ? new Class[] {} : parameterTypes;
+        this.exceptionTypes = exceptionTypes == null ? new Class[] {} : exceptionTypes;
+    }
+
+    /**
+     * Generate MethodSignature object from a Method object.
+     * It's used to get the current method signature for a method.
+     * @param method the method
+     */
+    public MethodSignature(Method method) {
+        this.name = method.getName();
+        this.parameterTypes = method.getParameterTypes();
+        this.modifiers = method.getModifiers();
+        this.returnType = method.getReturnType();
+        this.exceptionTypes = method.getExceptionTypes();
+    }
+
+    /**
+     * Register a MethodSignature object for a constructor.
+     * It's used to register a MethodSignature for a API constructor in API test.
+     * @param name the name of the constructor
+     * @param modifiers the modifiers of the constructor
+     * @param parameterTypes the parameters
+     * @param exceptionTypes the array of the exceptions
+     */
+    public MethodSignature(String name, Class<?>[] parameterTypes, int modifiers, Class<?>[] exceptionTypes) {
+        this.name = name;
+        this.parameterTypes = parameterTypes == null ? new Class[] {} : parameterTypes;
+        this.modifiers = modifiers;
+        this.exceptionTypes = exceptionTypes == null ? new Class[] {} : exceptionTypes;
+    }
+
+    /**
+     * Generate MethodSignature object from a Constructor object.
+     * It's used to get the current method signature for a constructor.
+     * @param constructor the constructor
+     */
+    public MethodSignature(Constructor constructor) {
+        String name = constructor.getName();
+        String[] nameSplit = name.split("\\.");
+        this.name = nameSplit[nameSplit.length-1];
+
+        this.parameterTypes = constructor.getParameterTypes();
+        this.modifiers = constructor.getModifiers();
+        this.exceptionTypes = constructor.getExceptionTypes();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    public Class<?>[] getParameterTypes() {
+        return parameterTypes;
+    }
+
+    public Class<?> getReturnType() {
+        return returnType;
+    }
+
+    public Class<?>[] getExceptionTypes() {
+        return exceptionTypes;
+    }
+
+    /**
+     * Two MethodSignatures are considered to be the same if their names and parameters are the same.
+     * This is used to identify which new method is added to an API class
+     * @param obj another MethodSignature method
+     * @return True if they have the same name and the same parameters
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof MethodSignature))return false;
+        MethodSignature other = (MethodSignature) obj;
+        if (name.equals(other.getName()) && Arrays.equals(parameterTypes,other.getParameterTypes())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean objectEquals(Object o1, Object o2) {
+        if (o1 == o2) return true;
+        if ((o1 == null)||(o2 == null)) return false;
+        return o1.equals(o2);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 7;
+        int c = name.hashCode() * 7 + (parameterTypes != null ? Arrays.hashCode(parameterTypes) : 0) * 29;
+        result = result * 37 + c;
+        return result;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/ComponentFieldUri.java
+++ b/engine/src/main/java/org/terasology/engine/ComponentFieldUri.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

A first attempt to #2317. In general, with @Cervator and @iaronaraujo, we will try to detect all the api method changes in a PR and detect the correct scroll to increment. 

In this PR, I wrote a first test for `org.terasology.engine.ComponentFieldUri`. It'll do:

1. Test all `public` constructors and methods, if there is a change in their signatures (`modifiers`, `parameters`, `return type` and `exceptions`) or a remove of a method , `majorIncreaseTest()` print "Major increase required" with details
2. If the class has a new `public` method & constructor, `minorIncreaseTest()` will print "Minor increase requierd"
3. There are also other tests generated by Evosuite for code coverage. If they are not passed  a major increment might be needed
4. If all the api-tests pass, but the test in regular tests in `engine-tests` don't 100% pass, that might be a minor increment
5. If all the tests pass, then that's a patch increment

In most cases, tests generated by Evosuite will detect method signature changes, too. E.g. If we change a parameter in a method, some tests will not be complied. Even if these tests don't detect the method changes, `majorIncreaseTest()` will detect it.

### How to test
In `org.terasology.engine.ComponentFieldUri`, try to do some changes in the method and run the tests

- If you change the the parameters or return types of a `public method` or remove a method, normally the tests can't be compiled. If you modified the modifiers, e.g. `public` to `public final`, `majorIncreaseTest()` will detect it
- If you add a new `public` method & constructor, `minorIncreaseTest()` will detect it

### Outstanding before merging

- [ ] Need to consider the **workflow** of the API test
- [ ] Need to evaluate the `MethodSignature` detection
- [ ] Need to evaluate whether the tests generated by Evosuite has meanings.

### Future work 

- [ ] Add more meaningful tests
- [ ] Tests to all API classes
- [ ] A scraper to show what API we have covered by the API test

Do I miss something? Thanks for comments :-) 