### PR TITLE
Create a new item that contains only the necessary visual components …

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -206,7 +206,7 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
         // ensure that there are no lingering items that are marked as still held. This situation happens with client side predicted items
         for (EntityRef entityRef : entityManager.getEntitiesWith(ItemIsHeldComponent.class)) {
             if (!entityRef.equals(currentHeldItem) && !entityRef.equals(handEntity)) {
-                entityRef.removeComponent(ItemIsHeldComponent.class);
+                entityRef.destroy();
             }
         }
 

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemTransformComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemTransformComponent.java
@@ -15,10 +15,10 @@
  */
 package org.terasology.logic.players;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.rendering.logic.VisualComponent;
 
-public class FirstPersonHeldItemTransformComponent implements Component {
+public class FirstPersonHeldItemTransformComponent implements VisualComponent {
     public Vector3f rotateDegrees = Vector3f.zero();
     public Vector3f translate = Vector3f.zero();
     public float scale = 1f;

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
@@ -15,13 +15,12 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.rendering.nui.Color;
 
 /**
  * Makes the game render the specified text at the current location of the enitity.
  */
-public class FloatingTextComponent implements Component {
+public class FloatingTextComponent implements VisualComponent {
     public String text;
     public Color textColor = Color.WHITE;
     public Color textShadowColor = Color.BLACK;

--- a/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.Replicate;
 import org.terasology.network.ReplicationCheck;
@@ -25,7 +24,7 @@ import org.terasology.reflection.metadata.FieldMetadata;
  * Add this component to an entity for it to transmit light from its location.  By default the component is configured to act similarly to a placed torch block.
  */
 // TODO: Split into multiple components? Point, Directional?
-public final class LightComponent implements Component, ReplicationCheck {
+public final class LightComponent implements VisualComponent, ReplicationCheck {
 
     public enum LightType {
         POINT,

--- a/engine/src/main/java/org/terasology/rendering/logic/LightFadeComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/LightFadeComponent.java
@@ -15,12 +15,11 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.network.Replicate;
 
 /**
  */
-public final class LightFadeComponent implements Component {
+public final class LightFadeComponent implements VisualComponent {
 
     @Replicate
     public float targetDiffuseIntensity = 1.0f;

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshComponent.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.network.Replicate;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.Mesh;
@@ -25,7 +24,7 @@ import org.terasology.world.block.ForceBlockActive;
 /**
  */
 @ForceBlockActive
-public final class MeshComponent implements Component {
+public final class MeshComponent implements VisualComponent {
 
     @Replicate
     public Mesh mesh;

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletalMeshComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletalMeshComponent.java
@@ -17,7 +17,6 @@
 package org.terasology.rendering.logic;
 
 import com.google.common.collect.Lists;
-import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.Owns;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.geom.Vector3f;
@@ -34,7 +33,7 @@ import java.util.Map;
 /**
  */
 @ForceBlockActive
-public class SkeletalMeshComponent implements Component {
+public class SkeletalMeshComponent implements VisualComponent {
     public SkeletalMesh mesh;
     public Material material;
 

--- a/engine/src/main/java/org/terasology/rendering/logic/VisualComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/VisualComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,7 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.math.geom.Vector3i;
-import org.terasology.rendering.nui.Color;
+import org.terasology.entitySystem.Component;
 
-/**
- * Entities with this component will cause a outline be drawn about the specified region in block coordinates.
- */
-public class RegionOutlineComponent implements VisualComponent {
-    public Vector3i corner1;
-    public Vector3i corner2;
-    public Color color = Color.WHITE;
+public interface VisualComponent extends Component {
 }


### PR DESCRIPTION
This should be a fix to #3126

I've reworked a bit of the system to use as few new entities as really needed. No more items will be lost and no objects floating in the world upon loading.

The downsides are:
 - There's always gonna be a null warning when switching to a block type item because of the way it's constructed from the prefab.
 - Any new visual stuff that we might want later to be visible first person will have to be manually implemented here (via adding the component) (This can be avoided by making the visual related components inherit a "Visual Component", but currently the system doesn't store components properly for such items (usually blocks), so that implementation will be postponed (unless there's time to look into that as well)