### PR TITLE
Fixed eye height movement debug command

### DIFF
--- a/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
+++ b/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
@@ -260,14 +260,16 @@ public class MovementDebugCommands extends BaseComponentSystem {
 
     @Command(shortDescription = "Sets the eye-height of the player", runOnServer = true,
             requiredPermission = PermissionManager.CHEAT_PERMISSION)
-    public String playerEyeHeight(@Sender EntityRef client, @CommandParam("height") float amount) {
-        ClientComponent clientComp = client.getComponent(ClientComponent.class);
+    public String playerEyeHeight(@Sender EntityRef client, @CommandParam("eye-height") float amount) {
+        EntityRef player = client.getComponent(ClientComponent.class).character;
         try {
-            GazeMountPointComponent gazeMountPointComponent = clientComp.character.getComponent(GazeMountPointComponent.class);
+            GazeMountPointComponent gazeMountPointComponent = player.getComponent(GazeMountPointComponent.class);
             if (gazeMountPointComponent != null) {
                 float prevHeight = gazeMountPointComponent.translate.y;
                 gazeMountPointComponent.translate.y = amount;
-                clientComp.character.saveComponent(gazeMountPointComponent);
+                Location.removeChild(player, gazeMountPointComponent.gazeEntity);
+                Location.attachChild(player, gazeMountPointComponent.gazeEntity, gazeMountPointComponent.translate, new Quat4f(Quat4f.IDENTITY));
+                player.saveComponent(gazeMountPointComponent);
                 return "Eye-height of player set to " + amount + " (was " + prevHeight + ")";
             }
             return "";

--- a/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
+++ b/engine/src/main/java/org/terasology/logic/debug/MovementDebugCommands.java
@@ -266,9 +266,8 @@ public class MovementDebugCommands extends BaseComponentSystem {
             GazeMountPointComponent gazeMountPointComponent = clientComp.character.getComponent(GazeMountPointComponent.class);
             if (gazeMountPointComponent != null) {
                 float prevHeight = gazeMountPointComponent.translate.y;
-                Location.removeChild(client, gazeMountPointComponent.gazeEntity);
                 gazeMountPointComponent.translate.y = amount;
-                Location.attachChild(client, gazeMountPointComponent.gazeEntity, gazeMountPointComponent.translate, new Quat4f(Quat4f.IDENTITY));
+                clientComp.character.saveComponent(gazeMountPointComponent);
                 return "Eye-height of player set to " + amount + " (was " + prevHeight + ")";
             }
             return "";


### PR DESCRIPTION
Contains a small fix for saving the gaze component when changing eye-height instead of reattaching the gazeEntity to the location only temporarily.