### PR TITLE
Slight SSAO Tweak

### DIFF
--- a/engine/src/main/resources/assets/shaders/ssao_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/ssao_frag.glsl
@@ -60,7 +60,7 @@ void main() {
     const float maxDepthDifference = 1;
 
     for (int i=0; i<SSAO_KERNEL_ELEMENTS; ++i) {
-        samplePosition = (tbn * ssaoSamples[i]) * ssaoRad + viewSpacePos;
+        samplePosition = (tbn * ssaoSamples[i]) * ssaoRadius + viewSpacePos;
 
         offset = vec4(samplePosition.x, samplePosition.y, samplePosition.z, 1.0);
         offset = projMatrix * offset;
@@ -75,7 +75,7 @@ void main() {
         if (depthDifference > maxDepthDifference) {
         	rangeCheck = 0;
         } else {
-        	rangeCheck = smoothstep(0.0, 1.0, ssaoRad / depthDifference);
+        	rangeCheck = smoothstep(0.0, 1.0, ssaoRadius / depthDifference);
         }
 
         occlusion += step(samplePosition.z, sampleDepth) * rangeCheck;

--- a/engine/src/main/resources/assets/shaders/ssao_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/ssao_frag.glsl
@@ -68,7 +68,7 @@ void main() {
         // TODO: Holy... frustum ray and linearized depth - please!
         sampleDepth = reconstructViewPos(texture2D(texDepth, offset.xy).r * 2.0 - 1.0, gl_TexCoord[0].xy, invProjMatrix).z;
 
-        rangeCheck = smoothstep(0.0, 1.0, ssaoRad / abs(viewSpacePos.z - sampleDepth));
+        rangeCheck = smoothstep(0.0, 1.0, 0.25 * ssaoRad / abs(viewSpacePos.z - sampleDepth));
         occlusion += step(samplePosition.z, sampleDepth) * rangeCheck;
 
         samplesTaken += 1.0;

--- a/engine/src/main/resources/assets/shaders/ssao_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/ssao_frag.glsl
@@ -68,10 +68,14 @@ void main() {
         // TODO: Holy... frustum ray and linearized depth - please!
         sampleDepth = reconstructViewPos(texture2D(texDepth, offset.xy).r * 2.0 - 1.0, gl_TexCoord[0].xy, invProjMatrix).z;
 
-        rangeCheck = smoothstep(0.0, 1.0, ssaoRad / abs(viewSpacePos.z - sampleDepth));
-        const float maxDepthDifference = 2;
-        if (abs(viewSpacePos.z - sampleDepth) > maxDepthDifference) {
+        const float maxDepthDifference = 1;
+        float depthDifference = abs(viewSpacePos.z - sampleDepth);
+
+        float rangeCheck;
+        if (depthDifference > maxDepthDifference) {
         	rangeCheck = 0;
+        } else {
+        	rangeCheck = smoothstep(0.0, 1.0, ssaoRad / abs(viewSpacePos.z - sampleDepth));
         }
         occlusion += step(samplePosition.z, sampleDepth) * rangeCheck;
 

--- a/engine/src/main/resources/assets/shaders/ssao_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/ssao_frag.glsl
@@ -68,7 +68,11 @@ void main() {
         // TODO: Holy... frustum ray and linearized depth - please!
         sampleDepth = reconstructViewPos(texture2D(texDepth, offset.xy).r * 2.0 - 1.0, gl_TexCoord[0].xy, invProjMatrix).z;
 
-        rangeCheck = smoothstep(0.0, 1.0, 0.25 * ssaoRad / abs(viewSpacePos.z - sampleDepth));
+        rangeCheck = smoothstep(0.0, 1.0, ssaoRad / abs(viewSpacePos.z - sampleDepth));
+        const float maxDepthDifference = 2;
+        if (abs(viewSpacePos.z - sampleDepth) > maxDepthDifference) {
+        	rangeCheck = 0;
+        }
         occlusion += step(samplePosition.z, sampleDepth) * rangeCheck;
 
         samplesTaken += 1.0;

--- a/engine/src/main/resources/assets/shaders/ssao_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/ssao_frag.glsl
@@ -16,7 +16,7 @@
 
 uniform vec4 ssaoSettings;
 #define ssaoStrength ssaoSettings.x
-#define ssaoRad ssaoSettings.y
+#define ssaoRadius ssaoSettings.y
 
 uniform vec2 texelSize;
 uniform vec2 noiseTexelSize;
@@ -54,29 +54,30 @@ void main() {
     float occlusion = 0.0;
     float sampleDepth = 0.0;
     float rangeCheck = 0.0;
-    vec3 samplePosition = vec3(0.0, 0.0, 0.0);
+    vec3 samplePosition = vec3(0.0);
+    vec4 offset = vec4(0.0);
     float samplesTaken = 0.0;
+    const float maxDepthDifference = 1;
 
     for (int i=0; i<SSAO_KERNEL_ELEMENTS; ++i) {
         samplePosition = (tbn * ssaoSamples[i]) * ssaoRad + viewSpacePos;
 
-        vec4 offset = vec4(samplePosition.x, samplePosition.y, samplePosition.z, 1.0);
+        offset = vec4(samplePosition.x, samplePosition.y, samplePosition.z, 1.0);
         offset = projMatrix * offset;
         offset.xy /= offset.w;
         offset.xy = offset.xy * vec2(0.5) + vec2(0.5);
 
         // TODO: Holy... frustum ray and linearized depth - please!
         sampleDepth = reconstructViewPos(texture2D(texDepth, offset.xy).r * 2.0 - 1.0, gl_TexCoord[0].xy, invProjMatrix).z;
-
-        const float maxDepthDifference = 1;
         float depthDifference = abs(viewSpacePos.z - sampleDepth);
 
         float rangeCheck;
         if (depthDifference > maxDepthDifference) {
         	rangeCheck = 0;
         } else {
-        	rangeCheck = smoothstep(0.0, 1.0, ssaoRad / abs(viewSpacePos.z - sampleDepth));
+        	rangeCheck = smoothstep(0.0, 1.0, ssaoRad / depthDifference);
         }
+
         occlusion += step(samplePosition.z, sampleDepth) * rangeCheck;
 
         samplesTaken += 1.0;


### PR DESCRIPTION
## Introduction
As things stand, with the SSAO setting enabled, items have a black "halo" around them, caused due to a huge difference in depths of adjecent pixels. The traditional way to handle this is by using a "rangeCheck" function, that ignores pixels with a huge difference in depth. This was already implemented in Terasology, but the halo still persisted.

## What this PR contains
Slightly tweaks the parameters of rangeCheck, to better handle the difference check.
The SSAO effect in general should remain unchanged, and should still apply to hand-held items.

## Screenies
Because who doesn't like images? :D
Before | After
![beforeafterssao](https://user-images.githubusercontent.com/18019423/31015410-91007f78-a53d-11e7-94ff-fca114d5cd5e.jpg)
