### PR TITLE
Remove light merging from LocalChunkProvider and refactor completeUpdate

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -19,14 +19,13 @@ import gnu.trove.map.hash.TShortObjectHashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.Mockito;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.EntityStore;
 import org.terasology.entitySystem.prefab.Prefab;
-import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.persistence.ChunkStore;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.event.OnChunkGenerated;
 import org.terasology.world.chunks.event.OnChunkLoaded;
@@ -89,6 +88,7 @@ public class LocalChunkProviderTest {
         verify(entityManager).create();
         verify(mockEntity).addComponent(eq(testComponent));
     }
+
     @Test
     public void testCompleteUpdateGeneratesStoredEntitiesFromPrefab() throws Exception {
         final EntityRef worldEntity = mock(EntityRef.class);
@@ -111,7 +111,23 @@ public class LocalChunkProviderTest {
         verify(mockEntity).addComponent(eq(testComponent));
     }
 
-    private static class ChunkProviderTestComponent implements Component{
+
+    @Test
+    public void testCompleteUpdateRestoresEntitiesFromChunkStore() throws Exception {
+        final EntityRef worldEntity = mock(EntityRef.class);
+        chunkProvider.setWorldEntity(worldEntity);
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final ChunkStore chunkStore = mock(ChunkStore.class);
+        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), chunkStore, Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        chunkProvider.completeUpdate();
+
+        verify(chunkStore).restoreEntities();
+    }
+
+    private static class ChunkProviderTestComponent implements Component {
 
     }
 }

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class LocalChunkProviderTest {
     private ChunkCache chunkCache;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp(){
         entityManager = mock(EntityManager.class);
         chunkFinalizer = mock(ChunkFinalizer.class);
         blockManager = mock(BlockManager.class);
@@ -148,9 +148,9 @@ public class LocalChunkProviderTest {
 
         chunkProvider.completeUpdate();
 
-        final InOrder inOrder = inOrder(worldEntity);
-        inOrder.verify(worldEntity).send(any(OnChunkGenerated.class));
-        inOrder.verify(worldEntity).send(any(OnChunkLoaded.class));
+        final InOrder inOrderVerification = inOrder(worldEntity);
+        inOrderVerification.verify(worldEntity).send(any(OnChunkGenerated.class));
+        inOrderVerification.verify(worldEntity).send(any(OnChunkLoaded.class));
     }
 
     @Test
@@ -186,7 +186,6 @@ public class LocalChunkProviderTest {
         verify(entityManager).create(eq(prefab));
         verify(mockEntity).addComponent(eq(testComponent));
     }
-
 
     @Test
     public void testCompleteUpdateRestoresEntitiesForRestoredChunks() throws Exception {

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -18,27 +18,39 @@ package org.terasology.world.chunks.localChunkProvider;
 import gnu.trove.map.hash.TShortObjectHashMap;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.EntityStore;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.event.OnChunkGenerated;
+import org.terasology.world.chunks.event.OnChunkLoaded;
 import org.terasology.world.chunks.internal.ReadyChunkInfo;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class LocalChunkProviderTest {
 
     private LocalChunkProvider chunkProvider;
     private ChunkFinalizer chunkFinalizer;
+    private EntityManager entityManager;
 
     @Before
     public void setUp() throws Exception {
+        entityManager = mock(EntityManager.class);
         chunkFinalizer = mock(ChunkFinalizer.class);
         chunkProvider = new LocalChunkProvider(null,
-                null, null, null, null, chunkFinalizer, null);
+                entityManager, null, null, null, chunkFinalizer, null);
     }
 
     @Test
@@ -52,6 +64,54 @@ public class LocalChunkProviderTest {
 
         chunkProvider.completeUpdate();
 
-        verify(worldEntity).send(any(OnChunkGenerated.class));
+        final InOrder inOrder = inOrder(worldEntity);
+        inOrder.verify(worldEntity).send(any(OnChunkGenerated.class));
+        inOrder.verify(worldEntity).send(any(OnChunkLoaded.class));
+    }
+
+    @Test
+    public void testCompleteUpdateGeneratesStoredEntities() throws Exception {
+        final EntityRef worldEntity = mock(EntityRef.class);
+        chunkProvider.setWorldEntity(worldEntity);
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final EntityStore entityStore = new EntityStore();
+        final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
+        entityStore.addComponent(testComponent);
+        final List<EntityStore> entityStores = Collections.singletonList(entityStore);
+        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), entityStores);
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        final EntityRef mockEntity = mock(EntityRef.class);
+        when(entityManager.create()).thenReturn(mockEntity);
+
+        chunkProvider.completeUpdate();
+
+        verify(entityManager).create();
+        verify(mockEntity).addComponent(eq(testComponent));
+    }
+    @Test
+    public void testCompleteUpdateGeneratesStoredEntitiesFromPrefab() throws Exception {
+        final EntityRef worldEntity = mock(EntityRef.class);
+        chunkProvider.setWorldEntity(worldEntity);
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Prefab prefab = mock(Prefab.class);
+        final EntityStore entityStore = new EntityStore(prefab);
+        final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
+        entityStore.addComponent(testComponent);
+        final List<EntityStore> entityStores = Collections.singletonList(entityStore);
+        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), entityStores);
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        final EntityRef mockEntity = mock(EntityRef.class);
+        when(entityManager.create(any(Prefab.class))).thenReturn(mockEntity);
+
+        chunkProvider.completeUpdate();
+
+        verify(entityManager).create(eq(prefab));
+        verify(mockEntity).addComponent(eq(testComponent));
+    }
+
+    private static class ChunkProviderTestComponent implements Component{
+
     }
 }

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.chunks.localChunkProvider;
+
+import gnu.trove.map.hash.TShortObjectHashMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.event.OnChunkGenerated;
+import org.terasology.world.chunks.internal.ReadyChunkInfo;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class LocalChunkProviderTest {
+
+    private LocalChunkProvider chunkProvider;
+    private ChunkFinalizer chunkFinalizer;
+
+    @Before
+    public void setUp() throws Exception {
+        chunkFinalizer = mock(ChunkFinalizer.class);
+        chunkProvider = new LocalChunkProvider(null,
+                null, null, null, null, chunkFinalizer, null);
+    }
+
+    @Test
+    public void testCompleteUpdateHandlesFinalizedChunkIfReady() throws Exception {
+        final EntityRef worldEntity = mock(EntityRef.class);
+        chunkProvider.setWorldEntity(worldEntity);
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        chunkProvider.completeUpdate();
+
+        verify(worldEntity).send(any(OnChunkGenerated.class));
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -92,9 +92,8 @@ public class LocalChunkProviderTest {
     @Test
     public void testCompleteUpdateGeneratesStoredEntities() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
-        final EntityStore entityStore = new EntityStore();
         final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
-        entityStore.addComponent(testComponent);
+        final EntityStore entityStore = createEntityStoreWithComponents(testComponent);
         final List<EntityStore> entityStores = Collections.singletonList(entityStore);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), entityStores);
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
@@ -103,7 +102,6 @@ public class LocalChunkProviderTest {
 
         chunkProvider.completeUpdate();
 
-        verify(entityManager).create();
         verify(mockEntity).addComponent(eq(testComponent));
     }
 
@@ -111,8 +109,8 @@ public class LocalChunkProviderTest {
     public void testCompleteUpdateGeneratesStoredEntitiesFromPrefab() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
         final Prefab prefab = mock(Prefab.class);
-        final EntityStore entityStore = new EntityStore(prefab);
         final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
+        final EntityStore entityStore = new EntityStore(prefab);
         entityStore.addComponent(testComponent);
         final List<EntityStore> entityStores = Collections.singletonList(entityStore);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), entityStores);
