### PR TITLE
synchronize moudles with advanced filters on window open.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/SelectModulesScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/SelectModulesScreen.java
@@ -106,6 +106,7 @@ public class SelectModulesScreen extends CoreScreenLayer {
         }
 
         refreshSelection();
+        filterModules();
     }
 
     @Override
@@ -570,6 +571,7 @@ public class SelectModulesScreen extends CoreScreenLayer {
                 info.setOnlineVersion(remote);
             }
         }
+        filterModules();
     }
 
     @Override


### PR DESCRIPTION
### Contains

Fixes problem with modules screen showing full list of modules after window has been opened.
Fixes problem with modules list showing full list of downloaded modules immediately after window is opened.

### How to test

Before:
Opening the modules panel shows the local modules, then all modules once the remote modules download.  Neither view considers advanced filter settings.

After:
Open modules screen.  Note that listed modules matches advanced filter settings before and after the remote modules download.
