### PR TITLE
FloatingTextRenderer accepts multiple \n separated lines

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -41,6 +41,7 @@ import org.terasology.rendering.opengl.OpenGLUtils;
 import org.terasology.world.WorldProvider;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
@@ -99,18 +100,24 @@ public class FloatingTextRenderer extends BaseComponentSystem implements  Render
 
             FloatingTextComponent floatingText = entity.getComponent(FloatingTextComponent.class);
 
-            String text = floatingText.text;
+            List<String> text = Arrays.asList(floatingText.text.split("\n"));
             Color baseColor = floatingText.textColor;
             Color shadowColor = floatingText.textShadowColor;
             boolean underline = false;
-            int textWidth = font.getWidth(text);
+
+            String longest = "";
+            for (String s : text) {
+                if (s.length() > longest.length())
+                    longest = s;
+            }
+            int textWidth = font.getWidth(longest);
 
             FontMeshBuilder meshBuilder = new FontMeshBuilder(underlineMaterial);
 
             Map<Material, Mesh> meshMap = entityMeshCache.get(entity);
             if (meshMap == null) {
                 meshMap = meshBuilder
-                        .createTextMesh(font, Arrays.asList(text), textWidth, HorizontalAlign.CENTER, baseColor,
+                        .createTextMesh(font, text, textWidth, HorizontalAlign.CENTER, baseColor,
                                 shadowColor, underline);
                 entityMeshCache.put(entity, meshMap);
             }

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -104,7 +104,7 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
             Color shadowColor = floatingText.textShadowColor;
             boolean underline = false;
 
-            int textWidth = font.getWidth("");
+            int textWidth = 0;
             for (String singleLine : linesOfText) {
                 if (font.getWidth(singleLine) > textWidth)
                     textWidth = font.getWidth(singleLine);

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -41,20 +41,13 @@ import org.terasology.rendering.opengl.OpenGLUtils;
 import org.terasology.world.WorldProvider;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glPopMatrix;
-import static org.lwjgl.opengl.GL11.glPushMatrix;
-import static org.lwjgl.opengl.GL11.glScaled;
-import static org.lwjgl.opengl.GL11.glTranslated;
+import static org.lwjgl.opengl.GL11.*;
 
 
 @RegisterSystem(RegisterMode.CLIENT)
-public class FloatingTextRenderer extends BaseComponentSystem implements  RenderSystem {
+public class FloatingTextRenderer extends BaseComponentSystem implements RenderSystem {
 
     private static final int PIXEL_PER_METER = 250;
 
@@ -100,24 +93,23 @@ public class FloatingTextRenderer extends BaseComponentSystem implements  Render
 
             FloatingTextComponent floatingText = entity.getComponent(FloatingTextComponent.class);
 
-            List<String> text = Arrays.asList(floatingText.text.split("\n"));
+            String[] linesOfText = floatingText.text.split("\n");
             Color baseColor = floatingText.textColor;
             Color shadowColor = floatingText.textShadowColor;
             boolean underline = false;
 
-            String longest = "";
-            for (String s : text) {
-                if (s.length() > longest.length())
-                    longest = s;
+            int textWidth = font.getWidth("");
+            for (String singleLine : linesOfText) {
+                if (font.getWidth(singleLine) > textWidth)
+                    textWidth = font.getWidth(singleLine);
             }
-            int textWidth = font.getWidth(longest);
 
             FontMeshBuilder meshBuilder = new FontMeshBuilder(underlineMaterial);
 
             Map<Material, Mesh> meshMap = entityMeshCache.get(entity);
             if (meshMap == null) {
                 meshMap = meshBuilder
-                        .createTextMesh(font, text, textWidth, HorizontalAlign.CENTER, baseColor,
+                        .createTextMesh(font, Arrays.asList(linesOfText), textWidth, HorizontalAlign.CENTER, baseColor,
                                 shadowColor, underline);
                 entityMeshCache.put(entity, meshMap);
             }
@@ -175,13 +167,13 @@ public class FloatingTextRenderer extends BaseComponentSystem implements  Render
     public void renderShadows() {
     }
 
-    @ReceiveEvent(components = {FloatingTextComponent.class })
+    @ReceiveEvent(components = {FloatingTextComponent.class})
     public void onDisplayNameChange(OnChangedComponent event, EntityRef entity) {
         disposeCachedMeshOfEntity(entity);
     }
 
 
-    @ReceiveEvent(components = {FloatingTextComponent.class })
+    @ReceiveEvent(components = {FloatingTextComponent.class})
     public void onNameTagOwnerRemoved(BeforeDeactivateComponent event, EntityRef entity) {
         disposeCachedMeshOfEntity(entity);
     }

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -43,7 +43,13 @@ import org.terasology.world.WorldProvider;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glScaled;
+import static org.lwjgl.opengl.GL11.glTranslated;
 
 
 @RegisterSystem(RegisterMode.CLIENT)


### PR DESCRIPTION
This PR allows the FloatingTextRenderer to now split lines and separate them at "\n".
The FloatingTextComponent can now have the `text` parameter contain multiple "\n" separated lines.

The width for the mesh is calculated based on the longest length String after having broken the text. 

This is an example of how it looks:
![terasology-170629201022-1152x720](https://user-images.githubusercontent.com/13916513/27694029-91e9b0da-5d08-11e7-96be-84cfed27ef86.jpg)