@@ -142,7 +140,7 @@ public class LocalChunkProviderTest {
     @Test
     public void testCompleteUpdateSendsBlockAddedEvents() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
-        final TShortObjectHashMap<TIntList> blockPositionMapppings = new TShortObjectHashMap<>();
+        final TShortObjectHashMap<TIntList> blockPositionMappings = new TShortObjectHashMap<>();
         final short blockId = 42;
         final EntityRef blockEntity = mock(EntityRef.class);
         final Block block = new Block();
@@ -153,8 +151,8 @@ public class LocalChunkProviderTest {
         positions.add(position.x);
         positions.add(position.y);
         positions.add(position.z);
-        blockPositionMapppings.put(blockId, positions);
-        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
+        blockPositionMappings.put(blockId, positions);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMappings, mock(ChunkStore.class), Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
         chunkProvider.completeUpdate();
@@ -169,7 +167,7 @@ public class LocalChunkProviderTest {
     @Test
     public void testCompleteUpdateSendsBlockActivatedEvents() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
-        final TShortObjectHashMap<TIntList> blockPositionMapppings = new TShortObjectHashMap<>();
+        final TShortObjectHashMap<TIntList> blockPositionMappings = new TShortObjectHashMap<>();
         final short blockId = 42;
         final EntityRef blockEntity = mock(EntityRef.class);
         final Block block = new Block();
@@ -180,8 +178,8 @@ public class LocalChunkProviderTest {
         positions.add(position.x);
         positions.add(position.y);
         positions.add(position.z);
-        blockPositionMapppings.put(blockId, positions);
-        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
+        blockPositionMappings.put(blockId, positions);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMappings, mock(ChunkStore.class), Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
         chunkProvider.completeUpdate();
@@ -191,6 +189,18 @@ public class LocalChunkProviderTest {
         final Event event = eventArgumentCaptor.getAllValues().get(1);
         assertThat(event, instanceOf(OnActivatedBlocks.class));
         assertThat(((OnActivatedBlocks) event).getBlockPositions(), hasItem(position));
+    }
+
+    private static EntityStore createEntityStoreWithComponents(Component... components) {
+        return createEntityStoreWithPrefabAndComponents(null, components);
+    }
+
+    private static EntityStore createEntityStoreWithPrefabAndComponents(Prefab prefab, Component... components) {
+        final EntityStore entityStore = new EntityStore(prefab);
+        for (Component component : components) {
+            entityStore.addComponent(component);
+        }
+        return entityStore;
     }
 
     private static Chunk mockChunkAt(final int x, final int y, final int z) {

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -15,17 +15,26 @@
  */
 package org.terasology.world.chunks.localChunkProvider;
 
+import gnu.trove.list.TIntList;
+import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TShortObjectHashMap;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.EntityStore;
+import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.persistence.ChunkStore;
+import org.terasology.world.BlockEntityRegistry;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.OnActivatedBlocks;
+import org.terasology.world.block.OnAddedBlocks;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.event.OnChunkGenerated;
 import org.terasology.world.chunks.event.OnChunkLoaded;
@@ -34,22 +43,34 @@ import org.terasology.world.chunks.internal.ReadyChunkInfo;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class LocalChunkProviderTest {
 
     private LocalChunkProvider chunkProvider;
     private ChunkFinalizer chunkFinalizer;
     private EntityManager entityManager;
+    private BlockManager blockManager;
+    private BlockEntityRegistry blockEntityRegistry;
 
     @Before
     public void setUp() throws Exception {
         entityManager = mock(EntityManager.class);
         chunkFinalizer = mock(ChunkFinalizer.class);
+        blockManager = mock(BlockManager.class);
+        blockEntityRegistry = mock(BlockEntityRegistry.class);
         chunkProvider = new LocalChunkProvider(null,
-                entityManager, null, null, null, chunkFinalizer, null);
+                entityManager, null, blockManager, null, chunkFinalizer, null);
+        chunkProvider.setBlockEntityRegistry(blockEntityRegistry);
     }
 
     @Test
@@ -125,6 +146,66 @@ public class LocalChunkProviderTest {
         chunkProvider.completeUpdate();
 
         verify(chunkStore).restoreEntities();
+    }
+
+    @Test
+    public void testCompleteUpdateSendsBlockAddedEvents() throws Exception {
+        final EntityRef worldEntity = mock(EntityRef.class);
+        chunkProvider.setWorldEntity(worldEntity);
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final TShortObjectHashMap<TIntList> blockPositionMapppings = new TShortObjectHashMap<>();
+        final short blockId = 42;
+        final EntityRef blockEntity = mock(EntityRef.class);
+        final Block block = new Block();
+        block.setEntity(blockEntity);
+        when(blockManager.getBlock(eq(blockId))).thenReturn(block);
+        final TIntArrayList positions = new TIntArrayList();
+        final Vector3i position = new Vector3i(1, 2, 3);
+        positions.add(position.x);
+        positions.add(position.y);
+        positions.add(position.z);
+        blockPositionMapppings.put(blockId, positions);
+        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        chunkProvider.completeUpdate();
+
+        final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(blockEntity, atLeastOnce()).send(eventArgumentCaptor.capture());
+        final Event event = eventArgumentCaptor.getAllValues().get(0);
+        assertThat(event, instanceOf(OnAddedBlocks.class));
+        assertThat(((OnAddedBlocks) event).getBlockPositions(), hasItem(position));
+    }
+
+    @Test
+    public void testCompleteUpdateSendsBlockActivatedEvents() throws Exception {
+        final EntityRef worldEntity = mock(EntityRef.class);
+        chunkProvider.setWorldEntity(worldEntity);
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final TShortObjectHashMap<TIntList> blockPositionMapppings = new TShortObjectHashMap<>();
+        final short blockId = 42;
+        final EntityRef blockEntity = mock(EntityRef.class);
+        final Block block = new Block();
+        block.setEntity(blockEntity);
+        when(blockManager.getBlock(eq(blockId))).thenReturn(block);
+        final TIntArrayList positions = new TIntArrayList();
+        final Vector3i position = new Vector3i(1, 2, 3);
+        positions.add(position.x);
+        positions.add(position.y);
+        positions.add(position.z);
+        blockPositionMapppings.put(blockId, positions);
+        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        chunkProvider.completeUpdate();
+
+        final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(blockEntity, atLeastOnce()).send(eventArgumentCaptor.capture());
+        final Event event = eventArgumentCaptor.getAllValues().get(1);
+        assertThat(event, instanceOf(OnActivatedBlocks.class));
+        assertThat(((OnActivatedBlocks) event).getBlockPositions(), hasItem(position));
     }
 
     private static class ChunkProviderTestComponent implements Component {

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -42,6 +42,7 @@ import org.terasology.world.chunks.internal.ReadyChunkInfo;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -49,8 +50,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,6 +65,7 @@ public class LocalChunkProviderTest {
     private BlockManager blockManager;
     private BlockEntityRegistry blockEntityRegistry;
     private EntityRef worldEntity;
+    private ChunkCache chunkCache;
 
     @Before
     public void setUp() throws Exception {
@@ -70,10 +74,70 @@ public class LocalChunkProviderTest {
         blockManager = mock(BlockManager.class);
         blockEntityRegistry = mock(BlockEntityRegistry.class);
         worldEntity = mock(EntityRef.class);
+        chunkCache = new ConcurrentMapChunkCache();
         chunkProvider = new LocalChunkProvider(null,
-                entityManager, null, blockManager, null, chunkFinalizer, null);
+                entityManager, null, blockManager, null, chunkFinalizer, null, chunkCache);
         chunkProvider.setBlockEntityRegistry(blockEntityRegistry);
         chunkProvider.setWorldEntity(worldEntity);
+    }
+
+    @Test
+    public void testCompleteUpdateMarksChunkReady() throws Exception {
+        final Chunk chunk = mockChunkAt(0, 0, 0);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        chunkProvider.completeUpdate();
+
+        verify(chunk).markReady();
+    }
+
+    @Test
+    public void testCompleteUpdateSetsChunkAdjacentChunksReady() throws Exception {
+        final Chunk chunk = mockChunkAt(0, 0, 0);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        generateMockChunkCubeWithSideWidthAround(chunk.getPosition(), 1, chunkCache);
+        markAllChunksAsReady(chunkCache);
+
+        chunkProvider.completeUpdate();
+
+        verify(chunk).setAdjacentChunksReady(true);
+    }
+
+    @Test
+    public void testCompleteUpdateSetsChunkAdjacentChunksNotReadyIfChunksMissing() throws Exception {
+        final Chunk chunk = mockChunkAt(0, 0, 0);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        generateMockChunkCubeWithSideWidthAround(chunk.getPosition(), 1, chunkCache);
+        markAllChunksAsReadyExcludingPosition(chunkCache, new Vector3i(1, 0, 0));
+
+        chunkProvider.completeUpdate();
+
+        verify(chunk, never()).setAdjacentChunksReady(true);
+    }
+
+    @Test
+    public void testCompleteUpdateSetsAdjacentChunksAdjacentChunksReady() throws Exception {
+        generateMockChunkCubeWithSideWidthAround(new Vector3i(0, 1, 0), 1, chunkCache);
+        chunkCache.removeChunkAt(new Vector3i(0, 0, 0));
+        markAllChunksAsReady(chunkCache);
+        final Chunk adjacentChunk = mockChunkAt(0, 1, 0);
+        chunkCache.put(adjacentChunk.getPosition(), adjacentChunk);
+        final Chunk chunk = mockChunkWithReadinessStateAt(0, 0, 0);
+        chunkCache.put(chunk.getPosition(), chunk);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
+        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+
+        // chunk at 0,1,0 is not ready and all adjacent chunks around it except 0,0,0 are marked ready.
+        // we expect chunk 0,0,0 to become ready and all adjacent chunks to be updated
+        chunkProvider.completeUpdate();
+
+        // therefore chunk 0,1,0 should have its adjacent chunk readiness state set to true
+        // because now all of its adjacent chunks are ready
+        verify(adjacentChunk).setAdjacentChunksReady(true);
     }
 
     @Test
@@ -176,6 +240,30 @@ public class LocalChunkProviderTest {
         assertThat(((OnActivatedBlocks) event).getBlockPositions(), hasItem(new Vector3i(1, 2, 3)));
     }
 
+    private static void markAllChunksAsReady(final ChunkCache chunkCache) {
+        markAllChunksAsReadyExcludingPosition(chunkCache, null);
+    }
+
+    private static void markAllChunksAsReadyExcludingPosition(final ChunkCache chunkCache, final Vector3i positionToExclude) {
+        chunkCache.getAllChunks().stream()
+                .filter(chunk -> !chunk.getPosition().equals(positionToExclude))
+                .forEach(c -> when(c.isReady()).thenReturn(true));
+    }
+
+    private static void generateMockChunkCubeWithSideWidthAround(final Vector3i position, final int sideWidth, final ChunkCache chunkCache) {
+        for (int x = position.getX() - sideWidth; x <= position.getX() + sideWidth; x++) {
+            for (int y = position.getY() - sideWidth; y <= position.getY() + sideWidth; y++) {
+                for (int z = position.getZ() - sideWidth; z <= position.getZ() + sideWidth; z++) {
+                    if (x == position.getX() && y == position.getY() && z == position.getZ()) {
+                        //dont override the inner chunk
+                        continue;
+                    }
+                    chunkCache.put(new Vector3i(x, y, z), mockChunkAt(x, y, z));
+                }
+            }
+        }
+    }
+
     private static EntityStore createEntityStoreWithComponents(Component... components) {
         return createEntityStoreWithPrefabAndComponents(null, components);
     }
@@ -191,6 +279,18 @@ public class LocalChunkProviderTest {
     private static Chunk mockChunkAt(final int x, final int y, final int z) {
         final Chunk chunk = mock(Chunk.class);
         when(chunk.getPosition()).thenReturn(new Vector3i(x, y, z));
+        return chunk;
+    }
+
+
+    private static Chunk mockChunkWithReadinessStateAt(final int x, final int y, final int z) {
+        final Chunk chunk = mockChunkAt(x, y, z);
+        AtomicBoolean chunkReady = new AtomicBoolean();
+        when(chunk.isReady()).thenAnswer(i -> chunkReady.get());
+        doAnswer(i -> {
+            chunkReady.set(true);
+            return null;
+        }).when(chunk).markReady();
         return chunk;
     }
 

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -61,6 +61,7 @@ public class LocalChunkProviderTest {
     private EntityManager entityManager;
     private BlockManager blockManager;
     private BlockEntityRegistry blockEntityRegistry;
+    private EntityRef worldEntity;
 
     @Before
     public void setUp() throws Exception {
@@ -68,17 +69,16 @@ public class LocalChunkProviderTest {
         chunkFinalizer = mock(ChunkFinalizer.class);
         blockManager = mock(BlockManager.class);
         blockEntityRegistry = mock(BlockEntityRegistry.class);
+        worldEntity = mock(EntityRef.class);
         chunkProvider = new LocalChunkProvider(null,
                 entityManager, null, blockManager, null, chunkFinalizer, null);
         chunkProvider.setBlockEntityRegistry(blockEntityRegistry);
+        chunkProvider.setWorldEntity(worldEntity);
     }
 
     @Test
     public void testCompleteUpdateHandlesFinalizedChunkIfReady() throws Exception {
-        final EntityRef worldEntity = mock(EntityRef.class);
-        chunkProvider.setWorldEntity(worldEntity);
-        final Chunk chunk = mock(Chunk.class);
-        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Chunk chunk = mockChunkAt(0, 0, 0);
         final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
@@ -91,10 +91,7 @@ public class LocalChunkProviderTest {
 
     @Test
     public void testCompleteUpdateGeneratesStoredEntities() throws Exception {
-        final EntityRef worldEntity = mock(EntityRef.class);
-        chunkProvider.setWorldEntity(worldEntity);
-        final Chunk chunk = mock(Chunk.class);
-        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Chunk chunk = mockChunkAt(0, 0, 0);
         final EntityStore entityStore = new EntityStore();
         final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
         entityStore.addComponent(testComponent);
@@ -112,10 +109,7 @@ public class LocalChunkProviderTest {
 
     @Test
     public void testCompleteUpdateGeneratesStoredEntitiesFromPrefab() throws Exception {
-        final EntityRef worldEntity = mock(EntityRef.class);
-        chunkProvider.setWorldEntity(worldEntity);
-        final Chunk chunk = mock(Chunk.class);
-        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Chunk chunk = mockChunkAt(0, 0, 0);
         final Prefab prefab = mock(Prefab.class);
         final EntityStore entityStore = new EntityStore(prefab);
         final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
@@ -135,10 +129,7 @@ public class LocalChunkProviderTest {
 
     @Test
     public void testCompleteUpdateRestoresEntitiesFromChunkStore() throws Exception {
-        final EntityRef worldEntity = mock(EntityRef.class);
-        chunkProvider.setWorldEntity(worldEntity);
-        final Chunk chunk = mock(Chunk.class);
-        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Chunk chunk = mockChunkAt(0, 0, 0);
         final ChunkStore chunkStore = mock(ChunkStore.class);
         final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), chunkStore, Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
@@ -150,10 +141,7 @@ public class LocalChunkProviderTest {
 
     @Test
     public void testCompleteUpdateSendsBlockAddedEvents() throws Exception {
-        final EntityRef worldEntity = mock(EntityRef.class);
-        chunkProvider.setWorldEntity(worldEntity);
-        final Chunk chunk = mock(Chunk.class);
-        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Chunk chunk = mockChunkAt(0, 0, 0);
         final TShortObjectHashMap<TIntList> blockPositionMapppings = new TShortObjectHashMap<>();
         final short blockId = 42;
         final EntityRef blockEntity = mock(EntityRef.class);
@@ -180,10 +168,7 @@ public class LocalChunkProviderTest {
 
     @Test
     public void testCompleteUpdateSendsBlockActivatedEvents() throws Exception {
-        final EntityRef worldEntity = mock(EntityRef.class);
-        chunkProvider.setWorldEntity(worldEntity);
-        final Chunk chunk = mock(Chunk.class);
-        when(chunk.getPosition()).thenReturn(new Vector3i(0, 0, 0));
+        final Chunk chunk = mockChunkAt(0, 0, 0);
         final TShortObjectHashMap<TIntList> blockPositionMapppings = new TShortObjectHashMap<>();
         final short blockId = 42;
         final EntityRef blockEntity = mock(EntityRef.class);
@@ -206,6 +191,12 @@ public class LocalChunkProviderTest {
         final Event event = eventArgumentCaptor.getAllValues().get(1);
         assertThat(event, instanceOf(OnActivatedBlocks.class));
         assertThat(((OnActivatedBlocks) event).getBlockPositions(), hasItem(position));
+    }
+
+    private static Chunk mockChunkAt(final int x, final int y, final int z) {
+        final Chunk chunk = mock(Chunk.class);
+        when(chunk.getPosition()).thenReturn(new Vector3i(x, y, z));
+        return chunk;
     }
 
     private static class ChunkProviderTestComponent implements Component {

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -79,7 +79,7 @@ public class LocalChunkProviderTest {
     @Test
     public void testCompleteUpdateHandlesFinalizedChunkIfReady() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
-        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
         chunkProvider.completeUpdate();
@@ -96,7 +96,7 @@ public class LocalChunkProviderTest {
         final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
         entityStore.addComponent(testComponent);
         final List<EntityStore> entityStores = Collections.singletonList(entityStore);
-        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), entityStores);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), entityStores);
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
         final EntityRef mockEntity = mock(EntityRef.class);
         when(entityManager.create()).thenReturn(mockEntity);
@@ -115,7 +115,7 @@ public class LocalChunkProviderTest {
         final ChunkProviderTestComponent testComponent = new ChunkProviderTestComponent();
         entityStore.addComponent(testComponent);
         final List<EntityStore> entityStores = Collections.singletonList(entityStore);
-        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), entityStores);
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), entityStores);
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
         final EntityRef mockEntity = mock(EntityRef.class);
         when(entityManager.create(any(Prefab.class))).thenReturn(mockEntity);
@@ -128,10 +128,10 @@ public class LocalChunkProviderTest {
 
 
     @Test
-    public void testCompleteUpdateRestoresEntitiesFromChunkStore() throws Exception {
+    public void testCompleteUpdateRestoresEntitiesForRestoredChunks() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
         final ChunkStore chunkStore = mock(ChunkStore.class);
-        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, new TShortObjectHashMap<>(), chunkStore, Collections.emptyList());
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, new TShortObjectHashMap<>(), chunkStore, Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
         chunkProvider.completeUpdate();
@@ -154,7 +154,7 @@ public class LocalChunkProviderTest {
         positions.add(position.y);
         positions.add(position.z);
         blockPositionMapppings.put(blockId, positions);
-        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
         chunkProvider.completeUpdate();
@@ -181,7 +181,7 @@ public class LocalChunkProviderTest {
         positions.add(position.y);
         positions.add(position.z);
         blockPositionMapppings.put(blockId, positions);
-        final ReadyChunkInfo readyChunkInfo = new ReadyChunkInfo(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
+        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMapppings, mock(ChunkStore.class), Collections.emptyList());
         when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
 
         chunkProvider.completeUpdate();

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ReadyChunkInfo.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ReadyChunkInfo.java
@@ -35,6 +35,14 @@ public class ReadyChunkInfo {
     private boolean newChunk;
     private List<EntityStore> entities;
 
+    public static ReadyChunkInfo createForNewChunk(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings, List<EntityStore> entities){
+        return new ReadyChunkInfo(chunk,blockPositionMapppings,entities);
+    }
+
+    public static ReadyChunkInfo createForRestoredChunk(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings, ChunkStore chunkStore, List<EntityStore> entities){
+        return new ReadyChunkInfo(chunk, blockPositionMapppings, chunkStore, entities);
+    }
+
     public ReadyChunkInfo(Chunk chunk, TShortObjectMap<TIntList> blockPositionMapppings, List<EntityStore> entities) {
         this.pos = chunk.getPosition();
         this.blockPositionMapppings = blockPositionMapppings;

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkCache.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkCache.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.chunks.localChunkProvider;
+
+import org.terasology.math.geom.Vector3i;
+import org.terasology.world.chunks.Chunk;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+interface ChunkCache {
+    Chunk get(Vector3i chunkPosition);
+
+    void put(Vector3i chunkPosition, Chunk chunk);
+
+    Iterator<Vector3i> iterateChunkPositions();
+
+    Collection<Chunk> getAllChunks();
+
+    void clear();
+
+    boolean containsChunkAt(Vector3i chunkPosition);
+
+    void removeChunkAt(Vector3i chunkPosition);
+}

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkCache.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@ import org.terasology.world.chunks.Chunk;
 import java.util.Collection;
 import java.util.Iterator;
 
+/**
+ * Chunk storage which allows to look up for chunks based on their world position.
+ */
 interface ChunkCache {
     Chunk get(Vector3i chunkPosition);
 

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkFinalizer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkFinalizer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.chunks.localChunkProvider;
+
+import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.internal.GeneratingChunkProvider;
+import org.terasology.world.chunks.internal.ReadyChunkInfo;
+
+public interface ChunkFinalizer {
+
+    void initialize(GeneratingChunkProvider generatingChunkProvider);
+
+    ReadyChunkInfo completeFinalization();
+
+    void beginFinalization(Chunk chunk, ReadyChunkInfo readyChunkInfo);
+
+    void restart();
+
+    void shutdown();
+}

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkFinalizer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.internal.GeneratingChunkProvider;
 import org.terasology.world.chunks.internal.ReadyChunkInfo;
 
+/**
+ * Post-processor for loaded or generated chunks.
+ * Can be used to add extra runtime-metadata like light merging to a chunk before the chunk is stored in memory.
+ */
 public interface ChunkFinalizer {
 
     void initialize(GeneratingChunkProvider generatingChunkProvider);

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ConcurrentMapChunkCache.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ConcurrentMapChunkCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ConcurrentMapChunkCache.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ConcurrentMapChunkCache.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.chunks.localChunkProvider;
+
+import com.google.common.collect.Maps;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.world.chunks.Chunk;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+class ConcurrentMapChunkCache implements ChunkCache{
+
+    private Map<Vector3i, Chunk> cache = Maps.newConcurrentMap();
+
+    @Override
+    public Chunk get(final Vector3i chunkPosition) {
+        return cache.get(chunkPosition);
+    }
+
+    @Override
+    public void put(final Vector3i chunkPosition, final Chunk chunk) {
+        cache.put(chunkPosition, chunk);
+    }
+
+    @Override
+    public Iterator<Vector3i> iterateChunkPositions() {
+        return cache.keySet().iterator();
+    }
+
+    @Override
+    public Collection<Chunk> getAllChunks() {
+        return cache.values();
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    @Override
+    public boolean containsChunkAt(final Vector3i chunkPosition) {
+        return cache.containsKey(chunkPosition);
+    }
+
+    @Override
+    public void removeChunkAt(final Vector3i chunkPosition) {
+        cache.remove(chunkPosition);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LightMergingChunkFinalizer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LightMergingChunkFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LightMergingChunkFinalizer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LightMergingChunkFinalizer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.chunks.localChunkProvider;
+
+import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.internal.GeneratingChunkProvider;
+import org.terasology.world.chunks.internal.ReadyChunkInfo;
+import org.terasology.world.propagation.light.LightMerger;
+
+class LightMergingChunkFinalizer implements ChunkFinalizer {
+
+    private LightMerger<ReadyChunkInfo> lightMerger;
+
+    @Override
+    public void initialize(final GeneratingChunkProvider generatingChunkProvider) {
+        lightMerger = new LightMerger<>(generatingChunkProvider);
+    }
+
+    @Override
+    public ReadyChunkInfo completeFinalization() {
+        return lightMerger.completeMerge();
+    }
+
+    @Override
+    public void beginFinalization(final Chunk chunk, final ReadyChunkInfo readyChunkInfo) {
+        lightMerger.beginMerge(chunk, readyChunkInfo);
+    }
+
+    @Override
+    public void restart() {
+        lightMerger.restart();
+    }
+
+    @Override
+    public void shutdown() {
+        lightMerger.shutdown();
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -126,6 +126,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
         this.pipeline = new ChunkGenerationPipeline(new ChunkTaskRelevanceComparator());
         this.unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 4);
         this.chunkFinalizer = chunkFinalizer;
+        chunkFinalizer.initialize(this);
         this.chunkFinalizerSupplier = chunkFinalizerSupplier;
         ChunkMonitor.fireChunkProviderInitialized(this);
     }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -70,6 +70,7 @@ import org.terasology.world.internal.ChunkViewCore;
 import org.terasology.world.internal.ChunkViewCoreImpl;
 import org.terasology.world.propagation.light.InternalLightProcessor;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -456,31 +457,33 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
     }
 
     private boolean areAdjacentChunksReady(Chunk chunk) {
-        Vector3i centerChunkPos = chunk.getPosition();
-        for (Side side : Side.values()) {
-            Vector3i adjChunkPos = side.getAdjacentPos(centerChunkPos);
-            Chunk adjChunk = chunkCache.get(adjChunkPos);
-            boolean adjChunkReady = (adjChunk != null && adjChunk.isReady());
-            if (!adjChunkReady) {
+        for (Chunk adjacentChunk : listAdjacentChunks(chunk)) {
+            if (!adjacentChunk.isReady()) {
                 return false;
             }
         }
         return true;
     }
 
+    private void updateAdjacentChunksReadyFieldOfAdjChunks(Chunk chunkInCenter) {
+        listAdjacentChunks(chunkInCenter).forEach(this::updateAdjacentChunksReadyFieldOf);
+    }
+
     private void updateAdjacentChunksReadyFieldOf(Chunk chunk) {
         chunk.setAdjacentChunksReady(areAdjacentChunksReady(chunk));
     }
 
-    private void updateAdjacentChunksReadyFieldOfAdjChunks(Chunk chunkInCenter) {
-        Vector3i centerChunkPos = chunkInCenter.getPosition();
+    private List<Chunk> listAdjacentChunks(Chunk chunk) {
+        final Vector3i centerChunkPosition = chunk.getPosition();
+        List<Chunk> adjacentChunks = new ArrayList<>(6);
         for (Side side : Side.values()) {
-            Vector3i adjChunkPos = side.getAdjacentPos(centerChunkPos);
-            Chunk adjacentChunk = chunkCache.get(adjChunkPos);
+            final Vector3i adjacentChunkPosition = side.getAdjacentPos(centerChunkPosition);
+            final Chunk adjacentChunk = chunkCache.get(adjacentChunkPosition);
             if (adjacentChunk != null) {
-                updateAdjacentChunksReadyFieldOf(adjacentChunk);
+                adjacentChunks.add(adjacentChunk);
             }
         }
+        return adjacentChunks;
     }
 
     private void updateRelevance() {

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,6 +269,8 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
 
     private void processReadyChunk(final ReadyChunkInfo readyChunkInfo) {
         updateChunkReadinessState(readyChunkInfo);
+        //TODO, it is not clear if the activate/addedBlocks event logic is correct.
+        //See https://github.com/MovingBlocks/Terasology/issues/3244
         if (readyChunkInfo.isNewChunk()) {
             generateQueuedEntities(readyChunkInfo);
             sendOnActivatedBlocks(readyChunkInfo);


### PR DESCRIPTION
This PR prepares an overhaul of the ChunkProviding system which is coupled to a different othere concepts like light merging, chunk loading and network transfer of chunks.

Changing any behavior of the system is out of scope of this PR and will be done in a follow up.
Therefore the goal here is just to put the system under test and do small refactorings to make the current API more expressive, even if it means to keep bugs or inintuitive concepts for the moment.