### PR TITLE
Small fix for in-game torches not producing lights

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredPointLightsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DeferredPointLightsNode.java
@@ -198,6 +198,8 @@ public class DeferredPointLightsNode extends AbstractNode {
                         lightComponent.lightColorAmbient.y, lightComponent.lightColorAmbient.z, true);
                     lightGeometryMaterial.setFloat3("lightProperties", lightComponent.lightAmbientIntensity,
                         lightComponent.lightDiffuseIntensity, lightComponent.lightSpecularPower, true);
+                    lightGeometryMaterial.setFloat4("lightExtendedProperties", lightComponent.lightAttenuationRange,
+                        lightComponent.lightAttenuationFalloff, 0.0f, 0.0f, true);
 
                     // setting shader parameters for the light position in camera space
                     Vector3f lightPositionInViewSpace = new Vector3f(lightPositionRelativeToCamera);


### PR DESCRIPTION
Fixes a bug introduced in an earlier ShaderParameter removal PR, which caused held objects to not produce any light.

Testing : Hold a torch and go to a dark place, and it should light things up.