### PR TITLE
Add loop functionality to AudioManager, loop menu theme

### DIFF
--- a/engine/src/main/java/org/terasology/audio/AudioEndListener.java
+++ b/engine/src/main/java/org/terasology/audio/AudioEndListener.java
@@ -17,6 +17,7 @@ package org.terasology.audio;
 
 /**
  * Is called by AudioManager to inform about end of playing music or sound.
+ * The listener will only be called once. If the same track is played multiple times, a new listener has to be used each time.
  * <br><br>
  * Notice: The code in onAudioEnd is run in the update() method of the AudioManager once the sound/music ends playing.
  */
@@ -25,6 +26,7 @@ public interface AudioEndListener {
 
     /**
      * Called when the sound or music stops playing
+     * @param interrupted, true when the track was interrupted, e.g. via {@link AudioManager#stopAllSounds()}, false if not.
      */
-    void onAudioEnd();
+    void onAudioEnd(boolean interrupted);
 }

--- a/engine/src/main/java/org/terasology/audio/AudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/AudioManager.java
@@ -31,7 +31,6 @@ public interface AudioManager {
     int PRIORITY_LOW = 3;
     int PRIORITY_LOWEST = 1;
 
-
     /**
      * @return A boolean indicting the mute status
      */
@@ -41,7 +40,6 @@ public interface AudioManager {
      * @param mute A boolean indicating the new mute status.
      */
     void setMute(boolean mute);
-
 
     void playSound(StaticSound sound);
 
@@ -66,21 +64,51 @@ public interface AudioManager {
      */
     void playSound(StaticSound sound, Vector3f position, float volume, int priority, AudioEndListener endListener);
 
-
+    /**
+     * Plays music once, this does not have a direction unlike playSound.
+     *
+     * @param music The music to play
+     */
     void playMusic(StreamingSound music);
 
+    /**
+     * Plays music once, this does not have a direction unlike playSound.
+     *
+     * @param volume The volume to play it at
+     */
     void playMusic(StreamingSound music, float volume);
 
+    /**
+     * Plays music once, this does not have a direction unlike playSound.
+     *
+     * @param music The music to play
+     * @param endListener The listener to call once the music ends
+     */
     void playMusic(StreamingSound music, AudioEndListener endListener);
 
     /**
-     * Plays music, this does not have a direction unlike playSound.
+     * Plays music once, this does not have a direction unlike playSound.
      *
      * @param music The music to play
-     * @param volume THe volume to play it at
+     * @param volume The volume to play it at
      * @param endListener The listener to call once the music ends
      */
     void playMusic(StreamingSound music, float volume, AudioEndListener endListener);
+
+    /**
+     * Loops music until it gets stopped, this does not have a direction unlike playSound.
+     *
+     * @param music The music to play
+     */
+    void loopMusic(StreamingSound music);
+
+    /**
+     * Loops music until it gets stopped, this does not have a direction unlike playSound.
+     *
+     * @param music The music to play
+     * @param volume The volume to play it at
+     */
+    void loopMusic(StreamingSound music, float volume);
 
     /**
      * Update AudioManager sound sources.

--- a/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
@@ -108,4 +108,12 @@ public class NullAudioManager implements AudioManager {
     public AssetFactory<StreamingSound, StreamingSoundData> getStreamingSoundFactory() {
         return NullStreamingSound::new;
     }
+
+    @Override
+    public void loopMusic(StreamingSound music) {
+    }
+
+    @Override
+    public void loopMusic(StreamingSound music, float volume) {
+    }
 }

--- a/engine/src/main/java/org/terasology/audio/openAL/OpenALManager.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/OpenALManager.java
@@ -120,10 +120,10 @@ public class OpenALManager implements AudioManager {
         AL.destroy();
     }
 
-
     @Override
     public void stopAllSounds() {
         pools.values().forEach(SoundPool::stopAll);
+        notifyEndListeners(true);
     }
 
     @Override
@@ -236,6 +236,21 @@ public class OpenALManager implements AudioManager {
     }
 
     @Override
+    public void loopMusic(StreamingSound music) {
+        loopMusic(music, 1.0f);
+    }
+
+    @Override
+    public void loopMusic(StreamingSound music, float volume) {
+        AudioEndListener loopingEndListener = interrupted -> {
+            if (!interrupted) {
+                loopMusic(music, volume);
+            }
+        };
+        playMusic(music, volume, loopingEndListener);
+    }
+
+    @Override
     public void updateListener(Vector3f position, Quat4f orientation, Vector3f velocity) {
 
         AL10.alListener3f(AL10.AL_VELOCITY, velocity.x, velocity.y, velocity.z);
@@ -245,7 +260,7 @@ public class OpenALManager implements AudioManager {
         Vector3f dir = orientation.rotate(Direction.FORWARD.getVector3f(), new Vector3f());
         Vector3f up = orientation.rotate(Direction.UP.getVector3f(), new Vector3f());
 
-        FloatBuffer listenerOri = BufferUtils.createFloatBuffer(6).put(new float[]{dir.x, dir.y, dir.z, up.x, up.y, up.z});
+        FloatBuffer listenerOri = BufferUtils.createFloatBuffer(6).put(new float[] {dir.x, dir.y, dir.z, up.x, up.y, up.z});
         listenerOri.flip();
         AL10.alListener(AL10.AL_ORIENTATION, listenerOri);
 
@@ -262,6 +277,10 @@ public class OpenALManager implements AudioManager {
         for (SoundPool<?, ?> pool : pools.values()) {
             pool.update(delta);
         }
+        notifyEndListeners(false);
+    }
+
+    private void notifyEndListeners(boolean interrupted) {
         Iterator<Map.Entry<SoundSource<?>, AudioEndListener>> iterator = endListeners.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<SoundSource<?>, AudioEndListener> entry = iterator.next();
@@ -269,7 +288,7 @@ public class OpenALManager implements AudioManager {
                 iterator.remove();
 
                 try {
-                    entry.getValue().onAudioEnd();
+                    entry.getValue().onAudioEnd(interrupted);
                 } catch (Exception e) {
                     logger.error("onAudioEnd() notification failed for {}", entry.getValue(), e);
                 }
@@ -299,4 +318,5 @@ public class OpenALManager implements AudioManager {
             pool.purge(sound);
         }
     }
+
 }

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -65,7 +65,6 @@ public class StateMainMenu implements GameState {
         messageOnLoad = showMessageOnLoad;
     }
 
-
     @Override
     public void init(GameEngine gameEngine) {
         context = gameEngine.createChildContext();
@@ -136,7 +135,7 @@ public class StateMainMenu implements GameState {
     }
 
     private void playBackgroundMusic() {
-        context.get(AudioManager.class).playMusic(Assets.getMusic("engine:MenuTheme").get());
+        context.get(AudioManager.class).loopMusic(Assets.getMusic("engine:MenuTheme").get());
     }
 
     private void stopBackgroundMusic() {

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/PlayMusicNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/PlayMusicNode.java
@@ -51,7 +51,7 @@ public class PlayMusicNode extends Node {
         private boolean playing;
         private boolean finished;
 
-         PlayMusicTask(PlayMusicNode node) {
+        PlayMusicTask(PlayMusicNode node) {
             super(node);
         }
 
@@ -68,7 +68,7 @@ public class PlayMusicNode extends Node {
         }
 
         @Override
-        public void onAudioEnd() {
+        public void onAudioEnd(boolean interrupted) {
             if (playing) {
                 playing = false;
                 finished = true;

--- a/engine/src/main/java/org/terasology/logic/behavior/tree/PlaySoundNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/tree/PlaySoundNode.java
@@ -69,7 +69,7 @@ public class PlaySoundNode extends Node {
         }
 
         @Override
-        public void onAudioEnd() {
+        public void onAudioEnd(boolean interrupted) {
             if (playing) {
                 playing = false;
                 finished = true;


### PR DESCRIPTION
Contains snippets and changes from PRs #2846, #2545 and #2542 which are all inactive for more than a month. I would like to continue here and close the old PRs.

This fixes #2527. 
I was unable to reproduce #2364, so maybe @ratz or @Cervator can test this again?

Note that the change in the `AudioEndListener` will require a follow-up PR in the [MusicDirector](https://github.com/Terasology/MusicDirector) module.
If you want to keep the API untouched we could either introduce a new listener for the interrupt action on a music track or just omit the end listener entirely when music stops early.
