### PR TITLE
rollback the changes that were done to enable world collisions

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -710,15 +710,9 @@ public class BulletPhysics implements PhysicsEngine {
                     if (((CollisionObject) initialPair.pProxy1.clientObject).getUserPointer() instanceof EntityRef) {
                         otherEntity = (EntityRef) ((CollisionObject) initialPair.pProxy1.clientObject).getUserPointer();
                     }
-                    else if(((CollisionObject) initialPair.pProxy1.clientObject).getUserPointer() instanceof Vector3i){
-                        otherEntity = blockEntityRegistry.getEntityAt((Vector3i)((CollisionObject) initialPair.pProxy1.clientObject).getUserPointer());
-                    }
                 } else {
                     if (((CollisionObject) initialPair.pProxy0.clientObject).getUserPointer() instanceof EntityRef) {
                         otherEntity = (EntityRef) ((CollisionObject) initialPair.pProxy0.clientObject).getUserPointer();
-                    }
-                    else if(((CollisionObject) initialPair.pProxy0.clientObject).getUserPointer() instanceof Vector3i){
-                        otherEntity = blockEntityRegistry.getEntityAt((Vector3i)((CollisionObject) initialPair.pProxy0.clientObject).getUserPointer());
                     }
                 }
                 if (otherEntity == null || otherEntity == EntityRef.NULL) {


### PR DESCRIPTION
turns out that those changes triggered multiple CollideEvent for same entity and for same collisions. Found another way to achieve what i needed, so please do merge this to rollback the changes.