### PR TITLE
Hide FloatingTextComponent behind objects

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
@@ -25,5 +25,5 @@ public class FloatingTextComponent implements VisualComponent {
     public Color textColor = Color.WHITE;
     public Color textShadowColor = Color.BLACK;
     public float scale = 1f;
-    public boolean isOccluded;
+    public boolean isOverlay;
 }

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextComponent.java
@@ -25,4 +25,5 @@ public class FloatingTextComponent implements VisualComponent {
     public Color textColor = Color.WHITE;
     public Color textShadowColor = Color.BLACK;
     public float scale = 1f;
+    public boolean isOccluded;
 }

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -94,7 +94,6 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
             // If the FloatingTextComponent is meant to be occluded, enable depth tests
             if (floatingText.isOccluded) {
                 glEnable(GL_DEPTH_TEST);
-                glDepthFunc(GL_LESS);
             } else {
                 glDisable(GL_DEPTH_TEST);
             }

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -97,13 +97,6 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
 
             FloatingTextComponent floatingText = entity.getComponent(FloatingTextComponent.class);
 
-            // If the FloatingTextComponent is meant to be occluded, enable depth tests
-            if (floatingText.isOverlay) {
-                glEnable(GL_DEPTH_TEST);
-            } else {
-                glDisable(GL_DEPTH_TEST);
-            }
-
             String[] linesOfText = floatingText.text.split("\n");
             Color baseColor = floatingText.textColor;
             Color shadowColor = floatingText.textShadowColor;
@@ -125,6 +118,11 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
                                 shadowColor, underline);
                 entityMeshCache.put(entity, meshMap);
             }
+
+            if (floatingText.isOverlay) {
+                glDisable(GL_DEPTH_TEST);
+            }
+
             glPushMatrix();
 
             float scale = METER_PER_PIXEL * floatingText.scale;
@@ -146,8 +144,12 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
             }
 
             glPopMatrix();
+
+            // Revert to default state
+            if (floatingText.isOverlay) {
+                glEnable(GL_DEPTH_TEST);
+            }
         }
-        glEnable(GL_DEPTH_TEST);
     }
 
     private void diposeMeshMap(Map<Material, Mesh> meshMap) {

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -43,7 +43,13 @@ import org.terasology.world.WorldProvider;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glScaled;
+import static org.lwjgl.opengl.GL11.glTranslated;
 
 
 @RegisterSystem(RegisterMode.CLIENT)

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -43,13 +43,7 @@ import org.terasology.world.WorldProvider;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glPopMatrix;
-import static org.lwjgl.opengl.GL11.glPushMatrix;
-import static org.lwjgl.opengl.GL11.glScaled;
-import static org.lwjgl.opengl.GL11.glTranslated;
+import static org.lwjgl.opengl.GL11.*;
 
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -82,8 +76,6 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
     }
 
     private void render(Iterable<EntityRef> floatingTextEntities) {
-        glDisable(GL_DEPTH_TEST);
-
         Vector3f cameraPosition = camera.getPosition();
 
         for (EntityRef entity : floatingTextEntities) {
@@ -98,6 +90,14 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
             }
 
             FloatingTextComponent floatingText = entity.getComponent(FloatingTextComponent.class);
+
+            // If the FloatingTextComponent is meant to be occluded, enable depth tests
+            if (floatingText.isOccluded) {
+                glEnable(GL_DEPTH_TEST);
+                glDepthFunc(GL_LESS);
+            } else {
+                glDisable(GL_DEPTH_TEST);
+            }
 
             String[] linesOfText = floatingText.text.split("\n");
             Color baseColor = floatingText.textColor;

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -98,7 +98,7 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
             FloatingTextComponent floatingText = entity.getComponent(FloatingTextComponent.class);
 
             // If the FloatingTextComponent is meant to be occluded, enable depth tests
-            if (floatingText.isOccluded) {
+            if (floatingText.isOverlay) {
                 glEnable(GL_DEPTH_TEST);
             } else {
                 glDisable(GL_DEPTH_TEST);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

Adds a `boolean` to the `FloatingTextComponent` called `isOccluded` that occludes the floating text if enabled. This patch simply enables/disables depth testing based on the value of `isOccluded`.

### How to test

Place a `FloatingTextComponent` behind an obstacle with `isOccluded` set to `true`. The text will not be visible. It will, however, be visible behind an obstacle with `isOccluded` set to `true`.
