### PR TITLE
Checking isHeadless from DisplayDevice

### DIFF
--- a/engine/src/main/java/org/terasology/telemetry/metrics/SystemContextMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/SystemContextMetric.java
@@ -18,6 +18,9 @@ package org.terasology.telemetry.metrics;
 import com.snowplowanalytics.snowplow.tracker.events.Unstructured;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import org.lwjgl.opengl.GL11;
+import org.terasology.context.Context;
+import org.terasology.engine.subsystem.DisplayDevice;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.telemetry.TelemetryCategory;
 import org.terasology.telemetry.TelemetryField;
 
@@ -28,10 +31,12 @@ import java.util.Map;
  */
 @TelemetryCategory(id = "systemContext",
         displayName = "${engine:menu#telemetry-system-context}"
-        )
+)
 public class SystemContextMetric extends Metric {
 
     public static final String SCHEMA_OS = "iglu:org.terasology/systemContext/jsonschema/1-0-0";
+    private boolean isHeadless;
+    private Context context;
 
     @TelemetryField
     private String osName;
@@ -79,15 +84,20 @@ public class SystemContextMetric extends Metric {
         javaVersion = System.getProperty("java.version");
         jvmName = System.getProperty("java.vm.name");
         jvmVersion = System.getProperty("java.vm.version");
-        openGLVendor = GL11.glGetString(GL11.GL_VENDOR);
-        openGLVersion = GL11.glGetString(GL11.GL_VERSION);
-        openGLRenderer = GL11.glGetString(GL11.GL_RENDERER);
+        context = CoreRegistry.get(Context.class);
+        DisplayDevice display = context.get(DisplayDevice.class);
+        isHeadless = display.isHeadless();
+        if (!isHeadless) {
+            openGLVendor = GL11.glGetString(GL11.GL_VENDOR);
+            openGLVersion = GL11.glGetString(GL11.GL_VERSION);
+            openGLRenderer = GL11.glGetString(GL11.GL_RENDERER);
+        }
         processorNumbers = Runtime.getRuntime().availableProcessors();
         memoryMaxByte = Runtime.getRuntime().maxMemory();
     }
 
     @Override
-    public  Unstructured getUnstructuredMetric() {
+    public Unstructured getUnstructuredMetric() {
 
         Map<String, Object> metricMap = getFieldValueMap();
 

--- a/engine/src/main/java/org/terasology/telemetry/metrics/SystemContextMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/SystemContextMetric.java
@@ -35,7 +35,6 @@ import java.util.Map;
 public class SystemContextMetric extends Metric {
 
     public static final String SCHEMA_OS = "iglu:org.terasology/systemContext/jsonschema/1-0-0";
-    private boolean isHeadless;
     private Context context;
 
     @TelemetryField
@@ -86,8 +85,7 @@ public class SystemContextMetric extends Metric {
         jvmVersion = System.getProperty("java.vm.version");
         context = CoreRegistry.get(Context.class);
         DisplayDevice display = context.get(DisplayDevice.class);
-        isHeadless = display.isHeadless();
-        if (!isHeadless) {
+        if (!display.isHeadless()) {
             openGLVendor = GL11.glGetString(GL11.GL_VENDOR);
             openGLVersion = GL11.glGetString(GL11.GL_VERSION);
             openGLRenderer = GL11.glGetString(GL11.GL_RENDERER);


### PR DESCRIPTION
Quick Fix for #3021 

Fetches the context from `CoreRegistry.get()` (since `@In` wasn't working, maybe because it is not a registered system). Finds the `DisplayDevice` from the context and uses the built in method `isHeadless` to check if it is headless.