### PR TITLE
Fix underwater tint not working

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
@@ -125,6 +125,10 @@ public class InitialPostProcessingNode extends AbstractNode implements PropertyC
     public void process() {
         PerformanceMonitor.startActivity("rendering/initialPostProcessing");
 
+        // Common Shader Parameters
+
+        initialPostMaterial.setFloat("swimming", activeCamera.isUnderWater() ? 1.0f : 0.0f, true);
+
         // Shader Parameters
 
         initialPostMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(activeCamera.getPosition()).getTint(), true);


### PR DESCRIPTION
Fixes issue #3092.

Testing: Start a new game with "vignette" option enabled, and go inside water.
Expected behaviour: water will be dark and murky ("tinted").
