### PR TITLE
Added null check

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -34,6 +34,7 @@ import org.terasology.rendering.primitives.ChunkTessellator;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.world.ChunkView;
 import org.terasology.world.WorldProvider;
+import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.RenderableChunk;
@@ -101,8 +102,13 @@ class RenderableWorldImpl implements RenderableWorld {
     @Override
     public void onChunkLoaded(Vector3i chunkCoordinates) {
         if (renderableRegion.encompasses(chunkCoordinates)) {
-            chunksInProximityOfCamera.add(chunkProvider.getChunk(chunkCoordinates));
-            Collections.sort(chunksInProximityOfCamera, new ChunkFrontToBackComparator());
+            Chunk chunk = chunkProvider.getChunk(chunkCoordinates);
+            if (chunk == null) {
+                logger.warn("Warning: onChunkLoaded called for a null chunk!");
+            } else {
+                chunksInProximityOfCamera.add(chunk);
+                Collections.sort(chunksInProximityOfCamera, new ChunkFrontToBackComparator());
+            }
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -103,11 +103,11 @@ class RenderableWorldImpl implements RenderableWorld {
     public void onChunkLoaded(Vector3i chunkCoordinates) {
         if (renderableRegion.encompasses(chunkCoordinates)) {
             Chunk chunk = chunkProvider.getChunk(chunkCoordinates);
-            if (chunk == null) {
-                logger.warn("Warning: onChunkLoaded called for a null chunk!");
-            } else {
+            if (chunk != null) {
                 chunksInProximityOfCamera.add(chunk);
                 Collections.sort(chunksInProximityOfCamera, new ChunkFrontToBackComparator());
+            } else {
+                logger.warn("Warning: onChunkLoaded called for a null chunk!");
             }
         }
     }


### PR DESCRIPTION
Potential fix for #2590.

My current working hypothesis is:

Here is a method from RenderableWorldImpl:
```    @Override
    public void onChunkLoaded(Vector3i chunkCoordinates) {
        if (renderableRegion.encompasses(chunkCoordinates)) {
            chunksInProximityOfCamera.add(chunkProvider.getChunk(chunkCoordinates));
            Collections.sort(chunksInProximityOfCamera, new ChunkFrontToBackComparator());
        }
    }
```

We are directly adding the retrieved chunk to a list, which is then sorted. Now, java expects objects in the list to be non-null, which in turn leads to NPEs because `getChunk()` sometimes returns null.

Why does a chunk for which `onChunkLoaded` was called is null, I can't say. Maybe because the server sent a chunkLoaded request to a player, the player took some time to process the request during which server unloaded the chunk? Not sure, but I think that's the most likely thing.

We can dig into this more properly when @oniatus starts his chunk refactor.