### PR TITLE
Refactor groovy module script - builds on #3164

### DIFF
--- a/module.groovy
+++ b/module.groovy
@@ -1,7 +1,7 @@
 // We use GrGit for interacting with Git. This gets a hold of it as a dependency like Gradle would
 // TODO: Consider if we should do something to fix/suppress the SLF4J warning that gets logged on first usage?
 @GrabResolver(name = 'jcenter', root = 'http://jcenter.bintray.com/')
-@Grab(group='org.ajoberstar', module='grgit', version='1.9.3')
+@Grab(group = 'org.ajoberstar', module = 'grgit', version = '1.9.3')
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Remote
 
@@ -179,77 +179,71 @@ def updateModule(String name) {
  * Accepts input from the user, showing a descriptive prompt.
  * @param prompt the prompt to show the user
  */
-def getUserString (String prompt) {
-    println ('\n*** ' + prompt + '\n')
+def getUserString(String prompt) {
+    println('\n*** ' + prompt + '\n')
 
-    def reader = new BufferedReader(new InputStreamReader(System.in)) // Note: Do not close reader, it will close System.in (Big no-no)
+    def reader = new BufferedReader(new InputStreamReader(System.in))
+    // Note: Do not close reader, it will close System.in (Big no-no)
 
     return reader.readLine()
 }
 
 /**
- *List all remotes of a module.
+ * List all remotes of a module.
  */
- def remoteList(String moduleName) {
-	 File moduleExistence = new File("modules/$moduleName")
-        if (!moduleExistence.exists()) {
-            println "Module $moduleName not found. Run gradlew module get $moduleName"
-            return
-        }
-	 def remoteGit = Grgit.open(dir: "modules/$moduleName")
-	 def remote = remoteGit.remote.list()
-	  x = 1
-	 for (Remote item : remote){
-		println (x + " " + item.name + " " + "(" + item.url + ")")
-		x += 1
-	 }
- }
- 
- /**
- *Add a remote.
- */
- def remoteAdd(String moduleName, String remoteName, String URL){
-	    File moduleExistence = new File("modules/$moduleName")
-        if (!moduleExistence.exists()) {
-            println "Module $moduleName not found. Run gradlew module get $moduleName"
-            return
-        }
-		def remoteGit = Grgit.open(dir: "modules/$moduleName")
-		def remote = remoteGit.remote.list()
-		def check = remote.find { it.name == "$remoteName" }
-		if(!check){
-		 remoteGit.remote.add(name: "$remoteName" , url: "$URL")
-		 println "Successfully added remote $remoteName for $moduleName"
-		}
-		else {
-		 println "Remote already exists"
-		}
-	
- }
- 
- def remoteAddAuto(String moduleName, String remoteName){
-	remoteAdd(moduleName, remoteName, "https://gitub.com/$remoteName/$moduleName"+".git")	
- }
- 
- def remote(String[] modules, String name) {
-    for (String module : modules) {
-		
-        remoteAdd(module, name, "https://gitub.com/$name/$module"+".git")
+def remoteList(String moduleName) {
+    File moduleExistence = new File("modules/$moduleName")
+    if (!moduleExistence.exists()) {
+        println "Module $moduleName not found. Run gradlew module get $moduleName"
+        return
+    }
+    def remoteGit = Grgit.open(dir: "modules/$moduleName")
+    def remote = remoteGit.remote.list()
+    x = 1
+    for (Remote item : remote) {
+        println(x + " " + item.name + " " + "(" + item.url + ")")
+        x += 1
     }
 }
-def lstremote(){
-	
-	def remoteGit = Grgit.open(dir: "modules/Sample")
-	
-	Grgit.lsremote(){
-		
-  heads = true
-  tags = true
-  remote = 'Sample'
-	}
 
-	
+/**
+ * Add a remote.
+ */
+def remoteAdd(String moduleName, String remoteName, String URL) {
+    File moduleExistence = new File("modules/$moduleName")
+    if (!moduleExistence.exists()) {
+        println "Module $moduleName not found. Run gradlew module get $moduleName"
+        return
+    }
+    def remoteGit = Grgit.open(dir: "modules/$moduleName")
+    def remote = remoteGit.remote.list()
+    def check = remote.find { it.name == "$remoteName" }
+    if (!check) {
+        remoteGit.remote.add(name: "$remoteName", url: "$URL")
+        println "Successfully added remote $remoteName for $moduleName"
+    } else {
+        println "Remote already exists"
+    }
+}
 
+def remoteAddAuto(String moduleName, String remoteName) {
+    remoteAdd(moduleName, remoteName, "https://gitub.com/$remoteName/$moduleName" + ".git")
+}
+
+def remote(String[] modules, String name) {
+    for (String module : modules) {
+        remoteAdd(module, name, "https://gitub.com/$name/$module" + ".git")
+    }
+}
+
+def lstremote() {
+    def remoteGit = Grgit.open(dir: "modules/Sample")
+
+    Grgit.lsremote() {
+        heads = true
+        tags = true
+        remote = 'Sample'
+    }
 }
 
 /**
@@ -259,13 +253,13 @@ def printUsage() {
     println ""
     println "Utility script for interacting with modules. Available sub commands:"
     println "- 'get' - retrieves one or more modules in source form (separate with spaces)"
-	println "        - use '-remote' to specify the name for the remotes of the newly cloned modules. "
+    println "        - use '-remote' to specify the name for the remotes of the newly cloned modules. "
     println "- 'recurse' - retrieves the given module(s) *and* their dependencies in source form"
     println "- 'create' - creates a new module"
     println "- 'update' - updates a module (git pulls latest from current origin, if workspace is clean"
     println "- 'update-all' - updates all local modules"
-	println "- 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with the default URL."
-	println "- 'add-remote (module) (name) (URL)' - adds a remote with the given URL"
+    println "- 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with the default URL."
+    println "- 'add-remote (module) (name) (URL)' - adds a remote with the given URL"
     println "- 'list-remotes (module)' - lists all remotes for (module) "
     println ""
     println "Example: 'groovyw module recurse GooeysQuests Sample' - would retrieve those modules plus their dependencies"
@@ -278,6 +272,7 @@ def printUsage() {
     println "A gradle.properties file (one exists under '/templates' in an engine workspace) can provide such overrides"
     println ""
 }
+
 //For proper fuctionality of get and remote (IGNORE)
 def remote_get_check = "False"
 
@@ -294,7 +289,7 @@ if (args.length == 0) {
         case "recurse":
             recurse = true
             println "We're retrieving recursively (all the things depended on too)"
-            // We just fall through here to the get logic after setting a boolean
+        // We just fall through here to the get logic after setting a boolean
         //noinspection GroovyFallthrough
         case "get":
             println "Preparing to get one or more modules"
@@ -307,59 +302,49 @@ if (args.length == 0) {
                 println "Now in an array: $moduleList"
                 retrieve moduleList, recurse
             } else {
-                
                 // Check for '-remote' and act accordingly.
-				
-				for (String item : args){
-				if (item == "-remote"){
-					String joint = args.join(" ")
-					String[] names = joint.split('-remote')
-					String[] moduleNames = names[0].split("\\s+")
-					def moduleNamesFinal = moduleNames.drop(1)
-					
-				    if (!(names.length == 2)){
-						// User did not specify the remote name, so ask for it.
-						def newName = getUserString('Enter Name for the Remote (no spaces)')
-                        println "Remote Name: $newName"
-						def remoteName = newName
-						retrieve moduleNamesFinal, recurse
-					    remote moduleNamesFinal, remoteName
-						println "All done retrieving requested modules: $moduleNamesFinal"
-						break
-					}
-					else {
-						def remoteName = names[1]
-						String[] checklist = remoteName.split("\\s+")
-						if (checklist.length == 2){
-						retrieve moduleNamesFinal, recurse
-					    remote moduleNamesFinal, remoteName.trim()
-						println "All done retrieving requested modules: $moduleNamesFinal"
-						}
-						else {
-							println "Please input one remote name only (no spaces)."
-						}
-					}
-					
-                break
-				}
-				
-				// If '-remote' not present then check for '/' syntax. LEFT TO BE DONE
-				
-				for (String item2 : args)
-					if (item2 == "-remote"){
-						remote_get_check = "True"
-					}
-				
-				}
-				//If no '-remote' is specified (normal operation)
-				if (!(remote_get_check == "True")){
-					def adjustedArgs = args.drop(1)
-					println "Retrieving: $adjustedArgs"
-					retrieve adjustedArgs, recurse
-				}
-				
+                for (String item : args) {
+                    if (item == "-remote") {
+                        String joint = args.join(" ")
+                        String[] names = joint.split('-remote')
+                        String[] moduleNames = names[0].split("\\s+")
+                        def moduleNamesFinal = moduleNames.drop(1)
+
+                        if (!(names.length == 2)) {
+                            // User did not specify the remote name, so ask for it.
+                            def newName = getUserString('Enter Name for the Remote (no spaces)')
+                            println "Remote Name: $newName"
+                            def remoteName = newName
+                            retrieve moduleNamesFinal, recurse
+                            remote moduleNamesFinal, remoteName
+                            println "All done retrieving requested modules: $moduleNamesFinal"
+                            break
+                        } else {
+                            def remoteName = names[1]
+                            String[] checklist = remoteName.split("\\s+")
+                            if (checklist.length == 2) {
+                                retrieve moduleNamesFinal, recurse
+                                remote moduleNamesFinal, remoteName.trim()
+                                println "All done retrieving requested modules: $moduleNamesFinal"
+                            } else {
+                                println "Please input one remote name only (no spaces)."
+                            }
+                        }
+                        break
+                    }
+                    // If '-remote' not present then check for '/' syntax. LEFT TO BE DONE
+                    for (String item2 : args)
+                        if (item2 == "-remote") {
+                            remote_get_check = "True"
+                        }
+                }
+                //If no '-remote' is specified (normal operation)
+                if (!(remote_get_check == "True")) {
+                    def adjustedArgs = args.drop(1)
+                    println "Retrieving: $adjustedArgs"
+                    retrieve adjustedArgs, recurse
+                }
             }
-            
             break
         case "create":
             println "We're doing a create"
@@ -367,12 +352,12 @@ if (args.length == 0) {
 
             // Get new module's name
             if (args.length > 2) {
-              println "Received more than one argument. Aborting."
-              break
+                println "Received more than one argument. Aborting."
+                break
             } else if (args.length == 2) {
-              name = args[1]
+                name = args[1]
             } else {
-              name = getUserString("Enter module name: ")
+                name = getUserString("Enter module name: ")
             }
             println "User wants to create a module named: $name"
 
@@ -393,7 +378,7 @@ if (args.length == 0) {
                 moduleList = args.drop(1)
             }
             println "List of modules to update: $moduleList"
-            for (String module: moduleList) {
+            for (String module : moduleList) {
                 updateModule(module)
             }
             break
@@ -407,41 +392,37 @@ if (args.length == 0) {
                 }
             }
             break
-		case "add-remote":
-			if (args.length == 3){
-				moduleName = args[1]
-				remoteName = args[2]
-				println "Adding Remote for $moduleName module."
-				remoteAddAuto(moduleName,remoteName)
-			}
-			else if (args.length == 4){
-				moduleName = args[1]
-				remoteName = args[2]
-				url = args[3]
-				println "Adding Remote for $moduleName module."
-				remoteAdd(moduleName,remoteName,url)
-			}
-			else {
-				println "Incorrect Syntax"
-				println "Usage: 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with default URL."
-				println "       'add-remote (module) (name)' - adds a remote to the module with the given URL."
-    
-			}
-			break
-		case "list-remotes":
-			if (args.length == 2){
-			moduleName = args[1]
-			println "Listing Remotes for $moduleName module."
-			remoteList(moduleName)
-			}
-	        else{
-				println "Incorrect Syntax"
-			println "Usage: 'list-remotes (module)' - lists all remotes for (module)"
-			}
-			break
-		case "lsremote":
-			lstremote()
-			break
+        case "add-remote":
+            if (args.length == 3) {
+                moduleName = args[1]
+                remoteName = args[2]
+                println "Adding Remote for $moduleName module."
+                remoteAddAuto(moduleName, remoteName)
+            } else if (args.length == 4) {
+                moduleName = args[1]
+                remoteName = args[2]
+                url = args[3]
+                println "Adding Remote for $moduleName module."
+                remoteAdd(moduleName, remoteName, url)
+            } else {
+                println "Incorrect Syntax"
+                println "Usage: 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with default URL."
+                println "       'add-remote (module) (name)' - adds a remote to the module with the given URL."
+            }
+            break
+        case "list-remotes":
+            if (args.length == 2) {
+                moduleName = args[1]
+                println "Listing Remotes for $moduleName module."
+                remoteList(moduleName)
+            } else {
+                println "Incorrect Syntax"
+                println "Usage: 'list-remotes (module)' - lists all remotes for (module)"
+            }
+            break
+        case "lsremote":
+            lstremote()
+            break
         default:
             println "UNRECOGNIZED COMMAND - please try again or use 'groovyw module usage' for help"
     }

--- a/module.groovy
+++ b/module.groovy
@@ -191,7 +191,11 @@ def getUserString (String prompt) {
  *List all remotes of a module.
  */
  def remoteList(String moduleName) {
-	 
+	 File moduleExistence = new File("modules/$moduleName")
+        if (!moduleExistence.exists()) {
+            println "Module $moduleName not found. Run gradlew module get $moduleName"
+            return
+        }
 	 def remoteGit = Grgit.open(dir: "modules/$moduleName")
 	 def remote = remoteGit.remote.list()
 	  x = 1
@@ -205,7 +209,11 @@ def getUserString (String prompt) {
  *Add a remote.
  */
  def remoteAdd(String moduleName, String remoteName, String URL){
-	
+	    File moduleExistence = new File("modules/$moduleName")
+        if (!moduleExistence.exists()) {
+            println "Module $moduleName not found. Run gradlew module get $moduleName"
+            return
+        }
 		def remoteGit = Grgit.open(dir: "modules/$moduleName")
 		def remote = remoteGit.remote.list()
 		def check = remote.find { it.name == "$remoteName" }
@@ -220,11 +228,7 @@ def getUserString (String prompt) {
  }
  
  def remoteAddAuto(String moduleName, String remoteName){
-	 def module_rep_Name = getUserString("Enter Name for the Module in $remoteName Repository (default - $moduleName)")
-		if (module_rep_Name == ""){
-			module_rep_Name = moduleName
-		}
-	remoteAdd(moduleName, remoteName, "https://gitub.com/$remoteName/$module_rep_Name"+".git")	
+	remoteAdd(moduleName, remoteName, "https://gitub.com/$remoteName/$moduleName"+".git")	
  }
  
  def remote(String[] modules, String name) {
@@ -232,6 +236,20 @@ def getUserString (String prompt) {
 		
         remoteAdd(module, name, "https://gitub.com/$name/$module"+".git")
     }
+}
+def lstremote(){
+	
+	def remoteGit = Grgit.open(dir: "modules/Sample")
+	
+	Grgit.lsremote(){
+		
+  heads = true
+  tags = true
+  remote = 'Sample'
+	}
+
+	
+
 }
 
 /**
@@ -246,7 +264,8 @@ def printUsage() {
     println "- 'create' - creates a new module"
     println "- 'update' - updates a module (git pulls latest from current origin, if workspace is clean"
     println "- 'update-all' - updates all local modules"
-	println "- 'add-remote (module) (name)' - adds a remote (name) to modules/(module) "
+	println "- 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with the default URL."
+	println "- 'add-remote (module) (name) (URL)' - adds a remote with the given URL"
     println "- 'list-remotes (module)' - lists all remotes for (module) "
     println ""
     println "Example: 'groovyw module recurse GooeysQuests Sample' - would retrieve those modules plus their dependencies"
@@ -390,14 +409,22 @@ if (args.length == 0) {
             break
 		case "add-remote":
 			if (args.length == 3){
-			moduleName = args[1]
-			remoteName = args[2]
-			println "Adding Remotes for $moduleName module."
-			remoteAddAuto(moduleName,remoteName)
+				moduleName = args[1]
+				remoteName = args[2]
+				println "Adding Remote for $moduleName module."
+				remoteAddAuto(moduleName,remoteName)
+			}
+			else if (args.length == 4){
+				moduleName = args[1]
+				remoteName = args[2]
+				url = args[3]
+				println "Adding Remote for $moduleName module."
+				remoteAdd(moduleName,remoteName,url)
 			}
 			else {
 				println "Incorrect Syntax"
-				println "Usage: 'add-remote (module) (name)' - adds a remote (name) to modules/(module) "
+				println "Usage: 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with default URL."
+				println "       'add-remote (module) (name)' - adds a remote to the module with the given URL."
     
 			}
 			break
@@ -411,6 +438,9 @@ if (args.length == 0) {
 				println "Incorrect Syntax"
 			println "Usage: 'list-remotes (module)' - lists all remotes for (module)"
 			}
+			break
+		case "lsremote":
+			lstremote()
 			break
         default:
             println "UNRECOGNIZED COMMAND - please try again or use 'groovyw module usage' for help"

--- a/module.groovy
+++ b/module.groovy
@@ -124,11 +124,11 @@ String[] readModuleDependencies(File targetModuleInfo) {
 /**
  * Creates a new module with the given name and adds the necessary .gitignore,
  * build.gradle and module.txt files.
- * @param name the name of the module to be created
+ * @param moduleName the name of the module to be created
  */
-def createModule(String name) {
+def createModule(String moduleName) {
     // Check if the module already exists. If not, create the module directory
-    File targetDir = new File("modules/$name")
+    File targetDir = new File("modules/$moduleName")
     if (targetDir.exists()) {
         println "Target directory already exists. Aborting."
         return
@@ -152,10 +152,11 @@ def createModule(String name) {
     println "Creating module.txt"
     File moduleManifest = new File(targetDir, "module.txt")
     def moduleText = new File("templates/module.txt").text
-    moduleManifest << moduleText.replaceAll('MODULENAME', name)
+    moduleManifest << moduleText.replaceAll('MODULENAME', moduleName)
 
     // Initialize git
     Grgit.init dir: targetDir, bare: false
+    addRemote(moduleName, "origin", "https://github.com/Terasology/${moduleName}.git")
 }
 
 /**
@@ -357,7 +358,7 @@ if (args.length == 0) {
             break
         case "create":
             println "We're doing a create"
-            String name = ""
+            String name
 
             // Get new module's name
             if (args.length > 2) {
@@ -376,7 +377,7 @@ if (args.length == 0) {
             break
         case "update":
             println "We're updating modules"
-            String[] moduleList = []
+            String[] moduleList
             if (args.length == 1) {
                 // User hasn't supplied any module names, so ask
                 def moduleString = getUserString('Enter Module Name(s - separate multiple with spaces, CapiTaliZation MatterS): ')

--- a/module.groovy
+++ b/module.groovy
@@ -5,7 +5,6 @@
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Remote
 
-
 import groovy.json.JsonSlurper
 
 // Grab override properties from the gradle.properties file (shared with various Gradle commands)
@@ -279,7 +278,7 @@ if (args.length == 0) {
             } else {
                 // User has supplied one or more module names, so pass them forward (skipping the "get" arg)
                 def adjustedArgs = args.drop(1)
-                println "Adjusted args: $adjustedArgs"
+                // Check for '-remote' and act accordingly.
 				for (String item : args){
 				if (item == "-remote"){
 					String hint = args.join(" ")
@@ -292,6 +291,8 @@ if (args.length == 0) {
 					retrieve adjustedFinal2, recurse
 					remote adjustedFinal2, old.trim()
 				}
+				// If '-remote' not present then check for '/' syntax. LEFT TO BE DONE
+				
 				}			
 				
                 

--- a/module.groovy
+++ b/module.groovy
@@ -189,12 +189,13 @@ def getUserString(String prompt) {
 }
 
 /**
- * List all remotes of a module.
+ * List all existing Git remotes for a given module.
+ * @param moduleName the module to list remotes for
  */
-def remoteList(String moduleName) {
+def listRemotes(String moduleName) {
     File moduleExistence = new File("modules/$moduleName")
     if (!moduleExistence.exists()) {
-        println "Module $moduleName not found. Run gradlew module get $moduleName"
+        println "Module '$moduleName' not found. Typo? Or run 'groovyw module get $moduleName' first"
         return
     }
     def remoteGit = Grgit.open(dir: "modules/$moduleName")
@@ -207,12 +208,16 @@ def remoteList(String moduleName) {
 }
 
 /**
- * Add a remote.
+ * Add a new Git remote for the given module.
+ * @param moduleName the module to add the remote for
+ * @param remoteName the name to give the new remote
+ * @param URL address to the remote Git repo
  */
-def remoteAdd(String moduleName, String remoteName, String URL) {
-    File moduleExistence = new File("modules/$moduleName")
-    if (!moduleExistence.exists()) {
-        println "Module $moduleName not found. Run gradlew module get $moduleName"
+
+def addRemote(String moduleName, String remoteName, String URL) {
+    File targetModule = new File("modules/$moduleName")
+    if (!targetModule.exists()) {
+        println "Module '$moduleName' not found. Typo? Or run 'groovyw module get $moduleName' first"
         return
     }
     def remoteGit = Grgit.open(dir: "modules/$moduleName")
@@ -226,13 +231,23 @@ def remoteAdd(String moduleName, String remoteName, String URL) {
     }
 }
 
-def remoteAddAuto(String moduleName, String remoteName) {
-    remoteAdd(moduleName, remoteName, "https://gitub.com/$remoteName/$moduleName" + ".git")
+/**
+ * Add a new Git remote for the given module, deducing a standard URL to the repo.
+ * @param moduleName the module to add the remote for
+ * @param remoteName the name to give the new remote
+ */
+def addRemote(String moduleName, String remoteName) {
+    addRemote(moduleName, remoteName, "https://github.com/$remoteName/$moduleName" + ".git")
 }
 
-def remote(String[] modules, String name) {
+/**
+ * Add new Git remotes for the given modules, all using the same remote name.
+ * @param modules the modules to add remotes for
+ * @param name the name to use for all the Git remotes
+ */
+def addRemotes(String[] modules, String name) {
     for (String module : modules) {
-        remoteAdd(module, name, "https://gitub.com/$name/$module" + ".git")
+        addRemote(module, name)
     }
 }
 
@@ -243,7 +258,7 @@ def printUsage() {
     println ""
     println "Utility script for interacting with modules. Available sub commands:"
     println "- 'get' - retrieves one or more modules in source form (separate with spaces)"
-    println "        - use '-remote' to specify the name for the remotes of the newly cloned modules. "
+    println "        - add '-remote [someRemote]' to define an additional remote for the newly cloned module(s). "
     println "- 'recurse' - retrieves the given module(s) *and* their dependencies in source form"
     println "- 'create' - creates a new module"
     println "- 'update' - updates a module (git pulls latest from current origin, if workspace is clean"
@@ -306,7 +321,7 @@ if (args.length == 0) {
                             println "Remote Name: $newName"
                             def remoteName = newName
                             retrieve moduleNamesFinal, recurse
-                            remote moduleNamesFinal, remoteName
+                            addRemotes moduleNamesFinal, remoteName
                             println "All done retrieving requested modules: $moduleNamesFinal"
                             break
                         } else {
@@ -314,7 +329,7 @@ if (args.length == 0) {
                             String[] checklist = remoteName.split("\\s+")
                             if (checklist.length == 2) {
                                 retrieve moduleNamesFinal, recurse
-                                remote moduleNamesFinal, remoteName.trim()
+                                addRemotes moduleNamesFinal, remoteName.trim()
                                 println "All done retrieving requested modules: $moduleNamesFinal"
                             } else {
                                 println "Please input one remote name only (no spaces)."
@@ -386,25 +401,25 @@ if (args.length == 0) {
             if (args.length == 3) {
                 moduleName = args[1]
                 remoteName = args[2]
-                println "Adding Remote for $moduleName module."
-                remoteAddAuto(moduleName, remoteName)
+                println "Adding Remote for module $moduleName"
+                addRemote(moduleName, remoteName)
             } else if (args.length == 4) {
                 moduleName = args[1]
                 remoteName = args[2]
                 url = args[3]
-                println "Adding Remote for $moduleName module."
-                remoteAdd(moduleName, remoteName, url)
+                println "Adding Remote for module $moduleName"
+                addRemote(moduleName, remoteName, url)
             } else {
                 println "Incorrect Syntax"
                 println "Usage: 'add-remote (module) (name)' - adds a remote (name) to modules/(module) with default URL."
-                println "       'add-remote (module) (name)' - adds a remote to the module with the given URL."
+                println "       'add-remote (module) (name) (url)' - adds a remote to the module with the given URL."
             }
             break
         case "list-remotes":
             if (args.length == 2) {
                 moduleName = args[1]
-                println "Listing Remotes for $moduleName module."
-                remoteList(moduleName)
+                println "Listing Remotes for module $moduleName"
+                listRemotes(moduleName)
             } else {
                 println "Incorrect Syntax"
                 println "Usage: 'list-remotes (module)' - lists all remotes for (module)"

--- a/module.groovy
+++ b/module.groovy
@@ -92,8 +92,8 @@ def retrieveModule(String module, boolean recurse) {
             println "Doing a retrieve from a custom remote: $githubHome - will name it as such plus add the Terasology remote as 'origin'"
             //noinspection GroovyAssignabilityCheck - GrGit has its own .clone but a warning gets issued for Object.clone
             Grgit.clone dir: targetDir, uri: targetUrl, remote: githubHome
-            println "Primary clone operation complete, about to add the 'origin' remote"
-            addRemote(module, "origin", "https://github.com/Terasology/${module}.git")
+            println "Primary clone operation complete, about to add the 'origin' remote for the Terasology org address"
+            addRemote(module, "origin", "https://github.com/Terasology/${module}")
         } else {
             //noinspection GroovyAssignabilityCheck - GrGit has its own .clone but a warning gets issued for Object.clone
             Grgit.clone dir: targetDir, uri: targetUrl
@@ -272,12 +272,14 @@ def addRemote(String moduleName, String remoteName, String url) {
     def remote = remoteGit.remote.list()
     def check = remote.find { it.name == "$remoteName" }
     if (!check) {
+        // Always add the remote whether it exists or not
+        remoteGit.remote.add(name: "$remoteName", url: "$url")
+        // But then do a validation check to advise the user and do a fetch if it is valid
         if (isUrlValid(url)) {
-            remoteGit.remote.add(name: "$remoteName", url: "$url")
-            println "Successfully added remote $remoteName for $moduleName - doing a 'git fetch'"
+            println "Successfully added remote '$remoteName' for '$moduleName' - doing a 'git fetch'"
             remoteGit.fetch remote: remoteName
         } else {
-            println "Unable to add remote '$remoteName' - URL $url failed a test lookup. Typo? Not created yet?"
+            println "Added the remote '$remoteName' for module '$moduleName' - but the URL $url failed a test lookup. Typo? Not created yet?"
         }
     } else {
         println "Remote already exists"

--- a/module.groovy
+++ b/module.groovy
@@ -26,6 +26,19 @@ modulesRetrieved = []
 excludedDependencies = ["engine", "Core", "CoreSampleGameplay", "BuilderSampleGameplay"]
 
 /**
+ * Accepts input from the user, showing a descriptive prompt.
+ * @param prompt the prompt to show the user
+ */
+def getUserString(String prompt) {
+    println('\n*** ' + prompt + '\n')
+
+    def reader = new BufferedReader(new InputStreamReader(System.in))
+    // Note: Do not close reader, it will close System.in (Big no-no)
+
+    return reader.readLine()
+}
+
+/**
  * Primary entry point for retrieving modules, kicks off recursively if needed.
  * @param modules the modules we want to retrieve
  * @param recurse whether to also retrieve dependencies of the desired modules
@@ -184,19 +197,6 @@ def updateModule(String name) {
 }
 
 /**
- * Accepts input from the user, showing a descriptive prompt.
- * @param prompt the prompt to show the user
- */
-def getUserString(String prompt) {
-    println('\n*** ' + prompt + '\n')
-
-    def reader = new BufferedReader(new InputStreamReader(System.in))
-    // Note: Do not close reader, it will close System.in (Big no-no)
-
-    return reader.readLine()
-}
-
-/**
  * List all existing Git remotes for a given module.
  * @param moduleName the module to list remotes for
  */
@@ -214,6 +214,27 @@ def listRemotes(String moduleName) {
         x += 1
     }
 }
+
+/**
+ * Add new Git remotes for the given modules, all using the same remote name.
+ * @param modules the modules to add remotes for
+ * @param name the name to use for all the Git remotes
+ */
+def addRemotes(String[] modules, String name) {
+    for (String module : modules) {
+        addRemote(module, name)
+    }
+}
+
+/**
+ * Add a new Git remote for the given module, deducing a standard URL to the repo.
+ * @param moduleName the module to add the remote for
+ * @param remoteName the name to give the new remote
+ */
+def addRemote(String moduleName, String remoteName) {
+    addRemote(moduleName, remoteName, "https://github.com/$remoteName/$moduleName" + ".git")
+}
+
 
 /**
  * Add a new Git remote for the given module.
@@ -236,26 +257,6 @@ def addRemote(String moduleName, String remoteName, String URL) {
         println "Successfully added remote $remoteName for $moduleName"
     } else {
         println "Remote already exists"
-    }
-}
-
-/**
- * Add a new Git remote for the given module, deducing a standard URL to the repo.
- * @param moduleName the module to add the remote for
- * @param remoteName the name to give the new remote
- */
-def addRemote(String moduleName, String remoteName) {
-    addRemote(moduleName, remoteName, "https://github.com/$remoteName/$moduleName" + ".git")
-}
-
-/**
- * Add new Git remotes for the given modules, all using the same remote name.
- * @param modules the modules to add remotes for
- * @param name the name to use for all the Git remotes
- */
-def addRemotes(String[] modules, String name) {
-    for (String module : modules) {
-        addRemote(module, name)
     }
 }
 

--- a/module.groovy
+++ b/module.groovy
@@ -219,8 +219,17 @@ def getUserString (String prompt) {
 	
  }
  
+ def remoteAddAuto(String moduleName, String remoteName){
+	 def module_rep_Name = getUserString("Enter Name for the Module in $remoteName Repository (default - $moduleName)")
+		if (module_rep_Name == ""){
+			module_rep_Name = moduleName
+		}
+	remoteAdd(moduleName, remoteName, "https://gitub.com/$remoteName/$module_rep_Name"+".git")	
+ }
+ 
  def remote(String[] modules, String name) {
     for (String module : modules) {
+		
         remoteAdd(module, name, "https://gitub.com/$name/$module"+".git")
     }
 }
@@ -237,7 +246,7 @@ def printUsage() {
     println "- 'create' - creates a new module"
     println "- 'update' - updates a module (git pulls latest from current origin, if workspace is clean"
     println "- 'update-all' - updates all local modules"
-	println "- 'add-remote (module) (name) (URL)' - adds a remote (name) with url (URL) to modules/(module) "
+	println "- 'add-remote (module) (name)' - adds a remote (name) to modules/(module) "
     println "- 'list-remotes (module)' - lists all remotes for (module) "
     println ""
     println "Example: 'groovyw module recurse GooeysQuests Sample' - would retrieve those modules plus their dependencies"
@@ -380,16 +389,15 @@ if (args.length == 0) {
             }
             break
 		case "add-remote":
-			if (args.length == 4){
+			if (args.length == 3){
 			moduleName = args[1]
 			remoteName = args[2]
-			url = args[3]
 			println "Adding Remotes for $moduleName module."
-			remoteAdd(moduleName,remoteName,url)
+			remoteAddAuto(moduleName,remoteName)
 			}
 			else {
 				println "Incorrect Syntax"
-				println "Usage: 'add-remote (module) (name) (URL)' - adds a remote (name) with url (URL) to modules/(module) "
+				println "Usage: 'add-remote (module) (name)' - adds a remote (name) to modules/(module) "
     
 			}
 			break

--- a/module.groovy
+++ b/module.groovy
@@ -236,16 +236,6 @@ def remote(String[] modules, String name) {
     }
 }
 
-def lstremote() {
-    def remoteGit = Grgit.open(dir: "modules/Sample")
-
-    Grgit.lsremote() {
-        heads = true
-        tags = true
-        remote = 'Sample'
-    }
-}
-
 /**
  * Simply prints usage information.
  */
@@ -419,9 +409,6 @@ if (args.length == 0) {
                 println "Incorrect Syntax"
                 println "Usage: 'list-remotes (module)' - lists all remotes for (module)"
             }
-            break
-        case "lsremote":
-            lstremote()
             break
         default:
             println "UNRECOGNIZED COMMAND - please try again or use 'groovyw module usage' for help"


### PR DESCRIPTION
This enhances PR #3164 from @digitalripperynr some - contains a variety of code quality and clarity improvements I think would be a bit much to expect from a GCI task, since you can kinda keep moving and changing things around a while before settling on something that seems satisfactory ;-)

I used fairly granular commits to point out various good practices and to keep the changes easier to see.

One extra enhancement is favoring the user-supplied remote over the default Git clone target under the Terasology org. The module repo will now be cloned from the user-supplied remote *but* that will be named accordingly while `origin` gets added as well, pointing to the Terasology org version of the module.

Sample output (tweaked a little for clarity):

```
C:\Dev\Terasology\Git\Terasology>groovyw module get Compass -remote Nanoware
Preparing to get one or more modules
Before processing custom remote: [get, Compass, -remote, Nanoware]
Going to look for and process remotes out of args if present - current: [get, Compass, -remote, Nanoware]
The remote arg was in position 2 and the value is -remote
Dropped two args from arguments which is now: [get, Compass]
Done with -remote if it was there, removing the first argument to leave only modules
After processing custom remote: [Compass]
Now inside retrieve, user (recursively? false) wants: [Compass]
Starting loop for module Compass, are we recursing? false
Modules retrieved so far: []
Request to retrieve module Compass would store it at modules\Compass - exists? false
Retrieving module Compass - if it doesn't appear to exist (typo for instance) you'll get an auth prompt (in case it is private)
Doing a retrieve from a custom remote: Nanoware - will name it as such plus add the Terasology remote as 'origin'
Successfully added remote origin for Compass

C:\Dev\Terasology\Git\Terasology>groovyw module list-remotes Compass
Listing Remotes for module Compass
1 Nanoware (https://github.com/Nanoware/Compass.git) <-- Clone happened from here
2 origin (https://github.com/Terasology/Compass.git)
```

Thanks @digitalripperynr for getting this kicked off and please review this in turn and let me know if you can find any problems with it and if you like the changes :-)

With this I'm somewhat walking away from the possibility of support for a command in the style of `Account/Module1 Account/Module2 Module3` - right now the cloning logic works off a class level variable so it is all or nothing. First it is set to either "Terasology" or the value loaded from `gradle.properties` (existing support, shared with various Gradle commands). Then if `-remote` is included that'll overwrite that variable.

I think adding a single automatic fetch to run after `add-remote` would be a nice touch, may look into how to do that real quick but not tonight :-)

Merging this should auto-close #3164 as merged, so nobody close that separately - just wait for this to get merged

Edit: Yay this also fixed the line endings so the overall diff is clean now

I'll also getting curious if the update commands would need to run a fetch first or if that's automatic ...