### PR TITLE
[Telemetry] block destroyed NPE fix

### DIFF
--- a/engine/src/main/java/org/terasology/logic/health/EntityDestructionAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/health/EntityDestructionAuthoritySystem.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class EntityDestructionAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void onDestroy(DestroyEvent event, EntityRef entity) {
-        recordDestroyed(event,entity);
+        recordDestroyed(event, entity);
         BeforeDestroyEvent destroyCheck = new BeforeDestroyEvent(event.getInstigator(), event.getDirectCause(), event.getDamageType());
         entity.send(destroyCheck);
         if (!destroyCheck.isConsumed()) {
@@ -41,40 +41,42 @@ public class EntityDestructionAuthoritySystem extends BaseComponentSystem {
 
     private void recordDestroyed(DestroyEvent event, EntityRef entityRef) {
         EntityRef instigator = event.getInstigator();
-        if (entityRef.hasComponent(BlockComponent.class)) {
-            BlockComponent blockComponent = entityRef.getComponent(BlockComponent.class);
-            String blockName = blockComponent.getBlock().getDisplayName();
-            if (instigator.hasComponent(GamePlayStatsComponent.class)) {
-                GamePlayStatsComponent gamePlayStatsComponent = instigator.getComponent(GamePlayStatsComponent.class);
-                Map<String, Integer> blockDestroyedMap = gamePlayStatsComponent.blockDestroyedMap;
-                if (blockDestroyedMap.containsKey(blockName)) {
-                    blockDestroyedMap.put(blockName, blockDestroyedMap.get(blockName) + 1);
+        if (instigator != null) {
+            if (entityRef.hasComponent(BlockComponent.class)) {
+                BlockComponent blockComponent = entityRef.getComponent(BlockComponent.class);
+                String blockName = blockComponent.getBlock().getDisplayName();
+                if (instigator.hasComponent(GamePlayStatsComponent.class)) {
+                    GamePlayStatsComponent gamePlayStatsComponent = instigator.getComponent(GamePlayStatsComponent.class);
+                    Map<String, Integer> blockDestroyedMap = gamePlayStatsComponent.blockDestroyedMap;
+                    if (blockDestroyedMap.containsKey(blockName)) {
+                        blockDestroyedMap.put(blockName, blockDestroyedMap.get(blockName) + 1);
+                    } else {
+                        blockDestroyedMap.put(blockName, 1);
+                    }
+                    instigator.saveComponent(gamePlayStatsComponent);
                 } else {
+                    GamePlayStatsComponent gamePlayStatsComponent = new GamePlayStatsComponent();
+                    Map<String, Integer> blockDestroyedMap = gamePlayStatsComponent.blockDestroyedMap;
                     blockDestroyedMap.put(blockName, 1);
+                    instigator.addOrSaveComponent(gamePlayStatsComponent);
                 }
-                instigator.saveComponent(gamePlayStatsComponent);
-            } else {
-                GamePlayStatsComponent gamePlayStatsComponent = new GamePlayStatsComponent();
-                Map<String, Integer> blockDestroyedMap = gamePlayStatsComponent.blockDestroyedMap;
-                blockDestroyedMap.put(blockName, 1);
-                instigator.addOrSaveComponent(gamePlayStatsComponent);
-            }
-        } else if (entityRef.hasComponent(CharacterComponent.class)) {
-            String monsterName = entityRef.getParentPrefab().getName();
-            if (instigator.hasComponent(GamePlayStatsComponent.class)) {
-                GamePlayStatsComponent gamePlayStatsComponent = instigator.getComponent(GamePlayStatsComponent.class);
-                Map<String, Integer> creatureKilled = gamePlayStatsComponent.creatureKilled;
-                if (creatureKilled.containsKey(monsterName)) {
-                    creatureKilled.put(monsterName, creatureKilled.get(monsterName) + 1);
+            } else if (entityRef.hasComponent(CharacterComponent.class)) {
+                String monsterName = entityRef.getParentPrefab().getName();
+                if (instigator.hasComponent(GamePlayStatsComponent.class)) {
+                    GamePlayStatsComponent gamePlayStatsComponent = instigator.getComponent(GamePlayStatsComponent.class);
+                    Map<String, Integer> creatureKilled = gamePlayStatsComponent.creatureKilled;
+                    if (creatureKilled.containsKey(monsterName)) {
+                        creatureKilled.put(monsterName, creatureKilled.get(monsterName) + 1);
+                    } else {
+                        creatureKilled.put(monsterName, 1);
+                    }
+                    instigator.saveComponent(gamePlayStatsComponent);
                 } else {
+                    GamePlayStatsComponent gamePlayStatsComponent = new GamePlayStatsComponent();
+                    Map<String, Integer> creatureKilled = gamePlayStatsComponent.creatureKilled;
                     creatureKilled.put(monsterName, 1);
+                    instigator.addOrSaveComponent(gamePlayStatsComponent);
                 }
-                instigator.saveComponent(gamePlayStatsComponent);
-            } else {
-                GamePlayStatsComponent gamePlayStatsComponent = new GamePlayStatsComponent();
-                Map<String, Integer> creatureKilled = gamePlayStatsComponent.creatureKilled;
-                creatureKilled.put(monsterName, 1);
-                instigator.addOrSaveComponent(gamePlayStatsComponent);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/logic/health/EntityDestructionAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/health/EntityDestructionAuthoritySystem.java
@@ -61,20 +61,20 @@ public class EntityDestructionAuthoritySystem extends BaseComponentSystem {
                     instigator.addOrSaveComponent(gamePlayStatsComponent);
                 }
             } else if (entityRef.hasComponent(CharacterComponent.class)) {
-                String monsterName = entityRef.getParentPrefab().getName();
+                String creatureName = entityRef.getParentPrefab().getName();
                 if (instigator.hasComponent(GamePlayStatsComponent.class)) {
                     GamePlayStatsComponent gamePlayStatsComponent = instigator.getComponent(GamePlayStatsComponent.class);
                     Map<String, Integer> creatureKilled = gamePlayStatsComponent.creatureKilled;
-                    if (creatureKilled.containsKey(monsterName)) {
-                        creatureKilled.put(monsterName, creatureKilled.get(monsterName) + 1);
+                    if (creatureKilled.containsKey(creatureName)) {
+                        creatureKilled.put(creatureName, creatureKilled.get(creatureName) + 1);
                     } else {
-                        creatureKilled.put(monsterName, 1);
+                        creatureKilled.put(creatureName, 1);
                     }
                     instigator.saveComponent(gamePlayStatsComponent);
                 } else {
                     GamePlayStatsComponent gamePlayStatsComponent = new GamePlayStatsComponent();
                     Map<String, Integer> creatureKilled = gamePlayStatsComponent.creatureKilled;
-                    creatureKilled.put(monsterName, 1);
+                    creatureKilled.put(creatureName, 1);
                     instigator.addOrSaveComponent(gamePlayStatsComponent);
                 }
             }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

Thanks for finding the bug！

### Contains

Fix #3091 
When a Torch destroy because of the `supportRemovedDamage`， there is no instigator. Add a null pointer checker to instigator.

### How to test

Break a block below a billboard plant, torch, or loose rock, there will be no NPE and the plant or torch or rock is destroyed as well.

### Outstanding before merging

By this way, the Torch destroyed because of `supportRemovedDamage` doesn't count as a block destroyed.