### PR TITLE
Rework path management to be more explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Thumbs.db
 /saves/
 /screenshots/
 /logs/
+/configs/
 /terasology-server/
 /terasology-2ndclient/
 /terasology-3rdclient/

--- a/engine/src/main/java/org/terasology/config/flexible/FlexibleConfigManagerImpl.java
+++ b/engine/src/main/java/org/terasology/config/flexible/FlexibleConfigManagerImpl.java
@@ -87,21 +87,10 @@ public class FlexibleConfigManagerImpl implements FlexibleConfigManager {
         }
     }
 
-    private void ensureDirectoryExists(Path filePath) {
-        try {
-            Files.createDirectories(filePath.getParent());
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot create directory for FC!");
-        }
-    }
-
     private Path getPathForFlexibleConfig(SimpleUri flexibleConfigId) {
-        Path filePath = PathManager.getInstance()
-                                        .getHomePath()
-                                        .resolve("configs")
-                                        .resolve(flexibleConfigId.getModuleName().toString())
-                                        .resolve(flexibleConfigId.getObjectName().toString() + ".cfg");
-        ensureDirectoryExists(filePath);
-        return filePath;
+        return PathManager.getInstance()
+                            .getConfigsPath()
+                            .resolve(flexibleConfigId.getModuleName().toString())
+                            .resolve(flexibleConfigId.getObjectName().toString() + ".cfg");
     }
 }

--- a/engine/src/main/java/org/terasology/engine/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/paths/PathManager.java
@@ -46,6 +46,7 @@ public final class PathManager {
     private static final String MOD_DIR = "modules";
     private static final String SCREENSHOT_DIR = "screenshots";
     private static final String NATIVES_DIR = "natives";
+    private static final String CONFIGS_DIR = "configs";
 
     private static PathManager instance;
     private Path installPath;
@@ -58,6 +59,7 @@ public final class PathManager {
     private ImmutableList<Path> modPaths = ImmutableList.of();
     private Path screenshotPath;
     private Path nativesPath;
+    private Path configsPath;
 
     private PathManager() {
         // By default, the path should be the code location (where terasology.jar is)
@@ -237,6 +239,14 @@ public final class PathManager {
     }
 
     /**
+     *
+     * @return Path in which the game's config files are saved.
+     */
+    public Path getConfigsPath() {
+        return configsPath;
+    }
+
+    /**
      * Updates all of the path manager's file/directory references to match the path settings. Creates directories if they don't already exist.
      * @throws IOException Thrown when required directories cannot be accessed.
      */
@@ -260,6 +270,8 @@ public final class PathManager {
         screenshotPath = homePath.resolve(SCREENSHOT_DIR);
         Files.createDirectories(screenshotPath);
         nativesPath = installPath.resolve(NATIVES_DIR);
+        configsPath = installPath.resolve(CONFIGS_DIR);
+        Files.createDirectories(configsPath);
         if (currentWorldPath == null) {
             currentWorldPath = homePath;
         }


### PR DESCRIPTION
Adds the `configs` folder to gitignore, and makes the path selection for the same more organized.

Potentially relevant to @emanuele3d @oniatus @eviltak 