### PR TITLE
[v2.0.0] Convert alwaysRelevant to use entity scope instead

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityManagerTest.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
+import static org.terasology.entitySystem.entity.internal.EntityScope.CHUNK;
 
 /**
  */
@@ -99,7 +99,9 @@ public class PojoEntityManagerTest {
     public void testCreateEntity() {
         EntityRef entity = entityManager.create();
         assertNotNull(entity);
-        assertEquals(entity.getScope(), GLOBAL);
+        assertEquals(CHUNK, entity.getScope());
+        assertTrue(entityManager.getGlobalPool().contains(entity.getId()));
+        assertFalse(entityManager.getSectorManager().contains(entity.getId()));
     }
 
     @Test
@@ -109,6 +111,9 @@ public class PojoEntityManagerTest {
         assertNotNull(entity);
         assertNotNull(entity.getComponent(StringComponent.class));
         assertEquals(comp, entity.getComponent(StringComponent.class));
+        assertEquals(CHUNK, entity.getScope());
+        assertTrue(entityManager.getGlobalPool().contains(entity.getId()));
+        assertFalse(entityManager.getSectorManager().contains(entity.getId()));
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityPoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEntityPoolTest.java
@@ -76,13 +76,15 @@ public class PojoEntityPoolTest {
     public void testContains() {
         assertFalse(pool.contains(PojoEntityManager.NULL_ID));
         assertFalse(pool.contains(1000000));
-        EntityRef ref = pool.create();
+        EntityRef ref = entityManager.create();
+        entityManager.moveToPool(ref.getId(), pool);
         assertTrue(pool.contains(ref.getId()));
     }
 
     @Test
     public void testRemove() {
-        EntityRef ref = pool.create();
+        EntityRef ref = entityManager.create();
+        entityManager.moveToPool(ref.getId(), pool);
         assertTrue(pool.contains(ref.getId()));
 
         pool.remove(ref.getId());

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -34,9 +34,7 @@ public interface EntityManager extends EntityPool {
      *                 @see SectorSimulationComponent#maxDelta
      * @return the newly created EntityRef
      */
-    default EntityRef createSectorEntity(long maxDelta) {
-        return null;
-    }
+    EntityRef createSectorEntity(long maxDelta);
 
     /**
      * @return A new entity with a copy of each of the other entity's components

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -85,7 +85,9 @@ public abstract class EntityRef implements MutableComponentContainer {
      * not relevant
      *
      * @param alwaysRelevant
+     * @deprecated replaced by {{@link #setScope(EntityScope)}}
      */
+    @Deprecated
     public abstract void setAlwaysRelevant(boolean alwaysRelevant);
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -106,7 +106,7 @@ public abstract class EntityRef implements MutableComponentContainer {
      *
      * @param maxDelta the maxDelta for the sector-scope entity
      */
-    public void setSectorScope(float maxDelta) {
+    public void setSectorScope(long maxDelta) {
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -106,7 +106,7 @@ public abstract class EntityRef implements MutableComponentContainer {
      *
      * @param maxDelta the maxDelta for the sector-scope entity
      */
-    public void setSectorScope(long maxDelta) {
+    public void setSectorScope(float maxDelta) {
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -123,7 +123,7 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public void setSectorScope(float maxDelta) {
+    public void setSectorScope(long maxDelta) {
         setScope(SECTOR);
         SectorSimulationComponent simulationComponent = getComponent(SectorSimulationComponent.class);
         simulationComponent.maxDelta = maxDelta;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -123,9 +123,12 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public void setSectorScope(long maxDelta) {
+    public void setSectorScope(float maxDelta) {
         setScope(SECTOR);
-        getComponent(SectorSimulationComponent.class).maxDelta = maxDelta;
+        SectorSimulationComponent simulationComponent = getComponent(SectorSimulationComponent.class);
+        simulationComponent.maxDelta = maxDelta;
+        saveComponent(simulationComponent);
+
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -31,6 +31,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
 
+import static org.terasology.entitySystem.entity.internal.EntityScope.CHUNK;
+import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
 import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
 
 /**
@@ -51,16 +53,14 @@ public abstract class BaseEntityRef extends EntityRef {
 
     @Override
     public boolean isAlwaysRelevant() {
-        return isActive() && getEntityInfo().alwaysRelevant;
+        return isActive() && getScope().getAlwaysRelevant();
     }
 
     @Override
     public void setAlwaysRelevant(boolean alwaysRelevant) {
         if (exists()) {
-            EntityInfoComponent info = getEntityInfo();
-            if (info.alwaysRelevant != alwaysRelevant) {
-                info.alwaysRelevant = alwaysRelevant;
-                saveComponent(info);
+            if (alwaysRelevant != isAlwaysRelevant()) {
+                setScope(alwaysRelevant ? GLOBAL : CHUNK);
             }
         }
     }
@@ -101,6 +101,7 @@ public abstract class BaseEntityRef extends EntityRef {
                 EngineEntityPool newPool;
                 switch (scope) {
                     case GLOBAL:
+                    case CHUNK:
                         newPool = entityManager.getGlobalPool();
                         removeComponent(SectorSimulationComponent.class);
                         break;

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EngineEntityManager.java
@@ -125,4 +125,46 @@ public interface EngineEntityManager extends LowLevelEntityManager, EngineEntity
      */
     Optional<EngineEntityPool> getPool(long id);
 
+    /**
+     * Creates a new entity.
+     *
+     * This method is designed for internal use by the EntityBuilder; the {@link #create} methods should be used in
+     * most circumstances.
+     *
+     * @return the id of the newly created entity
+     */
+    long createEntity();
+
+    /**
+     * Attempts to register a new id with the entity manager.
+     *
+     * This method is designed for internal use by the EntityBuilder.
+     *
+     * @param id the id to register
+     * @return whether the registration was successful
+     */
+    boolean registerId(long id);
+
+    /**
+     * Notifies the appropriate subscribers that an entity's component was changed.
+     *
+     * This method is designed for internal use by the EntityBuilder.
+     *
+     * @param changedEntity the entity which the changed component belongs to
+     * @param component the class of the changed component
+     */
+    void notifyComponentAdded(EntityRef changedEntity, Class<? extends Component> component);
+
+    /**
+     *
+     * Tell the EntityManager which pool the given entity is in, so that its components can be found.
+     *
+     * This is designed for internal use; {@link #moveToPool(long, EngineEntityPool)} should be used to move entities
+     * between pools.
+     *
+     * @param entityId the id of the entity to assign
+     * @param pool the pool the entity is in
+     */
+    void assignToPool(long entityId, EngineEntityPool pool);
+
 }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityInfoComponent.java
@@ -22,8 +22,6 @@ import org.terasology.network.Replicate;
 
 import javax.annotation.Nullable;
 
-import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
-
 /**
  * Component for storing entity system information on an entity
  *
@@ -40,7 +38,7 @@ public class EntityInfoComponent implements Component {
     @Replicate
     public EntityRef owner = EntityRef.NULL;
     public boolean alwaysRelevant;
-    public EntityScope scope = GLOBAL;
+    public EntityScope scope = EntityScope.getDefaultScope();
 
     public EntityInfoComponent() {
     }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityScope.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/EntityScope.java
@@ -19,6 +19,21 @@ import org.terasology.module.sandbox.API;
 
 @API
 public enum EntityScope {
-    GLOBAL,
-    SECTOR
+    GLOBAL(true),
+    SECTOR(true),
+    CHUNK(false);
+
+    private boolean alwaysRelevant;
+
+    EntityScope(boolean alwaysRelevant) {
+        this.alwaysRelevant = alwaysRelevant;
+    }
+
+    public boolean getAlwaysRelevant() {
+        return alwaysRelevant;
+    }
+
+    public static EntityScope getDefaultScope() {
+        return CHUNK;
+    }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
@@ -16,7 +16,10 @@
 package org.terasology.entitySystem.sectors;
 
 import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.module.sandbox.API;
+
+import java.util.Set;
 
 /**
  * This event will be sent by the {@link SectorSimulationSystem} to allow sector-scope entities to have an effect on the world,
@@ -31,7 +34,26 @@ import org.terasology.module.sandbox.API;
  */
 @API
 public class LoadedSectorUpdateEvent implements Event {
-    public LoadedSectorUpdateEvent() {
 
+    /**
+     * The set of positions of chunks which the sector is watching, and which are ready to be used.
+     */
+    private Set<Vector3i> readyChunks;
+
+    /**
+     * Create a new event with the given {@link #readyChunks}.
+     *
+     * @param readyChunks the readyChunks for the event.
+     *                    @see #readyChunks
+     */
+    public LoadedSectorUpdateEvent(Set<Vector3i> readyChunks) {
+        this.readyChunks = readyChunks;
+    }
+
+    /**
+     * @see #readyChunks
+     */
+    public Set<Vector3i> getReadyChunks() {
+        return readyChunks;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorRegionComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorRegionComponent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.module.sandbox.API;
+import org.terasology.world.chunks.Chunk;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * When this component is added to a sector-scope entity, the {@link SectorSimulationComponent} will count any chunks
+ * listed in {@link #chunks} as watched chunks.
+ *
+ * {@link SectorUtil} contains helper methods for creating this component, and for modifying it using {@link Chunk},
+ * rather than positions, if desired.
+ */
+@API
+public class SectorRegionComponent implements Component {
+
+    /**
+     * The set of positions of chunks for this entity to watch.
+     */
+    public Set<Vector3i> chunks = new HashSet<>();
+
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
@@ -30,15 +30,17 @@ import org.terasology.module.sandbox.API;
 @API
 public class SectorSimulationComponent implements Component {
 
-    public static final float MAX_DELTA_DEFAULT = 10;
+    public static final long MAX_DELTA_DEFAULT = 10;
 
     /**
-     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent. This value does not change
-     * the fact that a simulation event is always sent when the chunk the entity is in is loaded.
+     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent, in ms. This value does not
+     * change the fact that a simulation event is always sent when the chunk the entity is in is loaded.
      *
-     * TODO: this should only affect the timing of events sent when the chunk is not loaded; a different value should
-     * TODO: be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
-     * TODO: non-simulating value) if all of the simulation can be postponed until chunk load.
+     *
+     * TODO: add a way of simulating at a different maxDelta when the entity is loaded
+     * This should only affect the timing of events sent when the chunk is not loaded; a different value should
+     * be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
+     * non-simulating value) if all of the simulation can be postponed until chunk load.
      *
      * This should be set as high as possible, so that fewer simulation events need to be sent in total. The purpose of
      * this value is to allow checking for whether its borders need to be expanded regularly, so that the appropriate
@@ -47,15 +49,15 @@ public class SectorSimulationComponent implements Component {
      * E.g. if a city expands while the player is away, it needs to tell the system to load buildings at the edge of
      * the city region without the centre of the city needing to be loaded (to force a simulation).
      */
-    public float maxDelta;
+    public long maxDelta;
 
     /**
-     * The last time a {@link SectorSimulationEvent} was sent to this entity.
+     * The last time (game time, in ms) a {@link SectorSimulationEvent} was sent to this entity.
      *
      * This is used to calculate the delta between simulation events, and should not be changed outside of this class
      * or the {@link SectorSimulationSystem}.
      */
-    protected float lastSimulationTime;
+    protected long lastSimulationTime;
 
     /**
      * Create a new {@link SectorSimulationComponent} with the default max delta.
@@ -67,7 +69,7 @@ public class SectorSimulationComponent implements Component {
     /**
      * @see SectorSimulationComponent#maxDelta
      */
-    public SectorSimulationComponent(float maxDelta) {
+    public SectorSimulationComponent(long maxDelta) {
         this.maxDelta = maxDelta;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationEvent.java
@@ -27,17 +27,17 @@ import org.terasology.module.sandbox.API;
  */
 @API
 public class SectorSimulationEvent implements Event {
-    private float delta;
+    private long delta;
 
     /**
      * @see SectorSimulationEvent#getDelta() for the delta parameter
      */
-    protected SectorSimulationEvent(float delta) {
+    protected SectorSimulationEvent(long delta) {
         this.delta = delta;
     }
 
     /**
-     * This gives the time elapsed, in seconds, since the last time this event was sent to the given {@link EntityRef}.
+     * This gives the time elapsed, in ms, since the last time this event was sent to the given {@link EntityRef}.
      *
      * Performing simulation based on the the number of times this event is sent is not reliable, because there may be
      * big variations in the time between sending these events (notably, an event will be sent whenever the chunk an
@@ -45,9 +45,9 @@ public class SectorSimulationEvent implements Event {
      *
      * Using the delta will give a reliable measure of how much simulation to perform.
      *
-     * @return the time, in seconds, since the last time this event was sent to the given entity
+     * @return the time, in ms, since the last time this event was sent to the given entity
      */
-    public float getDelta() {
+    public long getDelta() {
         return delta;
     }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -30,7 +30,6 @@ import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
 import org.terasology.registry.In;
 import org.terasology.world.WorldComponent;
-import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.event.BeforeChunkUnload;
 import org.terasology.world.chunks.event.OnChunkLoaded;
@@ -63,9 +62,6 @@ public class SectorSimulationSystem extends BaseComponentSystem {
 
     @In
     private EntityManager entityManager;
-
-    @In
-    private WorldProvider worldProvider;
 
     @In
     private DelayManager delayManager;
@@ -144,14 +140,13 @@ public class SectorSimulationSystem extends BaseComponentSystem {
         if (event.getActionId().equals(SECTOR_SIMULATION_ACTION)) {
             float delta = simulationDelta(entity);
 
-            long readyChunks = SectorUtil.getWatchedChunks(entity).stream()
-                    .filter(chunkProvider::isChunkReady)
-                    .count();
+            boolean anyChunksReady = SectorUtil.getWatchedChunks(entity).stream()
+                    .anyMatch(chunkProvider::isChunkReady);
 
-            if (readyChunks == 0) {
-                entity.send(new SectorSimulationEvent(delta));
-            } else {
+            if (anyChunksReady) {
                 sendLoadedSectorUpdateEvent(entity, delta);
+            } else {
+                entity.send(new SectorSimulationEvent(delta));
             }
         }
     }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationSystem.java
@@ -108,7 +108,7 @@ public class SectorSimulationSystem extends BaseComponentSystem {
         SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
 
         unregisterSimulationComponent(entity);
-        delayManager.addPeriodicAction(entity, SECTOR_SIMULATION_ACTION, 0, (long) (simulationComponent.maxDelta * 1000));
+        delayManager.addPeriodicAction(entity, SECTOR_SIMULATION_ACTION, 0, simulationComponent.maxDelta);
     }
 
     /**
@@ -138,7 +138,7 @@ public class SectorSimulationSystem extends BaseComponentSystem {
     @ReceiveEvent(components = SectorSimulationComponent.class)
     public void processPeriodicSectorEvent(PeriodicActionTriggeredEvent event, EntityRef entity) {
         if (event.getActionId().equals(SECTOR_SIMULATION_ACTION)) {
-            float delta = simulationDelta(entity);
+            long delta = simulationDelta(entity);
 
             boolean anyChunksReady = SectorUtil.getWatchedChunks(entity).stream()
                     .anyMatch(chunkProvider::isChunkReady);
@@ -186,9 +186,9 @@ public class SectorSimulationSystem extends BaseComponentSystem {
      * Send the appropriate events to a sector-scope entity in a loaded chunk.
      *
      * @param entity the entity to send the events to
-     * @param delta the time since the last time {@link SectorSimulationEvent} was sent
+     * @param delta the time since the last time {@link SectorSimulationEvent} was sent, in ms
      */
-    private void sendLoadedSectorUpdateEvent(EntityRef entity, float delta) {
+    private void sendLoadedSectorUpdateEvent(EntityRef entity, long delta) {
         entity.send(new SectorSimulationEvent(delta));
         entity.send(new LoadedSectorUpdateEvent(SectorUtil.getWatchedChunks(entity)
                 .stream()
@@ -202,13 +202,13 @@ public class SectorSimulationSystem extends BaseComponentSystem {
      * @param entity
      * @return
      */
-    private float simulationDelta(EntityRef entity) {
+    private long simulationDelta(EntityRef entity) {
         SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
-        float currentTime = time.getGameTime();
+        long currentTime = time.getGameTimeInMs();
         if (simulationComponent.lastSimulationTime == 0) {
             simulationComponent.lastSimulationTime = currentTime;
         }
-        float delta = currentTime - simulationComponent.lastSimulationTime;
+        long delta = currentTime - simulationComponent.lastSimulationTime;
         simulationComponent.lastSimulationTime = currentTime;
         return delta;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.ChunkMath;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.module.sandbox.API;
+import org.terasology.world.chunks.Chunk;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class for the {@link SectorSimulationSystem} and related components and events.
+ */
+@API
+public final class SectorUtil {
+
+    private SectorUtil() {
+    }
+
+    /**
+     * Create a new {@link SectorRegionComponent} with the given chunks, from a collection of chunk positions.
+     *
+     * @param chunks the positions of the chunks to add
+     * @return the newly created SectorRegionComponent
+     */
+    public static SectorRegionComponent createSectorRegionComponent(Collection<Vector3i> chunks) {
+        SectorRegionComponent regionComponent = new SectorRegionComponent();
+        regionComponent.chunks.addAll(chunks);
+        return regionComponent;
+    }
+
+    /**
+     * Add the given collection of chunks to the given component, converting the chunks to their positions.
+     *
+     * @param regionComponent the component to add the chunks to
+     * @param chunks the chunks to add
+     */
+    public static void addChunksToRegionComponent(SectorRegionComponent regionComponent, Collection<Chunk> chunks) {
+        regionComponent.chunks.addAll(chunks.stream()
+                .map(Chunk::getPosition)
+                .collect(Collectors.toSet()));
+    }
+
+    /**
+     * Add the given collection of chunk positions to the {@link SectorRegionComponent} of the entity, creating it if
+     * needed.
+     *
+     * @param entity the entity to which the chunks will be added
+     * @param chunks the positions of the chunks to add
+     */
+    public static void addChunksToRegionComponent(EntityRef entity, Collection<Vector3i> chunks) {
+        SectorRegionComponent regionComponent = entity.getComponent(SectorRegionComponent.class);
+        if (regionComponent == null) {
+            regionComponent = new SectorRegionComponent();
+        }
+        regionComponent.chunks.addAll(chunks);
+        entity.addOrSaveComponent(regionComponent);
+    }
+
+    /**
+     * Watched chunks are defined as the union of:
+     * <ul>
+     *     <li>The chunk in which the {@link LocationComponent#getWorldPosition()} resides, if any</li>
+     *     <li>The set of chunks in {@link SectorRegionComponent#chunks}, if any</li>
+     * </ul>
+     *
+     * @param entity the entity to query the watched chunks of
+     * @return the set of positions of this entity's watched chunks
+     */
+    public static Set<Vector3i> getWatchedChunks(EntityRef entity) {
+        Set<Vector3i> chunks = new HashSet<>();
+        LocationComponent loc = entity.getComponent(LocationComponent.class);
+        if (loc != null) {
+            chunks.add(ChunkMath.calcChunkPos(loc.getWorldPosition()));
+        }
+        SectorRegionComponent regionComponent = entity.getComponent(SectorRegionComponent.class);
+        if (regionComponent != null) {
+            chunks.addAll(regionComponent.chunks);
+        }
+        return chunks;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -273,4 +273,21 @@ public final class ChunkMath {
             target[dimX - 1 + dimX * (dimY - 1)] = Math.min(source[dimX - 2 + dimX * (dimY - 1)], source[dimX - 1 + dimX * (dimY - 2)]);
         }
     }
+
+    /**
+     * Works out whether the given block resides inside the given chunk.
+     *
+     * Both positions must be given as world position, not local position. In addition, the chunk position must be
+     * given in chunk coordinates, not in block coordinates.
+     *
+     * For example, using chunks of width 32, a block with x coordinate of 33 will be counted as inside a chunk with x
+     * coordinate of 1.
+     *
+     * @param blockWorldPos the block to check for
+     * @param chunkWorldPos the chunk to check in
+     * @return whether the block is inside the chunk
+     */
+    public static boolean blockInChunk(Vector3i blockWorldPos, Vector3i chunkWorldPos) {
+        return calcChunkPos(blockWorldPos).equals(chunkWorldPos);
+    }
 }

--- a/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/EntitySerializer.java
@@ -33,6 +33,7 @@ import org.terasology.protobuf.EntityData;
 import java.util.Map;
 import java.util.Set;
 
+import static org.terasology.protobuf.EntityData.Entity.Scope.CHUNK;
 import static org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
 import static org.terasology.protobuf.EntityData.Entity.Scope.SECTOR;
 
@@ -231,6 +232,9 @@ public class EntitySerializer {
             case SECTOR:
                 entityInfo.scope = EntityScope.SECTOR;
                 break;
+            case CHUNK:
+                entityInfo.scope = EntityScope.CHUNK;
+                break;
         }
 
         for (EntityData.Component componentData : entityData.getComponentList()) {
@@ -268,6 +272,10 @@ public class EntitySerializer {
                 case SECTOR:
                     entity.setScope(SECTOR);
                     break;
+                case CHUNK:
+                    entity.setScope(CHUNK);
+                    break;
+
             }
         }
 
@@ -305,6 +313,9 @@ public class EntitySerializer {
                     break;
                 case SECTOR:
                     entity.setScope(SECTOR);
+                    break;
+                case CHUNK:
+                    entity.setScope(CHUNK);
                     break;
             }
         }

--- a/engine/src/main/java/org/terasology/protobuf/EntityData.java
+++ b/engine/src/main/java/org/terasology/protobuf/EntityData.java
@@ -4435,6 +4435,10 @@ public final class EntityData {
        * <code>SECTOR = 1;</code>
        */
       SECTOR(1, 1),
+      /**
+       * <code>CHUNK = 2;</code>
+       */
+      CHUNK(2, 2),
       ;
 
       /**
@@ -4445,6 +4449,10 @@ public final class EntityData {
        * <code>SECTOR = 1;</code>
        */
       public static final int SECTOR_VALUE = 1;
+      /**
+       * <code>CHUNK = 2;</code>
+       */
+      public static final int CHUNK_VALUE = 2;
 
 
       public final int getNumber() { return value; }
@@ -4453,6 +4461,7 @@ public final class EntityData {
         switch (value) {
           case 0: return GLOBAL;
           case 1: return SECTOR;
+          case 2: return CHUNK;
           default: return null;
         }
       }
@@ -16754,52 +16763,52 @@ public final class EntityData {
       "\004name\030\001 \001(\t\022\025\n\005value\030\002 \001(\0132\006.Value\022\022\n\nna" +
       "me_index\030\003 \001(\005\"S\n\tComponent\022\022\n\ntype_inde" +
       "x\030\001 \001(\005\022\014\n\004type\030\017 \001(\t\022\031\n\005field\030\002 \003(\0132\n.N" +
-      "ameValue*\t\010\210\'\020\200\200\200\200\002\"\373\001\n\006Entity\022\n\n\002id\030\001 \001",
+      "ameValue*\t\010\210\'\020\200\200\200\200\002\"\206\002\n\006Entity\022\n\n\002id\030\001 \001",
       "(\003\022\035\n\tcomponent\030\002 \003(\0132\n.Component\022#\n\027rem" +
       "oved_component_index\030\003 \003(\005B\002\020\001\022\025\n\rparent" +
       "_prefab\030\004 \001(\t\022\026\n\016alwaysRelevant\030\005 \001(\010\022\r\n" +
       "\005owner\030\006 \001(\003\022\031\n\021removed_component\030\017 \003(\t\022" +
-      "\034\n\005scope\030\007 \001(\0162\r.Entity.Scope\"\037\n\005Scope\022\n" +
-      "\n\006GLOBAL\020\000\022\n\n\006SECTOR\020\001*\t\010\210\'\020\200\200\200\200\002\"\320\001\n\014Pa" +
-      "ckedEntity\022\n\n\002id\030\001 \001(\003\022\027\n\013componentId\030\002 " +
-      "\003(\005B\002\020\001\022\034\n\024componentFieldCounts\030\003 \001(\014\022\020\n" +
-      "\010fieldIds\030\004 \001(\014\022\032\n\nfieldValue\030\005 \003(\0132\006.Va" +
-      "lue\022\034\n\020removedComponent\030\006 \003(\005B\002\020\001\022\r\n\005own",
-      "er\030\007 \001(\003\022\027\n\017parentPrefabUri\030\020 \001(\t*\t\010\210\'\020\200" +
-      "\200\200\200\002\"\314\001\n\006Prefab\022\022\n\nname_index\030\001 \001(\005\022\035\n\tc" +
-      "omponent\030\002 \003(\0132\n.Component\022\026\n\ndeprecated" +
-      "\030\003 \003(\005B\002\020\001\022\027\n\tpersisted\030\004 \001(\010:\004true\022\030\n\020r" +
-      "emovedComponent\030\005 \003(\t\022\026\n\016alwaysRelevant\030" +
-      "\006 \001(\010\022\014\n\004name\030\017 \001(\t\022\023\n\013parent_name\030\020 \001(\t" +
-      "*\t\010\210\'\020\200\200\200\200\002\"N\n\005Event\022\014\n\004type\030\001 \001(\005\022\020\n\010fi" +
-      "eldIds\030\002 \001(\014\022\032\n\nfieldValue\030\003 \003(\0132\006.Value" +
-      "*\t\010\210\'\020\200\200\200\200\002\"w\n\013EntityStore\022\027\n\006entity\030\001 \003" +
-      "(\0132\007.Entity\022\027\n\017component_class\030\003 \003(\t\022\022\n\n",
-      "entityName\030\002 \003(\t\022\027\n\013entityNamed\030\004 \003(\003B\002\020" +
-      "\001*\t\010\210\'\020\200\200\200\200\002\"\220\001\n\013PlayerStore\022\033\n\005store\030\001 " +
-      "\001(\0132\014.EntityStore\022\025\n\rcharacterPosX\030\017 \001(\002" +
-      "\022\025\n\rcharacterPosY\030\020 \001(\002\022\025\n\rcharacterPosZ" +
-      "\030\021 \001(\002\022\024\n\014hasCharacter\030\022 \001(\010*\t\010\210\'\020\200\200\200\200\002\"" +
-      "\332\002\n\nChunkStore\022\033\n\005store\030\001 \001(\0132\014.EntitySt" +
-      "ore\022\t\n\001x\030\002 \001(\021\022\t\n\001y\030\003 \001(\021\022\t\n\001z\030\004 \001(\021\022\031\n\021" +
-      "deprecated_data_3\030\005 \001(\005\022\031\n\021deprecated_da" +
-      "ta_4\030\006 \001(\014\022\031\n\021deprecated_data_1\030\007 \001(\014\022\031\n" +
-      "\021deprecated_data_2\030\010 \001(\014\022\031\n\021deprecated_d",
-      "ata_5\030\t \001(\014\022(\n\nblock_data\030\n \001(\0132\024.RunLen" +
-      "gthEncoding16\022(\n\013liquid_data\030\013 \001(\0132\023.Run" +
-      "LengthEncoding8\022(\n\nbiome_data\030\014 \001(\0132\024.Ru" +
-      "nLengthEncoding16*\t\010\210\'\020\200\200\200\200\002\"L\n\023RunLengt" +
-      "hEncoding16\022\026\n\nrunLengths\030\001 \003(\021B\002\020\001\022\022\n\006v" +
-      "alues\030\002 \003(\021B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"G\n\022RunLengthE" +
-      "ncoding8\022\026\n\nrunLengths\030\001 \003(\021B\002\020\001\022\016\n\006valu" +
-      "es\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"\260\001\n\013GlobalStore\022\027\n\006e" +
-      "ntity\030\001 \003(\0132\007.Entity\022\027\n\006prefab\030\002 \003(\0132\007.P" +
-      "refab\022\027\n\017component_class\030\003 \003(\t\022\026\n\016next_e",
-      "ntity_id\030\020 \001(\003\022\036\n\022deprecated_data_17\030\021 \003" +
-      "(\003B\002\020\001\022\023\n\013prefab_name\030\022 \003(\t*\t\010\210\'\020\200\200\200\200\002*4" +
-      "\n\tStoreType\022\023\n\017PlayerStoreType\020\001\022\022\n\016Chun" +
-      "kStoreType\020\002B\'\n\027org.terasology.protobufB" +
-      "\nEntityDataH\001"
+      "\034\n\005scope\030\007 \001(\0162\r.Entity.Scope\"*\n\005Scope\022\n" +
+      "\n\006GLOBAL\020\000\022\n\n\006SECTOR\020\001\022\t\n\005CHUNK\020\002*\t\010\210\'\020\200" +
+      "\200\200\200\002\"\320\001\n\014PackedEntity\022\n\n\002id\030\001 \001(\003\022\027\n\013com" +
+      "ponentId\030\002 \003(\005B\002\020\001\022\034\n\024componentFieldCoun" +
+      "ts\030\003 \001(\014\022\020\n\010fieldIds\030\004 \001(\014\022\032\n\nfieldValue" +
+      "\030\005 \003(\0132\006.Value\022\034\n\020removedComponent\030\006 \003(\005",
+      "B\002\020\001\022\r\n\005owner\030\007 \001(\003\022\027\n\017parentPrefabUri\030\020" +
+      " \001(\t*\t\010\210\'\020\200\200\200\200\002\"\314\001\n\006Prefab\022\022\n\nname_index" +
+      "\030\001 \001(\005\022\035\n\tcomponent\030\002 \003(\0132\n.Component\022\026\n" +
+      "\ndeprecated\030\003 \003(\005B\002\020\001\022\027\n\tpersisted\030\004 \001(\010" +
+      ":\004true\022\030\n\020removedComponent\030\005 \003(\t\022\026\n\016alwa" +
+      "ysRelevant\030\006 \001(\010\022\014\n\004name\030\017 \001(\t\022\023\n\013parent" +
+      "_name\030\020 \001(\t*\t\010\210\'\020\200\200\200\200\002\"N\n\005Event\022\014\n\004type\030" +
+      "\001 \001(\005\022\020\n\010fieldIds\030\002 \001(\014\022\032\n\nfieldValue\030\003 " +
+      "\003(\0132\006.Value*\t\010\210\'\020\200\200\200\200\002\"w\n\013EntityStore\022\027\n" +
+      "\006entity\030\001 \003(\0132\007.Entity\022\027\n\017component_clas",
+      "s\030\003 \003(\t\022\022\n\nentityName\030\002 \003(\t\022\027\n\013entityNam" +
+      "ed\030\004 \003(\003B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"\220\001\n\013PlayerStore\022" +
+      "\033\n\005store\030\001 \001(\0132\014.EntityStore\022\025\n\rcharacte" +
+      "rPosX\030\017 \001(\002\022\025\n\rcharacterPosY\030\020 \001(\002\022\025\n\rch" +
+      "aracterPosZ\030\021 \001(\002\022\024\n\014hasCharacter\030\022 \001(\010*" +
+      "\t\010\210\'\020\200\200\200\200\002\"\332\002\n\nChunkStore\022\033\n\005store\030\001 \001(\013" +
+      "2\014.EntityStore\022\t\n\001x\030\002 \001(\021\022\t\n\001y\030\003 \001(\021\022\t\n\001" +
+      "z\030\004 \001(\021\022\031\n\021deprecated_data_3\030\005 \001(\005\022\031\n\021de" +
+      "precated_data_4\030\006 \001(\014\022\031\n\021deprecated_data" +
+      "_1\030\007 \001(\014\022\031\n\021deprecated_data_2\030\010 \001(\014\022\031\n\021d",
+      "eprecated_data_5\030\t \001(\014\022(\n\nblock_data\030\n \001" +
+      "(\0132\024.RunLengthEncoding16\022(\n\013liquid_data\030" +
+      "\013 \001(\0132\023.RunLengthEncoding8\022(\n\nbiome_data" +
+      "\030\014 \001(\0132\024.RunLengthEncoding16*\t\010\210\'\020\200\200\200\200\002\"" +
+      "L\n\023RunLengthEncoding16\022\026\n\nrunLengths\030\001 \003" +
+      "(\021B\002\020\001\022\022\n\006values\030\002 \003(\021B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"G\n" +
+      "\022RunLengthEncoding8\022\026\n\nrunLengths\030\001 \003(\021B" +
+      "\002\020\001\022\016\n\006values\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"\260\001\n\013Globa" +
+      "lStore\022\027\n\006entity\030\001 \003(\0132\007.Entity\022\027\n\006prefa" +
+      "b\030\002 \003(\0132\007.Prefab\022\027\n\017component_class\030\003 \003(",
+      "\t\022\026\n\016next_entity_id\030\020 \001(\003\022\036\n\022deprecated_" +
+      "data_17\030\021 \003(\003B\002\020\001\022\023\n\013prefab_name\030\022 \003(\t*\t" +
+      "\010\210\'\020\200\200\200\200\002*4\n\tStoreType\022\023\n\017PlayerStoreTyp" +
+      "e\020\001\022\022\n\016ChunkStoreType\020\002B\'\n\027org.terasolog" +
+      "y.protobufB\nEntityDataH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/engine/src/main/protobuf/EntityData.proto
+++ b/engine/src/main/protobuf/EntityData.proto
@@ -45,11 +45,12 @@ message Entity {
     optional bool alwaysRelevant = 5;
     optional int64 owner = 6;
     repeated string removed_component = 15;
+
     enum Scope {
         GLOBAL = 0;
         SECTOR = 1;
+        CHUNK = 2;
     }
-
     optional Scope scope = 7;
 
     extensions 5000 to max;


### PR DESCRIPTION
### Contains

This removes the `alwaysRelevant` entity field, and makes the relevant methods look at the `alwaysRelevant` field on the entity's scope instead.

`GLOBAL` and `SECTOR` scope are `alwaysRelevant`, but `CHUNK` scope is not. The default scope is `CHUNK`, so the default for `alwaysRelevant` is still `false.`.

This also updates some entity-related tests, and fixes some problems found by them (now all of the entity creation code goes through the `EntityBuilder` (previously almost all of it did, but methods like `createEntityWithId()` didn't), so that the scope can be set properly without putting it in multiple places).


### How to test

Load the [TutorialSectors](https://github.com/Terasology/TutorialSectors/tree/remove-alwaysrelevant) module on the `remove-alwaysrelevant` branch, and observe that the entity doesn't need to be set to `alwaysRelevant`, because it has already been marked as sector-scope (it will still simulate when you have unloaded all of its chunks).


### Outstanding before merging

Note: this depends on #3022

Some internal methods on the `PojoEntityManager` had to be exposed for use by the `EntityBuilder`, so it might be worth having a look at how the classes are structured (e.g. extracting the `EntityBuilder` to be an interface, and having a `PojoEntityBuilder` to make the Pojo-specific entities. Or putting the `EntityBuilder`'s `bulid()` method back into the `EntityManager`, now that it handles all of the different scenarios (scope, id, etc.) in one method.).

(Also, while on the topic of the `EntityBuilder`, it's probably worth looking at whether the `EntityBuilder` and `EntityStore` can be combined. They both do the same thing, they just differ in that the `EntityBuilder` requires an `EntityManager` when it is created, but the `EntityStore` involves the `EntityManager` when the entities are being built.)

There's also a possible issue that the `OnAddedComponent` is still sent when the entity is re-created from storage. With the previous implementation, this wasn't sent when re-created with the `createEntityWithId()` method, but if `ignoringEntityId` is true in the `EntitySerializer`, it would still send that event (but I don't know if that is ever actually used).