### PR TITLE
Fix typos and wildcard error in EnvironmentSwitchHandler

### DIFF
--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -64,6 +64,7 @@ public final class EnvironmentSwitchHandler {
     public EnvironmentSwitchHandler() {
     }
 
+    @SuppressWarnings("unchecked")
     public void handleSwitchToGameEnvironment(Context context) {
         ModuleManager moduleManager = context.get(ModuleManager.class);
 
@@ -75,11 +76,7 @@ public final class EnvironmentSwitchHandler {
             }
             Class<?> targetType = ReflectionUtil.getTypeParameterForSuper(copyStrategy, CopyStrategy.class, 0);
             if (targetType != null) {
-                try {
-                    copyStrategyLibrary.register(targetType, copyStrategy.newInstance());
-                } catch (InstantiationException | IllegalAccessException e) {
-                    logger.error("Cannot register CopyStrategy '{}' - failed to instantiate", copyStrategy, e);
-                }
+                registerCopyStrategy(copyStrategyLibrary, targetType, copyStrategy);
             } else {
                 logger.error("Cannot register CopyStrategy '{}' - unable to determine target type", copyStrategy);
             }
@@ -107,7 +104,7 @@ public final class EnvironmentSwitchHandler {
         ModuleAwareAssetTypeManager assetTypeManager = context.get(ModuleAwareAssetTypeManager.class);
 
         /*
-         * The registring of the prefab formats is done in this method, because it needs to be done before
+         * The registering of the prefab formats is done in this method, because it needs to be done before
          * the environment of the asset manager gets changed.
          *
          * It can't be done before this method gets called because the ComponentLibrary isn't
@@ -121,6 +118,14 @@ public final class EnvironmentSwitchHandler {
 
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
 
+    }
+
+    private <T, U extends CopyStrategy<T>> void registerCopyStrategy(CopyStrategyLibrary copyStrategyLibrary, Class<T> type, Class<U> strategy) {
+        try {
+            copyStrategyLibrary.register(type, strategy.newInstance());
+        } catch (InstantiationException | IllegalAccessException e) {
+            logger.error("Cannot register CopyStrategy '{}' - failed to instantiate", strategy, e);
+        }
     }
 
     /**
@@ -153,7 +158,7 @@ public final class EnvironmentSwitchHandler {
     }
 
 
-    public void handleSwitchToEmptyEnivronment(Context context) {
+    public void handleSwitchToEmptyEnvironment(Context context) {
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         cheapAssetManagerUpdate(context, environment);
     }

--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -150,7 +150,7 @@ public class StateIngame implements GameState {
         ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
         context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);
         if (!shuttingDown) {
-            context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnivronment(context);
+            context.get(EnvironmentSwitchHandler.class).handleSwitchToEmptyEnvironment(context);
         }
         if (oldEnvironment != null) {
             oldEnvironment.close();


### PR DESCRIPTION
Fixes a compile error in specification-compliant Java compilers, of which javac is not one.
