### PR TITLE
Fix explode sound

### DIFF
--- a/modules/Core/assets/prefabs/explodeTool.prefab
+++ b/modules/Core/assets/prefabs/explodeTool.prefab
@@ -9,8 +9,5 @@
     },
     "ExplosionAction": {
         "relativeTo": "Target"
-    },
-    "PlaySoundAction": {
-        "sounds": ["Explode1", "Explode2", "Explode3", "Explode4", "Explode5"]
     }
 }

--- a/modules/Core/assets/prefabs/railgunTool.prefab
+++ b/modules/Core/assets/prefabs/railgunTool.prefab
@@ -7,8 +7,5 @@
         "icon": "engine:items#dynamite",
         "usage": "IN_DIRECTION"
     },
-    "TunnelAction": {},
-    "PlaySoundAction": {
-        "sounds": ["Explode1", "Explode2", "Explode3", "Explode4", "Explode5"]
-    }
+    "TunnelAction": {}
 }

--- a/modules/Core/assets/prefabs/shallowRailgunTool.prefab
+++ b/modules/Core/assets/prefabs/shallowRailgunTool.prefab
@@ -10,14 +10,5 @@
     "TunnelAction": {
         "damageType": "core:NonDestructiveExplosiveDamage",
         "maxDestroyedBlocks": 300
-    },
-    "PlaySoundAction": {
-        "sounds": [
-            "Explode1",
-            "Explode2",
-            "Explode3",
-            "Explode4",
-            "Explode5"
-        ]
     }
 }

--- a/modules/Core/assets/prefabs/thoroughRailgunTool.prefab
+++ b/modules/Core/assets/prefabs/thoroughRailgunTool.prefab
@@ -10,14 +10,5 @@
     "TunnelAction": {
         "damageType": "core:DestructiveExplosiveDamage",
         "thoroughness": 1
-    },
-    "PlaySoundAction": {
-        "sounds": [
-            "Explode1",
-            "Explode2",
-            "Explode3",
-            "Explode4",
-            "Explode5"
-        ]
     }
 }

--- a/modules/Core/assets/prefabs/tnt.prefab
+++ b/modules/Core/assets/prefabs/tnt.prefab
@@ -1,7 +1,4 @@
 {
-    "PlaySoundAction": {
-        "sounds": ["Explode1", "Explode2", "Explode3", "Explode4", "Explode5"]
-    },
     "ExplosionAction": {
         "relativeTo": "Self",
         "maxRange": 120

--- a/modules/Core/src/main/java/org/terasology/logic/actions/TunnelAction.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/TunnelAction.java
@@ -15,6 +15,9 @@
  */
 package org.terasology.logic.actions;
 
+import com.google.common.collect.Lists;
+import org.terasology.audio.StaticSound;
+import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -29,11 +32,15 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.Physics;
 import org.terasology.registry.In;
+import org.terasology.utilities.Assets;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
+
+import java.util.List;
+import java.util.Optional;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class TunnelAction extends BaseComponentSystem {
@@ -50,13 +57,23 @@ public class TunnelAction extends BaseComponentSystem {
     private EntityManager entityManager;
 
     private Random random = new FastRandom();
+    private List<Optional<StaticSound>> explosionSounds = Lists.newArrayList();
 
     @Override
     public void initialise() {
+        explosionSounds.add(Assets.getSound("core:explode1"));
+        explosionSounds.add(Assets.getSound("core:explode2"));
+        explosionSounds.add(Assets.getSound("core:explode3"));
+        explosionSounds.add(Assets.getSound("core:explode4"));
+        explosionSounds.add(Assets.getSound("core:explode5"));
     }
 
     @Override
     public void shutdown() {
+    }
+
+    private StaticSound getRandomExplosionSound() {
+        return explosionSounds.get(random.nextInt(0, explosionSounds.size() - 1)).get();
     }
 
     @ReceiveEvent
@@ -101,6 +118,7 @@ public class TunnelAction extends BaseComponentSystem {
                         }
                         if (random.nextFloat() < tunnelActionComponent.thoroughness) {
                             EntityRef blockEntity = blockEntityRegistry.getEntityAt(blockPos);
+                            blockEntity.send(new PlaySoundEvent(getRandomExplosionSound(), 1.0f));
                             blockEntity.send(new DoDamageEvent(tunnelActionComponent.damageAmount, tunnelActionComponent.damageType));
                         }
 


### PR DESCRIPTION
### Contains

Fixes #3171 , also fixes the railgun which has the same problem.

### How to test

The explodeTool and the railgun should not play an explode sound when there's no block destroyed.
