### PR TITLE
Prevent chests from losing items.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -39,6 +39,7 @@ import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkComponent;
 import org.terasology.physics.components.RigidBodyComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.logic.MeshComponent;
 import org.terasology.rendering.world.WorldRenderer;
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -155,10 +156,8 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
             if (mountPointComponent != null) {
 
                 if (clientHeldItem.exists()) {
-                    clientHeldItem.destroy();
-                    clientHeldItem = EntityRef.NULL;
+                    clientHeldItem.removeComponent(MeshComponent.class);
                 }
-
 
                 // remove the location from the old item
                 if (oldItem != null && oldItem.exists()) {


### PR DESCRIPTION
Fixes  #3067 by preventing the held item component deletion. The mesh is removed when held but otherwise it is untouched. This is a temporary fix while a better solution will be underway.

How to test:
Plonk down the starting chest, you'll see that it now has items inside. 

I've tested it thoroughly before judging it as an ok fix, but I might miss something, so a secondary test would be neat to have before merging :)
