### PR TITLE
Fixes block particle effects

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -18,6 +18,7 @@ package org.terasology.world.block.entity;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.StaticSound;
 import org.terasology.audio.events.PlaySoundEvent;
+import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
@@ -155,6 +156,14 @@ public class BlockEntitySystem extends BaseComponentSystem {
         BlockDamageModifierComponent blockDamageModifierComponent = event.getDamageType().getComponent(BlockDamageModifierComponent.class);
         // TODO: Configurable via block definition
         if (blockDamageModifierComponent == null || !blockDamageModifierComponent.skipPerBlockEffects) {
+            // dust particle effect
+            if (entity.hasComponent(LocationComponent.class) && block.isDebrisOnDestroy()) {
+                EntityBuilder dustBuilder = entityManager.newBuilder("core:dustEffect");
+                dustBuilder.getComponent(LocationComponent.class).setWorldPosition(entity.getComponent(LocationComponent.class).getWorldPosition());
+                dustBuilder.build();
+            }
+
+            // sound to play for destroyed block
             BlockSounds sounds = block.getSounds();
             if (!sounds.getDestroySounds().isEmpty()) {
                 StaticSound sound = random.nextItem(sounds.getDestroySounds());

--- a/modules/Core/assets/prefabs/particleEffects/defaultBlockParticles.prefab
+++ b/modules/Core/assets/prefabs/particleEffects/defaultBlockParticles.prefab
@@ -12,7 +12,7 @@
         "maxVelocity": [1.5, 4, 1.5]
     },
     "scaleRangeGenerator": {
-        "minScale": [0.2, 0.2, 0.2],
+        "minScale": [0.1, 0.1, 0.1],
         "maxScale": [0.2, 0.2, 0.2]
     },
     "textureOffsetGenerator": {},


### PR DESCRIPTION
- particles when damaging a block now have the block's texture (randomly selected from all sides)
![001-block-damage-particle-effect](https://user-images.githubusercontent.com/1448874/27985818-3ce6b154-63f3-11e7-84ac-cb4497756b5c.gif)
![002-block-damage-particle-effect](https://user-images.githubusercontent.com/1448874/27985819-3ce8225a-63f3-11e7-9f88-a549b862648d.gif)
- smoke effect is only shown when block is destroyed and drops debris
![003-block-damage-particle-effect](https://user-images.githubusercontent.com/1448874/27985820-3ceabe02-63f3-11e7-8d32-c810d5e6b670.gif)
