### PR TITLE
update mockito-all to latest mockito-core, fixes #2934

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
     // Test lib dependencies
     compile group: 'junit', name: 'junit', version: '4.12'
-    compile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    compile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
     compile group: 'org.jboss.shrinkwrap', name: 'shrinkwrap-depchain-java7', version: '1.1.3'
 }
 

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/InterpreterTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/InterpreterTest.java
@@ -22,12 +22,11 @@ import org.terasology.logic.behavior.tree.Node;
 import org.terasology.logic.behavior.tree.Status;
 import org.terasology.logic.behavior.tree.Task;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-
 
 /**
  */
@@ -125,7 +124,7 @@ public class InterpreterTest {
         Interpreter interpreter = new Interpreter(null);
         interpreter.start(node, null);
         interpreter.tick(0);
-        verify(task).update(anyInt());
+        verify(task).update(anyFloat());
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/ParallelTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/ParallelTest.java
@@ -23,7 +23,7 @@ import org.terasology.logic.behavior.tree.ParallelNode;
 import org.terasology.logic.behavior.tree.Status;
 import org.terasology.logic.behavior.tree.Task;
 
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -35,8 +35,8 @@ public class ParallelTest {
         Interpreter interpreter = new Interpreter(null);
         ParallelNode parallel = new ParallelNode(ParallelNode.Policy.RequireAll, ParallelNode.Policy.RequireOne);
 
-        Node one = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.SUCCESS));
-        Node two = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.RUNNING, Status.SUCCESS));
+        Node one = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.SUCCESS));
+        Node two = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.RUNNING, Status.SUCCESS));
         parallel.children().add(one);
         parallel.children().add(two);
 
@@ -53,8 +53,8 @@ public class ParallelTest {
     public void testSuccessRequireOne() {
         Interpreter interpreter = new Interpreter(null);
         ParallelNode parallel = new ParallelNode(ParallelNode.Policy.RequireOne, ParallelNode.Policy.RequireAll);
-        Node one = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.SUCCESS));
-        Node two = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.RUNNING));
+        Node one = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.SUCCESS));
+        Node two = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.RUNNING));
         parallel.children().add(one);
         parallel.children().add(two);
 
@@ -69,8 +69,8 @@ public class ParallelTest {
     public void testFailureRequireAll() {
         Interpreter interpreter = new Interpreter(null);
         ParallelNode parallel = new ParallelNode(ParallelNode.Policy.RequireOne, ParallelNode.Policy.RequireAll);
-        Node one = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.FAILURE));
-        Node two = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.RUNNING, Status.FAILURE));
+        Node one = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.FAILURE));
+        Node two = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.RUNNING, Status.FAILURE));
         parallel.children().add(one);
         parallel.children().add(two);
 
@@ -87,8 +87,8 @@ public class ParallelTest {
     public void testFailureRequireOne() {
         Interpreter interpreter = new Interpreter(null);
         ParallelNode parallel = new ParallelNode(ParallelNode.Policy.RequireAll, ParallelNode.Policy.RequireOne);
-        Node one = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.FAILURE));
-        Node two = create(spy -> when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.RUNNING));
+        Node one = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.FAILURE));
+        Node two = create(spy -> when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.RUNNING));
         parallel.children().add(one);
         parallel.children().add(two);
 

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/SelectorTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/SelectorTest.java
@@ -23,7 +23,7 @@ import org.terasology.logic.behavior.tree.SelectorNode;
 import org.terasology.logic.behavior.tree.Status;
 import org.terasology.logic.behavior.tree.Task;
 
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,7 @@ public class SelectorTest {
         final Task[] spies = new Task[2];
         Interpreter interpreter = new Interpreter(null);
         Node one = create(spy -> {
-            when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.SUCCESS);
+            when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.SUCCESS);
             spies[0] = spy;
         });
         Node two = create(spy -> spies[1] = spy);
