### PR TITLE
Added back face culling to several nodes

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/AlphaRejectBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/AlphaRejectBlocksNode.java
@@ -88,13 +88,13 @@ public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapa
         renderQueues = context.get(RenderQueuesHelper.class);
         worldProvider = context.get(WorldProvider.class);
 
-        wireframeStateChange = new SetWireframe(true);
-        RenderingDebugConfig renderingDebugConfig =  context.get(Config.class).getRendering().getDebug();
-        new WireframeTrigger(renderingDebugConfig, this);
-
         worldRenderer = context.get(WorldRenderer.class);
         activeCamera = worldRenderer.getActiveCamera();
         addDesiredStateChange(new LookThrough(activeCamera));
+
+        wireframeStateChange = new SetWireframe(true);
+        RenderingDebugConfig renderingDebugConfig =  context.get(Config.class).getRendering().getDebug();
+        new WireframeTrigger(renderingDebugConfig, this);
 
         addDesiredStateChange(new BindFbo(context.get(DisplayResolutionDependentFBOs.class).getGBufferPair().getLastUpdatedFbo()));
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -31,6 +31,7 @@ import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.WireframeCapable;
 import org.terasology.rendering.dag.WireframeTrigger;
 import org.terasology.rendering.dag.stateChanges.BindFbo;
+import org.terasology.rendering.dag.stateChanges.EnableFaceCulling;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.LookThrough;
 import org.terasology.rendering.dag.stateChanges.SetInputTexture2D;
@@ -95,6 +96,8 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
 
         addDesiredStateChange(new BindFbo(context.get(DisplayResolutionDependentFBOs.class).getGBufferPair().getLastUpdatedFbo()));
 
+        addDesiredStateChange(new EnableFaceCulling());
+
         addDesiredStateChange(new EnableMaterial(CHUNK_MATERIAL_URN));
 
         chunkMaterial = getMaterial(CHUNK_MATERIAL_URN);
