### PR TITLE
Added support for replacing skins through deltas

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/asset/UIDeltaFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/asset/UIDeltaFormat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.asset;
+
+import com.google.common.base.Charsets;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import org.terasology.assets.format.AbstractAssetAlterationFileFormat;
+import org.terasology.assets.format.AssetDataFile;
+import org.terasology.assets.module.annotations.RegisterAssetDeltaFileFormat;
+import org.terasology.utilities.Assets;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@RegisterAssetDeltaFileFormat
+public class UIDeltaFormat extends AbstractAssetAlterationFileFormat<UIData> {
+    public UIDeltaFormat() {
+        super("ui");
+    }
+
+    @Override
+    public void apply(AssetDataFile input, UIData assetData) throws IOException {
+        try (JsonReader reader = new JsonReader(new InputStreamReader(input.openStream(), Charsets.UTF_8))) {
+            JsonElement jsonElement = new JsonParser().parse(reader);
+
+            String skinUri = jsonElement.getAsJsonObject().get("skin").getAsString();
+            String filePath = input.toString();
+            String moduleName = filePath.substring(1, filePath.indexOf('/', 1));
+
+            assetData.getRootWidget().setSkin(Assets.getSkin(moduleName + ":" + skinUri).get());
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/asset/UIDeltaFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/asset/UIDeltaFormat.java
@@ -19,16 +19,29 @@ import com.google.common.base.Charsets;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.assets.format.AbstractAssetAlterationFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetDeltaFileFormat;
+import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.utilities.Assets;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Optional;
 
+/**
+ * Enables UI screens (.ui) to have delta files.
+ * The delta files share the same extension as UI screens.
+ *
+ * Note that in the current form, only skinning is supported via delta files.
+ * Further, the skin you are overriding the existing skin with should reside in the same module as the delta file.
+*/
 @RegisterAssetDeltaFileFormat
 public class UIDeltaFormat extends AbstractAssetAlterationFileFormat<UIData> {
+    private static final Logger logger = LoggerFactory.getLogger(UIDeltaFormat.class);
+
     public UIDeltaFormat() {
         super("ui");
     }
@@ -42,7 +55,12 @@ public class UIDeltaFormat extends AbstractAssetAlterationFileFormat<UIData> {
             String filePath = input.toString();
             String moduleName = filePath.substring(1, filePath.indexOf('/', 1));
 
-            assetData.getRootWidget().setSkin(Assets.getSkin(moduleName + ":" + skinUri).get());
+            Optional<UISkin> skin = Assets.getSkin(moduleName + ":" + skinUri);
+            if (skin.isPresent()) {
+                assetData.getRootWidget().setSkin(skin.get());
+            } else {
+                logger.warn("Failed to load skin " + skinUri + " for the delta file " + input.getFilename());
+            }
         }
     }
 }


### PR DESCRIPTION
Partially solution for the problems outlined in #3238.

# Changes
Allows module creators to replace the skin for a particular UI screen by providing a delta file. Note that only support for skin has been added right now, and (if required) everything else will have to implemented separately.

# How to test
(I'm considering you're developing Sample module, and want to replace the skin used in `toolbar.ui` (hud) with a custom skin (hudLarge))
- Checkout the PR
- Add the skin you want to replace an existing skin with (in my example, create `\modules\Sample\assets\skins\hudLarge.skin`)
- Add the delta for the UI skin you want to update (in my example, add a file `\modules\Sample\deltas\engine\ui\hud\toolbar.ui` with the following content: `{ "skin": "HUDLarge" }`)
- Run the game, and have the skin in `toolbar.ui` screen replaced from `hud` to `hudLarge`