### PR TITLE
Added EditScreen as parameter to InteractionScreenComponent

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -36,6 +36,10 @@ public final class CharacterComponent implements Component {
      */
     public float interactionRange = 5f;
     /**
+     * Specifies whether the character can interact with entities that have an edit screen.
+     */
+    public boolean editScreenInteraction = false;
+    /**
      * The current interaction target of a character which has been authorized by the authority (e.g. the server).
      * <br><br>
      * Modules should not modify this field directly.

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterComponent.java
@@ -38,7 +38,7 @@ public final class CharacterComponent implements Component {
     /**
      * Specifies whether the character can interact with entities that have an edit screen.
      */
-    public boolean editScreenInteraction = false;
+    public boolean editMode = false;
     /**
      * The current interaction target of a character which has been authorized by the authority (e.g. the server).
      * <br><br>

--- a/engine/src/main/java/org/terasology/logic/characters/events/ActivationPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/ActivationPredicted.java
@@ -16,13 +16,14 @@
 package org.terasology.logic.characters.events;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.AbstractConsumableEvent;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 
 /**
  */
-public class ActivationPredicted implements Event {
+public class ActivationPredicted extends AbstractConsumableEvent {
 
     private EntityRef instigator;
     private EntityRef target;

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/EditScreenComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/EditScreenComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ import org.terasology.entitySystem.Component;
 import org.terasology.module.sandbox.API;
 
 /**
- * Entities with this component will show an UI during interactions.
+ * Entities with this component will show a different UI Screen during interactions when edit mode is on. <br/>
  *
  */
 @API
-public class InteractionScreenComponent implements Component {
-    public String screen;
+public class EditScreenComponent implements Component {
+    public String screen = null;
 }

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionScreenComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionScreenComponent.java
@@ -25,5 +25,5 @@ import org.terasology.module.sandbox.API;
 @API
 public class InteractionScreenComponent implements Component {
     public String screen;
-
+    public boolean editScreen = false;
 }

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionStartPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionStartPredicted.java
@@ -16,6 +16,7 @@
 package org.terasology.logic.characters.interactions;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.AbstractConsumableEvent;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.module.sandbox.API;
 
@@ -31,7 +32,7 @@ import org.terasology.module.sandbox.API;
  *
  */
 @API
-public class InteractionStartPredicted implements Event {
+public class InteractionStartPredicted extends AbstractConsumableEvent {
     private EntityRef instigator;
 
     protected InteractionStartPredicted() {

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
@@ -112,6 +112,10 @@ public class InteractionSystem extends BaseComponentSystem {
             logger.error("Interaction start predicted for entity without character component");
             return;
         }
+        if (interactionScreenComponent.editScreen) {
+            logger.debug("Interaction screen disallowed because target has an edit screen.");
+            return;
+        }
         ClientComponent controller = characterComponent.controller.getComponent(ClientComponent.class);
         if (controller != null && controller.local) {
             nuiManager.closeAllScreens();

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
@@ -112,7 +112,7 @@ public class InteractionSystem extends BaseComponentSystem {
             logger.error("Interaction start predicted for entity without character component");
             return;
         }
-        if (interactionScreenComponent.editScreen) {
+        if (interactionScreenComponent.editScreen && !characterComponent.editScreenInteraction) {
             logger.debug("Interaction screen disallowed because target has an edit screen.");
             return;
         }

--- a/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/interactions/InteractionSystem.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -59,6 +60,36 @@ public class InteractionSystem extends BaseComponentSystem {
         characterComponent.authorizedInteractionId = event.getActivationId();
         instigator.saveComponent(characterComponent);
 
+    }
+
+    /**
+     * To consume the activation event in the edit mode if the target entity has an EditScreenComponent with no screen defined.
+     * @param event
+     * @param target
+     * @param editScreenComponent
+     */
+    @ReceiveEvent(components = {InteractionTargetComponent.class}, priority = EventPriority.PRIORITY_HIGH)
+    public void onEditModeActivationPredicted(ActivationPredicted event, EntityRef target,
+                                              EditScreenComponent editScreenComponent) {
+        EntityRef character = event.getInstigator();
+        CharacterComponent characterComponent = character.getComponent(CharacterComponent.class);
+        if (characterComponent == null) {
+            return;
+        }
+        if (characterComponent.predictedInteractionTarget.exists()) {
+            InteractionUtil.cancelInteractionAsClient(character);
+        }
+        if (editScreenComponent.screen == null && characterComponent.editMode) {
+            logger.info("No screen defined in Edit Mode");
+            event.consume();
+        }
+        if (editScreenComponent.screen != null && characterComponent.editMode) {
+            return;
+        }
+        if (!target.hasComponent(InteractionScreenComponent.class) && !characterComponent.editMode) {
+            logger.info("No screen defined in Normal Mode");
+            event.consume();
+        }
     }
 
     @ReceiveEvent(components = {InteractionTargetComponent.class})
@@ -102,18 +133,33 @@ public class InteractionSystem extends BaseComponentSystem {
         nuiManager.closeScreen(screenComponent.screen);
     }
 
-
-    @ReceiveEvent(components = {InteractionScreenComponent.class})
-    public void onInteractionStartPredicted(InteractionStartPredicted event, EntityRef container,
-                                            InteractionScreenComponent interactionScreenComponent) {
+    @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
+    public void onEditModeInteractionStartPredicted(InteractionStartPredicted event, EntityRef container,
+                                                    EditScreenComponent editScreenComponent) {
         EntityRef investigator = event.getInstigator();
         CharacterComponent characterComponent = investigator.getComponent(CharacterComponent.class);
         if (characterComponent == null) {
             logger.error("Interaction start predicted for entity without character component");
             return;
         }
-        if (interactionScreenComponent.editScreen && !characterComponent.editScreenInteraction) {
-            logger.debug("Interaction screen disallowed because target has an edit screen.");
+        if (!characterComponent.editMode) {
+            return;
+        }
+        ClientComponent controller = characterComponent.controller.getComponent(ClientComponent.class);
+        if (controller != null && controller.local) {
+            event.consume();
+            nuiManager.closeAllScreens();
+            nuiManager.pushScreen(editScreenComponent.screen);
+        }
+    }
+
+    @ReceiveEvent
+    public void onInteractionStartPredicted(InteractionStartPredicted event, EntityRef container,
+                                            InteractionScreenComponent interactionScreenComponent) {
+        EntityRef investigator = event.getInstigator();
+        CharacterComponent characterComponent = investigator.getComponent(CharacterComponent.class);
+        if (characterComponent == null) {
+            logger.error("Interaction start predicted for entity without character component");
             return;
         }
         ClientComponent controller = characterComponent.controller.getComponent(ClientComponent.class);

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -36,6 +36,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.i18n.TranslationProject;
 import org.terasology.i18n.TranslationSystem;
+import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.console.Console;
 import org.terasology.logic.console.ConsoleColors;
 import org.terasology.logic.console.commandSystem.ConsoleCommand;
@@ -518,6 +519,16 @@ public class CoreCommands extends BaseComponentSystem {
 
         blockItem.send(new DropItemEvent(spawnPos));
         return "Spawned block.";
+    }
+
+    @Command(shortDescription = "Toggle edit mode", helpText = "Toggles the edit mode to allow interaction with edit screens",
+            runOnServer = true, requiredPermission = PermissionManager.CHEAT_PERMISSION)
+    public String toggleEditMode(@Sender EntityRef sender) {
+        EntityRef character = sender.getComponent(ClientComponent.class).character;
+        CharacterComponent characterComponent = character.getComponent(CharacterComponent.class);
+        characterComponent.editScreenInteraction ^= true;
+        character.saveComponent(characterComponent);
+        return "Edit Mode changed to " + characterComponent.editScreenInteraction;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -526,9 +526,9 @@ public class CoreCommands extends BaseComponentSystem {
     public String toggleEditMode(@Sender EntityRef sender) {
         EntityRef character = sender.getComponent(ClientComponent.class).character;
         CharacterComponent characterComponent = character.getComponent(CharacterComponent.class);
-        characterComponent.editScreenInteraction ^= true;
+        characterComponent.editMode ^= true;
         character.saveComponent(characterComponent);
-        return "Edit Mode changed to " + characterComponent.editScreenInteraction;
+        return "Edit Mode changed to " + characterComponent.editMode;
     }
 
     /**


### PR DESCRIPTION
Adds an `editScreen` parameter to the InteractionScreenComponent, which is *false* by default. Setting it to `true` would disallow opening of the screen, when the editMode (in CharacterComponent) is set to false.

editMode can be toggled by the new command from console `toggleEditMode`