### PR TITLE
Added overloads for methods in ChunkImpl

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -49,7 +49,11 @@ public interface CoreChunk {
 
     Biome setBiome(int x, int y, int z, Biome biome);
 
+    Biome setBiome(BaseVector3i pos, Biome biome);
+
     Biome getBiome(int x, int y, int z);
+
+    Biome getBiome(BaseVector3i pos);
 
     void setLiquid(BaseVector3i pos, LiquidData state);
 

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -51,7 +51,6 @@ import java.text.DecimalFormat;
  * <br><br>
  * Chunks are tessellated on creation and saved to vertex arrays. From those VBOs are generated
  * which are then used for the actual rendering process.
- *
  */
 public class ChunkImpl implements Chunk {
 
@@ -266,6 +265,11 @@ public class ChunkImpl implements Chunk {
     }
 
     @Override
+    public Biome getBiome(BaseVector3i pos) {
+        return getBiome(pos.x(), pos.y(), pos.z());
+    }
+
+    @Override
     public Biome setBiome(int x, int y, int z, Biome biome) {
         if (biomeData == biomeDataSnapshot) {
             biomeData = biomeData.copy();
@@ -273,6 +277,11 @@ public class ChunkImpl implements Chunk {
         short shortId = biomeManager.getBiomeShortId(biome);
         short previousShortId = (short) biomeData.set(x, y, z, shortId);
         return biomeManager.getBiomeByShortId(previousShortId);
+    }
+
+    @Override
+    public Biome setBiome(BaseVector3i pos, Biome biome) {
+        return setBiome(pos.x(), pos.y(), pos.z(), biome);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Added overload for setBiome() and getBiome() with BaseVector3i, like set/getBlock() and set/getLiquid() already had.

