### PR TITLE
[v2.0.0] Allow sector entities to simulate at a different rate when loaded

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityManager.java
@@ -30,11 +30,23 @@ public interface EntityManager extends EntityPool {
     /**
      * Creates a new EntityRef in sector-scope
      *
-     * @param maxDelta the maximum delta for the sector entity's simulations
-     *                 @see SectorSimulationComponent#maxDelta
+     * @param maxDelta the maximum delta for the sector entity's simulations (both unloaded and loaded)
+     *                 @see SectorSimulationComponent#unloadedMaxDelta
+     *                 @see SectorSimulationComponent#loadedMaxDelta
      * @return the newly created EntityRef
      */
     EntityRef createSectorEntity(long maxDelta);
+
+    /**
+     * Creates a new EntityRef in sector-scope
+     *
+     * @param unloadedMaxDelta the maximum delta for the simulations when the entity's watched chunks aren't loaded
+     *                         @see SectorSimulationComponent#unloadedMaxDelta
+     * @param loadedMaxDelta the maximum delta when at least one of the entity's watched chunks is loaded
+     *                       @see SectorSimulationComponent#loadedMaxDelta
+     * @return the newly created EntityRef
+     */
+    EntityRef createSectorEntity(long unloadedMaxDelta, long loadedMaxDelta);
 
     /**
      * @return A new entity with a copy of each of the other entity's components

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityRef.java
@@ -104,11 +104,22 @@ public abstract class EntityRef implements MutableComponentContainer {
     }
 
     /**
-     * Sets the scope of this entity to sector-scope, and sets the {@link SectorSimulationComponent#maxDelta}.
+     * Sets the scope of this entity to sector-scope, and sets the {@link SectorSimulationComponent#unloadedMaxDelta}
+     * and {@link SectorSimulationComponent#loadedMaxDelta} to the same given value.
      *
-     * @param maxDelta the maxDelta for the sector-scope entity
+     * @param maxDelta the maximum delta for the sector-scope entity (loaded and unloaded)
      */
     public void setSectorScope(long maxDelta) {
+    }
+
+    /**
+     * Sets the scope of this entity to sector-scope, and sets the {@link SectorSimulationComponent#unloadedMaxDelta}
+     * and {@link SectorSimulationComponent#loadedMaxDelta} to the given values.
+     *
+     * @param unloadedMaxDelta the maximum unloaded delta for the sector-scope entity
+     * @param loadedMaxDelta the maximum loaded delta for the sector-scope entity
+     */
+    public void setSectorScope(long unloadedMaxDelta, long loadedMaxDelta) {
     }
 
     /**

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -125,11 +125,16 @@ public abstract class BaseEntityRef extends EntityRef {
 
     @Override
     public void setSectorScope(long maxDelta) {
+        setSectorScope(maxDelta, maxDelta);
+    }
+
+    @Override
+    public void setSectorScope(long unloadedMaxDelta, long loadedMaxDelta) {
         setScope(SECTOR);
         SectorSimulationComponent simulationComponent = getComponent(SectorSimulationComponent.class);
-        simulationComponent.maxDelta = maxDelta;
+        simulationComponent.unloadedMaxDelta = unloadedMaxDelta;
+        simulationComponent.loadedMaxDelta = loadedMaxDelta;
         saveComponent(simulationComponent);
-
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -127,10 +127,18 @@ public class PojoEntityManager implements EngineEntityManager {
 
     @Override
     public EntityRef createSectorEntity(long maxDelta) {
+        return createSectorEntity(maxDelta, maxDelta);
+    }
+
+    @Override
+    public EntityRef createSectorEntity(long unloadedMaxDelta, long loadedMaxDelta) {
         EntityRef entity = sectorManager.create();
         entity.setScope(SECTOR);
 
-        entity.addOrSaveComponent(new SectorSimulationComponent(maxDelta));
+        SectorSimulationComponent simulationComponent = entity.getComponent(SectorSimulationComponent.class);
+        simulationComponent.unloadedMaxDelta = unloadedMaxDelta;
+        simulationComponent.loadedMaxDelta = loadedMaxDelta;
+        entity.saveComponent(simulationComponent);
 
         return entity;
     }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/LoadedSectorUpdateEvent.java
@@ -27,10 +27,6 @@ import java.util.Set;
  *
  * This event will always be immediately preceded by a {@link SectorSimulationEvent}, so no extra simulation needs to
  * take place for this event.
- *
- * TODO: This is currently sent on the same schedule as {@link SectorSimulationEvent}, based on
- * TODO: {@link SectorSimulationComponent#maxDelta}. It should be able to have its own schedule for when the chunk is
- * TODO: loaded.
  */
 @API
 public class LoadedSectorUpdateEvent implements Event {
@@ -44,7 +40,6 @@ public class LoadedSectorUpdateEvent implements Event {
      * Create a new event with the given {@link #readyChunks}.
      *
      * @param readyChunks the readyChunks for the event.
-     *                    @see #readyChunks
      */
     public LoadedSectorUpdateEvent(Set<Vector3i> readyChunks) {
         this.readyChunks = readyChunks;

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorEntityLoad.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorEntityLoad.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * Event sent to sector-scope entities when the first of its watched chunks load.
+ */
+public class SectorEntityLoad implements Event {
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorEntityUnload.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorEntityUnload.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.entitySystem.sectors;
+
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * Event sent to sector-scope entities when all of its watched chunks unload.
+ */
+public class SectorEntityUnload implements Event {
+}

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorSimulationComponent.java
@@ -30,17 +30,13 @@ import org.terasology.module.sandbox.API;
 @API
 public class SectorSimulationComponent implements Component {
 
-    public static final long MAX_DELTA_DEFAULT = 10;
+    public static final long UNLOADED_MAX_DELTA_DEFAULT = 60_000;
+    public static final long LOADED_MAX_DELTA_DEFAULT = 10_000;
 
     /**
-     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent, in ms. This value does not
-     * change the fact that a simulation event is always sent when the chunk the entity is in is loaded.
-     *
-     *
-     * TODO: add a way of simulating at a different maxDelta when the entity is loaded
-     * This should only affect the timing of events sent when the chunk is not loaded; a different value should
-     * be used when the chunk is loaded. This will allow this value to be set as high as possible (or even to a
-     * non-simulating value) if all of the simulation can be postponed until chunk load.
+     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent, in ms, when none of the
+     * entity's watched chunks are loaded. This value does not change the fact that a simulation event is always sent
+     * when the chunk the entity is in is loaded.
      *
      * This should be set as high as possible, so that fewer simulation events need to be sent in total. The purpose of
      * this value is to allow checking for whether its borders need to be expanded regularly, so that the appropriate
@@ -49,7 +45,13 @@ public class SectorSimulationComponent implements Component {
      * E.g. if a city expands while the player is away, it needs to tell the system to load buildings at the edge of
      * the city region without the centre of the city needing to be loaded (to force a simulation).
      */
-    public long maxDelta;
+    public long unloadedMaxDelta;
+
+    /**
+     * The maximum time that can elapse between {@link SectorSimulationEvent}s being sent, in ms, when at least one of
+     * this entity's watched chunks is loaded.
+     */
+    public long loadedMaxDelta;
 
     /**
      * The last time (game time, in ms) a {@link SectorSimulationEvent} was sent to this entity.
@@ -63,13 +65,8 @@ public class SectorSimulationComponent implements Component {
      * Create a new {@link SectorSimulationComponent} with the default max delta.
      */
     public SectorSimulationComponent() {
-        new SectorSimulationComponent(MAX_DELTA_DEFAULT);
+        unloadedMaxDelta = UNLOADED_MAX_DELTA_DEFAULT;
+        loadedMaxDelta = LOADED_MAX_DELTA_DEFAULT;
     }
 
-    /**
-     * @see SectorSimulationComponent#maxDelta
-     */
-    public SectorSimulationComponent(long maxDelta) {
-        this.maxDelta = maxDelta;
-    }
 }

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
@@ -21,6 +21,7 @@ import org.terasology.math.ChunkMath;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.module.sandbox.API;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.ChunkProvider;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -97,6 +98,21 @@ public final class SectorUtil {
             chunks.addAll(regionComponent.chunks);
         }
         return chunks;
+    }
+
+    /**
+     * Calculate whether the entity is watching no loaded chunks, or only the given chunk is loaded.
+     *
+     * @param entity the sector-scope entity to query
+     * @param chunkPos the position of the chunk to check
+     * @param chunkProvider the chunkProvider, so that it can check which chunks are loaded
+     * @return whether the entity is watching no loaded chunks, or only the given chunk is loaded
+     */
+    public static boolean onlyWatchedChunk(EntityRef entity, Vector3i chunkPos, ChunkProvider chunkProvider) {
+        Set<Vector3i> readyChunks = getWatchedChunks(entity).stream()
+                .filter(chunkProvider::isChunkReady)
+                .collect(Collectors.toSet());
+        return readyChunks.isEmpty() || (readyChunks.size() == 1 && readyChunks.contains(chunkPos));
     }
 
 }


### PR DESCRIPTION
### Contains

This splits SectorEntityComponent's maxDelta field into unloadedMaxDelta and loadedMaxDelta, which specify the maximum simulation delta for when all of the entity's watched chunks are unloaded, or when at least one is loaded, respectively.

This the simulation rate to be adjusted depending on whether or not the entity is loaded, so the unloaded simulation rate can be set as low as possible to maximise performance, while the loaded simulation rate can be higher to allow the player to observe the changes more frequently.

### How to test

Load the [TutorialSectors](https://github.com/Terasology/TutorialSectors/tree/v2-branches/loaded-max-delta) module on the `v2-branches/loaded-max-delta` branch, and observe that the the entity simulates every second while the player is standing at (0, 0) (when a watched chunk is loaded), but simulates every 10 seconds when the player is at (-1000, -1000) (because none of the watched chunks are loaded).

### Outstanding before merging

Note: this depends on #3022