### PR TITLE
Support for optional dependencies

### DIFF
--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoEventSystemTests.java
@@ -34,6 +34,7 @@ import org.terasology.entitySystem.prefab.internal.PojoPrefabManager;
 import org.terasology.entitySystem.stubs.IntegerComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.naming.Name;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -42,6 +43,7 @@ import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -73,7 +75,7 @@ public class PojoEventSystemTests {
         entityManager.setPrefabManager(new PojoPrefabManager(context));
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
-        eventSystem = new EventSystemImpl(entitySystemLibrary.getEventLibrary(), networkSystem);
+        eventSystem = new EventSystemImpl(entitySystemLibrary.getEventLibrary(), networkSystem, new ArrayList<>());
         entityManager.setEventSystem(eventSystem);
         entity = entityManager.create();
     }

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -111,7 +111,7 @@ public final class EntitySystemSetupUtil {
         entityManager.setComponentLibrary(library.getComponentLibrary());
 
         // Event System
-        EventSystem eventSystem = new EventSystemImpl(library.getEventLibrary(), networkSystem);
+        EventSystem eventSystem = new EventSystemImpl(library.getEventLibrary(), networkSystem, environment.getModuleIdsOrderedByDependencies());
         entityManager.setEventSystem(eventSystem);
         context.put(EventSystem.class, eventSystem);
 

--- a/engine/src/main/java/org/terasology/engine/module/ModuleEnvironmentInfo.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleEnvironmentInfo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.module;
+
+import org.terasology.module.sandbox.API;
+import org.terasology.naming.Name;
+
+@API
+public interface ModuleEnvironmentInfo {
+
+    boolean moduleLoaded(String name);
+    boolean moduleLoaded(Name name);
+}

--- a/engine/src/main/java/org/terasology/engine/module/ModuleEnvironmentInfoImpl.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleEnvironmentInfoImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.module;
+
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.module.sandbox.API;
+import org.terasology.naming.Name;
+import org.terasology.registry.In;
+import org.terasology.registry.Share;
+
+
+@Share(ModuleEnvironmentInfo.class)
+@API
+@RegisterSystem
+public class ModuleEnvironmentInfoImpl extends BaseComponentSystem implements ModuleEnvironmentInfo {
+    @In
+    private ModuleManager moduleManager;
+
+    @Override
+    public boolean moduleLoaded(String name) {
+        return moduleLoaded(new Name(name));
+    }
+
+    @Override
+    public boolean moduleLoaded(Name name) {
+        return moduleManager.getEnvironment().get(name) != null;
+    }
+}

--- a/engine/src/main/java/org/terasology/entitySystem/event/ReceiveEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/ReceiveEvent.java
@@ -28,7 +28,6 @@ import java.lang.annotation.Target;
  * <br><br>
  * These methods should have the form
  * <code>public void handlerMethod(EventType event, EntityRef entity)</code>
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
@@ -37,6 +36,8 @@ public @interface ReceiveEvent {
      * What components that the entity must have for this method to be invoked
      */
     Class<? extends Component>[] components() default {};
+
+    String[] requiredModules() default {};
 
     RegisterMode netFilter() default RegisterMode.ALWAYS;
 


### PR DESCRIPTION
Provides functionality for having code/events run only if specific modules are enabled. This allows for modules to implement content that will only be activated and run when some optional dependencies are included.

Making a PR now to get some eyes on the code I have so far, I want to implement a method for having optional assets so this shouldn't be merged until that's sorted.

