### PR TITLE
Separated spawnLocation calculation from respawnPlayer method

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -206,13 +207,18 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         removeRelevanceEntity(entity);
     }
 
-    @ReceiveEvent(components = {ClientComponent.class})
-    public void onRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
+    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
+    public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
         Vector3f spawnPosition = worldGenerator.getSpawnPosition(entity);
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         loc.setWorldPosition(spawnPosition);
         loc.setLocalRotation(new Quat4f());  // reset rotation
         entity.saveComponent(loc);
+    }
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL, components = {ClientComponent.class})
+    public void onRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
+        Vector3f spawnPosition = entity.getComponent(LocationComponent.class).getWorldPosition();
 
         if (worldProvider.isBlockRelevant(spawnPosition)) {
             respawnPlayer(entity);

--- a/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/HealthAuthoritySystem.java
@@ -174,7 +174,6 @@ public class HealthAuthoritySystem extends BaseComponentSystem implements Update
         if ((health != null) && !ghost) {
             int damagedAmount = health.currentHealth - Math.max(health.currentHealth - damageAmount, 0);
             health.currentHealth -= damagedAmount;
-            logger.info(String.valueOf(damageAmount) + " damage of type " + damageType);
             health.nextRegenTick = time.getGameTimeInMs() + TeraMath.floorToInt(health.waitBeforeRegen * 1000);
             entity.saveComponent(health);
             entity.send(new OnDamagedEvent(damageAmount, damagedAmount, damageType, instigator));


### PR DESCRIPTION
This PR is linked to https://github.com/Terasology/AdventureAssets/pull/11
Separates the existing RespawnRequestEvent handler into two handlers with different priorities. The RespawnRequestEvent is sent to the client entity once the "Respawn" button is clicked on the Death Screen.

Basically, this is what happens now:

- The spawn location for a player is calculated using the worldGenerator information at the earliest step (`CRITICAL` priority).
- Any other system which wants to change the respawn location can then intercept the RespawnRequestEvent and make change to the entity's (client's) location component. (priority between `TRIVIAL` and `CRITICAL`, both exclusive)
- Finally, the RespawnRequestEvent is received by the PlayerSystem again. This time the respawnPlayer method is called and the player respawns. (`TRIVIAL` priority).

Also, someone left the tap on in the HealthAuthoritySystem. Removed the heavy logging.