### PR TITLE
Slight update to the code metrics / scanning stuff.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     natives group: 'org.lwjgl.lwjgl', name: 'lwjgl', version: LwjglVersion
 
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
-    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.1.0', ext: 'zip'
+    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.2.0', ext: 'zip'
 }
 
 task extractWindowsNatives(type:Sync) {


### PR DESCRIPTION
Brings in https://github.com/MovingBlocks/TeraConfig/releases/tag/v1.2.0 to the engine - two tiny tweaks for Checkstyle, including the fix for #3113

Does enable nagging over empty Javadoc so it'll add some new warnings.

Requires updating the metrics config files via `gradlew extractConfig` or it won't make a difference. On the plus side no IntelliJ restart needed, just hit the button that reloads Checkstyle rules!