### PR TITLE
Add method for inline messages (Issue #3268)

### DIFF
--- a/engine-tests/src/test/java/org/terasology/logic/console/ConsoleTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/console/ConsoleTest.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 
 public class ConsoleTest extends TerasologyTestingEnvironment {
 
+    private final String MSG_TXT = "Test message";
+
     @Test
     public void testClearCommand() {
         for (int i = 0; i < 10; i++) {
@@ -33,6 +35,43 @@ public class ConsoleTest extends TerasologyTestingEnvironment {
         getConsole().clear();
 
         Iterator<Message> it = getConsole().getMessages().iterator();
+        Assert.assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void testAddMessage() {
+        getConsole().addMessage(MSG_TXT);
+
+        checkMessage(getConsole().getMessages().iterator(), true);
+    }
+
+    @Test
+    public void testAddConsoleMessage() {
+        getConsole().addMessage(new Message(MSG_TXT));
+
+        checkMessage(getConsole().getMessages().iterator(), true);
+    }
+
+    @Test
+    public void testAddInlineMessage() {
+        getConsole().addInlineMessage(MSG_TXT);
+
+        checkMessage(getConsole().getMessages().iterator(), false);
+    }
+
+    @Test
+    public void testAddInlineMessage2() {
+        getConsole().addInlineMessage(new Message(MSG_TXT));
+
+        checkMessage(getConsole().getMessages().iterator(), false);
+    }
+
+    private void checkMessage(Iterator<Message> it, boolean hasNewLine) {
+        Assert.assertNotNull(it);
+        Assert.assertTrue(it.hasNext());
+        final Message message = it.next();
+        Assert.assertEquals(MSG_TXT, message.getMessage());
+        Assert.assertEquals(hasNewLine, message.hasNewLine());
         Assert.assertFalse(it.hasNext());
     }
 

--- a/engine-tests/src/test/java/org/terasology/logic/console/ConsoleTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/console/ConsoleTest.java
@@ -54,14 +54,14 @@ public class ConsoleTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testAddInlineMessage() {
-        getConsole().addInlineMessage(MSG_TXT);
+        getConsole().addMessage(MSG_TXT, false);
 
         checkMessage(getConsole().getMessages().iterator(), false);
     }
 
     @Test
     public void testAddInlineMessage2() {
-        getConsole().addInlineMessage(new Message(MSG_TXT));
+        getConsole().addMessage(new Message(MSG_TXT, false));
 
         checkMessage(getConsole().getMessages().iterator(), false);
     }

--- a/engine/src/main/java/org/terasology/logic/console/Console.java
+++ b/engine/src/main/java/org/terasology/logic/console/Console.java
@@ -60,27 +60,21 @@ public interface Console {
     void addMessage(Message message);
 
     /**
-     * Adds a message to the console (as a CoreMessageType.CONSOLE message) without new line at the end
+     * Adds a message to the console (as a CoreMessageType.CONSOLE message)
      *
      * @param message
+     * @param newLine Flag indicates about new line at the end of message
      */
-    void addInlineMessage(String message);
+    void addMessage(String message, boolean newLine);
 
     /**
-     * Adds a message to the console without new line at the end
+     * Adds a message to the console (as a CoreMessageType.CONSOLE message)
      *
      * @param message
      * @param type
+     * @param newLine Flag indicates about new line at the end of message
      */
-    void addInlineMessage(String message, MessageType type);
-
-    /**
-     * Adds a message to the console without new line at the end
-     *
-     * @param message
-     */
-    void addInlineMessage(Message message);
-
+    void addMessage(String message, MessageType type, boolean newLine);
     /**
      * @return An iterator over all messages in the console
      */

--- a/engine/src/main/java/org/terasology/logic/console/Console.java
+++ b/engine/src/main/java/org/terasology/logic/console/Console.java
@@ -60,6 +60,28 @@ public interface Console {
     void addMessage(Message message);
 
     /**
+     * Adds a message to the console (as a CoreMessageType.CONSOLE message) without new line at the end
+     *
+     * @param message
+     */
+    void addInlineMessage(String message);
+
+    /**
+     * Adds a message to the console without new line at the end
+     *
+     * @param message
+     * @param type
+     */
+    void addInlineMessage(String message, MessageType type);
+
+    /**
+     * Adds a message to the console without new line at the end
+     *
+     * @param message
+     */
+    void addInlineMessage(Message message);
+
+    /**
      * @return An iterator over all messages in the console
      */
     Iterable<Message> getMessages();

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -118,6 +118,40 @@ public class ConsoleImpl implements Console {
     }
 
     /**
+     * Adds a message to the console (as a CoreMessageType.CONSOLE message) without new line at the end
+     *
+     * @param message The message content
+     */
+    @Override
+    public void addInlineMessage(String message)
+    {
+        addMessage(new Message(message, false));
+    }
+
+    /**
+     * Adds a message to the console without new line at the end
+     *
+     * @param message The content of the message
+     * @param type    The type of the message
+     */
+    @Override
+    public void addInlineMessage(String message, MessageType type)
+    {
+        addMessage(new Message(message, type, false));
+    }
+
+    /**
+     * Adds a message to the console without new line at the end
+     *
+     * @param message The message to be added
+     */
+    @Override
+    public void addInlineMessage(Message message)
+    {
+        addMessage(new Message(message.getMessage(), message.getType(), false));
+    }
+
+    /**
      * Adds a message to the console
      *
      * @param message The message to be added

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleImpl.java
@@ -118,37 +118,27 @@ public class ConsoleImpl implements Console {
     }
 
     /**
-     * Adds a message to the console (as a CoreMessageType.CONSOLE message) without new line at the end
+     * Adds a message to the console
      *
-     * @param message The message content
+     * @param message    The message to be added
+     * @param newLine    Flag indicates about new line at the of message
      */
     @Override
-    public void addInlineMessage(String message)
+    public void addMessage(String message, boolean newLine)
     {
-        addMessage(new Message(message, false));
+        addMessage(new Message(message, newLine));
     }
 
     /**
-     * Adds a message to the console without new line at the end
+     * Adds a message to the console
      *
-     * @param message The content of the message
-     * @param type    The type of the message
+     * @param message    The message to be added
+     * @param type       The type of the message
+     * @param newLine    Flag indicates about new line at the of message
      */
     @Override
-    public void addInlineMessage(String message, MessageType type)
-    {
-        addMessage(new Message(message, type, false));
-    }
-
-    /**
-     * Adds a message to the console without new line at the end
-     *
-     * @param message The message to be added
-     */
-    @Override
-    public void addInlineMessage(Message message)
-    {
-        addMessage(new Message(message.getMessage(), message.getType(), false));
+    public void addMessage(String message, MessageType type, boolean newLine) {
+        addMessage(new Message(message, type, newLine));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/console/Message.java
+++ b/engine/src/main/java/org/terasology/logic/console/Message.java
@@ -21,15 +21,30 @@ public class Message {
 
     private final MessageType type;
     private final String message;
+    private final boolean newLine;
 
     public Message(String message) {
         this.message = message;
         this.type = CoreMessageType.CONSOLE;
+        this.newLine = true;
     }
 
     public Message(String message, MessageType type) {
         this.message = message;
         this.type = type;
+        this.newLine = true;
+    }
+
+    public Message(String message, MessageType type, boolean newLine) {
+        this.message = message;
+        this.type = type;
+        this.newLine = newLine;
+    }
+
+    public Message(String message, boolean newLine) {
+        this.message = message;
+        this.type = CoreMessageType.CONSOLE;
+        this.newLine = newLine;
     }
 
     public String getMessage() {
@@ -39,7 +54,12 @@ public class Message {
     public MessageType getType() {
         return type;
     }
-    
+
+    public boolean hasNewLine()
+    {
+        return newLine;
+    }
+
     @Override
     public String toString() {
         return String.format("[%s] '%s'", type, message); 

--- a/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/ConsoleScreen.java
@@ -88,7 +88,9 @@ public class ConsoleScreen extends CoreScreenLayer {
                 StringBuilder messageList = new StringBuilder();
                 for (Message message : console.getMessages()) {
                     messageList.append(FontColor.getColored(message.getMessage(), message.getType().getColor()));
-                    messageList.append(Console.NEW_LINE);
+                    if (message.hasNewLine()) {
+                        messageList.append(Console.NEW_LINE);
+                    }
                 }
                 return messageList.toString();
             }

--- a/engine/src/main/java/org/terasology/logic/console/ui/NotificationOverlay.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/NotificationOverlay.java
@@ -78,7 +78,7 @@ public class NotificationOverlay extends CoreScreenLayer {
                 for (Message msg : msgs) {
                     if (count > size - MAX_MESSAGES) {
                         messageHistory.append(StringUtils.abbreviate(msg.getMessage(), MAX_CHAR_PER_MSG));
-                        if (count < size) {
+                        if (count < size && msg.hasNewLine()) {
                             messageHistory.append(Console.NEW_LINE);
                         }
                     }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -785,7 +785,7 @@ public final class WorldRendererImpl implements WorldRenderer {
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
-        console.addInlineMessage("Recompiling shaders... ");
+        console.addMessage("Recompiling shaders... ", false);
         shaderManager.recompileAllShaders();
         console.addMessage("done!");
     }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -785,7 +785,7 @@ public final class WorldRendererImpl implements WorldRenderer {
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
-        console.addMessage("Recompiling shaders... ");
+        console.addInlineMessage("Recompiling shaders... ");
         shaderManager.recompileAllShaders();
         console.addMessage("done!");
     }


### PR DESCRIPTION
### Contains

Hi All,
I've added new method which we can use to solve an issue #3268. 

### How to test

1. Open Console
2. Write "recompileShaders". So, at present we don't have new line between messages.
=> Recompiling shaders... done.
3. PROFIT :)

### Notes

I'm not sure, will it be useful to add this functionality to ChatScreen widget. If so, let me know...
