### PR TITLE
Fixed bug where ESC would not close Join Game Screen. Fixes #3034

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -185,6 +185,7 @@ public class JoinGameScreen extends CoreScreenLayer {
 
     @Override
     public void onClosed() {
+        System.out.println("Want to exit");
         infoService.close();
 
         super.onClosed();
@@ -481,14 +482,16 @@ public class JoinGameScreen extends CoreScreenLayer {
     }
 
     public boolean onKeyEvent(NUIKeyEvent event) {
-        if (event.isDown() && event.getKey() == Keyboard.Key.ESCAPE) {
-            if (isEscapeToCloseAllowed()) {
-                triggerBackAnimation();
-                return true;
+        if (event.isDown()) {
+            if (event.getKey() == Keyboard.Key.ESCAPE) {
+                if (isEscapeToCloseAllowed()) {
+                    triggerBackAnimation();
+                    return true;
+                }
             }
-        }
-        if (event.isDown() && event.getKey() == Keyboard.Key.R) {
-            refresh();
+            else if (event.getKey() == Keyboard.Key.R) {
+                refresh();
+            }
         }
         return false;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -481,6 +481,12 @@ public class JoinGameScreen extends CoreScreenLayer {
     }
 
     public boolean onKeyEvent(NUIKeyEvent event) {
+        if (event.isDown() && event.getKey() == Keyboard.Key.ESCAPE) {
+            if (isEscapeToCloseAllowed()) {
+                triggerBackAnimation();
+                return true;
+            }
+        }
         if (event.isDown() && event.getKey() == Keyboard.Key.R) {
             refresh();
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -185,7 +185,6 @@ public class JoinGameScreen extends CoreScreenLayer {
 
     @Override
     public void onClosed() {
-        System.out.println("Want to exit");
         infoService.close();
 
         super.onClosed();


### PR DESCRIPTION
Fixes the bug #3034. 

The code was missing a piece for the game screen to close if escape was pressed. This fixes the bug and allows the escape button to work for all the different screens/tabs at startup. This is my first pull request to this project, so if anything is wrong let me know. Thanks.
