### PR TITLE
PathManager fix - better identify working directory on launch

### DIFF
--- a/engine/src/main/java/org/terasology/engine/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/paths/PathManager.java
@@ -66,8 +66,17 @@ public final class PathManager {
         try {
             URL urlToSource = PathManager.class.getProtectionDomain().getCodeSource().getLocation();
 
+            // TODO: Probably remove this after a while, confirming via logs that this is no longer needed
             Path codeLocation = Paths.get(urlToSource.toURI());
-            System.out.println("codeLocation: " + codeLocation);
+            System.out.println("PathManager being initialized. Initial code location is " + codeLocation.toAbsolutePath());
+
+            // Theory that whatever reason we needed to get the path that way isn't needed anymore - try just current dir ...
+            codeLocation = Paths.get("").toAbsolutePath();
+            System.out.println("Switched it to expected working dir: " + codeLocation.toAbsolutePath());
+
+            // If that fails in some situations a different approach could test for the following in the path:
+            // if (codeLocation.toString().contains(".gradle") || codeLocation.toString().contains(".m2")) {
+
             if (Files.isRegularFile(codeLocation)) {
                 installPath = findNativesHome(codeLocation.getParent(), 5);
                 if (installPath == null) {


### PR DESCRIPTION
Once upon a time for some reason I forgot we determined the working directory when the engine starts based on where the `PathManager` class literally sat, including inside a jar file in some cases. This works fine for the game but in some cases when working in a standalone workspace (like module builds in Jenkins) that would mean the game's working directory became a jar file in the local system's Gradle cache - not ideal. Maybe before `Paths.get("")` was a thing we couldn't get a good dir with plain `File` ?

That broke the use of any sort of environment-based module unit tests in Jenkins and apparently also the ServerFacade which works somewhat similar at build time. The fix in this PR still seems to let the game work out of the correct dir, both from source, as a binary, starting as a headless server, _as well_ as when starting environment based unit tests in a module ... except that next up some OpenVR link in `FirstPersonHeldItemMountPointComponent` fails to find some of its stuff. Probably fixable, but this PR does allow the FacadeServer to build in a standalone workspace, both locally (if you copy in the `config` dir and `natives` like with standalone modules)

Needed for @Inei1's GSOC project, also pinging @gianluca-nitti for reference. This will be paired with a FacadeServer PR updating its Gradle a bit.

I'd like somebody on Linux (and maybe Mac?) to double check that they can launch the game from source locally, both as a client and as headless. I can't think of a reason it wouldn't work (the build server is Linux) but just as a sanity check.