### PR TITLE
LocalPlayerSetup Event

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitCharacterSpawn.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitCharacterSpawn.java
@@ -47,6 +47,7 @@ public class AwaitCharacterSpawn implements LoadProcess {
         LocalPlayer localPlayer = context.get(LocalPlayer.class);
         ClientComponent client = localPlayer.getClientEntity().getComponent(ClientComponent.class);
         if (client != null && client.character.exists()) {
+            client.character.send(new AwaitedLocalCharacterSpawnEvent());
             return true;
         } else {
             chunkProvider.completeUpdate();

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitedLocalCharacterSpawnEvent.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitedLocalCharacterSpawnEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.modes.loadProcesses;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.module.sandbox.API;
+
+/**
+ * Event which is triggered when LocalPlayer is setup with a character entity. Allows for detection of when LocalPlayer is
+ * completely setup for a character, in case a system needs to wait until it is setup and therefore cannot act in {@link BaseComponentSystem#postBegin()}
+ * Event is sent to the character entity. This only triggers at the setup of the local player(once per in game session). It is sent by
+ * {@link AwaitCharacterSpawn}
+ *
+ * API annotation is to allow modules to utilize this event as well.
+ */
+@API
+public class AwaitedLocalCharacterSpawnEvent implements Event {
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains
@flo  for reference/review.


This is a PR that implements an event into the setup of a local player, when the local character entity is setup then it sends out this event. This allows for component systems that might rely on LocalPlayer to actually watch it for completion. It is only sent to the local client and will only trigger if a character entity is setup(won't trigger on a headless server or on someone joining a server, just the client's side)

### How to test

Can test with any component system that would watch the event. An example that utilizes it is in the latest PR of the ScenarioModule. https://github.com/Terasology/Scenario/pull/36/commits/6bd6603e37c2a3bdab64c9c35ce23f6cfc904644

in 

https://github.com/ThompsonTyler/Scenario/blob/6bd6603e37c2a3bdab64c9c35ce23f6cfc904644/src/main/java/org/terasology/scenario/internal/systems/RegionDisplaySystem.java#L101-L104

Can test in game by creating a save with the scenario module, "give hubtool" creating a region using the hubtool(right click while holding the hub tool and go to the region tab, right click regions and select add new region)

After region creation is completed the region should be visible, close and reload the save to see that the region is still visible(the system that allows it to be shown on startup utilizes the event as a trigger and NEEDS the local character to be setup to work)

