### PR TITLE
Add `onScreenOpened` lifecycle method to `CoreScreenLayer`.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/CoreScreenLayer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/CoreScreenLayer.java
@@ -78,6 +78,17 @@ public abstract class CoreScreenLayer extends AbstractWidget implements UIScreen
     @Override
     public void onOpened() {
         animationSystem.triggerFromPrev();
+        onScreenOpened();
+    }
+
+    /**
+     * Lifecycle method called when this screen is displayed under any circumstance.
+     * <p>
+     * This differs from {@link #onOpened} and {@link #onShow} in that it is called both when the
+     * screen is first opened (as {@code onOpened}) as well as when a screen previously opened
+     * (e.g., a parent menu in the menu system) is returned to (as {@code onShow}).
+     */
+    public void onScreenOpened() {
     }
 
     @Override
@@ -129,6 +140,7 @@ public abstract class CoreScreenLayer extends AbstractWidget implements UIScreen
     @Override
     public void onShow() {
         animationSystem.triggerFromNext();
+        onScreenOpened();
     }
 
     @Override


### PR DESCRIPTION
### Contains

This closes #3101.  The new lifecycle method is called both when the
screen is first opened (as the existing `onOpened`), as well as when a
screen that's already open is made visible again (as `onShow`).

### How to test

Unfortunately, I couldn't see any easy way to add automated tests for the UI system.  Since there aren't any existing tests for this system, either, and this is a very simple change, I figure this may be okay.  Anyway, I tested this manually by adding a temporary logger statement inside the method and clicking around the menu system.

### Outstanding before merging

Nothing I'm aware of.