### PR TITLE
[WIP] Sectors/pools: v2.0.0 branch

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
@@ -32,14 +32,15 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.entitySystem.prefab.internal.PojoPrefab;
 import org.terasology.network.NetworkSystem;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
+import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
 
 /**
  */
@@ -75,19 +76,19 @@ public class BaseEntityRefTest {
 
     @Test
     public void testSetScope() {
-        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
+        assertEquals(ref.getScope(), GLOBAL);
         assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
         assertFalse(entityManager.getSectorManager().contains(ref.getId()));
 
         //Move into sector scope
-        ref.setScope(EntityData.Entity.Scope.SECTOR);
-        assertEquals(ref.getScope(), EntityData.Entity.Scope.SECTOR);
+        ref.setScope(SECTOR);
+        assertEquals(ref.getScope(), SECTOR);
         assertTrue(entityManager.getSectorManager().contains(ref.getId()));
         assertFalse(entityManager.getGlobalPool().contains(ref.getId()));
 
         //And move back to global scope
-        ref.setScope(EntityData.Entity.Scope.GLOBAL);
-        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
+        ref.setScope(GLOBAL);
+        assertEquals(ref.getScope(), GLOBAL);
         assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
         assertFalse(entityManager.getSectorManager().contains(ref.getId()));
     }

--- a/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terasology.assets.AssetFactory;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.assets.module.ModuleAwareAssetTypeManager;
+import org.terasology.context.Context;
+import org.terasology.context.internal.ContextImpl;
+import org.terasology.engine.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.PojoEntityManager;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabData;
+import org.terasology.entitySystem.prefab.internal.PojoPrefab;
+import org.terasology.network.NetworkSystem;
+import org.terasology.protobuf.EntityData;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.testUtil.ModuleManagerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ */
+public class BaseEntityRefTest {
+
+    private static Context context;
+    private PojoEntityManager entityManager;
+    //private Prefab prefab;
+    private EntityRef ref;
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        context = new ContextImpl();
+        ModuleManager moduleManager = ModuleManagerFactory.create();
+        context.put(ModuleManager.class, moduleManager);
+        ModuleAwareAssetTypeManager assetTypeManager = new ModuleAwareAssetTypeManager();
+        assetTypeManager.registerCoreAssetType(Prefab.class,
+                (AssetFactory<Prefab, PrefabData>) PojoPrefab::new, "prefabs");
+        assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
+        context.put(AssetManager.class, assetTypeManager.getAssetManager());
+        CoreRegistry.setContext(context);
+    }
+
+    @Before
+    public void setup() {
+        context.put(NetworkSystem.class, mock(NetworkSystem.class));
+        EntitySystemSetupUtil.addReflectionBasedLibraries(context);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = (PojoEntityManager) context.get(EntityManager.class);
+
+        ref = entityManager.create();
+    }
+
+    @Test
+    public void testSetScope() {
+        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
+        assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
+
+        //Move into sector scope
+        ref.setScope(EntityData.Entity.Scope.SECTOR);
+        assertEquals(ref.getScope(), EntityData.Entity.Scope.SECTOR);
+        assertTrue(entityManager.getSectorManager().contains(ref.getId()));
+
+        //And move back to global scope
+        ref.setScope(EntityData.Entity.Scope.GLOBAL);
+        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
+        assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
+    }
+
+}

--- a/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/BaseEntityRefTest.java
@@ -42,13 +42,10 @@ import static org.mockito.Mockito.mock;
 import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
 import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
 
