### PR TITLE
Converted WorldRenderer to a non-system class

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -101,9 +101,6 @@ public class CoreCommands extends BaseComponentSystem {
     private EntityManager entityManager;
 
     @In
-    private WorldRenderer worldRenderer;
-
-    @In
     private PrefabManager prefabManager;
 
     @In
@@ -687,14 +684,5 @@ public class CoreCommands extends BaseComponentSystem {
     @Command(shortDescription = "Clears the console window of previous messages.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void clear() {
         console.clear();
-    }
-
-    /**
-     * Forces all the shaders to recompile
-     */
-    @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
-    public void recompileShaders() {
-        WorldRendererImpl worldRendererImpl = (WorldRendererImpl) worldRenderer;
-        worldRendererImpl.recompileShaders();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -776,9 +776,9 @@ public final class WorldRendererImpl implements WorldRenderer {
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
-        console.addMessage("Recompiling shaders..");
+        console.addMessage("Recompiling shaders... ");
         shaderManager.recompileAllShaders();
-        console.addMessage("Done!");
+        console.addMessage("done!");
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -769,6 +769,9 @@ public final class WorldRendererImpl implements WorldRenderer {
     /**
      * Forces a recompilation of all shaders. This command, backed by Gestalt's monitoring feature,
      * allows developers to hot-swap shaders for easy development.
+     *
+     * Usage:
+     *      recompileShaders
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
@@ -778,6 +781,12 @@ public final class WorldRendererImpl implements WorldRenderer {
     /**
      * Acts as an interface between the console and the Nodes. All parameters passed to command are redirected to the
      * concerned Nodes, which in turn take care of executing them.
+     *
+     * Usage:
+     *      dagCommandNode <nodeUri> <command> <parameters>
+     *
+     * Sample Usage:
+     *      dagNodeCommand engine:outputToScreenNode setFbo engine:fbo.ssao
      */
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void dagNodeCommand(@CommandParam("nodeUri") final String nodeUri, @CommandParam("command") final String command, @CommandParam(value= "arguments") final String... arguments) {

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -22,8 +22,9 @@ import org.terasology.engine.SimpleUri;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.engine.subsystem.lwjgl.LwjglGraphics;
-import org.terasology.entitySystem.systems.ComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.console.Console;
+import org.terasology.logic.console.commandSystem.MethodCommand;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.permission.PermissionManager;
@@ -119,10 +120,9 @@ import static org.terasology.rendering.opengl.ScalingFactors.QUARTER_SCALE;
  * - a RenderableWorld instance, providing acceleration structures caching blocks requiring different rendering treatments<br/>
  */
 @RegisterSystem
-public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
-
+public final class WorldRendererImpl implements WorldRenderer {
     /*
-     * presumably, the eye height should be context.get(Config.class).getPlayer().getEyeHeight() above the ground plane.
+     * Presumably, the eye height should be context.get(Config.class).getPlayer().getEyeHeight() above the ground plane.
      * It's not, so for now, we use this factor to adjust for the disparity.
      */
     private static final float GROUND_PLANE_HEIGHT_DISPARITY = -0.7f;
@@ -159,22 +159,6 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
     private ImmutableFBOs immutableFBOs;
     private DisplayResolutionDependentFBOs displayResolutionDependentFBOs;
     private ShadowMapResolutionDependentFBOs shadowMapResolutionDependentFBOs;
-
-    // Required for ComponentSystem to register the system (via @RegisterSystem).
-    // @RegisterSystem requires a default constructor, and since we have final variables in the class,
-    // it was essential to set them to some value (in this case, null) in this constructor.
-    // Note that this constructor shouldn't be actually used normally anywhere in code.
-    public WorldRendererImpl() {
-        renderingConfig = null;
-        vrProvider = null;
-        renderQueues = null;
-        context = null;
-        backdropProvider = null;
-        worldProvider = null;
-        renderableWorld = null;
-        shaderManager = null;
-        playerCamera = null;
-    }
 
     /**
      * Instantiates a WorldRenderer implementation.
@@ -231,6 +215,8 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
         renderQueues = renderableWorld.getRenderQueues();
 
         initRenderingSupport();
+
+        MethodCommand.registerAvailable(this, context.get(Console.class), context);
     }
 
     private void initRenderingSupport() {
@@ -782,30 +768,6 @@ public final class WorldRendererImpl implements WorldRenderer, ComponentSystem {
 
     public void recompileShaders() {
         shaderManager.recompileAllShaders();
-    }
-
-    @Override
-    public void initialise() {
-    }
-
-    @Override
-    public void preBegin() {
-    }
-
-    @Override
-    public void postBegin() {
-    }
-
-    @Override
-    public void preSave() {
-    }
-
-    @Override
-    public void postSave() {
-    }
-
-    @Override
-    public void shutdown() {
     }
 
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -149,6 +149,7 @@ public final class WorldRendererImpl implements WorldRenderer {
     private int statRenderedTriangles;
 
     private final RenderingConfig renderingConfig;
+    private final Console console;
 
     private RenderTaskListGenerator renderTaskListGenerator;
     private boolean requestedTaskListRefresh;
@@ -216,7 +217,8 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         initRenderingSupport();
 
-        MethodCommand.registerAvailable(this, context.get(Console.class), context);
+        console = context.get(Console.class);
+        MethodCommand.registerAvailable(this, console, context);
     }
 
     private void initRenderingSupport() {
@@ -774,7 +776,9 @@ public final class WorldRendererImpl implements WorldRenderer {
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
+        console.addMessage("Recompiling shaders..");
         shaderManager.recompileAllShaders();
+        console.addMessage("Done!");
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -770,8 +770,7 @@ public final class WorldRendererImpl implements WorldRenderer {
      * Forces a recompilation of all shaders. This command, backed by Gestalt's monitoring feature,
      * allows developers to hot-swap shaders for easy development.
      *
-     * Usage:
-     *      recompileShaders
+     * To run the command simply type "recompileShaders" and then press Enter in the console.
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
@@ -785,7 +784,7 @@ public final class WorldRendererImpl implements WorldRenderer {
      * Usage:
      *      dagCommandNode <nodeUri> <command> <parameters>
      *
-     * Sample Usage:
+     * Example:
      *      dagNodeCommand engine:outputToScreenNode setFbo engine:fbo.ssao
      */
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -137,7 +137,6 @@ public final class WorldRendererImpl implements WorldRenderer {
     private final ShaderManager shaderManager;
     private final SubmersibleCamera playerCamera;
 
-    // TODO: @In
     private final OpenVRProvider vrProvider;
 
     private float timeSmoothedMainLightIntensity;
@@ -182,6 +181,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         this.backdropProvider = context.get(BackdropProvider.class);
         this.renderingConfig = context.get(Config.class).getRendering();
         this.shaderManager = context.get(ShaderManager.class);
+        // TODO: Instantiate the VR provider at a more reasonable location, and just obtain it via context here.
         vrProvider = OpenVRProvider.getInstance();
         if (renderingConfig.isVrSupport()) {
             context.put(OpenVRProvider.class, vrProvider);
@@ -766,10 +766,19 @@ public final class WorldRendererImpl implements WorldRenderer {
         return currentRenderingStage;
     }
 
+    /**
+     * Forces a recompilation of all shaders. This command, backed by Gestalt's monitoring feature,
+     * allows developers to hot-swap shaders for easy development.
+     */
+    @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
         shaderManager.recompileAllShaders();
     }
 
+    /**
+     * Acts as an interface between the console and the Nodes. All parameters passed to command are redirected to the
+     * concerned Nodes, which in turn take care of executing them.
+     */
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void dagNodeCommand(@CommandParam("nodeUri") final String nodeUri, @CommandParam("command") final String command, @CommandParam(value= "arguments") final String... arguments) {
         Node node = renderGraph.findNode(nodeUri);


### PR DESCRIPTION
As discussed in #3254, WR should not be a system, since that leads to 2 instances of this singleton class. This PR addresses the issue by removing the System status of the class, and instead registering the commands in it through `MethodCommand.registerAvailable`.

This PR contains a second smaller commit, that moves the `recompileShaders` command from CoreCommands to WorldRenderer.

As a side note, I still feel like WorldRenderer is becoming a monolith class, and we should consider moving commands to a different class. Any feedback on this idea would be great.