### PR TITLE
Fixes `dumpEntities` console command

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/serializers/EntityDataJSONFormat.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntityDataJSONFormat.java
@@ -93,6 +93,7 @@ public final class EntityDataJSONFormat {
                 .registerTypeAdapter(EntityData.Component.class, new ComponentHandler())
                 .registerTypeAdapter(EntityData.Component.Builder.class, new ComponentBuilderHandler())
                 .registerTypeAdapter(EntityData.Value.class, new ValueHandler())
+                .serializeSpecialFloatingPointValues()
                 .create();
     }
 


### PR DESCRIPTION
Added serializeSpecialFloatingPointValues to the Gson builder.
This solves the error which appears on using `dumpEntities` command in console:
```
An error occurred while executing command 'dumpEntities': NaN is not a valid double value as per JSON specification. To override this behavior, use GsonBuilder.serializeSpecialFloatingPointValues() method.
```