### PR TITLE
CollisionShape API formalization

### DIFF
--- a/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
@@ -101,8 +101,7 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
 
         if (blockFamily.getArchetypeBlock().getCollisionShape() instanceof BoxShape) {
             BoxShape collisionShape = (BoxShape) blockFamily.getArchetypeBlock().getCollisionShape();
-            Vector3f extents = collisionShape.getHalfExtentsWithoutMargin();
-            extents.scale(2.0f);
+            Vector3f extents = collisionShape.getExtents();
             extents.x = Math.max(extents.x, 0.5f);
             extents.y = Math.max(extents.y, 0.5f);
             extents.z = Math.max(extents.z, 0.5f);

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletBoxShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletBoxShape.java
@@ -43,8 +43,8 @@ public class BulletBoxShape extends BulletCollisionShape implements org.terasolo
     }
 
     @Override
-    public Vector3f getHalfExtentsWithoutMargin() {
+    public Vector3f getExtents() {
         javax.vecmath.Vector3f out = new javax.vecmath.Vector3f();
-        return VecMath.from(boxShape.getHalfExtentsWithoutMargin(out));
+        return VecMath.from(boxShape.getHalfExtentsWithoutMargin(out)).scale(2);
     }
 }

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletConvexHullShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletConvexHullShape.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class BulletConvexHullShape extends BulletCollisionShape implements org.terasology.physics.shapes.ConvexHullShape {
+    // TODO: Handle scale
     private final ConvexHullShape convexHullShape;
 
     public BulletConvexHullShape(List<Vector3f> vertices) {
@@ -51,5 +52,12 @@ public class BulletConvexHullShape extends BulletCollisionShape implements org.t
             transformedVerts.add(com.bulletphysics.linearmath.QuaternionUtil.quatRotate(VecMath.to(rot), vert, new javax.vecmath.Vector3f()));
         }
         return new BulletConvexHullShape(transformedVerts);
+    }
+
+    @Override
+    public Vector3f[] getVertices() {
+        return convexHullShape.getPoints().stream()
+                .map(VecMath::from)
+                .toArray(Vector3f[]::new);
     }
 }

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletSphereShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletSphereShape.java
@@ -31,4 +31,9 @@ public class BulletSphereShape extends BulletCollisionShape implements org.teras
     public CollisionShape rotate(Quat4f rot) {
         return this;
     }
+
+    @Override
+    public float getRadius() {
+        return sphereShape.getRadius();
+    }
 }

--- a/engine/src/main/java/org/terasology/physics/shapes/BoxShape.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/BoxShape.java
@@ -22,9 +22,9 @@ import org.terasology.math.geom.Vector3f;
  */
 public interface BoxShape extends CollisionShape {
     /**
-     * Returns the half extents of the box shape without adding a margin.
+     * Returns the extents (size) of the box shape in every dimension.
      *
-     * @return The {@link Vector3f} containing the half extents of the box shape in each dimension.
+     * @return The {@link Vector3f} containing the dimensional extents of the box shape.
      */
-    Vector3f getHalfExtentsWithoutMargin();
+    Vector3f getExtents();
 }

--- a/engine/src/main/java/org/terasology/physics/shapes/ConvexHullShape.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/ConvexHullShape.java
@@ -15,8 +15,16 @@
  */
 package org.terasology.physics.shapes;
 
+import org.terasology.math.geom.Vector3f;
+
 /**
  * Represents a convex hull collision shape in the physics engine.
  */
 public interface ConvexHullShape extends CollisionShape {
+    /**
+     * Returns the scaled vertices of the {@link ConvexHullShape}.
+     *
+     * @return An array containing the scaled vertices.
+     */
+    Vector3f[] getVertices();
 }

--- a/engine/src/main/java/org/terasology/physics/shapes/SphereShape.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/SphereShape.java
@@ -19,4 +19,8 @@ package org.terasology.physics.shapes;
  * Represents a sphere collision shape in the physics engine.
  */
 public interface SphereShape extends CollisionShape {
+    /**
+     * Returns the radius of the sphere shape.
+     */
+    float getRadius();
 }


### PR DESCRIPTION
#3199 introduced a wrapper over collision shapes to remove engine and module dependencies on the physics engine. However, the introduced wrappers are merely functional and have inconsistent and incomplete public APIs. This PR formalizes the `CollisionShape` API and establish a consistent set of methods in the relevant interfaces.

# Changes
## Additions
- [x] `SphereShape.getRadius`
- [x] `BoxShape.getExtents`
- [x] `ConvexHullShape.getVertices`
- [ ] Child shape getters and removal methods to `CompoundShape`
- [ ] `CompoundShapeChild` interface 
- [ ] `CapsuleShape` interface
- [ ] `CylinderShape` interface

## Modifications
- [ ] Make `BulletCompoundShapeChild` public and an implementor of `CompoundShapeChild`
- [ ] Rename `CollisionShapeFactory` methods to use `create` prefix instead of `getNew`

## Removals
- [x] Remove `BoxShape.getHalfExtentsWithoutMargin` in favour of `BoxShape.getExtents`
