### PR TITLE
Fix #2246 Volumetric Fog broken

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/PrePostCompositeNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/PrePostCompositeNode.java
@@ -49,7 +49,7 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 
 /**
  * An instance of this class takes advantage of the content of a number of previously filled buffers
- * to add screen-space ambient occlusion (SSAO), outlines, reflections [1], atmospheric haze and volumetric fog [2]
+ * to add screen-space ambient occlusion (SSAO), outlines, reflections [1], atmospheric haze and volumetric fog
  *
  * As this node does not quite use 3D geometry and only relies on 2D sources and a 2D output buffer, it
  * could be argued that, despite its name, it represents the first step of the PostProcessing portion
@@ -58,7 +58,6 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  * has been shot on stage or on location.
  *
  * [1] And refractions? To be verified.
- * [2] Currently not working: the code is there but it is never enabled.
  */
 public class PrePostCompositeNode extends AbstractNode implements PropertyChangeListener {
     private static final ResourceUrn PRE_POST_MATERIAL_URN = new ResourceUrn("engine:prog.prePostComposite");
@@ -97,6 +96,14 @@ public class PrePostCompositeNode extends AbstractNode implements PropertyChange
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 1.0f)
     private float hazeThreshold = 0.8f;
+    
+    @SuppressWarnings("FieldCanBeLocal")
+    @Range(min = 0.0f, max = 0.1f)
+    private float volFogGlobalDensity = 0.005f;
+    @SuppressWarnings("FieldCanBeLocal")
+    @Range(min = -0.1f, max = 0.1f)
+    private float volFogHeightFalloff = -0.01f;
+    
 
     public PrePostCompositeNode(Context context) {
         worldRenderer = context.get(WorldRenderer.class);
@@ -177,7 +184,7 @@ public class PrePostCompositeNode extends AbstractNode implements PropertyChange
 
         if (volumetricFogIsEnabled) {
             prePostMaterial.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
-            //TODO: Other parameters and volumetric fog test case is needed
+            prePostMaterial.setFloat3("volumetricFogSettings", 1f, volFogGlobalDensity, volFogHeightFalloff, true);
         }
 
         if (hazeIsEnabled) {

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/PrePostCompositeNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/PrePostCompositeNode.java
@@ -99,11 +99,10 @@ public class PrePostCompositeNode extends AbstractNode implements PropertyChange
     
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.1f)
-    private float volFogGlobalDensity = 0.005f;
+    private float volumetricFogGlobalDensity = 0.005f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = -0.1f, max = 0.1f)
-    private float volFogHeightFalloff = -0.01f;
-    
+    private float volumetricFogHeightFalloff = -0.01f;
 
     public PrePostCompositeNode(Context context) {
         worldRenderer = context.get(WorldRenderer.class);
@@ -184,7 +183,7 @@ public class PrePostCompositeNode extends AbstractNode implements PropertyChange
 
         if (volumetricFogIsEnabled) {
             prePostMaterial.setMatrix4("invViewProjMatrix", activeCamera.getInverseViewProjectionMatrix(), true);
-            prePostMaterial.setFloat3("volumetricFogSettings", 1f, volFogGlobalDensity, volFogHeightFalloff, true);
+            prePostMaterial.setFloat3("volumetricFogSettings", 1f, volumetricFogGlobalDensity, volumetricFogHeightFalloff, true);
         }
 
         if (hazeIsEnabled) {

--- a/engine/src/main/resources/assets/shaders/prePostComposite_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/prePostComposite_frag.glsl
@@ -67,14 +67,11 @@ void main() {
     vec4 colorTransparent = texture2D(texSceneReflectiveRefractive, gl_TexCoord[0].xy);
     vec4 lightBufferOpaque = texture2D(texSceneOpaqueLightBuffer, gl_TexCoord[0].xy);
 
-#ifdef VOLUMETRIC_FOG
-    // TODO: As costly as in the deferred light geometry pass - frustum ray method would be great here
-    vec3 worldPosition = reconstructViewPos(depthOpaque, gl_TexCoord[0].xy, invViewProjMatrix);
+#if defined VOLUMETRIC_FOG || defined LOCAL_REFLECTIONS
+    vec3 worldPositionViewSpace = reconstructViewPos(depthOpaque, gl_TexCoord[0].xy, invProjMatrix);
 #endif
 
 #if defined (LOCAL_REFLECTIONS)
-    vec3 worldPositionViewSpace = reconstructViewPos(depthOpaque, gl_TexCoord[0].xy, invProjMatrix);
-
     vec4 transparentNormalColorValue = texture2D(texSceneReflectiveRefractiveNormals, gl_TexCoord[0].xy).xyzw;
     vec3 reflectionNormal = transparentNormalColorValue.xyz * 2.0 - 1.0;
     vec3 viewingDirection = normalize(worldPositionViewSpace.xyz);
@@ -163,7 +160,7 @@ void main() {
 
 #ifdef VOLUMETRIC_FOG
     // Use lightValueAtPlayerPos to avoid volumetric fog in caves
-    float volumetricFogValue = calcVolumetricFog(worldPosition - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
+    float volumetricFogValue = calcVolumetricFog(worldPositionViewSpace - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
 
     vec3 volFogColor = vec3(VOLUMETRIC_FOG_COLOR);
 

--- a/engine/src/main/resources/assets/shaders/prePostComposite_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/prePostComposite_frag.glsl
@@ -67,11 +67,14 @@ void main() {
     vec4 colorTransparent = texture2D(texSceneReflectiveRefractive, gl_TexCoord[0].xy);
     vec4 lightBufferOpaque = texture2D(texSceneOpaqueLightBuffer, gl_TexCoord[0].xy);
 
-#if defined VOLUMETRIC_FOG || defined LOCAL_REFLECTIONS
-    vec3 worldPositionViewSpace = reconstructViewPos(depthOpaque, gl_TexCoord[0].xy, invProjMatrix);
+#if defined VOLUMETRIC_FOG
+    // TODO: As costly as in the deferred light geometry pass - frustum ray method would be great here
+    vec3 fragmentPositionInCameraSpace = reconstructViewPos(depthOpaque, gl_TexCoord[0].xy, invViewProjMatrix);
 #endif
 
 #if defined (LOCAL_REFLECTIONS)
+    vec3 worldPositionViewSpace = reconstructViewPos(depthOpaque, gl_TexCoord[0].xy, invProjMatrix);
+
     vec4 transparentNormalColorValue = texture2D(texSceneReflectiveRefractiveNormals, gl_TexCoord[0].xy).xyzw;
     vec3 reflectionNormal = transparentNormalColorValue.xyz * 2.0 - 1.0;
     vec3 viewingDirection = normalize(worldPositionViewSpace.xyz);
@@ -160,7 +163,7 @@ void main() {
 
 #ifdef VOLUMETRIC_FOG
     // Use lightValueAtPlayerPos to avoid volumetric fog in caves
-    float volumetricFogValue = calcVolumetricFog(worldPositionViewSpace - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
+    float volumetricFogValue = calcVolumetricFog(fragmentPositionInCameraSpace - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
 
     vec3 volFogColor = vec3(VOLUMETRIC_FOG_COLOR);
 

--- a/engine/src/main/resources/assets/shaders/prePostComposite_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/prePostComposite_frag.glsl
@@ -52,11 +52,10 @@ uniform float outlineThickness;
 #define VOLUMETRIC_FOG_COLOR 1.0, 1.0, 1.0
 
 uniform mat4 invViewProjMatrix;
-uniform vec4 volumetricFogSettings;
+uniform vec3 volumetricFogSettings;
 #define volFogDensityAtViewer volumetricFogSettings.x
 #define volFogGlobalDensity volumetricFogSettings.y
 #define volFogHeightFalloff volumetricFogSettings.z
-#define volFogDensity volumetricFogSettings.w
 
 uniform vec3 fogWorldPosition;
 #endif
@@ -164,8 +163,7 @@ void main() {
 
 #ifdef VOLUMETRIC_FOG
     // Use lightValueAtPlayerPos to avoid volumetric fog in caves
-    float volumetricFogValue = volFogDensity *
-        calcVolumetricFog(worldPosition - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
+    float volumetricFogValue = calcVolumetricFog(worldPosition - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
 
     vec3 volFogColor = vec3(VOLUMETRIC_FOG_COLOR);
 

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -386,13 +386,11 @@
                                 },
                                 {
                                     "type": "UILabel",
-                                    "text": "${engine:menu#volumetric-fog}: ",
-                                    "enabled": false
+                                    "text": "${engine:menu#volumetric-fog}: "
                                 },
                                 {
                                     "type": "UICheckbox",
-                                    "id": "volumetricFog",
-                                    "enabled": false
+                                    "id": "volumetricFog"
                                 }
                             ]
                         },

--- a/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
+++ b/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
@@ -149,14 +149,14 @@ float calcVolumetricFog(vec3 fogWorldPosition, float volumetricHeightDensityAtVi
 
     float fogInt = length(cameraToFogWorldPosition) * volumetricHeightDensityAtViewer;
     const float slopeThreshold = 0.01;
+    float t = heightFalloff * cameraToFogWorldPosition.y;
 
-    if (abs(cameraToFogWorldPosition.y) > slopeThreshold)
+    if (abs(t) > slopeThreshold)
     {
-        float t = heightFalloff * cameraToFogWorldPosition.y;
         fogInt *= (1.0 - exp(-t)) / t;
     }
 
-    return exp(-globalDensity * fogInt);
+    return 1 - exp(-globalDensity * fogInt);
 }
 
 float calcLuminance(vec3 color) {

--- a/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
+++ b/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
@@ -147,16 +147,15 @@ float calcPcfShadowTerm(sampler2D shadowMap, float lightDepth, vec2 texCoord, fl
 float calcVolumetricFog(vec3 fogWorldPosition, float volumetricHeightDensityAtViewer, float globalDensity, float heightFalloff) {
     vec3 cameraToFogWorldPosition = -fogWorldPosition;
 
-    float fogInt = length(cameraToFogWorldPosition) * volumetricHeightDensityAtViewer;
+    float fogTotal = length(cameraToFogWorldPosition) * volumetricHeightDensityAtViewer;
     const float slopeThreshold = 0.01;
-    float t = heightFalloff * cameraToFogWorldPosition.y;
+    float heightDensityFactor = heightFalloff * cameraToFogWorldPosition.y;
 
-    if (abs(t) > slopeThreshold)
-    {
-        fogInt *= (1.0 - exp(-t)) / t;
+    if (abs(heightDensityFactor) > slopeThreshold) {
+        fogTotal *= (1.0 - exp(-heightDensityFactor)) / heightDensityFactor;
     }
 
-    return 1 - exp(-globalDensity * fogInt);
+    return 1 - exp(-globalDensity * fogTotal);
 }
 
 float calcLuminance(vec3 color) {

--- a/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
+++ b/engine/src/main/resources/org/terasology/include/globalFunctionsFragIncl.glsl
@@ -147,15 +147,15 @@ float calcPcfShadowTerm(sampler2D shadowMap, float lightDepth, vec2 texCoord, fl
 float calcVolumetricFog(vec3 fogWorldPosition, float volumetricHeightDensityAtViewer, float globalDensity, float heightFalloff) {
     vec3 cameraToFogWorldPosition = -fogWorldPosition;
 
-    float fogTotal = length(cameraToFogWorldPosition) * volumetricHeightDensityAtViewer;
+    float totalFogToSample = length(cameraToFogWorldPosition) * globalDensity * volumetricHeightDensityAtViewer;
+    
     const float slopeThreshold = 0.01;
     float heightDensityFactor = heightFalloff * cameraToFogWorldPosition.y;
-
     if (abs(heightDensityFactor) > slopeThreshold) {
-        fogTotal *= (1.0 - exp(-heightDensityFactor)) / heightDensityFactor;
+        totalFogToSample *= (1.0 - exp(-heightDensityFactor)) / heightDensityFactor;
     }
 
-    return 1 - exp(-globalDensity * fogTotal);
+    return 1 - exp(-totalFogToSample);
 }
 
 float calcLuminance(vec3 color) {


### PR DESCRIPTION
I don't fully understand the intention behind volumetric fog or how it's meant to interact with haze, but the obvious issue is fixed and it now looks like fog.

### Contains

Fix #2246. Re-enable menu item for volumetric fog. Add default setting for fog density and things. Remove volFogDensity, which looked like it was intended to make the fog never obscure things more than a certain amount, no matter how far away they are, as that seems to make it less useful for obscuring unloaded chunks.

The main part that resolves the original issue and the other issue this fix reveals is in globalFunctionsFragIncl.glsl .

### How to test

Turn on volumetric fog and turn off inscattering/fog from the video menu. Look around a large open area in-game.

### Outstanding before merging

fogDensityAtViewer is fixed at 1, rather than being used.
