### PR TITLE
[telemetry] More user options

### DIFF
--- a/engine/src/main/java/org/terasology/config/MetricsUserPermissionConfig.java
+++ b/engine/src/main/java/org/terasology/config/MetricsUserPermissionConfig.java
@@ -19,8 +19,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
+ * This config is used in Telemetry.
+ * It gives the user more options such as sending one part of the fields but not the other part.
  */
 public class MetricsUserPermissionConfig {
+
+    private Map<String, Boolean> bindingMap = new HashMap<>();
 
     public Map<String, Boolean> getBindingMap() {
         return bindingMap;
@@ -29,7 +33,4 @@ public class MetricsUserPermissionConfig {
     public void setBindingMap(Map<String, Boolean> bindingMap) {
         this.bindingMap = bindingMap;
     }
-
-    private Map<String, Boolean> bindingMap = new HashMap<>();
-
 }

--- a/engine/src/main/java/org/terasology/config/MetricsUserPermissionConfig.java
+++ b/engine/src/main/java/org/terasology/config/MetricsUserPermissionConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ */
+public class MetricsUserPermissionConfig {
+
+    public Map<String, Boolean> getBindingMap() {
+        return bindingMap;
+    }
+
+    public void setBindingMap(Map<String, Boolean> bindingMap) {
+        this.bindingMap = bindingMap;
+    }
+
+    private Map<String, Boolean> bindingMap = new HashMap<>();
+
+}

--- a/engine/src/main/java/org/terasology/config/TelemetryConfig.java
+++ b/engine/src/main/java/org/terasology/config/TelemetryConfig.java
@@ -15,6 +15,13 @@
  */
 package org.terasology.config;
 
+import org.terasology.telemetry.TelemetryEmitter;
+import org.terasology.telemetry.logstash.TelemetryLogstashAppender;
+
+import static org.terasology.telemetry.TelemetryEmitter.DEFAULT_COLLECTOR_HOST;
+import static org.terasology.telemetry.TelemetryEmitter.DEFAULT_COLLECTOR_PORT;
+import static org.terasology.telemetry.TelemetryEmitter.DEFAULT_COLLECTOR_PROTOCOL;
+
 /**
  *  Configuration (authorisation) for telemetry system.
  */
@@ -22,27 +29,27 @@ public class TelemetryConfig {
 
     private boolean telemetryEnabled;
 
-    private String telemetryDestination;
+    private String telemetryDestination = TelemetryEmitter.getDefaultCollectorURL(DEFAULT_COLLECTOR_PROTOCOL, DEFAULT_COLLECTOR_HOST, DEFAULT_COLLECTOR_PORT).toString();
 
-    private String telemetryServerName;
+    private String telemetryServerName = TelemetryEmitter.DEFAULT_COLLECTOR_NAME;
 
-    private String telemetryServerOwner;
+    private String telemetryServerOwner = TelemetryEmitter.DEFAULT_COLLECTOR_OWNER;
 
     private boolean errorReportingEnabled;
 
-    private String errorReportingDestination;
+    private String errorReportingDestination = TelemetryLogstashAppender.DEFAULT_LOGSTASH_HOST + ":" + TelemetryLogstashAppender.DEFAULT_LOGSTASH_PORT;
 
-    private String errorReportingServerName;
+    private String errorReportingServerName = TelemetryLogstashAppender.DEFAULT_LOGSTASH_NAME;
 
-    private String errorReportingServerOwner;
+    private String errorReportingServerOwner = TelemetryLogstashAppender.DEFAULT_LOGSTASH_OWNER;
 
     private boolean launchPopupDisabled;
+
+    private MetricsUserPermissionConfig metricsUserPermissionConfig = new MetricsUserPermissionConfig();
 
     public boolean isTelemetryEnabled() {
         return telemetryEnabled;
     }
-
-    private MetricsUserPermissionConfig metricsUserPermissionConfig = new MetricsUserPermissionConfig();
 
     public MetricsUserPermissionConfig getMetricsUserPermissionConfig() {
         return metricsUserPermissionConfig;

--- a/engine/src/main/java/org/terasology/config/TelemetryConfig.java
+++ b/engine/src/main/java/org/terasology/config/TelemetryConfig.java
@@ -42,6 +42,16 @@ public class TelemetryConfig {
         return telemetryEnabled;
     }
 
+    private MetricsUserPermissionConfig metricsUserPermissionConfig = new MetricsUserPermissionConfig();
+
+    public MetricsUserPermissionConfig getMetricsUserPermissionConfig() {
+        return metricsUserPermissionConfig;
+    }
+
+    public void setMetricsUserPermissionConfig(MetricsUserPermissionConfig metricsUserPermissionConfig) {
+        this.metricsUserPermissionConfig = metricsUserPermissionConfig;
+    }
+
     public void setTelemetryEnabled(boolean telemetryEnabled) {
         this.telemetryEnabled = telemetryEnabled;
     }

--- a/engine/src/main/java/org/terasology/telemetry/Metrics.java
+++ b/engine/src/main/java/org/terasology/telemetry/Metrics.java
@@ -58,12 +58,12 @@ public class Metrics {
 
     public void initialise(Context context) {
 
-        systemContextMetric = new SystemContextMetric();
+        systemContextMetric = new SystemContextMetric(context);
         modulesMetric = new ModulesMetric(context);
         gameConfigurationMetric = new GameConfigurationMetric(context);
         blockDestroyedMetric = new BlockDestroyedMetric();
         blockPlacedMetric = new BlockPlacedMetric();
-        gamePlayMetric = new GamePlayMetric();
+        gamePlayMetric = new GamePlayMetric(context);
         monsterKilledMetric = new MonsterKilledMetric();
     }
 

--- a/engine/src/main/java/org/terasology/telemetry/TelemetryCategory.java
+++ b/engine/src/main/java/org/terasology/telemetry/TelemetryCategory.java
@@ -36,4 +36,6 @@ public @interface TelemetryCategory {
      * @return The displayable name for this category
      */
     String displayName();
+
+    boolean isOneMapMetric();
 }

--- a/engine/src/main/java/org/terasology/telemetry/TelemetryEmitter.java
+++ b/engine/src/main/java/org/terasology/telemetry/TelemetryEmitter.java
@@ -116,7 +116,7 @@ public class TelemetryEmitter extends BatchEmitter {
 
     private static RequestCallback getDefaultRequestCallback() {
 
-        RequestCallback callback = new RequestCallback() {
+        return new RequestCallback() {
 
             public void onSuccess(int successCount) {
                 logger.info("Success sent, successCount: " + successCount);
@@ -126,8 +126,6 @@ public class TelemetryEmitter extends BatchEmitter {
                 logger.warn("Failure, successCount: " + successCount + "\nfailedEvent:\n" + failedEvents.toString());
             }
         };
-
-        return callback;
     }
 
     public void changeUrl(URL url) {

--- a/engine/src/main/java/org/terasology/telemetry/TelemetryScreen.java
+++ b/engine/src/main/java/org/terasology/telemetry/TelemetryScreen.java
@@ -17,6 +17,7 @@ package org.terasology.telemetry;
 
 import com.google.common.collect.Maps;
 import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
+import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
@@ -38,23 +39,24 @@ import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.BindHelper;
 import org.terasology.rendering.nui.databinding.Binding;
-import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.layers.mainMenu.AddServerPopup;
 import org.terasology.rendering.nui.layouts.ColumnLayout;
 import org.terasology.rendering.nui.layouts.RowLayout;
 import org.terasology.rendering.nui.layouts.ScrollableArea;
 import org.terasology.rendering.nui.widgets.UICheckbox;
 import org.terasology.rendering.nui.widgets.UILabel;
+import org.terasology.rendering.nui.widgets.UISpace;
 import org.terasology.telemetry.logstash.TelemetryLogstashAppender;
 import org.terasology.telemetry.metrics.Metric;
 
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The metrics menu lists the telemetry field names and values that will be sent to the server.
@@ -86,13 +88,15 @@ public class TelemetryScreen extends CoreScreenLayer {
 
     private final int horizontalSpacing = 12;
 
+    private Map<TelemetryCategory, Class> telemetryCategories;
+
     @Override
     public void initialise() {
         setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
         refreshContent();
 
         WidgetUtil.trySubscribe(this, "back", button -> triggerBackAnimation());
-        WidgetUtil.tryBindCheckBoxWithListener(this, "telemetryEnabled", BindHelper.bindBeanProperty("telemetryEnabled", config.getTelemetryConfig(), Boolean.TYPE),(checkbox) -> {
+        WidgetUtil.tryBindCheckBoxWithListener(this, "telemetryEnabled", BindHelper.bindBeanProperty("telemetryEnabled", config.getTelemetryConfig(), Boolean.TYPE), (checkbox) -> {
             if (config.getTelemetryConfig().isTelemetryEnabled()) {
                 pushAddServerPopupAndStartEmitter();
             }
@@ -102,22 +106,78 @@ public class TelemetryScreen extends CoreScreenLayer {
                 pushAddServerPopupAndStartLogBackAppender();
             } else {
                 TelemetryLogstashAppender telemetryLogstashAppender = TelemetryUtils.fetchTelemetryLogstashAppender();
-                telemetryLogstashAppender.stop();
+                if (telemetryLogstashAppender != null) {
+                    telemetryLogstashAppender.stop();
+                }
             }
         });
+
+        addEnablingAllTelemetryListener();
     }
 
     @Override
     public void onOpened() {
         super.onOpened();
         refreshContent();
+
+        addGroupEnablingListener();
+    }
+
+    private void addEnablingAllTelemetryListener() {
+        UICheckbox uiCheckbox = this.find("telemetryEnabled", UICheckbox.class);
+        if (uiCheckbox != null) {
+            uiCheckbox.subscribe((checkbox) -> {
+                boolean telemetryEnabled = config.getTelemetryConfig().isTelemetryEnabled();
+                Map<String, Boolean> bindingMap = config.getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
+                for (Map.Entry<String, Boolean> entry : bindingMap.entrySet()) {
+                    entry.setValue(telemetryEnabled);
+                }
+
+                fetchTelemetryCategoriesFromEnvironment();
+                for (Map.Entry<TelemetryCategory, Class> telemetryCategory : telemetryCategories.entrySet()) {
+                    UICheckbox categoryBox = this.find(telemetryCategory.getKey().id(), UICheckbox.class);
+                    if (categoryBox != null) {
+                        categoryBox.setEnabled(telemetryEnabled);
+                    }
+                    Set<Field> fields = ReflectionUtils.getFields(telemetryCategory.getValue(), ReflectionUtils.withAnnotation(TelemetryField.class));
+                    for (Field field : fields) {
+                        String fieldName = field.getName();
+                        UICheckbox fieldBox = this.find(fieldName, UICheckbox.class);
+                        if (fieldBox != null) {
+                            fieldBox.setEnabled(telemetryEnabled);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    private void addGroupEnablingListener() {
+        fetchTelemetryCategoriesFromEnvironment();
+        for (Map.Entry<TelemetryCategory, Class> telemetryCategory: telemetryCategories.entrySet()) {
+            if (!telemetryCategory.getKey().isOneMapMetric()) {
+                UICheckbox uiCheckbox = this.find(telemetryCategory.getKey().id(), UICheckbox.class);
+                if (uiCheckbox == null) {
+                    continue;
+                }
+                uiCheckbox.subscribe((checkbox) -> {
+                    Map<String, Boolean> bindingMap = config.getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
+                    boolean isGroupEnable = bindingMap.get(telemetryCategory.getKey().id());
+                    Set<Field> fields = ReflectionUtils.getFields(telemetryCategory.getValue(), ReflectionUtils.withAnnotation(TelemetryField.class));
+                    for (Field field : fields) {
+                        String fieldName = field.getName();
+                        bindingMap.put(fieldName, isGroupEnable);
+                    }
+                });
+            }
+        }
     }
 
     private void refreshContent() {
         ColumnLayout mainLayout = new ColumnLayout();
         mainLayout.setHorizontalSpacing(8);
         mainLayout.setVerticalSpacing(8);
-        Map<TelemetryCategory, Class> telemetryCategories = fetchTelemetryCategoriesFromEnvironment();
+        fetchTelemetryCategoriesFromEnvironment();
 
         for (Map.Entry<TelemetryCategory, Class> telemetryCategory: telemetryCategories.entrySet()) {
             Class metricClass = telemetryCategory.getValue();
@@ -132,7 +192,9 @@ public class TelemetryScreen extends CoreScreenLayer {
         }
 
         ScrollableArea area = find("area", ScrollableArea.class);
-        area.setContent(mainLayout);
+        if (area != null) {
+            area.setContent(mainLayout);
+        }
     }
 
     private void pushAddServerPopupAndStartEmitter() {
@@ -170,9 +232,7 @@ public class TelemetryScreen extends CoreScreenLayer {
                 telemetryConfig.setTelemetryServerOwner(item.getOwner());
             }
         });
-        addServerPopup.onCancel((button) -> {
-            config.getTelemetryConfig().setTelemetryEnabled(false);
-        });
+        addServerPopup.onCancel((button) -> config.getTelemetryConfig().setTelemetryEnabled(false));
     }
 
     private void pushAddServerPopupAndStartLogBackAppender() {
@@ -183,7 +243,7 @@ public class TelemetryScreen extends CoreScreenLayer {
         TelemetryConfig telemetryConfig = config.getTelemetryConfig();
         if (telemetryConfig.getErrorReportingDestination() != null) {
             try {
-                URL url = new URL(telemetryConfig.getErrorReportingDestination());
+                URL url = new URL("http://" + telemetryConfig.getErrorReportingDestination());
                 serverInfo = new ServerInfo(telemetryConfig.getErrorReportingServerName(), url.getHost(), url.getPort());
                 serverInfo.setOwner(telemetryConfig.getErrorReportingServerOwner());
             } catch (Exception e) {
@@ -199,26 +259,23 @@ public class TelemetryScreen extends CoreScreenLayer {
         }
         addServerPopup.setServerInfo(serverInfo);
         addServerPopup.onSuccess((item) -> {
-            StringBuilder destinationLogstash = new StringBuilder();
-            destinationLogstash.append(item.getAddress());
-            destinationLogstash.append(":");
-            destinationLogstash.append(item.getPort());
+            String destinationLogstash = item.getAddress() + ":" + item.getPort();
             TelemetryLogstashAppender telemetryLogstashAppender = TelemetryUtils.fetchTelemetryLogstashAppender();
-            telemetryLogstashAppender.addDestination(destinationLogstash.toString());
-            telemetryLogstashAppender.start();
+            if (telemetryLogstashAppender != null) {
+                telemetryLogstashAppender.addDestination(destinationLogstash);
+                telemetryLogstashAppender.start();
+            }
 
             // Save the destination
-            telemetryConfig.setErrorReportingDestination(destinationLogstash.toString());
+            telemetryConfig.setErrorReportingDestination(destinationLogstash);
             telemetryConfig.setErrorReportingServerName(item.getName());
             telemetryConfig.setErrorReportingServerOwner(item.getOwner());
         });
-        addServerPopup.onCancel((button) -> {
-            telemetryConfig.setErrorReportingEnabled(false);
-        });
+        addServerPopup.onCancel((button) -> telemetryConfig.setErrorReportingEnabled(false));
     }
 
-    private Map<TelemetryCategory, Class> fetchTelemetryCategoriesFromEnvironment() {
-        Map<TelemetryCategory, Class> telemetryCategories = Maps.newHashMap();
+    private void fetchTelemetryCategoriesFromEnvironment() {
+        telemetryCategories = Maps.newHashMap();
 
         DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
         for (Name moduleId : moduleManager.getRegistry().getModuleIds()) {
@@ -235,8 +292,6 @@ public class TelemetryScreen extends CoreScreenLayer {
                 }
             }
         }
-
-        return telemetryCategories;
     }
 
     /**
@@ -246,25 +301,48 @@ public class TelemetryScreen extends CoreScreenLayer {
      * @param map the map which includes the telemetry field name and value
      */
     private void addTelemetrySection(TelemetryCategory telemetryCategory, ColumnLayout layout, Map<String, ?> map) {
+        UILabel categoryHeader = new UILabel(translationSystem.translate(telemetryCategory.displayName()));
+        categoryHeader.setFamily("subheading");
+        UICheckbox uiCheckbox = new UICheckbox(telemetryCategory.id());
+        Map<String, Boolean> bindingMap = config.getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
+        if (!bindingMap.containsKey(telemetryCategory.id())) {
+            bindingMap.put(telemetryCategory.id(), config.getTelemetryConfig().isTelemetryEnabled());
+        }
+        Binding<Boolean> binding = getBindingFromBooleanMap(bindingMap, telemetryCategory.id());
+        uiCheckbox.bindChecked(binding);
+        RowLayout newRow = new RowLayout(categoryHeader, new UISpace(), uiCheckbox)
+                .setColumnRatios(0.4f, 0.5f, 0.1f)
+                .setHorizontalSpacing(horizontalSpacing);
+        layout.addWidget(newRow);
 
-        if (!telemetryCategory.isOneMapMetric()) {
-            UILabel categoryHeader = new UILabel(translationSystem.translate(telemetryCategory.displayName()));
-            categoryHeader.setFamily("subheading");
-            layout.addWidget(categoryHeader);
-            List<Map.Entry> telemetryFields = sortFields(map);
-            for (Map.Entry entry : telemetryFields) {
-                Object value = entry.getValue();
-                if (value == null) {
-                    value = "Value Unknown";
-                }
-                if (value instanceof List) {
-                    List list = (List) value;
-                    addTelemetryField(entry.getKey().toString(), list, layout);
-                } else {
-                    addTelemetryField(entry.getKey().toString(), value, layout);
-                }
+        List<Map.Entry<String, ?>> telemetryFields = sortFields(map);
+        for (Map.Entry entry : telemetryFields) {
+            Object value = entry.getValue();
+            if (value == null) {
+                value = "Value unknown yet";
             }
-        } 
+            boolean isWithCheckbox = !telemetryCategory.isOneMapMetric();
+            if (value instanceof List) {
+                List list = (List) value;
+                addTelemetryField(entry.getKey().toString(), list, layout, isWithCheckbox, telemetryCategory);
+            } else {
+                addTelemetryField(entry.getKey().toString(), value, layout, isWithCheckbox, telemetryCategory);
+            }
+        }
+    }
+
+    private Binding<Boolean> getBindingFromBooleanMap(Map<String, Boolean> bindingMap, String fieldName) {
+        return new Binding<Boolean>() {
+            @Override
+            public Boolean get() {
+                return bindingMap.get(fieldName);
+            }
+
+            @Override
+            public void set(Boolean value) {
+                bindingMap.put(fieldName, value);
+            }
+        };
     }
 
     /**
@@ -272,28 +350,41 @@ public class TelemetryScreen extends CoreScreenLayer {
      * @param type the type(name) of the this field
      * @param value the value of this field
      * @param layout the layout where the new line will be added
+     * @param isWithCheckbox whether add a check box in the line
+     * @param telemetryCategory the TelemetryCategory that this field belongs to
      */
-    private void addTelemetryField(String type, Object value, ColumnLayout layout) {
-        UICheckbox uiCheckbox = new UICheckbox(type);
-        Map<String, Boolean> bindingMap = config.getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
-        if (!bindingMap.containsKey(type)) {
-            bindingMap.put(type, true);
+    private void addTelemetryField(String type, Object value, ColumnLayout layout, boolean isWithCheckbox, TelemetryCategory telemetryCategory) {
+        RowLayout newRow;
+        if (isWithCheckbox) {
+            UICheckbox uiCheckbox = new UICheckbox(type);
+            Map<String, Boolean> bindingMap = config.getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
+            if (!bindingMap.containsKey(type)) {
+                bindingMap.put(type, config.getTelemetryConfig().isTelemetryEnabled());
+            }
+            Binding<Boolean> binding = getBindingFromBooleanMap(bindingMap, type);
+            uiCheckbox.bindChecked(binding);
+            uiCheckbox.subscribe((checkbox) -> {
+                if (bindingMap.get(type)) {
+                    bindingMap.put(telemetryCategory.id(), true);
+                } else {
+                    Set<Field> fields = ReflectionUtils.getFields(telemetryCategories.get(telemetryCategory), ReflectionUtils.withAnnotation(TelemetryField.class));
+                    boolean isOneEnabled = false;
+                    for (Field field : fields) {
+                        isOneEnabled = isOneEnabled || bindingMap.get(field.getName());
+                    }
+                    if (!isOneEnabled) {
+                        bindingMap.put(telemetryCategory.id(), false);
+                    }
+                }
+            });
+            newRow = new RowLayout(new UILabel(type), new UILabel(value.toString()), uiCheckbox)
+                    .setColumnRatios(0.4f, 0.5f, 0.1f)
+                    .setHorizontalSpacing(horizontalSpacing);
+        } else {
+            newRow = new RowLayout(new UILabel(type), new UILabel(value.toString()))
+                    .setColumnRatios(0.4f, 0.5f)
+                    .setHorizontalSpacing(horizontalSpacing);
         }
-        Binding<Boolean> binding = new Binding<Boolean>() {
-            @Override
-            public Boolean get() {
-                return bindingMap.get(type);
-            }
-
-            @Override
-            public void set(Boolean value) {
-                bindingMap.put(type, value);
-            }
-        };
-        uiCheckbox.bindChecked(binding);
-        RowLayout newRow = new RowLayout(new UILabel(type), new UILabel(value.toString()), uiCheckbox)
-                .setColumnRatios(0.4f)
-                .setHorizontalSpacing(horizontalSpacing);
 
         layout.addWidget(newRow);
     }
@@ -304,15 +395,16 @@ public class TelemetryScreen extends CoreScreenLayer {
      * @param type the type(name) of the this field
      * @param value the value of this field (a List)
      * @param layout the layout where the new line will be added
+     * @param isWithCheckbox whether add a check box in the line
      */
-    private void addTelemetryField(String type, List value, ColumnLayout layout) {
+    private void addTelemetryField(String type, List value, ColumnLayout layout, boolean isWithCheckbox, TelemetryCategory telemetryCategory) {
         int moduleCount = 1;
         for (Object o : value) {
             StringBuilder sb = new StringBuilder();
             sb.append(type);
             sb.append(" ");
             sb.append(moduleCount);
-            addTelemetryField(sb.toString(), o, layout);
+            addTelemetryField(sb.toString(), o, layout, isWithCheckbox, telemetryCategory);
             moduleCount = moduleCount + 1;
         }
     }
@@ -322,15 +414,9 @@ public class TelemetryScreen extends CoreScreenLayer {
      * @param map the map that will be sorted
      * @return a list of map entry that is ordered by fields' names
      */
-    private List<Map.Entry> sortFields(Map<String, ?> map) {
-        List<Map.Entry> list = new ArrayList<>(map.entrySet());
-        Collections.sort(list, new Comparator<Map.Entry>() {
-            @Override
-            public int compare(Map.Entry o1, Map.Entry o2) {
-                return o1.getKey().toString().compareTo(o2.getKey().toString());
-            }
-        });
-
+    private List<Map.Entry<String, ?>> sortFields(Map<String, ?> map) {
+        List<Map.Entry<String, ?>> list = new ArrayList<>(map.entrySet());
+        list.sort(Comparator.comparing(Map.Entry::getKey));
         return list;
     }
 }

--- a/engine/src/main/java/org/terasology/telemetry/TelemetryScreen.java
+++ b/engine/src/main/java/org/terasology/telemetry/TelemetryScreen.java
@@ -123,6 +123,9 @@ public class TelemetryScreen extends CoreScreenLayer {
         addGroupEnablingListener();
     }
 
+    /**
+     * Add a listener to the telemetryEnable checkbox. If the checkbox os enabled/disabled, it will enable/disable all the telemetry field.
+     */
     private void addEnablingAllTelemetryListener() {
         UICheckbox uiCheckbox = this.find("telemetryEnabled", UICheckbox.class);
         if (uiCheckbox != null) {
@@ -152,6 +155,10 @@ public class TelemetryScreen extends CoreScreenLayer {
         }
     }
 
+    /**
+     * Add a listener to the checkbox in the telemetry category row.
+     * If this checkbox is checked, all the sub telemetry fields will be enabled/disabled.
+     */
     private void addGroupEnablingListener() {
         fetchTelemetryCategoriesFromEnvironment();
         for (Map.Entry<TelemetryCategory, Class> telemetryCategory: telemetryCategories.entrySet()) {
@@ -162,11 +169,13 @@ public class TelemetryScreen extends CoreScreenLayer {
                 }
                 uiCheckbox.subscribe((checkbox) -> {
                     Map<String, Boolean> bindingMap = config.getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
-                    boolean isGroupEnable = bindingMap.get(telemetryCategory.getKey().id());
-                    Set<Field> fields = ReflectionUtils.getFields(telemetryCategory.getValue(), ReflectionUtils.withAnnotation(TelemetryField.class));
-                    for (Field field : fields) {
-                        String fieldName = field.getName();
-                        bindingMap.put(fieldName, isGroupEnable);
+                    if (bindingMap.containsKey(telemetryCategory.getKey().id())) {
+                        boolean isGroupEnable = bindingMap.get(telemetryCategory.getKey().id());
+                        Set<Field> fields = ReflectionUtils.getFields(telemetryCategory.getValue(), ReflectionUtils.withAnnotation(TelemetryField.class));
+                        for (Field field : fields) {
+                            String fieldName = field.getName();
+                            bindingMap.put(fieldName, isGroupEnable);
+                        }
                     }
                 });
             }
@@ -274,6 +283,9 @@ public class TelemetryScreen extends CoreScreenLayer {
         addServerPopup.onCancel((button) -> telemetryConfig.setErrorReportingEnabled(false));
     }
 
+    /**
+     * refresh the telemtryCategories map.
+     */
     private void fetchTelemetryCategoriesFromEnvironment() {
         telemetryCategories = Maps.newHashMap();
 

--- a/engine/src/main/java/org/terasology/telemetry/TelemetryUtils.java
+++ b/engine/src/main/java/org/terasology/telemetry/TelemetryUtils.java
@@ -64,8 +64,10 @@ public class TelemetryUtils {
         } else if (bindingMap.size() != 0) {
             TelemetryCategory telemetryCategory = metric.getClass().getAnnotation(TelemetryCategory.class);
             if (telemetryCategory != null) {
-                if ((bindingMap.get(telemetryCategory.id()))) {
-                    tracker.track(event);
+                if (bindingMap.containsKey(telemetryCategory.id())) {
+                    if ((bindingMap.get(telemetryCategory.id()))) {
+                        tracker.track(event);
+                    }
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/telemetry/metrics/BlockDestroyedMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/BlockDestroyedMetric.java
@@ -31,7 +31,8 @@ import java.util.Map;
  * A player statistic metric for blocks destroyed in a game.
  */
 @TelemetryCategory(id = "blockDestroyed",
-        displayName = "${engine:menu#telemetry-block-destroyed}"
+        displayName = "${engine:menu#telemetry-block-destroyed}",
+        isOneMapMetric = true
 )
 public final class BlockDestroyedMetric extends Metric {
 

--- a/engine/src/main/java/org/terasology/telemetry/metrics/BlockPlacedMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/BlockPlacedMetric.java
@@ -31,7 +31,8 @@ import java.util.Map;
  * A players statistic metric for blocks placed.
  */
 @TelemetryCategory(id = "blockPlaced",
-        displayName = "${engine:menu#telemetry-block-placed}"
+        displayName = "${engine:menu#telemetry-block-placed}",
+        isOneMapMetric = true
 )
 public final class BlockPlacedMetric extends Metric {
 

--- a/engine/src/main/java/org/terasology/telemetry/metrics/GameConfigurationMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/GameConfigurationMetric.java
@@ -35,11 +35,14 @@ import java.util.Map;
  * A metric tracking game configuration such as world generator, network mode,etc.
  */
 @TelemetryCategory(id = "gameConfiguration",
-        displayName = "${engine:menu#telemetry-game-configuration}"
+        displayName = "${engine:menu#telemetry-game-configuration}",
+        isOneMapMetric = false
 )
 public final class GameConfigurationMetric extends Metric {
 
     public static final String SCHEMA_GAME_CONFIGURATION = "iglu:org.terasology/gameConfiguration/jsonschema/1-0-0";
+
+    private Map<String, Boolean> bindingMap;
 
     @TelemetryField
     private String worldGenerator;
@@ -60,12 +63,14 @@ public final class GameConfigurationMetric extends Metric {
 
     public GameConfigurationMetric(Context context) {
         this.context = context;
+        bindingMap = context.get(Config.class).getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
     }
 
     @Override
     public Unstructured getUnstructuredMetric() {
         getFieldValueMap();
-        SelfDescribingJson modulesData = new SelfDescribingJson(SCHEMA_GAME_CONFIGURATION, metricMap);
+        Map filteredMetricMap = filterMetricMap(bindingMap);
+        SelfDescribingJson modulesData = new SelfDescribingJson(SCHEMA_GAME_CONFIGURATION, filteredMetricMap);
 
         return Unstructured.builder()
                 .eventData(modulesData)

--- a/engine/src/main/java/org/terasology/telemetry/metrics/Metric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/Metric.java
@@ -83,10 +83,12 @@ public abstract class Metric {
         Map metricMapAfterPermission = new HashMap<>();
         for (Object key : metricMap.keySet()) {
             String fieldName = key.toString();
-            if (bindingMap.get(fieldName)) {
-                metricMapAfterPermission.put(fieldName, metricMap.get(fieldName));
-            } else {
-                metricMapAfterPermission.put(fieldName, "Disabled Field");
+            if (bindingMap.containsKey(fieldName)) {
+                if (bindingMap.get(fieldName)) {
+                    metricMapAfterPermission.put(fieldName, metricMap.get(fieldName));
+                } else {
+                    metricMapAfterPermission.put(fieldName, "Disabled Field");
+                }
             }
         }
 

--- a/engine/src/main/java/org/terasology/telemetry/metrics/Metric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/Metric.java
@@ -16,10 +16,12 @@
 package org.terasology.telemetry.metrics;
 
 import com.snowplowanalytics.snowplow.tracker.events.Unstructured;
-import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
+import org.terasology.engine.subsystem.DisplayDevice;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.telemetry.TelemetryField;
 
 import java.lang.reflect.Field;
@@ -50,7 +52,7 @@ public abstract class Metric {
      */
     public Map<String, ?> getFieldValueMap() {
 
-        metricMap = new HashMap<>();
+        metricMap = new HashMap();
         Set<Field> fields = ReflectionUtils.getFields(this.getClass(), ReflectionUtils.withAnnotation(TelemetryField.class));
 
         for (Field field : fields) {
@@ -63,5 +65,31 @@ public abstract class Metric {
         }
 
         return metricMap;
+    }
+
+    /**
+     * Filter the metric map by the binding map.
+     * If the user doesn't want the field to be sent, its value will be covered by "Disabled Field".
+     * @param bindingMap the binding map.
+     * @return a new metric map that covers the field that the user doesn't want to send by "Disabled Field".
+     */
+    protected Map<String, ?> filterMetricMap(Map<String, Boolean> bindingMap) {
+
+        Context context = CoreRegistry.get(Context.class);
+        DisplayDevice display = context.get(DisplayDevice.class);
+        if (display.isHeadless()) {
+            return metricMap;
+        }
+        Map metricMapAfterPermission = new HashMap<>();
+        for (Object key : metricMap.keySet()) {
+            String fieldName = key.toString();
+            if (bindingMap.get(fieldName)) {
+                metricMapAfterPermission.put(fieldName, metricMap.get(fieldName));
+            } else {
+                metricMapAfterPermission.put(fieldName, "Disabled Field");
+            }
+        }
+
+        return metricMapAfterPermission;
     }
 }

--- a/engine/src/main/java/org/terasology/telemetry/metrics/ModulesMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/ModulesMetric.java
@@ -35,7 +35,8 @@ import java.util.Map;
  * Metric includes module name and module version.
  */
 @TelemetryCategory(id = "modules",
-        displayName = "${engine:menu#telemetry-modules}"
+        displayName = "${engine:menu#telemetry-modules}",
+        isOneMapMetric = true
 )
 public final class ModulesMetric extends Metric {
 

--- a/engine/src/main/java/org/terasology/telemetry/metrics/MonsterKilledMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/MonsterKilledMetric.java
@@ -30,7 +30,8 @@ import java.util.Map;
  * A player statistic metric for monsters killed in a game.
  */
 @TelemetryCategory(id = "monsterKilled",
-        displayName = "${engine:menu#telemetry-monster-killed}"
+        displayName = "${engine:menu#telemetry-monster-killed}",
+        isOneMapMetric = true
 )
 public final class MonsterKilledMetric extends Metric {
 
@@ -40,9 +41,6 @@ public final class MonsterKilledMetric extends Metric {
 
     @TelemetryField
     private Map monsterKilledMap;
-
-    public MonsterKilledMetric() {
-    }
 
     @Override
     public Unstructured getUnstructuredMetric() {

--- a/engine/src/main/java/org/terasology/telemetry/metrics/SystemContextMetric.java
+++ b/engine/src/main/java/org/terasology/telemetry/metrics/SystemContextMetric.java
@@ -18,24 +18,29 @@ package org.terasology.telemetry.metrics;
 import com.snowplowanalytics.snowplow.tracker.events.Unstructured;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import org.lwjgl.opengl.GL11;
+import org.terasology.config.Config;
+import org.terasology.config.TelemetryConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.telemetry.TelemetryCategory;
 import org.terasology.telemetry.TelemetryField;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * This is a metric for system context.
  */
 @TelemetryCategory(id = "systemContext",
-        displayName = "${engine:menu#telemetry-system-context}"
+        displayName = "${engine:menu#telemetry-system-context}",
+        isOneMapMetric = false
 )
 public final class SystemContextMetric extends Metric {
 
     public static final String SCHEMA_OS = "iglu:org.terasology/systemContext/jsonschema/1-0-0";
-    private Context context;
+    private Context contextInCoreRegistry;
+    private Map<String, Boolean> bindingMap;
 
     @TelemetryField
     private String osName;
@@ -73,7 +78,9 @@ public final class SystemContextMetric extends Metric {
     @TelemetryField
     private long memoryMaxByte;
 
-    public SystemContextMetric() {
+    public SystemContextMetric(Context context) {
+
+        bindingMap = context.get(Config.class).getTelemetryConfig().getMetricsUserPermissionConfig().getBindingMap();
 
         osName = System.getProperty("os.name");
         osVersion = System.getProperty("os.version");
@@ -82,8 +89,8 @@ public final class SystemContextMetric extends Metric {
         javaVersion = System.getProperty("java.version");
         jvmName = System.getProperty("java.vm.name");
         jvmVersion = System.getProperty("java.vm.version");
-        context = CoreRegistry.get(Context.class);
-        DisplayDevice display = context.get(DisplayDevice.class);
+        contextInCoreRegistry = CoreRegistry.get(Context.class);
+        DisplayDevice display = contextInCoreRegistry.get(DisplayDevice.class);
         if (!display.isHeadless()) {
             openGLVendor = GL11.glGetString(GL11.GL_VENDOR);
             openGLVersion = GL11.glGetString(GL11.GL_VERSION);
@@ -101,8 +108,8 @@ public final class SystemContextMetric extends Metric {
     public Unstructured getUnstructuredMetric() {
 
         getFieldValueMap();
-
-        SelfDescribingJson systemContextData = new SelfDescribingJson(SCHEMA_OS, metricMap);
+        Map<String, ?> filteredMetricMap = filterMetricMap(bindingMap);
+        SelfDescribingJson systemContextData = new SelfDescribingJson(SCHEMA_OS, filteredMetricMap);
 
         return Unstructured.builder()
                 .eventData(systemContextData)


### PR DESCRIPTION


<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Now the user can choose which field he wants to send in the `metrics menu`. 
- He can enable/disable a single field, e.g. the "language" field.
- He can enable/disable a whole metric e.g. "System Context", then all fields in that metric will be enabled/disabled.
- Click the check box "Send metrics to server" will enable/disable all fields.
- If all fields in the metric is disabled, that metric will be disabled automatically. If one field is enabled, that metric will be enabled automatically.
![2017-08-09 10 40 01](https://user-images.githubusercontent.com/17897358/29142895-9f35b6b0-7d53-11e7-8097-ed854ab4178e.png)


Make all the string default to `no_analysed` in ELK, we can finally do some pie graphs :)  The utility.terasology.org:5601 is updated. Here is an example proposed in #3024 

![2017-08-09 10 50 15](https://user-images.githubusercontent.com/17897358/29143412-55b9a012-7d55-11e7-8d18-e482a3bbcd22.png)

### Outstanding before merging
For the headless server, we need to edit in `terasology-server/config.cfg`:
- `"telemetryEnabled": true` to enable telemetry
- `"errorReportingEnabled": true` to enable error reporting
-  copy `bindingMap` in `/config.cfg` to `terasology-server/config.cfg` to have more options :)

The telemetry in the headless server is too manual, if you have some more ideas, please let me know! Thanks :)

Thanks @rzats @oniatus @Cervator @skaldarnar @msteiger @qwc for review and comments!