### PR TITLE
fix issue #2755

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/relative/RelativeLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/relative/RelativeLayout.java
@@ -190,9 +190,13 @@ public class RelativeLayout extends CoreLayout<RelativeLayoutHint> {
             }
             WidgetInfo target = contentLookup.get(id);
             if (target != null) {
-                Rect2i region = getRegion(target, canvas);
-                loopDetectionId = "";
-                return region;
+                try {
+                    Rect2i region = getRegion(target, canvas);
+                    loopDetectionId = "";
+                    return region;
+                } catch (StackOverflowError e){
+                    logger.error("Stack Overflow detected resolving layout of element {}, unable to render", loopDetectionId);
+                }
             }
         }
         loopDetectionId = "";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fix #2755, stack overflow error caused by infinite recursion between the methods getRegion() and getTargetRegion(). If one element in the NUI editor is set to be below another element, and the second element is set to be above the first, then the getRegion() and getTargetRegion() repeatedly call each other when trying to resolve the location of the elements. This results in a stack overflow.

The fix is a simple try/catch checking for a StackOverflowError exception in the getRegion() method when calling the getTargetRegion() method. The exception only fires when the game would otherwise crash, so the performance impact is minimal.

### How to test

The NUI editor seems to be a bit buggy, so it is best to test this issue by manually adding elements.

1. Open NUI editor
2. Select new screen and make sure it is the default example
3. Under the item named contents in the editor tree, click "Add Widget" and choose engine:UILabel
4. Expand the new widget and right click on the newly created "layoutInfo" button
5. Select add->position-top
6. On the new position-top, select add->widget and make the string "sampleLabel
7. Open the default widget created by the editor, and select the layoutInfo button
8. Select add->position-bottom
9. on the new position-bottom, select add->widget and make the string "newWidget"

Without this fix, the program would crash here, but with the fix it repeatedly prints an error message to the console and continues.