### PR TITLE
RefractiveReflectiveBlocksNode.java Checkstyle Fix

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
@@ -72,26 +72,6 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
     public static final SimpleUri REFRACTIVE_REFLECTIVE_FBO_URI = new SimpleUri("engine:fbo.sceneReflectiveRefractive");
     private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("engine:prog.chunk");
 
-    private RenderQueuesHelper renderQueues;
-    private WorldRenderer worldRenderer;
-    private BackdropProvider backdropProvider;
-    private RenderingConfig renderingConfig;
-    private WorldProvider worldProvider;
-
-    private Material chunkMaterial;
-
-    private FBO lastUpdatedGBuffer;
-    private FBO refractiveReflectiveFbo;
-
-    private SubmersibleCamera activeCamera;
-
-    private boolean normalMappingIsEnabled;
-    private boolean parallaxMappingIsEnabled;
-    private boolean animatedWaterIsEnabled;
-
-    private StateChange setTerrainNormalsInputTexture;
-    private StateChange setTerrainHeightInputTexture;
-
     // TODO: rename to more meaningful/precise variable names, like waveAmplitude or waveHeight.
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 2.0f)
@@ -114,6 +94,26 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 5.0f)
     public static float waterOffsetY;
+    
+    private RenderQueuesHelper renderQueues;
+    private WorldRenderer worldRenderer;
+    private BackdropProvider backdropProvider;
+    private RenderingConfig renderingConfig;
+    private WorldProvider worldProvider;
+
+    private Material chunkMaterial;
+
+    private FBO lastUpdatedGBuffer;
+    private FBO refractiveReflectiveFbo;
+
+    private SubmersibleCamera activeCamera;
+
+    private boolean normalMappingIsEnabled;
+    private boolean parallaxMappingIsEnabled;
+    private boolean animatedWaterIsEnabled;
+
+    private StateChange setTerrainNormalsInputTexture;
+    private StateChange setTerrainHeightInputTexture;
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 2.0f)


### PR DESCRIPTION
Originally, the static variables were declared after the instance variables, resulting in 14 Checkstyle violations. I moved the instance variables below the static variables to fix these issues.

