### PR TITLE
Permission level displayed for a command on using help

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -601,6 +601,12 @@ public class CoreCommands extends BaseComponentSystem {
                     msg.append("=====================================================================================================================");
                     msg.append(Console.NEW_LINE);
                 }
+                if(!cmd.getRequiredPermission().isEmpty()) {
+                    msg.append("Required permission level - "+cmd.getRequiredPermission());
+                    msg.append(Console.NEW_LINE);
+                    msg.append("=====================================================================================================================");
+                    msg.append(Console.NEW_LINE);
+                }
 
                 return msg.toString();
             }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #3094 

### How to test

Open the console and type `help give` It will display `Required Permission Level - cheat` 

