### PR TITLE
Item persisting on the map after saving fix

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/systems/BaseComponentSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/BaseComponentSystem.java
@@ -35,6 +35,14 @@ public abstract class BaseComponentSystem implements ComponentSystem {
     }
 
     @Override
+    public void preAutoSave() {
+    }
+
+    @Override
+    public void postAutoSave() {
+    }
+
+    @Override
     public void preSave() {
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/systems/ComponentSystem.java
+++ b/engine/src/main/java/org/terasology/entitySystem/systems/ComponentSystem.java
@@ -34,6 +34,16 @@ public interface ComponentSystem {
     void postBegin();
 
     /**
+     * Called before the game is auto-saved
+     */
+    void preAutoSave();
+
+    /**
+     * Called after the game is auto-saved
+     */
+    void postAutoSave();
+
+    /**
      * Called before the game is saved (this may be after shutdown)
      */
     void preSave();

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -38,9 +38,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkComponent;
 import org.terasology.physics.components.RigidBodyComponent;
-import org.terasology.physics.engine.RigidBody;
 import org.terasology.registry.In;
-import org.terasology.rendering.logic.MeshComponent;
 import org.terasology.rendering.world.WorldRenderer;
 
 @RegisterSystem(RegisterMode.CLIENT)

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -192,6 +192,7 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
                     heldItemTransformComponent = new FirstPersonHeldItemTransformComponent();
                     clientHeldItem.addComponent(heldItemTransformComponent);
                 }
+
                 Location.attachChild(mountPointComponent.mountPointEntity, clientHeldItem,
                         heldItemTransformComponent.translate,
                         new Quat4f(
@@ -199,6 +200,8 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
                                 TeraMath.DEG_TO_RAD * heldItemTransformComponent.rotateDegrees.x,
                                 TeraMath.DEG_TO_RAD * heldItemTransformComponent.rotateDegrees.z),
                         heldItemTransformComponent.scale);
+
+                currentHeldItem = clientHeldItem;
             }
         }
     }
@@ -254,8 +257,7 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
     }
 
     @Override
-    public void preSave()
-    {
+    public void preSave() {
         if (clientHeldItem != EntityRef.NULL){
             clientHeldItem.destroy();
         }

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -38,7 +38,9 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkComponent;
 import org.terasology.physics.components.RigidBodyComponent;
+import org.terasology.physics.engine.RigidBody;
 import org.terasology.registry.In;
+import org.terasology.rendering.logic.MeshComponent;
 import org.terasology.rendering.world.WorldRenderer;
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -251,5 +253,13 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
         locationComponent.setLocalPosition(offset);
 
         mountPointComponent.mountPointEntity.saveComponent(locationComponent);
+    }
+
+    @Override
+    public void preSave()
+    {
+        if (clientHeldItem != EntityRef.NULL){
+            clientHeldItem.destroy();
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
+++ b/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
@@ -191,6 +191,16 @@ public class SpriteParticleRenderer implements RenderSystem {
     }
 
     @Override
+    public void preAutoSave() {
+
+    }
+
+    @Override
+    public void postAutoSave() {
+
+    }
+
+    @Override
     public void preSave() {
 
     }

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -99,6 +99,14 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     }
 
     @Override
+    public void preAutoSave() {
+    }
+
+    @Override
+    public void postAutoSave() {
+    }
+
+    @Override
     public void preSave() {
     }
 


### PR DESCRIPTION
This should fix #2810 's fix

There shouldn't be a case for seeing other people's items (yet)

This fix adds `preAutoSave` and `postAutoSave` to the game so that items can be destroyed before they are saved by the system. The save method was just separated into 2 not so distinct ones.

This should prevent items from being despawned from your hand while playing as well (at least from the save PoV)

The problem was that the item held in your hand wasn't ever being destroyed, and was kept in the save as well. This created a floating mesh for the rest of eternity on the map.

The fix is that it's destroyed only during forced save and not auto.

I checked for the item remaining on the map in single player and multiplayer, and there doesn't seem to be any type of issue.