### PR TITLE
changed CollideEvent to be consumable

### DIFF
--- a/engine/src/main/java/org/terasology/physics/events/CollideEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/CollideEvent.java
@@ -17,13 +17,12 @@
 package org.terasology.physics.events;
 
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.Event;
-import org.terasology.math.VecMath;
+import org.terasology.entitySystem.event.AbstractConsumableEvent;
 import org.terasology.math.geom.Vector3f;
 
 /**
  */
-public class CollideEvent implements Event {
+public class CollideEvent extends AbstractConsumableEvent {
     private EntityRef otherEntity;
     private Vector3f entityContactPoint;
     private Vector3f otherEntityContactPoint;


### PR DESCRIPTION
Required for CombatSystem module where this event is consumed if the other entity the weapon collided with was the player who fired it, so that no action is taken on the player.
For eg. arrows that player fire are spawned in the bounding box of the player and shouldn't hurt him.