### PR TITLE
Add a logger when @Sender annotation is missing in EntityRef parameters

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/ComponentSystemManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/ComponentSystemManagerTest.java
@@ -1,23 +1,41 @@
 
 package org.terasology.engine;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.google.common.collect.Iterables;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.internal.EventSystem;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RenderSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.console.Console;
+import org.terasology.logic.console.commandSystem.MethodCommand;
+import org.terasology.logic.console.commandSystem.annotations.Command;
+import org.terasology.logic.console.commandSystem.annotations.CommandParam;
+import org.terasology.logic.console.commandSystem.annotations.Sender;
 
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class ComponentSystemManagerTest {
 
     private ComponentSystemManager systemUnderTest;
+    private Console console;
 
     @Before
     public void setUp() {
@@ -25,6 +43,8 @@ public class ComponentSystemManagerTest {
         EntityManager entityManager = mock(EntityManager.class);
         when(entityManager.getEventSystem()).thenReturn(mock(EventSystem.class));
         when(context.get(EntityManager.class)).thenReturn(entityManager);
+        console = mock(Console.class);
+        when(context.get(Console.class)).thenReturn(console);
         systemUnderTest = new ComponentSystemManager(context);
     }
 
@@ -67,4 +87,68 @@ public class ComponentSystemManagerTest {
         assertThat(Iterables.size(systemUnderTest.iterateRenderSubscribers()), is(0));
     }
 
+    @Test
+    public void shouldRegisterCommand(){
+        systemUnderTest.register(new SystemWithValidCommand());
+        systemUnderTest.initialise();
+
+        ArgumentCaptor<MethodCommand> methodCommandArgumentCaptor = ArgumentCaptor.forClass(MethodCommand.class);
+        verify(console).registerCommand(methodCommandArgumentCaptor.capture());
+
+        MethodCommand command = methodCommandArgumentCaptor.getValue();
+        assertThat(command.getName().toString(), is("validCommandName"));
+    }
+
+    @Test
+    public void shouldRegisterCommandWithoutSenderAnnotation() {
+        //see https://github.com/MovingBlocks/Terasology/issues/2679
+        systemUnderTest.register(new SystemWithCommandMissingSenderAnnotation());
+        systemUnderTest.initialise();
+
+        ArgumentCaptor<MethodCommand> methodCommandArgumentCaptor = ArgumentCaptor.forClass(MethodCommand.class);
+        verify(console).registerCommand(methodCommandArgumentCaptor.capture());
+
+        MethodCommand command = methodCommandArgumentCaptor.getValue();
+        assertThat(command.getName().toString(), is("commandWithoutSenderAnnotation"));
+    }
+
+    @Test
+    public void shouldLogErrorWhenRegisterCommandWithoutSenderAnnotation(){
+        //see https://github.com/MovingBlocks/Terasology/issues/2679
+        Appender<ILoggingEvent> appender = mockAppender();
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).addAppender(appender);
+
+        systemUnderTest.register(new SystemWithCommandMissingSenderAnnotation());
+        systemUnderTest.initialise();
+
+        ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(appender).doAppend(loggingEventArgumentCaptor.capture());
+        List<String> allErrorLogMessages = loggingEventArgumentCaptor.getAllValues().stream()
+                .filter(e -> e.getLevel().isGreaterOrEqual(Level.ERROR))
+                .map(LoggingEvent::getFormattedMessage)
+                .collect(toList());
+        String expectedMessage = "Command commandWithoutSenderAnnotation provided by " +
+                "SystemWithCommandMissingSenderAnnotation contains a EntityRef without @Sender annotation, " +
+                "may cause a NullPointerException";
+        assertThat(allErrorLogMessages, hasItem(expectedMessage));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Appender<ILoggingEvent> mockAppender() {
+        return mock(Appender.class);
+    }
+
+    private static class SystemWithValidCommand extends BaseComponentSystem {
+        @Command()
+        public String validCommandName(@CommandParam(value = "parameter") String value, @Sender EntityRef sender) {
+            return value;
+        }
+    }
+
+    private static class SystemWithCommandMissingSenderAnnotation extends BaseComponentSystem {
+        @Command()
+        public String commandWithoutSenderAnnotation(@CommandParam(value = "parameter") String value, EntityRef sender) {
+            return value;
+        }
+    }
 }

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
@@ -119,7 +119,7 @@ public final class MethodCommand extends AbstractCommand {
             }
 
         }
