### PR TITLE
Fix parallax and normal mapping

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/AlphaRejectBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/AlphaRejectBlocksNode.java
@@ -79,10 +79,10 @@ public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapa
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.5f)
-    private float parallaxBias = 0.05f;
+    private float parallaxBias = 0.25f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.50f)
-    private float parallaxScale = 0.05f;
+    private float parallaxScale = 0.5f;
 
     public AlphaRejectBlocksNode(Context context) {
         renderQueues = context.get(RenderQueuesHelper.class);

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/AlphaRejectBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/AlphaRejectBlocksNode.java
@@ -117,10 +117,10 @@ public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapa
 
         if (normalMappingIsEnabled) {
             addDesiredStateChange(setTerrainNormalsInputTexture);
+        }
 
-            if (parallaxMappingIsEnabled) {
-                addDesiredStateChange(setTerrainHeightInputTexture);
-            }
+        if (parallaxMappingIsEnabled) {
+            addDesiredStateChange(setTerrainHeightInputTexture);
         }
     }
 
@@ -168,10 +168,10 @@ public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapa
         chunkMaterial.setInt("textureLava", 2, true);
         if (normalMappingIsEnabled) {
             chunkMaterial.setInt("textureAtlasNormal", 3, true);
-            if (parallaxMappingIsEnabled) {
-                chunkMaterial.setInt("textureAtlasHeight", 4, true);
-                chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
-            }
+        }
+        if (parallaxMappingIsEnabled) {
+            chunkMaterial.setInt("textureAtlasHeight", 4, true);
+            chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
         }
 
         chunkMaterial.setFloat("clip", 0.0f, true);
@@ -215,24 +215,16 @@ public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapa
                 normalMappingIsEnabled = renderingConfig.isNormalMapping();
                 if (normalMappingIsEnabled) {
                     addDesiredStateChange(setTerrainNormalsInputTexture);
-                    if (parallaxMappingIsEnabled) {
-                        addDesiredStateChange(setTerrainHeightInputTexture);
-                    }
                 } else {
                     removeDesiredStateChange(setTerrainNormalsInputTexture);
-                    if (parallaxMappingIsEnabled) {
-                        removeDesiredStateChange(setTerrainHeightInputTexture);
-                    }
                 }
                 break;
             case RenderingConfig.PARALLAX_MAPPING:
                 parallaxMappingIsEnabled = renderingConfig.isParallaxMapping();
-                if (normalMappingIsEnabled) {
-                    if (parallaxMappingIsEnabled) {
-                        addDesiredStateChange(setTerrainHeightInputTexture);
-                    } else {
-                        removeDesiredStateChange(setTerrainHeightInputTexture);
-                    }
+                if (parallaxMappingIsEnabled) {
+                    addDesiredStateChange(setTerrainHeightInputTexture);
+                } else {
+                    removeDesiredStateChange(setTerrainHeightInputTexture);
                 }
                 break;
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -78,10 +78,10 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.5f)
-    private float parallaxBias = 0.05f;
+    private float parallaxBias = 0.25f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.50f)
-    private float parallaxScale = 0.05f;
+    private float parallaxScale = 0.5f;
 
     public OpaqueBlocksNode(Context context) {
         renderQueues = context.get(RenderQueuesHelper.class);

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -125,10 +125,10 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
 
         if (normalMappingIsEnabled) {
             addDesiredStateChange(setTerrainNormalsInputTexture);
+        }
 
-            if (parallaxMappingIsEnabled) {
-                addDesiredStateChange(setTerrainHeightInputTexture);
-            }
+        if (parallaxMappingIsEnabled) {
+            addDesiredStateChange(setTerrainHeightInputTexture);
         }
     }
 
@@ -175,10 +175,8 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
 
         chunkMaterial.setFloat("clip", 0.0f, true);
 
