### PR TITLE
Show chunks faster and reduce amount of invisible chunks (Issue #1886).

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -53,7 +53,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -90,54 +89,6 @@ public class LocalChunkProviderTest {
         chunkProvider.completeUpdate();
 
         verify(chunk).markReady();
-    }
-
-    @Test
-    public void testCompleteUpdateSetsChunkAdjacentChunksReady() throws Exception {
-        final Chunk chunk = mockChunkAt(0, 0, 0);
-        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
-
-        generateMockChunkCubeWithSideWidthAround(chunk.getPosition(), 1, chunkCache);
-        markAllChunksAsReady(chunkCache);
-
-        chunkProvider.completeUpdate();
-
-        verify(chunk).setAdjacentChunksReady(true);
-    }
-
-    @Test
-    public void testCompleteUpdateSetsChunkAdjacentChunksNotReadyIfChunksMissing() throws Exception {
-        final Chunk chunk = mockChunkAt(0, 0, 0);
-        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
-        generateMockChunkCubeWithSideWidthAround(chunk.getPosition(), 1, chunkCache);
-        markAllChunksAsReadyExcludingPosition(chunkCache, new Vector3i(1, 0, 0));
-
-        chunkProvider.completeUpdate();
-
-        verify(chunk, never()).setAdjacentChunksReady(true);
-    }
-
-    @Test
-    public void testCompleteUpdateSetsAdjacentChunksAdjacentChunksReady() throws Exception {
-        generateMockChunkCubeWithSideWidthAround(new Vector3i(0, 1, 0), 1, chunkCache);
-        chunkCache.removeChunkAt(new Vector3i(0, 0, 0));
-        markAllChunksAsReady(chunkCache);
-        final Chunk adjacentChunk = mockChunkAt(0, 1, 0);
-        chunkCache.put(adjacentChunk.getPosition(), adjacentChunk);
-        final Chunk chunk = mockChunkWithReadinessStateAt(0, 0, 0);
-        chunkCache.put(chunk.getPosition(), chunk);
-        final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
-
-        // chunk at 0,1,0 is not ready and all adjacent chunks around it except 0,0,0 are marked ready.
-        // we expect chunk 0,0,0 to become ready and all adjacent chunks to be updated
-        chunkProvider.completeUpdate();
-
-        // therefore chunk 0,1,0 should have its adjacent chunk readiness state set to true
-        // because now all of its adjacent chunks are ready
-        verify(adjacentChunk).setAdjacentChunksReady(true);
     }
 
     @Test

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -377,7 +377,14 @@ class RenderableWorldImpl implements RenderableWorld {
     }
 
     private boolean isChunkValidForRender(RenderableChunk chunk) {
-        return chunk.isReady() && chunk.areAdjacentChunksReady();
+        if (!chunk.isReady()) {
+            return false;
+        }
+        boolean surroundingChunksLoaded = worldProvider.getWorldViewAround(chunk.getPosition()) == null;
+        if (surroundingChunksLoaded) {
+            return false;
+        }
+        return true;
     }
 
     private boolean isChunkVisibleFromMainLight(RenderableChunk chunk) {

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -377,14 +377,11 @@ class RenderableWorldImpl implements RenderableWorld {
     }
 
     private boolean isChunkValidForRender(RenderableChunk chunk) {
-        if (!chunk.isReady()) {
-            return false;
-        }
-        boolean surroundingChunksLoaded = worldProvider.getWorldViewAround(chunk.getPosition()) == null;
-        if (surroundingChunksLoaded) {
-            return false;
-        }
-        return true;
+        return chunk.isReady() && areSurroundingChunksLoaded(chunk);
+    }
+
+    private boolean areSurroundingChunksLoaded(RenderableChunk chunk) {
+        return worldProvider.getWorldViewAround(chunk.getPosition()) != null;
     }
 
     private boolean isChunkVisibleFromMainLight(RenderableChunk chunk) {

--- a/engine/src/main/java/org/terasology/world/chunks/RenderableChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/RenderableChunk.java
@@ -48,9 +48,6 @@ public interface RenderableChunk extends LitChunk {
 
     void disposeMesh();
 
-    void setAdjacentChunksReady(boolean b);
-
-    boolean areAdjacentChunksReady();
-
     boolean isReady();
+
 }

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -538,16 +538,6 @@ public class ChunkImpl implements Chunk {
     }
 
     @Override
-    public void setAdjacentChunksReady(boolean value) {
-        this.adjacentChunksReady = value;
-    }
-
-    @Override
-    public boolean areAdjacentChunksReady() {
-        return this.adjacentChunksReady;
-    }
-
-    @Override
     public boolean isDisposed() {
         return disposed;
     }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -181,7 +181,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
         Chunk[] chunks = new Chunk[region.sizeX() * region.sizeY() * region.sizeZ()];
         for (Vector3i chunkPos : region) {
             Chunk chunk = chunkCache.get(chunkPos);
-            if (chunk == null || !chunk.isReady()) {
+            if (chunk == null) {
                 return null;
             }
             chunkPos.sub(region.minX(), region.minY(), region.minZ());
@@ -322,8 +322,6 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
     private void updateChunkReadinessState(final ReadyChunkInfo readyChunkInfo) {
         Chunk chunk = readyChunkInfo.getChunk();
         chunk.markReady();
-        updateAdjacentChunksReadyFieldOf(chunk);
-        updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
     }
 
     private void generateQueuedEntities(EntityStore store) {
@@ -447,7 +445,6 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
         }
         storageManager.deactivateChunk(chunk);
         chunk.dispose();
-        updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
 
         try {
             unloadRequestTaskMaster.put(new ChunkUnloadRequest(chunk, this));
@@ -465,14 +462,6 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
             }
         }
         return true;
-    }
-
-    private void updateAdjacentChunksReadyFieldOfAdjChunks(Chunk chunkInCenter) {
-        listAdjacentChunks(chunkInCenter).forEach(this::updateAdjacentChunksReadyFieldOf);
-    }
-
-    private void updateAdjacentChunksReadyFieldOf(Chunk chunk) {
-        chunk.setAdjacentChunksReady(areAdjacentChunksReady(chunk));
     }
 
     private List<Chunk> listAdjacentChunks(Chunk chunk) {

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -19,14 +19,12 @@ package org.terasology.world.chunks.remoteChunkProvider;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
-import org.terasology.math.Side;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -122,7 +120,6 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
                     Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
                     if (oldChunk != null) {
                         oldChunk.dispose();
-                        updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
                     }
                 }
             }
@@ -268,8 +265,6 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
         Chunk chunk = lightMerger.completeMerge();
         if (chunk != null) {
             chunk.markReady();
-            updateAdjacentChunksReadyFieldOf(chunk);
-            updateAdjacentChunksReadyFieldOfAdjChunks(chunk);
             listener.onChunkReady(chunk.getPosition());
             worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
         }
@@ -289,33 +284,6 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
         return chunkCache.get(pos);
     }
 
-    private boolean areAdjacentChunksReady(Chunk chunk) {
-        Vector3i centerChunkPos = chunk.getPosition();
-        for (Side side : Side.values()) {
-            Vector3i adjChunkPos = side.getAdjacentPos(centerChunkPos);
-            Chunk adjChunk = chunkCache.get(adjChunkPos);
-            boolean adjChunkReady = (adjChunk != null && adjChunk.isReady());
-            if (!adjChunkReady) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private void updateAdjacentChunksReadyFieldOf(Chunk chunk) {
-        chunk.setAdjacentChunksReady(areAdjacentChunksReady(chunk));
-    }
-
-    private void updateAdjacentChunksReadyFieldOfAdjChunks(Chunk chunkInCenter) {
-        Vector3i centerChunkPos = chunkInCenter.getPosition();
-        for (Side side : Side.values()) {
-            Vector3i adjChunkPos = side.getAdjacentPos(centerChunkPos);
-            Chunk adjChunk = chunkCache.get(adjChunkPos);
-            if (adjChunk != null) {
-                updateAdjacentChunksReadyFieldOf(adjChunk);
-            }
-        }
-    }
 
     private class ChunkTaskRelevanceComparator implements Comparator<ChunkTask> {
 


### PR DESCRIPTION
### Contains

Improves the situation described in issue #1886.  In single player chunks become now visible when the nearby chunks got loaded and the chunk in the current location got light merged.

In multiplayer the amount of needed chunks before the first chunk becomes visible should be reduced from 7x7x7 to 5x5x5. It is an improvement but there is still room for further optimization.

### How to test

Change the view distance to "Legally Bild (5x5x5)" and then start a single player game. Do this once with and without the changes of this PR. Without this PR only a single chunk is visible. With this PR 9 chunks are visible (3x3x3).
