### PR TITLE
Altered contructorTest() to use JUnit's built in Exception handling

### DIFF
--- a/engine-tests/src/test/java/org/terasology/particles/ParticlePoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/particles/ParticlePoolTest.java
@@ -105,7 +105,7 @@ public class ParticlePoolTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void constructorTest() {
         final int[] poolSizes = {1, 27, 133};
 
@@ -124,13 +124,9 @@ public class ParticlePoolTest {
 
             assertEquals(size * 4, pool.color.length);
         }
-
-        try {
-            ParticlePool pool = new ParticlePool(0);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertTrue(true); //succeed
-        }
+        // Should throw exception after creating the pool
+        ParticlePool pool = new ParticlePool(0);
+        
     }
 
     @Test


### PR DESCRIPTION

### Contains

Alters the constructorTest() unit test to use JUnit 4's built in Exception testing framework. 

I made this change because I noticed that little try/catch block in the method, which included some code that could be considered "unreachable". 

### How to test

It is a pretty small change, as this is my first Pull Request (just trying things out) 

To test, you could change the zero in the bottom ParticlePool to a '1' and run the test, which will cause it to fail. Then, change it back to '0' to make the test then pass. 