-        if (normalMappingIsEnabled) {
-            if (parallaxMappingIsEnabled) {
-                chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
-            }
+        if (parallaxMappingIsEnabled) {
+            chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
         }
 
         // Actual Node Processing
@@ -237,25 +235,17 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
                 normalMappingIsEnabled = renderingConfig.isNormalMapping();
                 if (normalMappingIsEnabled) {
                     addDesiredStateChange(setTerrainNormalsInputTexture);
-                    if (parallaxMappingIsEnabled) {
-                        addDesiredStateChange(setTerrainHeightInputTexture);
-                    }
                 } else {
                     removeDesiredStateChange(setTerrainNormalsInputTexture);
-                    if (parallaxMappingIsEnabled) {
-                        removeDesiredStateChange(setTerrainHeightInputTexture);
-                    }
                 }
                 break;
 
             case RenderingConfig.PARALLAX_MAPPING:
                 parallaxMappingIsEnabled = renderingConfig.isParallaxMapping();
-                if (normalMappingIsEnabled) {
-                    if (parallaxMappingIsEnabled) {
-                        addDesiredStateChange(setTerrainHeightInputTexture);
-                    } else {
-                        removeDesiredStateChange(setTerrainHeightInputTexture);
-                    }
+                if (parallaxMappingIsEnabled) {
+                    addDesiredStateChange(setTerrainHeightInputTexture);
+                } else {
+                    removeDesiredStateChange(setTerrainHeightInputTexture);
                 }
                 break;
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
@@ -190,10 +190,10 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
 
         if (normalMappingIsEnabled) {
             addDesiredStateChange(setTerrainNormalsInputTexture);
+        }
 
-            if (parallaxMappingIsEnabled) {
-                addDesiredStateChange(setTerrainHeightInputTexture);
-            }
+        if (parallaxMappingIsEnabled) {
+            addDesiredStateChange(setTerrainHeightInputTexture);
         }
     }
 
@@ -235,10 +235,10 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
         chunkMaterial.setInt("texSceneOpaque", 6, true);
         if (normalMappingIsEnabled) {
             chunkMaterial.setInt("textureAtlasNormal", 7, true);
-            if (parallaxMappingIsEnabled) {
-                chunkMaterial.setInt("textureAtlasHeight", 8, true);
-                chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
-            }
+        }
+        if (parallaxMappingIsEnabled) {
+            chunkMaterial.setInt("textureAtlasHeight", 8, true);
+            chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
         }
 
         chunkMaterial.setFloat4("lightingSettingsFrag", 0, 0, waterSpecExp, 0, true);
@@ -303,25 +303,17 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
                 normalMappingIsEnabled = renderingConfig.isNormalMapping();
                 if (normalMappingIsEnabled) {
                     addDesiredStateChange(setTerrainNormalsInputTexture);
-                    if (parallaxMappingIsEnabled) {
-                        addDesiredStateChange(setTerrainHeightInputTexture);
-                    }
                 } else {
                     removeDesiredStateChange(setTerrainNormalsInputTexture);
-                    if (parallaxMappingIsEnabled) {
-                        removeDesiredStateChange(setTerrainHeightInputTexture);
-                    }
                 }
                 break;
 
             case RenderingConfig.PARALLAX_MAPPING:
-                if (normalMappingIsEnabled) {
-                    parallaxMappingIsEnabled = renderingConfig.isParallaxMapping();
-                    if (parallaxMappingIsEnabled) {
-                        addDesiredStateChange(setTerrainHeightInputTexture);
-                    } else {
-                        removeDesiredStateChange(setTerrainHeightInputTexture);
-                    }
+                parallaxMappingIsEnabled = renderingConfig.isParallaxMapping();
+                if (parallaxMappingIsEnabled) {
+                    addDesiredStateChange(setTerrainHeightInputTexture);
+                } else {
+                    removeDesiredStateChange(setTerrainHeightInputTexture);
                 }
                 break;
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
@@ -140,10 +140,10 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.5f)
-    private float parallaxBias = 0.05f;
+    private float parallaxBias = 0.25f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.50f)
-    private float parallaxScale = 0.05f;
+    private float parallaxScale = 0.5f;
 
     @SuppressWarnings("FieldCanBeLocal")
     private Vector3f sunDirection;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -174,10 +174,10 @@ public class WorldReflectionNode extends ConditionDependentNode {
         chunkMaterial.setInt("textureLava", 2, true);
         if (isNormalMapping) {
             chunkMaterial.setInt("textureAtlasNormal", 3, true);
-            if (isParallaxMapping) {
-                chunkMaterial.setInt("textureAtlasHeight", 4, true);
-                chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
-            }
+        }
+        if (isParallaxMapping) {
+            chunkMaterial.setInt("textureAtlasHeight", 4, true);
+            chunkMaterial.setFloat4("parallaxProperties", parallaxBias, parallaxScale, 0.0f, 0.0f, true);
         }
 
         chunkMaterial.setFloat("clip", activeCamera.getReflectionHeight(), true);
@@ -224,25 +224,17 @@ public class WorldReflectionNode extends ConditionDependentNode {
                 isNormalMapping = renderingConfig.isNormalMapping();
                 if (isNormalMapping) {
                     addDesiredStateChange(setNormalTerrain);
-                    if (isParallaxMapping) {
-                        addDesiredStateChange(setHeightTerrain);
-                    }
                 } else {
                     removeDesiredStateChange(setNormalTerrain);
-                    if (isParallaxMapping) {
-                        removeDesiredStateChange(setHeightTerrain);
-                    }
                 }
                 break;
 
             case RenderingConfig.PARALLAX_MAPPING:
                 isParallaxMapping = renderingConfig.isParallaxMapping();
-                if (isNormalMapping) {
-                    if (isParallaxMapping) {
-                        addDesiredStateChange(setHeightTerrain);
-                    } else {
-                        removeDesiredStateChange(setHeightTerrain);
-                    }
+                if (isParallaxMapping) {
+                    addDesiredStateChange(setHeightTerrain);
+                } else {
+                    removeDesiredStateChange(setHeightTerrain);
                 }
                 break;
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/WorldReflectionNode.java
@@ -85,10 +85,10 @@ public class WorldReflectionNode extends ConditionDependentNode {
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.5f)
-    private float parallaxBias = 0.05f;
+    private float parallaxBias = 0.25f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.50f)
-    private float parallaxScale = 0.05f;
+    private float parallaxScale = 0.5f;
 
     /**
      * Constructs an instance of this class.

--- a/engine/src/main/java/org/terasology/world/block/tiles/WorldAtlasImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/tiles/WorldAtlasImpl.java
@@ -63,7 +63,7 @@ public class WorldAtlasImpl implements WorldAtlas {
     private static final int MAX_TILES = 65536;
     private static final Color UNIT_Z_COLOR = new Color(0.5f, 0.5f, 1.0f, 1.0f);
     private static final Color TRANSPARENT_COLOR = new Color(0.0f, 0.0f, 0.0f, 0.0f);
-    private static final Color BLACK_COLOR = new Color(0.0f, 0.0f, 0.0f, 1.0f);
+    private static final Color MID_RED_COLOR = new Color(0.5f, 0.0f, 0.0f, 1.0f);
 
     private int maxAtlasSize = 4096;
     private int atlasSize = 256;
@@ -225,7 +225,7 @@ public class WorldAtlasImpl implements WorldAtlas {
         int numMipMaps = getNumMipmaps();
         ByteBuffer[] data = createAtlasMipmaps(numMipMaps, TRANSPARENT_COLOR, tiles, "tiles.png");
         ByteBuffer[] dataNormal = createAtlasMipmaps(numMipMaps, UNIT_Z_COLOR, tilesNormal, "tilesNormal.png", tilesGloss);
-        ByteBuffer[] dataHeight = createAtlasMipmaps(numMipMaps, BLACK_COLOR, tilesHeight, "tilesHeight.png");
+        ByteBuffer[] dataHeight = createAtlasMipmaps(numMipMaps, MID_RED_COLOR, tilesHeight, "tilesHeight.png");
 
         TextureData terrainTexData = new TextureData(atlasSize, atlasSize, data, Texture.WrapMode.CLAMP, Texture.FilterMode.NEAREST);
         Texture terrainTex = Assets.generateAsset(new ResourceUrn("engine:terrain"), terrainTexData, Texture.class);
@@ -233,7 +233,7 @@ public class WorldAtlasImpl implements WorldAtlas {
         TextureData terrainNormalData = new TextureData(atlasSize, atlasSize, dataNormal, Texture.WrapMode.CLAMP, Texture.FilterMode.NEAREST);
         Assets.generateAsset(new ResourceUrn("engine:terrainNormal"), terrainNormalData, Texture.class);
 
-        TextureData terrainHeightData = new TextureData(atlasSize, atlasSize, dataHeight, Texture.WrapMode.CLAMP, Texture.FilterMode.NEAREST);
+        TextureData terrainHeightData = new TextureData(atlasSize, atlasSize, dataHeight, Texture.WrapMode.CLAMP, Texture.FilterMode.LINEAR);
         Assets.generateAsset(new ResourceUrn("engine:terrainHeight"), terrainHeightData, Texture.class);
 
         MaterialData terrainMatData = new MaterialData(Assets.getShader("engine:block").get());

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -106,10 +106,15 @@ void main() {
     mat3 tbn = mat3(uvToView[0], uvToView[1], normal);
 
 #if defined (PARALLAX_MAPPING)
-    vec3 eyeTangentSpace = transpose(tbn) * normalizedVPos;
+    vec3 eyeTangentSpace = normalizedVPos * tbn;
 
     float height =  parallaxScale * texture2D(textureAtlasHeight, texCoord).r - parallaxBias;
 	texCoord += height * eyeTangentSpace.xy / eyeTangentSpace.z * TEXTURE_OFFSET;
+	
+	//Crudely prevent the parallax from extending to other textures in the same atlas.
+	vec2 texCorner = floor(gl_TexCoord[0].xy/TEXTURE_OFFSET)*TEXTURE_OFFSET;
+	vec2 texSize = vec2(1,1)*TEXTURE_OFFSET*0.9999; //Remain strictly this side of the edge.
+	texCoord = clamp(texCoord, texCorner, texCorner + texSize);
 #endif
 #if defined (NORMAL_MAPPING)
     //Normalised but not orthonormalised. It should usually be orthogonal anyway, but it's not obvious what's the best thing to do when it isn't.

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -45,6 +45,7 @@ varying vec3 worldSpaceNormal;
 varying mat3 normalMatrix;
 
 uniform sampler2D textureAtlasNormal;
+#endif
 
 #if defined (PARALLAX_MAPPING)
 uniform vec4 parallaxProperties;
@@ -52,7 +53,6 @@ uniform vec4 parallaxProperties;
 #define parallaxScale parallaxProperties.y
 
 uniform sampler2D textureAtlasHeight;
-#endif
 #endif
 
 
@@ -92,7 +92,7 @@ void main() {
     vec3 normalOpaque = normal;
     float shininess = 0.0;
 
-#if defined (NORMAL_MAPPING)
+#if defined (NORMAL_MAPPING) || defined (PARALLAX_MAPPING)
     // TODO: Calculates the tangent frame on the fly - this is absurdly costly... But storing
     // the tangent for each vertex in the chunk VBO might be not the best idea either.
     vec3 dp1 = dFdx(vertexProjPos.xyz);
@@ -114,11 +114,12 @@ void main() {
     float height =  parallaxScale * texture2D(textureAtlasHeight, texCoord).r - parallaxBias;
 	texCoord += height * normalize(eyeTangentSpace).xy * TEXTURE_OFFSET;
 #endif
-
+#if defined (NORMAL_MAPPING)
     normalOpaque = normalize(texture2D(textureAtlasNormal, texCoord).xyz * 2.0 - 1.0);
     normalOpaque = normalize(tbn * normalOpaque);
 
     shininess = texture2D(textureAtlasNormal, texCoord).w;
+#endif
 #endif
 
 #ifdef FEATURE_REFRACTIVE_PASS

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -109,7 +109,9 @@ void main() {
     vec3 eyeTangentSpace = normalizedVPos * tbn;
 
     float height =  parallaxScale * texture2D(textureAtlasHeight, texCoord).r - parallaxBias;
-	texCoord += height * eyeTangentSpace.xy / eyeTangentSpace.z * TEXTURE_OFFSET;
+    //Ideally this should be divided by eyeTangentSpace.z, but in practice this looks better at
+    //low angles, as it can't extend beyond its original space.
+	texCoord += height * eyeTangentSpace.xy * TEXTURE_OFFSET;
 	
 	//Crudely prevent the parallax from extending to other textures in the same atlas.
 	vec2 texCorner = floor(gl_TexCoord[0].xy/TEXTURE_OFFSET)*TEXTURE_OFFSET;

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -101,7 +101,9 @@ void main() {
 #if defined (NORMAL_MAPPING) || defined (PARALLAX_MAPPING)
     // TODO: Calculates the tangent frame on the fly - this is absurdly costly... But storing
     // the tangent for each vertex in the chunk VBO might be not the best idea either.
-    // The only reason dFdx and dFdy are used here is that it happens to be possible to relate both view and UV coordinates to screen-space coordinated. The specific relationship between screen coordinates and view coordinates is irrelevant.
+    // The only reason dFdx and dFdy are used here is that it happens to be possible to relate 
+    // both view and UV coordinates to screen-space coordinated. The specific relationship between 
+    // screen coordinates and view coordinates is irrelevant.
     mat2x3 screenToView = mat2x3(dFdx(vertexViewPos.xyz), dFdy(vertexViewPos.xyz));
     mat2   screenToUv   = mat2  (dFdx(gl_TexCoord[0].xy), dFdy(gl_TexCoord[0].xy)) / TEXTURE_OFFSET;
     mat2 uvToScreen = inverse2(screenToUv);
@@ -120,7 +122,8 @@ void main() {
 	texCoord = clamp(texCoord, texCorner, texCorner + texSize);
 #endif
 #if defined (NORMAL_MAPPING)
-    //Normalised but not orthonormalised. It should be orthogonal anyway (except for some non-rectangular block shapes like torches), but it's not obvious what's the best thing to do when it isn't.
+    // Normalised but not orthonormalised. It should be orthogonal anyway (except for some non-rectangular 
+    // block shapes like torches), but it's not obvious what's the best thing to do when it isn't.
     mat3 uvnSpaceToViewSpace = mat3(normalize(uvToView[0]), normalize(uvToView[1]), normal);
     normalOpaque = normalize(texture2D(textureAtlasNormal, texCoord).xyz * 2.0 - 1.0);
     normalOpaque = normalize(uvnSpaceToViewSpace * normalOpaque);

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -93,7 +93,7 @@ void main() {
 
     vec2 texCoord = gl_TexCoord[0].xy;
 
-    vec3 normalizedVPos = -normalize(vertexViewPos.xyz);
+    vec3 normalizedViewPos = -normalize(vertexViewPos.xyz);
     vec2 projectedPos = projectVertexToTexCoord(vertexProjPos);
     vec3 normalOpaque = normal;
     float shininess = 0.0;
@@ -101,18 +101,18 @@ void main() {
 #if defined (NORMAL_MAPPING) || defined (PARALLAX_MAPPING)
     // TODO: Calculates the tangent frame on the fly - this is absurdly costly... But storing
     // the tangent for each vertex in the chunk VBO might be not the best idea either.
-    // The specific relationship between screen coordinates and view coordinates is irrelevant here. Screen coordinates just happen to be a basis that it's possible to relate both view and UV space coordinates to.
+    // The only reason dFdx and dFdy are used here is that it happens to be possible to relate both view and UV coordinates to screen-space coordinated. The specific relationship between screen coordinates and view coordinates is irrelevant.
     mat2x3 screenToView = mat2x3(dFdx(vertexViewPos.xyz), dFdy(vertexViewPos.xyz));
     mat2   screenToUv   = mat2  (dFdx(gl_TexCoord[0].xy), dFdy(gl_TexCoord[0].xy)) / TEXTURE_OFFSET;
     mat2 uvToScreen = inverse2(screenToUv);
     mat2x3 uvToView = screenToView * uvToScreen;
 
 #if defined (PARALLAX_MAPPING)
-    vec2 viewDirectionTextureOffset = normalizedVPos * uvToView;
+    vec2 viewDirectionUvProjection = -normalizedViewPos * uvToView;
 
     float height = parallaxScale * texture2D(textureAtlasHeight, texCoord).r - parallaxBias;
-    //Ideally this should be divided by dot(normal, normalizedVPos), as the texture offset is the amount the light-ray travels in across the texture in the time it takes to traverse the distance "height" perpendicular to the surface, but in practice this way looks better at low angles, as the height-map can't make the triangle extend beyond its normal size.
-	texCoord += height * viewDirectionTextureOffset * TEXTURE_OFFSET;
+    //Ideally this should be divided by dot(normal, normalizedViewPos), as the offset for texCoord is the component parallel to the surface of a vector along the view's forward axis, the other component being a vector perpendicular to the surface and having magnitude "height". In practice the current way looks better at low angles, as the height-map can't make the triangle protrude beyond its boundaries like displacement mapping would.
+	texCoord += height * viewDirectionUvProjection * TEXTURE_OFFSET;
 	
 	//Crudely prevent the parallax from extending to other textures in the same atlas.
 	vec2 texCorner = floor(gl_TexCoord[0].xy/TEXTURE_OFFSET)*TEXTURE_OFFSET;
@@ -121,9 +121,9 @@ void main() {
 #endif
 #if defined (NORMAL_MAPPING)
     //Normalised but not orthonormalised. It should be orthogonal anyway (except for some non-rectangular block shapes like torches), but it's not obvious what's the best thing to do when it isn't.
-    mat3 extendedTangentSpaceToViewSpace = mat3(normalize(uvToView[0]), normalize(uvToView[1]), normal);
+    mat3 uvnSpaceToViewSpace = mat3(normalize(uvToView[0]), normalize(uvToView[1]), normal);
     normalOpaque = normalize(texture2D(textureAtlasNormal, texCoord).xyz * 2.0 - 1.0);
-    normalOpaque = normalize(extendedTangentSpaceToViewSpace * normalOpaque);
+    normalOpaque = normalize(uvnSpaceToViewSpace * normalOpaque);
 
     shininess = texture2D(textureAtlasNormal, texCoord).w;
 #endif
@@ -237,7 +237,7 @@ void main() {
     // Apply reflection and refraction AFTER the lighting has been applied (otherwise bright areas below water become dark)
     // The water tint has still to be adjusted adjusted though...
      if (isWater && isOceanWater) {
-            float specularHighlight = WATER_SPEC * calcDayAndNightLightingFactor(daylightValue, daylight) * calcSpecLightNormalized(normalWater, sunVecViewAdjusted, normalizedVPos, waterSpecExp);
+            float specularHighlight = WATER_SPEC * calcDayAndNightLightingFactor(daylightValue, daylight) * calcSpecLightNormalized(normalWater, sunVecViewAdjusted, normalizedViewPos, waterSpecExp);
             color.xyz += vec3(specularHighlight, specularHighlight, specularHighlight);
 
             vec4 reflectionColor = vec4(texture2D(textureWaterReflection, projectedPos + normalWaterOffset.xy * waterRefraction).xyz, 1.0);
@@ -247,7 +247,7 @@ void main() {
 
             /* FRESNEL */
             if (!swimming) {
-                float f = fresnel(dot(normalWater, normalizedVPos), waterFresnelBias, waterFresnelPow);
+                float f = fresnel(dot(normalWater, normalizedViewPos), waterFresnelBias, waterFresnelPow);
                 color += mix(refractionColor * (1.0 - waterTint) +  waterTint * litWaterTint,
                     reflectionColor * (1.0 - waterTint) + waterTint * litWaterTint, f);
             } else {

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -97,7 +97,7 @@ void main() {
     // the tangent for each vertex in the chunk VBO might be not the best idea either.
     // Screen-space coordinates happen to be a coordinate system to which it's possible to relate both view-space and texture coordinates, but are themselves irrelevant.
     mat2x3 screenToView = mat2x3(dFdx(vertexViewPos.xyz), dFdy(vertexViewPos.xyz));
-    mat2   screenToUv   = mat2  (dFdx(gl_TexCoord[0].xy), dFdy(gl_TexCoord[0].xy));
+    mat2   screenToUv   = mat2  (dFdx(gl_TexCoord[0].xy), dFdy(gl_TexCoord[0].xy)) / TEXTURE_OFFSET;
     //mat2 uvToScreem = inverse(screenToUv);
     //inverse is not available in GLSL 1.20, so calculate it manually:
         float det = screenToUv[0][0] * screenToUv[1][1] - screenToUv[1][0] * screenToUv[0][1];


### PR DESCRIPTION
### Contains

This PR:
 1. Corrects the formulae used in the shaders to calculate parallax and normal maps.
 1. Restricts parallax maps to not fetch colours from beyond the current texture.
 1. Alters the default setting for parallax maps to improve their appearance.
 1. Enables the use of parallax mapping without normal mapping.

Parts 2 and 3 resolve #2418, and part 4 deals with some of the confusingness of the settings discussed in that issue.

The branch 4Denthusiast/Terasology:parallax uses a more realistic version but looks worse due to parallax mapping being unable to extend the block's rendering beyond its original size. This branch is a compromise which makes the block appear flatter at shallow angles.

### How to test

Activate parallax mapping in the video menu. Activating extra lighting as well should no longer be necessary.

Place some core:depthTest or core:ironBar blocks, and look at them from various angles.

To see that the parallax calculations are now more correct, it's easier to compare a094555 to develop, rather than the final version. In that version, it looks as though every block is a little window through onto the texture atlas. (This is more apparent in worlds with large-ish texture atlases i.e. many blocks. I used coreSampleGameplay.) This behaviour is correct (except the issues fixed in later commits), as it corresponds to realistic parallax. The current version in develop, by contrast, changes its appearance depending on camera angle, which is clearly incorrect.

### Outstanding before merging

- [ ] The effect of normal maps are more subtle, so I haven't managed to test that they're actually working properly.
- [ ] I'm not sure if it's appropriate to leave gaps of unused texture indices, or whether it would be better to reduce the index of textureAtlasHeight if textureAtlasNormal isn't used (e.g. WorldRelfectionNode line 179).
- [ ] I'd like some more opinions on whether 466a1d7 or 034b678 (realistic but more distorted, or compromise) is better.
- [ ] Is there any way to get linear interpolation for textures that's actually linear everywhere, rather than flat near the defined points? Setting textureAtlasHeight to use that would be better if possible.
