### PR TITLE
Log an error when all modules aren't found locally in the /modules folder when running from source

### DIFF
--- a/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
+++ b/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
@@ -81,6 +81,9 @@ public class ClientConnectionHandler extends SimpleChannelUpstreamHandler {
                             && joinStatus.getStatus() != JoinStatus.Status.FAILED) {
                         joinStatus.setErrorMessage("Server stopped responding.");
                         channel.close();
+                        if(server.getRemoteAddress().startsWith("localhost")) {
+                            logger.error("Could not find all the modules in /modules folder locally");
+                        }
                         logger.error("Server timeout threshold of {} ms exceeded.", timeoutThreshold);
                     }
                 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains
Fixes #2381 
Added a simple logger which runs when there is a server timeout and the game is running from source.
