### PR TITLE
API fix for #3184 and minor code quality tweaks

### DIFF
--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,11 @@ package org.terasology.input;
 import com.google.common.collect.Queues;
 import org.terasology.config.ControllerConfig.ControllerInfo;
 import org.terasology.config.facade.InputDeviceConfiguration;
+import org.terasology.engine.SimpleUri;
 import org.terasology.engine.Time;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.config.BindsManager;
+import org.terasology.engine.subsystem.config.BindsSubsystem;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
@@ -53,6 +55,7 @@ import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.registry.In;
 
+import java.util.List;
 import java.util.Queue;
 
 /**
@@ -80,6 +83,9 @@ public class InputSystem extends BaseComponentSystem {
 
     @In
     private CameraTargetSystem targetSystem;
+
+    @In
+    private BindsSubsystem bindsSubsystem;
 
     private MouseDevice mouse = new NullMouseDevice();
     private KeyboardDevice keyboard = new NullKeyboardDevice();
@@ -379,5 +385,15 @@ public class InputSystem extends BaseComponentSystem {
         mouse.getInputQueue();
         keyboard.getInputQueue();
         controllers.getInputQueue();
+    }
+
+    /**
+     * API-exposed caller to {@link BindsSubsystem#getInputsForBindButton(SimpleUri)}
+     * TODO: Restored for API reasons, may be duplicating code elsewhere. Should be reviewed
+     * @param bindId the ID
+     * @return a list of keyboard/mouse inputs that trigger the binding.
+     */
+    public List<Input> getInputsForBindButton(SimpleUri bindId) {
+        return bindsSubsystem.getInputsForBindButton((bindId));
     }
 }


### PR DESCRIPTION
More or less stole the fix @anuar2k put in #3219 (thanks! Even if it is just a restored method) but with a method in the old class that's flagged API that just calls the restored method in a new non-API place. So as far as the Dialogs module is concerned everything is back to normal and we're in API compliance again.

That is probably not ideal from a code perspective, since #2948 was doing some input binding overhaul activity, and this just puts one of the old methods back. I left TODOs in both places for future review and hopefully later on in some other input related effort we can sort it out. Maybe even in v2 since then we can break API in a valid fashion :D

Again may be interesting to @oniatus @msteiger @rzats @vampcat @ThompsonTyler @eviltak - but I'll merge this soonish just so work on Alpha 9 can continue. 

Note that I haven't actually *tested* the fix to Dialogs, as the one example I know of that uses it is in the `develop` branch for LightAndShadow, which is 2 years out of date. Tried to get it up to date but too much effort right now :-(

On a related note but not directly I found another API violation in #3118 while digging around for this issue, and am fixing that in Terasology/PolyWorld#15 (only module affected I've found so far, so fixing in module land with the engine violation OKed)