### PR TITLE
Close online players overlay when pause menu opened

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
@@ -38,4 +38,10 @@ public class PauseMenu extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "devTools", widget -> getManager().pushScreen("devToolsMenuScreen"));
         WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
     }
+
+    @Override
+    public void onScreenOpened() {
+        getManager().removeOverlay( "engine:onlinePlayersOverlay" );
+    }
+
 }


### PR DESCRIPTION
### Contains

I'm not sure will it be useful, but from my perspective it could be useful. 
Well, to avoid mixing of layers I removed OnlinePlayers overlay when we open PauseMenu.
Also I think debug overlay is fine as is. Don't it?
![screen shot 2018-04-12 at 23 15 54](https://user-images.githubusercontent.com/3996860/38701784-8143634e-3ea7-11e8-89b3-f81e1d6a5f58.png)

### How to test

1. Load/create game
2. Pressing TAB 
3. And press Esc together
