### PR TITLE
Check if empty server list is obtained and display a proper message

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ServerListDownloader.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ServerListDownloader.java
@@ -134,8 +134,13 @@ class ServerListDownloader {
             }
 
             jsonReader.endArray();
-
-            status = String.format("${engine:menu#server-list-complete}");
+            
+            if(servers.size()==0) {
+                status = String.format("Server Error!");
+            }
+            else {
+                status = String.format("${engine:menu#server-list-complete}");
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains
Fixes #3069 

### How to test
I am not sure if there is a way of testing this, I couldn't re-create the error myself. On changing just the `masterServer` in `config.cfg`, the downloader tries to download from `defaultAddress` which has been set to meta.terasology.org in `NetworkConfig.java` and successfully downloads it. However when I changed that as well, as proper message saying "Error Downloading Server List!" was displayed. However I understand that the error caused was due to the empty list returned by the server, so I have added a simple check for that.
