### PR TITLE
Remove setupConditions

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BloomBlurNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BloomBlurNode.java
@@ -45,17 +45,9 @@ public class BloomBlurNode extends BlurNode {
      */
     public BloomBlurNode(Context context, FBO inputFbo, FBO outputFbo) {
         super(context, inputFbo, outputFbo, BLUR_RADIUS);
-    }
 
-    /**
-     * This method establishes the conditions in which the blur will take place, by enabling or disabling the node.
-     *
-     * In this particular case the node is enabled if RenderingConfig.isBloom is true.
-     */
-    @Override
-    protected void setupConditions(Context context) {
         RenderingConfig renderingConfig = context.get(Config.class).getRendering();
-        renderingConfig.subscribe(RenderingConfig.BLOOM, this);
         requiresCondition(renderingConfig::isBloom);
+        renderingConfig.subscribe(RenderingConfig.BLOOM, this);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/BlurNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/BlurNode.java
@@ -53,8 +53,6 @@ public class BlurNode extends ConditionDependentNode {
 
         this.blurRadius = blurRadius;
 
-        setupConditions(context);
-
         this.inputFbo = inputFbo;
         this.outputFbo = outputFbo;
         addDesiredStateChange(new BindFbo(outputFbo));
@@ -63,13 +61,6 @@ public class BlurNode extends ConditionDependentNode {
         addDesiredStateChange(new EnableMaterial(BLUR_MATERIAL_URN));
         this.blurMaterial = getMaterial(BLUR_MATERIAL_URN);
     }
-
-    /**
-     * This method does nothing. It is meant to be overridden by inheriting classes if needed.
-     * On the other hand, there might be situations in which the blur should always occur,
-     * in which case this BlurNode class is good as it is.
-     */
-    protected void setupConditions(Context context) { }
 
     /**
      * Performs the blur.

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DownSamplerForExposureNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DownSamplerForExposureNode.java
@@ -43,17 +43,10 @@ public class DownSamplerForExposureNode extends DownSamplerNode {
     public DownSamplerForExposureNode(Context context, FBOConfig inputFboConfig, BaseFBOsManager inputFboManager,
                                                         FBOConfig outputFboConfig, BaseFBOsManager outputFboManager) {
         super(context, inputFboConfig, inputFboManager, outputFboConfig, outputFboManager);
-    }
 
-    /**
-     * This method establishes the conditions in which the downsampling will take place, by enabling or disabling the node.
-     *
-     * In this particular case the node is enabled if RenderingConfig.isEyeAdaptation returns true.
-     */
-    @Override
-    protected void setupConditions(Context context) {
         RenderingConfig renderingConfig = context.get(Config.class).getRendering();
-        renderingConfig.subscribe(RenderingConfig.EYE_ADAPTATION, this);
         requiresCondition(renderingConfig::isEyeAdaptation);
+
+        renderingConfig.subscribe(RenderingConfig.EYE_ADAPTATION, this);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/DownSamplerNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/DownSamplerNode.java
@@ -62,18 +62,9 @@ public class DownSamplerNode extends ConditionDependentNode {
         addDesiredStateChange(new SetInputTextureFromFbo(0, inputFbo, ColorTexture, inputFboManager,
                 DOWN_SAMPLER_MATERIAL_URN, TEXTURE_NAME));
 
-        setupConditions(context);
-
         addDesiredStateChange(new EnableMaterial(DOWN_SAMPLER_MATERIAL_URN));
         downSampler = getMaterial(DOWN_SAMPLER_MATERIAL_URN);
     }
-
-    /**
-     * This method does nothing. It is meant to be overridden by inheriting classes if needed.
-     * On the other hand, there might be situations in which downsampling should always occur,
-     * in which case this DownSamplerNode class is good as it is.
-     */
-    protected void setupConditions(Context context) { }
 
     /**
      * Processes the input FBO downsampling its color attachment into the color attachment of the output FBO.

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/HazeNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/HazeNode.java
@@ -47,17 +47,9 @@ public class HazeNode extends BlurNode {
      */
     public HazeNode(Context context, FBO inputFbo, FBO outputFbo) {
         super(context, inputFbo, outputFbo, BLUR_RADIUS);
-    }
 
-    /**
-     * This method establishes the conditions in which the blur will take place, by enabling or disabling the node.
-     *
-     * In this particular case the node is enabled if RenderingConfig.isInscattering() returns true.
-     */
-    @Override
-    protected void setupConditions(Context context) {
         renderingConfig = context.get(Config.class).getRendering();
+        requiresCondition(renderingConfig::isInscattering);
         renderingConfig.subscribe(RenderingConfig.INSCATTERING, this);
-        requiresCondition(() -> renderingConfig.isInscattering());
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/LateBlurNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/LateBlurNode.java
@@ -54,19 +54,12 @@ public class LateBlurNode extends BlurNode implements PropertyChangeListener {
      */
     public LateBlurNode(Context context, FBO inputFbo, FBO outputFbo) {
         super(context, inputFbo, outputFbo, 0); // note: blurRadius is 0.0 at this stage.
-        updateBlurRadius(); // only here blurRadius is properly set.
-    }
 
-    /**
-     * This method establishes the conditions in which the blur will take place, by enabling or disabling the node.
-     *
-     * In this particular case the node is enabled if RenderingConfig.getBlurIntensity is not 0 - or blur is enabled.
-     */
-    @Override
-    protected void setupConditions(Context context) {
         renderingConfig = context.get(Config.class).getRendering();
+        requiresCondition(() -> renderingConfig.getBlurIntensity() != 0); // getBlurIntensity > 0 implies blur is enabled.
         renderingConfig.subscribe(RenderingConfig.BLUR_INTENSITY, this);
-        requiresCondition(() -> renderingConfig.getBlurIntensity() != 0);
+
+        updateBlurRadius(); // only here blurRadius is properly set.
     }
 
     @Override


### PR DESCRIPTION
This PR removes the setupConditions used by BlurNode and DownsamplerNode. This was probably required with the NodeFactory approach, but as things stand, it's very easy to move the contents of setupConditions to the constructor itself, which in turn makes the code cleaner and simpler.

This is an experimental move, and feedback would be appreciated.