### PR TITLE
Fix jumping in water and in mid-air

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -709,7 +709,10 @@ public class KinematicCharacterMover implements CharacterMover {
                 movementComp.numberOfJumpsLeft--;
             }
 
-            state.setGrounded(false);
+            if (state.isGrounded()) {
+                movementComp.numberOfJumpsLeft--;
+                state.setGrounded(false);
+            }
         }
         if (input.isFirstRun() && moveResult.isHorizontalHit()) {
             Vector3f hitVelocity = new Vector3f(state.getVelocity());


### PR DESCRIPTION
When walking off a cliff, the player can press spacebar to jump mid-air. This shouldn't happen when their `numberOfJumpsMax` is set to 1 (one ground jump, no air jumps).

To fix this behavior, `numberOfJumpsLeft` is decreased when player's `isGrounded()` state is changed from grounded to not grounded.

As a side effect, this fixes the problem mentioned in PR #3269 (issue #3267), where the player was able to jump in water when he fell or walked into it.

### How to test
Mid-air bug:
1. Build a tower 4-6 blocks high.
2. Walk off the top.
3. While falling, try to jump.

Water bug:
1. Walk or fall into water (without jumping).
2. While in water, try to jump.
