### PR TITLE
Fix duplicate chat message notifications

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/ConsoleSystem.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleSystem.java
@@ -45,7 +45,11 @@ public class ConsoleSystem extends BaseComponentSystem {
         overlay = nuiManager.addOverlay(NotificationOverlay.ASSET_URI, NotificationOverlay.class);
         console.subscribe((Message message) -> {
             if (!nuiManager.isOpen("engine:console")) {
-                overlay.setVisible(true);
+                // make sure the message isn't already shown in the chat overlay
+                if (message.getType() != CoreMessageType.CHAT && message.getType() != CoreMessageType.NOTIFICATION
+                        || !nuiManager.isOpen("engine:chat")) {
+                    overlay.setVisible(true);
+                }
             }
         });
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #2990 

### How to test

1. Start up 2 Terasology clients and connect to a server with client 1.
2. Connect to the server with client 2 and confirm that client 1 receives a popup notification.
3. Send a message from client 2 and confirm that client 1 receives a popup notification.
4. Open the chat window on client 1 (leave it open for the remaining steps).
5. Send a message from client 2 and confirm that client 1 sees the message, but does not receive a popup notification.
6. Disconnect client 2 from the server and confirm that client 1 sees the notification, but does not receive a popup notification. 