@@ -58,11 +58,11 @@ public class SelectorTest {
         final Task[] spies = new Task[2];
         Interpreter interpreter = new Interpreter(null);
         Node one = create(spy -> {
-            when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.FAILURE);
+            when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.FAILURE);
             spies[0] = spy;
         });
         Node two = create(spy -> {
-            when(spy.update(anyInt())).thenReturn(Status.RUNNING);
+            when(spy.update(anyFloat())).thenReturn(Status.RUNNING);
             spies[1] = spy;
         });
         SelectorNode node = new SelectorNode();
@@ -84,7 +84,7 @@ public class SelectorTest {
     @Test
     public void testOnePassThrough() {
         final Task[] spies = new Task[1];
-        Status[] stats = new Status[]{Status.SUCCESS, Status.FAILURE};
+        Status[] stats = new Status[] {Status.SUCCESS, Status.FAILURE};
         for (final Status status : stats) {
             Interpreter interpreter = new Interpreter(null);
             Node mock = create(spy -> {

--- a/engine-tests/src/test/java/org/terasology/logic/behavior/SequenceTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/behavior/SequenceTest.java
@@ -23,7 +23,7 @@ import org.terasology.logic.behavior.tree.SequenceNode;
 import org.terasology.logic.behavior.tree.Status;
 import org.terasology.logic.behavior.tree.Task;
 
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,7 @@ public class SequenceTest {
         final Task[] spies = new Task[2];
         Interpreter interpreter = new Interpreter(null);
         Node one = create(spy -> {
-            when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.FAILURE);
+            when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.FAILURE);
             spies[0] = spy;
         });
         Node two = create(spy -> spies[1] = spy);
@@ -58,11 +58,11 @@ public class SequenceTest {
         final Task[] spies = new Task[2];
         Interpreter interpreter = new Interpreter(null);
         Node one = create(spy -> {
-            when(spy.update(anyInt())).thenReturn(Status.RUNNING, Status.SUCCESS);
+            when(spy.update(anyFloat())).thenReturn(Status.RUNNING, Status.SUCCESS);
             spies[0] = spy;
         });
         Node two = create(spy -> {
-            when(spy.update(anyInt())).thenReturn(Status.RUNNING);
+            when(spy.update(anyFloat())).thenReturn(Status.RUNNING);
             spies[1] = spy;
         });
         SequenceNode node = new SequenceNode();
@@ -84,7 +84,7 @@ public class SequenceTest {
     @Test
     public void testOneChildPassThrough() {
         final Task[] spies = new Task[1];
-        Status[] stats = new Status[]{Status.SUCCESS, Status.FAILURE};
+        Status[] stats = new Status[] {Status.SUCCESS, Status.FAILURE};
         for (final Status status : stats) {
             Interpreter interpreter = new Interpreter(null);
             Node mock = create(spy -> {

--- a/modules/Core/src/test/java/org/terasology/logic/inventory/InventoryAuthoritySystemTest.java
+++ b/modules/Core/src/test/java/org/terasology/logic/inventory/InventoryAuthoritySystemTest.java
@@ -17,10 +17,7 @@ package org.terasology.logic.inventory;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.mockito.internal.verification.AtLeast;
-import org.mockito.internal.verification.Times;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.inventory.action.GiveItemAction;
@@ -38,6 +35,9 @@ import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
 
 /**
  */
@@ -80,14 +80,14 @@ public class InventoryAuthoritySystemTest {
         assertEquals(1, itemComp.stackCount);
         assertEquals(1, itemCompCopy.stackCount);
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).iterateComponents();
         Mockito.verify(item).saveComponent(itemComp);
-        Mockito.verify(itemCopy, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(itemCopy, new AtLeast(0)).iterateComponents();
+        Mockito.verify(itemCopy, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(itemCopy, atLeast(0)).iterateComponents();
         Mockito.verify(itemCopy).saveComponent(itemCompCopy);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(inventory).send(Matchers.any(InventorySlotStackSizeChangedEvent.class));
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory).send(any(InventorySlotStackSizeChangedEvent.class));
         Mockito.verify(entityManager).copy(item);
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item, itemCopy);
@@ -112,13 +112,13 @@ public class InventoryAuthoritySystemTest {
 
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(0));
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
-        Mockito.verify(item, new AtLeast(0)).iterateComponents();
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(item, atLeast(0)).iterateComponents();
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory, new Times(2)).send(Matchers.any(BeforeItemRemovedFromInventory.class));
-        Mockito.verify(inventory, new Times(2)).send(Matchers.any(InventorySlotChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(BeforeItemRemovedFromInventory.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item);
     }
@@ -136,10 +136,10 @@ public class InventoryAuthoritySystemTest {
 
         assertEquals(1, itemComp.stackCount);
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item).saveComponent(itemComp);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(inventory).send(Matchers.any(InventorySlotStackSizeChangedEvent.class));
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory).send(any(InventorySlotStackSizeChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item);
 
@@ -163,13 +163,13 @@ public class InventoryAuthoritySystemTest {
 
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(0));
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
         Mockito.verify(item).destroy();
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory, new Times(2)).send(Matchers.any(BeforeItemRemovedFromInventory.class));
-        Mockito.verify(inventory, new Times(2)).send(Matchers.any(InventorySlotChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(Mockito.any(BeforeItemRemovedFromInventory.class));
+        Mockito.verify(inventory, times(1)).send(Mockito.any(InventorySlotChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item);
     }
@@ -197,18 +197,18 @@ public class InventoryAuthoritySystemTest {
         assertTrue(action.isConsumed());
         assertEquals(item1, action.getRemovedItem());
 
-        Mockito.verify(item1, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item1, new AtLeast(0)).exists();
-        Mockito.verify(item1, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item1, atLeast(0)).exists();
+        Mockito.verify(item1, atLeast(0)).iterateComponents();
         Mockito.verify(item1).saveComponent(itemComp1);
-        Mockito.verify(item2, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item2, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item2, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item2, atLeast(0)).iterateComponents();
         Mockito.verify(item2).saveComponent(itemComp2);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(BeforeItemRemovedFromInventory.class));
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(InventorySlotChangedEvent.class));
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(InventorySlotStackSizeChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(BeforeItemRemovedFromInventory.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotStackSizeChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item1, item2);
     }
@@ -235,18 +235,18 @@ public class InventoryAuthoritySystemTest {
         assertTrue(action.isConsumed());
         assertNull(action.getRemovedItem());
 
-        Mockito.verify(item1, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item1, new AtLeast(0)).exists();
-        Mockito.verify(item1, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item1, atLeast(0)).exists();
+        Mockito.verify(item1, atLeast(0)).iterateComponents();
         Mockito.verify(item1).destroy();
-        Mockito.verify(item2, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item2, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item2, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item2, atLeast(0)).iterateComponents();
         Mockito.verify(item2).saveComponent(itemComp2);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(BeforeItemRemovedFromInventory.class));
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(InventorySlotChangedEvent.class));
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(InventorySlotStackSizeChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(BeforeItemRemovedFromInventory.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotStackSizeChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item1, item2);
     }
@@ -259,13 +259,12 @@ public class InventoryAuthoritySystemTest {
 
         inventoryComp.itemSlots.set(0, item);
 
-        Mockito.when(inventory.send(Matchers.any(BeforeItemRemovedFromInventory.class))).then(
+        Mockito.when(inventory.send(any(BeforeItemRemovedFromInventory.class))).then(
                 invocation -> {
                     BeforeItemRemovedFromInventory event = (BeforeItemRemovedFromInventory) invocation.getArguments()[0];
                     event.consume();
                     return null;
-                }
-        );
+                });
 
         RemoveItemAction action = new RemoveItemAction(instigator, item, true, 2);
         inventoryAuthoritySystem.removeItem(action, inventory);
@@ -273,10 +272,10 @@ public class InventoryAuthoritySystemTest {
         assertFalse(action.isConsumed());
         assertNull(action.getRemovedItem());
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(inventory).send(Matchers.any(BeforeItemRemovedFromInventory.class));
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory).send(any(BeforeItemRemovedFromInventory.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item);
     }
@@ -290,13 +289,13 @@ public class InventoryAuthoritySystemTest {
         GiveItemAction action = new GiveItemAction(instigator, item);
         inventoryAuthoritySystem.giveItem(action, inventory);
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
         Mockito.verify(item).saveComponent(itemComp);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory, new Times(2)).send(Matchers.any(BeforeItemPutInInventory.class));
-        Mockito.verify(inventory, new Times(2)).send(Matchers.any(InventorySlotChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(BeforeItemPutInInventory.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item);
 
@@ -319,16 +318,16 @@ public class InventoryAuthoritySystemTest {
         GiveItemAction action = new GiveItemAction(instigator, item);
         inventoryAuthoritySystem.giveItem(action, inventory);
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
-        Mockito.verify(item, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(item, atLeast(0)).iterateComponents();
         Mockito.verify(item).destroy();
-        Mockito.verify(partialItem, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(partialItem, new AtLeast(0)).exists();
-        Mockito.verify(partialItem, new AtLeast(0)).iterateComponents();
+        Mockito.verify(partialItem, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(partialItem, atLeast(0)).exists();
+        Mockito.verify(partialItem, atLeast(0)).iterateComponents();
         Mockito.verify(partialItem).saveComponent(partialItemComp);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(inventory).send(Matchers.any(InventorySlotStackSizeChangedEvent.class));
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory).send(any(InventorySlotStackSizeChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item, partialItem);
 
@@ -352,19 +351,19 @@ public class InventoryAuthoritySystemTest {
         GiveItemAction action = new GiveItemAction(instigator, item);
         inventoryAuthoritySystem.giveItem(action, inventory);
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
-        Mockito.verify(item, new AtLeast(0)).iterateComponents();
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(item, atLeast(0)).iterateComponents();
         Mockito.verify(item).saveComponent(itemComp);
-        Mockito.verify(partialItem, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(partialItem, new AtLeast(0)).exists();
-        Mockito.verify(partialItem, new AtLeast(0)).iterateComponents();
+        Mockito.verify(partialItem, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(partialItem, atLeast(0)).exists();
+        Mockito.verify(partialItem, atLeast(0)).iterateComponents();
         Mockito.verify(partialItem).saveComponent(partialItemComp);
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(InventorySlotStackSizeChangedEvent.class));
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(InventorySlotChangedEvent.class));
-        Mockito.verify(inventory, new Times(3)).send(Matchers.any(BeforeItemPutInInventory.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotStackSizeChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(inventory, times(1)).send(any(BeforeItemPutInInventory.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item, partialItem);
 
@@ -381,21 +380,20 @@ public class InventoryAuthoritySystemTest {
         EntityRef item = Mockito.mock(EntityRef.class);
         setupItemRef(item, itemComp, 2, 10);
 
-        Mockito.when(inventory.send(Matchers.any(BeforeItemPutInInventory.class))).then(
+        Mockito.when(inventory.send(any(BeforeItemPutInInventory.class))).then(
                 invocation -> {
                     BeforeItemPutInInventory event = (BeforeItemPutInInventory) invocation.getArguments()[0];
                     event.consume();
                     return null;
-                }
-        );
+                });
 
         GiveItemAction action = new GiveItemAction(instigator, item);
         inventoryAuthoritySystem.giveItem(action, inventory);
 
-        Mockito.verify(item, new AtLeast(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, new AtLeast(0)).exists();
-        Mockito.verify(inventory, new AtLeast(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(inventory, new Times(5)).send(Matchers.any(BeforeItemPutInInventory.class));
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory, times(5)).send(any(BeforeItemPutInInventory.class));
 
         Mockito.verifyNoMoreInteractions(instigator, inventory, entityManager, item);
 
@@ -411,7 +409,6 @@ public class InventoryAuthoritySystemTest {
         Mockito.when(item.getComponent(ItemComponent.class)).thenReturn(itemComp);
         Mockito.when(item.iterateComponents()).thenReturn(new LinkedList<>());
     }
-
 
     private EntityRef createItem(String stackId, int stackCount, int stackSize) {
         ItemComponent itemComp = new ItemComponent();
@@ -485,7 +482,6 @@ public class InventoryAuthoritySystemTest {
         assertFalse(fromInventoryComp.itemSlots.get(fromSlot).exists());
     }
 
-
     @Test
     public void testMoveItemToSlotsWithToLessSpaceInTargetSlots() {
         int stackSize = 10;
@@ -517,7 +513,6 @@ public class InventoryAuthoritySystemTest {
         assertEquals(itemA3, fromInventoryComp.itemSlots.get(fromSlot));
     }
 
-
     @Test
     public void testMoveItemToSlotsWithTargetVetos() {
         int stackSize = 10;
@@ -534,7 +529,7 @@ public class InventoryAuthoritySystemTest {
         fromInventoryComp.itemSlots.set(fromSlot, itemA2);
 
         // Placement to slots 1 gets blocked by veto
-        Mockito.when(inventory.send(Matchers.any(BeforeItemPutInInventory.class))).then(
+        Mockito.when(inventory.send(any(BeforeItemPutInInventory.class))).then(
                 invocation -> {
                     Object arg = invocation.getArguments()[0];
                     if (arg instanceof BeforeItemPutInInventory) {
@@ -544,11 +539,9 @@ public class InventoryAuthoritySystemTest {
                         }
                     }
                     return null;
-                }
-        );
+                });
 
         List<Integer> toSlots = Arrays.asList(0, 1, 2, 3, 4);
-
 
         // The method that gets tested:
         boolean result = inventoryAuthoritySystem.moveItemToSlots(instigator, fromInventory, fromSlot, toInventory, toSlots);
@@ -564,7 +557,6 @@ public class InventoryAuthoritySystemTest {
         assertEquals(itemA2, toInventoryComp.itemSlots.get(2));
         assertFalse(fromInventoryComp.itemSlots.get(fromSlot).exists());
     }
-
 
     /**
      * A shift click isn't possible because the removal of the item gets blocked
@@ -585,7 +577,7 @@ public class InventoryAuthoritySystemTest {
         fromInventoryComp.itemSlots.set(fromSlot, itemA2);
 
         // Placement to slots 1 gets blocked by veto
-        Mockito.when(fromInventory.send(Matchers.any(BeforeItemRemovedFromInventory.class))).then(
+        Mockito.when(fromInventory.send(any(BeforeItemRemovedFromInventory.class))).then(
                 invocation -> {
                     Object arg = invocation.getArguments()[0];
                     if (arg instanceof BeforeItemRemovedFromInventory) {
@@ -595,11 +587,9 @@ public class InventoryAuthoritySystemTest {
                         }
                     }
                     return null;
-                }
-        );
+                });
 
         List<Integer> toSlots = Arrays.asList(0, 1, 2, 3, 4);
-
 
         // The method that gets tested:
         boolean result = inventoryAuthoritySystem.moveItemToSlots(instigator, fromInventory, fromSlot, toInventory, toSlots);
@@ -610,7 +600,6 @@ public class InventoryAuthoritySystemTest {
         assertEquals(EntityRef.NULL, toInventoryComp.itemSlots.get(1));
         assertEquals(itemA2, fromInventoryComp.itemSlots.get(fromSlot));
     }
-
 
     @Test
     public void testMoveItemToSlotsWithFullTargetInventorySlots() {


### PR DESCRIPTION
Updates the mockito dependency to the latest version which does not include hamcrest 1.1
See #2934 for details.

Also updated some tests, as mockito 2.x is more restrictive on type checks as 1.x, see https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#incompatible-changes-with-110 for details.