### PR TITLE
Fix ambiguous class definition in FieldSerializeCheck

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/serializers/FieldSerializeCheck.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/FieldSerializeCheck.java
@@ -46,13 +46,13 @@ public interface FieldSerializeCheck<T> extends DeserializeFieldCheck {
      */
      final class NullCheck<T> implements FieldSerializeCheck<T> {
 
-        private static final NullCheck INSTANCE = new NullCheck();
+        private static final FieldSerializeCheck.NullCheck INSTANCE = new FieldSerializeCheck.NullCheck();
 
         private NullCheck() {
         }
 
         @SuppressWarnings("unchecked")
-        public static <T> NullCheck<T> newInstance() {
+        public static <T> FieldSerializeCheck.NullCheck<T> newInstance() {
             return INSTANCE;
         }
 


### PR DESCRIPTION
For some reason there is a compiler warning at `NetworkEntitySerializer:206`, the line looks like this:
`deserializeOnto(entity, entityData, FieldSerializeCheck.NullCheck.<Component>newInstance());`

`FieldSerializeCheck` extends `DeserializeFieldCheck` and both define an inner class withe the same name.

The situation can be reproduced with the following situation:
```
public interface Super {
    final class Something implements Super{
        private static Something INSTANCE = new Something();
        public static Something instance(){
            return INSTANCE;
        }
    }
}
public interface Sub extends Super{
    final class Something implements Sub{
        private static Something INSTANCE = new Something();
        public static Something instance(){
            return INSTANCE;
        }
    }
}
```
Error: _Reference to 'Something' is ambiguous, both 'Sub.Something' and 'Super.Something' match_
However it does compile and `System.out.println(Sub.Something.instance().getClass());` will print "class Sub$Something".