### PR TITLE
Fix for filtered modules in SelectModulesScreen [Issue #3050]

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/SelectModulesScreen.java
@@ -526,7 +526,7 @@ public class SelectModulesScreen extends CoreScreenLayer {
     }
 
     private List<Name> getExplicitlySelectedModules() {
-        return sortedModules.stream().filter(ModuleSelectionInfo::isExplicitSelection).map(info ->
+        return allSortedModules.stream().filter(ModuleSelectionInfo::isExplicitSelection).map(info ->
                 info.getMetadata().getId()).collect(Collectors.toCollection(ArrayList::new));
     }
 


### PR DESCRIPTION

### Contains

Small fix for the Issue #3050. 
The issue was that _getExplicitlySelectedModules_() method use _sortedModules_, and _filterText()_ method do the same. In this case, when we call _refreshSelection()_ it works with "filtered/searched" modules which might be are not explicitly selected. 

### How to test

1. Create new game
2. Activate **JoshariasSurvival** module.
3. Search "help". You should get list from 3 items (In Game Help, In Game Help API, and WorkstationInGameHelp)
4. Activate and deactivate "In Game Help API". 
5. Check that search result is still yellow and presented.
