### PR TITLE
prevents characters from colliding with sensors

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -933,6 +933,7 @@ public class BulletPhysics implements PhysicsEngine {
             BulletSweepCallback callback = new BulletSweepCallback(collider, new org.terasology.math.geom.Vector3f(0, 1, 0), slopeFactor);
             callback.collisionFilterGroup = collider.getBroadphaseHandle().collisionFilterGroup;
             callback.collisionFilterMask = collider.getBroadphaseHandle().collisionFilterMask;
+            callback.collisionFilterMask = (short)(callback.collisionFilterMask & (~StandardCollisionGroup.SENSOR.getFlag()));
             collider.convexSweepTest((ConvexShape) (collider.getCollisionShape()), startTransform, endTransform, callback, allowedPenetration);
             return callback;
         }


### PR DESCRIPTION
Because the characters in the game use convex sweep on every input to check for collisions. The consuming of CollideEvent was useless in this case. Thats why the required changes have been introduced where a character ignores the collisions with a trigger that has Sensor collision group to avoid responding to invisible sensors.
Please note that if you require a Trigger for an entity that is not a Sensor and wants to collide with Characters than you are free to do so but do change the collisionGroup to something relevant in the TriggerComponent. The default collisionGroup is Sensor, so be sure to change it in that case.