-/**
- */
 public class BaseEntityRefTest {
 
     private static Context context;
     private PojoEntityManager entityManager;
-    //private Prefab prefab;
     private EntityRef ref;
 
     @BeforeClass

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -30,6 +30,7 @@ import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.PojoEntityManager;
+import org.terasology.entitySystem.entity.internal.PojoEntityPool;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
@@ -43,6 +44,7 @@ import org.terasology.entitySystem.stubs.EntityRefComponent;
 import org.terasology.entitySystem.stubs.IntegerComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.network.NetworkSystem;
+import org.terasology.protobuf.EntityData;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.utilities.Assets;
@@ -97,6 +99,7 @@ public class PojoEntityManagerTest {
     public void testCreateEntity() {
         EntityRef entity = entityManager.create();
         assertNotNull(entity);
+        assertEquals(entity.getScope(), EntityData.Entity.Scope.GLOBAL);
     }
 
     @Test
@@ -381,5 +384,17 @@ public class PojoEntityManagerTest {
         assertTrue(entity.exists());
         entity.destroy();
         assertTrue(entity.exists());
+    }
+
+    @Test
+    public void testMoveToPool() {
+        EntityRef entity = entityManager.create();
+        long id = entity.getId();
+
+        PojoEntityPool pool = new PojoEntityPool(entityManager);
+
+        entityManager.moveToPool(id, pool);
+
+        assertTrue(pool.contains(id));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -391,10 +391,18 @@ public class PojoEntityManagerTest {
         EntityRef entity = entityManager.create();
         long id = entity.getId();
 
-        PojoEntityPool pool = new PojoEntityPool(entityManager);
+        PojoEntityPool pool1 = new PojoEntityPool(entityManager);
+        PojoEntityPool pool2 = new PojoEntityPool(entityManager);
 
-        entityManager.moveToPool(id, pool);
+        assertFalse(pool1.contains(id));
+        assertFalse(pool2.contains(id));
 
-        assertTrue(pool.contains(id));
+        assertTrue(entityManager.moveToPool(id, pool1));
+        assertTrue(pool1.contains(id));
+        assertFalse(pool2.contains(id));
+
+        assertTrue(entityManager.moveToPool(id, pool2));
+        assertTrue(pool2.contains(id));
+        assertFalse(pool1.contains(id));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -44,7 +44,6 @@ import org.terasology.entitySystem.stubs.EntityRefComponent;
 import org.terasology.entitySystem.stubs.IntegerComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.network.NetworkSystem;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.utilities.Assets;
@@ -61,6 +60,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
 
 /**
  */
@@ -99,7 +99,7 @@ public class PojoEntityManagerTest {
     public void testCreateEntity() {
         EntityRef entity = entityManager.create();
         assertNotNull(entity);
-        assertEquals(entity.getScope(), EntityData.Entity.Scope.GLOBAL);
+        assertEquals(entity.getScope(), GLOBAL);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityPoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityPoolTest.java
@@ -28,27 +28,25 @@ import org.terasology.engine.module.ModuleManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.PojoEntityManager;
+import org.terasology.entitySystem.entity.internal.PojoEntityPool;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
 import org.terasology.entitySystem.prefab.internal.PojoPrefab;
 import org.terasology.network.NetworkSystem;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 /**
  */
-public class BaseEntityRefTest {
+public class PojoEntityPoolTest {
 
+    private PojoEntityPool pool;
     private static Context context;
     private PojoEntityManager entityManager;
-    //private Prefab prefab;
-    private EntityRef ref;
 
     @BeforeClass
     public static void setupClass() throws Exception {
@@ -70,26 +68,25 @@ public class BaseEntityRefTest {
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
         entityManager = (PojoEntityManager) context.get(EntityManager.class);
 
-        ref = entityManager.create();
+        pool = new PojoEntityPool(entityManager);
+    }
+
+
+    @Test
+    public void testContains() {
+        assertFalse(pool.contains(PojoEntityManager.NULL_ID));
+        assertFalse(pool.contains(1000000));
+        EntityRef ref = pool.create();
+        assertTrue(pool.contains(ref.getId()));
     }
 
     @Test
-    public void testSetScope() {
-        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
-        assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
-        assertFalse(entityManager.getSectorManager().contains(ref.getId()));
+    public void testRemove() {
+        EntityRef ref = pool.create();
+        assertTrue(pool.contains(ref.getId()));
 
-        //Move into sector scope
-        ref.setScope(EntityData.Entity.Scope.SECTOR);
-        assertEquals(ref.getScope(), EntityData.Entity.Scope.SECTOR);
-        assertTrue(entityManager.getSectorManager().contains(ref.getId()));
-        assertFalse(entityManager.getGlobalPool().contains(ref.getId()));
-
-        //And move back to global scope
-        ref.setScope(EntityData.Entity.Scope.GLOBAL);
-        assertEquals(ref.getScope(), EntityData.Entity.Scope.GLOBAL);
-        assertTrue(entityManager.getGlobalPool().contains(ref.getId()));
-        assertFalse(entityManager.getSectorManager().contains(ref.getId()));
+        pool.remove(ref.getId());
+        assertFalse(pool.contains(ref.getId()));
     }
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.MutableComponentContainer;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.entity.internal.EntityInfoComponent;
+import org.terasology.entitySystem.entity.internal.EntityScope;
 import org.terasology.entitySystem.prefab.Prefab;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ public class EntityBuilder implements MutableComponentContainer {
     private EngineEntityManager entityManager;
 
     private boolean sendLifecycleEvents = true;
+    private EntityScope scope;
 
     public EntityBuilder(EngineEntityManager entityManager) {
         this.entityManager = entityManager;
@@ -94,11 +96,19 @@ public class EntityBuilder implements MutableComponentContainer {
      * @return The built entity.
      */
     public EntityRef build() {
-        return pool.create(components.values(), sendLifecycleEvents);
+        EntityRef entity = pool.create(components.values(), sendLifecycleEvents);
+        if (scope != null) {
+            entity.setScope(scope);
+        }
+        return entity;
     }
 
     public EntityRef buildWithoutLifecycleEvents() {
-        return pool.create(components.values(), false);
+        EntityRef entity = pool.create(components.values(), false);
+        if (scope != null) {
+            entity.setScope(scope);
+        }
+        return entity;
     }
 
     @Override
@@ -146,6 +156,14 @@ public class EntityBuilder implements MutableComponentContainer {
 
     public void setAlwaysRelevant(boolean alwaysRelevant) {
         getEntityInfo().alwaysRelevant = alwaysRelevant;
+    }
+
+    public void setScope(EntityScope scope) {
+        this.scope = scope;
+    }
+
+    public EntityScope getScope() {
+        return scope;
     }
 
     public void setOwner(EntityRef owner) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -69,10 +69,4 @@ public interface EntityManager extends EntityPool {
      */
     ComponentLibrary getComponentLibrary();
 
-    EngineEntityPool getGlobalPool();
-
-    EngineSectorManager getSectorManager();
-
-    boolean moveToPool(long id, EngineEntityPool pool);
-
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -36,12 +36,6 @@ public interface EntityManager extends EntityPool {
     }
 
     /**
-     * @param id
-     * @return The entity with the given id, or the null entity
-     */
-    EntityRef getEntity(long id);
-
-    /**
      * @param other
      * @return A new entity with a copy of each of the other entity's components
      * @deprecated Use EntityRef.copy() instead.

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -33,7 +33,7 @@ public interface EntityManager extends EntityPool {
      *
      * @return the newly created EntityRef
      */
-    default EntityRef createSectorEntity() {
+    default EntityRef createSectorEntity(long maxDelta) {
         return null;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -16,6 +16,8 @@
 package org.terasology.entitySystem.entity;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.internal.EngineEntityPool;
+import org.terasology.entitySystem.entity.internal.EngineSectorManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.PrefabManager;
@@ -67,8 +69,10 @@ public interface EntityManager extends EntityPool {
      */
     ComponentLibrary getComponentLibrary();
 
-    EntityPool getGlobalPool();
+    EngineEntityPool getGlobalPool();
 
-    SectorManager getSectorManager();
+    EngineSectorManager getSectorManager();
+
+    boolean moveToPool(long id, EngineEntityPool pool);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -18,88 +18,13 @@ package org.terasology.entitySystem.entity;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
-import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
 
 import java.util.Map;
 
 /**
  */
 public interface EntityManager extends EntityPool {
-
-    /**
-     * Creates an EntityBuilder.
-     *
-     * @return A new entity builder
-     */
-    EntityBuilder newBuilder();
-
-    /**
-     * Creates an EntityBuilder, from a prefab
-     *
-     * @return A new entity builder
-     */
-    EntityBuilder newBuilder(String prefabName);
-
-    /**
-     * Creates an EntityBuilder, from a prefab
-     *
-     * @return A new entity builder
-     */
-    EntityBuilder newBuilder(Prefab prefab);
-
-    /**
-     * @return A references to a new, unused entity
-     */
-    EntityRef create();
-
-    /**
-     * @return A references to a new, unused entity with the desired components
-     */
-    EntityRef create(Component... components);
-
-    /**
-     * @return A references to a new, unused entity with the desired components
-     */
-    EntityRef create(Iterable<Component> components);
-
-    /**
-     * @param prefabName The name of the prefab to create.
-     * @return A new entity, based on the the prefab of the given name. If the prefab doesn't exist, just a new entity.
-     */
-    EntityRef create(String prefabName);
-
-    /**
-     * @param prefab
-     * @return A new entity, based on the given prefab
-     */
-    EntityRef create(Prefab prefab);
-
-    // TODO: Review. Probably better to move these into a static helper
-
-    /**
-     * @param prefab
-     * @param position
-     * @return A new entity, based on the given prefab, at the desired position
-     */
-    EntityRef create(String prefab, Vector3f position);
-
-    /**
-     * @param prefab
-     * @param position
-     * @return A new entity, based on the given prefab, at the desired position
-     */
-    EntityRef create(Prefab prefab, Vector3f position);
-
-    /**
-     * @param prefab
-     * @param position
-     * @param rotation
-     * @return
-     */
-    EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation);
 
     /**
      * Creates a new EntityRef in sector-scope
@@ -134,23 +59,6 @@ public interface EntityManager extends EntityPool {
     Map<Class<? extends Component>, Component> copyComponents(EntityRef original);
 
     /**
-     * @return An iterable over all entities
-     */
-    Iterable<EntityRef> getAllEntities();
-
-    /**
-     * @param componentClasses
-     * @return An iterable over all entities with the provided component types.
-     */
-    Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses);
-
-    /**
-     * @param componentClasses
-     * @return A count of entities with the provided component types
-     */
-    int getCountOfEntitiesWith(Class<? extends Component>... componentClasses);
-
-    /**
      * @return The event system being used by the entity manager
      */
     EventSystem getEventSystem();
@@ -164,11 +72,6 @@ public interface EntityManager extends EntityPool {
      * @return The component library being used by the entity manager
      */
     ComponentLibrary getComponentLibrary();
-
-    /**
-     * @return A count of currently active entities
-     */
-    int getActiveEntityCount();
 
     EntityPool getGlobalPool();
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -172,6 +172,6 @@ public interface EntityManager extends EntityPool {
 
     EntityPool getGlobalPool();
 
-    EntityPool getSectorPool();
+    SectorManager getSectorManager();
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -21,16 +21,17 @@ import org.terasology.entitySystem.entity.internal.EngineSectorManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.PrefabManager;
+import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 
 import java.util.Map;
 
-/**
- */
 public interface EntityManager extends EntityPool {
 
     /**
      * Creates a new EntityRef in sector-scope
      *
+     * @param maxDelta the maximum delta for the sector entity's simulations
+     *                 @see SectorSimulationComponent#maxDelta
      * @return the newly created EntityRef
      */
     default EntityRef createSectorEntity(long maxDelta) {
@@ -38,7 +39,6 @@ public interface EntityManager extends EntityPool {
     }
 
     /**
-     * @param other
      * @return A new entity with a copy of each of the other entity's components
      * @deprecated Use EntityRef.copy() instead.
      */
@@ -48,7 +48,6 @@ public interface EntityManager extends EntityPool {
     /**
      * Creates a copy of the components of an entity.
      *
-     * @param original
      * @return A map of components types to components copied from the target entity.
      */
     // TODO: Remove? A little dangerous due to ownership

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -173,7 +173,7 @@ public interface EntityPool {
     /**
      * Does this pool contain the given entity?
      *
-     * @param id the id to search for
+     * @param id the id of the entity to search for
      * @return true if this pool contains the entity; false otherwise
      */
     boolean contains(long id);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -20,8 +20,6 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 
-/**
- */
 public interface EntityPool {
 
     /**
@@ -82,7 +80,6 @@ public interface EntityPool {
     EntityRef create(String prefabName);
 
     /**
-     * @param prefab
      * @return A new entity, based on the given prefab
      */
     EntityRef create(Prefab prefab);
@@ -90,24 +87,17 @@ public interface EntityPool {
     // TODO: Review. Probably better to move these into a static helper
 
     /**
-     * @param prefab
-     * @param position
      * @return A new entity, based on the given prefab, at the desired position
      */
     EntityRef create(String prefab, Vector3f position);
 
     /**
-     * @param prefab
-     * @param position
      * @return A new entity, based on the given prefab, at the desired position
      */
     EntityRef create(Prefab prefab, Vector3f position);
 
     /**
-     * @param prefab
-     * @param position
-     * @param rotation
-     * @return
+     * @return A new entity, based on the given prefab, at the desired position, and with the desired rotation
      */
     EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation);
 
@@ -116,7 +106,6 @@ public interface EntityPool {
      * <br><br>
      * This is used by the block entity system to give an illusion of permanence to temporary block entities.
      *
-     * @param components
      * @return The newly created entity ref.
      */
     EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components);
@@ -126,7 +115,6 @@ public interface EntityPool {
      * <br><br>
      * This is used by the block entity system to give an illusion of permanence to temporary block entities.
      *
-     * @param prefab
      * @return The newly created entity ref.
      */
     EntityRef createEntityWithoutLifecycleEvents(String prefab);
@@ -137,8 +125,6 @@ public interface EntityPool {
      * Allows the creation of an entity with a given id - this is used
      * when loading persisted entities
      *
-     * @param id
-     * @param components
      * @return The entityRef for the newly created entity
      */
     EntityRef createEntityWithId(long id, Iterable<Component> components);
@@ -146,21 +132,21 @@ public interface EntityPool {
     /**
      * Retrieve the entity ref with the given id.
      *
-     * @param id
      * @return the {@link EntityRef}, if it exists; {@link EntityRef#NULL} otherwise
      */
     EntityRef getEntity(long id);
 
+    /**
+     * @return an iterable over all of the entities in this pool
+     */
     Iterable<EntityRef> getAllEntities();
 
     /**
-     * @param componentClasses
      * @return An iterable over all entities with the provided component types.
      */
     Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses);
 
     /**
-     * @param componentClasses
      * @return A count of entities with the provided component types
      */
     int getCountOfEntitiesWith(Class<? extends Component>... componentClasses);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -65,6 +65,16 @@ public interface EntityPool {
      */
     EntityRef create(Iterable<Component> components);
 
+
+    /**
+     * Creates a new entity from the given components.
+     *
+     * @param components the components to create this entity from
+     * @param sendLifecycleEvents will only send lifecycle events if this is true
+     * @return
+     */
+    EntityRef create(Iterable<Component> components, boolean sendLifecycleEvents);
+
     /**
      * @param prefabName The name of the prefab to create.
      * @return A new entity, based on the the prefab of the given name. If the prefab doesn't exist, just a new entity.
@@ -141,10 +151,6 @@ public interface EntityPool {
      */
     EntityRef createEntityRefWithId(long id);
 
-    void destroy(long entityId);
-
-    void destroyEntityWithoutEvents(EntityRef entity);
-
     Iterable<EntityRef> getAllEntities();
 
     /**
@@ -153,6 +159,15 @@ public interface EntityPool {
      */
     Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses);
 
+    /**
+     * @param componentClasses
+     * @return A count of entities with the provided component types
+     */
+    int getCountOfEntitiesWith(Class<? extends Component>... componentClasses);
+
+    /**
+     * @return A count of currently active entities
+     */
     int getActiveEntityCount();
 
     /**
@@ -163,12 +178,4 @@ public interface EntityPool {
      */
     EntityRef getExistingEntity(long id);
 
-    /**
-     * Fund out if a particular entity has a component of the given class.
-     *
-     * @param entityId the entity to check
-     * @param componentClass the class to check for
-     * @return whether the entity has the component
-     */
-    boolean hasComponent(long entityId, Class<? extends Component> componentClass);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -16,18 +16,18 @@
 package org.terasology.entitySystem.entity;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.event.internal.EventSystem;
-import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.Prefab;
-import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 
-import java.util.Map;
-
 /**
  */
-public interface EntityManager extends EntityPool {
+public interface EntityPool {
+
+    /**
+     * Removes all entities from the pool.
+     */
+    void clear();
 
     /**
      * Creates an EntityBuilder.
@@ -102,40 +102,49 @@ public interface EntityManager extends EntityPool {
     EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation);
 
     /**
-     * Creates a new EntityRef in sector-scope
+     * Creates an entity but doesn't send any lifecycle events.
+     * <br><br>
+     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
      *
-     * @return the newly created EntityRef
+     * @param components
+     * @return The newly created entity ref.
      */
-    default EntityRef createSectorEntity() {
-        return null;
-    }
+    EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components);
 
     /**
+     * Creates an entity but doesn't send any lifecycle events.
+     * <br><br>
+     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
+     *
+     * @param prefab
+     * @return The newly created entity ref.
+     */
+    EntityRef createEntityWithoutLifecycleEvents(String prefab);
+
+    EntityRef createEntityWithoutLifecycleEvents(Prefab prefab);
+
+    /**
+     * Allows the creation of an entity with a given id - this is used
+     * when loading persisted entities
+     *
      * @param id
-     * @return The entity with the given id, or the null entity
+     * @param components
+     * @return The entityRef for the newly created entity
      */
-    EntityRef getEntity(long id);
+    EntityRef createEntityWithId(long id, Iterable<Component> components);
 
     /**
-     * @param other
-     * @return A new entity with a copy of each of the other entity's components
-     * @deprecated Use EntityRef.copy() instead.
-     */
-    @Deprecated
-    EntityRef copy(EntityRef other);
-
-    /**
-     * Creates a copy of the components of an entity.
+     * Creates an entity ref with the given id. This is used when loading components with references.
      *
-     * @param original
-     * @return A map of components types to components copied from the target entity.
+     * @param id
+     * @return The entityRef for the given id
      */
-    // TODO: Remove? A little dangerous due to ownership
-    Map<Class<? extends Component>, Component> copyComponents(EntityRef original);
+    EntityRef createEntityRefWithId(long id);
 
-    /**
-     * @return An iterable over all entities
-     */
+    void destroy(long entityId);
+
+    void destroyEntityWithoutEvents(EntityRef entity);
+
     Iterable<EntityRef> getAllEntities();
 
     /**
@@ -144,34 +153,22 @@ public interface EntityManager extends EntityPool {
      */
     Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses);
 
-    /**
-     * @param componentClasses
-     * @return A count of entities with the provided component types
-     */
-    int getCountOfEntitiesWith(Class<? extends Component>... componentClasses);
-
-    /**
-     * @return The event system being used by the entity manager
-     */
-    EventSystem getEventSystem();
-
-    /**
-     * @return The prefab manager being used by the entity manager
-     */
-    PrefabManager getPrefabManager();
-
-    /**
-     * @return The component library being used by the entity manager
-     */
-    ComponentLibrary getComponentLibrary();
-
-    /**
-     * @return A count of currently active entities
-     */
     int getActiveEntityCount();
 
-    EntityPool getGlobalPool();
+    /**
+     * Gets an entity, if it already exists.
+     *
+     * @param id the id of the desired entity
+     * @return the {@link EntityRef}, if it exists; {@link EntityRef#NULL} otherwise
+     */
+    EntityRef getExistingEntity(long id);
 
-    EntityPool getSectorPool();
-
+    /**
+     * Fund out if a particular entity has a component of the given class.
+     *
+     * @param entityId the entity to check
+     * @param componentClass the class to check for
+     * @return whether the entity has the component
+     */
+    boolean hasComponent(long entityId, Class<? extends Component> componentClass);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -170,4 +170,11 @@ public interface EntityPool {
      */
     int getActiveEntityCount();
 
+    /**
+     * Does this pool contain the given entity?
+     *
+     * @param id the id to search for
+     * @return true if this pool contains the entity; false otherwise
+     */
+    boolean contains(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityPool.java
@@ -144,12 +144,12 @@ public interface EntityPool {
     EntityRef createEntityWithId(long id, Iterable<Component> components);
 
     /**
-     * Creates an entity ref with the given id. This is used when loading components with references.
+     * Retrieve the entity ref with the given id.
      *
      * @param id
-     * @return The entityRef for the given id
+     * @return the {@link EntityRef}, if it exists; {@link EntityRef#NULL} otherwise
      */
-    EntityRef createEntityRefWithId(long id);
+    EntityRef getEntity(long id);
 
     Iterable<EntityRef> getAllEntities();
 
@@ -169,13 +169,5 @@ public interface EntityPool {
      * @return A count of currently active entities
      */
     int getActiveEntityCount();
-
-    /**
-     * Gets an entity, if it already exists.
-     *
-     * @param id the id of the desired entity
-     * @return the {@link EntityRef}, if it exists; {@link EntityRef#NULL} otherwise
-     */
-    EntityRef getExistingEntity(long id);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -17,10 +17,11 @@ package org.terasology.entitySystem.entity;
 
 import com.google.common.base.Objects;
 import org.terasology.entitySystem.MutableComponentContainer;
+import org.terasology.entitySystem.entity.internal.EntityScope;
 import org.terasology.entitySystem.entity.internal.NullEntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
-import org.terasology.protobuf.EntityData;
+import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 
 /**
  * A wrapper around an entity id providing access to common functionality
@@ -97,13 +98,21 @@ public abstract class EntityRef implements MutableComponentContainer {
      *
      * @param scope
      */
-    public void setScope(EntityData.Entity.Scope scope) {
+    public void setScope(EntityScope scope) {
+    }
+
+    /**
+     * Sets the scope of this entity to sector-scope, and sets the {@link SectorSimulationComponent#maxDelta}.
+     *
+     * @param maxDelta the maxDelta for the sector-scope entity
+     */
+    public void setSectorScope(long maxDelta) {
     }
 
     /**
      * @return the scope of the entity
      */
-    public EntityData.Entity.Scope getScope() {
+    public EntityScope getScope() {
         return null;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -124,4 +124,10 @@ public abstract class EntityRef implements MutableComponentContainer {
     public final int hashCode() {
         return Objects.hashCode(getId());
     }
+
+    /**
+     * Invalidates this EntityRef
+     */
+    public void invalidate() {
+    }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -96,7 +96,7 @@ public abstract class EntityRef implements MutableComponentContainer {
     /**
      * Sets the scope of the entity
      *
-     * @param scope
+     * @param scope the new scope for the entity
      */
     public void setScope(EntityScope scope) {
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -20,6 +20,7 @@ import org.terasology.entitySystem.MutableComponentContainer;
 import org.terasology.entitySystem.entity.internal.NullEntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.protobuf.EntityData;
 
 /**
  * A wrapper around an entity id providing access to common functionality
@@ -90,6 +91,21 @@ public abstract class EntityRef implements MutableComponentContainer {
      * @return The owning entity of this entity
      */
     public abstract EntityRef getOwner();
+
+    /**
+     * Sets the scope of the entity
+     *
+     * @param scope
+     */
+    public void setScope(EntityData.Entity.Scope scope) {
+    }
+
+    /**
+     * @return the scope of the entity
+     */
+    public EntityData.Entity.Scope getScope() {
+        return null;
+    }
 
     /**
      * Sets the entity that owns this entity.

--- a/engine/src/main/java/org/terasology/entitySystem/entity/LowLevelEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/LowLevelEntityManager.java
@@ -16,6 +16,8 @@
 package org.terasology.entitySystem.entity;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.internal.EngineEntityPool;
+import org.terasology.entitySystem.entity.internal.EngineSectorManager;
 
 /**
  */
@@ -38,5 +40,25 @@ public interface LowLevelEntityManager extends EntityManager {
     Iterable<Component> iterateComponents(long id);
 
     void destroy(long id);
+
+    /**
+     * @return the global entity pool
+     */
+    EngineEntityPool getGlobalPool();
+
+    /**
+     * @return the sector manager
+     */
+    EngineSectorManager getSectorManager();
+
+    /**
+     * Moves the given entity into the given pool. This will move the entity and all of its components, as well as
+     * re-assigning it in the entity manager.
+     *
+     * @param id the id of the entity to move
+     * @param pool the pool to move the entity into
+     * @return whether the move was successful
+     */
+    boolean moveToPool(long id, EngineEntityPool pool);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/LowLevelEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/LowLevelEntityManager.java
@@ -19,8 +19,6 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.internal.EngineEntityPool;
 import org.terasology.entitySystem.entity.internal.EngineSectorManager;
 
-/**
- */
 public interface LowLevelEntityManager extends EntityManager {
 
     boolean isExistingEntity(long id);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/SectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/SectorManager.java
@@ -15,7 +15,5 @@
  */
 package org.terasology.entitySystem.entity;
 
-/**
- */
 public interface SectorManager extends EntityPool {
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/SectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/SectorManager.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity;
+
+/**
+ */
+public interface SectorManager extends EntityPool {
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 public abstract class BaseEntityRef extends EntityRef {
 
     protected LowLevelEntityManager entityManager;
-    private Logger logger = LoggerFactory.getLogger(BaseEntityRef.class);
+    private static final Logger logger = LoggerFactory.getLogger(BaseEntityRef.class);
 
     public BaseEntityRef(LowLevelEntityManager entityManager) {
         this.entityManager = entityManager;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.entitySystem.entity.internal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
@@ -34,6 +36,7 @@ import java.util.Collections;
 public abstract class BaseEntityRef extends EntityRef {
 
     protected LowLevelEntityManager entityManager;
+    private Logger logger = LoggerFactory.getLogger(BaseEntityRef.class);
 
     public BaseEntityRef(LowLevelEntityManager entityManager) {
         this.entityManager = entityManager;
@@ -92,6 +95,21 @@ public abstract class BaseEntityRef extends EntityRef {
         if (exists()) {
             EntityInfoComponent info = getEntityInfo();
             if (!info.scope.equals(scope)) {
+
+                EngineEntityPool newPool;
+                switch (scope) {
+                    case GLOBAL:
+                        newPool = entityManager.getGlobalPool();
+                        break;
+                    case SECTOR:
+                        newPool = entityManager.getSectorManager();
+                        break;
+                    default:
+                        logger.error("Unrecognised scope {}.", scope);
+                        return;
+                }
+
+                entityManager.moveToPool(getId(), newPool);
                 info.scope = scope;
                 saveComponent(info);
             }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 import org.terasology.network.NetworkComponent;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.EntitySerializer;
@@ -100,9 +101,13 @@ public abstract class BaseEntityRef extends EntityRef {
                 switch (scope) {
                     case GLOBAL:
                         newPool = entityManager.getGlobalPool();
+                        removeComponent(SectorSimulationComponent.class);
                         break;
                     case SECTOR:
                         newPool = entityManager.getSectorManager();
+                        if (!hasComponent(SectorSimulationComponent.class)) {
+                            addComponent(new SectorSimulationComponent());
+                        }
                         break;
                     default:
                         logger.error("Unrecognised scope {}.", scope);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -172,6 +172,7 @@ public abstract class BaseEntityRef extends EntityRef {
         return builder.toString();
     }
 
+    @Override
     public void invalidate() {
         entityManager = null;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -26,11 +26,12 @@ import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 import org.terasology.network.NetworkComponent;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.EntitySerializer;
-import org.terasology.protobuf.EntityData;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
+
+import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
 
 /**
  */
@@ -84,7 +85,7 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public EntityData.Entity.Scope getScope() {
+    public EntityScope getScope() {
         if (exists()) {
             return getEntityInfo().scope;
         }
@@ -92,7 +93,7 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public void setScope(EntityData.Entity.Scope scope) {
+    public void setScope(EntityScope scope) {
         if (exists()) {
             EntityInfoComponent info = getEntityInfo();
             if (!info.scope.equals(scope)) {
@@ -119,6 +120,12 @@ public abstract class BaseEntityRef extends EntityRef {
                 saveComponent(info);
             }
         }
+    }
+
+    @Override
+    public void setSectorScope(long maxDelta) {
+        setScope(SECTOR);
+        getComponent(SectorSimulationComponent.class).maxDelta = maxDelta;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -23,6 +23,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.network.NetworkComponent;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.EntitySerializer;
+import org.terasology.protobuf.EntityData;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -73,6 +74,25 @@ public abstract class BaseEntityRef extends EntityRef {
             EntityInfoComponent info = getEntityInfo();
             if (!info.owner.equals(owner)) {
                 info.owner = owner;
+                saveComponent(info);
+            }
+        }
+    }
+
+    @Override
+    public EntityData.Entity.Scope getScope() {
+        if (exists()) {
+            return getEntityInfo().scope;
+        }
+        return null;
+    }
+
+    @Override
+    public void setScope(EntityData.Entity.Scope scope) {
+        if (exists()) {
+            EntityInfoComponent info = getEntityInfo();
+            if (!info.scope.equals(scope)) {
+                info.scope = scope;
                 saveComponent(info);
             }
         }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/ComponentTable.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/ComponentTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import java.util.Map;
  * A table for storing entities and components. Focused on allowing iteration across a components of a given type
  *
  */
-class ComponentTable {
+public class ComponentTable {
     private Map<Class<?>, TLongObjectMap<Component>> store = Maps.newConcurrentMap();
 
     public <T extends Component> T get(long entityId, Class<T> componentClass) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -126,4 +126,5 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @return an {@link Optional} containing the pool if it exists, or empty
      */
     Optional<EngineEntityPool> getPool(long id);
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -21,6 +21,8 @@ import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
+import java.util.Optional;
+
 /**
  */
 public interface EngineEntityManager extends LowLevelEntityManager, EngineEntityPool {
@@ -103,8 +105,6 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      */
     void unsubscribe(EntityChangeSubscriber subscriber);
 
-    void remove(long entityId);
-
     /**
      * Sets the event system the entity manager will use to propagate life cycle events.
      *
@@ -116,4 +116,14 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @return The default serialization library to use for serializing components
      */
     TypeSerializationLibrary getTypeSerializerLibrary();
+
+    /**
+     * Gets the entity pool associated with a given entity.
+     *
+     * If the pool isn't assigned or the entity doesn't exist, an error is logged and the optional is returned empty
+     *
+     * @param id the id of the entity
+     * @return an {@link Optional} containing the pool if it exists, or empty
+     */
+    Optional<EngineEntityPool> getPool(long id);
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -50,6 +50,8 @@ public interface EngineEntityManager extends LowLevelEntityManager {
 
     EntityRef createEntityWithoutLifecycleEvents(Prefab prefab);
 
+    RefStrategy getEntityRefStrategy();
+
     /**
      * Destroys an entity without sending lifecycle events.
      * <br><br>
@@ -123,6 +125,18 @@ public interface EngineEntityManager extends LowLevelEntityManager {
      * @param subscriber
      */
     void unsubscribe(EntityChangeSubscriber subscriber);
+
+    void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component);
+
+    void notifyComponentRemoved(EntityRef changedEntity, Class<? extends Component> component);
+
+    void notifyComponentChanged(EntityRef changedEntity, Class<? extends Component> component);
+
+    void notifyComponentRemovalAndEntityDestruction(long entityId, EntityRef ref);
+
+    long createEntity();
+
+    void remove(long entityId);
 
     /**
      * Sets the event system the entity manager will use to propagate life cycle events.

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -54,7 +54,7 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @param id
      * @return The entityRef for the given id
      */
-    EntityRef createEntityRefWithId(long id);
+    EntityRef getEntity(long id);
 
     /**
      * This is used to persist the entity manager's state
@@ -102,16 +102,6 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      * @param subscriber
      */
     void unsubscribe(EntityChangeSubscriber subscriber);
-
-    void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component);
-
-    void notifyComponentRemoved(EntityRef changedEntity, Class<? extends Component> component);
-
-    void notifyComponentChanged(EntityRef changedEntity, Class<? extends Component> component);
-
-    void notifyComponentRemovalAndEntityDestruction(long entityId, EntityRef ref);
-
-    long createEntity();
 
     void remove(long entityId);
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -19,36 +19,13 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.event.internal.EventSystem;
-import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 /**
  */
-public interface EngineEntityManager extends LowLevelEntityManager {
+public interface EngineEntityManager extends LowLevelEntityManager, EngineEntityPool {
 
     void setEntityRefStrategy(RefStrategy strategy);
-
-    /**
-     * Creates an entity but doesn't send any lifecycle events.
-     * <br><br>
-     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
-     *
-     * @param components
-     * @return The newly created entity ref.
-     */
-    EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components);
-
-    /**
-     * Creates an entity but doesn't send any lifecycle events.
-     * <br><br>
-     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
-     *
-     * @param prefab
-     * @return The newly created entity ref.
-     */
-    EntityRef createEntityWithoutLifecycleEvents(String prefab);
-
-    EntityRef createEntityWithoutLifecycleEvents(Prefab prefab);
 
     RefStrategy getEntityRefStrategy();
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -23,8 +23,6 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 import java.util.Optional;
 
-/**
- */
 public interface EngineEntityManager extends LowLevelEntityManager, EngineEntityPool {
 
     void setEntityRefStrategy(RefStrategy strategy);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -73,18 +73,34 @@ public interface EngineEntityPool extends EntityPool {
     boolean hasComponent(long entityId, Class<? extends Component> componentClass);
 
     /**
-     * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link EntityRef}
+     * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link BaseEntityRef}
      * and the {@link Component}s from this pool, so that the entity can be moved to a different pool. It does
      * not invalidate the {@link EntityRef}.
      *
-     * Returns an {@link Optional} {@link BaseEntityRef} if it was removed, ready to be put into another pool. If nothing
-     * was removed, return {@link Optional#empty()}.
+     * Returns an {@link Optional} {@link BaseEntityRef} if it was removed, ready to be put into another pool. If
+     * nothing was removed, return {@link Optional#empty()}.
+     *
+     * This method is intended for use by {@link EngineEntityManager#moveToPool(long, EngineEntityPool)}. Caution
+     * should be taken if this method is used elsewhere, and the caller should ensure that the the entity is
+     * immediately placed in a new pool. All of the components are removed, so should be manually copied before this
+     * method is called if they are to be kept in use.
      *
      * @param id the id of the entity to remove
      * @return an optional {@link BaseEntityRef}, containing the removed entity
      */
     Optional<BaseEntityRef> remove(long id);
 
+    /**
+     * Insert the {@link BaseEntityRef} into this pool, with these {@link Component}s. This only inserts the ref, adds the
+     * components, and assigns the entity to this pool in the EntityManager.
+     *
+     * No events are sent, so this should only be used when inserting a ref that has been created elsewhere. It is
+     * intended for use by {@link EngineEntityManager#moveToPool(long, EngineEntityPool)}, so caution should be taken
+     * if this method is used elsewhere.
+     *
+     * @param ref the EntityRef of the entity to be inserted
+     * @param components the entity's components
+     */
     void insertRef(BaseEntityRef ref, Iterable<Component> components);
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -20,6 +20,8 @@ import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 
+import java.util.Optional;
+
 /**
  */
 public interface EngineEntityPool extends EntityPool {
@@ -69,4 +71,20 @@ public interface EngineEntityPool extends EntityPool {
      * @return whether the entity has the component
      */
     boolean hasComponent(long entityId, Class<? extends Component> componentClass);
+
+    /**
+     * Remove the entity from the pool. This does not destroy the entity, it only removes the {@link EntityRef}
+     * and the {@link Component}s from this pool, so that the entity can be moved to a different pool. It does
+     * not invalidate the {@link EntityRef}.
+     *
+     * Returns an {@link Optional} {@link BaseEntityRef} if it was removed, ready to be put into another pool. If nothing
+     * was removed, return {@link Optional#empty()}.
+     *
+     * @param id the id of the entity to remove
+     * @return an optional {@link BaseEntityRef}, containing the removed entity
+     */
+    Optional<BaseEntityRef> remove(long id);
+
+    void insertRef(BaseEntityRef ref, Iterable<Component> components);
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -22,8 +22,6 @@ import org.terasology.entitySystem.prefab.Prefab;
 
 import java.util.Optional;
 
-/**
- */
 public interface EngineEntityPool extends EntityPool {
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityPool.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity.internal;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityPool;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.prefab.Prefab;
+
+/**
+ */
+public interface EngineEntityPool extends EntityPool {
+
+    /**
+     * Creates an entity but doesn't send any lifecycle events.
+     * <br><br>
+     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
+     *
+     * @param components
+     * @return The newly created entity ref.
+     */
+    EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components);
+
+    /**
+     * Creates an entity but doesn't send any lifecycle events.
+     * <br><br>
+     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
+     *
+     * @param prefab
+     * @return The newly created entity ref.
+     */
+    EntityRef createEntityWithoutLifecycleEvents(String prefab);
+
+    EntityRef createEntityWithoutLifecycleEvents(Prefab prefab);
+
+    void putEntity(long entityId, BaseEntityRef ref);
+
+    ComponentTable getComponentStore();
+
+    /**
+     * Destroys an entity without sending lifecycle events.
+     * <br><br>
+     * This is used by the block entity system to give an illusion of permanence to temporary block entities.
+     *
+     * @param entity
+     */
+    void destroyEntityWithoutEvents(EntityRef entity);
+
+    void destroy(long id);
+
+    /**
+     * Fund out if a particular entity has a component of the given class.
+     *
+     * @param entityId the entity to check
+     * @param componentClass the class to check for
+     * @return whether the entity has the component
+     */
+    boolean hasComponent(long entityId, Class<? extends Component> componentClass);
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineSectorManager.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity.internal;
+
+import org.terasology.entitySystem.entity.SectorManager;
+
+/**
+ */
+public interface EngineSectorManager extends SectorManager, EngineEntityPool {
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineSectorManager.java
@@ -17,7 +17,5 @@ package org.terasology.entitySystem.entity.internal;
 
 import org.terasology.entitySystem.entity.SectorManager;
 
-/**
- */
 public interface EngineSectorManager extends SectorManager, EngineEntityPool {
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
@@ -19,9 +19,10 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.network.Replicate;
-import org.terasology.protobuf.EntityData.Entity.Scope;
 
 import javax.annotation.Nullable;
+
+import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
 
 /**
  * Component for storing entity system information on an entity
@@ -39,7 +40,7 @@ public class EntityInfoComponent implements Component {
     @Replicate
     public EntityRef owner = EntityRef.NULL;
     public boolean alwaysRelevant;
-    public Scope scope = Scope.GLOBAL;
+    public EntityScope scope = GLOBAL;
 
     public EntityInfoComponent() {
     }
@@ -50,7 +51,7 @@ public class EntityInfoComponent implements Component {
         this.alwaysRelevant = alwaysRelevant;
     }
 
-    public EntityInfoComponent(@Nullable Prefab parentPrefab, boolean persisted, boolean alwaysRelevant, Scope scope) {
+    public EntityInfoComponent(@Nullable Prefab parentPrefab, boolean persisted, boolean alwaysRelevant, EntityScope scope) {
         this(parentPrefab, persisted, alwaysRelevant);
         this.scope = scope;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
@@ -19,6 +19,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.network.Replicate;
+import org.terasology.protobuf.EntityData.Entity.Scope;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +39,7 @@ public class EntityInfoComponent implements Component {
     @Replicate
     public EntityRef owner = EntityRef.NULL;
     public boolean alwaysRelevant;
+    public Scope scope = Scope.GLOBAL;
 
     public EntityInfoComponent() {
     }
@@ -46,5 +48,10 @@ public class EntityInfoComponent implements Component {
         this.parentPrefab = parentPrefab;
         this.persisted = persisted;
         this.alwaysRelevant = alwaysRelevant;
+    }
+
+    public EntityInfoComponent(@Nullable Prefab parentPrefab, boolean persisted, boolean alwaysRelevant, Scope scope) {
+        this(parentPrefab, persisted, alwaysRelevant);
+        this.scope = scope;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
@@ -40,7 +40,7 @@ public class EntityIterator implements Iterator<EntityRef> {
 
     @Override
     public EntityRef next() {
-        return pool.createEntityRefWithId(idIterator.next());
+        return pool.getEntity(idIterator.next());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity.internal;
+
+import gnu.trove.iterator.TLongIterator;
+import org.terasology.entitySystem.entity.EntityRef;
+
+import java.util.Iterator;
+
+/**
+ * Provides an iterator over EntityRefs, after being given an iterator over entity IDs.
+ */
+public class EntityIterator implements Iterator<EntityRef> {
+    private TLongIterator idIterator;
+    private PojoEntityPool pool;
+
+    EntityIterator(TLongIterator idIterator, PojoEntityPool pool) {
+        this.idIterator = idIterator;
+        this.pool = pool;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return idIterator.hasNext();
+    }
+
+    @Override
+    public EntityRef next() {
+        return pool.createEntityRefWithId(idIterator.next());
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityIterator.java
@@ -16,6 +16,7 @@
 package org.terasology.entitySystem.entity.internal;
 
 import gnu.trove.iterator.TLongIterator;
+import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 
 import java.util.Iterator;
@@ -25,9 +26,9 @@ import java.util.Iterator;
  */
 public class EntityIterator implements Iterator<EntityRef> {
     private TLongIterator idIterator;
-    private PojoEntityPool pool;
+    private EntityPool pool;
 
-    EntityIterator(TLongIterator idIterator, PojoEntityPool pool) {
+    EntityIterator(TLongIterator idIterator, EntityPool pool) {
         this.idIterator = idIterator;
         this.pool = pool;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityScope.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityScope.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity.internal;
+
+import org.terasology.module.sandbox.API;
+
+@API
+public enum EntityScope {
+    GLOBAL,
+    SECTOR
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityBuilder;
-import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
@@ -52,6 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
 
 /**
  */
@@ -130,9 +131,9 @@ public class PojoEntityManager implements EngineEntityManager {
     @Override
     public EntityRef createSectorEntity(long maxDelta) {
         EntityRef entity = sectorManager.create();
-        entity.setScope(EntityData.Entity.Scope.SECTOR);
+        entity.setScope(SECTOR);
 
-        entity.addComponent(new SectorSimulationComponent(maxDelta));
+        entity.addOrSaveComponent(new SectorSimulationComponent(maxDelta));
 
         //TODO: look into keeping all sector entities loaded, or converting alwaysRelevant into another scope
         entity.setAlwaysRelevant(true);
@@ -303,8 +304,10 @@ public class PojoEntityManager implements EngineEntityManager {
         //TODO: clean this up
         for (Component c : components) {
             if (c instanceof EntityInfoComponent) {
-                if (((EntityInfoComponent) c).scope == EntityData.Entity.Scope.SECTOR) {
-                    return sectorManager.createEntityWithId(id, components);
+                if (((EntityInfoComponent) c).scope == SECTOR) {
+                    EntityRef entity = sectorManager.createEntityWithId(id, components);
+                    entity.setScope(SECTOR);
+                    return entity;
                 } else {
                     break;
                 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -560,6 +560,20 @@ public class PojoEntityManager implements EngineEntityManager {
         }
     }
 
+    /**
+     * Remove the assignment of an entity to a pool.
+     *
+     * This does not affect anything else related to the entity, but may lead to the entity or its components being
+     * unable to be found.
+     *
+     * When using this method, be sure to properly re-assign the entity to its correct pool afterwards.
+     *
+     * @param id the id of the entity to remove the assignment for
+     */
+    protected void unassignPool(long id) {
+        poolMap.remove(id);
+    }
+
     public boolean moveToPool(long id, EngineEntityPool pool) {
 
         if (getPool(id).isPresent() && getPool(id).get().equals(pool)) {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -39,6 +39,7 @@ import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
+import org.terasology.entitySystem.sectors.SectorSimulationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -127,9 +128,14 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     @Override
-    public EntityRef createSectorEntity() {
+    public EntityRef createSectorEntity(long maxDelta) {
         EntityRef entity = sectorManager.create();
         entity.setScope(EntityData.Entity.Scope.SECTOR);
+
+        entity.addComponent(new SectorSimulationComponent(maxDelta));
+
+        //TODO: look into keeping all sector entities loaded, or converting alwaysRelevant into another scope
+        entity.setAlwaysRelevant(true);
         return entity;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -54,8 +54,6 @@ import java.util.Set;
 
 import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
 
-/**
- */
 public class PojoEntityManager implements EngineEntityManager {
     public static final long NULL_ID = 0;
 
@@ -136,7 +134,6 @@ public class PojoEntityManager implements EngineEntityManager {
         entity.addOrSaveComponent(new SectorSimulationComponent(maxDelta));
 
         //TODO: look into keeping all sector entities loaded, or converting alwaysRelevant into another scope
-        entity.setAlwaysRelevant(true);
         return entity;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -31,6 +31,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityPool;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.SectorManager;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeEntityCreated;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
@@ -64,8 +65,7 @@ public class PojoEntityManager implements EngineEntityManager {
     private TLongSet loadedIds = new TLongHashSet();
 
     private PojoEntityPool globalPool = new PojoEntityPool(this);
-    private PojoEntityPool sectorPool = new PojoEntityPool(this);
-
+    private PojoSectorManager sectorManager = new PojoSectorManager(this);
     private Map<Long, PojoEntityPool> poolMap = new MapMaker().initialCapacity(1000).makeMap();
 
     private Set<EntityChangeSubscriber> subscribers = Sets.newLinkedHashSet();
@@ -77,9 +77,6 @@ public class PojoEntityManager implements EngineEntityManager {
     private RefStrategy refStrategy = new DefaultRefStrategy();
 
     private TypeSerializationLibrary typeSerializerLibrary;
-
-    public PojoEntityManager() {
-    }
 
     public void setTypeSerializerLibrary(TypeSerializationLibrary serializerLibrary) {
         this.typeSerializerLibrary = serializerLibrary;
@@ -104,14 +101,9 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     @Override
-    public EntityPool getSectorPool() {
-        return sectorPool;
-    }
-
-    @Override
     public void clear() {
         globalPool.clear();
-        sectorPool.clear();
+        sectorManager.clear();
         nextEntityId = 1;
         loadedIds.clear();
     }
@@ -138,7 +130,7 @@ public class PojoEntityManager implements EngineEntityManager {
 
     @Override
     public EntityRef createSectorEntity() {
-        return sectorPool.create();
+        return sectorManager.create();
     }
 
     @Override
@@ -308,14 +300,14 @@ public class PojoEntityManager implements EngineEntityManager {
 
     @Override
     public int getActiveEntityCount() {
-        return globalPool.getEntityStore().size() + sectorPool.getEntityStore().size();
+        return globalPool.getActiveEntityCount() + sectorManager.getActiveEntityCount();
     }
 
     @Override
     public EntityRef getExistingEntity(long id) {
         EntityRef entity = globalPool.getExistingEntity(id);
         if (entity == EntityRef.NULL || entity == null) {
-            entity = sectorPool.getExistingEntity(id);
+            entity = sectorManager.getExistingEntity(id);
         }
         return (entity == null) ? EntityRef.NULL : entity;
     }
@@ -420,6 +412,11 @@ public class PojoEntityManager implements EngineEntityManager {
     }
 
     @Override
+    public SectorManager getSectorManager() {
+        return sectorManager;
+    }
+
+    @Override
     //Todo: include sector entities
     public void deactivateForStorage(EntityRef entity) {
         if (entity.exists()) {
@@ -459,8 +456,8 @@ public class PojoEntityManager implements EngineEntityManager {
      */
     @Override
     public boolean hasComponent(long entityId, Class<? extends Component> componentClass) {
-        return (globalPool.getComponentStore().get(entityId, componentClass) != null) ||
-               (sectorPool.getComponentStore().get(entityId, componentClass) != null);
+        return globalPool.getComponentStore().get(entityId, componentClass) != null
+                || sectorManager.hasComponent(entityId, componentClass);
     }
 
     @Override
@@ -634,12 +631,9 @@ public class PojoEntityManager implements EngineEntityManager {
         }
 
         //Return existing entity if it exists
-        BaseEntityRef globalEntity = globalPool.getEntityStore().get(entityId);
-        BaseEntityRef sectorEntity = sectorPool.getEntityStore().get(entityId);
-        if(globalEntity != null) {
-            return globalEntity;
-        } else if (sectorEntity != null) {
-            return sectorEntity;
+        EntityRef existing = getExistingEntity(entityId);
+        if(existing != EntityRef.NULL && existing != null) {
+            return existing;
         }
 
         BaseEntityRef newRef = refStrategy.createRefFor(entityId, this);

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -131,14 +131,17 @@ public class PojoEntityPool implements EngineEntityPool {
         EntityBuilder builder = newBuilder(prefab);
         builder.setSendLifecycleEvents(sendLifecycleEvents);
 
-        LocationComponent locationComponent = builder.getComponent(LocationComponent.class);
-        if (locationComponent != null) {
-            if (position != null) {
-                locationComponent.setWorldPosition(position);
-            }
-            if (rotation != null) {
-                locationComponent.setWorldRotation(rotation);
-            }
+        LocationComponent loc = builder.getComponent(LocationComponent.class);
+        if (loc == null && (position != null || rotation != null)) {
+            loc = new LocationComponent();
+            builder.addComponent(loc);
+        }
+
+        if (position != null) {
+            loc.setWorldPosition(position);
+        }
+        if (rotation != null) {
+            loc.setWorldRotation(rotation);
         }
 
         return builder.build();

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -36,6 +36,7 @@ import org.terasology.math.geom.Vector3f;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.terasology.entitySystem.entity.internal.PojoEntityManager.NULL_ID;
 
@@ -189,7 +190,7 @@ public class PojoEntityPool implements EngineEntityPool {
         // Don't allow the destruction of unloaded entities.
         long entityId = ref.getId();
         entityStore.remove(entityId);
-        entityManager.remove(entityId);
+        entityManager.unregister(entityId);
         ref.invalidate();
         componentStore.remove(entityId);
     }
@@ -391,6 +392,23 @@ public class PojoEntityPool implements EngineEntityPool {
     @Override
     public boolean hasComponent(long entityId, Class<? extends Component> componentClass) {
         return componentStore.get(entityId, componentClass) != null;
+    }
+
+    @Override
+    public Optional<BaseEntityRef> remove(long id) {
+        componentStore.remove(id);
+        return Optional.of(entityStore.get(id));
+    }
+
+    @Override
+    public void insertRef(BaseEntityRef ref, Iterable<Component> components) {
+        entityStore.put(ref.getId(), ref);
+        components.forEach(comp -> componentStore.put(ref.getId(), comp));
+    }
+
+    @Override
+    public boolean contains(long id) {
+        return entityStore.containsKey(id);
     }
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -32,6 +32,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.protobuf.EntityData;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -96,6 +97,7 @@ public class PojoEntityPool implements EngineEntityPool {
         for (Component component: components) {
             entityManager.notifyComponentAdded(entity, component.getClass());
         }
+
         return entity;
     }
 
@@ -194,7 +196,7 @@ public class PojoEntityPool implements EngineEntityPool {
     }
 
     private EntityRef createEntity(Iterable<Component> components) {
-        long entityId = entityManager.createEntity(this);
+        long entityId = entityManager.createEntity();
 
         Prefab prefab = null;
         for (Component component : components) {
@@ -344,13 +346,14 @@ public class PojoEntityPool implements EngineEntityPool {
         if (entityId == NULL_ID) {
             return EntityRef.NULL;
         }
-        EntityRef existing = entityManager.getEntity(entityId);
-        if (existing != null) {
+        EntityRef existing = entityManager.getExistingEntity(entityId);
+        if (existing != EntityRef.NULL && existing != null) {
             //Entity exists, but is not in this pool
             return existing;
         }
         //Todo: look into whether RefStrategy should use manager or pool?
         BaseEntityRef newRef = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
+
         entityStore.put(entityId, newRef);
         return newRef;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -40,8 +40,6 @@ import java.util.Optional;
 
 import static org.terasology.entitySystem.entity.internal.PojoEntityManager.NULL_ID;
 
-/**
- */
 public class PojoEntityPool implements EngineEntityPool {
 
     private PojoEntityManager entityManager;
@@ -94,7 +92,8 @@ public class PojoEntityPool implements EngineEntityPool {
             }
         }
 
-        for (Component component: components) {
+        //Retrieve the components again in case they were modified by the previous events
+        for (Component component : entityManager.iterateComponents(entity.getId())) {
             entityManager.notifyComponentAdded(entity, component.getClass());
         }
 
@@ -126,7 +125,6 @@ public class PojoEntityPool implements EngineEntityPool {
         return create(prefab, position, rotation, true);
     }
 
-    //@Override
     private EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation, boolean sendLifecycleEvents) {
         EntityBuilder builder = newBuilder(prefab);
         builder.setSendLifecycleEvents(sendLifecycleEvents);
@@ -147,8 +145,7 @@ public class PojoEntityPool implements EngineEntityPool {
         return builder.build();
     }
 
-    //@Override
-    public EntityRef create(String prefabName, Vector3f position, Quat4f rotation) {
+    private EntityRef create(String prefabName, Vector3f position, Quat4f rotation) {
         return create(prefabName, position, rotation, true);
     }
 
@@ -170,7 +167,7 @@ public class PojoEntityPool implements EngineEntityPool {
     /**
      * Destroys this entity, sending event
      *
-     * @param entityId
+     * @param entityId the id of the entity to destroy
      */
     @Override
     public void destroy(long entityId) {
@@ -288,6 +285,7 @@ public class PojoEntityPool implements EngineEntityPool {
         return entity;
     }
 
+    @Override
     public EntityBuilder newBuilder() {
         return new EntityBuilder(entityManager, this);
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -400,13 +400,15 @@ public class PojoEntityPool implements EngineEntityPool {
     @Override
     public Optional<BaseEntityRef> remove(long id) {
         componentStore.remove(id);
-        return Optional.of(entityStore.get(id));
+        entityManager.unassignPool(id);
+        return Optional.of(entityStore.remove(id));
     }
 
     @Override
     public void insertRef(BaseEntityRef ref, Iterable<Component> components) {
         entityStore.put(ref.getId(), ref);
         components.forEach(comp -> componentStore.put(ref.getId(), comp));
+        entityManager.assignToPool(ref.getId(), this);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity.internal;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapMaker;
+import gnu.trove.iterator.TLongObjectIterator;
+import gnu.trove.list.TLongList;
+import gnu.trove.list.array.TLongArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.entitySystem.entity.EntityPool;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeEntityCreated;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
+import org.terasology.entitySystem.event.internal.EventSystem;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.terasology.entitySystem.entity.internal.PojoEntityManager.NULL_ID;
+
+/**
+ */
+public class PojoEntityPool implements EntityPool {
+
+    private PojoEntityManager entityManager;
+
+    private static final Logger logger = LoggerFactory.getLogger(PojoEntityPool.class);
+
+    private Map<Long, BaseEntityRef> entityStore = new MapMaker().weakValues().concurrencyLevel(4).initialCapacity(1000).makeMap();
+    private ComponentTable componentStore = new ComponentTable();
+
+    public PojoEntityPool(PojoEntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    public void clear() {
+        //Todo: should also clear out ids from the EntityManager
+        for (EntityRef entity : entityStore.values()) {
+            entity.invalidate();
+        }
+        componentStore.clear();
+        entityStore.clear();
+    }
+
+
+    @Override
+    public EntityRef create() {
+        EntityRef entityRef = createEntityRef(entityManager.createEntity(this));
+        /*
+         * The entity change listener are also used to detect new entities. By adding one component we inform those
+         * listeners about the new entity.
+         */
+        entityRef.addComponent(new EntityInfoComponent());
+        return entityRef;
+    }
+
+    @Override
+    public EntityRef create(Component... components) {
+        return create(Arrays.asList(components));
+    }
+
+    @Override
+    public EntityRef create(Iterable<Component> components) {
+        components = (components == null) ? Collections.EMPTY_LIST : components;
+        EntityRef entity = createEntity(components);
+
+        EventSystem eventSystem = entityManager.getEventSystem();
+        if (eventSystem != null) {
+            eventSystem.send(entity, OnAddedComponent.newInstance());
+            eventSystem.send(entity, OnActivatedComponent.newInstance());
+        }
+
+        for (Component component: components) {
+            entityManager.notifyComponentAdded(entity, component.getClass());
+        }
+        return entity;
+    }
+
+    @Override
+    public EntityRef create(String prefabName) {
+        if (prefabName != null && !prefabName.isEmpty()) {
+            Prefab prefab = entityManager.getPrefabManager().getPrefab(prefabName);
+
+            if (prefab == null) {
+                logger.warn("Unable to instantiate unknown prefab: \"{}\"", prefabName);
+                return EntityRef.NULL;
+            }
+
+            return create(prefab);
+        }
+        return create();
+    }
+
+    @Override
+    public EntityRef create(String prefabName, Vector3f position) {
+        if (prefabName != null && !prefabName.isEmpty()) {
+            Prefab prefab = entityManager.getPrefabManager().getPrefab(prefabName);
+
+            if (prefab == null) {
+                logger.warn("Unable to instantiate unknown prefab: \"{}\"", prefabName);
+                return EntityRef.NULL;
+            }
+
+            return create(prefab, position);
+        }
+        return create();
+    }
+
+    @Override
+    public EntityRef create(Prefab prefab, Vector3f position) {
+        if (prefab == null) {
+            logger.warn("Unable to instantiate null prefab");
+            return EntityRef.NULL;
+        }
+
+        List<Component> components = Lists.newArrayList();
+        for (Component component : prefab.iterateComponents()) {
+            Component newComp = entityManager.getComponentLibrary().copy(component);
+            components.add(newComp);
+            if (newComp instanceof LocationComponent) {
+                LocationComponent loc = (LocationComponent) newComp;
+                loc.setWorldPosition(position);
+            }
+        }
+        components.add(new EntityInfoComponent(prefab, prefab.isPersisted(), prefab.isAlwaysRelevant()));
+        return create(components);
+    }
+
+    @Override
+    public EntityRef create(Prefab prefab) {
+        if (prefab == null) {
+            logger.warn("Unable to instantiate null prefab");
+            return EntityRef.NULL;
+        }
+
+        List<Component> components = Lists.newArrayList();
+        for (Component component : prefab.iterateComponents()) {
+            components.add(entityManager.getComponentLibrary().copy(component));
+        }
+        components.add(new EntityInfoComponent(prefab, prefab.isPersisted(), prefab.isAlwaysRelevant()));
+        return create(components);
+    }
+
+    @Override
+    public EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation) {
+        if (prefab == null) {
+            logger.warn("Unable to instantiate null prefab");
+            return EntityRef.NULL;
+        }
+
+        List<Component> components = Lists.newArrayList();
+        for (Component component : prefab.iterateComponents()) {
+            Component newComp = entityManager.getComponentLibrary().copy(component);
+            components.add(newComp);
+            if (newComp instanceof LocationComponent) {
+                LocationComponent loc = (LocationComponent) newComp;
+                loc.setWorldPosition(position);
+                loc.setWorldRotation(rotation);
+            }
+        }
+        components.add(new EntityInfoComponent(prefab, prefab.isPersisted(), prefab.isAlwaysRelevant()));
+        return create(components);
+    }
+
+
+    /**
+     * Destroys this entity, sending event
+     *
+     * @param entityId
+     */
+    @Override
+    public void destroy(long entityId) {
+        // Don't allow the destruction of unloaded entities.
+        if (!entityManager.idLoaded(entityId)) {
+            return;
+        }
+        EntityRef ref = createEntityRef(entityId);
+
+        EventSystem eventSystem = entityManager.getEventSystem();
+        if (eventSystem != null) {
+            eventSystem.send(ref, BeforeDeactivateComponent.newInstance());
+            eventSystem.send(ref, BeforeRemoveComponent.newInstance());
+        }
+        entityManager.notifyComponentRemovalAndEntityDestruction(entityId, ref);
+        destroy(ref);
+    }
+
+    private void destroy(EntityRef ref) {
+        // Don't allow the destruction of unloaded entities.
+        long entityId = ref.getId();
+        entityStore.remove(entityId);
+        entityManager.remove(entityId);
+        ref.invalidate();
+        componentStore.remove(entityId);
+    }
+
+    private EntityRef createEntity(Iterable<Component> components) {
+        long entityId = entityManager.createEntity(this);
+
+        Prefab prefab = null;
+        for (Component component : components) {
+            if (component instanceof EntityInfoComponent) {
+                EntityInfoComponent comp = (EntityInfoComponent) component;
+                prefab = comp.parentPrefab;
+                break;
+            }
+        }
+
+        Iterable<Component> finalComponents;
+        EventSystem eventSystem = entityManager.getEventSystem();
+        if (eventSystem != null) {
+            BeforeEntityCreated event = new BeforeEntityCreated(prefab, components);
+            BaseEntityRef tempRef = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
+            eventSystem.send(tempRef, event);
+            tempRef.invalidate();
+            finalComponents = event.getResultComponents();
+        } else {
+            finalComponents = components;
+        }
+
+        for (Component c : finalComponents) {
+            componentStore.put(entityId, c);
+        }
+        return createEntityRef(entityId);
+    }
+
+    @Override
+    public EntityRef createEntityRefWithId(long id) {
+        if (entityManager.isExistingEntity(id)) {
+            return createEntityRef(id);
+        }
+        return EntityRef.NULL;
+    }
+
+    /**
+     * Creates the entity without sending any events. The entity life cycle subscriber will however be informed.
+     */
+    @Override
+    public EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components) {
+        components = (components == null) ? Collections.EMPTY_LIST : components;
+
+        EntityRef entity = createEntity(components);
+        for (Component component: components) {
+            entityManager.notifyComponentAdded(entity, component.getClass());
+        }
+        return entity;
+    }
+
+    /**
+     * Creates the entity without sending any events. The entity life cycle subscriber will however be informed.
+     */
+    @Override
+    public EntityRef createEntityWithoutLifecycleEvents(String prefabName) {
+        return createEntityWithoutLifecycleEvents(entityManager.getPrefabManager().getPrefab(prefabName));
+    }
+
+    /**
+     * Creates the entity without sending any events. The entity life cycle subscriber will however be informed.
+     */
+    @Override
+    public EntityRef createEntityWithoutLifecycleEvents(Prefab prefab) {
+        if (prefab != null) {
+            List<Component> components = Lists.newArrayList();
+            for (Component component : prefab.iterateComponents()) {
+                components.add(entityManager.getComponentLibrary().copy(component));
+            }
+            components.add(new EntityInfoComponent(prefab, prefab.isPersisted(), prefab.isAlwaysRelevant()));
+
+            return createEntityWithoutLifecycleEvents(components);
+        } else {
+            return createEntityWithoutLifecycleEvents(Collections.<Component>emptyList());
+        }
+    }
+
+    /**
+     * Destroys the entity without sending any events. The entity life cycle subscriber will however be informed.
+     */
+    @Override
+    public void destroyEntityWithoutEvents(EntityRef entity) {
+        if (entity.isActive()) {
+            entityManager.notifyComponentRemovalAndEntityDestruction(entity.getId(), entity);
+            destroy(entity);
+        }
+    }
+
+    @Override
+    public EntityRef createEntityWithId(long id, Iterable<Component> components) {
+        if (!entityManager.registerId(id)) {
+            return EntityRef.NULL;
+        }
+
+        components = (components == null) ? Collections.EMPTY_LIST : components;
+
+        for (Component c : components) {
+            componentStore.put(id, c);
+        }
+
+        EntityRef entity = createEntityRef(id);
+        EventSystem eventSystem = entityManager.getEventSystem();
+        if (eventSystem != null) {
+            eventSystem.send(entity, OnActivatedComponent.newInstance());
+        }
+
+        for (Component component : components) {
+            entityManager.notifyComponentAdded(entity, component.getClass());
+        }
+        return entity;
+    }
+
+    public EntityBuilder newBuilder() {
+        return new EntityBuilder(entityManager, this);
+    }
+
+    @Override
+    public EntityBuilder newBuilder(String prefabName) {
+        EntityBuilder builder = newBuilder();
+        if (!builder.addPrefab(prefabName)) {
+            logger.warn("Unable to instantiate unknown prefab: \"{}\"", prefabName);
+        }
+        return builder;
+    }
+
+    @Override
+    public EntityBuilder newBuilder(Prefab prefab) {
+        EntityBuilder builder = newBuilder();
+        builder.addPrefab(prefab);
+        return builder;
+    }
+
+    /**
+     * Gets the internal entity store.
+     * <p>
+     * It is returned as an unmodifiable map, so cannot be edited. Use {@link #putEntity} to modify the map.
+     *
+     * @return an unmodifiable version of the internal entity store
+     */
+    protected Map<Long, BaseEntityRef> getEntityStore() {
+        return Collections.unmodifiableMap(entityStore);
+    }
+
+    /**
+     * Puts an entity into the internal storage.
+     * <p>
+     * This is intended for use by the {@link PojoEntityManager}.
+     * In most cases, it is better to use the {@link #create} or {@link #newBuilder} methods instead.
+     *
+     * @param entityId the id of the entity to add
+     * @param ref the {@link BaseEntityRef} to add
+     */
+    protected void putEntity(long entityId, BaseEntityRef ref) {
+        entityStore.put(entityId, ref);
+    }
+
+    public ComponentTable getComponentStore() {
+        return componentStore;
+    }
+
+    private EntityRef createEntityRef(long entityId) {
+        if (entityId == NULL_ID) {
+            return EntityRef.NULL;
+        }
+        EntityRef existing = entityManager.getEntity(entityId);
+        if (existing != null) {
+            //Entity exists, but is not in this pool
+            return existing;
+        }
+        //Todo: look into whether RefStrategy should use manager or pool?
+        BaseEntityRef newRef = entityManager.getEntityRefStrategy().createRefFor(entityId, entityManager);
+        entityStore.put(entityId, newRef);
+        return newRef;
+    }
+
+    @SafeVarargs
+    @Override
+    public final Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses) {
+        if (componentClasses.length == 0) {
+            return getAllEntities();
+        }
+        TLongList idList = new TLongArrayList();
+        TLongObjectIterator<? extends Component> primeIterator = componentStore.componentIterator(componentClasses[0]);
+        if (primeIterator == null) {
+            return Collections.emptyList();
+        }
+
+        while (primeIterator.hasNext()) {
+            primeIterator.advance();
+            long id = primeIterator.key();
+            boolean discard = false;
+            for (int i = 1; i < componentClasses.length; ++i) {
+                if (componentStore.get(id, componentClasses[i]) == null) {
+                    discard = true;
+                    break;
+                }
+            }
+            if (!discard) {
+                idList.add(primeIterator.key());
+            }
+        }
+        return () -> new EntityIterator(idList.iterator(), this);
+    }
+
+    @Override
+    public int getActiveEntityCount() {
+        return entityStore.size();
+    }
+
+    @Override
+    public EntityRef getExistingEntity(long id) {
+        EntityRef entity = entityStore.get(id);
+        return (entity == null) ? EntityRef.NULL : entity;
+    }
+
+    @Override
+    public Iterable<EntityRef> getAllEntities() {
+        return () -> new EntityIterator(componentStore.entityIdIterator(), this);
+    }
+
+    @Override
+    public boolean hasComponent(long entityId, Class<? extends Component> componentClass) {
+        return componentStore.get(entityId, componentClass) != null;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -144,11 +144,6 @@ public class PojoSectorManager implements EngineSectorManager {
         return getPool().createEntityWithId(id, components);
     }
 
-    @Override
-    public EntityRef createEntityRefWithId(long id) {
-        return getPool().createEntityRefWithId(id);
-    }
-
     public void destroy(long entityId) {
         getPool().destroy(entityId);
     }
@@ -196,15 +191,8 @@ public class PojoSectorManager implements EngineSectorManager {
     }
 
     @Override
-    public EntityRef getExistingEntity(long id) {
-        EntityRef entity;
-        for (EntityPool pool : pools) {
-            entity = pool.getExistingEntity(id);
-            if (entity != EntityRef.NULL && entity != null) {
-                return entity;
-            }
-        }
-        return EntityRef.NULL;
+    public EntityRef getEntity(long id) {
+        return entityManager.getEntity(id);
     }
 
     private EngineEntityPool getPool() {

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.entity.internal;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.entitySystem.entity.EntityPool;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.SectorManager;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ */
+public class PojoSectorManager implements SectorManager {
+
+    private List<PojoEntityPool> pools;
+
+    private PojoEntityManager entityManager;
+
+    public PojoSectorManager(PojoEntityManager entityManager) {
+        this.entityManager = entityManager;
+        pools = new ArrayList<>();
+        pools.add(new PojoEntityPool(entityManager));
+    }
+
+    @Override
+    public void clear() {
+        for (EntityPool pool : pools) {
+            pool.clear();
+        }
+    }
+
+    @Override
+    public EntityBuilder newBuilder() {
+        return new EntityBuilder(entityManager, this);
+    }
+
+    @Override
+    public EntityBuilder newBuilder(String prefabName) {
+        EntityBuilder builder = newBuilder();
+        if (!builder.addPrefab(prefabName)) {
+            return null;
+        }
+        return builder;
+    }
+
+    @Override
+    public EntityBuilder newBuilder(Prefab prefab) {
+        EntityBuilder builder = newBuilder();
+        builder.addPrefab(prefab);
+        return builder;
+    }
+
+    @Override
+    public EntityRef create() {
+        return getPool().create();
+    }
+
+    @Override
+    public EntityRef create(Component... components) {
+        return getPool().create(components);
+    }
+
+    @Override
+    public EntityRef create(Iterable<Component> components) {
+        return getPool().create(components);
+    }
+
+    @Override
+    public EntityRef create(String prefabName) {
+        return getPool().create(prefabName);
+    }
+
+    @Override
+    public EntityRef create(Prefab prefab) {
+        return getPool().create(prefab);
+    }
+
+    @Override
+    public EntityRef create(String prefab, Vector3f position) {
+        return getPool().create(prefab, position);
+    }
+
+    @Override
+    public EntityRef create(Prefab prefab, Vector3f position) {
+        return getPool().create(prefab, position);
+    }
+
+    @Override
+    public EntityRef create(Prefab prefab, Vector3f position, Quat4f rotation) {
+        return getPool().create(prefab, position, rotation);
+    }
+
+    @Override
+    public EntityRef createEntityWithoutLifecycleEvents(Iterable<Component> components) {
+        return getPool().createEntityWithoutLifecycleEvents(components);
+    }
+
+    @Override
+    public EntityRef createEntityWithoutLifecycleEvents(String prefab) {
+        return getPool().createEntityWithoutLifecycleEvents(prefab);
+    }
+
+    @Override
+    public EntityRef createEntityWithoutLifecycleEvents(Prefab prefab) {
+        return getPool().createEntityWithoutLifecycleEvents(prefab);
+    }
+
+    @Override
+    public EntityRef createEntityWithId(long id, Iterable<Component> components) {
+        return getPool().createEntityWithId(id, components);
+    }
+
+    @Override
+    public EntityRef createEntityRefWithId(long id) {
+        return getPool().createEntityRefWithId(id);
+    }
+
+    @Override
+    public void destroy(long entityId) {
+        getPool().destroy(entityId);
+    }
+
+    @Override
+    public void destroyEntityWithoutEvents(EntityRef entity) {
+        getPool().destroyEntityWithoutEvents(entity);
+    }
+
+    @Override
+    public Iterable<EntityRef> getAllEntities() {
+        return getPool().getAllEntities();
+    }
+
+    @Override
+    public Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses) {
+        return getPool().getEntitiesWith(componentClasses);
+    }
+
+    @Override
+    public int getActiveEntityCount() {
+        int count = 0;
+        for (EntityPool pool : pools) {
+            count += pool.getActiveEntityCount();
+        }
+        return count;
+    }
+
+    @Override
+    public EntityRef getExistingEntity(long id) {
+        EntityRef entity;
+        for (EntityPool pool : pools) {
+            entity = pool.getExistingEntity(id);
+            if (entity != EntityRef.NULL && entity != null) {
+                return entity;
+            }
+        }
+        return EntityRef.NULL;
+    }
+
+    private PojoEntityPool getPool() {
+        return pools.get(0);
+    }
+
+    @Override
+    public boolean hasComponent(long entityId, Class<? extends Component> componentClass) {
+        for (EntityPool pool : pools) {
+            if (pool.hasComponent(entityId, componentClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -28,8 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-/**
- */
 public class PojoSectorManager implements EngineSectorManager {
 
     private List<EngineEntityPool> pools;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoSectorManager.java
@@ -26,6 +26,7 @@ import org.terasology.math.geom.Vector3f;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  */
@@ -206,6 +207,26 @@ public class PojoSectorManager implements EngineSectorManager {
             }
         }
         return false;
+    }
+
+    @Override
+    public Optional<BaseEntityRef> remove(long id) {
+        if (contains(id)) {
+            return entityManager.getPool(id)
+                    .flatMap(pool -> pool.remove(id));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void insertRef(BaseEntityRef ref, Iterable<Component> components) {
+        getPool().insertRef(ref, components);
+    }
+
+    @Override
+    public boolean contains(long id) {
+        return pools.stream().anyMatch(pool -> pool.contains(id));
     }
 
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.module.sandbox.API;
+
+/**
+ * This event will be sent by the {@link SectorSimulationSystem} to allow sector-scope entities to have an effect on the world,
+ * whenever the chunk they are in is loaded.
+ *
+ * This event will always be immediately preceded by a {@link SectorSimulationEvent}, so no extra simulation needs to
+ * take place for this event.
+ *
+ * TODO: This is currently sent on the same schedule as {@link SectorSimulationEvent}, based on
+ * TODO: {@link SectorSimulationComponent#maxDelta}. It should be able to have its own schedule for when the chunk is
+ * TODO: loaded.
+ */
+@API
+public class LoadedSectorUpdateEvent implements Event {
+    public LoadedSectorUpdateEvent() {
+
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
@@ -18,14 +18,14 @@ package org.terasology.entitySystem.sectors;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.entitySystem.entity.internal.EntityScope;
 import org.terasology.module.sandbox.API;
-import org.terasology.protobuf.EntityData;
 
 /**
  * The component that allows the {@link SectorSimulationSystem} to send simulation events to a sector-scope entity.
  *
  * This should be automatically added by either {@link EntityManager#createSectorEntity(long)} or
- * {@link BaseEntityRef#setScope(EntityData.Entity.Scope)}, so modules should not need to modify or add it.
+ * {@link BaseEntityRef#setScope(EntityScope)}, so modules should not need to modify or add it.
  */
 @API
 public class SectorSimulationComponent implements Component {

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.module.sandbox.API;
+import org.terasology.protobuf.EntityData;
+
+/**
+ * The component that allows the {@link SectorSimulationSystem} to send simulation events to a sector-scope entity.
+ *
+ * This should be automatically added by either {@link EntityManager#createSectorEntity(long)} or
+ * {@link BaseEntityRef#setScope(EntityData.Entity.Scope)}, so modules should not need to modify or add it.
+ */
+@API
+public class SectorSimulationComponent implements Component {
+
+    public static final float MAX_DELTA_DEFAULT = 10;
+
+    /**
+     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent. This value does not change
+     * the fact that a simulation event is always sent when the chunk the entity is in is loaded.
+     *
+     * TODO: this should only affect the timing of events sent when the chunk is not loaded; a different value should
+     * TODO: be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
+     * TODO: non-simulating value) if all of the simulation can be postponed until chunk load.
+     *
+     * This should be set as high as possible, so that fewer simulation events need to be sent in total. The purpose of
+     * this value is to allow checking for whether its borders need to be expanded regularly, so that the appropriate
+     * events are called if those expanded regions are loaded.
+     *
+     * E.g. if a city expands while the player is away, it needs to tell the system to load buildings at the edge of
+     * the city region without the centre of the city needing to be loaded (to force a simulation).
+     */
+    public float maxDelta;
+
+    /**
+     * The last time a {@link SectorSimulationEvent} was sent to this entity.
+     *
+     * This is used to calculate the delta between simulation events, and should not be changed outside of this class
+     * or the {@link SectorSimulationSystem}.
+     */
+    protected float lastSimulationTime;
+
+    /**
+     * Create a new {@link SectorSimulationComponent} with the default max delta.
+     */
+    public SectorSimulationComponent() {
+        new SectorSimulationComponent(MAX_DELTA_DEFAULT);
+    }
+
+    /**
+     * @see SectorSimulationComponent#maxDelta
+     */
+    public SectorSimulationComponent(float maxDelta) {
+        this.maxDelta = maxDelta;
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.module.sandbox.API;
+
+/**
+ * This is the event sent to all sector-level entities by the {@link SectorSimulationSystem}, allowing them to do simulation. It
+ * is sent regardless of whether the chunk the entity is in is loaded or not.
+ *
+ * @see SectorSimulationEvent#getDelta()
+ */
+@API
+public class SectorSimulationEvent implements Event {
+    private float delta;
+
+    /**
+     * @see SectorSimulationEvent#getDelta() for the delta parameter
+     */
+    protected SectorSimulationEvent(float delta) {
+        this.delta = delta;
+    }
+
+    /**
+     * This gives the time elapsed, in seconds, since the last time this event was sent to the given {@link EntityRef}.
+     *
+     * Performing simulation based on the the number of times this event is sent is not reliable, because there may be
+     * big variations in the time between sending these events (notably, an event will be sent whenever the chunk an
+     * entity is in is loaded, even if one has just been sent.
+     *
+     * Using the delta will give a relaible measure of how much simulation to perform.
+     *
+     * @return the time, in seconds, since the last time this event was sent to the given entity
+     */
+    public float getDelta() {
+        return delta;
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
@@ -43,7 +43,7 @@ public class SectorSimulationEvent implements Event {
      * big variations in the time between sending these events (notably, an event will be sent whenever the chunk an
      * entity is in is loaded, even if one has just been sent.
      *
-     * Using the delta will give a relaible measure of how much simulation to perform.
+     * Using the delta will give a reliable measure of how much simulation to perform.
      *
      * @return the time, in seconds, since the last time this event was sent to the given entity
      */

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
+import org.terasology.protobuf.EntityData;
+import org.terasology.registry.In;
+import org.terasology.world.WorldComponent;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.chunks.event.BeforeChunkUnload;
+import org.terasology.world.chunks.event.OnChunkLoaded;
+
+/**
+ * This system handles the sending of sector-level simulation events, so module systems can subscribe to them for their
+ * own sector-scope entities.
+ *
+ * For the purposes of this class, sector-scope means any {@link EntityRef} that's scope is SECTOR, and that has a
+ * {@link SectorSimulationComponent}. The entity should automatically have the component, as long as it was created by
+ * {@link EntityManager#createSectorEntity(long)} or its scope was set by
+ * {@link BaseEntityRef#setScope(EntityData.Entity.Scope)}.
+ *
+ * It periodically sends a {@link SectorSimulationEvent} to all sector-scope entities, which should trigger any
+ * simulation that needs to happen regardless of whether or not the entity's chunk is loaded.
+ *
+ * It periodically sends a {@link LoadedSectorUpdateEvent} to all sector-scope entities which are in a loaded chunk.
+ * This should trigger any block-based or chunk-based actions that need to happen.
+ *
+ * It also sends {@link OnChunkLoaded} and {@link BeforeChunkUnload} events to the entities, where appropriate. These
+ * should be captured by filtering only to entities with a {@link SectorSimulationComponent}, to avoid capturing the
+ * event sent to the world entity.
+ */
+@RegisterSystem
+public class SectorSimulationSystem extends BaseComponentSystem {
+
+    @In
+    private EntityManager entityManager;
+
+    @In
+    private WorldProvider worldProvider;
+
+    @In
+    private DelayManager delayManager;
+
+    @In
+    private Time time;
+
+    public static final String SECTOR_SIMULATION_ACTION = "sector:simulationAction";
+
+
+    /* Set periodic events for each entity */
+
+
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void simulationComponentAdded(OnAddedComponent event, EntityRef entity) {
+        registerSimulationComponent(entity);
+    }
+
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void simulationComponentChanged(OnChangedComponent event, EntityRef entity) {
+        registerSimulationComponent(entity);
+    }
+
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void simulationComponentRemoved(BeforeRemoveComponent event, EntityRef entity) {
+        unregisterSimulationComponent(entity);
+    }
+
+    /**
+     * Add the sector simulation periodic action event for this sector-level entity.
+     *
+     * This event will be sent on a schedule based on {@link SectorSimulationComponent#maxDelta}, and will be used to
+     * send {@link SectorSimulationEvent} and/or {@link LoadedSectorUpdateEvent}, as appropriate.
+     *
+     * This periodic event gets processed by
+     * {@link SectorSimulationSystem#processPeriodicSectorEvent(PeriodicActionTriggeredEvent, EntityRef)};
+     *
+     * @param entity the entity to add the periodic event for
+     */
+    private void registerSimulationComponent(EntityRef entity) {
+        SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
+
+        unregisterSimulationComponent(entity);
+        delayManager.addPeriodicAction(entity, SECTOR_SIMULATION_ACTION, 0, (long) (simulationComponent.maxDelta * 1000));
+    }
+
+    /**
+     * Cancel any sector simulation periodic event for this sector-level entity
+     *
+     * @param entity the event to cancel the periodic event for
+     */
+    private void unregisterSimulationComponent(EntityRef entity) {
+        if (delayManager.hasPeriodicAction(entity, SECTOR_SIMULATION_ACTION)) {
+            delayManager.cancelPeriodicAction(entity, SECTOR_SIMULATION_ACTION);
+        }
+    }
+
+
+    /* Send events for the module to capture */
+
+
+    /**
+     * Retrieve the periodic event sent to each sector-scope entity, and send the appropriate event(s) depending on the
+     * status of the the chunk the entity is in.
+     *
+     * Also send the correct delta, and update the {@link SectorSimulationComponent#lastSimulationTime}.
+     *
+     * @param event the periodic action event sent at intervals of {@link SectorSimulationComponent#maxDelta}
+     * @param entity the sector-scope entity the event was sent to
+     */
+    @ReceiveEvent(components = SectorSimulationComponent.class)
+    public void processPeriodicSectorEvent(PeriodicActionTriggeredEvent event, EntityRef entity) {
+        if (event.getActionId().equals(SECTOR_SIMULATION_ACTION)) {
+            float delta = simulationDelta(entity);
+
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc != null && worldProvider.isBlockRelevant(loc.getWorldPosition())) {
+                sendLoadedSectorUpdateEvent(entity, delta);
+            } else {
+                entity.send(new SectorSimulationEvent(delta));
+            }
+        }
+    }
+
+    /**
+     * Forward the OnChunkLoaded event to the appropriate sector-scope entities, if their chunk was loaded.
+     *
+     * @param event the event sent when any chunk is loaded
+     * @param worldEntity ignored
+     */
+    @ReceiveEvent(components = WorldComponent.class)
+    public void forwardOnChunkLoaded(OnChunkLoaded event, EntityRef worldEntity) {
+        for (EntityRef entity : entityManager.getEntitiesWith(SectorSimulationComponent.class)) {
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc != null && ChunkMath.calcChunkPos(loc.getWorldPosition()).equals(event.getChunkPos())) {
+                entity.send(new OnChunkLoaded(event.getChunkPos()));
+                sendLoadedSectorUpdateEvent(entity, simulationDelta(entity));
+            }
+        }
+    }
+
+    /**
+     * Forward the BeforeChunkUnloaded event to the appropriate sector-scope entities, if their chunk was unloaded.
+     *
+     * @param event the event sent when any chunk is about to be unloaded
+     * @param worldEntity ignored
+     */
+    @ReceiveEvent(components = WorldComponent.class)
+    public void forwardChunkUnload(BeforeChunkUnload event, EntityRef worldEntity) {
+        for (EntityRef entity : entityManager.getEntitiesWith(SectorSimulationComponent.class)) {
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc != null && ChunkMath.calcChunkPos(loc.getWorldPosition()).equals(event.getChunkPos())) {
+                entity.send(new BeforeChunkUnload(event.getChunkPos()));
+            }
+        }
+    }
+
+    /**
+     * Send the appropriate events to a sector-scope entity in a loaded chunk.
+     *
+     * @param entity the entity to send the events to
+     * @param delta the time since the last time {@link SectorSimulationEvent} was sent
+     */
+    private void sendLoadedSectorUpdateEvent(EntityRef entity, float delta) {
+        entity.send(new SectorSimulationEvent(delta));
+        entity.send(new LoadedSectorUpdateEvent());
+    }
+
+    /**
+     * Calculate the time since the last {@link SectorSimulationEvent} was sent. This also updates the
+     * {@link SectorSimulationComponent#lastSimulationTime}, so future deltas will be correct.
+     * @param entity
+     * @return
+     */
+    private float simulationDelta(EntityRef entity) {
+        SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
+        float currentTime = time.getGameTime();
+        if (simulationComponent.lastSimulationTime == 0) {
+            simulationComponent.lastSimulationTime = currentTime;
+        }
+        float delta = currentTime - simulationComponent.lastSimulationTime;
+        simulationComponent.lastSimulationTime = currentTime;
+        return delta;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -19,6 +19,7 @@ import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.BaseEntityRef;
+import org.terasology.entitySystem.entity.internal.EntityScope;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
@@ -29,7 +30,6 @@ import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.ChunkMath;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.In;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.WorldProvider;
@@ -43,7 +43,7 @@ import org.terasology.world.chunks.event.OnChunkLoaded;
  * For the purposes of this class, sector-scope means any {@link EntityRef} that's scope is SECTOR, and that has a
  * {@link SectorSimulationComponent}. The entity should automatically have the component, as long as it was created by
  * {@link EntityManager#createSectorEntity(long)} or its scope was set by
- * {@link BaseEntityRef#setScope(EntityData.Entity.Scope)}.
+ * {@link BaseEntityRef#setScope(EntityScope)}.
  *
  * It periodically sends a {@link SectorSimulationEvent} to all sector-scope entities, which should trigger any
  * simulation that needs to happen regardless of whether or not the entity's chunk is loaded.

--- a/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
@@ -220,6 +220,9 @@ public class EntitySerializer {
         if (entityData.hasAlwaysRelevant()) {
             entityInfo.alwaysRelevant = entityData.getAlwaysRelevant();
         }
+        if (entityData.hasScope()) {
+            entityInfo.scope = entityData.getScope();
+        }
 
         for (EntityData.Component componentData : entityData.getComponentList()) {
             ComponentMetadata<? extends Component> metadata = componentSerializer.getComponentMetadata(componentData);
@@ -247,6 +250,11 @@ public class EntitySerializer {
         if (owner.exists()) {
             entity.setOwner(owner.getId());
         }
+        EntityData.Entity.Scope scope = entityRef.getScope();
+        if (scope != null) {
+            entity.setScope(scope);
+        }
+
         for (Component component : entityRef.iterateComponents()) {
             if (!componentSerializeCheck.serialize(componentLibrary.getMetadata(component.getClass()))) {
                 continue;
@@ -273,6 +281,12 @@ public class EntitySerializer {
         if (owner.exists()) {
             entity.setOwner(owner.getId());
         }
+        EntityData.Entity.Scope scope = entityRef.getScope();
+        if (scope != null) {
+            entity.setScope(scope);
+        }
+
+
         Set<Class<? extends Component>> presentClasses = Sets.newHashSet();
         for (Component component : entityRef.iterateComponents()) {
             if (!componentSerializeCheck.serialize(componentLibrary.getMetadata(component.getClass()))) {

--- a/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.entity.internal.EntityInfoComponent;
+import org.terasology.entitySystem.entity.internal.EntityScope;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
 import org.terasology.entitySystem.metadata.ComponentMetadata;
 import org.terasology.entitySystem.prefab.Prefab;
@@ -31,6 +32,9 @@ import org.terasology.protobuf.EntityData;
 
 import java.util.Map;
 import java.util.Set;
+
+import static org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
+import static org.terasology.protobuf.EntityData.Entity.Scope.SECTOR;
 
 /**
  * Provides the ability to serialize and deserialize entities to the EntityData.Entity proto buffer format.
@@ -220,8 +224,13 @@ public class EntitySerializer {
         if (entityData.hasAlwaysRelevant()) {
             entityInfo.alwaysRelevant = entityData.getAlwaysRelevant();
         }
-        if (entityData.hasScope()) {
-            entityInfo.scope = entityData.getScope();
+        switch (entityData.getScope()) {
+            case GLOBAL:
+                entityInfo.scope = EntityScope.GLOBAL;
+                break;
+            case SECTOR:
+                entityInfo.scope = EntityScope.SECTOR;
+                break;
         }
 
         for (EntityData.Component componentData : entityData.getComponentList()) {
@@ -250,9 +259,16 @@ public class EntitySerializer {
         if (owner.exists()) {
             entity.setOwner(owner.getId());
         }
-        EntityData.Entity.Scope scope = entityRef.getScope();
+        EntityScope scope = entityRef.getScope();
         if (scope != null) {
-            entity.setScope(scope);
+            switch (scope) {
+                case GLOBAL:
+                    entity.setScope(GLOBAL);
+                    break;
+                case SECTOR:
+                    entity.setScope(SECTOR);
+                    break;
+            }
         }
 
         for (Component component : entityRef.iterateComponents()) {
@@ -281,9 +297,16 @@ public class EntitySerializer {
         if (owner.exists()) {
             entity.setOwner(owner.getId());
         }
-        EntityData.Entity.Scope scope = entityRef.getScope();
+        EntityScope scope = entityRef.getScope();
         if (scope != null) {
-            entity.setScope(scope);
+            switch (scope) {
+                case GLOBAL:
+                    entity.setScope(GLOBAL);
+                    break;
+                case SECTOR:
+                    entity.setScope(SECTOR);
+                    break;
+            }
         }
 
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
@@ -51,7 +51,7 @@ public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
     @Override
     public EntityRef deserialize(PersistedData data, DeserializationContext context) {
         if (data.isNumber()) {
-            return entityManager.createEntityRefWithId(data.getAsLong());
+            return entityManager.getEntity(data.getAsLong());
         }
         return EntityRef.NULL;
     }
@@ -85,7 +85,7 @@ public class EntityRefTypeHandler implements TypeHandler<EntityRef> {
         TLongIterator iterator = array.getAsLongArray().iterator();
         while (iterator.hasNext()) {
             long item = iterator.next();
-            result.add(entityManager.createEntityRefWithId(item));
+            result.add(entityManager.getEntity(item));
         }
     }
 

--- a/engine/src/main/java/org/terasology/protobuf/EntityData.java
+++ b/engine/src/main/java/org/terasology/protobuf/EntityData.java
@@ -4241,6 +4241,15 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString
         getRemovedComponentBytes(int index);
+
+    /**
+     * <code>optional .Entity.Scope scope = 7;</code>
+     */
+    boolean hasScope();
+    /**
+     * <code>optional .Entity.Scope scope = 7;</code>
+     */
+    org.terasology.protobuf.EntityData.Entity.Scope getScope();
   }
   /**
    * Protobuf type {@code Entity}
@@ -4345,6 +4354,17 @@ public final class EntityData {
               owner_ = input.readInt64();
               break;
             }
+            case 56: {
+              int rawValue = input.readEnum();
+              org.terasology.protobuf.EntityData.Entity.Scope value = org.terasology.protobuf.EntityData.Entity.Scope.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(7, rawValue);
+              } else {
+                bitField0_ |= 0x00000010;
+                scope_ = value;
+              }
+              break;
+            }
             case 122: {
               com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
@@ -4400,6 +4420,88 @@ public final class EntityData {
     @java.lang.Override
     public com.google.protobuf.Parser<Entity> getParserForType() {
       return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code Entity.Scope}
+     */
+    public enum Scope
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>GLOBAL = 0;</code>
+       */
+      GLOBAL(0, 0),
+      /**
+       * <code>SECTOR = 1;</code>
+       */
+      SECTOR(1, 1),
+      ;
+
+      /**
+       * <code>GLOBAL = 0;</code>
+       */
+      public static final int GLOBAL_VALUE = 0;
+      /**
+       * <code>SECTOR = 1;</code>
+       */
+      public static final int SECTOR_VALUE = 1;
+
+
+      public final int getNumber() { return value; }
+
+      public static Scope valueOf(int value) {
+        switch (value) {
+          case 0: return GLOBAL;
+          case 1: return SECTOR;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<Scope>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<Scope>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<Scope>() {
+              public Scope findValueByNumber(int number) {
+                return Scope.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return org.terasology.protobuf.EntityData.Entity.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final Scope[] VALUES = values();
+
+      public static Scope valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private Scope(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:Entity.Scope)
     }
 
     private int bitField0_;
@@ -4577,6 +4679,21 @@ public final class EntityData {
       return removedComponent_.getByteString(index);
     }
 
+    public static final int SCOPE_FIELD_NUMBER = 7;
+    private org.terasology.protobuf.EntityData.Entity.Scope scope_;
+    /**
+     * <code>optional .Entity.Scope scope = 7;</code>
+     */
+    public boolean hasScope() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional .Entity.Scope scope = 7;</code>
+     */
+    public org.terasology.protobuf.EntityData.Entity.Scope getScope() {
+      return scope_;
+    }
+
     private void initFields() {
       id_ = 0L;
       component_ = java.util.Collections.emptyList();
@@ -4585,6 +4702,7 @@ public final class EntityData {
       alwaysRelevant_ = false;
       owner_ = 0L;
       removedComponent_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      scope_ = org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4634,6 +4752,9 @@ public final class EntityData {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeInt64(6, owner_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeEnum(7, scope_.getNumber());
+      }
       for (int i = 0; i < removedComponent_.size(); i++) {
         output.writeBytes(15, removedComponent_.getByteString(i));
       }
@@ -4680,6 +4801,10 @@ public final class EntityData {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(6, owner_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(7, scope_.getNumber());
       }
       {
         int dataSize = 0;
@@ -4828,6 +4953,8 @@ public final class EntityData {
         bitField0_ = (bitField0_ & ~0x00000020);
         removedComponent_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000040);
+        scope_ = org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
+        bitField0_ = (bitField0_ & ~0x00000080);
         return this;
       }
 
@@ -4891,6 +5018,10 @@ public final class EntityData {
           bitField0_ = (bitField0_ & ~0x00000040);
         }
         result.removedComponent_ = removedComponent_;
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.scope_ = scope_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4966,6 +5097,9 @@ public final class EntityData {
             removedComponent_.addAll(other.removedComponent_);
           }
           onChanged();
+        }
+        if (other.hasScope()) {
+          setScope(other.getScope());
         }
         this.mergeExtensionFields(other);
         this.mergeUnknownFields(other.getUnknownFields());
@@ -5572,6 +5706,41 @@ public final class EntityData {
   }
   ensureRemovedComponentIsMutable();
         removedComponent_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private org.terasology.protobuf.EntityData.Entity.Scope scope_ = org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
+      /**
+       * <code>optional .Entity.Scope scope = 7;</code>
+       */
+      public boolean hasScope() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional .Entity.Scope scope = 7;</code>
+       */
+      public org.terasology.protobuf.EntityData.Entity.Scope getScope() {
+        return scope_;
+      }
+      /**
+       * <code>optional .Entity.Scope scope = 7;</code>
+       */
+      public Builder setScope(org.terasology.protobuf.EntityData.Entity.Scope value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000080;
+        scope_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .Entity.Scope scope = 7;</code>
+       */
+      public Builder clearScope() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        scope_ = org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
         onChanged();
         return this;
       }
@@ -16585,50 +16754,52 @@ public final class EntityData {
       "\004name\030\001 \001(\t\022\025\n\005value\030\002 \001(\0132\006.Value\022\022\n\nna" +
       "me_index\030\003 \001(\005\"S\n\tComponent\022\022\n\ntype_inde" +
       "x\030\001 \001(\005\022\014\n\004type\030\017 \001(\t\022\031\n\005field\030\002 \003(\0132\n.N" +
-      "ameValue*\t\010\210\'\020\200\200\200\200\002\"\274\001\n\006Entity\022\n\n\002id\030\001 \001",
+      "ameValue*\t\010\210\'\020\200\200\200\200\002\"\373\001\n\006Entity\022\n\n\002id\030\001 \001",
       "(\003\022\035\n\tcomponent\030\002 \003(\0132\n.Component\022#\n\027rem" +
       "oved_component_index\030\003 \003(\005B\002\020\001\022\025\n\rparent" +
       "_prefab\030\004 \001(\t\022\026\n\016alwaysRelevant\030\005 \001(\010\022\r\n" +
-      "\005owner\030\006 \001(\003\022\031\n\021removed_component\030\017 \003(\t*" +
-      "\t\010\210\'\020\200\200\200\200\002\"\320\001\n\014PackedEntity\022\n\n\002id\030\001 \001(\003\022" +
-      "\027\n\013componentId\030\002 \003(\005B\002\020\001\022\034\n\024componentFie" +
-      "ldCounts\030\003 \001(\014\022\020\n\010fieldIds\030\004 \001(\014\022\032\n\nfiel" +
-      "dValue\030\005 \003(\0132\006.Value\022\034\n\020removedComponent" +
-      "\030\006 \003(\005B\002\020\001\022\r\n\005owner\030\007 \001(\003\022\027\n\017parentPrefa" +
-      "bUri\030\020 \001(\t*\t\010\210\'\020\200\200\200\200\002\"\314\001\n\006Prefab\022\022\n\nname",
-      "_index\030\001 \001(\005\022\035\n\tcomponent\030\002 \003(\0132\n.Compon" +
-      "ent\022\026\n\ndeprecated\030\003 \003(\005B\002\020\001\022\027\n\tpersisted" +
-      "\030\004 \001(\010:\004true\022\030\n\020removedComponent\030\005 \003(\t\022\026" +
-      "\n\016alwaysRelevant\030\006 \001(\010\022\014\n\004name\030\017 \001(\t\022\023\n\013" +
-      "parent_name\030\020 \001(\t*\t\010\210\'\020\200\200\200\200\002\"N\n\005Event\022\014\n" +
-      "\004type\030\001 \001(\005\022\020\n\010fieldIds\030\002 \001(\014\022\032\n\nfieldVa" +
-      "lue\030\003 \003(\0132\006.Value*\t\010\210\'\020\200\200\200\200\002\"w\n\013EntitySt" +
-      "ore\022\027\n\006entity\030\001 \003(\0132\007.Entity\022\027\n\017componen" +
-      "t_class\030\003 \003(\t\022\022\n\nentityName\030\002 \003(\t\022\027\n\013ent" +
-      "ityNamed\030\004 \003(\003B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"\220\001\n\013Player",
-      "Store\022\033\n\005store\030\001 \001(\0132\014.EntityStore\022\025\n\rch" +
-      "aracterPosX\030\017 \001(\002\022\025\n\rcharacterPosY\030\020 \001(\002" +
-      "\022\025\n\rcharacterPosZ\030\021 \001(\002\022\024\n\014hasCharacter\030" +
-      "\022 \001(\010*\t\010\210\'\020\200\200\200\200\002\"\332\002\n\nChunkStore\022\033\n\005store" +
-      "\030\001 \001(\0132\014.EntityStore\022\t\n\001x\030\002 \001(\021\022\t\n\001y\030\003 \001" +
-      "(\021\022\t\n\001z\030\004 \001(\021\022\031\n\021deprecated_data_3\030\005 \001(\005" +
-      "\022\031\n\021deprecated_data_4\030\006 \001(\014\022\031\n\021deprecate" +
-      "d_data_1\030\007 \001(\014\022\031\n\021deprecated_data_2\030\010 \001(" +
-      "\014\022\031\n\021deprecated_data_5\030\t \001(\014\022(\n\nblock_da" +
-      "ta\030\n \001(\0132\024.RunLengthEncoding16\022(\n\013liquid",
-      "_data\030\013 \001(\0132\023.RunLengthEncoding8\022(\n\nbiom" +
-      "e_data\030\014 \001(\0132\024.RunLengthEncoding16*\t\010\210\'\020" +
-      "\200\200\200\200\002\"L\n\023RunLengthEncoding16\022\026\n\nrunLengt" +
-      "hs\030\001 \003(\021B\002\020\001\022\022\n\006values\030\002 \003(\021B\002\020\001*\t\010\210\'\020\200\200" +
-      "\200\200\002\"G\n\022RunLengthEncoding8\022\026\n\nrunLengths\030" +
-      "\001 \003(\021B\002\020\001\022\016\n\006values\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"\260\001\n" +
-      "\013GlobalStore\022\027\n\006entity\030\001 \003(\0132\007.Entity\022\027\n" +
-      "\006prefab\030\002 \003(\0132\007.Prefab\022\027\n\017component_clas" +
-      "s\030\003 \003(\t\022\026\n\016next_entity_id\030\020 \001(\003\022\036\n\022depre" +
-      "cated_data_17\030\021 \003(\003B\002\020\001\022\023\n\013prefab_name\030\022",
-      " \003(\t*\t\010\210\'\020\200\200\200\200\002*4\n\tStoreType\022\023\n\017PlayerSt" +
-      "oreType\020\001\022\022\n\016ChunkStoreType\020\002B\'\n\027org.ter" +
-      "asology.protobufB\nEntityDataH\001"
+      "\005owner\030\006 \001(\003\022\031\n\021removed_component\030\017 \003(\t\022" +
+      "\034\n\005scope\030\007 \001(\0162\r.Entity.Scope\"\037\n\005Scope\022\n" +
+      "\n\006GLOBAL\020\000\022\n\n\006SECTOR\020\001*\t\010\210\'\020\200\200\200\200\002\"\320\001\n\014Pa" +
+      "ckedEntity\022\n\n\002id\030\001 \001(\003\022\027\n\013componentId\030\002 " +
+      "\003(\005B\002\020\001\022\034\n\024componentFieldCounts\030\003 \001(\014\022\020\n" +
+      "\010fieldIds\030\004 \001(\014\022\032\n\nfieldValue\030\005 \003(\0132\006.Va" +
+      "lue\022\034\n\020removedComponent\030\006 \003(\005B\002\020\001\022\r\n\005own",
+      "er\030\007 \001(\003\022\027\n\017parentPrefabUri\030\020 \001(\t*\t\010\210\'\020\200" +
+      "\200\200\200\002\"\314\001\n\006Prefab\022\022\n\nname_index\030\001 \001(\005\022\035\n\tc" +
+      "omponent\030\002 \003(\0132\n.Component\022\026\n\ndeprecated" +
+      "\030\003 \003(\005B\002\020\001\022\027\n\tpersisted\030\004 \001(\010:\004true\022\030\n\020r" +
+      "emovedComponent\030\005 \003(\t\022\026\n\016alwaysRelevant\030" +
+      "\006 \001(\010\022\014\n\004name\030\017 \001(\t\022\023\n\013parent_name\030\020 \001(\t" +
+      "*\t\010\210\'\020\200\200\200\200\002\"N\n\005Event\022\014\n\004type\030\001 \001(\005\022\020\n\010fi" +
+      "eldIds\030\002 \001(\014\022\032\n\nfieldValue\030\003 \003(\0132\006.Value" +
+      "*\t\010\210\'\020\200\200\200\200\002\"w\n\013EntityStore\022\027\n\006entity\030\001 \003" +
+      "(\0132\007.Entity\022\027\n\017component_class\030\003 \003(\t\022\022\n\n",
+      "entityName\030\002 \003(\t\022\027\n\013entityNamed\030\004 \003(\003B\002\020" +
+      "\001*\t\010\210\'\020\200\200\200\200\002\"\220\001\n\013PlayerStore\022\033\n\005store\030\001 " +
+      "\001(\0132\014.EntityStore\022\025\n\rcharacterPosX\030\017 \001(\002" +
+      "\022\025\n\rcharacterPosY\030\020 \001(\002\022\025\n\rcharacterPosZ" +
+      "\030\021 \001(\002\022\024\n\014hasCharacter\030\022 \001(\010*\t\010\210\'\020\200\200\200\200\002\"" +
+      "\332\002\n\nChunkStore\022\033\n\005store\030\001 \001(\0132\014.EntitySt" +
+      "ore\022\t\n\001x\030\002 \001(\021\022\t\n\001y\030\003 \001(\021\022\t\n\001z\030\004 \001(\021\022\031\n\021" +
+      "deprecated_data_3\030\005 \001(\005\022\031\n\021deprecated_da" +
+      "ta_4\030\006 \001(\014\022\031\n\021deprecated_data_1\030\007 \001(\014\022\031\n" +
+      "\021deprecated_data_2\030\010 \001(\014\022\031\n\021deprecated_d",
+      "ata_5\030\t \001(\014\022(\n\nblock_data\030\n \001(\0132\024.RunLen" +
+      "gthEncoding16\022(\n\013liquid_data\030\013 \001(\0132\023.Run" +
+      "LengthEncoding8\022(\n\nbiome_data\030\014 \001(\0132\024.Ru" +
+      "nLengthEncoding16*\t\010\210\'\020\200\200\200\200\002\"L\n\023RunLengt" +
+      "hEncoding16\022\026\n\nrunLengths\030\001 \003(\021B\002\020\001\022\022\n\006v" +
+      "alues\030\002 \003(\021B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"G\n\022RunLengthE" +
+      "ncoding8\022\026\n\nrunLengths\030\001 \003(\021B\002\020\001\022\016\n\006valu" +
+      "es\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"\260\001\n\013GlobalStore\022\027\n\006e" +
+      "ntity\030\001 \003(\0132\007.Entity\022\027\n\006prefab\030\002 \003(\0132\007.P" +
+      "refab\022\027\n\017component_class\030\003 \003(\t\022\026\n\016next_e",
+      "ntity_id\030\020 \001(\003\022\036\n\022deprecated_data_17\030\021 \003" +
+      "(\003B\002\020\001\022\023\n\013prefab_name\030\022 \003(\t*\t\010\210\'\020\200\200\200\200\002*4" +
+      "\n\tStoreType\022\023\n\017PlayerStoreType\020\001\022\022\n\016Chun" +
+      "kStoreType\020\002B\'\n\027org.terasology.protobufB" +
+      "\nEntityDataH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -16665,7 +16836,7 @@ public final class EntityData {
     internal_static_Entity_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_Entity_descriptor,
-        new java.lang.String[] { "Id", "Component", "RemovedComponentIndex", "ParentPrefab", "AlwaysRelevant", "Owner", "RemovedComponent", });
+        new java.lang.String[] { "Id", "Component", "RemovedComponentIndex", "ParentPrefab", "AlwaysRelevant", "Owner", "RemovedComponent", "Scope", });
     internal_static_PackedEntity_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_PackedEntity_fieldAccessorTable = new

--- a/engine/src/main/protobuf/EntityData.proto
+++ b/engine/src/main/protobuf/EntityData.proto
@@ -45,6 +45,12 @@ message Entity {
     optional bool alwaysRelevant = 5;
     optional int64 owner = 6;
     repeated string removed_component = 15;
+    enum Scope {
+        GLOBAL = 0;
+        SECTOR = 1;
+    }
+
+    optional Scope scope = 7;
 
     extensions 5000 to max;
 }


### PR DESCRIPTION
This PR contains the work done so far on sectors/entity pools. There's nothing new in here that isn't in the following PRs:

#2975
https://github.com/Vizaxo/Terasology/pull/2
https://github.com/Vizaxo/Terasology/pull/3
https://github.com/Vizaxo/Terasology/pull/4

This PR just consolidates the work done so far, rebases it on top of the v2.0.0 branch (which is on par with develop, at the time of writing), and squashes the commits from 54 down to 8.

Also, any references to caches have been removed, so pool is used all the way through.

### Summary of sectors/pools

This adds entity pools, which split up the storage of entities into multiple pools, rather than storing them all together. It implements sectors on top of that, which are a new scope for entities to allow better simulation when no players are close to the entity.

More details about the motivation behind sectors:
http://forum.terasology.org/threads/new-conceptual-layer-sector-plus-musings-on-multi-world-node.1420/

Discussion of sectors architecture:
#2976