### PR TITLE
Adding Reset Filters button and module categories title (fix for #3354)

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/SelectModulesScreen.java
@@ -409,7 +409,6 @@ public class SelectModulesScreen extends CoreScreenLayer {
             });
 
             UIButton resetAdvancedFilters = find("resetFilters", UIButton.class);
-            filterModules();
             if (resetAdvancedFilters != null) {
 
                 //on clicking 'reset filters' button, uncheck all advanced filters

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -238,6 +238,8 @@
     "select-game-title": "select-game-title",
     "select-modules": "select-modules",
     "select-modules-title": "select-modules-title",
+    "select-modules-filter-reset": "select-modules-filter-reset",
+    "select-modules-filter-title": "select-modules-filter-title",
     "select-multiplayer-game-sub-title": "select-multiplayer-game-sub-title",
     "select-singleplayer-game-sub-title": "select-singleplayer-game-sub-title",
     "select-world-gen": "select-world-gen",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -244,6 +244,8 @@
     "select-game-title": "Select Game",
     "select-modules": "Modules...",
     "select-modules-title": "Select Modules...",
+    "select-modules-filter-reset": "Reset Filters",
+    "select-modules-filter-title": "Module Categories",
     "select-multiplayer-game-sub-title": "Multiplayer",
     "select-singleplayer-game-sub-title": "Singleplayer",
     "select-world-gen": "Choose World Generator",

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -216,7 +216,7 @@
                             },
                             {
                                 "type": "RowLayout",
-                                "id": "resetButton",
+                                "id": "advancedFilterResetButton",
                                 "horizontalSpacing": 8,
                                 "contents": [
                                     {

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -89,13 +89,30 @@
                         "type":"RelativeLayout",
                         "family":"AdvanceFilter",
                         "contents": [
+                        {
+                            "type": "RowLayout",
+                            "id": "AdvanceFilterTitle",
+                            "verticalSpacing": 4,
+                            "contents": [
+                                {
+                                    "type": "UILabel",
+                                    "text": "${engine:menu#select-modules-filter-title}"
+                                }
+                                ],
+                                "layoutInfo": {
+                                    "use-content-height": true,
+                                    "position-top": {
+                                        "target": "TOP"
+                                    }
+                                }
+                            },
                             {
                                 "type":"ColumnLayout",
                                 "id":"advanceFilterItems",
                                 "columns":2,
                                 "column-widths":[0.1,0.90],
                                 "verticalSpacing": 4,
-                                "horizontalSpacing": -32 ,
+                                "horizontalSpacing": -32,
                                 "contents": [
                                     {
                                         "type": "UICheckbox",
@@ -192,7 +209,28 @@
                                     "use-content-height": true,
                                     "position-horizontal-center": {},
                                     "position-top": {
-                                        "target": "TOP"
+                                        "target": "TOP",
+                                            "offset": 32
+                                        }
+                                }
+                            },
+                            {
+                                "type": "RowLayout",
+                                "id": "resetButton",
+                                "horizontalSpacing": 8,
+                                "contents": [
+                                    {
+                                        "type": "UIButton",
+                                        "id": "resetFilters",
+                                        "text": "${engine:menu#select-modules-filter-reset}"
+                                    }
+                                ],
+                                "layoutInfo": {
+                                    "width": 250,
+                                    "height": 24,
+                                    "position-horizontal-center": {},
+                                    "position-bottom": {
+                                        "target": "BOTTOM"
                                     }
                                 }
                             }


### PR DESCRIPTION
### Contains
Fix for #3354, adds a label for the new module categories and a reset filters button that clears out all checked filters. 

### How to test

Load up game, open up module select menu, and try selecting / resetting advanced filters.

### Outstanding 
* Translations needed for the new button and title
