### PR TITLE
Fixes related to recent changes in SelectGameScreen

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateIngame.java
@@ -119,14 +119,15 @@ public class StateIngame implements GameState {
 
     @Override
     public void dispose(boolean shuttingDown) {
-        ScreenGrabber screenGrabber = context.get(ScreenGrabber.class);
-        screenGrabber.takeGamePreview(PathManager.getInstance().getSavePath(gameManifest.getTitle()));
 
         ChunkProvider chunkProvider = context.get(ChunkProvider.class);
         chunkProvider.dispose();
 
         boolean save = networkSystem.getMode().isAuthority();
         if (save) {
+            ScreenGrabber screenGrabber = context.get(ScreenGrabber.class);
+            screenGrabber.takeGamePreview(PathManager.getInstance().getSavePath(gameManifest.getTitle()));
+
             storageManager.waitForCompletionOfPreviousSaveAndStartSaving();
         }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -30,6 +30,7 @@ import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.module.StandardModuleExtension;
 import org.terasology.game.GameManifest;
 import org.terasology.i18n.TranslationSystem;
+import org.terasology.input.Keyboard;
 import org.terasology.module.DependencyInfo;
 import org.terasology.module.DependencyResolver;
 import org.terasology.module.Module;
@@ -45,6 +46,7 @@ import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.BindHelper;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
+import org.terasology.rendering.nui.events.NUIKeyEvent;
 import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
@@ -236,7 +238,7 @@ public class CreateGameScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "close", button -> {
             triggerBackAnimation();
             // get back to main screen if no saved games
-            if (GameProvider.getSavedGames().isEmpty()) {
+            if (!isSavedGamesExist()) {
                 triggerBackAnimation();
             }
         });
@@ -443,6 +445,23 @@ public class CreateGameScreen extends CoreScreenLayer {
 
     @Override
     public boolean isLowerLayerVisible() {
+        return false;
+    }
+
+    private boolean isSavedGamesExist() {
+        return !GameProvider.getSavedGames().isEmpty();
+    }
+
+    @Override
+    public boolean onKeyEvent(NUIKeyEvent event) {
+        if (event.isDown() && event.getKey() == Keyboard.Key.ESCAPE && isEscapeToCloseAllowed()) {
+            triggerBackAnimation();
+            if (!isSavedGamesExist()) {
+                // get back to main screen
+                triggerBackAnimation();
+            }
+            return true;
+        }
         return false;
     }
 }


### PR DESCRIPTION
### Contains

Quick fix for issue #3378.
And small improvement - skip showing SelectGame screen when no saved games are present by pressing ESC key on CreateGame screen.

### How to test

[issue #3378]:

*  Run a headless server
*  Run the game normally as a client
*  Connect to the server and leave again

Expected: Log should be clear

[issue with ESC]:
* Remove saved games if exist
* Open Single player
* Press Back button and/or key ESC -> result should be the same. 

