### PR TITLE
Add blockDamageModifierComponent null check

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -131,7 +131,14 @@ public class BlockEntitySystem extends BaseComponentSystem {
             entity.send(new OnBlockToItem(item));
 
             if (shouldDropToWorld(event, block, blockDamageModifierComponent, item)) {
-                processDropping(item, location, blockDamageModifierComponent.impulsePower);
+                float impulsePower;
+                if (blockDamageModifierComponent != null) {
+                    impulsePower = blockDamageModifierComponent.impulsePower;
+                } else {
+                    impulsePower = 0;
+                }
+                
+                processDropping(item, location, impulsePower);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -131,11 +131,9 @@ public class BlockEntitySystem extends BaseComponentSystem {
             entity.send(new OnBlockToItem(item));
 
             if (shouldDropToWorld(event, block, blockDamageModifierComponent, item)) {
-                float impulsePower;
+                float impulsePower = 0;
                 if (blockDamageModifierComponent != null) {
                     impulsePower = blockDamageModifierComponent.impulsePower;
-                } else {
-                    impulsePower = 0;
                 }
                 
                 processDropping(item, location, impulsePower);


### PR DESCRIPTION
Fixes #3196 and closes Terasology/Rails#32.

If `blockDamageModifierComponent` is null, uses `0` as the `impulsePower`.

## Testing
Problem detailed in Terasology/Rails#32 does not occur anymore, needs confirmation.
@anuar2k