### PR TITLE
Debug node

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -26,6 +26,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
+import org.terasology.rendering.dag.nodes.DebugNode;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -184,6 +185,11 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     @Override
     public RenderingStage getCurrentRenderStage() {
         // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public DebugNode getDebugNode() {
         return null;
     }
 

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -628,8 +628,8 @@ public class CoreCommands extends BaseComponentSystem {
      * Debugging command for DAG.
      */
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)
-    public void dagDebug() {
+    public void dagDebug(@CommandParam("fboUri") final String fboUri) {
         WorldRendererImpl worldRendererImpl = (WorldRendererImpl)worldRenderer;
-        worldRendererImpl.getDebugNode().setFbo("engine:fbo.ssao");
+        worldRendererImpl.getDebugNode().setFbo(fboUri);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -623,4 +623,13 @@ public class CoreCommands extends BaseComponentSystem {
         WorldRendererImpl worldRendererImpl = (WorldRendererImpl)worldRenderer;
         worldRendererImpl.recompileShaders();
     }
+
+    /**
+     * Debugging command for DAG.
+     */
+    @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)
+    public void dagDebug() {
+        WorldRendererImpl worldRendererImpl = (WorldRendererImpl)worldRenderer;
+        worldRendererImpl.getDebugNode().setFbo("engine:fbo.ssao");
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DebugNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DebugNode.java
@@ -63,6 +63,9 @@ public class DebugNode extends AbstractNode {
             default:
                 // TODO: We should probably do some more error checking here.
                 fbo = displayResolutionDependentFBOs.get(new SimpleUri(fboUri));
+                if (fbo == null) {
+                    fbo = lastUpdatedGBuffer;
+                }
                 break;
         }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DebugNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DebugNode.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.nodes;
+
+import org.terasology.context.Context;
+import org.terasology.engine.SimpleUri;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.SwappableFBO;
+import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
+
+public class DebugNode extends AbstractNode {
+    private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
+    private FBO lastUpdatedGBuffer;
+    private FBO staleGBuffer;
+
+    private CopyFboColorAttachmentToScreenNode outputNode;
+
+    public DebugNode(Context context) {
+    	displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
+        SwappableFBO gBufferPair = displayResolutionDependentFBOs.getGBufferPair();
+
+        lastUpdatedGBuffer = gBufferPair.getLastUpdatedFbo();
+        staleGBuffer = gBufferPair.getStaleFbo();
+
+    }
+
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/debugNode");
+        PerformanceMonitor.endActivity();
+    }
+
+    public void setOutputNode(CopyFboColorAttachmentToScreenNode outputNode) {
+    	this.outputNode = outputNode;
+    }
+
+    public void setFbo(String fboUri) {
+    	FBO fbo;
+
+        switch (fboUri) {
+            case "engine:fbo.gBuffer":
+            case "engine:fbo.lastUpdatedGBuffer":
+                fbo = lastUpdatedGBuffer;
+                break;
+            case "engine:fbo.staleGBuffer":
+                fbo = staleGBuffer;
+                break;
+            default:
+                // TODO: We should probably do some more error checking here.
+                fbo = displayResolutionDependentFBOs.get(new SimpleUri(fboUri));
+                break;
+        }
+
+        outputNode.setFbo(fbo);
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -20,6 +20,8 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
+import org.terasology.rendering.dag.nodes.CopyFboColorAttachmentToScreenNode;
+import org.terasology.rendering.dag.nodes.DebugNode;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 
 /**
@@ -218,4 +220,7 @@ public interface WorldRenderer {
      */
     // TODO: transform this to return an object or a map. Consumers would then take care of formatting.
     String getMetrics();
+
+    // TODO: Remove this method
+    DebugNode getDebugNode();
 }


### PR DESCRIPTION
Adds a new Debug Node that can be used to display the Color attachments of FBOs. Also adds associated console commands that can be used to control the debug Node, like `dagDebug engine:fbo.ssao` (that will become something like `dagDebugger setFbo engine:fbo.ssao` after some polish).

Vision for the future: Ideally, we will have an abstract DebugNode class, that gets extended by ColorAttachmentDebugNode (currently the DebugNode), DepthAttachmentDebugNode and StencilAttachmentDebugNodes.

@emanuele3d Ping! :D