### PR TITLE
Fixed : Time remains paused even when the back button is clicked in the pause menu.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
@@ -18,8 +18,12 @@ package org.terasology.rendering.nui.layers.ingame;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.LoggingContext;
+import org.terasology.engine.Time;
 import org.terasology.engine.modes.StateMainMenu;
+import org.terasology.network.NetworkMode;
+import org.terasology.network.NetworkSystem;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.telemetry.TelemetryScreen;
@@ -27,6 +31,12 @@ import org.terasology.telemetry.TelemetryScreen;
 /**
  */
 public class PauseMenu extends CoreScreenLayer {
+
+    @In
+    private Time time;
+
+    @In
+    private NetworkSystem networkSystem;
 
     @Override
     public void initialise() {
@@ -44,4 +54,10 @@ public class PauseMenu extends CoreScreenLayer {
         getManager().removeOverlay( "engine:onlinePlayersOverlay" );
     }
 
+    @Override
+    public void onClosed() {
+        if (networkSystem.getMode() == NetworkMode.NONE) {
+            time.setPaused(false);
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->
On toggling the pause menu, if the player chooses to click on the `Back` button to return to the game, it results in the time still being paused (Only pressing `Escape` to return would unpause the time correctly). So, this fix unpauses the time state when the button is clicked.

### How to test

- Create a game, and toggle pause menu (Pressing Esc)
- Click on the `Back` button to return to the game.

### Outstanding before merging

Nothing as of now.