### PR TITLE
Somewhat hacky fix for #3066 - validate the particle prefab being available

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -159,8 +159,11 @@ public class BlockEntitySystem extends BaseComponentSystem {
             // dust particle effect
             if (entity.hasComponent(LocationComponent.class) && block.isDebrisOnDestroy()) {
                 EntityBuilder dustBuilder = entityManager.newBuilder("core:dustEffect");
-                dustBuilder.getComponent(LocationComponent.class).setWorldPosition(entity.getComponent(LocationComponent.class).getWorldPosition());
-                dustBuilder.build();
+                // TODO: particle system stuff should be split out better - this is effectively a stealth dependency on Core from the engine
+                if (dustBuilder.hasComponent(LocationComponent.class)) {
+                    dustBuilder.getComponent(LocationComponent.class).setWorldPosition(entity.getComponent(LocationComponent.class).getWorldPosition());
+                    dustBuilder.build();
+                }
             }
 
             // sound to play for destroyed block


### PR DESCRIPTION
### Contains

Fixes #3066 by adding a check to catch situations in which the particle prefab doesn't exist, such as when the Core module isn't enabled

### How to test

Run BuilderSampleGameplay. Break a block. Should not get a `NullPointerException` and the block should disappear.

Admittedly I think behavior a while ago didn't even include a physics cube dropping - just the active block you place changes to the last you broke.

### Outstanding before merging

Nothing really. There are better fixes, such as grabbing the PrefabManager to see if the prefab exists before trying to use it, but at that point you might get tempted to try to fix it deeper. Should we cache the dust prefab in the system so we don't need to find it every time? Would that cause trouble if the player modifies the prefab on disk and wants a hot reload? Etc.

Ultimate fix would be better packaging / organizing of the particle system so it doesn't have a "soft" dependency on Core despite being inside the engine.