### PR TITLE
Changes to enable FlowingLiquids module

### DIFF
--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -160,6 +160,16 @@ public class MapWorldProvider implements WorldProviderCore {
     }
 
     @Override
+    public boolean setRawLiquid(int x, int y, int z, byte newData, byte oldData) {
+        return false;
+    }
+
+    @Override
+    public byte getRawLiquid(int x, int y, int z) {
+        return 0;
+    }
+
+    @Override
     public byte getLight(int x, int y, int z) {
         return 0;
     }

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -132,6 +132,16 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     }
 
     @Override
+    public boolean setRawLiquid(int x, int y, int z, byte newData, byte oldData) {
+        return false;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public byte getRawLiquid(int x, int y, int z) {
+        return 0;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
     public Block getBlock(int x, int y, int z) {
         Block result = blocks.get(new Vector3i(x, y, z));
         if (result == null) {

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkMesh.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkMesh.java
@@ -25,6 +25,7 @@ import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL15;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.module.sandbox.API;
 import org.terasology.rendering.VertexBufferObjectUtil;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.world.chunks.ChunkConstants;
@@ -56,6 +57,7 @@ public class ChunkMesh {
     /**
      * Possible rendering types.
      */
+    @API
     public enum RenderType {
         OPAQUE(0),
         TRANSLUCENT(1),

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkVertexFlag.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkVertexFlag.java
@@ -15,8 +15,11 @@
  */
 package org.terasology.rendering.primitives;
 
+import org.terasology.module.sandbox.API;
+
 /**
  */
+@API
 public enum ChunkVertexFlag {
     NORMAL(0, "BLOCK_HINT_NORMAL"),
     WATER(1, "BLOCK_HINT_WATER"),

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -187,6 +187,38 @@ public interface ChunkView {
     void setLiquid(int x, int y, int z, LiquidData newState);
 
     /**
+     * @param pos
+     * @return The state of liquid at the given position. This will be no liquid outside the view.
+     */
+    byte getRawLiquid(Vector3i pos);
+
+    /**
+     * @param x
+     * @param y
+     * @param z
+     * @return The state of liquid at the given position. This will be no liquid outside the view.
+     */
+    byte getRawLiquid(int x, int y, int z);
+
+    /**
+     * Sets the liquid state at the given position, if it is within the view
+     *
+     * @param pos
+     * @param newState
+     */
+    void setRawLiquid(Vector3i pos, byte newState);
+
+    /**
+     * Sets the liquid state at the given position, if it is within the view
+     *
+     * @param x
+     * @param y
+     * @param z
+     * @param newState
+     */
+    void setRawLiquid(int x, int y, int z, byte newState);
+
+    /**
      * Converts a coordinate from view-space to world space.
      *
      * @param localPos

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -188,7 +188,7 @@ public interface ChunkView {
 
     /**
      * @param pos
-     * @return The state of liquid at the given position. This will be no liquid outside the view.
+     * @return The state of liquid at the given position. This will be 0 outside the view.
      */
     byte getRawLiquid(Vector3i pos);
 
@@ -196,7 +196,7 @@ public interface ChunkView {
      * @param x
      * @param y
      * @param z
-     * @return The state of liquid at the given position. This will be no liquid outside the view.
+     * @return The state of liquid at the given position. This will be 0 outside the view.
      */
     byte getRawLiquid(int x, int y, int z);
 

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -54,6 +54,22 @@ public interface WorldProvider extends WorldProviderCore {
     LiquidData getLiquid(Vector3i blockPos);
 
     /**
+     * @param pos
+     * @param state    The new value of the liquid state
+     * @param oldState The expected previous value of the liquid state
+     * @return Whether the liquid change was made successfully. Will fail of oldState != the current state, or if the underlying chunk is not available
+     */
+    boolean setRawLiquid(Vector3i pos, byte state, byte oldState);
+
+    /**
+     * Returns the liquid state at the given position.
+     *
+     * @param blockPos
+     * @return The state of the block
+     */
+    byte getRawLiquid(Vector3i blockPos);
+
+    /**
      * Returns the block value at the given position.
      *
      * @param pos The position

--- a/engine/src/main/java/org/terasology/world/block/tiles/WorldAtlasImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/tiles/WorldAtlasImpl.java
@@ -158,6 +158,7 @@ public class WorldAtlasImpl implements WorldAtlas {
     }
 
     private int indexTile(ResourceUrn uri) {
+        logger.info("Adding tile: "+uri.toString());
         if (tiles.size() == MAX_TILES) {
             logger.error("Maximum tiles exceeded");
             return 0;

--- a/engine/src/main/java/org/terasology/world/block/tiles/WorldAtlasImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/tiles/WorldAtlasImpl.java
@@ -158,7 +158,6 @@ public class WorldAtlasImpl implements WorldAtlas {
     }
 
     private int indexTile(ResourceUrn uri) {
-        logger.info("Adding tile: "+uri.toString());
         if (tiles.size() == MAX_TILES) {
             logger.error("Maximum tiles exceeded");
             return 0;

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -155,6 +155,42 @@ public interface CoreChunk {
     LiquidData getLiquid(int x, int y, int z);
 
     /**
+     * Sets raw liquid data at given position relative to the chunk.
+     *
+     * @param pos   Position of the block relative to corner of the chunk
+     * @param state Liquid state to set the block to
+     */
+    void setRawLiquid(BaseVector3i pos, byte state);
+
+    /**
+     * Sets raw liquid data at given position relative to the chunk.
+     *
+     * @param x        X offset from the corner of the chunk
+     * @param y        Y offset from the corner of the chunk
+     * @param z        Z offset from the corner of the chunk
+     * @param newState Liquid state to set the block to
+     */
+    void setRawLiquid(int x, int y, int z, byte newState);
+
+    /**
+     * Returns raw liquid data at given position relative to the chunk.
+     *
+     * @param pos Position of the block relative to corner of the chunk
+     * @return Liquid state currently assigned to the block
+     */
+    byte getRawLiquid(BaseVector3i pos);
+
+    /**
+     * Returns raw liquid data at given position relative to the chunk.
+     *
+     * @param x X offset from the corner of the chunk
+     * @param y Y offset from the corner of the chunk
+     * @param z Z offset from the corner of the chunk
+     * @return Liquid state currently assigned to the block
+     */
+    byte getRawLiquid(int x, int y, int z);
+
+    /**
      * Returns offset of this chunk to the world center (0:0:0), with one unit being one chunk.
      *
      * @return Offset of this chunk from world center in chunks

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -260,6 +260,29 @@ public class ChunkImpl implements Chunk {
     }
 
     @Override
+    public void setRawLiquid(BaseVector3i pos, byte state) {
+        setRawLiquid(pos.x(), pos.y(), pos.z(), state);
+    }
+
+    @Override
+    public void setRawLiquid(int x, int y, int z, byte newState) {
+        if (extraData == extraDataSnapshot) {
+            extraData = extraData.copy();
+        }
+        extraData.set(x, y, z, newState);
+    }
+
+    @Override
+    public byte getRawLiquid(BaseVector3i pos) {
+        return getRawLiquid(pos.x(), pos.y(), pos.z());
+    }
+
+    @Override
+    public byte getRawLiquid(int x, int y, int z) {
+        return (byte) extraData.get(x, y, z);
+    }
+
+    @Override
     public Biome getBiome(int x, int y, int z) {
         return biomeManager.getBiomeByShortId((short) biomeData.get(x, y, z));
     }

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -113,6 +113,16 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     }
 
     @Override
+    public boolean setRawLiquid(int x, int y, int z, byte newState, byte oldState) {
+        return base.setRawLiquid(x, y, z, newState, oldState);
+    }
+
+    @Override
+    public byte getRawLiquid(int x, int y, int z) {
+        return base.getRawLiquid(x, y, z);
+    }
+
+    @Override
     public Block getBlock(int x, int y, int z) {
         return base.getBlock(x, y, z);
     }

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -210,6 +210,36 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     }
 
     @Override
+    public byte getRawLiquid(Vector3i pos) {
+        return getRawLiquid(pos.x, pos.y, pos.z);
+    }
+
+    @Override
+    public byte getRawLiquid(int x, int y, int z) {
+        if (!blockRegion.encompasses(x, y, z)) {
+            return 0;
+        }
+
+        int chunkIndex = relChunkIndex(x, y, z);
+        return chunks[chunkIndex].getRawLiquid(ChunkMath.calcBlockPos(x, y, z, chunkFilterSize));
+    }
+
+    @Override
+    public void setRawLiquid(Vector3i pos, byte newState) {
+        setRawLiquid(pos.x, pos.y, pos.z, newState);
+    }
+
+    @Override
+    public void setRawLiquid(int x, int y, int z, byte newState) {
+        if (blockRegion.encompasses(x, y, z)) {
+            int chunkIndex = relChunkIndex(x, y, z);
+            chunks[chunkIndex].setRawLiquid(ChunkMath.calcBlockPos(x, y, z, chunkFilterSize), newState);
+        } else {
+            throw new IllegalStateException("Attempted to modify liquid data though an unlocked view");
+        }
+    }
+
+    @Override
     public void setLight(Vector3i pos, byte light) {
         setLight(pos.x, pos.y, pos.z, light);
     }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -163,6 +163,26 @@ public interface WorldProviderCore {
     LiquidData getLiquid(int x, int y, int z);
 
     /**
+     * @param x
+     * @param y
+     * @param z
+     * @param newData
+     * @param oldData
+     * @return Whether the liquid change was made successfully. Will fail if the current data doesn't match the oldData, or if the underlying chunk is not available
+     */
+    boolean setRawLiquid(int x, int y, int z, byte newData, byte oldData);
+
+    /**
+     * Returns the liquid state at the given position.
+     *
+     * @param x The X-coordinate
+     * @param y The Y-coordinate
+     * @param z The Z-coordinate
+     * @return The liquid data of the block
+     */
+    byte getRawLiquid(int x, int y, int z);
+
+    /**
      * Returns the block at the given position.
      *
      * @param x The X-coordinate

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -318,8 +318,8 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
-            LiquidData liquidState = chunk.getLiquid(blockPos);
-            if (liquidState.equals(oldState)) {
+            byte liquidState = chunk.getRawLiquid(blockPos);
+            if (liquidState == oldState) {
                 chunk.setRawLiquid(blockPos, newState);
                 return true;
             }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -202,12 +202,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 } else {
                     oldChange.setTo(type);
                 }
-                for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
-                    RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
-                    if (dirtiedChunk != null) {
-                        dirtiedChunk.setDirty(true);
-                    }
-                }
+                markBlockDirty(worldPos);
                 notifyBlockChanged(worldPos, type, oldBlockType);
             }
             return oldBlockType;
@@ -222,7 +217,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
          * Hint: This method has a benchmark available in the BenchmarkScreen, The screen can be opened ingame via the
          * command "showSCreen BenchmarkScreen".
          */
-        Set<RenderableChunk> dirtiedChunks = new HashSet<>();
         Set<BlockChange> changedBlocks = new HashSet<>();
         Map<Vector3i, Block> result = new HashMap<>(blocks.size());
 
@@ -242,12 +236,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                     } else {
                         oldChange.setTo(type);
                     }
-                    for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
-                        RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
-                        if (dirtiedChunk != null) {
-                            dirtiedChunks.add(dirtiedChunk);
-                        }
-                    }
+                    markBlockDirty(worldPos);
                     changedBlocks.add(new BlockChange(worldPos, oldBlockType, type));
                 }
                 result.put(worldPos, oldBlockType);
@@ -256,14 +245,20 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             }
         }
 
-        for (RenderableChunk chunk : dirtiedChunks) {
-            chunk.setDirty(true);
-        }
         for (BlockChange change : changedBlocks) {
             notifyBlockChanged(change.getPosition(), change.getTo(), change.getFrom());
         }
 
         return result;
+    }
+    
+    private void markBlockDirty(Vector3i worldPos) {
+        for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
+            RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+            if (dirtiedChunk != null) {
+                dirtiedChunk.setDirty(true);
+            }
+        }
     }
 
     private void notifyBlockChanged(Vector3i pos, Block type, Block oldType) {
@@ -295,6 +290,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             LiquidData liquidState = chunk.getLiquid(blockPos);
             if (liquidState.equals(oldState)) {
                 chunk.setLiquid(blockPos, newState);
+                markBlockDirty(new Vector3i(x,y,z));
                 return true;
             }
         }
@@ -321,6 +317,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             byte liquidState = chunk.getRawLiquid(blockPos);
             if (liquidState == oldState) {
                 chunk.setRawLiquid(blockPos, newState);
+                markBlockDirty(new Vector3i(x,y,z));
                 return true;
             }
         }
@@ -372,12 +369,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 } else {
                     oldChange.setTo(biome);
                 }
-                for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
-                    RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
-                    if (dirtiedChunk != null) {
-                        dirtiedChunk.setDirty(true);
-                    }
-                }
+                markBlockDirty(worldPos);
                 notifyBiomeChanged(worldPos, biome, oldBiomeType);
             }
             return oldBiomeType;

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -313,6 +313,32 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     @Override
+    public boolean setRawLiquid(int x, int y, int z, byte newState, byte oldState) {
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
+        CoreChunk chunk = chunkProvider.getChunk(chunkPos);
+        if (chunk != null) {
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
+            LiquidData liquidState = chunk.getLiquid(blockPos);
+            if (liquidState.equals(oldState)) {
+                chunk.setRawLiquid(blockPos, newState);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public byte getRawLiquid(int x, int y, int z) {
+        Vector3i chunkPos = ChunkMath.calcChunkPos(x, y, z);
+        CoreChunk chunk = chunkProvider.getChunk(chunkPos);
+        if (chunk != null) {
+            Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
+            return chunk.getRawLiquid(blockPos);
+        }
+        return 0;
+    }
+
+    @Override
     public Block getBlock(int x, int y, int z) {
         CoreChunk chunk = chunkProvider.getChunk(ChunkMath.calcChunkPosX(x), ChunkMath.calcChunkPosY(y), ChunkMath.calcChunkPosZ(z));
         if (chunk != null) {

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -63,6 +63,16 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public boolean setRawLiquid(Vector3i pos, byte state, byte oldState) {
+        return core.setRawLiquid(pos.x, pos.y, pos.z, state, oldState);
+    }
+
+    @Override
+    public byte getRawLiquid(Vector3i blockPos) {
+        return core.getRawLiquid(blockPos.x, blockPos.y, blockPos.z);
+    }
+
+    @Override
     public Block getBlock(Vector3f pos) {
         return getBlock(new Vector3i(pos, RoundingMode.HALF_UP));
     }


### PR DESCRIPTION
The block data assigned to liquid information is currently only accessible via LiquidData, which restricts its uses in alternative systems. This PR adds getRawLiquid and setRawLiquid methods corresponding to all of the existing getLiquid and setLiquid methods. It also exposes as APIs 2 enums used for rendering that are necessary for the implementation of custom instances of BlockMeshGenerator.

### API Changes
This PR only adds things to the engine API, so the only backwards-compatibility issue would be if modules implemented the extended interfaces, and these implementations became incomplete. This seems unlikely in these cases, but if it's a problem then it can just wait for v2.