### PR TITLE
Null check and warning log in ItemPickupAuthoritySystem if no block family for a block is present

### DIFF
--- a/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
@@ -17,6 +17,8 @@
 package org.terasology.logic.inventory;
 
 import com.bulletphysics.collision.shapes.BoxShape;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -44,6 +46,8 @@ import org.terasology.world.block.items.BlockItemComponent;
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class ItemPickupAuthoritySystem extends BaseComponentSystem {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ItemPickupAuthoritySystem.class);
+
     @In
     private EntitySystemLibrary library;
 
@@ -91,6 +95,7 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
         BlockFamily blockFamily = blockItemComponent.blockFamily;
 
         if (blockFamily == null) {
+            LOGGER.warn("Prefab " + itemEntity.getParentPrefab().getName() + " does not have a block family");
             return;
         }
 

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
@@ -89,6 +89,11 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
                                                  BlockItemComponent blockItemComponent,
                                                  BoxShapeComponent boxShapeComponent) {
         BlockFamily blockFamily = blockItemComponent.blockFamily;
+
+        if (blockFamily == null) {
+            return;
+        }
+
         if (blockFamily.getArchetypeBlock().getCollisionShape() instanceof BoxShape) {
             javax.vecmath.Vector3f extents = ((BoxShape) blockFamily.getArchetypeBlock().getCollisionShape()).getHalfExtentsWithoutMargin(new javax.vecmath.Vector3f());
             extents.scale(2.0f);


### PR DESCRIPTION
Resolves #3158.

### Testing
Load a world with the the BasicCrafting module enabled. Instead of a NPE as detailed in #3158 being thrown, an appropriate warning for the absence of a block family for the specified prefab is logged.
