### PR TITLE
[v2.0.0] Add SectorRegionComponent to allow sector entities to span multiple chunks

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -34,9 +34,7 @@ public interface EntityManager extends EntityPool {
      *                 @see SectorSimulationComponent#maxDelta
      * @return the newly created EntityRef
      */
-    default EntityRef createSectorEntity(long maxDelta) {
-        return null;
-    }
+    EntityRef createSectorEntity(long maxDelta);
 
     /**
      * @return A new entity with a copy of each of the other entity's components

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -106,7 +106,7 @@ public abstract class EntityRef implements MutableComponentContainer {
      *
      * @param maxDelta the maxDelta for the sector-scope entity
      */
-    public void setSectorScope(float maxDelta) {
+    public void setSectorScope(long maxDelta) {
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -106,7 +106,7 @@ public abstract class EntityRef implements MutableComponentContainer {
      *
      * @param maxDelta the maxDelta for the sector-scope entity
      */
-    public void setSectorScope(long maxDelta) {
+    public void setSectorScope(float maxDelta) {
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -123,7 +123,7 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public void setSectorScope(float maxDelta) {
+    public void setSectorScope(long maxDelta) {
         setScope(SECTOR);
         SectorSimulationComponent simulationComponent = getComponent(SectorSimulationComponent.class);
         simulationComponent.maxDelta = maxDelta;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -123,9 +123,12 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public void setSectorScope(long maxDelta) {
+    public void setSectorScope(float maxDelta) {
         setScope(SECTOR);
-        getComponent(SectorSimulationComponent.class).maxDelta = maxDelta;
+        SectorSimulationComponent simulationComponent = getComponent(SectorSimulationComponent.class);
+        simulationComponent.maxDelta = maxDelta;
+        saveComponent(simulationComponent);
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
@@ -16,7 +16,10 @@
 package org.terasology.entitySystem.sectors;
 
 import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.module.sandbox.API;
+
+import java.util.Set;
 
 /**
  * This event will be sent by the {@link SectorSimulationSystem} to allow sector-scope entities to have an effect on the world,
@@ -31,7 +34,26 @@ import org.terasology.module.sandbox.API;
  */
 @API
 public class LoadedSectorUpdateEvent implements Event {
-    public LoadedSectorUpdateEvent() {
 
+    /**
+     * The set of positions of chunks which the sector is watching, and which are ready to be used.
+     */
+    private Set<Vector3i> readyChunks;
+
+    /**
+     * Create a new event with the given {@link #readyChunks}.
+     *
+     * @param readyChunks the readyChunks for the event.
+     *                    @see #readyChunks
+     */
+    public LoadedSectorUpdateEvent(Set<Vector3i> readyChunks) {
+        this.readyChunks = readyChunks;
+    }
+
+    /**
+     * @see #readyChunks
+     */
+    public Set<Vector3i> getReadyChunks() {
+        return readyChunks;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorRegionComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorRegionComponent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.module.sandbox.API;
+import org.terasology.world.chunks.Chunk;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * When this component is added to a sector-scope entity, the {@link SectorSimulationComponent} will count any chunks
+ * listed in {@link #chunks} as watched chunks.
+ *
+ * {@link SectorUtil} contains helper methods for creating this component, and for modifying it using {@link Chunk},
+ * rather than positions, if desired.
+ */
+@API
+public class SectorRegionComponent implements Component {
+
+    /**
+     * The set of positions of chunks for this entity to watch.
+     */
+    public Set<Vector3i> chunks = new HashSet<>();
+
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
@@ -30,15 +30,17 @@ import org.terasology.module.sandbox.API;
 @API
 public class SectorSimulationComponent implements Component {
 
-    public static final float MAX_DELTA_DEFAULT = 10;
+    public static final long MAX_DELTA_DEFAULT = 10;
 
     /**
-     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent. This value does not change
-     * the fact that a simulation event is always sent when the chunk the entity is in is loaded.
+     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent, in ms. This value does not
+     * change the fact that a simulation event is always sent when the chunk the entity is in is loaded.
      *
-     * TODO: this should only affect the timing of events sent when the chunk is not loaded; a different value should
-     * TODO: be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
-     * TODO: non-simulating value) if all of the simulation can be postponed until chunk load.
+     *
+     * TODO: add a way of simulating at a different maxDelta when the entity is loaded
+     * This should only affect the timing of events sent when the chunk is not loaded; a different value should
+     * be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
+     * non-simulating value) if all of the simulation can be postponed until chunk load.
      *
      * This should be set as high as possible, so that fewer simulation events need to be sent in total. The purpose of
      * this value is to allow checking for whether its borders need to be expanded regularly, so that the appropriate
@@ -47,15 +49,15 @@ public class SectorSimulationComponent implements Component {
      * E.g. if a city expands while the player is away, it needs to tell the system to load buildings at the edge of
      * the city region without the centre of the city needing to be loaded (to force a simulation).
      */
-    public float maxDelta;
+    public long maxDelta;
 
     /**
-     * The last time a {@link SectorSimulationEvent} was sent to this entity.
+     * The last time (game time, in ms) a {@link SectorSimulationEvent} was sent to this entity.
      *
      * This is used to calculate the delta between simulation events, and should not be changed outside of this class
      * or the {@link SectorSimulationSystem}.
      */
-    protected float lastSimulationTime;
+    protected long lastSimulationTime;
 
     /**
      * Create a new {@link SectorSimulationComponent} with the default max delta.
@@ -67,7 +69,7 @@ public class SectorSimulationComponent implements Component {
     /**
      * @see SectorSimulationComponent#maxDelta
      */
-    public SectorSimulationComponent(float maxDelta) {
+    public SectorSimulationComponent(long maxDelta) {
         this.maxDelta = maxDelta;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
@@ -27,17 +27,17 @@ import org.terasology.module.sandbox.API;
  */
 @API
 public class SectorSimulationEvent implements Event {
-    private float delta;
+    private long delta;
 
     /**
      * @see SectorSimulationEvent#getDelta() for the delta parameter
      */
-    protected SectorSimulationEvent(float delta) {
+    protected SectorSimulationEvent(long delta) {
         this.delta = delta;
     }
 
     /**
-     * This gives the time elapsed, in seconds, since the last time this event was sent to the given {@link EntityRef}.
+     * This gives the time elapsed, in ms, since the last time this event was sent to the given {@link EntityRef}.
      *
      * Performing simulation based on the the number of times this event is sent is not reliable, because there may be
      * big variations in the time between sending these events (notably, an event will be sent whenever the chunk an
@@ -45,9 +45,9 @@ public class SectorSimulationEvent implements Event {
      *
      * Using the delta will give a reliable measure of how much simulation to perform.
      *
-     * @return the time, in seconds, since the last time this event was sent to the given entity
+     * @return the time, in ms, since the last time this event was sent to the given entity
      */
-    public float getDelta() {
+    public long getDelta() {
         return delta;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -30,7 +30,6 @@ import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
 import org.terasology.registry.In;
 import org.terasology.world.WorldComponent;
-import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.event.BeforeChunkUnload;
 import org.terasology.world.chunks.event.OnChunkLoaded;
@@ -63,9 +62,6 @@ public class SectorSimulationSystem extends BaseComponentSystem {
 
     @In
     private EntityManager entityManager;
-
-    @In
-    private WorldProvider worldProvider;
 
     @In
     private DelayManager delayManager;
@@ -144,14 +140,13 @@ public class SectorSimulationSystem extends BaseComponentSystem {
         if (event.getActionId().equals(SECTOR_SIMULATION_ACTION)) {
             float delta = simulationDelta(entity);
 
-            long readyChunks = SectorUtil.getWatchedChunks(entity).stream()
-                    .filter(chunkProvider::isChunkReady)
-                    .count();
+            boolean anyChunksReady = SectorUtil.getWatchedChunks(entity).stream()
+                    .anyMatch(chunkProvider::isChunkReady);
 
-            if (readyChunks == 0) {
-                entity.send(new SectorSimulationEvent(delta));
-            } else {
+            if (anyChunksReady) {
                 sendLoadedSectorUpdateEvent(entity, delta);
+            } else {
+                entity.send(new SectorSimulationEvent(delta));
             }
         }
     }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -108,7 +108,7 @@ public class SectorSimulationSystem extends BaseComponentSystem {
         SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
 
         unregisterSimulationComponent(entity);
-        delayManager.addPeriodicAction(entity, SECTOR_SIMULATION_ACTION, 0, (long) (simulationComponent.maxDelta * 1000));
+        delayManager.addPeriodicAction(entity, SECTOR_SIMULATION_ACTION, 0, simulationComponent.maxDelta);
     }
 
     /**
@@ -138,7 +138,7 @@ public class SectorSimulationSystem extends BaseComponentSystem {
     @ReceiveEvent(components = SectorSimulationComponent.class)
     public void processPeriodicSectorEvent(PeriodicActionTriggeredEvent event, EntityRef entity) {
         if (event.getActionId().equals(SECTOR_SIMULATION_ACTION)) {
-            float delta = simulationDelta(entity);
+            long delta = simulationDelta(entity);
 
             boolean anyChunksReady = SectorUtil.getWatchedChunks(entity).stream()
                     .anyMatch(chunkProvider::isChunkReady);
@@ -186,9 +186,9 @@ public class SectorSimulationSystem extends BaseComponentSystem {
      * Send the appropriate events to a sector-scope entity in a loaded chunk.
      *
      * @param entity the entity to send the events to
-     * @param delta the time since the last time {@link SectorSimulationEvent} was sent
+     * @param delta the time since the last time {@link SectorSimulationEvent} was sent, in ms
      */
-    private void sendLoadedSectorUpdateEvent(EntityRef entity, float delta) {
+    private void sendLoadedSectorUpdateEvent(EntityRef entity, long delta) {
         entity.send(new SectorSimulationEvent(delta));
         entity.send(new LoadedSectorUpdateEvent(SectorUtil.getWatchedChunks(entity)
                 .stream()
@@ -202,13 +202,13 @@ public class SectorSimulationSystem extends BaseComponentSystem {
      * @param entity
      * @return
      */
-    private float simulationDelta(EntityRef entity) {
+    private long simulationDelta(EntityRef entity) {
         SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
-        float currentTime = time.getGameTime();
+        long currentTime = time.getGameTimeInMs();
         if (simulationComponent.lastSimulationTime == 0) {
             simulationComponent.lastSimulationTime = currentTime;
         }
-        float delta = currentTime - simulationComponent.lastSimulationTime;
+        long delta = currentTime - simulationComponent.lastSimulationTime;
         simulationComponent.lastSimulationTime = currentTime;
         return delta;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.module.sandbox.API;
+import org.terasology.world.chunks.Chunk;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class for the {@link SectorSimulationSystem} and related components and events.
+ */
+@API
+public final class SectorUtil {
+
+    private SectorUtil() {
+    }
+
+    /**
+     * Create a new {@link SectorRegionComponent} with the given chunks, from a collection of chunk positions.
+     *
+     * @param chunks the positions of the chunks to add
+     * @return the newly created SectorRegionComponent
+     */
+    public static SectorRegionComponent createSectorRegionComponent(Collection<Vector3i> chunks) {
+        SectorRegionComponent regionComponent = new SectorRegionComponent();
+        regionComponent.chunks.addAll(chunks);
+        return regionComponent;
+    }
+
+    /**
+     * Add the given collection of chunks to the given component, converting the chunks to their positions.
+     *
+     * @param regionComponent the component to add the chunks to
+     * @param chunks the chunks to add
+     */
+    public static void addChunksToRegionComponent(SectorRegionComponent regionComponent, Collection<Chunk> chunks) {
+        regionComponent.chunks.addAll(chunks.stream()
+                .map(Chunk::getPosition)
+                .collect(Collectors.toSet()));
+    }
+
+    /**
+     * Add the given collection of chunk positions to the {@link SectorRegionComponent} of the entity, creating it if
+     * needed.
+     *
+     * @param entity the entity to which the chunks will be added
+     * @param chunks the positions of the chunks to add
+     */
+    public static void addChunksToRegionComponent(EntityRef entity, Collection<Vector3i> chunks) {
+        SectorRegionComponent regionComponent = entity.getComponent(SectorRegionComponent.class);
+        if (regionComponent == null) {
+            regionComponent = new SectorRegionComponent();
+        }
+        regionComponent.chunks.addAll(chunks);
+        entity.addOrSaveComponent(regionComponent);
+    }
+
+    /**
+     * Watched chunks are defined as the union of:
+     * <ul>
+     *     <li>The chunk in which the {@link LocationComponent#getWorldPosition()} resides, if any</li>
+     *     <li>The set of chunks in {@link SectorRegionComponent#chunks}, if any</li>
+     * </ul>
+     *
+     * @param entity the entity to query the watched chunks of
+     * @return the set of positions of this entity's watched chunks
+     */
+    public static Set<Vector3i> getWatchedChunks(EntityRef entity) {
+        Set<Vector3i> chunks = new HashSet<>();
+        LocationComponent loc = entity.getComponent(LocationComponent.class);
+        if (loc != null) {
+            chunks.add(ChunkMath.calcChunkPos(loc.getWorldPosition()));
+        }
+        SectorRegionComponent regionComponent = entity.getComponent(SectorRegionComponent.class);
+        if (regionComponent != null) {
+            chunks.addAll(regionComponent.chunks);
+        }
+        return chunks;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -273,4 +273,21 @@ public final class ChunkMath {
             target[dimX - 1 + dimX * (dimY - 1)] = Math.min(source[dimX - 2 + dimX * (dimY - 1)], source[dimX - 1 + dimX * (dimY - 2)]);
         }
     }
+
+    /**
+     * Works out whether the given block resides inside the given chunk.
+     *
+     * Both positions must be given as world position, not local position. In addition, the chunk position must be
+     * given in chunk coordinates, not in block coordinates.
+     *
+     * For example, using chunks of width 32, a block with x coordinate of 33 will be counted as inside a chunk with x
+     * coordinate of 1.
+     *
+     * @param blockWorldPos the block to check for
+     * @param chunkWorldPos the chunk to check in
+     * @return whether the block is inside the chunk
+     */
+    public static boolean blockInChunk(Vector3i blockWorldPos, Vector3i chunkWorldPos) {
+        return calcChunkPos(blockWorldPos).equals(chunkWorldPos);
+    }
 }


### PR DESCRIPTION
This PR implements the `SectorRegionComponent`, which allows sector entities to watch a set of chunks, rather than just one chunk. This allows the entity to span a region, e.g. a city, or a big herd of deer. If any of the chunks in the region are loaded, the `LoadedSectorUpdateEvent` will be sent to the entity.

It also adds some helper methods in the `SectorUtil` class for dealing with the `SectorRegionComponent`.

There are also a few other small fixes/improvements, and the addition of the `blockInChunk()` method to `ChunkMath`, which I've used in my changes to DynamicCities.

I've updated the [TutorialSectors](https://github.com/terasology/tutorialsectors) module to demonstrate its use. The `postBegin()` method of the `TestSystem` adds the SectorRegionComponent. It can be tested in-game by going to position `0, 0, 0` and verifying that the log shows `Entity 47 loaded. Value is ...`, then moving away so that the chunk unloads and the loaded message stops appearing. Then teleporting to `1000, 0, 1000` should cause the loaded messages to return.