### PR TITLE
expose executor service in taskmaster

### DIFF
--- a/engine/src/main/java/org/terasology/utilities/concurrency/Task.java
+++ b/engine/src/main/java/org/terasology/utilities/concurrency/Task.java
@@ -17,12 +17,27 @@
 package org.terasology.utilities.concurrency;
 
 /**
+ * Task interface for use with {@link TaskMaster}. Typically, this interface is implemented by a BaseTask class
+ * specific to your TaskMaster client code. For example, a pathfinder might create a PathfindingBaseTask, and
+ * extend that to make a PathfindingMapAnalysisTask.
+ * <p>
+ * The {@link #run()} method is called (generally on a separate task processing thread) when the task manager is
+ * ready to execute the task.
+ *
+ * @see TaskMaster
  */
 public interface Task {
 
     String getName();
 
+    /**
+     * Called when the Task is ready to be executed
+     */
     void run();
 
+    /**
+     * Return true if the {@link TaskProcessor} should shut down after performing this task
+     * @return
+     */
     boolean isTerminateSignal();
 }

--- a/engine/src/main/java/org/terasology/utilities/concurrency/TaskMaster.java
+++ b/engine/src/main/java/org/terasology/utilities/concurrency/TaskMaster.java
@@ -31,6 +31,31 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * Manages execution of tasks on a queue.
+ *
+ * TaskMasters execute Tasks on separate threads, meaning that long running tasks can be performed without affecting
+ * rendering or other processing on the main thread. The usual caveats regarding threading and Events, Components,
+ * and Entities apply to the Tasks being processed.
+ * <p>
+ * Create TaskMaster instances using the static "create" helper methods, then use {@link #offer(Task)} to add tasks to
+ * the queue. In most cases the simple FIFO TaskMaster is good enough. However, you can create a prioritized queue by
+ * implementing {@link Comparable} in your {@link Task} implementations.
+ * <p>
+ * When you create a TaskMaster, it is important to shut it down after you're finished with it, generally in the
+ * shutdown method of a ComponentSystem. A basic usage example follows:
+ * <p>
+ * <pre>
+ * {@literal
+ * TaskMaster<MyBaseTask> taskMaster = TaskMaster.createFIFOTaskMaster("MyTaskMaster", 1);
+ * taskMaster.offer(new MyFooTask());
+ * taskMaster.offer(new MyBarTask());
+ * taskMaster.shutdown(new ShutdownTask());
+ * }
+ * </pre>
+ *
+ * @see Task
+ * @see #createFIFOTaskMaster(String, int)
+ * @see #createPriorityTaskMaster(String, int, int)
  */
 public final class TaskMaster<T extends Task> {
     private static final Logger logger = LoggerFactory.getLogger(TaskMaster.class);
@@ -51,10 +76,17 @@ public final class TaskMaster<T extends Task> {
         restart();
     }
 
+    /**
+     * Creates a FIFO taskmaster which simply reads from a task queue in order
+     */
     public static <T extends Task> TaskMaster<T> createFIFOTaskMaster(String name, int threads) {
         return new TaskMaster<>(name, threads, new LinkedBlockingQueue<>());
     }
 
+    /**
+     * Creates a prioritized taskmaster which uses {@link Comparable} Tasks to establish priority. The <em>least</em>
+     * task (according to the Comparable interface) is processed first.
+     */
     public static <T extends Task & Comparable<? super T>> TaskMaster<T> createPriorityTaskMaster(String name, int threads, int queueSize) {
         return new TaskMaster<>(name, threads, new PriorityBlockingQueue<>(queueSize));
     }

--- a/engine/src/main/java/org/terasology/utilities/concurrency/TaskMaster.java
+++ b/engine/src/main/java/org/terasology/utilities/concurrency/TaskMaster.java
@@ -126,4 +126,17 @@ public final class TaskMaster<T extends Task> {
         }
     }
 
+    /**
+     * Get the {@link ExecutorService} underlying this TaskMaster. Note that by default the service will have a
+     * {@link TaskProcessor} enqueued for each thread. In order to use the ExecutorService directly you will need to
+     * {@method offer} a {@link ShutdownTask} as shown:
+     * <p>
+     * {@code
+     * taskMaster.offer(new ShutdownTask());
+     * }
+     * @return the {@link ExecutorService} used by this instance
+     */
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
 }


### PR DESCRIPTION
### Contains

A getter method for the ExecutorService used by TaskMaster

There are useful Guava utilities that can make use of ExecutorServices, for example the [SimpleTimeLimiter](https://google.github.io/guava/releases/22.0/api/docs/com/google/common/util/concurrent/SimpleTimeLimiter.html)

I make use of this in FlexiblePathfinding to [manage timeouts](https://github.com/kaen/FlexiblePathfinding/blob/master/src/main/java/org/terasology/flexiblepathfinding/JPSImpl.java#L66-L85) for pathfinding executions. This way I can use google time limiting logic instead of writing my own.

Currently, we can instantiate an ExecutorService directly ourselves, but we can't properly manage its lifecycle. Calling `executorService.shutdown` results in the following permissions error:
```
11:57:17.881 [Pathfinder-0] ERROR o.t.u.concurrency.TaskProcessor - Error in thread Pathfinder-0
java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "modifyThread")
```
Without the ability to call that method in module code, the thread and executor are left quietly running in the background after Terasology shutdown. This is messy and requires use of the red "stop" button in IDEA to fix.

This getter allows use of a managed `ExecutorService` without changing the API whitelist. There is an idiosyncrasy with the behavior but I believe that's well documented in the getter's javadoc, and an example of its usage can be [seen here](https://github.com/kaen/FlexiblePathfinding/blob/master/src/main/java/org/terasology/flexiblepathfinding/PathfinderSystem.java)