### PR TITLE
Add functionality to take server MOTD from a file motd.md.

### DIFF
--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -20,9 +20,7 @@ import com.google.common.collect.Lists;
 
 import org.terasology.engine.TerasologyConstants;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.util.Collections;
 import java.util.List;
 
@@ -75,13 +73,15 @@ public class NetworkConfig {
         try {
             StringBuffer mOTD = new StringBuffer();
 
-            FileReader reader = new FileReader("motd.md");
+            InputStreamReader reader = new InputStreamReader(new FileInputStream("motd.md"), "UTF8");
             BufferedReader bufferedReader = new BufferedReader(reader);
 
             String line;
             while ((line = bufferedReader.readLine()) != null) {
                 mOTD.append(line);
             }
+
+            reader.close();
 
             serverMOTD =  mOTD.toString();
 

--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -26,8 +26,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-/**
- */
+
 public class NetworkConfig {
 
     private List<ServerInfo> servers = Lists.newArrayList(new ServerInfo("localhost", "localhost", TerasologyConstants.DEFAULT_PORT));
@@ -73,14 +72,14 @@ public class NetworkConfig {
     }
 
     public String getServerMOTD() {
-        try{
+        try {
             StringBuffer mOTD = new StringBuffer();
 
             FileReader reader = new FileReader("motd.md");
             BufferedReader bufferedReader = new BufferedReader(reader);
 
             String line;
-            while((line = bufferedReader.readLine()) != null){
+            while ((line = bufferedReader.readLine()) != null) {
                 mOTD.append(line);
             }
 
@@ -88,8 +87,7 @@ public class NetworkConfig {
 
             return serverMOTD;
 
-        }
-        catch(IOException e) {
+        } catch (IOException e) {
             return serverMOTD;
         }
     }

--- a/engine/src/main/java/org/terasology/config/NetworkConfig.java
+++ b/engine/src/main/java/org/terasology/config/NetworkConfig.java
@@ -20,6 +20,9 @@ import com.google.common.collect.Lists;
 
 import org.terasology.engine.TerasologyConstants;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -70,7 +73,25 @@ public class NetworkConfig {
     }
 
     public String getServerMOTD() {
-        return serverMOTD;
+        try{
+            StringBuffer mOTD = new StringBuffer();
+
+            FileReader reader = new FileReader("motd.md");
+            BufferedReader bufferedReader = new BufferedReader(reader);
+
+            String line;
+            while((line = bufferedReader.readLine()) != null){
+                mOTD.append(line);
+            }
+
+            serverMOTD =  mOTD.toString();
+
+            return serverMOTD;
+
+        }
+        catch(IOException e) {
+            return serverMOTD;
+        }
     }
 
     public void setServerMOTD(String serverMOTD) {

--- a/engine/src/main/java/org/terasology/protobuf/NetData.java
+++ b/engine/src/main/java/org/terasology/protobuf/NetData.java
@@ -15638,33 +15638,18 @@ public final class NetData {
      * <code>optional string MOTD = 19;</code>
      */
     public java.lang.String getMOTD() {
-      try{
-        StringBuffer mOTD = new StringBuffer();
 
-        FileReader reader = new FileReader("motd.md");
-        BufferedReader bufferedReader = new BufferedReader(reader);
-
-        String line;
-        while((line = bufferedReader.readLine()) != null){
-          mOTD.append(line);
+      java.lang.Object ref = mOTD_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          mOTD_ = s;
         }
-
-        return mOTD.toString();
-
-      }
-      catch(IOException e) {
-        java.lang.Object ref = mOTD_;
-        if (ref instanceof java.lang.String) {
-          return (java.lang.String) ref;
-        } else {
-          com.google.protobuf.ByteString bs =
-                  (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            mOTD_ = s;
-          }
-          return s;
-        }
+        return s;
       }
     }
     /**

--- a/engine/src/main/java/org/terasology/protobuf/NetData.java
+++ b/engine/src/main/java/org/terasology/protobuf/NetData.java
@@ -3,6 +3,11 @@
 
 package org.terasology.protobuf;
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
 public final class NetData {
   private NetData() {}
   public static void registerAllExtensions(
@@ -15633,17 +15638,33 @@ public final class NetData {
      * <code>optional string MOTD = 19;</code>
      */
     public java.lang.String getMOTD() {
-      java.lang.Object ref = mOTD_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          mOTD_ = s;
+      try{
+        StringBuffer mOTD = new StringBuffer();
+
+        FileReader reader = new FileReader("motd.md");
+        BufferedReader bufferedReader = new BufferedReader(reader);
+
+        String line;
+        while((line = bufferedReader.readLine()) != null){
+          mOTD.append(line);
         }
-        return s;
+
+        return mOTD.toString();
+
+      }
+      catch(IOException e) {
+        java.lang.Object ref = mOTD_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs =
+                  (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            mOTD_ = s;
+          }
+          return s;
+        }
       }
     }
     /**


### PR DESCRIPTION
### Contains
Add feature for server MOTD input from file as mentioned in #2855 

### How to test
- Create a motd.md file in the root directory(temporary placement of the file for development)
- Spin up a server using `./gradlew server`
- Stop the server and edit the `config.cfg` file in the server directory as below
     `"upstreamBandwidth": 1024,`
     `"serverPort": 25777,`
     `"serverMOTD": "[Text would appear as MOTD in absence of the motd.md file]",`
     `"masterServer": "meta.terasology.org"`
- Now start the server again and start a client.
- Join the server (localhost if on the same machine).
