### PR TITLE
changed Direction to rotation

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -19,6 +19,7 @@ import com.bulletphysics.collision.shapes.CollisionShape;
 import com.bulletphysics.linearmath.Transform;
 import com.google.common.collect.Maps;
 
+import org.terasology.math.Rotation;
 import org.terasology.utilities.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -73,8 +74,7 @@ public final class Block {
     private BlockUri uri;
     private String displayName = "Untitled block";
     private BlockFamily family;
-    // TODO: Remove this and replace with the rotation applied to the block
-    private Side direction = Side.FRONT;
+    private Rotation rotation = Rotation.none();
 
     /* PROPERTIES */
 
@@ -174,12 +174,16 @@ public final class Block {
         this.family = value;
     }
 
-    public void setDirection(Side direction) {
-        this.direction = direction;
+    public void setRotation(Rotation rotation) {
+        this.rotation = rotation;
+    }
+
+    public Rotation getRotation() {
+        return rotation;
     }
 
     public Side getDirection() {
-        return direction;
+        return rotation.rotate(Side.FRONT);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.terasology.math.Pitch;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -54,7 +55,7 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
         Map<Side, Block> blockMap = Maps.newEnumMap(Side.class);
         if (definition.getData().hasSection("top")) {
             Block block = blockBuilder.constructSimpleBlock(definition, "top");
-            block.setDirection(Side.TOP);
+            block.setRotation(Rotation.rotate(Pitch.CLOCKWISE_270));
             blockMap.put(Side.TOP, block);
         }
         if (definition.getData().hasSection("front")) {
@@ -65,7 +66,7 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
         }
         if (definition.getData().hasSection("bottom")) {
             Block block = blockBuilder.constructSimpleBlock(definition, "bottom");
-            block.setDirection(Side.BOTTOM);
+            block.setRotation(Rotation.rotate(Pitch.CLOCKWISE_90));
             blockMap.put(Side.BOTTOM, block);
         }
 

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
@@ -117,7 +117,7 @@ public class BlockBuilder implements BlockBuilderHelper {
     @Override
     public Block constructCustomBlock(String defaultName, BlockShape shape, Rotation rotation, SectionDefinitionData section) {
         Block block = createRawBlock(defaultName, section);
-        block.setDirection(rotation.rotate(Side.FRONT));
+        block.setRotation(rotation);
         block.setPrimaryAppearance(createAppearance(shape, section.getBlockTiles(), rotation));
         setBlockFullSides(block, shape, rotation);
         block.setCollision(shape.getCollisionOffset(rotation), shape.getCollisionShape(rotation));


### PR DESCRIPTION
This is a small tweak where I exchange direction for rotation. For SegmentedPaths and MarcineScModule there is a separate interface that gets added to identify the new sides based on the rotation. This should remove some of this duplicate code by exchanging direction of the block for rotation. The side itself can be assumed to be pointing forward in the world and rotated accordingly. 