@@ -122,15 +125,39 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
     }
 
     public void enableWireframe() {
+        boolean refreshTaskList = false;
+
+        EnableFaceCulling faceCullingStateChange = new EnableFaceCulling();
+        if (getDesiredStateChanges().contains(faceCullingStateChange)) {
+            removeDesiredStateChange(faceCullingStateChange);
+            refreshTaskList = true;
+        }
+
         if (!getDesiredStateChanges().contains(wireframeStateChange)) {
             addDesiredStateChange(wireframeStateChange);
+            refreshTaskList = true;
+        }
+
+        if (refreshTaskList) {
             worldRenderer.requestTaskListRefresh();
         }
     }
 
     public void disableWireframe() {
+        boolean refreshTaskList = false;
+
+        EnableFaceCulling faceCullingStateChange = new EnableFaceCulling();
+        if (!getDesiredStateChanges().contains(faceCullingStateChange)) {
+            addDesiredStateChange(faceCullingStateChange);
+            refreshTaskList = true;
+        }
+
         if (getDesiredStateChanges().contains(wireframeStateChange)) {
             removeDesiredStateChange(wireframeStateChange);
+            refreshTaskList = true;
+        }
+
+        if (refreshTaskList) {
             worldRenderer.requestTaskListRefresh();
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -91,7 +91,12 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
         activeCamera = worldRenderer.getActiveCamera();
         addDesiredStateChange(new LookThrough(activeCamera));
 
-        // Added before instantiating WireframeTrigger so it can remove this state change if needed - see enableWireframe()
+        // IF wireframe is enabled the WireframeTrigger will remove the face culling state change
+        // from the set of desired state changes.
+        // The alternative would have been to check here first if wireframe mode is enabled and *if not*
+        // add the face culling state change. However, if wireframe *is* enabled, the WireframeTrigger
+        // would attempt to remove the face culling state even though it isn't there, relying on the
+        // quiet behaviour of Set.remove(nonExistentItem). We therefore favored the first solution.
         faceCullingStateChange = new EnableFaceCulling();
         addDesiredStateChange(faceCullingStateChange);
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -87,6 +87,10 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
         renderQueues = context.get(RenderQueuesHelper.class);
         worldProvider = context.get(WorldProvider.class);
 
+        worldRenderer = context.get(WorldRenderer.class);
+        activeCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new LookThrough(activeCamera));
+
         // Added before instantiating WireframeTrigger so it can remove this state change if needed - see enableWireframe()
         faceCullingStateChange = new EnableFaceCulling();
         addDesiredStateChange(faceCullingStateChange);
@@ -94,10 +98,6 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
         wireframeStateChange = new SetWireframe(true);
         renderingDebugConfig = context.get(Config.class).getRendering().getDebug();
         new WireframeTrigger(renderingDebugConfig, this);
-
-        worldRenderer = context.get(WorldRenderer.class);
-        activeCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new LookThrough(activeCamera));
 
         addDesiredStateChange(new BindFbo(context.get(DisplayResolutionDependentFBOs.class).getGBufferPair().getLastUpdatedFbo()));
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueObjectsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueObjectsNode.java
@@ -49,6 +49,10 @@ public class OpaqueObjectsNode extends AbstractNode implements WireframeCapable 
     public OpaqueObjectsNode(Context context) {
         componentSystemManager = context.get(ComponentSystemManager.class);
 
+        worldRenderer = context.get(WorldRenderer.class);
+        Camera playerCamera = worldRenderer.getActiveCamera();
+        addDesiredStateChange(new LookThrough(playerCamera));
+
         // Added before instantiating WireframeTrigger so it can remove this state change if needed - see enableWireframe()
         faceCullingStateChange = new EnableFaceCulling();
         addDesiredStateChange(faceCullingStateChange);
@@ -56,10 +60,6 @@ public class OpaqueObjectsNode extends AbstractNode implements WireframeCapable 
         wireframeStateChange = new SetWireframe(true);
         RenderingDebugConfig renderingDebugConfig = context.get(Config.class).getRendering().getDebug();
         new WireframeTrigger(renderingDebugConfig, this);
-
-        worldRenderer = context.get(WorldRenderer.class);
-        Camera playerCamera = worldRenderer.getActiveCamera();
-        addDesiredStateChange(new LookThrough(playerCamera));
 
         addDesiredStateChange(new BindFbo(context.get(DisplayResolutionDependentFBOs.class).getGBufferPair().getLastUpdatedFbo()));
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueObjectsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueObjectsNode.java
@@ -53,7 +53,12 @@ public class OpaqueObjectsNode extends AbstractNode implements WireframeCapable 
         Camera playerCamera = worldRenderer.getActiveCamera();
         addDesiredStateChange(new LookThrough(playerCamera));
 
-        // Added before instantiating WireframeTrigger so it can remove this state change if needed - see enableWireframe()
+        // IF wireframe is enabled the WireframeTrigger will remove the face culling state change
+        // from the set of desired state changes.
+        // The alternative would have been to check here first if wireframe mode is enabled and *if not*
+        // add the face culling state change. However, if wireframe *is* enabled, the WireframeTrigger
+        // would attempt to remove the face culling state even though it isn't there, relying on the
+        // quiet behaviour of Set.remove(nonExistentItem). We therefore favored the first solution.
         faceCullingStateChange = new EnableFaceCulling();
         addDesiredStateChange(faceCullingStateChange);
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueObjectsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueObjectsNode.java
@@ -26,6 +26,7 @@ import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.WireframeCapable;
 import org.terasology.rendering.dag.WireframeTrigger;
 import org.terasology.rendering.dag.stateChanges.BindFbo;
+import org.terasology.rendering.dag.stateChanges.EnableFaceCulling;
 import org.terasology.rendering.dag.stateChanges.LookThrough;
 import org.terasology.rendering.dag.stateChanges.SetWireframe;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
@@ -56,18 +57,44 @@ public class OpaqueObjectsNode extends AbstractNode implements WireframeCapable 
         addDesiredStateChange(new LookThrough(playerCamera));
 
         addDesiredStateChange(new BindFbo(context.get(DisplayResolutionDependentFBOs.class).getGBufferPair().getLastUpdatedFbo()));
+
+        addDesiredStateChange(new EnableFaceCulling());
     }
 
     public void enableWireframe() {
+        boolean refreshTaskList = false;
+
+        EnableFaceCulling faceCullingStateChange = new EnableFaceCulling();
+        if (getDesiredStateChanges().contains(faceCullingStateChange)) {
+            removeDesiredStateChange(faceCullingStateChange);
+            refreshTaskList = true;
+        }
+
         if (!getDesiredStateChanges().contains(wireframeStateChange)) {
             addDesiredStateChange(wireframeStateChange);
+            refreshTaskList = true;
+        }
+
+        if (refreshTaskList) {
             worldRenderer.requestTaskListRefresh();
         }
     }
 
     public void disableWireframe() {
+        boolean refreshTaskList = false;
+
+        EnableFaceCulling faceCullingStateChange = new EnableFaceCulling();
+        if (!getDesiredStateChanges().contains(faceCullingStateChange)) {
+            addDesiredStateChange(faceCullingStateChange);
+            refreshTaskList = true;
+        }
+
         if (getDesiredStateChanges().contains(wireframeStateChange)) {
             removeDesiredStateChange(wireframeStateChange);
+            refreshTaskList = true;
+        }
+
+        if (refreshTaskList) {
             worldRenderer.requestTaskListRefresh();
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OverlaysNode.java
@@ -50,13 +50,13 @@ public class OverlaysNode extends AbstractNode implements WireframeCapable {
     public OverlaysNode(Context context) {
         componentSystemManager = context.get(ComponentSystemManager.class);
 
-        wireframeStateChange = new SetWireframe(true);
-        RenderingDebugConfig renderingDebugConfig = context.get(Config.class).getRendering().getDebug();
-        new WireframeTrigger(renderingDebugConfig, this);
-
         worldRenderer = context.get(WorldRenderer.class);
         SubmersibleCamera playerCamera = worldRenderer.getActiveCamera();
         addDesiredStateChange(new LookThrough(playerCamera));
+
+        wireframeStateChange = new SetWireframe(true);
+        RenderingDebugConfig renderingDebugConfig = context.get(Config.class).getRendering().getDebug();
+        new WireframeTrigger(renderingDebugConfig, this);
 
         addDesiredStateChange(new BindFbo(context.get(DisplayResolutionDependentFBOs.class).getGBufferPair().getLastUpdatedFbo()));
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/ShadowMapNode.java
@@ -29,6 +29,7 @@ import org.terasology.rendering.cameras.OrthographicCamera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
 import org.terasology.rendering.dag.ConditionDependentNode;
 import org.terasology.rendering.dag.stateChanges.BindFbo;
+import org.terasology.rendering.dag.stateChanges.EnableFaceCulling;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.opengl.FBO;
@@ -94,6 +95,8 @@ public class ShadowMapNode extends ConditionDependentNode implements PropertyCha
         addDesiredStateChange(new BindFbo(shadowMapFbo));
         addDesiredStateChange(new SetViewportToSizeOf(shadowMapFbo));
         addDesiredStateChange(new EnableMaterial(SHADOW_MAP_MATERIAL_URN));
+
+        addDesiredStateChange(new EnableFaceCulling());
     }
 
     private float calculateTexelSize(int shadowMapResolution) {

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkMesh.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkMesh.java
@@ -275,9 +275,7 @@ public class ChunkMesh {
                 break;
             case ALPHA_REJECT:
                 renderVbo(1);
-                glDisable(GL_CULL_FACE);
                 renderVbo(2);
-                glEnable(GL_CULL_FACE);
                 break;
             case REFRACTIVE:
                 renderVbo(3);


### PR DESCRIPTION
### Contains
This pull request adds back face culling into nodes that can take advantage of it (#3044).

Back face culling can make rendering more efficient by not rendering triangles that are facing away from the camera. This is very useful for opaque models. The camera can't see through them, which means there's no point in rendering the away-facing triangles. As most of the blocks and objects are opaque, this change should speed up the rendering process.

### Changes:
- Added back face culling to OpaqueBlocksNode, OpaqueObjectsNode and ShadowMapNode.
- Wireframe mode disables back face culling in OpaqueBlocksNode and OpaqueObjectsNode.
