### PR TITLE
Show error if module loading fails.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WaitPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WaitPopup.java
@@ -97,6 +97,7 @@ public class WaitPopup<T> extends CoreScreenLayer {
         } catch (InterruptedException | ExecutionException e) {
             logger.warn("An error occurred during execution", e);
             getManager().popScreen();
+            getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Error", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Currently, if something goes wrong during module loading, the module loading dialog goes away without explanation.

This change displays an error message informing the user that something went wrong, possibly with enough information to debug.

Fixes #3333