### PR TITLE
Fix for (beginner) issue #3272.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -82,6 +82,7 @@ public class SelectGameScreen extends CoreScreenLayer {
         final UIList<GameInfo> gameList = find("gameList", UIList.class);
 
         refreshList(gameList);
+        gameList.select(0);
         gameList.subscribe((widget, item) -> loadGame(item));
 
         CreateGameScreen screen = getManager().createScreen(CreateGameScreen.ASSET_URI, CreateGameScreen.class);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains
My attempt at fixing issue #3272 .
I added a select(0) method to the SelectGameScreen class. It now selects the first saved game(if it exists).

There's no need to verify if index 0 is valid, since index checking is already performed in the select() method.
### How to test
1. Launch Terasology and create a saved world.
2. Go to the SelectGame screen from either 'Singleplayer' or 'Host Game' options in the main menu.
3. The first entry in the list is selected by default.
![image](https://user-images.githubusercontent.com/11874996/36825237-66969d00-1d2c-11e8-9b50-a365bc39c9fe.png)

