### PR TITLE
Change ActivationPredicted to consumable event

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/events/ActivationPredicted.java
+++ b/engine/src/main/java/org/terasology/logic/characters/events/ActivationPredicted.java
@@ -16,13 +16,14 @@
 package org.terasology.logic.characters.events;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.AbstractConsumableEvent;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 
 /**
  */
-public class ActivationPredicted implements Event {
+public class ActivationPredicted extends AbstractConsumableEvent {
 
     private EntityRef instigator;
     private EntityRef target;


### PR DESCRIPTION
Linked to https://github.com/Terasology/StructureTemplates/pull/18

This changes `ActivationPredicted` to a consumable event, allowing for activation to be blocked completely when needed.