-        return false;
+        return true;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
@@ -117,7 +117,6 @@ public final class MethodCommand extends AbstractCommand {
                     }
                 }
             }
-
         }
         return true;
     }

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
@@ -87,24 +87,8 @@ public final class MethodCommand extends AbstractCommand {
         Predicate<? super Method> predicate = Predicates.<Method>and(ReflectionUtils.withModifier(Modifier.PUBLIC), ReflectionUtils.withAnnotation(Command.class));
         Set<Method> commandMethods = ReflectionUtils.getAllMethods(provider.getClass(), predicate);
         for (Method method : commandMethods) {
-            final Class[] paramTypes = method.getParameterTypes();
-            final Annotation[][] paramAnnotations = method.getParameterAnnotations();
-            boolean hasSenderAnnotation = false;
-            for (int i = 0; i < paramAnnotations.length; i++) {
-                if(paramTypes[i].getTypeName().equals(ENTITY_REF_NAME)) {
-                    if(paramAnnotations[i].length == 0) {
-                        logger.error("Command {} provided by {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName(), provider.getClass().getSimpleName());
-                    } else {
-                        for (Annotation annotation: paramAnnotations[i]) {
-                            if (annotation instanceof Sender) {
-                                hasSenderAnnotation = true;
-                            }
-                        }
-                        if(!hasSenderAnnotation){
-                            logger.error("Command {} provided by {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName(), provider.getClass().getSimpleName());
-                        }
-                    }
-                }
+            if(!hasSenderAnnotation(method)){
+                logger.error("Command {} provided by {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName(), provider.getClass().getSimpleName());
             }
             logger.debug("Registering command method {} in class {}", method.getName(), method.getDeclaringClass().getCanonicalName());
             try {
@@ -116,6 +100,26 @@ public final class MethodCommand extends AbstractCommand {
                 logger.error("Failed to load command method {} in class {}", method.getName(), method.getDeclaringClass().getCanonicalName(), t);
             }
         }
+    }
+
+    private static boolean hasSenderAnnotation(Method method) {
+        final Class[] paramTypes = method.getParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+        for (int i = 0; i < paramAnnotations.length; i++) {
+            if(paramTypes[i].getTypeName().equals(ENTITY_REF_NAME)) {
+                if(paramAnnotations[i].length == 0) {
+                    return false;
+                } else {
+                    for (Annotation annotation: paramAnnotations[i]) {
+                        if (annotation instanceof Sender) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+        }
+        return false;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
@@ -89,16 +89,19 @@ public final class MethodCommand extends AbstractCommand {
         for (Method method : commandMethods) {
             final Class[] paramTypes = method.getParameterTypes();
             final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+            boolean hasSenderAnnotation = false;
             for (int i = 0; i < paramAnnotations.length; i++) {
                 if(paramTypes[i].getTypeName().equals(ENTITY_REF_NAME)) {
                     if(paramAnnotations[i].length == 0) {
-                        logger.info("Command {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName());
+                        logger.error("Command {} provided by {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName(), provider.getClass().getSimpleName());
                     } else {
                         for (Annotation annotation: paramAnnotations[i]) {
                             if (annotation instanceof Sender) {
-                            } else {
-                                logger.info("Command {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName());
+                                hasSenderAnnotation = true;
                             }
+                        }
+                        if(!hasSenderAnnotation){
+                            logger.error("Command {} provided by {} contains a EntityRef without @Sender annotation, may cause a NullPointerException", method.getName(), provider.getClass().getSimpleName());
                         }
                     }
                 }

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/MethodCommand.java
@@ -101,7 +101,6 @@ public final class MethodCommand extends AbstractCommand {
                             }
                         }
                     }
-
                 }
             }
             logger.debug("Registering command method {} in class {}", method.getName(), method.getDeclaringClass().getCanonicalName());


### PR DESCRIPTION
### Contains

Fixes #2679 

### How to test

As mentioned by @oniatus in that issue, download the Hunger module and remove `@Sender` annotation from `hungerCheck` command. Run the game as a host and you will see a log saying `Command hungerCheck contains a EntityRef without @Sender annotation, may cause a NullPointerException`. Already pinged oniatus for potential testing. 🙂 
