### PR TITLE
Brought back ensureDirectoryExists() for FCs

### DIFF
--- a/engine/src/main/java/org/terasology/config/flexible/FlexibleConfigManagerImpl.java
+++ b/engine/src/main/java/org/terasology/config/flexible/FlexibleConfigManagerImpl.java
@@ -73,6 +73,14 @@ public class FlexibleConfigManagerImpl implements FlexibleConfigManager {
         }
     }
 
+    private void ensureDirectoryExists(Path filePath) {
+        try {
+            Files.createDirectories(filePath.getParent());
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot create directory for flexibleConfig " + filePath.getFileName() + "!");
+        }
+    }
+
     @Override
     public void saveAllConfigs() {
         for (Entry<SimpleUri, FlexibleConfig> entry : flexibleConfigs.entrySet()) {
@@ -88,9 +96,12 @@ public class FlexibleConfigManagerImpl implements FlexibleConfigManager {
     }
 
     private Path getPathForFlexibleConfig(SimpleUri flexibleConfigId) {
-        return PathManager.getInstance()
-                            .getConfigsPath()
-                            .resolve(flexibleConfigId.getModuleName().toString())
-                            .resolve(flexibleConfigId.getObjectName().toString() + ".cfg");
+        Path filePath = PathManager.getInstance()
+                                   .getConfigsPath()
+                                   .resolve(flexibleConfigId.getModuleName().toString())
+                                   .resolve(flexibleConfigId.getObjectName().toString() + ".cfg");
+        // This call ensures that the entire directory structure (like configs/engine/) exists.
+        ensureDirectoryExists(filePath);
+        return filePath;
     }
 }

--- a/engine/src/main/java/org/terasology/engine/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/paths/PathManager.java
@@ -271,7 +271,6 @@ public final class PathManager {
         Files.createDirectories(screenshotPath);
         nativesPath = installPath.resolve(NATIVES_DIR);
         configsPath = installPath.resolve(CONFIGS_DIR);
-        Files.createDirectories(configsPath);
         if (currentWorldPath == null) {
             currentWorldPath = homePath;
         }


### PR DESCRIPTION
Rolls back some of the changes made in #3252, because creating the directory in PathManager create the `configs` directory, but did not create the `configs/engine` (or `configs/moduleName`, in general case) directory.

Relevant to @emanuele3d and @Cervator.