### PR TITLE
adding scala-lib packages to whitelist

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
+++ b/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
@@ -46,6 +46,14 @@ public final class ExternalApiWhitelist {
             .add("java.awt")
             .add("java.awt.geom")
             .add("java.awt.image")
+            // sub-packages of root for scala-lib: https://www.scala-lang.org/api/current/ 
+            .add("scala.collection")
+            .add("scala.concurrent")
+            .add("scala.io")
+            .add("scala.math")
+            .add("scala.sys")
+            .add("scala.util")
+            // end of scala-lib packages
             .add("jdk.internal.reflect")
             .add("com.google.common.annotations")
             .add("com.google.common.cache")

--- a/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
+++ b/engine/src/main/java/org/terasology/engine/module/ExternalApiWhitelist.java
@@ -49,7 +49,6 @@ public final class ExternalApiWhitelist {
             // sub-packages of root for scala-lib: https://www.scala-lang.org/api/current/ 
             .add("scala.collection")
             .add("scala.concurrent")
-            .add("scala.io")
             .add("scala.math")
             .add("scala.sys")
             .add("scala.util")


### PR DESCRIPTION
This is simply a partial fix for getting Scala working; we've established that Scala libraries need to be whitelisted. However, the libraries also need to be loaded, which is not fixed in this PR.