### PR TITLE
added API annotations to classes in the particles sysem

### DIFF
--- a/engine/src/main/java/org/terasology/particles/ParticleData.java
+++ b/engine/src/main/java/org/terasology/particles/ParticleData.java
@@ -18,11 +18,14 @@ package org.terasology.particles;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
+import org.terasology.module.sandbox.API;
 
 /**
  * Data object to store the data of a single particle.
  * Used for generator and affector operations.
  */
+
+@API
 public final class ParticleData {
     // scalars
     public float energy;

--- a/engine/src/main/java/org/terasology/particles/ParticleDataMask.java
+++ b/engine/src/main/java/org/terasology/particles/ParticleDataMask.java
@@ -15,9 +15,12 @@
  */
 package org.terasology.particles;
 
+import org.terasology.module.sandbox.API;
+
 /**
  * Data mask used internally by the particle system.
  */
+@API
 public enum ParticleDataMask {
 
     ENERGY(0b0000001),

--- a/engine/src/main/java/org/terasology/particles/ParticleSystemManager.java
+++ b/engine/src/main/java/org/terasology/particles/ParticleSystemManager.java
@@ -16,6 +16,7 @@
 package org.terasology.particles;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.module.sandbox.API;
 import org.terasology.particles.functions.affectors.AffectorFunction;
 import org.terasology.particles.functions.generators.GeneratorFunction;
 import org.terasology.particles.rendering.ParticleRenderingData;
@@ -27,6 +28,8 @@ import java.util.stream.Stream;
  * Also maintains a registry of generator and affector functions to be used when processing generators
  * and affectors during a particle system update.
  */
+
+@API
 public interface ParticleSystemManager {
 
     void registerAffectorFunction(AffectorFunction affectorFunction);


### PR DESCRIPTION
Adds API annotations to three classes in the particles system package. These classes are required for people to define and use custom particle affectors and generators in their modules.