### PR TITLE
Changed REGEX format of FLOAT_PATTERN for boundary of mesh

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
@@ -47,7 +47,8 @@ import java.util.stream.Collectors;
 public class MD5AnimationLoader extends AbstractAssetFileFormat<MeshAnimationData> {
 
     private static final String INTEGER_PATTERN = "((?:[\\+-]?\\d+)(?:[eE][\\+-]?\\d+)?)";
-    private static final String FLOAT_PATTERN = "((?:[\\+-]?\\d(?:\\.\\d*)?|\\.\\d+)(?:[eE][\\+-]?(?:\\d(?:\\.\\d*)?|\\.\\d+))?)";
+    //private static final String FLOAT_PATTERN = "((?:[\\+-]?\\d(?:\\.\\d*)?|\\.\\d+)(?:[eE][\\+-]?(?:\\d(?:\\.\\d*)?|\\.\\d+))?)";
+    private static final String FLOAT_PATTERN = "([-+]?[0-9]*\\.?[0-9]+)";
     private static final String VECTOR3_PATTERN = "\\(\\s*" + FLOAT_PATTERN + "\\s+" + FLOAT_PATTERN + "\\s+" + FLOAT_PATTERN + "\\s+\\)";
 
     private static final int POSITION_X_FLAG = 0x1;


### PR DESCRIPTION
The earlier REGEX format did not recognize longer numbers as the boundary for the mesh. It caused problems with the MawGooey model. The new pattern has been tested with all the models that have animation and is working in all cases.