### PR TITLE
Store DoorRegion prefab as component parameter

### DIFF
--- a/modules/Core/assets/prefabs/door.prefab
+++ b/modules/Core/assets/prefabs/door.prefab
@@ -13,7 +13,8 @@
         "topBlockFamily": "DoorTop",
         "bottomBlockFamily": "DoorBottom",
         "openSound": "DoorOpen",
-        "closeSound": "DoorClose"
+        "closeSound": "DoorClose",
+        "doorRegionPrefab": "Core:doorRegion"
     },
     "Health": {
         "currentHealth": 5,

--- a/modules/Core/src/main/java/org/terasology/core/logic/door/DoorComponent.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/door/DoorComponent.java
@@ -18,6 +18,7 @@ package org.terasology.core.logic.door;
 
 import org.terasology.audio.StaticSound;
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.Side;
 import org.terasology.world.block.family.BlockFamily;
 
@@ -30,6 +31,7 @@ public class DoorComponent implements Component {
     public Side openSide;
     public StaticSound openSound;
     public StaticSound closeSound;
+    public Prefab doorRegionPrefab;
 
     public boolean isOpen;
 }

--- a/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
@@ -133,7 +133,7 @@ public class DoorSystem extends BaseComponentSystem {
         worldProvider.getWorldEntity().send(blockEvent);
 
         if (!blockEvent.isConsumed()) {
-            EntityRef newDoor = entityManager.create("DoorRegion");
+            EntityRef newDoor = entityManager.create(door.doorRegionPrefab);
             entity.removeComponent(MeshComponent.class);
             newDoor.addComponent(new BlockRegionComponent(Region3i.createBounded(bottomBlockPos, topBlockPos)));
             Vector3f doorCenter = bottomBlockPos.toVector3f();


### PR DESCRIPTION
This is linked to https://github.com/Terasology/AdventureAssets/pull/12
It basically allows the "Core" door placement mechanism to be extendable while creating different types of doors- password locked doors, pressure plate operated doors, level operated doors etc.

It links the doorRegion prefab as a parameter in the DoorComponent, which was earlier hardcoded in the DoorSystem.