### PR TITLE
Add confirmation popup for button Delete on SelectGame screen

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -33,6 +33,7 @@ import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
+import org.terasology.rendering.nui.layers.mainMenu.TwoButtonPopup;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
 import org.terasology.utilities.FilesUtil;
@@ -99,21 +100,29 @@ public class SelectGameScreen extends CoreScreenLayer {
         });
 
         WidgetUtil.trySubscribe(this, "delete", button -> {
-            GameInfo gameInfo = gameList.getSelection();
-            if (gameInfo != null) {
-                Path world = PathManager.getInstance().getSavePath(gameInfo.getManifest().getTitle());
-                try {
-                    FilesUtil.recursiveDelete(world);
-                    gameList.getList().remove(gameInfo);
-                    gameList.setSelection(null);
-                } catch (Exception e) {
-                    logger.error("Failed to delete saved game", e);
-                    getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Error Deleting Game", e.getMessage());
-                }
-            }
+            TwoButtonPopup confirmationPopup = getManager().pushScreen(TwoButtonPopup.ASSET_URI, TwoButtonPopup.class);
+            confirmationPopup.setMessage(translationSystem.translate("${engine:menu#remove-confirmation-popup-title}"),
+                    translationSystem.translate("${engine:menu#remove-confirmation-popup-message}"));
+            confirmationPopup.setLeftButton(translationSystem.translate("${engine:menu#dialog-yes}"), () -> removeSelectedGame(gameList));
+            confirmationPopup.setRightButton(translationSystem.translate("${engine:menu#dialog-no}"), () -> { });
         });
 
         WidgetUtil.trySubscribe(this, "close", button -> triggerBackAnimation());
+    }
+
+    private void removeSelectedGame(final UIList<GameInfo> gameList) {
+        GameInfo gameInfo = gameList.getSelection();
+        if (gameInfo != null) {
+            Path world = PathManager.getInstance().getSavePath(gameInfo.getManifest().getTitle());
+            try {
+                FilesUtil.recursiveDelete(world);
+                gameList.getList().remove(gameInfo);
+                gameList.setSelection(null);
+            } catch (Exception e) {
+                logger.error("Failed to delete saved game", e);
+                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Error Deleting Game", e.getMessage());
+            }
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/TwoButtonPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/TwoButtonPopup.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UILabel;
+
+public class TwoButtonPopup extends CoreScreenLayer {
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:twoButtonPopup!instance");
+
+    private Runnable leftActon;
+    private Runnable rightAction;
+
+    @Override
+    public void initialise() {
+        WidgetUtil.trySubscribe(this, "leftButton", button -> buttonCallback(leftActon));
+        WidgetUtil.trySubscribe(this, "rightButton", button -> buttonCallback(rightAction));
+    }
+
+    private void buttonCallback(Runnable action) {
+        getManager().popScreen();
+        action.run();
+    }
+
+    public void setLeftButton(String text, Runnable action) {
+        find("leftButton", UIButton.class).setText(text);
+        leftActon = action;
+    }
+
+    public void setRightButton(String text, Runnable action) {
+        find("rightButton", UIButton.class).setText(text);
+        rightAction = action;
+    }
+
+    public void setMessage(String title, String message) {
+        find("title", UILabel.class).setText(title);
+        find("message", UILabel.class).setText(message);
+    }
+
+}

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -217,6 +217,8 @@
     "preview-world-title": "preview-world-title",
     "preview-zoom-factor": "preview-zoom-factor",
     "previous-toolbar-item": "previous-toolbar-item",
+    "remove-confirmation-popup-title": "remove-confirmation-popup-title",
+    "remove-confirmation-popup-message": "remove-confirmation-popup-message",
     "remove-binding": "remove-binding",
     "remove-server": "remove-server",
     "reset-default": "reset-default",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -223,6 +223,8 @@
     "preview-world-title": "Preview World...",
     "preview-zoom-factor": "Zoom",
     "previous-toolbar-item": "Previous Toolbar Item",
+    "remove-confirmation-popup-title": "Confirm delete",
+    "remove-confirmation-popup-message": "Are you sure you want to delete it?",
     "remove-binding": "Remove",
     "remove-server": "Remove",
     "reset-default": "Reset",

--- a/engine/src/main/resources/assets/i18n/menu_ru.lang
+++ b/engine/src/main/resources/assets/i18n/menu_ru.lang
@@ -174,6 +174,8 @@
     "preview-world-title": "Предварительный просмотр мира",
     "preview-zoom-factor": "Масштаб",
     "previous-toolbar-item": "Предыдущий инструмент",
+    "remove-confirmation-popup-title": "Подтвердите удаление",
+    "remove-confirmation-popup-message": "Вы уверены, что хотите это удалить?",
     "remove-binding": "удалить",
     "remove-server": "Удалить",
     "reset-default": "Сброс настроек",

--- a/engine/src/main/resources/assets/ui/menu/twoButtonPopup.ui
+++ b/engine/src/main/resources/assets/ui/menu/twoButtonPopup.ui
@@ -1,0 +1,66 @@
+{
+    "type": "twoButtonPopup",
+    "skin": "messageBox",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "UIBox",
+                "layoutInfo": {
+                    "width": 500,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-vertical-center": {}
+                },
+                "content": {
+                    "type": "ColumnLayout",
+                    "columns": 1,
+                    "verticalSpacing": 8,
+                    "contents": [
+                        {
+                            "type": "UILabel",
+                            "id": "title",
+                            "family": "title"
+                        },
+                        {
+                            "type": "UISpace",
+                            "size": [
+                                1,
+                                16
+                            ]
+                        },
+                        {
+                            "type": "UILabel",
+                            "id": "message"
+                        },
+                        {
+                            "type": "UISpace",
+                            "size": [
+                                1,
+                                16
+                            ]
+                        },
+                        {
+                            "type": "RowLayout",
+                            "horizontalSpacing": 4,
+                            "contents": [
+                                {
+                                    "type": "UIButton",
+                                    "id": "leftButton"
+                                },
+                                {
+                                    "type": "UIButton",
+                                    "id": "rightButton"
+                                }
+                            ],
+                            "layoutInfo": {
+                                "width": 200,
+                                "position-right": {}
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
### Contains

I'd like to add additional confirmation popup before remove saved game to prevent accidental deletion.

### How to test

1. Open SelectGame menu
2. Select saved game
3. Push Delete button

![confirm](https://user-images.githubusercontent.com/3996860/37857230-7fb5e8d2-2f0a-11e8-9ae4-c4fbc178e9d1.png)

