### PR TITLE
Add method to set entity at location

### DIFF
--- a/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
+++ b/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
@@ -28,6 +28,15 @@ import org.terasology.world.block.Block;
 public interface BlockEntityRegistry {
 
     /**
+     * Sets a new entity at the given position.
+     * This new entity is not temporary and will overwrite any existing entity at this point.
+     * @param blockPosition The position to set the new entity in
+     * @param bockEntity The new entity to set
+     * @return The previous entity at the location, or a null entity if one didn't exist yet.
+     */
+    EntityRef setPermanentBlockEntity(Vector3i blockPosition, EntityRef bockEntity);
+
+    /**
      * This method returns the block entity at the given location, but will not produce a temporary entity if
      * one isn't currently in memory.
      *

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -156,6 +156,17 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     }
 
     @Override
+    public EntityRef setPermanentBlockEntity(Vector3i blockPosition, EntityRef blockEntity) {
+        if (GameThread.isCurrentThread()) {
+            EntityRef oldEntity =  getExistingBlockEntityAt(blockPosition);
+            blockEntityLookup.put(blockPosition, blockEntity);
+            return oldEntity;
+        }
+        logger.error("Attempted to set block entity off-thread");
+        return EntityRef.NULL;
+    }
+
+    @Override
     public EntityRef getExistingBlockEntityAt(Vector3i blockPosition) {
         if (GameThread.isCurrentThread()) {
             EntityRef result = blockEntityLookup.get(blockPosition);


### PR DESCRIPTION
This PR adds a method to `BlockEntityRegistry` that sets the entity at a given location. I've added it to this class because it already keeps track of entities linked with positions in the world.
This is something I wish to use for the multiblock style towers in my Tower Defense GSOC project but I can also see applications for it in modules like Simple Farming.

I also wish to note that this doesn't break the API as it only adds a method