### PR TITLE
Clear state buffer on impulse/teleport.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/ServerCharacterPredictionSystem.java
@@ -143,6 +143,7 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
         CharacterStateEvent newState = new CharacterStateEvent(lastState);
         newState.setPosition(new Vector3f(event.getTargetPosition()));
         newState.setTime(time.getGameTimeInMs());
+        stateBuffer.clear();
         stateBuffer.add(newState);
         characterMovementSystemUtility.setToState(entity, newState);
 
@@ -158,6 +159,7 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
         newState.setVelocity(impulse.add(newState.getVelocity()));
         newState.setTime(time.getGameTimeInMs());
         newState.setGrounded(false);
+        stateBuffer.clear();
         stateBuffer.add(newState);
         characterMovementSystemUtility.setToState(entity, newState);
     }


### PR DESCRIPTION
### Contains

Improvements to the impulse (and teleport) event.

Clear the character state buffer onImpulse and onTeleport to get rid of outdated and and to prevent to many collision events to occur that a impulse tried to avoid.

Reasoning: There should be no further client decided movement when the
server decided that there was an impulse. Otherwise there
can be more collisions that the impulse event should have prevented.

### How to test

1. Start a multiplayer game with https://github.com/Terasology/AdventureAssets/pull/2
2. spawn the room with the swinging blade via structure tempalte in your inventory (white paper like item)
3. Start a second game instance and join the multiplayer game
4. Walk into the swinging blade in the second game instance that is the client.
5. You should not die instantly but instead should be pushed slightly back and take only a little bit of damage.
