### PR TITLE
BehaviorSystem- changed Map to ConcurrentHashMap

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.terasology.assets.ResourceUrn;
@@ -73,7 +74,7 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
     @In
     private AssetManager assetManager;
 
-    private Map<EntityRef, Interpreter> entityInterpreters = Maps.newHashMap();
+    private ConcurrentHashMap<EntityRef, Interpreter> entityInterpreters = new ConcurrentHashMap<EntityRef, Interpreter>();
     private List<BehaviorTree> trees = Lists.newArrayList();
 
     @Override

--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -15,17 +15,7 @@
  */
 package org.terasology.logic.behavior;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.Lists;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.audio.StaticSound;
@@ -34,6 +24,7 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -50,8 +41,15 @@ import org.terasology.naming.Name;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Behavior tree system
@@ -60,7 +58,6 @@ import com.google.common.collect.Maps;
  * is loaded and an interpreter is started.
  * <br><br>
  * Modifications made to a behavior tree will reflect to all entities using this tree.
- *
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 @Share(BehaviorSystem.class)
@@ -74,6 +71,10 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
     @In
     private AssetManager assetManager;
 
+    /*
+     * Using a ConcurrentHashMap in place of a regular Map because the UpdateBehaviorEvent-handlers can remove the entityInterpreter
+     * while it is being iterated over in the update loop
+     */
     private ConcurrentHashMap<EntityRef, Interpreter> entityInterpreters = new ConcurrentHashMap<EntityRef, Interpreter>();
     private List<BehaviorTree> trees = Lists.newArrayList();
 
@@ -93,6 +94,11 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
     @ReceiveEvent
     public void onBehaviorActivated(OnActivatedComponent event, EntityRef entityRef, BehaviorComponent behaviorComponent) {
         addEntity(entityRef, behaviorComponent);
+    }
+
+    @ReceiveEvent
+    public void onBehaviorChanged(OnChangedComponent event, EntityRef entityRef, BehaviorComponent behaviorComponent) {
+        updateEntity(entityRef, behaviorComponent);
     }
 
     @ReceiveEvent
@@ -164,6 +170,15 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
             if (tree != null) {
                 interpreter.start(tree.getRoot());
             }
+        }
+    }
+
+    private void updateEntity(EntityRef entityRef, BehaviorComponent behaviorComponent) {
+        Interpreter interpreter = new Interpreter(new Actor(entityRef));
+        BehaviorTree tree = behaviorComponent.tree;
+        entityInterpreters.put(entityRef, interpreter);
+        if (tree != null) {
+            interpreter.start(tree.getRoot());
         }
     }
 }

--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -75,7 +75,8 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
 
 
     /*
-     * A hash map that maps entity to their interpreters
+     * A hash map that maps entity to their interpreters. Behavior tree processing
+     * can trigger a behavior tree switch and thus map can change during iteration.
      * These are stored in a List for iteration in the update method,
      * so that a ConcurrentModificationException is avoided.
      */


### PR DESCRIPTION
This is done for the new changes merged in https://github.com/Terasology/WildAnimals/ to work.

The additions to the WildAnimals module make changes to the entity's behavior component to switch behavior.

The current system uses events to trigger changes in the Behavior Tree. This means that if the deer is hit, the deer's `BehaviorComponent.tree` is extracted and it's value is changed from "Pathfinding:Stray" to "WildAnimals:Flee". The exact reverse happens when the deer reaches a safe distance from the player, i.e. `BehaviorComponent.tree` is changed from "WildAnimals:Flee" to "Pathfinding:Stray".
Whenever a change is made, the entity's (deer's) new entry is added to the `entityInterpreter` defined in the `BehaviorSystem`. (Using the `onBehaviorActivated` and `onBehaviorDeactivated` methods)
Now the `BehaviorSystem` has a `update` running, which gets called from time to time. The `update` fetches values from the `entityInterpreter`.
`entityInterpreter` is a hashMap, mapping entityRefs to their behaviorComponent.
So the problem that surfaces on every second or third run is that I get a `java.util.ConcurrentModificationException`, which I reckon means that the `onBehaviorDeactivated` makes a change to `entityInterpreter` just while the `update` method tries to read it.


This PR changes the `Map` to `ConcurrentHashMap` in the `BehaviorSystem`, which solves the above issue.