### PR TITLE
Re-activate removal of underwater surfaces from reflections.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorldGenerator.java
@@ -46,7 +46,7 @@ public class InitialiseWorldGenerator extends SingleStepLoadProcess {
         worldGenerator.initialize();
 
         WorldRenderer worldRenderer = context.get(WorldRenderer.class);
-        worldRenderer.getActiveCamera().setReflectionHeight(worldGenerator.getWorld().getSeaLevel());
+        worldRenderer.getActiveCamera().setReflectionHeight(worldGenerator.getWorld().getSeaLevel() + 0.5f);
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetworkSystemImpl.java
@@ -847,7 +847,7 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
         }
         WorldGenerator worldGen = context.get(WorldGenerator.class);
         if (worldGen != null) {
-            serverInfoMessageBuilder.setReflectionHeight(worldGen.getWorld().getSeaLevel());
+            serverInfoMessageBuilder.setReflectionHeight(worldGen.getWorld().getSeaLevel() + 0.5f);
         }
         for (Module module : CoreRegistry.get(ModuleManager.class).getEnvironment()) {
             if (!StandardModuleExtension.isServerSideOnly(module)) {

--- a/engine/src/main/java/org/terasology/rendering/cameras/Camera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/Camera.java
@@ -156,12 +156,6 @@ public abstract class Camera {
         prevViewProjectionMatrix.set(viewProjectionMatrix);
     }
 
-    public float getClipHeight() {
-        // msteiger: I believe the offset results from the
-        // slightly lowered water surface height.
-        return reflectionHeight - 0.5f;
-    }
-
     public Matrix4f getViewMatrix() {
         if (!reflected) {
             return viewMatrix;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -180,7 +180,7 @@ public class WorldReflectionNode extends ConditionDependentNode {
             }
         }
 
-        chunkMaterial.setFloat("clip", activeCamera.getClipHeight(), true);
+        chunkMaterial.setFloat("clip", activeCamera.getReflectionHeight(), true);
 
         // Actual Node Processing
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -180,7 +180,7 @@ public class WorldReflectionNode extends ConditionDependentNode {
             }
         }
 
-        chunkMaterial.setFloat("clip", 0.0f, true);
+        chunkMaterial.setFloat("clip", activeCamera.getClipHeight(), true);
 
         // Actual Node Processing
 

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -80,7 +80,7 @@ void main() {
 
 // Only necessary for opaque objects
 #if !defined (FEATURE_REFRACTIVE_PASS)
-	if (clip > 0.001 && vertexWorldPos.y < clip) {
+	if (vertexWorldPos.y < clip) {
         discard;
 	}
 #endif

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -78,8 +78,8 @@ uniform float clip;
 
 void main() {
 
-// Only necessary for opaque objects
-#if !defined (FEATURE_REFRACTIVE_PASS)
+// Active for worldReflectionNode only.
+#if defined FEATURE_USE_FORWARD_LIGHTING
 	if (vertexWorldPos.y < clip) {
         discard;
 	}


### PR DESCRIPTION
The code for doing this all already exists, but was inactive, leading to surfaces below the water's surface being reflected above it. This was disabled in 296558, for unclear reasons, which makes me suspicious there's something I'm missing, but the result does seem to look better.

### How to test

Activate global water reflections. View a water surface from a reasonably high angle, with well-lit surfaces beneath the water. Before this commit, they're reflected and obscure the correct reflections. After, they are omitted.
Before:
![incorrect reflections](https://user-images.githubusercontent.com/25589515/37826110-240bf13c-2e8a-11e8-988d-ce616a2aa638.png)
After:
![correct reflections](https://user-images.githubusercontent.com/25589515/37826118-2869f6ac-2e8a-11e8-8e78-e23ce524e6bc.png)



### Outstanding before merging

~~In Builder-sample mode, this causes nothing below sea-level to render.~~
