### PR TITLE
Display events

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/DisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/DisplayDevice.java
@@ -16,8 +16,9 @@
 package org.terasology.engine.subsystem;
 
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.DisplayModeSetting;
+import org.terasology.utilities.subscribables.Subscribable;
 
-public interface DisplayDevice {
+public interface DisplayDevice extends Subscribable {
 
     boolean hasFocus();
 
@@ -43,5 +44,7 @@ public interface DisplayDevice {
 
     // TODO: another method that possibly doesn't need to exist, but I need to check with Immortius on this
     void prepareToRender();
+
+    void update();
 
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/device/HeadlessDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/device/HeadlessDisplayDevice.java
@@ -17,8 +17,9 @@ package org.terasology.engine.subsystem.headless.device;
 
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.DisplayModeSetting;
+import org.terasology.utilities.subscribables.AbstractSubscribable;
 
-public class HeadlessDisplayDevice implements DisplayDevice {
+public class HeadlessDisplayDevice extends AbstractSubscribable implements DisplayDevice {
 
     public HeadlessDisplayDevice() {
     }
@@ -63,5 +64,9 @@ public class HeadlessDisplayDevice implements DisplayDevice {
 
     @Override
     public void prepareToRender() {
+    }
+
+    @Override
+    public void update() {
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -31,6 +31,7 @@ import static org.lwjgl.opengl.GL11.glLoadIdentity;
 import static org.lwjgl.opengl.GL11.glViewport;
 
 public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayDevice {
+    public static final String DISPLAY_RESOLUTION_CHANGE = "displayResolutionChange";
 
     private RenderingConfig config;
 
@@ -127,7 +128,7 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
     public void update() {
         if (Display.wasResized()) {
             glViewport(0, 0, Display.getWidth(), Display.getHeight());
-            propertyChangeSupport.firePropertyChange("displayResolution", 0, 1);
+            propertyChangeSupport.firePropertyChange(DISPLAY_RESOLUTION_CHANGE, 0, 1);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -22,6 +22,7 @@ import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.DisplayModeSetting;
+import org.terasology.utilities.subscribables.AbstractSubscribable;
 
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
@@ -29,7 +30,7 @@ import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glLoadIdentity;
 import static org.lwjgl.opengl.GL11.glViewport;
 
-public class LwjglDisplayDevice implements DisplayDevice {
+public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayDevice {
 
     private RenderingConfig config;
 
@@ -121,5 +122,12 @@ public class LwjglDisplayDevice implements DisplayDevice {
     public void prepareToRender() {
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         glLoadIdentity();
+    }
+
+    public void update() {
+        if (Display.wasResized()) {
+            glViewport(0, 0, Display.getWidth(), Display.getHeight());
+            propertyChangeSupport.firePropertyChange("displayResolution", 0, 1);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -129,7 +129,8 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
         if (Display.wasResized()) {
             glViewport(0, 0, Display.getWidth(), Display.getHeight());
             propertyChangeSupport.firePropertyChange(DISPLAY_RESOLUTION_CHANGE, 0, 1);
-            // Note that the "old" and "new" values (0 and 1) in the above call aren't actually used.
+            // Note that the "old" and "new" values (0 and 1) in the above call aren't actually
+            // used: they are only necessary to ensure that the event is fired up correctly.
         }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -129,6 +129,7 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
         if (Display.wasResized()) {
             glViewport(0, 0, Display.getWidth(), Display.getHeight());
             propertyChangeSupport.firePropertyChange(DISPLAY_RESOLUTION_CHANGE, 0, 1);
+            // Note that the "old" and "new" values (0 and 1) in the above call aren't actually used.
         }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -188,15 +188,11 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         }
         currentState.render();
 
-        if (Display.wasResized()) {
-            glViewport(0, 0, Display.getWidth(), Display.getHeight());
-        }
+        lwjglDisplay.update();
 
         if (lwjglDisplay.isCloseRequested()) {
             engine.shutdown();
         }
-
-
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -54,13 +54,11 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
 
     private Vector3f tempRightVector = new Vector3f();
 
-    public PerspectiveCamera(WorldProvider worldProvider, RenderingConfig renderingConfig) {
+    public PerspectiveCamera(WorldProvider worldProvider, RenderingConfig renderingConfig, DisplayDevice displayDevice) {
         super(worldProvider, renderingConfig);
         this.cameraSettings = renderingConfig.getCameraSettings();
 
-        // TODO: Switch to context.
-        DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
-        display.subscribe(this);
+        displayDevice.subscribe(this);
     }
 
     @Override
@@ -198,8 +196,8 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
         return MatrixUtils.createPerspectiveProjectionMatrix(fovY, aspectRatio, zNear, zFar);
     }
 
-    public void propertyChange(PropertyChangeEvent evt) {
-        if (evt.getPropertyName().equals("displayResolution")) {
+    public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+        if (propertyChangeEvent.getPropertyName().equals("displayResolution")) {
             cachedFov = -1; // Invalidate the cache, so that matrices get regenerated.
             updateMatrices();
         }

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -34,6 +34,7 @@ import java.util.LinkedList;
 
 import static org.lwjgl.opengl.GL11.GL_PROJECTION;
 import static org.lwjgl.opengl.GL11.glMatrixMode;
+import static org.terasology.engine.subsystem.lwjgl.LwjglDisplayDevice.DISPLAY_RESOLUTION_CHANGE;
 
 /**
  * Simple default camera.
@@ -58,7 +59,7 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
         super(worldProvider, renderingConfig);
         this.cameraSettings = renderingConfig.getCameraSettings();
 
-        displayDevice.subscribe(this);
+        displayDevice.subscribe(DISPLAY_RESOLUTION_CHANGE, this);
     }
 
     @Override
@@ -197,7 +198,7 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
     }
 
     public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
-        if (propertyChangeEvent.getPropertyName().equals("displayResolution")) {
+        if (propertyChangeEvent.getPropertyName().equals(DISPLAY_RESOLUTION_CHANGE)) {
             cachedFov = -1; // Invalidate the cache, so that matrices get regenerated.
             updateMatrices();
         }

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -18,13 +18,17 @@ package org.terasology.rendering.cameras;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
 import org.terasology.config.RenderingConfig;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.math.MatrixUtils;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Matrix4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.CameraSetting;
 import org.terasology.world.WorldProvider;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -34,7 +38,7 @@ import static org.lwjgl.opengl.GL11.glMatrixMode;
 /**
  * Simple default camera.
  */
-public class PerspectiveCamera extends SubmersibleCamera {
+public class PerspectiveCamera extends SubmersibleCamera implements PropertyChangeListener {
     // Values used for smoothing
     private Deque<Vector3f> previousPositions = new LinkedList<>();
     private Deque<Vector3f> previousViewingDirections = new LinkedList<>();
@@ -53,6 +57,8 @@ public class PerspectiveCamera extends SubmersibleCamera {
     public PerspectiveCamera(WorldProvider worldProvider, RenderingConfig renderingConfig) {
         super(worldProvider, renderingConfig);
         this.cameraSettings = renderingConfig.getCameraSettings();
+        DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
+        display.subscribe(this);
     }
 
     @Override
@@ -188,5 +194,11 @@ public class PerspectiveCamera extends SubmersibleCamera {
         float fovY = (float) (2 * Math.atan2(Math.tan(0.5 * fov * TeraMath.DEG_TO_RAD), aspectRatio));
 
         return MatrixUtils.createPerspectiveProjectionMatrix(fovY, aspectRatio, zNear, zFar);
+    }
+
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals("displayResolution")) {
+            createPerspectiveProjectionMatrix(cachedFov, zNear, zFar);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -57,6 +57,8 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
     public PerspectiveCamera(WorldProvider worldProvider, RenderingConfig renderingConfig) {
         super(worldProvider, renderingConfig);
         this.cameraSettings = renderingConfig.getCameraSettings();
+
+        // TODO: Switch to context.
         DisplayDevice display = CoreRegistry.get(DisplayDevice.class);
         display.subscribe(this);
     }
@@ -198,7 +200,8 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
 
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals("displayResolution")) {
-            createPerspectiveProjectionMatrix(cachedFov, zNear, zFar);
+            cachedFov = -1; // Invalidate the cache, so that matrices get regenerated.
+            updateMatrices();
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -154,7 +154,7 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
 
         renderFullscreenQuad();
 
-        if (!screenGrabber.isNotTakingScreenshot()) {
+        if (!screenGrabber.isTakingScreenshot()) {
             screenGrabber.saveScreenshot();
         }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -154,7 +154,7 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
 
         renderFullscreenQuad();
 
-        if (!screenGrabber.isTakingScreenshot()) {
+        if (screenGrabber.isTakingScreenshot()) {
             screenGrabber.saveScreenshot();
         }
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
@@ -680,7 +680,6 @@ public final class FBO {
             return new Dimensions(width / divisor, height / divisor);
         }
 
-
         public Dimensions multiplyBy(float multiplier) {
             int w = (int) (width * multiplier);
             int h = (int) (height * multiplier);
@@ -737,6 +736,25 @@ public final class FBO {
          */
         public int height() {
             return this.height;
+        }
+
+        /**
+         * Updates the dimensions.
+         * @param width An integer representing the new width.
+         * @param height An integer representing the new height.
+         */
+        public void set(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+
+        /**
+         * Updates the dimensions.
+         * @param other A Dimension to use the width and height from.
+         */
+        public void set(Dimensions other) {
+            this.width = other.width;
+            this.height = other.height;
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/FBO.java
@@ -651,6 +651,14 @@ public final class FBO {
         private int height;
 
         /**
+         * Default Constructor - returns a Dimensions object.
+         */
+        public Dimensions() {
+            this.width = 0;
+            this.height = 0;
+        }
+
+        /**
          * Standard Constructor - returns a Dimensions object.
          *
          * @param width An integer, representing the width of the FBO in pixels.
@@ -743,7 +751,7 @@ public final class FBO {
          * @param width An integer representing the new width.
          * @param height An integer representing the new height.
          */
-        public void set(int width, int height) {
+        public void setDimensions(int width, int height) {
             this.width = width;
             this.height = height;
         }
@@ -752,7 +760,7 @@ public final class FBO {
          * Updates the dimensions.
          * @param other A Dimension to use the width and height from.
          */
-        public void set(Dimensions other) {
+        public void setDimensions(Dimensions other) {
             this.width = other.width;
             this.height = other.height;
         }

--- a/engine/src/main/java/org/terasology/rendering/opengl/ScreenGrabber.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/ScreenGrabber.java
@@ -144,13 +144,12 @@ public class ScreenGrabber {
     }
 
     /**
-     * Returns true if the rendering engine is not in the process of taking a screenshot.
-     * Returns false if a screenshot is being taken.
+     * Returns true if the rendering engine is in the process of taking a screenshot.
+     * Returns false if a screenshot is not being taken.
      *
-     * @return true if no screenshot is being taken, false otherwise
+     * @return true if a screenshot is being taken, false otherwise
      */
-    // for code readability it make sense to have this method rather than its opposite.
-    public boolean isNotTakingScreenshot() {
-        return !isTakingScreenshot;
+    public boolean isTakingScreenshot() {
+        return isTakingScreenshot;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -97,19 +97,19 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager implemen
     public void update() {
         if (!screenGrabber.isTakingScreenshot()) {
             if (wasTakingScreenshotLastFrame) {
-                ScreenshotSize screenshotSize = renderingConfig.getScreenshotSize();
-                // TODO: Remove dependency on Display
-                fullScale.setDimensions(screenshotSize.getWidth(Display.getWidth()),
-                        screenshotSize.getHeight(Display.getHeight()));
+                updateFullScale();
                 regenerateFbos();
 
-                wasTakingScreenshotLastFrame = true;
+                wasTakingScreenshotLastFrame = false;
             }
         } else {
-            updateFullScale();
+            ScreenshotSize screenshotSize = renderingConfig.getScreenshotSize();
+            // TODO: Remove dependency on Display
+            fullScale.setDimensions(screenshotSize.getWidth(Display.getWidth()),
+                    screenshotSize.getHeight(Display.getHeight()));
             regenerateFbos();
 
-            wasTakingScreenshotLastFrame = false;
+            wasTakingScreenshotLastFrame = true;
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -54,7 +54,7 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager implemen
 
         renderingConfig.subscribe(FBO_SCALE, this);
 
-        displayDevice.subscribe(this);
+        displayDevice.subscribe(DISPLAY_RESOLUTION_CHANGE, this);
 
         updateFullScale();
         generateDefaultFBOs();
@@ -95,15 +95,17 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager implemen
      * Invoked before real-rendering starts
     */
     public void update() {
-        if (screenGrabber.isTakingScreenshot()) {
-            ScreenshotSize screenshotSize = renderingConfig.getScreenshotSize();
-            // TODO: Remove dependency on Display
-            fullScale.setDimensions(screenshotSize.getWidth(Display.getWidth()),
-                                    screenshotSize.getHeight(Display.getHeight()));
-            regenerateFbos();
+        if (!screenGrabber.isTakingScreenshot()) {
+            if (wasTakingScreenshotLastFrame) {
+                ScreenshotSize screenshotSize = renderingConfig.getScreenshotSize();
+                // TODO: Remove dependency on Display
+                fullScale.setDimensions(screenshotSize.getWidth(Display.getWidth()),
+                        screenshotSize.getHeight(Display.getHeight()));
+                regenerateFbos();
 
-            wasTakingScreenshotLastFrame = true;
-        } else if (wasTakingScreenshotLastFrame) {
+                wasTakingScreenshotLastFrame = true;
+            }
+        } else {
             updateFullScale();
             regenerateFbos();
 

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -24,13 +24,16 @@ import org.terasology.rendering.opengl.FBOConfig;
 import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.SwappableFBO;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
 
 /**
  * TODO: Add javadocs
  * TODO: Better naming
  */
-public class DisplayResolutionDependentFBOs extends AbstractFBOsManager {
+public class DisplayResolutionDependentFBOs extends AbstractFBOsManager implements PropertyChangeListener {
     public static final SimpleUri FINAL_BUFFER = new SimpleUri("engine:fbo.finalBuffer");
 
     private SwappableFBO gBufferPair;
@@ -88,16 +91,10 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager {
 
     /**
      * Invoked before real-rendering starts
-     * TODO: how about completely removing this, and make Display observable and this FBM as an observer
+     * TODO: Completely remove this.
      */
     public void update() {
         updateFullScale();
-
-        FBO readOnlyGBuffer = gBufferPair.getStaleFbo();
-        if (readOnlyGBuffer.dimensions().areDifferentFrom(fullScale)) {
-            regenerateFbos();
-            notifySubscribers();
-        }
     }
 
     private void regenerateFbos() {
@@ -118,5 +115,14 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager {
 
     public SwappableFBO getGBufferPair() {
         return gBufferPair;
+    }
+
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals("displayResolution")) {
+            regenerateFbos();
+            notifySubscribers();
+        }
+
+        // TODO: What if user changes "scale" ? Subscribe to renderingConfig to handle it.
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/fbms/DisplayResolutionDependentFBOs.java
@@ -98,19 +98,19 @@ public class DisplayResolutionDependentFBOs extends AbstractFBOsManager implemen
      * TODO: Completely remove this, once we have a better way to handle screenshots.
      */
     public void update() {
-        if (screenGrabber.isNotTakingScreenshot()) {
+        if (screenGrabber.isTakingScreenshot()) {
+            fullScale.set(renderingConfig.getScreenshotSize().getWidth(Display.getWidth()),
+                    renderingConfig.getScreenshotSize().getHeight(Display.getHeight()));
+            regenerateFbos();
+
+            wasTakingScreenshotLastFrame = true;
+        } else {
             if (wasTakingScreenshotLastFrame) {
                 updateFullScale();
                 regenerateFbos();
 
                 wasTakingScreenshotLastFrame = false;
             }
-        } else {
-            fullScale.set(renderingConfig.getScreenshotSize().getWidth(Display.getWidth()),
-                            renderingConfig.getScreenshotSize().getHeight(Display.getHeight()));
-            regenerateFbos();
-
-            wasTakingScreenshotLastFrame = true;
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.rendering.world;
 
-import javafx.stage.Screen;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,10 +15,12 @@
  */
 package org.terasology.rendering.world;
 
+import javafx.stage.Screen;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
+import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.engine.subsystem.lwjgl.LwjglGraphics;
 import org.terasology.entitySystem.systems.ComponentSystem;
@@ -215,11 +217,11 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
                         GROUND_PLANE_HEIGHT_DISPARITY  - context.get(Config.class).getPlayer().getEyeHeight());
                 currentRenderingStage = RenderingStage.LEFT_EYE;
             } else {
-                playerCamera = new PerspectiveCamera(worldProvider, renderingConfig);
+                playerCamera = new PerspectiveCamera(worldProvider, renderingConfig, context.get(DisplayDevice.class));
                 currentRenderingStage = RenderingStage.MONO;
             }
         } else {
-            playerCamera = new PerspectiveCamera(worldProvider, renderingConfig);
+            playerCamera = new PerspectiveCamera(worldProvider, renderingConfig, context.get(DisplayDevice.class));
             currentRenderingStage = RenderingStage.MONO;
         }
         // TODO: won't need localPlayerSystem here once camera is in the ES proper
@@ -233,10 +235,11 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
     }
 
     private void initRenderingSupport() {
-        context.put(ScreenGrabber.class, new ScreenGrabber(context));
+        ScreenGrabber screenGrabber = new ScreenGrabber(context);
+        context.put(ScreenGrabber.class, screenGrabber);
 
         immutableFBOs = new ImmutableFBOs();
-        displayResolutionDependentFBOs = new DisplayResolutionDependentFBOs(context.get(Config.class).getRendering(), context.get(ScreenGrabber.class));
+        displayResolutionDependentFBOs = new DisplayResolutionDependentFBOs(context.get(Config.class).getRendering(), screenGrabber, context.get(DisplayDevice.class));
         shadowMapResolutionDependentFBOs = new ShadowMapResolutionDependentFBOs();
 
         context.put(DisplayResolutionDependentFBOs.class, displayResolutionDependentFBOs);


### PR DESCRIPTION
Allows the DisplayDevice class to act as an observable system, that generates an event for resizing.

## Need

As things stand, certain systems in Rendering Land (like Cameras and DisplayResolutionDependentFBOManagers) should react to resizing events, but due to lack of the events, they either react late or they have to manually check `Display.isResized()`. For instance, in the screenshot attached, the world is rendered incorrectly (squashed) because perspectiveCamera does not immediately register the change.

With these events, it should also be possible to optimize certain parts of the code like not regenerating the projectionMatrix every frame, which currently happens.

![problem](https://user-images.githubusercontent.com/18019423/30698132-a5259762-9efe-11e7-8197-ac34d6b2354d.jpg)
