### PR TITLE
Fix scrolling when there's already enough space.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIScrollbar.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIScrollbar.java
@@ -218,7 +218,7 @@ public class UIScrollbar extends CoreWidget {
      * @return The max value scrollable to.
      */
     public int getRange() {
-        return range.get();
+        return Math.max(0, range.get());
     }
 
     /**


### PR DESCRIPTION
### Contains

Scrollbars for ScrollableAreas in spaces large enough that they don't need to scroll are now fixed at 0, rather than flickering between the top and bottom when the scrollwheel is used.

### How to test

Open the video config menu. Resize the window so that there is space left below the menu. Use the mouse scrollwheel.
