### PR TITLE
add support for module jars passed via -classpath

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
@@ -16,33 +16,25 @@
 package org.terasology.engine.module;
 
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.assets.Asset;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.paths.PathManager;
-import org.terasology.module.ClasspathModule;
-import org.terasology.module.DependencyInfo;
-import org.terasology.module.Module;
-import org.terasology.module.ModuleEnvironment;
-import org.terasology.module.ModuleLoader;
-import org.terasology.module.ModuleMetadata;
-import org.terasology.module.ModuleMetadataJsonAdapter;
-import org.terasology.module.ModulePathScanner;
-import org.terasology.module.ModuleRegistry;
-import org.terasology.module.TableModuleRegistry;
-import org.terasology.module.sandbox.APIScanner;
-import org.terasology.module.sandbox.BytecodeInjector;
-import org.terasology.module.sandbox.ModuleSecurityManager;
-import org.terasology.module.sandbox.ModuleSecurityPolicy;
-import org.terasology.module.sandbox.StandardPermissionProviderFactory;
+import org.terasology.module.*;
+import org.terasology.module.sandbox.*;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.ReflectPermission;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Policy;
-import java.util.Collections;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class ModuleManagerImpl implements ModuleManager {
@@ -52,6 +44,7 @@ public class ModuleManagerImpl implements ModuleManager {
     private ModuleRegistry registry;
     private ModuleEnvironment environment;
     private ModuleMetadataJsonAdapter metadataReader;
+    private static Logger logger = LoggerFactory.getLogger(ModuleManagerImpl.class);
 
     public ModuleManagerImpl() {
         metadataReader = new ModuleMetadataJsonAdapter();
@@ -70,6 +63,9 @@ public class ModuleManagerImpl implements ModuleManager {
 
         registry = new TableModuleRegistry();
         registry.add(engineModule);
+
+        loadModulesFromClassPath();
+
         ModulePathScanner scanner = new ModulePathScanner(new ModuleLoader(metadataReader));
         scanner.getModuleLoader().setModuleInfoPath(TerasologyConstants.MODULE_INFO_FILENAME);
         scanner.scan(registry, PathManager.getInstance().getModulePaths());
@@ -83,6 +79,44 @@ public class ModuleManagerImpl implements ModuleManager {
 
         setupSandbox();
         loadEnvironment(Sets.newHashSet(engineModule), true);
+    }
+
+    /**
+     * Overrides modules in modules/ with those specified via -classpath in the JVM
+     */
+    private void loadModulesFromClassPath() {
+        try {
+            // Only attempt this if we're using the standard URLClassLoader
+            if (ClassLoader.getSystemClassLoader() instanceof URLClassLoader) {
+                URLClassLoader urlClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+                ModuleLoader loader = new ModuleLoader(metadataReader);
+                loader.setModuleInfoPath(TerasologyConstants.MODULE_INFO_FILENAME);
+
+                // We're looking for jars on the classpath with a module.txt
+                Enumeration<URL> moduleInfosInClassPath = urlClassLoader.findResources(TerasologyConstants.MODULE_INFO_FILENAME.toString());
+                for (URL url : Collections.list(moduleInfosInClassPath)) {
+                    if(!url.getProtocol().equalsIgnoreCase("jar")) {
+                        continue;
+                    }
+                    Reader reader = new InputStreamReader(url.openStream());
+                    String displayName = metadataReader.read(reader).getDisplayName().toString();
+                    logger.info("Loading module {} from class path at {}", displayName, url.getFile());
+
+                    // the url contains a protocol, and points to the module.txt
+                    // we need to trim both of those away to get the module's path
+                    Path path = Paths.get(url.getFile()
+                            .replace("file:", "")
+                            .replace("!/" + TerasologyConstants.MODULE_INFO_FILENAME, "")
+                            .replace("/" + TerasologyConstants.MODULE_INFO_FILENAME, "")
+                    );
+
+                    Module module = loader.load(path);
+                    registry.add(module);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read classpath modules", e);
+        }
     }
 
     private void setupSandbox() {


### PR DESCRIPTION
This is a fix for a fairly esoteric problem, but I'll do my best to explain:

The Problem
===

Specifying module `.jar` files in the classpath causes `ModuleEnvironment.getModuleProviding` to fail [while registering components](https://github.com/MovingBlocks/Terasology/blob/8d3173cad52fd0305f39013ee20cdea4ff19a42d/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java#L134) for any classes loaded from that jar. This occurs when trying to use the `ModuleManagerImpl` in a module's test environment within IDEA for the purpose of running integration tests using full `TerasologyEngine` instances.

In the module configurations, module dependencies are parsed by the gradle scripts and listed as compile time dependencies in the generated IDEA project. This means that they are passed in to the executable via `-classpath` when tests are run. When gradle downloads module jars they are stored in some place like `$HOME/.gradle/caches/`. However, the jar is copied to `modules` by some extra gradle logic, and registered with classpaths that live in `$projectRoot/modules` by the `ModulePathScanner`. This causes the equality check in `getModuleProviding` to fail because the [left side does not equal the right side here](https://github.com/MovingBlocks/gestalt/blob/bca6b16808c7bb77f69cec986529aa644a6c2eed/gestalt-module/src/main/java/org/terasology/module/ModuleEnvironment.java#L291). The code location as seen from the class itself will be in `$HOME/.gradle/caches/` while the module's classpaths will all be in `$projectRoot/modules`.

Semantically, this means the `ModuleEnvironment` can't find a module containing the class's self-reported code location, because it's been loaded from a jar in the gradle cache as directed by `-classpath` and not from the `modules` subdir.

The Solution
===

This PR looks for Terasology modules provided on the classpath. Any class path URL pointing to a jar containing a valid `module.txt` is assumed to be a Terasology module. When found, it parses the URL from the system's default `ClassLoader`, which is assumed to be a `URLClassLoader`. The jar path extracted from the URL is then loaded by way of a standard `ModuleLoader`, passing in the extracted file path. This creates an `ArchiveModule` entry in the registry that *does* match the reported source location of the loaded class, and allows `getModuleProviding` to work as expected.

Extra Thoughts
===

- It might be possible to solve this by use the `$projectRoot/modules` file path when specifying dependencies in gradle. However, I couldn't get this to work without breaking automatic module JAR downloads.
- In theory `gestalt-modules` could contain this logic, but semantically it feels more correct that Terasology supports this feature than gestalt-module,  because it's caused by an idiosyncrasy of the Terasology build system. 
- This may fix some heisenbugs where tests with module resolution sporadically fail depending on the gradle cache's state