### PR TITLE
Added ability to manipulate UIRadialSections on the run (+quick bugfix)

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialRing.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialRing.java
@@ -35,7 +35,6 @@ import java.util.List;
  * A radial menu widget
  */
 public class UIRadialRing extends CoreWidget {
-    private static final Logger logger = LoggerFactory.getLogger(UIRadialRing.class);
 
     @LayoutConfig
     private List<UIRadialSection> sections = new ArrayList<>();

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialRing.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialRing.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.rendering.nui.widgets;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.rendering.nui.BaseInteractionListener;
@@ -26,13 +28,21 @@ import org.terasology.rendering.nui.events.NUIMouseDragEvent;
 import org.terasology.rendering.nui.events.NUIMouseOverEvent;
 import org.terasology.rendering.nui.events.NUIMouseReleaseEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A radial menu widget
  */
 public class UIRadialRing extends CoreWidget {
+    private static final Logger logger = LoggerFactory.getLogger(UIRadialRing.class);
 
     @LayoutConfig
-    private UIRadialSection[] sections = {};
+    private List<UIRadialSection> sections = new ArrayList<>();
+
+    public int getSelectedTab() {
+        return selectedTab;
+    }
 
     private int selectedTab = -1;
     private boolean hasInitialised;
@@ -44,11 +54,11 @@ public class UIRadialRing extends CoreWidget {
         public void onMouseOver(NUIMouseOverEvent event) {
             int sectionOver = getSectionOver(event.getRelativeMousePosition());
             if (selectedTab != -1) {
-                sections[selectedTab].setSelected(false);
+                sections.get(selectedTab).setSelected(false);
             }
 
             if (sectionOver != -1) {
-                sections[sectionOver].setSelected(true);
+                sections.get(sectionOver).setSelected(true);
             }
             selectedTab = sectionOver;
         }
@@ -65,8 +75,8 @@ public class UIRadialRing extends CoreWidget {
         @Override
         public void onMouseRelease(NUIMouseReleaseEvent event) {
             if (selectedTab != -1) {
-                sections[selectedTab].setSelected(false);
-                sections[selectedTab].activateSection();
+                sections.get(selectedTab).setSelected(false);
+                sections.get(selectedTab).activateSection();
                 selectedTab = -1;
             }
         }
@@ -91,7 +101,7 @@ public class UIRadialRing extends CoreWidget {
         int sectionWidth = region.width() / 4;
         double offset = sectionWidth * 1.5;
         radius = sectionWidth * 2;
-        sectionAngle = (Math.PI * 2) / sections.length;
+        sectionAngle = (Math.PI * 2) / sections.size();
         int infoSquareSize = (int) (radius * circleToSquare);
         int sectionSquareSize = (int) (sectionWidth * circleToSquare);
         Rect2i infoRegion = Rect2i.createFromMinAndSize(
@@ -100,16 +110,16 @@ public class UIRadialRing extends CoreWidget {
                 infoSquareSize,
                 infoSquareSize);
 
-        for (int i = 0; i < sections.length; i++) {
-            sections[i].setDrawRegion(Rect2i.createFromMinAndSize(
+        for (int i = 0; i < sections.size(); i++) {
+            sections.get(i).setDrawRegion(Rect2i.createFromMinAndSize(
                     (int) (Math.cos(i * sectionAngle + sectionAngle / 2) * offset + sectionWidth * 1.5),
                     (int) (Math.sin(i * sectionAngle + sectionAngle / 2) * offset + sectionWidth * 1.5),
                     sectionWidth, sectionWidth));
-            sections[i].setInnerRegion(Rect2i.createFromMinAndSize(
+            sections.get(i).setInnerRegion(Rect2i.createFromMinAndSize(
                     (int) (Math.cos(i * sectionAngle + sectionAngle / 2) * offset + sectionWidth * 1.5 + sectionSquareSize / 4),
                     (int) (Math.sin(i * sectionAngle + sectionAngle / 2) * offset + sectionWidth * 1.5 + sectionSquareSize / 4),
                     sectionSquareSize, sectionSquareSize));
-            sections[i].setInfoRegion(infoRegion);
+            sections.get(i).setInfoRegion(infoRegion);
         }
     }
 
@@ -120,9 +130,28 @@ public class UIRadialRing extends CoreWidget {
      * @param listener   The listener to attach
      */
     public void subscribe(int sectionNum, ActivateEventListener listener) {
-        if (sectionNum >= 0 && sectionNum < sections.length) {
-            sections[sectionNum].addListener(listener);
+        if (sectionNum >= 0 && sectionNum < sections.size()) {
+            sections.get(sectionNum).addListener(listener);
         }
+    }
+
+    public int addSection(UIRadialSection section) {
+        sections.add(section);
+        hasInitialised = false;
+        return sections.size()-1;
+    }
+
+    public UIRadialSection getSection(int index) {
+        return sections.get(index);
+    }
+
+    public void setSections(List<UIRadialSection> sections) {
+        this.sections = sections;
+        hasInitialised = false;
+    }
+
+    public List<UIRadialSection> getSections() {
+        return sections;
     }
 
     /**
@@ -132,8 +161,8 @@ public class UIRadialRing extends CoreWidget {
      * @param listener   The listener to unsubscribe
      */
     public void unsubscribe(int sectionNum, ActivateEventListener listener) {
-        if (sectionNum >= 0 && sectionNum < sections.length) {
-            sections[sectionNum].removeListener(listener);
+        if (sectionNum >= 0 && sectionNum < sections.size()) {
+            sections.get(sectionNum).removeListener(listener);
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialSection.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialSection.java
@@ -42,7 +42,7 @@ public class UIRadialSection extends CoreWidget {
     private Boolean isSelected = false;
     private List<ActivateEventListener> listeners;
 
-    //TODO: Use bindings in future. Currently broken. @rzats is investigating this.
+    //TODO: Use bindings in future. Previously used bindings were throwing some exceptions not even allowing to open the screen with UIRadialRing, so this is a quick fix - conversion from binded properties to standard ones.
     @LayoutConfig
     private TextureRegion icon;
     @LayoutConfig
@@ -120,7 +120,6 @@ public class UIRadialSection extends CoreWidget {
         isSelected = selected;
     }
 
-    //TODO: Use bindings in future. Currently broken.
     /**
      * Sets info widget
      */

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialSection.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIRadialSection.java
@@ -42,12 +42,13 @@ public class UIRadialSection extends CoreWidget {
     private Boolean isSelected = false;
     private List<ActivateEventListener> listeners;
 
+    //TODO: Use bindings in future. Currently broken. @rzats is investigating this.
     @LayoutConfig
-    private Binding<TextureRegion> icon = new DefaultBinding<>();
+    private TextureRegion icon;
     @LayoutConfig
-    private Binding<String> text = new DefaultBinding<>();
+    private String text;
     @LayoutConfig
-    private Binding<UIWidget> widget = new DefaultBinding<>();
+    private UIWidget widget;
 
     /**
      * Draws the widget
@@ -58,17 +59,17 @@ public class UIRadialSection extends CoreWidget {
         canvas.getRegion();
         canvas.drawTexture(sectionTexture, sectionRegion);
 
-        if (icon.get() != null) {
-            canvas.drawTexture(icon.get(), innerRegion);
+        if (icon != null) {
+            canvas.drawTexture(icon, innerRegion);
         }
 
-        if (text.get() != null) {
-            canvas.drawText(text.get(), innerRegion);
+        if (text != null) {
+            canvas.drawText(text, innerRegion);
         }
         if (isSelected) {
             canvas.drawTexture(selectedTexture, sectionRegion);
-            if (widget.get() != null) {
-                canvas.drawWidget(widget.get(), infoRegion);
+            if (widget != null) {
+                canvas.drawWidget(widget, infoRegion);
             }
         }
     }
@@ -119,38 +120,49 @@ public class UIRadialSection extends CoreWidget {
         isSelected = selected;
     }
 
+    //TODO: Use bindings in future. Currently broken.
     /**
      * Sets info widget
      */
     public void setInfoWidget(UIWidget infoWidget) {
-        widget.set(infoWidget);
-    }
-
-    public void setInfoWidget(Binding<UIWidget> infoWidget) {
         widget = infoWidget;
     }
+    //public void setInfoWidget(UIWidget infoWidget) {
+    //    widget.set(infoWidget);
+    //}
+
+    //public void setInfoWidget(Binding<UIWidget> infoWidget) {
+    //    widget = infoWidget;
+    //}
 
     /**
      * Set icon texture
      */
     public void setIcon(TextureRegion newIcon) {
-        icon.set(newIcon);
-    }
-
-    public void setIcon(Binding<TextureRegion> newIcon) {
         icon = newIcon;
     }
+    //public void setIcon(TextureRegion newIcon) {
+    //    icon.set(newIcon);
+    //}
+
+    //public void setIcon(Binding<TextureRegion> newIcon) {
+    //    icon = newIcon;
+    //}
 
     /**
      * Set section text
      */
     public void setText(String newText) {
-        text.set(newText);
-    }
-
-    public void setText(Binding<String> newText) {
         text = newText;
     }
+    //public void setText(String newText) {
+    //    text.set(newText);
+    //}
+
+    //public void setText(Binding<String> newText) {
+    //    text = newText;
+    //}
+
 
     /**
      * Sets the region in which to draw the info widget


### PR DESCRIPTION
### Contains
Brings UIRadialRing to usable state. Previous version was throwing an exception related to binding, so I converted these binded properties to standard ones (temporary fix).
I've added also some functionality to UIRadialRing and UIRadialSection to create them and manipulate during the runtime. Previous version accepted only values from 

### How to test
Just open the RadialRing example from TutorialNui. At least it works correctly now... :P