### PR TITLE
Fix to online players overlay not displayig all of the players

### DIFF
--- a/engine/src/main/java/org/terasology/network/ServerPingSystem.java
+++ b/engine/src/main/java/org/terasology/network/ServerPingSystem.java
@@ -98,6 +98,9 @@ public class ServerPingSystem extends BaseComponentSystem implements UpdateSubsc
                 } else {
                     pingStockComponent = client.getComponent(PingStockComponent.class);
                 }
+                if (localPlayer != null && localPlayer.getClientEntity() != null) {
+                    pingMap.put(localPlayer.getClientEntity(), new Long(5));
+                }
                 pingStockComponent.setValues(pingMap);
                 client.addOrSaveComponent(pingStockComponent);
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/OnlinePlayersOverlay.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/OnlinePlayersOverlay.java
@@ -81,15 +81,15 @@ public class OnlinePlayersOverlay extends CoreScreenLayer {
     }
 
     private String determinePlayerAndPing(PingStockComponent pingStockComponent) {
-        Iterable<EntityRef> allClients = entityManager.getEntitiesWith(ClientComponent.class);
         Map<EntityRef, Long> pingMap = pingStockComponent.getValues();
         StringBuilder sb = new StringBuilder();
         boolean first = true;
-        for (EntityRef clientEntity : allClients) {
+        for (Map.Entry<EntityRef, Long> entry : pingMap.entrySet()) {
             if (!first) {
                 sb.append("\n");
             }
-            ClientComponent clientComp = clientEntity.getComponent(ClientComponent.class);
+            EntityRef clientEntity = entry.getKey();
+            ClientComponent clientComp = clientEntity.getComponent(ClientComponent.class);;
             sb.append(PlayerUtil.getColoredPlayerName(clientComp.clientInfo));
             sb.append(" ");
             Long pingValue = pingMap.get(clientEntity);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #3318 
For some reason in function `determinePlayerAndPing` `allClients` would not contain all of the clients sometimes. I did not figure out why was that, but instead I used client entities directly from `pingMap`. It didn't contain client local to the server, but I just put it into the map with 5ms ping.

### How to test

- Start two game clients
- Have one host and the other join
- Hold down TAB and observe both names listed
