### PR TITLE
'groovyw * list' output condensed format

### DIFF
--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -132,30 +132,44 @@ switch(cleanerArgs[0]) {
     case "list":
         String[] availableItems = common.retrieveAvailableItems()
         String[] localItems = common.retrieveLocalItems()
+        String[] downloadableItems = availableItems.minus(localItems)
         println "The following items are available for download:"
-        if (availableItems.size() == 0){
+        if (availableItems.size() == 0) {
             println "No items available for download."
-        } else if (localItems == availableItems){
+        } else if (downloadableItems.size() == 0) {
             println "All items are already downloaded."
         } else {
-            for (item in availableItems){
-                if(!(localItems.contains(item))){
-                    println "--$item"
-                }
-            }
+            printListItems(downloadableItems)
         }
         println "\nThe following items are already downloaded:"
-        if(localItems.size() == 0){
+        if(localItems.size() == 0) {
             println "No items downloaded."
         } else {
-            for(item in localItems){
-                println "--$item"
-            }
+            printListItems(localItems)
         }
         break
 
     default:
         println "UNRECOGNIZED COMMAND '" + cleanerArgs[0] + "' - please try again or use 'groovyw usage' for help"
+}
+
+private void printListItems(String[] items) {
+    def final CONDENSED_FORMAT_THRESHOLD = 50
+    items.size() < CONDENSED_FORMAT_THRESHOLD ?
+        printListItemsSimple(items) :
+        printListItemsCondensed(items)
+}
+
+private void printListItemsSimple(String[] items) {
+    for (item in items.sort()) {
+        println "--$item"
+    }
+}
+
+private void printListItemsCondensed(String[] items) {
+    for (group in items.groupBy {it[0].toUpperCase()}) {
+        println "--" + group.key + ": " + group.value.sort().join(", ")
+    }
 }
 
 /**


### PR DESCRIPTION
### Contains

Addresses condensed output format for long lists mentioned in #3279

### How to test

Run: **groovyw module list**
Long lists are presented like below. Currently output format depends only on list size (threshold is hardcoded to 50). I think it would be a good idea to allow user override it and explicte specify which format he wants to use.

> --A: AdditionalFruits, AdditionalItemPipes, AdditionalRails, AdditionalVegetables, AdditionalWorlds, AdvancedBehaviors, Adventure, AdventureAssets, Alchemy, AlchemyPlantGenerator, AlterationEffects, Anatomy, AnotherWorld, AnotherWorldPlants
> --B: BasicCrafting, Behaviors, BlockDetector, BlockFamilyTutorial, BlockNetwork, BlockPicker, Books, BoomSticks, BoundlessWorlds, Breathing
> --C: CakeLie, Caves, ChangingBlocks, CheatsForAll, ChiselBlocks, ChrisVolume1OST, ChrisVolume2OST, Cities, ClimateConditions, Climbables, Combat, CombatSystem, CommonWorld, Compass, ComputerMonitors, Cooking, CopperAndBronze, Crafting, Crops, CustomOreGen
> --D: DamagingBlocks, DangerMod, Dialogs, Drills, Durability, DynamicBlocks, DynamicCities
> --E: Economy, EdibleFlora, EdibleSubstance, Equipment, EquipmentSmithing, EventualSkills
> --F: Fences, FlightModeToggleButton, Fluid, FluidComputerIntegration, FunnyBlocks
> --G: GelCubes, Genome, GooeysQuests, GrammarSystem, GrowingFlora, Guards
> --H: HUDToggleButtons, HealingBlocks, Herbalism, HjerlHede, Holdings, HumanoidCharacters, Hunger
> --I: IRLCorp, InGameHelp, InGameHelpAPI, Indicators, Inferno, ItemPipes, ItemRendering
> --J: JoshariasSurvival, Journal
> --K: KotlinLib
> --L: Lakes, LandOfTerra, LegacyMusic, LightAndShadow, LightAndShadowResources, LootPools, Lost
> --M: Machines, MagicalStats, Malicious, ManualLabor, ManualLaborEventualSkills, MarcinScIncubator, MarkovChains, MasterOfOreon, MedievalCities, MetalliFabrica, Minerals, Mineshafts, Minesweeper, Miniion, Minimap, MobileBlocks, ModularComputers, ModuleTestingEnvironment, MoreLights, MultiBlock, MusicDirector
> --N: NameGenerator, NeoTTA, NetworkTransport
> --O: OreGeneration, Oreons
> --P: Pathfinding, PhysicalStats, PlantPack, PolyWorld, Portals, PotentialEnergyDevices, Potions, Projectile, ProtoSignals
> --Q: QuestExamples
> --R: Rails, RomanCities, RpgSystem
> --S: Sample, ScalaLib, Scenario, Seasons, SegmentedPaths, Sensors, ServerMOTD, ShatteredPlanes, Signalling, SimpleFarming, SimpleLiquids, Smithing, SnakeTournament, Soils, Spawning, StaticCities, StoneCrafting, StructuralResources, StructureTemplates, SubstanceMatters, SurfaceFacets
> --T: Tasks, TheBetweenlands, Thirst, ThroughoutTheAges, TutorialAssetSystem, TutorialBehaviors, TutorialDynamicCities, TutorialGraphicTweaks, TutorialI18n, TutorialNui, TutorialParticleSystem, TutorialSectors, TutorialTelemetry, TutorialWorldGeneration
> --U: Underworld
> --V: Valentines
> --W: WeatherManager, WildAnimals, WildAnimalsGenome, WoodAndStone, WoodAndStoneCraftingJournal, WoodCrafting, Workstation, WorkstationCrafting, WorkstationInGameHelp, WorldPortals, WorldlyTooltip, WorldlyTooltipAPI