### PR TITLE
Added setSpawnLocation command

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
@@ -15,13 +15,18 @@
  */
 package org.terasology.logic.console.commands;
 
+import org.terasology.engine.modes.loadProcesses.LoadEntities;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
+import org.terasology.logic.console.commandSystem.annotations.Sender;
+import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.permission.PermissionManager;
+import org.terasology.logic.players.SpawnLocationComponent;
+import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
@@ -62,5 +67,21 @@ public class ClientCommands extends BaseComponentSystem {
     public String setWorldTime(@CommandParam("day") float day) {
         worldProvider.getTime().setDays(day);
         return "World time changed";
+    }
+
+    /**
+     * Sets the spawn location for the client to the current location
+     * @return String containing debug information on the entity
+     */
+    @Command(shortDescription = "Sets the spawn location for the client to the current location", runOnServer = true, requiredPermission = PermissionManager.CHEAT_PERMISSION)
+    public String setSpawnLocation(@Sender EntityRef sender) {
+        EntityRef clientInfo = sender.getComponent(ClientComponent.class).clientInfo;
+        SpawnLocationComponent spawnLocationComponent = new SpawnLocationComponent();
+        if (clientInfo.hasComponent(SpawnLocationComponent.class)) {
+            spawnLocationComponent = clientInfo.getComponent(SpawnLocationComponent.class);
+        }
+        spawnLocationComponent.position = sender.getComponent(ClientComponent.class).character.getComponent(LocationComponent.class).getWorldPosition();
+        clientInfo.addOrSaveComponent(spawnLocationComponent);
+        return "Set spawn location to- " + spawnLocationComponent.position;
     }
 }

--- a/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/ClientCommands.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.logic.console.commands;
 
-import org.terasology.engine.modes.loadProcesses.LoadEntities;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -25,7 +24,7 @@ import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.permission.PermissionManager;
-import org.terasology.logic.players.SpawnLocationComponent;
+import org.terasology.logic.players.StaticSpawnLocationComponent;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.In;
@@ -76,12 +75,12 @@ public class ClientCommands extends BaseComponentSystem {
     @Command(shortDescription = "Sets the spawn location for the client to the current location", runOnServer = true, requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String setSpawnLocation(@Sender EntityRef sender) {
         EntityRef clientInfo = sender.getComponent(ClientComponent.class).clientInfo;
-        SpawnLocationComponent spawnLocationComponent = new SpawnLocationComponent();
-        if (clientInfo.hasComponent(SpawnLocationComponent.class)) {
-            spawnLocationComponent = clientInfo.getComponent(SpawnLocationComponent.class);
+        StaticSpawnLocationComponent staticSpawnLocationComponent = new StaticSpawnLocationComponent();
+        if (clientInfo.hasComponent(StaticSpawnLocationComponent.class)) {
+            staticSpawnLocationComponent = clientInfo.getComponent(StaticSpawnLocationComponent.class);
         }
-        spawnLocationComponent.position = sender.getComponent(ClientComponent.class).character.getComponent(LocationComponent.class).getWorldPosition();
-        clientInfo.addOrSaveComponent(spawnLocationComponent);
-        return "Set spawn location to- " + spawnLocationComponent.position;
+        staticSpawnLocationComponent.position = sender.getComponent(ClientComponent.class).character.getComponent(LocationComponent.class).getWorldPosition();
+        clientInfo.addOrSaveComponent(staticSpawnLocationComponent);
+        return "Set spawn location to- " + staticSpawnLocationComponent.position;
     }
 }

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -214,8 +214,8 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
         EntityRef clientInfo = entity.getComponent(ClientComponent.class).clientInfo;
         Vector3f spawnPosition;
-        if (clientInfo.hasComponent(SpawnLocationComponent.class)) {
-            spawnPosition = clientInfo.getComponent(SpawnLocationComponent.class).position;
+        if (clientInfo.hasComponent(StaticSpawnLocationComponent.class)) {
+            spawnPosition = clientInfo.getComponent(StaticSpawnLocationComponent.class).position;
         } else {
             spawnPosition = worldGenerator.getSpawnPosition(entity);
         }

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -212,7 +212,13 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
-        Vector3f spawnPosition = worldGenerator.getSpawnPosition(entity);
+        EntityRef clientInfo = entity.getComponent(ClientComponent.class).clientInfo;
+        Vector3f spawnPosition;
+        if (clientInfo.hasComponent(SpawnLocationComponent.class)) {
+            spawnPosition = clientInfo.getComponent(SpawnLocationComponent.class).position;
+        } else {
+            spawnPosition = worldGenerator.getSpawnPosition(entity);
+        }
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         loc.setWorldPosition(spawnPosition);
         loc.setLocalRotation(new Quat4f());  // reset rotation

--- a/engine/src/main/java/org/terasology/logic/players/SpawnLocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/SpawnLocationComponent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.network.Replicate;
+
+/**
+ * This is attached to the player entities in order to manually set a custom spawn location.
+ */
+public class SpawnLocationComponent implements Component {
+    @Replicate
+    public Vector3f position;
+}

--- a/engine/src/main/java/org/terasology/logic/players/StaticSpawnLocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/StaticSpawnLocationComponent.java
@@ -22,7 +22,7 @@ import org.terasology.network.Replicate;
 /**
  * This is attached to the player entities in order to manually set a custom spawn location.
  */
-public class SpawnLocationComponent implements Component {
+public class StaticSpawnLocationComponent implements Component {
     @Replicate
     public Vector3f position;
 }


### PR DESCRIPTION
The PlayerSystem receives the RespawnRequestEvent and finds the location from the world generator.

This behavior has been modified such that it now checks for the existence of a SpawnLocationComponent attached to the ClientInfo Entity. If the component exists, the location is not found from the world generator and instead used directly.

The command that allows the player to set the spawn location is `setSpawnLocation`.

### To Test:
Use a world generator that dynamically finds the spawn location, for e.g.- PolyWorld (Island World)
1. Enable PolyWorld
2. `kill` yourself repeatedly by moving around. Notice that the spawn location changes every time.
3. Use the `setSpawnLocaiton` command to set a custom spawn location
4. Use `kill` command again and notice that the spawn location has now become static.