### PR TITLE
Fixed "Failed to resolve property oculusVrSupport" message

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -245,7 +245,7 @@ public class VideoSettingsScreen extends CoreScreenLayer {
         }
 
         WidgetUtil.tryBindCheckbox(this, "menu-animations", BindHelper.bindBeanProperty("animatedMenu", config.getRendering(), Boolean.TYPE));
-        WidgetUtil.tryBindCheckbox(this, "oculusVrSupport", BindHelper.bindBeanProperty("oculusVrSupport", config.getRendering(), Boolean.TYPE));
+        WidgetUtil.tryBindCheckbox(this, "oculusVrSupport", BindHelper.bindBeanProperty("vrSupport", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "animateGrass", BindHelper.bindBeanProperty("animateGrass", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "animateWater", BindHelper.bindBeanProperty("animateWater", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "volumetricFog", BindHelper.bindBeanProperty("volumetricFog", config.getRendering(), Boolean.TYPE));
@@ -270,9 +270,7 @@ public class VideoSettingsScreen extends CoreScreenLayer {
             WidgetUtil.trySubscribe(this, "fovReset", widget -> fovSlider.setValue(100.0f));
         }
 
-        WidgetUtil.trySubscribe(this, "close", button -> {
-            saveSettings();
-        });
+        WidgetUtil.trySubscribe(this, "close", button -> saveSettings());
     }
 
 


### PR DESCRIPTION
So far, the video settings page contained an invalid variable reference for vrSupport, which caused an error to log every time you opened the video settings:
`[main] WARN  o.t.r.nui.databinding.BindHelper - Failed to resolve property oculusVrSupport of type class org.terasology.config.RenderingConfig - is the getter or setter missing?`
This PR fixes that reference.

Testing: Try opening the video settings page without the PR, and you should get the warning. With the PR, that warning should be gone.