### PR TITLE
Move `TimeRange` class from `SimpleFarming` module; rename it `Interval`

### DIFF
--- a/modules/Core/src/main/java/org/terasology/core/logic/random/Interval.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/random/Interval.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.core.logic.random;
+
+import org.terasology.reflection.MappedContainer;
+import org.terasology.utilities.random.FastRandom;
+import org.terasology.utilities.random.Random;
+
+/**
+ * A representation of a uniformly-distributed integer range, for use as a datatype by {@code Component}s
+ *
+ * For example, suppose that {@code ExampleComponent} is a {@link org.terasology.entitySystem.Component} whose {@code
+ * timeToGrow} field is an {@code Interval}.  Then the following prefab snippet says that, whenever the {@code timeToGrow}
+ * is {@link #sample}d, a random number will be returned that is uniformly distributed between 1000 and 6000.
+ *
+ * {@code
+ *   "ExampleComponent": {
+ *     "timeToGrow": {
+ *       "maxRandom": 1000
+ *       "fixed": 5000
+ *     }
+ *   }
+ * }
+ */
+@MappedContainer
+public class Interval {
+    /**
+     * Minimum bounds of variation.
+     *
+     * The default value of 0 is probably correct for most applications, since {@code fixed} and {@code maxRandom} are
+     * sufficient to describe the interval, but this field is still provided for those situations where a different value is
+     * more convenient (e.g., 1000 +/- 37 is clearer than [963, 1037]).
+     */
+    public long minRandom = 0;
+
+    /**
+     * Maximum bounds of variation.
+     *
+     * It probably doesn't make sense to have this be less than {@code minRandom}, but this constraint is not enforced.
+     */
+    public long maxRandom = 5000;
+
+    /** The base number before random variation is applied. */
+    public long fixed = 10000;
+
+    /**
+     * Return a random integer uniformly distributed between {@code fixed + minRandom} and {@code fixed + maxRandom}.
+     */
+    public long sample() {
+        long total = fixed;
+        Random random = new FastRandom();
+        total += random.nextFloat(minRandom, maxRandom);
+        return total;
+    }
+}

--- a/modules/Core/src/test/java/org/terasology/core/logic/random/IntervalTest.java
+++ b/modules/Core/src/test/java/org/terasology/core/logic/random/IntervalTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.core.logic.random;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class IntervalTest {
+
+  private static final Interval TEST_INTERVAL = new Interval();
+  static {
+    TEST_INTERVAL.fixed = 1000;
+    TEST_INTERVAL.minRandom = 500;
+    TEST_INTERVAL.maxRandom = 1000;
+  }
+
+  private static final int NUMBER_OF_SAMPLES = 20;
+
+  @Test
+  public void sampleShouldBeWithinBounds() {
+    final long minRange = TEST_INTERVAL.fixed + TEST_INTERVAL.minRandom;
+    final long maxRange = TEST_INTERVAL.fixed + TEST_INTERVAL.maxRandom;
+    long value;
+    for (int i = 1; i <= NUMBER_OF_SAMPLES; i++) {
+      value = TEST_INTERVAL.sample();
+      assertTrue(String.format("Sample %d not in range [%d, %d]", value, minRange, maxRange),
+          value >= minRange && value <= maxRange);
+    }
+  }
+}


### PR DESCRIPTION
### Contains

Moves the `TimeRange` class from the `SimpleFarming` module into the `Core` module.  (I used the new package `org.terasology.core.logic.random`; let me know if there's a better place to put this.)  

Also renames this class `Interval` to make it more clear that there's nothing about the class that mandates viewing the interval as a time range; it's just a way to get a random number in a certain range, and allow components to have that range as a field type.  Similarly, renames the sampling method from `getTimeRange` to `sample`.

The goal here is just to make this functionality available to other modules; I'm working on Terasology/WildAnimals#25 and am trying not to reinvent this particular wheel.

### How to test

Not much testing is required at this stage, since the new class is essentially a copy of the original with no references to it.  I did add a basic unit test that verifies that the samples are in the correct range, but I don't see any way that this could break anything.

A second PR Terasology/SimpleFarming#60 handles updating the usages within `SimpleFarming` to point at the new class.
