### PR TITLE
Small refactor in AbstractClient

### DIFF
--- a/engine/src/main/java/org/terasology/network/internal/AbstractClient.java
+++ b/engine/src/main/java/org/terasology/network/internal/AbstractClient.java
@@ -23,7 +23,6 @@ import org.terasology.network.Client;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.ClientInfoComponent;
 import org.terasology.network.ColorComponent;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.Color;
 
 import java.util.HashSet;
@@ -51,8 +50,8 @@ public abstract class AbstractClient implements Client {
         clientEntity.destroy();
     }
 
-    private EntityRef findClientEntityRef() {
-        for (EntityRef entityRef: CoreRegistry.get(EntityManager.class).getEntitiesWith(ClientInfoComponent.class)) {
+    private EntityRef findClientEntityRef(EntityManager entityManager) {
+        for (EntityRef entityRef: entityManager.getEntitiesWith(ClientInfoComponent.class)) {
             ClientInfoComponent clientInfoComponent = entityRef.getComponent(ClientInfoComponent.class);
             if (clientInfoComponent.playerId.equals(getId())) {
                 return entityRef;
@@ -67,7 +66,7 @@ public abstract class AbstractClient implements Client {
 
         // TODO: Send event for clientInfo creation, don't create here.
 
-        EntityRef clientInfo = findClientEntityRef();
+        EntityRef clientInfo = findClientEntityRef(entityManager);
         if (!clientInfo.exists()) {
             clientInfo = createClientInfoEntity(entityManager);
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

In the `AbstractClient` class, the private method `findClientEntityRef` is only called from `createEntity`, where we already have a handy reference to the `EntityManager`, so in my understanding there is no need to take it from the CoreRegistry.
Passing the reference as an argument also makes testing of the class and it's subclasses easier and cleaner (I needed to look at the `AbstractClient` class while writing tests for the `HeadlessClient` class I added in MovingBlocks/FacadeServer#2) since you don't have to set up a mocked context, add the entityManager to it, setting the CoreRegistry's context, etc.

### How to test

Not much to test, all the automated unit tests pass and if you can try to use the game normally (e.g. join a local world or multiplayer server) and you can see that everything is as before.

### Outstanding before merging

Nothing I can think of.
