### PR TITLE
Fixes #3139-Pause on menu

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -30,7 +30,8 @@ import org.terasology.input.binds.general.ScreenshotButton;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.events.PlayerDeathEvent;
 import org.terasology.network.ClientComponent;
-import org.terasology.network.ClientInfoComponent;
+import org.terasology.network.NetworkMode;
+import org.terasology.network.NetworkSystem;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
@@ -54,18 +55,13 @@ public class MenuControlSystem extends BaseComponentSystem {
     private Time time;
     @In
     private EntityManager entityManager;
+    @In
+    private NetworkSystem networkSystem;
 
     @Override
     public void initialise() {
         nuiManager.getHUD().addHUDElement("dropItemRegion");  //Ensure the drop region is behind the toolbar
         nuiManager.getHUD().addHUDElement("toolbar");
-    }
-
-    //TODO
-    //Implement this function in a separate file for reusabitility
-    private int getPlayerCount() {
-        int playerCount=entityManager.getCountOfEntitiesWith(ClientInfoComponent.class);
-        return playerCount;
     }
 
     @ReceiveEvent(components = ClientComponent.class)
@@ -74,12 +70,10 @@ public class MenuControlSystem extends BaseComponentSystem {
             nuiManager.toggleScreen("engine:pauseMenu");
             event.consume();
         }
-        if(getPlayerCount()==1)
-        {
-            if(nuiManager.isOpen("engine:pauseMenu")) {
+        if (networkSystem.getMode() == NetworkMode.NONE) {
+            if (nuiManager.isOpen("engine:pauseMenu")) {
                 time.setPaused(true);
-            }
-            else{
+            } else {
                 time.setPaused(false);
             }
         }

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -61,7 +61,7 @@ public class MenuControlSystem extends BaseComponentSystem {
         nuiManager.getHUD().addHUDElement("toolbar");
     }
 
-    private int getPlayerCount() {
+   private int getPlayerCount() {
         int playerCount=entityManager.getCountOfEntitiesWith(ClientInfoComponent.class);
         return playerCount;
     }
@@ -72,14 +72,13 @@ public class MenuControlSystem extends BaseComponentSystem {
             nuiManager.toggleScreen("engine:pauseMenu");
             event.consume();
         }
-        if ((event.getState() == ButtonState.DOWN) || (event.getState() == ButtonState.UP))
+        if(getPlayerCount()==1)
         {
-            if(getPlayerCount()==1) {
-                if (!time.isPaused()) {
-                    time.setPaused(true);
-                } else {
-                    time.setPaused(false);
-                }
+            if(nuiManager.isOpen("engine:pauseMenu")) {
+                time.setPaused(true);
+            }
+            else{
+                time.setPaused(false);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -36,6 +36,7 @@ import org.terasology.rendering.nui.layers.ingame.DeathScreen;
 import org.terasology.rendering.nui.layers.ingame.OnlinePlayersOverlay;
 import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.utilities.Assets;
+import org.terasology.engine.Time;
 
 /**
  * This system controls the client's in-game menus (Pause screen, Death screen, HUDs and overlays).
@@ -45,6 +46,12 @@ public class MenuControlSystem extends BaseComponentSystem {
 
     @In
     private NUIManager nuiManager;
+
+    @In
+    private Time time;
+
+    //private boolean isPaused=false;
+    //private float currTimeDilation=time.getGameTimeDilation();
 
     @Override
     public void initialise() {
@@ -57,6 +64,13 @@ public class MenuControlSystem extends BaseComponentSystem {
         if (event.getState() == ButtonState.DOWN) {
             nuiManager.toggleScreen("engine:pauseMenu");
             event.consume();
+        }
+
+        if(!time.isPaused()){
+            time.setPaused(true);
+        }
+        else{
+            time.setPaused(false);
         }
     }
 

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -71,7 +71,7 @@ public class MenuControlSystem extends BaseComponentSystem {
             nuiManager.toggleScreen("engine:pauseMenu");
             event.consume();
         }
-        if(getPlayerCount()==2) {
+        if(getPlayerCount()==1) {
             if (!time.isPaused()) {
                 time.setPaused(true);
             } else {

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -40,6 +40,7 @@ import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.utilities.Assets;
 import org.terasology.engine.Time;
 
+
 /**
  * This system controls the client's in-game menus (Pause screen, Death screen, HUDs and overlays).
  */
@@ -71,11 +72,14 @@ public class MenuControlSystem extends BaseComponentSystem {
             nuiManager.toggleScreen("engine:pauseMenu");
             event.consume();
         }
-        if(getPlayerCount()==1) {
-            if (!time.isPaused()) {
-                time.setPaused(true);
-            } else {
-                time.setPaused(false);
+        if ((event.getState() == ButtonState.DOWN) || (event.getState() == ButtonState.UP))
+        {
+            if(getPlayerCount()==1) {
+                if (!time.isPaused()) {
+                    time.setPaused(true);
+                } else {
+                    time.setPaused(false);
+                }
             }
         }
     }

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -61,7 +61,9 @@ public class MenuControlSystem extends BaseComponentSystem {
         nuiManager.getHUD().addHUDElement("toolbar");
     }
 
-   private int getPlayerCount() {
+    //TODO
+    //Implement this function in a separate file for reusabitility
+    private int getPlayerCount() {
         int playerCount=entityManager.getCountOfEntitiesWith(ClientInfoComponent.class);
         return playerCount;
     }

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -17,6 +17,7 @@
 package org.terasology.logic.players;
 
 import org.terasology.audio.AudioManager;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -29,6 +30,7 @@ import org.terasology.input.binds.general.ScreenshotButton;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.events.PlayerDeathEvent;
 import org.terasology.network.ClientComponent;
+import org.terasology.network.ClientInfoComponent;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
@@ -49,14 +51,18 @@ public class MenuControlSystem extends BaseComponentSystem {
 
     @In
     private Time time;
-
-    //private boolean isPaused=false;
-    //private float currTimeDilation=time.getGameTimeDilation();
+    @In
+    private EntityManager entityManager;
 
     @Override
     public void initialise() {
         nuiManager.getHUD().addHUDElement("dropItemRegion");  //Ensure the drop region is behind the toolbar
         nuiManager.getHUD().addHUDElement("toolbar");
+    }
+
+    private int getPlayerCount() {
+        int playerCount=entityManager.getCountOfEntitiesWith(ClientInfoComponent.class);
+        return playerCount;
     }
 
     @ReceiveEvent(components = ClientComponent.class)
@@ -65,12 +71,12 @@ public class MenuControlSystem extends BaseComponentSystem {
             nuiManager.toggleScreen("engine:pauseMenu");
             event.consume();
         }
-
-        if(!time.isPaused()){
-            time.setPaused(true);
-        }
-        else{
-            time.setPaused(false);
+        if(getPlayerCount()==2) {
+            if (!time.isPaused()) {
+                time.setPaused(true);
+            } else {
+                time.setPaused(false);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to run Checkstyle on it first
If you add unit tests we'll love you forever! -->

### Contains

Fixes #3139 .

### How to test

Pressing Escape in the game pauses the world time.

### Outstanding before merging
Maybe the getPlayerCount() method could be a separate file, so that other developers may use it too.
The player count may be updated whenever a player joins/leaves so that the engine doesn't iterate over all clients every time the escape menu is pressed.
Maybe raise a new issue for this?