### PR TITLE
Close online player overlay before showing death screen

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -73,6 +73,7 @@ public class MenuControlSystem extends BaseComponentSystem {
     public void onPlayerDeath(PlayerDeathEvent event, EntityRef character) {
         EntityRef client = character.getComponent(CharacterComponent.class).controller;
         if (client.getComponent(ClientComponent.class).local) {
+            nuiManager.removeOverlay("engine:onlinePlayersOverlay");
             nuiManager.pushScreen("engine:deathScreen");
             if (event.damageTypeName != null) {
                 ((DeathScreen) nuiManager.getScreen("engine:deathScreen")).setDeathDetails(event.instigatorName, event.damageTypeName);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains
Solves #2939 by closing the overlay prior to pushing the death screen. 

Problem was happening because the ping/online players is an overlay and therefore is not actually in the screen stack and won't be closed when the death screen is pushed (death screen is set to not have lower screens visible).

I think functionally overlays and screens work as intended so no need to change their functionality, just this specific case, as overlays are "above" other elements and therefore should still show with screens displayed.

### How to test

Go into game, hit tab to show online players then go into console and kill with online players screen open, screen should close and allow access to death screen.

Open/close online players to make sure that still functions. 

Kill with out player screen open to verify it still works.

### Outstanding before merging

Nothing that I know of, unless we want to instead actually check for any open overlays on displaying a screen with `isLowerLayerVisible return false`