### PR TITLE
Fixed weird light bugs with fog settings on

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/RenderGraph.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/RenderGraph.java
@@ -91,19 +91,18 @@ public class RenderGraph {
         for (Node toNode : nodeList) {
             Preconditions.checkNotNull(toNode, "toNode cannot be null!");
 
-            if (fromNode == null) {
-                fromNode = toNode;
-                continue;
+            if (fromNode != null) {
+                boolean success = edgeMap.put(fromNode, toNode);
+                if (success) {
+                    reverseEdgeMap.put(toNode, fromNode);
+                } else {
+                    logger.warn("Trying to connect two already connected nodes, " + fromNode.getClass() + " and " + toNode.getClass());
+                }
+
+                returnValue = returnValue && success;
             }
 
-            boolean success = edgeMap.put(fromNode, toNode);
-            if (success) {
-                reverseEdgeMap.put(toNode, fromNode);
-            } else {
-                logger.warn("Trying to connect two already connected nodes, " + fromNode.getClass() + " and " + toNode.getClass());
-            }
-
-            returnValue = returnValue && success;
+            fromNode = toNode;
         }
 
         return returnValue;

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -316,24 +316,26 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
     private void addWorldRenderingNodes(RenderGraph renderGraph) {
         // Ideally, world rendering nodes only depend on gBufferClearingNode. However, since haze is produced
         // by blurring the gBuffer and we don't want world objects/lighting to be a part of the haze,
-        // the world rendering nodes need to run after hazeIntermediateNode.
-        Node hazeIntermediateNode = renderGraph.findNode("engine:hazeIntermediateNode");
+        // the world rendering nodes need to run after hazeFinalNode. Strictly speaking the dependency is on
+        // HazeIntermediateNode rather than HazeFinalNode, but we wish to keep the haze nodes grouped together.
+        // See diagram: https://sketchboard.me/nAE1f4q2pDpd#/
+        Node hazeFinalNode = renderGraph.findNode("engine:hazeFinalNode");
 
         Node opaqueObjectsNode = new OpaqueObjectsNode(context);
         renderGraph.addNode(opaqueObjectsNode, "opaqueObjectsNode");
-        renderGraph.connect(hazeIntermediateNode, opaqueObjectsNode);
+        renderGraph.connect(hazeFinalNode, opaqueObjectsNode);
 
         Node opaqueBlocksNode = new OpaqueBlocksNode(context);
         renderGraph.addNode(opaqueBlocksNode, "opaqueBlocksNode");
-        renderGraph.connect(hazeIntermediateNode, opaqueBlocksNode);
+        renderGraph.connect(hazeFinalNode, opaqueBlocksNode);
 
         Node alphaRejectBlocksNode = new AlphaRejectBlocksNode(context);
         renderGraph.addNode(alphaRejectBlocksNode, "alphaRejectBlocksNode");
-        renderGraph.connect(hazeIntermediateNode, alphaRejectBlocksNode);
+        renderGraph.connect(hazeFinalNode, alphaRejectBlocksNode);
 
         Node overlaysNode = new OverlaysNode(context);
         renderGraph.addNode(overlaysNode, "overlaysNode");
-        renderGraph.connect(hazeIntermediateNode, overlaysNode);
+        renderGraph.connect(hazeFinalNode, overlaysNode);
     }
 
     private void addLightingNodes(RenderGraph renderGraph) {

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -314,11 +314,15 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
     }
 
     private void addWorldRenderingNodes(RenderGraph renderGraph) {
-        // Ideally, world rendering nodes only depend on gBufferClearingNode. However, since haze is produced
-        // by blurring the gBuffer and we don't want world objects/lighting to be a part of the haze,
-        // the world rendering nodes need to run after hazeFinalNode. Strictly speaking the dependency is on
-        // HazeIntermediateNode rather than HazeFinalNode, but we wish to keep the haze nodes grouped together.
-        // See diagram: https://sketchboard.me/nAE1f4q2pDpd#/
+        /* Ideally, world rendering nodes only depend on the gBufferClearingNode. However,
+        since the haze is produced by blurring the content of the gBuffer and we only want
+        the sky color to contribute  to the haze, the world rendering nodes need to run
+        after hazeFinalNode, so that the landscape and other meshes are not part of the haze.
+
+        Strictly speaking however, it is only the hazeIntermediateNode that should be processed
+        before the world rendering nodes. Here we have chosen to also ensure that hazeFinalNode is
+        processed before the world rendering nodes - not because it's necessary, but to keep all
+        the haze-related nodes together. */
         Node hazeFinalNode = renderGraph.findNode("engine:hazeFinalNode");
 
         Node opaqueObjectsNode = new OpaqueObjectsNode(context);


### PR DESCRIPTION
Currently, with the fog setting on, during the night objects far away will appear illuminated instead of being pitch black.

Cause: There were two different causes. First, the `connect` method was not working properly. Second, an additional dependency of worldNodes had to be added to hazeIntermediateNode, so that haze did not contain objects/lighting.