### PR TITLE
Dead players alive-d on join

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -175,6 +175,9 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
             characterComp.controller = entity;
             character.saveComponent(characterComp);
             character.setOwner(entity);
+            if (!character.hasComponent(AliveCharacterComponent.class)) {
+                character.addComponent(new AliveCharacterComponent());
+            }
             Location.attachChild(character, entity, new Vector3f(), new Quat4f(0, 0, 0, 1));
         } else {
             character.destroy();


### PR DESCRIPTION
If the last save happens when a player is dead (on the death screen) then the player entity is saved in the player store without the AliveCharacterComponent.

When a client rejoins, the player is spawned but without the AliveCharacterComponent. This PR ensures that all players that join a game have a AliveCharacterComponent.