### PR TITLE
Multiline UIText, enter produces newline

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -446,6 +446,10 @@ public class UIText extends CoreWidget {
                         }
                         case KeyId.ENTER:
                         case KeyId.NUMPAD_ENTER: {
+                            if (multiline) {
+                                setText(fullText + "\n");
+                                increaseCursorPosition(1);
+                            }
                             for (ActivateEventListener listener : activationListeners) {
                                 listener.onActivated(this);
                             }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -446,9 +446,12 @@ public class UIText extends CoreWidget {
                         }
                         case KeyId.ENTER:
                         case KeyId.NUMPAD_ENTER: {
-                            if (multiline) {
-                                setText(fullText + "\n");
-                                increaseCursorPosition(1);
+                            if (event.getKeyboard().isKeyDown(Keyboard.Key.LEFT_SHIFT.getId()) ||
+                                    event.getKeyboard().isKeyDown(Keyboard.Key.RIGHT_SHIFT.getId())) {
+                                if (multiline) {
+                                    setText(fullText + "\n");
+                                    increaseCursorPosition(1);
+                                }
                             }
                             for (ActivateEventListener listener : activationListeners) {
                                 listener.onActivated(this);


### PR DESCRIPTION
For a UIText widget with `"multiline": true`, an `ENTER` key would now produce a newline (\n).