### PR TITLE
Allow non-block entities to explode

### DIFF
--- a/modules/Core/src/main/java/org/terasology/logic/actions/ExplosionAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/ExplosionAuthoritySystem.java
@@ -16,8 +16,6 @@
 package org.terasology.logic.actions;
 
 import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.audio.StaticSound;
 import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.entitySystem.entity.EntityBuilder;


### PR DESCRIPTION
### Contains

A modification of the ExplosionAuthoritySystem.
onDelayedExplosion event handler required the exploding entities to be a block. Now, with this modification, every entity which does have LocationComponent should be able to explode.

I have also made the DELAYED_EXPLOSION_ACTION_ID public to allow other systems use it, instead of statically defining it again in other places (Minesweeper module is the perfect example).