### PR TITLE
Adjustment for #3061- another default method to avoid API violation

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/UILayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/UILayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,9 @@ public interface UILayout<T extends LayoutHint> extends UIWidget {
 
     /**
      * Remove all widgets from the layout.
+     * TODO: Method made default to avoid API violation. Consider making non-default later or provide "real" implementation
      */
-    void removeAllWidgets();
+    default void removeAllWidgets() {
+        throw new UnsupportedOperationException("Not implemented yet (default method)");
+    }
 }


### PR DESCRIPTION
Very minor PR to restore API compatibility after #3061. That broke EventualSkills and maybe other stuff.

This seems like a decent approach as it maintains API yet if somebody tries to use the method in question in a class that hasn't yet adjusted a clear error will occur. That pushes the problem out to module land where we know at the time of the API fix no error should occur as nothing uses the new method yet. But if somebody tries to develop using new stuff on top of unmodified module code they'll raise an exception

`throw new UnsupportedOperationException("Not implemented yet (default method)");`

Example: If after this PR somebody tries to use `removeAllWidgets` for the layout class in EventualSkills they'll hit an exception while testing their change. But after this is merged EventualSkills as written still works perfectly fine since it doesn't touch the new method.

Maybe more tricky: if something like this introduced a new console command that would clear all widgets from any arbitrary UI screen, including some that might live in unmodified modules.