### PR TITLE
Basic groundwork for exposing render API (WiP)

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -26,6 +26,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
+import org.terasology.rendering.dag.RenderGraph;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -190,6 +191,11 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     @Override
     public String getMetrics() {
         return "";
+    }
+
+    @Override
+    public RenderGraph getRenderGraph() {
+        return null;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -100,9 +100,6 @@ public class CoreCommands extends BaseComponentSystem {
     private EntityManager entityManager;
 
     @In
-    private WorldRenderer worldRenderer;
-
-    @In
     private PrefabManager prefabManager;
 
     @In
@@ -615,14 +612,5 @@ public class CoreCommands extends BaseComponentSystem {
     @Command(shortDescription = "Clears the console window of previous messages.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void clear() {
         console.clear();
-    }
-
-    /**
-     * Forces all the shaders to recompile
-     */
-    @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
-    public void recompileShaders() {
-        WorldRendererImpl worldRendererImpl = (WorldRendererImpl) worldRenderer;
-        worldRendererImpl.recompileShaders();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/AbstractNode.java
@@ -38,7 +38,7 @@ public abstract class AbstractNode implements Node {
 
     private Set<StateChange> desiredStateChanges = Sets.newLinkedHashSet();
     private Map<SimpleUri, BaseFBOsManager> fboUsages = Maps.newHashMap();
-    private boolean enabled = true;
+    protected boolean enabled = true;
     private SimpleUri nodeUri = null;
 
     protected FBO requiresFBO(FBOConfig fboConfig, BaseFBOsManager fboManager) {

--- a/engine/src/main/java/org/terasology/rendering/dag/ConditionDependentNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/ConditionDependentNode.java
@@ -38,7 +38,6 @@ public abstract class ConditionDependentNode extends AbstractNode implements Pro
 
     protected void requiresCondition(Supplier<Boolean> condition) {
         conditions.add(condition);
-        checkConditions(); // TODO: better to remove this in near feature
     }
 
     private boolean checkConditions() {
@@ -46,23 +45,11 @@ public abstract class ConditionDependentNode extends AbstractNode implements Pro
         for (Supplier<Boolean> condition : conditions) {
             conditionsAreSatisfied = conditionsAreSatisfied && condition.get();
         }
-
-        if (conditionsAreSatisfied != isEnabled()) {
-            setEnabled(conditionsAreSatisfied);
-            // enabling/disabling here means we cannot enable/disable nodes directly:
-            // we must always go through the settings.
-            return true;
-        } else {
-            return false;
-        }
-
+        return conditionsAreSatisfied;
     }
 
     @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        boolean conditionsChanged = checkConditions();
-        if (conditionsChanged) {
-            worldRenderer.requestTaskListRefresh();
-        }
+    public boolean isEnabled() {
+        return enabled && checkConditions();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -17,9 +17,11 @@ package org.terasology.rendering.world;
 
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.module.sandbox.API;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
+import org.terasology.rendering.dag.RenderGraph;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 
 /**
@@ -218,4 +220,11 @@ public interface WorldRenderer {
      */
     // TODO: transform this to return an object or a map. Consumers would then take care of formatting.
     String getMetrics();
+
+    /**
+     * Returns the RenderGraph used to organize the nodes. This can be used to Modules to add/remove Nodes to the game.
+     *
+     * @return a RenderGraph used to organize the nodes.
+     */
+    RenderGraph getRenderGraph();
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -774,6 +774,15 @@ public final class WorldRendererImpl implements WorldRenderer {
     }
 
     /**
+     * Forces a recompilation of all shaders. This command, backed by Gestalt's monitoring feature,
+     * allows developers to hot-swap shaders for easy development.
+     */
+    @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
+    public void recompileShaders() {
+        shaderManager.recompileAllShaders();
+    }
+
+    /**
      * Acts as an interface between the console and the Nodes. All parameters passed to command are redirected to the
      * concerned Nodes, which in turn take care of executing them.
      */


### PR DESCRIPTION
The basic aim of this PR is to open up the RenderGraph and associated classes to modules, and enable them to add their own Nodes.

# Completed
Basic changes to expose RenderGraph to modules

# Remaining
- [ ] Add handler functions (onAdd, onRemove and so on) for Nodes
- [ ] Add `aka` attribute to Nodes
- [ ] Automatic module detection for Nodes, when setting their UID