### PR TITLE
New create game flow backend | Part 2

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -90,6 +90,10 @@ public class CreateGameScreen extends CoreScreenLayer {
     private Config config;
 
     private boolean loadingAsServer;
+
+    /**
+     * A UniverseWrapper object used here to determine if the game is single player or multi-player.
+     */
     private UniverseWrapper universeWrapper;
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/CreateGameScreen.java
@@ -90,6 +90,7 @@ public class CreateGameScreen extends CoreScreenLayer {
     private Config config;
 
     private boolean loadingAsServer;
+    private UniverseWrapper universeWrapper;
 
     @Override
     @SuppressWarnings("unchecked")
@@ -102,7 +103,7 @@ public class CreateGameScreen extends CoreScreenLayer {
             gameTypeTitle.bindText(new ReadOnlyBinding<String>() {
                 @Override
                 public String get() {
-                    if (loadingAsServer) {
+                    if (isLoadingAsServer()) {
                         return translationSystem.translate("${engine:menu#select-multiplayer-game-sub-title}");
                     } else {
                         return translationSystem.translate("${engine:menu#select-singleplayer-game-sub-title}");
@@ -264,7 +265,7 @@ public class CreateGameScreen extends CoreScreenLayer {
                         (long) (WorldTime.DAY_LENGTH * timeOffset), worldGenerator.getSelection().getUri());
                 gameManifest.addWorld(worldInfo);
 
-                gameEngine.changeState(new StateLoading(gameManifest, (loadingAsServer) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
+                gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
             }
         });
 
@@ -428,11 +429,11 @@ public class CreateGameScreen extends CoreScreenLayer {
     }
 
     public boolean isLoadingAsServer() {
-        return loadingAsServer;
+        return universeWrapper.getLoadingAsServer();
     }
 
-    public void setLoadingAsServer(boolean loadingAsServer) {
-        this.loadingAsServer = loadingAsServer;
+    public void setUniverseWrapper(UniverseWrapper wrapper) {
+        this.universeWrapper = wrapper;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/MainMenuScreen.java
@@ -66,13 +66,15 @@ public class MainMenuScreen extends CoreScreenLayer {
         jvmWarningLabel.setVisible(NonNativeJVMDetector.JVM_ARCH_IS_NONNATIVE);
 
         SelectGameScreen selectScreen = getManager().createScreen(SelectGameScreen.ASSET_URI, SelectGameScreen.class);
-
+        UniverseWrapper universeWrapper = new UniverseWrapper();
         WidgetUtil.trySubscribe(this, "singleplayer", button -> {
-            selectScreen.setLoadingAsServer(false);
+            universeWrapper.setLoadingAsServer(false);
+            selectScreen.setUniverseWrapper(universeWrapper);
             triggerForwardAnimation(selectScreen);
         });
         WidgetUtil.trySubscribe(this, "multiplayer", button -> {
-            selectScreen.setLoadingAsServer(true);
+            universeWrapper.setLoadingAsServer(true);
+            selectScreen.setUniverseWrapper(universeWrapper);
             triggerForwardAnimation(selectScreen);
         });
         WidgetUtil.trySubscribe(this, "join", button -> {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -100,7 +100,7 @@ public class NewGameScreen extends CoreScreenLayer {
                 }
             });
         }
-        final UIText gameName = find("gameName",UIText.class);
+        final UIText gameName = find("gameName", UIText.class);
         setGameName(gameName);
 
         final UIDropdownScrollable<Module> gameplay = find("gameplay", UIDropdownScrollable.class);
@@ -160,7 +160,7 @@ public class NewGameScreen extends CoreScreenLayer {
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
             ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());
             System.out.println(result.getModules());
-            if(!result.isSuccess()) {
+            if (!result.isSuccess()) {
                 MessagePopup errorMessagePopup = getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class);
                 if (errorMessagePopup != null) {
                     errorMessagePopup.setMessage("Invalid Module Selection", "Please review your module seleciton and try again");
@@ -223,6 +223,7 @@ public class NewGameScreen extends CoreScreenLayer {
         DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
         return resolver.resolve(moduleName).isSuccess();
     }
+
     private void setSelectedGameplayModule(Module module) {
         ModuleConfig moduleConfig = config.getDefaultModSelection();
         if (moduleConfig.getDefaultGameplayModuleName().equals(module.getId().toString())) {
@@ -258,10 +259,9 @@ public class NewGameScreen extends CoreScreenLayer {
     }
 
 
-
     @Override
     public void onOpened() {
-        final UIText gameName = find("gameName",UIText.class);
+        final UIText gameName = find("gameName", UIText.class);
         setGameName(gameName);
 
         final UIDropdown<Module> gameplay = find("gameplay", UIDropdown.class);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -174,7 +174,7 @@ public class NewGameScreen extends CoreScreenLayer {
             SimpleUri uri = config.getWorldGeneration().getDefaultGenerator();
             System.out.println(uri);
             float timeOffset = 0.25f + 0.025f;
-            WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, "thisisjustrandom69",
+            WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, "thisisjustrandom",
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
             gameManifest.addWorld(worldInfo);
             gameEngine.changeState(new StateLoading(gameManifest, (loadingAsServer) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -177,6 +177,7 @@ public class NewGameScreen extends CoreScreenLayer {
             }
 
             SimpleUri uri = config.getWorldGeneration().getDefaultGenerator();
+            // This is multiplied by the number of seconds in a day (86400000) to determine the exact  millisecond at which the game will start.
             float timeOffset = 0.50f;
             WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, tempSeed,
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -165,7 +165,6 @@ public class NewGameScreen extends CoreScreenLayer {
             gameManifest.setSeed(tempSeed);
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
             ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());
-            System.out.println(result.getModules());
             if (!result.isSuccess()) {
                 MessagePopup errorMessagePopup = getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class);
                 if (errorMessagePopup != null) {
@@ -178,8 +177,7 @@ public class NewGameScreen extends CoreScreenLayer {
             }
 
             SimpleUri uri = config.getWorldGeneration().getDefaultGenerator();
-            System.out.println(uri);
-            float timeOffset = 0.25f + 0.025f;
+            float timeOffset = 0.50f;
             WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, tempSeed,
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
             gameManifest.addWorld(worldInfo);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -185,6 +185,10 @@ public class NewGameScreen extends CoreScreenLayer {
         );
     }
 
+    /**
+     * Sets the game names based on the game number of the last saved game
+     * @param gameName The {@link UIText} in which the name will be displayed.
+     */
     private void setGameName(UIText gameName) {
         if (gameName != null) {
             int gameNumber = 1;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -50,6 +50,7 @@ import org.terasology.rendering.nui.widgets.UIDropdown;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
+import org.terasology.utilities.random.FastRandom;
 import org.terasology.world.generator.internal.WorldGeneratorInfo;
 import org.terasology.world.generator.internal.WorldGeneratorManager;
 import org.terasology.world.internal.WorldInfo;
@@ -160,7 +161,8 @@ public class NewGameScreen extends CoreScreenLayer {
             GameManifest gameManifest = new GameManifest();
 
             gameManifest.setTitle(gameName.getText());
-
+            String tempSeed = new FastRandom().nextString(32);
+            gameManifest.setSeed(tempSeed);
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
             ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());
             System.out.println(result.getModules());
@@ -178,7 +180,7 @@ public class NewGameScreen extends CoreScreenLayer {
             SimpleUri uri = config.getWorldGeneration().getDefaultGenerator();
             System.out.println(uri);
             float timeOffset = 0.25f + 0.025f;
-            WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, "thisisjustrandom",
+            WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, tempSeed,
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
             gameManifest.addWorld(worldInfo);
             gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -82,6 +82,8 @@ public class NewGameScreen extends CoreScreenLayer {
     @In
     private TranslationSystem translationSystem;
 
+    private UniverseWrapper universeWrapper;
+
     @Override
     public void initialise() {
 
@@ -92,7 +94,7 @@ public class NewGameScreen extends CoreScreenLayer {
             gameTypeTitle.bindText(new ReadOnlyBinding<String>() {
                 @Override
                 public String get() {
-                    if (loadingAsServer) {
+                    if (isLoadingAsServer()) {
                         return translationSystem.translate("${engine:menu#select-multiplayer-game-sub-title}");
                     } else {
                         return translationSystem.translate("${engine:menu#select-singleplayer-game-sub-title}");
@@ -148,9 +150,11 @@ public class NewGameScreen extends CoreScreenLayer {
         });
 
         AdvancedGameSetupScreen advancedSetupGameScreen = getManager().createScreen(AdvancedGameSetupScreen.ASSET_URI, AdvancedGameSetupScreen.class);
-        WidgetUtil.trySubscribe(this, "advancedSetup", button ->
-                triggerForwardAnimation(advancedSetupGameScreen)
-        );
+        WidgetUtil.trySubscribe(this, "advancedSetup", button -> {
+            universeWrapper.setGameName(gameName.getText());
+            advancedSetupGameScreen.setUniverseWrapper(universeWrapper);
+            triggerForwardAnimation(advancedSetupGameScreen);
+        });
 
         WidgetUtil.trySubscribe(this, "play", button -> {
             GameManifest gameManifest = new GameManifest();
@@ -177,7 +181,7 @@ public class NewGameScreen extends CoreScreenLayer {
             WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, "thisisjustrandom",
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
             gameManifest.addWorld(worldInfo);
-            gameEngine.changeState(new StateLoading(gameManifest, (loadingAsServer) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
+            gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
         });
 
         WidgetUtil.trySubscribe(this, "close", button ->
@@ -303,11 +307,11 @@ public class NewGameScreen extends CoreScreenLayer {
     }
 
     public boolean isLoadingAsServer() {
-        return loadingAsServer;
+        return universeWrapper.getLoadingAsServer();
     }
 
-    public void setLoadingAsServer(boolean loadingAsServer) {
-        this.loadingAsServer = loadingAsServer;
+    public void setUniverseWrapper(UniverseWrapper wrapper) {
+        this.universeWrapper = wrapper;
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -52,8 +52,7 @@ public class SelectGameScreen extends CoreScreenLayer {
     @In
     private TranslationSystem translationSystem;
 
-    private boolean loadingAsServer;
-
+    private UniverseWrapper universeWrapper;
 
     @Override
     public void initialise() {
@@ -64,7 +63,7 @@ public class SelectGameScreen extends CoreScreenLayer {
             gameTypeTitle.bindText(new ReadOnlyBinding<String>() {
                 @Override
                 public String get() {
-                    if (loadingAsServer) {
+                    if (isLoadingAsServer()) {
                         return translationSystem.translate("${engine:menu#select-multiplayer-game-sub-title}");
                     } else {
                         return translationSystem.translate("${engine:menu#select-singleplayer-game-sub-title}");
@@ -88,7 +87,7 @@ public class SelectGameScreen extends CoreScreenLayer {
 
         CreateGameScreen screen = getManager().createScreen(CreateGameScreen.ASSET_URI, CreateGameScreen.class);
         WidgetUtil.trySubscribe(this, "create", button -> {
-            screen.setLoadingAsServer(loadingAsServer);
+            screen.setUniverseWrapper(universeWrapper);
             triggerForwardAnimation(screen);
         });
 
@@ -107,9 +106,10 @@ public class SelectGameScreen extends CoreScreenLayer {
             confirmationPopup.setRightButton(translationSystem.translate("${engine:menu#dialog-no}"), () -> { });
         });
         NewGameScreen newGameScreen = getManager().createScreen(NewGameScreen.ASSET_URI, NewGameScreen.class);
-        WidgetUtil.trySubscribe(this, "test", button ->
-            triggerForwardAnimation(newGameScreen)
-        );
+        WidgetUtil.trySubscribe(this, "test", button -> {
+            newGameScreen.setUniverseWrapper(universeWrapper);
+            triggerForwardAnimation(newGameScreen);
+        });
 
         WidgetUtil.trySubscribe(this, "close", button -> triggerBackAnimation());
     }
@@ -137,7 +137,7 @@ public class SelectGameScreen extends CoreScreenLayer {
     @Override
     public void onOpened() {
         super.onOpened();
-        if (loadingAsServer && !config.getPlayer().hasEnteredUsername()) {
+        if (isLoadingAsServer() && !config.getPlayer().hasEnteredUsername()) {
             getManager().pushScreen(EnterUsernamePopup.ASSET_URI, EnterUsernamePopup.class);
         }
     }
@@ -148,7 +148,7 @@ public class SelectGameScreen extends CoreScreenLayer {
 
             config.getWorldGeneration().setDefaultSeed(manifest.getSeed());
             config.getWorldGeneration().setWorldTitle(manifest.getTitle());
-            CoreRegistry.get(GameEngine.class).changeState(new StateLoading(manifest, (loadingAsServer) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
+            CoreRegistry.get(GameEngine.class).changeState(new StateLoading(manifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
         } catch (Exception e) {
             logger.error("Failed to load saved game", e);
             getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Error Loading Game", e.getMessage());
@@ -156,11 +156,11 @@ public class SelectGameScreen extends CoreScreenLayer {
     }
 
     public boolean isLoadingAsServer() {
-        return loadingAsServer;
+        return universeWrapper.getLoadingAsServer();
     }
 
-    public void setLoadingAsServer(boolean loadingAsServer) {
-        this.loadingAsServer = loadingAsServer;
+    public void setUniverseWrapper(UniverseWrapper wrapper) {
+        this.universeWrapper = wrapper;
     }
 
     private void refreshList(UIList<GameInfo> gameList) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -84,6 +84,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
             }
 
             SimpleUri uri = world.getWorldGeneratorInfo().getUri();
+            // This is multiplied by the number of seconds in a day (86400000) to determine the exact  millisecond at which the game will start.
             float timeOffset = 0.50f;
             WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, world.getWorldGenerator().getWorldSeed(),
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
@@ -105,8 +106,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
      * This method is called before the screen comes to the forefront to set the world
      * in which the player is about to spawn.
      * @param targetWorld The world in which the player is going to spawn.
-     * @param targetWorldTexture The world texture generated in {@link WorldPreGenerationScreen} to be displayed on this
-     *                           screen.
+     * @param targetWorldTexture The world texture generated in {@link WorldPreGenerationScreen} to be displayed on this screen.
      */
     public void setTargetWorld(WorldSetupWrapper targetWorld, Texture targetWorldTexture, Context context) {
         texture = targetWorldTexture;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -62,7 +62,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "play", button -> {
             GameManifest gameManifest = new GameManifest();
 
-            gameManifest.setTitle(world.getWorldName().toString());
+            //gameManifest.setTitle(world.getWorldName().toString());
 
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
             ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -24,6 +24,7 @@ import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.modes.StateLoading;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.game.GameManifest;
+import org.terasology.i18n.TranslationSystem;
 import org.terasology.module.DependencyResolver;
 import org.terasology.module.Module;
 import org.terasology.module.ResolutionResult;
@@ -33,6 +34,7 @@ import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.widgets.UIImage;
+import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.world.WorldSetupWrapper;
 import org.terasology.world.internal.WorldInfo;
 import org.terasology.world.time.WorldTime;
@@ -47,6 +49,9 @@ public class StartPlayingScreen extends CoreScreenLayer {
 
     @In
     private GameEngine gameEngine;
+
+    @In
+    private TranslationSystem translationSystem;
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:startPlayingScreen");
     private Texture texture;
@@ -91,6 +96,9 @@ public class StartPlayingScreen extends CoreScreenLayer {
     public void onOpened() {
         UIImage previewImage = find("preview", UIImage.class);
         previewImage.setImage(texture);
+
+        UILabel subitle = find("subtitle", UILabel.class);
+        subitle.setText(translationSystem.translate("${engine:menu#start-playing}") + " in " + world.getWorldName().toString());
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -32,7 +32,7 @@ import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
 import org.terasology.rendering.nui.widgets.UIImage;
-import org.terasology.rendering.world.World;
+import org.terasology.rendering.world.WorldSetupWrapper;
 import org.terasology.world.internal.WorldInfo;
 import org.terasology.world.time.WorldTime;
 
@@ -49,7 +49,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:startPlayingScreen");
     private Texture texture;
-    private World world;
+    private WorldSetupWrapper world;
 
 
     @Override
@@ -92,7 +92,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
         previewImage.setImage(texture);
     }
 
-    public void setTargetWorld(World targetWorld, Texture targetWorldTexture) {
+    public void setTargetWorld(WorldSetupWrapper targetWorld, Texture targetWorldTexture) {
         texture = targetWorldTexture;
         world = targetWorld;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -52,7 +52,6 @@ public class StartPlayingScreen extends CoreScreenLayer {
     private World world;
 
 
-
     @Override
     public void initialise() {
 
@@ -67,8 +66,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
 
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
             ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());
-            System.out.println(result.getModules());
-            if(!result.isSuccess()) {
+            if (!result.isSuccess()) {
                 MessagePopup errorMessagePopup = getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class);
                 if (errorMessagePopup != null) {
                     errorMessagePopup.setMessage("Invalid Module Selection", "Please review your module seleciton and try again");

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.nui.layers.mainMenu;
 
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.TerasologyConstants;
@@ -50,7 +51,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:startPlayingScreen");
     private Texture texture;
     private WorldSetupWrapper world;
-
+    private UniverseWrapper universeWrapper;
 
     @Override
     public void initialise() {
@@ -62,7 +63,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "play", button -> {
             GameManifest gameManifest = new GameManifest();
 
-            //gameManifest.setTitle(world.getWorldName().toString());
+            gameManifest.setTitle(universeWrapper.getGameName());
 
             DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
             ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());
@@ -82,7 +83,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
             WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, world.getWorldGenerator().getWorldSeed(),
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
             gameManifest.addWorld(worldInfo);
-            gameEngine.changeState(new StateLoading(gameManifest, (false) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
+            gameEngine.changeState(new StateLoading(gameManifest, (universeWrapper.getLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
         });
     }
 
@@ -99,8 +100,9 @@ public class StartPlayingScreen extends CoreScreenLayer {
      * @param targetWorldTexture The world texture generated in {@link WorldPreGenerationScreen} to be displayed on this
      *                           screen.
      */
-    public void setTargetWorld(WorldSetupWrapper targetWorld, Texture targetWorldTexture) {
+    public void setTargetWorld(WorldSetupWrapper targetWorld, Texture targetWorldTexture, Context context) {
         texture = targetWorldTexture;
         world = targetWorld;
+        universeWrapper = context.get(UniverseWrapper.class);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -84,7 +84,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
             }
 
             SimpleUri uri = world.getWorldGeneratorInfo().getUri();
-            float timeOffset = 0.25f + 0.025f;
+            float timeOffset = 0.50f;
             WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, world.getWorldGenerator().getWorldSeed(),
                     (long) (WorldTime.DAY_LENGTH * timeOffset), uri);
             gameManifest.addWorld(worldInfo);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -92,6 +92,13 @@ public class StartPlayingScreen extends CoreScreenLayer {
         previewImage.setImage(texture);
     }
 
+    /**
+     * This method is called before the screen comes to the forefront to set the world
+     * in which the player is about to spawn.
+     * @param targetWorld The world in which the player is going to spawn.
+     * @param targetWorldTexture The world texture generated in {@link WorldPreGenerationScreen} to be displayed on this
+     *                           screen.
+     */
     public void setTargetWorld(WorldSetupWrapper targetWorld, Texture targetWorldTexture) {
         texture = targetWorldTexture;
         world = targetWorld;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -73,6 +73,7 @@ import org.terasology.world.generator.internal.WorldGeneratorManager;
 import org.terasology.world.generator.plugin.TempWorldGeneratorPluginLibrary;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -257,7 +258,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);
         context.put(CopyStrategyLibrary.class, copyStrategyLibrary);
         context.put(NUIManager.class, getManager());
-
+        context.put(UniverseSetupScreen.class, this);
         assetTypeManager = new ModuleAwareAssetTypeManager();
         context.put(AssetManager.class, assetTypeManager.getAssetManager());
         context.put(ModuleAwareAssetTypeManager.class, assetTypeManager);
@@ -304,7 +305,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     }
 
-    private List<String> worldNames() {
+    public List<String> worldNames() {
         List<String> worldNamesList = Lists.newArrayList();
         for (World world: worlds) {
             worldNamesList.add(world.getWorldName().toString());
@@ -312,13 +313,21 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         return worldNamesList;
     }
 
-    private World findWorldByName() {
+    public World findWorldByName() {
         for (World world: worlds) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
                 return world;
             }
         }
         return null;
+    }
+
+    public List<World> getWorldsList() {
+        return worlds;
+    }
+
+    public String getSelectedWorld() {
+        return selectedWorld;
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -202,7 +202,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "continue", button -> {
             if (!worlds.isEmpty()) {
                 try {
-                    worldPreGenerationScreen.setEnvironment(config.getWorldGeneration().getDefaultGenerator(), context);
+                    worldPreGenerationScreen.setEnvironment(context);
                     triggerForwardAnimation(worldPreGenerationScreen);
                 } catch (UnresolvedWorldGeneratorException e) {
                     e.getMessage();
@@ -247,6 +247,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
         selectedWorld = worldGeneratorInfo.getDisplayName() + '-' + worldNumber;
         worlds.add(new World(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo ));
+        System.out.println("" + findWorldByName().getWorldConfigurator());
         worldNumber++;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -247,7 +247,6 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
         selectedWorld = worldGeneratorInfo.getDisplayName() + '-' + worldNumber;
         worlds.add(new World(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo ));
-        System.out.println("" + findWorldByName().getWorldConfigurator());
         worldNumber++;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -84,7 +84,7 @@ import java.util.stream.Collectors;
 public class UniverseSetupScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:universeSetupScreen");
-    List<WorldSetupWrapper> worlds = Lists.newArrayList();
+    private List<WorldSetupWrapper> worlds = Lists.newArrayList();
     int worldNumber = 0;
     private String selectedWorld = "";
     @In
@@ -244,7 +244,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     }
 
     /**
-     * Called whenever the user decides to create a new world.
+     * Called whenever the user decides to add a new world.
      * @param worldGeneratorInfo The {@link WorldGeneratorInfo} object for the new world.
      */
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
@@ -257,6 +257,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
      * This method switched the environment of the game to a temporary one needed for
      * creating a game. It created a new {@link Context} and only puts the minimum classes
      * needed for successful game creation.
+     * @param wrapper passed from the {@link org.terasology.rendering.nui.layers.mainMenu.selectModulesScreen.AdvancedGameSetupScreen} and pushed into the new context.
      */
     public void setEnvironment(UniverseWrapper wrapper) {
         context = new ContextImpl();
@@ -340,11 +341,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         }
         return null;
     }
-
-    /**
-     *
-     * @return the list of worlds.
-     */
+    
     public List<WorldSetupWrapper> getWorldsList() {
         return worlds;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -77,6 +77,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Sets up the Universe for a user. Displays a list of {@link org.terasology.world.generator.WorldGenerator}
+ * for a particular game template.
+ */
 public class UniverseSetupScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:universeSetupScreen");
@@ -239,12 +243,21 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         }
     }
 
+    /**
+     * Called whenever the user decides to create a new world.
+     * @param worldGeneratorInfo The {@link WorldGeneratorInfo} object for the new world.
+     */
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
         selectedWorld = worldGeneratorInfo.getDisplayName() + '-' + worldNumber;
         worlds.add(new WorldSetupWrapper(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo));
         worldNumber++;
     }
 
+    /**
+     * This method switched the environment of the game to a temporary one needed for
+     * creating a game. It created a new {@link Context} and only puts the minimum classes
+     * needed for successful game creation.
+     */
     public void setEnvironment() {
         context = new ContextImpl();
         CoreRegistry.setContext(context);
@@ -300,6 +313,11 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     }
 
+    /**
+     * Create a list of the names of the world, so that they can be displayed as simple String
+     * in the drop-down.
+     * @return A list of world names in String.
+     */
     public List<String> worldNames() {
         List<String> worldNamesList = Lists.newArrayList();
         for (WorldSetupWrapper world : worlds) {
@@ -308,6 +326,11 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         return worldNamesList;
     }
 
+    /**
+     * This method takes the name of the selected world as String and return the corresponding
+     * WorldSetupWrapper object.
+     * @return {@link WorldSetupWrapper} object.
+     */
     public WorldSetupWrapper findWorldByName() {
         for (WorldSetupWrapper world : worlds) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
@@ -317,10 +340,17 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         return null;
     }
 
+    /**
+     *
+     * @return the list of worlds.
+     */
     public List<WorldSetupWrapper> getWorldsList() {
         return worlds;
     }
 
+    /**
+     * @return the selcted world in the drop-down.
+     */
     public String getSelectedWorld() {
         return selectedWorld;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -54,6 +54,7 @@ import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
 import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.rendering.nui.skin.UISkinData;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
+import org.terasology.rendering.world.World;
 import org.terasology.world.block.family.BlockFamilyFactoryRegistry;
 import org.terasology.world.block.family.DefaultBlockFamilyFactoryRegistry;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
@@ -66,14 +67,12 @@ import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.block.sounds.BlockSoundsData;
 import org.terasology.world.block.tiles.BlockTile;
 import org.terasology.world.block.tiles.TileData;
-import org.terasology.rendering.world.World;
 import org.terasology.world.generator.UnresolvedWorldGeneratorException;
 import org.terasology.world.generator.internal.WorldGeneratorInfo;
 import org.terasology.world.generator.internal.WorldGeneratorManager;
 import org.terasology.world.generator.plugin.TempWorldGeneratorPluginLibrary;
 import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,22 +80,18 @@ import java.util.stream.Collectors;
 public class UniverseSetupScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:universeSetupScreen");
+    List<World> worlds = Lists.newArrayList();
+    int worldNumber = 0;
     private String selectedWorld = "";
-
     @In
     private WorldGeneratorManager worldGeneratorManager;
-
     @In
     private ModuleManager moduleManager;
-
     @In
     private Config config;
-
     private ModuleEnvironment environment;
     private ModuleAwareAssetTypeManager assetTypeManager;
     private Context context;
-    List<World> worlds = Lists.newArrayList();
-    int worldNumber = 0;
 
     @Override
     public void initialise() {
@@ -246,7 +241,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
         selectedWorld = worldGeneratorInfo.getDisplayName() + '-' + worldNumber;
-        worlds.add(new World(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo ));
+        worlds.add(new World(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo));
         worldNumber++;
     }
 
@@ -307,14 +302,14 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     public List<String> worldNames() {
         List<String> worldNamesList = Lists.newArrayList();
-        for (World world: worlds) {
+        for (World world : worlds) {
             worldNamesList.add(world.getWorldName().toString());
         }
         return worldNamesList;
     }
 
     public World findWorldByName() {
-        for (World world: worlds) {
+        for (World world : worlds) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
                 return world;
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -274,7 +274,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
             EnvironmentSwitchHandler environmentSwitcher = new EnvironmentSwitchHandler();
             context.put(EnvironmentSwitchHandler.class, environmentSwitcher);
 
-            environmentSwitcher.handleSwitchToGameEnvironment(context);
+            environmentSwitcher.handleSwitchToPreviewEnvironment(context, environment);
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -54,7 +54,7 @@ import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
 import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.rendering.nui.skin.UISkinData;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
-import org.terasology.rendering.world.World;
+import org.terasology.rendering.world.WorldSetupWrapper;
 import org.terasology.world.block.family.BlockFamilyFactoryRegistry;
 import org.terasology.world.block.family.DefaultBlockFamilyFactoryRegistry;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
@@ -80,7 +80,7 @@ import java.util.stream.Collectors;
 public class UniverseSetupScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:universeSetupScreen");
-    List<World> worlds = Lists.newArrayList();
+    List<WorldSetupWrapper> worlds = Lists.newArrayList();
     int worldNumber = 0;
     private String selectedWorld = "";
     @In
@@ -188,7 +188,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
         WidgetUtil.trySubscribe(this, "addGenerator", button -> {
             addNewWorld(worldGenerator.getSelection());
-            List<World> worldOptions = worlds;
+            List<WorldSetupWrapper> worldOptions = worlds;
             worldsDropdown.setOptions(worldNames());
             //triggerForwardAnimation(worldSetupScreen);
         });
@@ -213,7 +213,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         worlds.clear();
         worldNumber = 0;
         final UIDropdownScrollable worldsDropdown = find("worlds", UIDropdownScrollable.class);
-        List<World> worldOptions = worlds;
+        List<WorldSetupWrapper> worldOptions = worlds;
         worldsDropdown.setOptions(worldNames());
         selectedWorld = "";
     }
@@ -241,7 +241,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
         selectedWorld = worldGeneratorInfo.getDisplayName() + '-' + worldNumber;
-        worlds.add(new World(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo));
+        worlds.add(new WorldSetupWrapper(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo));
         worldNumber++;
     }
 
@@ -302,14 +302,14 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     public List<String> worldNames() {
         List<String> worldNamesList = Lists.newArrayList();
-        for (World world : worlds) {
+        for (WorldSetupWrapper world : worlds) {
             worldNamesList.add(world.getWorldName().toString());
         }
         return worldNamesList;
     }
 
-    public World findWorldByName() {
-        for (World world : worlds) {
+    public WorldSetupWrapper findWorldByName() {
+        for (WorldSetupWrapper world : worlds) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
                 return world;
             }
@@ -317,7 +317,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         return null;
     }
 
-    public List<World> getWorldsList() {
+    public List<WorldSetupWrapper> getWorldsList() {
         return worlds;
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -258,7 +258,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
      * creating a game. It created a new {@link Context} and only puts the minimum classes
      * needed for successful game creation.
      */
-    public void setEnvironment() {
+    public void setEnvironment(UniverseWrapper wrapper) {
         context = new ContextImpl();
         CoreRegistry.setContext(context);
         ReflectFactory reflectFactory = new ReflectionReflectFactory();
@@ -272,6 +272,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         context.put(ModuleAwareAssetTypeManager.class, assetTypeManager);
         context.put(ModuleManager.class, moduleManager);
         DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());
+        context.put(UniverseWrapper.class, wrapper);
         ResolutionResult result = resolver.resolve(config.getDefaultModSelection().listModules());
 
         if (result.isSuccess()) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseWrapper.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseWrapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.mainMenu;
+
+public class UniverseWrapper {
+
+    private  String seed;
+    private  boolean loadingAsServer;
+    private  String gameName;
+
+    public void setSeed(String seed) {
+        this.seed = seed;
+    }
+
+    public String getSeed() {
+        return seed;
+    }
+
+    public void setLoadingAsServer(boolean loadingAsServer) {
+        this.loadingAsServer = loadingAsServer;
+    }
+
+    public boolean getLoadingAsServer() {
+        return loadingAsServer;
+    }
+
+    public void setGameName(String gameName) {
+        this.gameName = gameName;
+    }
+
+    public String getGameName() {
+        return gameName;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseWrapper.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseWrapper.java
@@ -15,6 +15,10 @@
  */
 package org.terasology.rendering.nui.layers.mainMenu;
 
+/**
+ * A class which store the universe level properties for a game like if
+ * the game is single-player or multi-player, seed value and the game name.
+ */
 public class UniverseWrapper {
 
     private  String seed;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -15,21 +15,85 @@
  */
 package org.terasology.rendering.nui.layers.mainMenu;
 
+import com.google.common.collect.Lists;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.config.Config;
+import org.terasology.context.Context;
+import org.terasology.engine.SimpleUri;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.math.TeraMath;
+import org.terasology.module.ModuleEnvironment;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.WidgetUtil;
-import org.terasology.world.generation.World;
+import org.terasology.rendering.nui.layers.mainMenu.preview.FacetLayerPreview;
+import org.terasology.rendering.nui.layers.mainMenu.preview.PreviewGenerator;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UIDropdown;
+import org.terasology.rendering.nui.widgets.UIImage;
+import org.terasology.rendering.nui.widgets.UISlider;
+import org.terasology.rendering.nui.widgets.UIText;
+import org.terasology.utilities.Assets;
+import org.terasology.world.generator.UnresolvedWorldGeneratorException;
+import org.terasology.world.generator.WorldGenerator;
+import org.terasology.world.generator.internal.WorldGeneratorManager;
+import org.terasology.world.generator.plugin.TempWorldGeneratorPluginLibrary;
+import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
+import org.terasology.world.zones.Zone;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 public class WorldPreGenerationScreen extends CoreScreenLayer {
 
+    @In
+    private ModuleManager moduleManager;
+
+    @In
+    private Config config;
+
+
+
+    private ModuleEnvironment environment;
+    private WorldGenerator worldGenerator;
+    private Texture texture;
+    private UIImage previewImage;
+    private Context context;
+    private PreviewGenerator previewGen;
+
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldPreGenerationScreen");
+
+    public WorldPreGenerationScreen() {
+    }
+
+    public void setEnvironment(SimpleUri worldGenUri, Context subContext) throws UnresolvedWorldGeneratorException {
+        context = subContext;
+        environment = context.get(ModuleEnvironment.class);
+        context.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(environment, context));
+        worldGenerator = WorldGeneratorManager.createWorldGenerator(worldGenUri, context, environment);
+        worldGenerator.setWorldSeed("thisisjustrancdom");
+        genTexture();
+
+        List<Zone> previewZones = Lists.newArrayList(worldGenerator.getZones())
+                .stream()
+                .filter(z -> !z.getPreviewLayers().isEmpty())
+                .collect(Collectors.toList());
+        if (previewZones.isEmpty()) {
+            previewGen = new FacetLayerPreview(environment, worldGenerator);
+        }
+    }
 
     @Override
     public void initialise() {
 
         StartPlayingScreen startPlayingScreen = getManager().createScreen(StartPlayingScreen.ASSET_URI, StartPlayingScreen.class);
         WidgetUtil.trySubscribe(this, "continue", button ->
-                triggerForwardAnimation(startPlayingScreen)
+                updatePreview()
         );
 
         WorldSetupScreen worldSetupScreen = getManager().createScreen(WorldSetupScreen.ASSET_URI, WorldSetupScreen.class);
@@ -42,4 +106,41 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
                 triggerBackAnimation()
         );
     }
+
+
+    private void genTexture() {
+        int imgWidth = 384;
+        int imgHeight = 384;
+        ByteBuffer buffer = ByteBuffer.allocateDirect(imgWidth * imgHeight * Integer.BYTES);
+        ByteBuffer[] data = new ByteBuffer[]{buffer};
+        ResourceUrn uri = new ResourceUrn("engine:terrainPreview");
+        TextureData texData = new TextureData(imgWidth, imgHeight, data, Texture.WrapMode.CLAMP, Texture.FilterMode.LINEAR);
+        texture = Assets.generateAsset(uri, texData, Texture.class);
+
+        previewImage = find("preview", UIImage.class);
+        previewImage.setImage(texture);
+    }
+
+    private void updatePreview() {
+
+        final NUIManager manager = context.get(NUIManager.class);
+        final WaitPopup<TextureData> popup = manager.pushScreen(WaitPopup.ASSET_URI, WaitPopup.class);
+        popup.setMessage("Updating Preview", "Please wait ...");
+
+        ProgressListener progressListener = progress ->
+                popup.setMessage("Updating Preview", String.format("Please wait ... %d%%", (int) (progress * 100f)));
+
+        Callable<TextureData> operation = () -> {
+            int zoom = 8;
+            TextureData data = texture.getData();
+
+            previewGen.render(data, zoom, progressListener);
+
+            return data;
+        };
+
+        popup.onSuccess(texture::reload);
+        popup.startOperation(operation, true);
+    }
+
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -48,6 +48,11 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+/**
+ * This class let's the user preview different worlds added in the
+ * {@link UniverseSetupScreen}. Each world is still configurable and it's seed
+ * can be changed by the re-roll button. Note that each world has a unique seed.
+ */
 public class WorldPreGenerationScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldPreGenerationScreen");
@@ -71,6 +76,13 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     public WorldPreGenerationScreen() {
     }
 
+    /**
+     * A function called before the screen comes to the forefront to setup the environment
+     * and extract necessary objects from the new Context.
+     * @param subContext As there is a new environment created in the {@link UniverseSetupScreen}, it's passed to
+     *                   this screen instead of using the old Context.
+     * @throws UnresolvedWorldGeneratorException The creation of a world generator can throw this Exception
+     */
     public void setEnvironment(Context subContext) throws UnresolvedWorldGeneratorException {
 
         context = subContext;
@@ -187,7 +199,9 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         }
     }
 
-
+    /**
+     * Generates a texture and set's to the image view, thus previewing the world.
+     */
     private void genTexture() {
         int imgWidth = 384;
         int imgHeight = 384;
@@ -201,6 +215,10 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         previewImage.setImage(texture);
     }
 
+    /**
+     * Updates the preview according to any changes to made the configurator.
+     * Also pops up a message and keeps track of percentage world preview prepared.
+     */
     private void updatePreview() {
 
         final NUIManager manager = context.get(NUIManager.class);
@@ -223,6 +241,11 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         popup.startOperation(operation, true);
     }
 
+    /**
+     * This method takes the name of the selected world as String and return the corresponding
+     * WorldSetupWrapper object.
+     * @return {@link WorldSetupWrapper} object.
+     */
     private WorldSetupWrapper findWorldByName() {
         for (WorldSetupWrapper world : worldList) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
@@ -232,6 +255,11 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         return null;
     }
 
+    /**
+     * Sets a unique seed by simply appending the world name with an incrementing number.
+     * @param world {@link WorldSetupWrapper} object whose seed is to be set.
+     * @return The seed as a string.
+     */
     private String createSeed(String world) {
         return world + seedNumber++;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -34,7 +34,7 @@ import org.terasology.rendering.nui.layers.mainMenu.preview.PreviewGenerator;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UISlider;
-import org.terasology.rendering.world.World;
+import org.terasology.rendering.world.WorldSetupWrapper;
 import org.terasology.utilities.Assets;
 import org.terasology.world.generator.UnresolvedWorldGeneratorException;
 import org.terasology.world.generator.WorldGenerator;
@@ -61,7 +61,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     private UIImage previewImage;
     private Context context;
     private PreviewGenerator previewGen;
-    private List<World> worldList;
+    private List<WorldSetupWrapper> worldList;
     private String selectedWorld;
     private List<String> worldNames;
     private UISlider zoomSlider;
@@ -202,8 +202,8 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         popup.startOperation(operation, true);
     }
 
-    private World findWorldByName() {
-        for (World world : worldList) {
+    private WorldSetupWrapper findWorldByName() {
+        for (WorldSetupWrapper world : worldList) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
                 return world;
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -71,15 +71,23 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     public WorldPreGenerationScreen() {
     }
 
-    public void setEnvironment(SimpleUri worldGenUri, Context subContext) throws UnresolvedWorldGeneratorException {
+    public void setEnvironment(Context subContext) throws UnresolvedWorldGeneratorException {
 
         context = subContext;
         environment = context.get(ModuleEnvironment.class);
         context.put(WorldGeneratorPluginLibrary.class, new TempWorldGeneratorPluginLibrary(environment, context));
-        worldGenerator = WorldGeneratorManager.createWorldGenerator(worldGenUri, context, environment);
+        //worldGenerator = WorldGeneratorManager.createWorldGenerator(worldGenUri, context, environment);
         worldList = context.get(UniverseSetupScreen.class).getWorldsList();
         selectedWorld = context.get(UniverseSetupScreen.class).getSelectedWorld();
         worldNames = context.get(UniverseSetupScreen.class).worldNames();
+        if (findWorldByName().getWorldGenerator() == null) {
+            worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName().getWorldGeneratorInfo().getUri(), context, environment);
+            findWorldByName().setWorldGenerator(worldGenerator);
+        } else {
+            worldGenerator = findWorldByName().getWorldGenerator();
+        }
+        //worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName().getWorldGeneratorInfo().getUri(), context, environment);
+
         worldGenerator.setWorldSeed("thisisjustrandom");
         final UIDropdownScrollable worldsDropdown = find("worlds", UIDropdownScrollable.class);
         worldsDropdown.setOptions(worldNames);
@@ -107,7 +115,20 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
             @Override
             public void set(String value) {
                 selectedWorld = value;
-                updatePreview();
+                System.out.println("" + worldList.get(0).getWorldConfigurator());
+                try {
+                    if (findWorldByName().getWorldGenerator() == null) {
+                        worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName().getWorldGeneratorInfo().getUri(), context, environment);
+                        findWorldByName().setWorldGenerator(worldGenerator);
+                    } else {
+                        worldGenerator = findWorldByName().getWorldGenerator();
+                    }
+                    worldGenerator.setWorldSeed("thisisjustrandom");
+                    previewGen = new FacetLayerPreview(environment, worldGenerator);
+                    updatePreview();
+                } catch (UnresolvedWorldGeneratorException e) {
+                    e.getMessage();
+                }
             }
         });
 
@@ -161,6 +182,15 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
 
         popup.onSuccess(texture::reload);
         popup.startOperation(operation, true);
+    }
+
+    public World findWorldByName() {
+        for (World world: worldList) {
+            if (world.getWorldName().toString().equals(selectedWorld)) {
+                return world;
+            }
+        }
+        return null;
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -69,6 +69,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     private String selectedWorld;
     private List<String> worldNames;
     private UISlider zoomSlider;
+    private int seedNumber = 0;
 
 
     public WorldPreGenerationScreen() {
@@ -91,7 +92,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         }
         //worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName().getWorldGeneratorInfo().getUri(), context, environment);
 
-        worldGenerator.setWorldSeed("thisisjustrandom");
+        worldGenerator.setWorldSeed(createSeed(selectedWorld));
         final UIDropdownScrollable worldsDropdown = find("worlds", UIDropdownScrollable.class);
         worldsDropdown.setOptions(worldNames);
         genTexture();
@@ -137,6 +138,11 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
                     e.getMessage();
                 }
             }
+        });
+
+        WidgetUtil.trySubscribe(this, "reRoll", button -> {
+            worldGenerator.setWorldSeed(createSeed(selectedWorld));
+            getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Ready to roll!", "World seed for " + selectedWorld + " has been changed");
         });
 
         StartPlayingScreen startPlayingScreen = getManager().createScreen(StartPlayingScreen.ASSET_URI, StartPlayingScreen.class);
@@ -200,13 +206,17 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         popup.startOperation(operation, true);
     }
 
-    public World findWorldByName() {
+    private World findWorldByName() {
         for (World world: worldList) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
                 return world;
             }
         }
         return null;
+    }
+
+    private String createSeed(String world) {
+        return world + seedNumber++;
     }
 
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.context.Context;
-import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.math.TeraMath;
 import org.terasology.module.ModuleEnvironment;
@@ -51,14 +50,11 @@ import java.util.stream.Collectors;
 
 public class WorldPreGenerationScreen extends CoreScreenLayer {
 
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldPreGenerationScreen");
     @In
     private ModuleManager moduleManager;
-
     @In
     private Config config;
-
-
-    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldPreGenerationScreen");
     private ModuleEnvironment environment;
     private WorldGenerator worldGenerator;
     private Texture texture;
@@ -207,7 +203,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     }
 
     private World findWorldByName() {
-        for (World world: worldList) {
+        for (World world : worldList) {
             if (world.getWorldName().toString().equals(selectedWorld)) {
                 return world;
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -115,7 +115,6 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
             @Override
             public void set(String value) {
                 selectedWorld = value;
-                System.out.println("" + worldList.get(0).getWorldConfigurator());
                 try {
                     if (findWorldByName().getWorldGenerator() == null) {
                         worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName().getWorldGeneratorInfo().getUri(), context, environment);
@@ -139,9 +138,18 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
 
         WorldSetupScreen worldSetupScreen = getManager().createScreen(WorldSetupScreen.ASSET_URI, WorldSetupScreen.class);
 
-        WidgetUtil.trySubscribe(this, "config", button ->
-                triggerForwardAnimation(worldSetupScreen)
-        );
+        WidgetUtil.trySubscribe(this, "config", button -> {
+            try {
+                if (!selectedWorld.isEmpty()) {
+                    worldSetupScreen.setWorld(context, findWorldByName());
+                    triggerForwardAnimation(worldSetupScreen);
+                } else {
+                    getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Worlds List Empty!", "No world found to configure.");
+                }
+            } catch (UnresolvedWorldGeneratorException e) {
+                e.getMessage();
+            }
+        });
 
         WidgetUtil.trySubscribe(this, "close", button ->
                 triggerBackAnimation()

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -146,12 +146,12 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         });
 
         StartPlayingScreen startPlayingScreen = getManager().createScreen(StartPlayingScreen.ASSET_URI, StartPlayingScreen.class);
-        WidgetUtil.trySubscribe(this, "continue", button ->
-                updatePreview()
-        );
+        WidgetUtil.trySubscribe(this, "continue", button -> {
+            startPlayingScreen.setTargetWorld(findWorldByName(), texture);
+            triggerForwardAnimation(startPlayingScreen);
+        });
 
         WorldSetupScreen worldSetupScreen = getManager().createScreen(WorldSetupScreen.ASSET_URI, WorldSetupScreen.class);
-
         WidgetUtil.trySubscribe(this, "config", button -> {
             try {
                 if (!selectedWorld.isEmpty()) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -127,7 +127,9 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
                     } else {
                         worldGenerator = findWorldByName().getWorldGenerator();
                     }
-                    worldGenerator.setWorldSeed("thisisjustrandom");
+                    if (worldGenerator.getWorldSeed() == null) {
+                        worldGenerator.setWorldSeed(createSeed(selectedWorld));
+                    }
                     previewGen = new FacetLayerPreview(environment, worldGenerator);
                     updatePreview();
                 } catch (UnresolvedWorldGeneratorException e) {
@@ -164,6 +166,25 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "close", button ->
                 triggerBackAnimation()
         );
+    }
+
+    @Override
+    public void onOpened() {
+        try {
+            if (findWorldByName().getWorldGenerator() == null) {
+                worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName().getWorldGeneratorInfo().getUri(), context, environment);
+                findWorldByName().setWorldGenerator(worldGenerator);
+            } else {
+                worldGenerator = findWorldByName().getWorldGenerator();
+            }
+            if (worldGenerator.getWorldSeed().isEmpty()) {
+                worldGenerator.setWorldSeed(createSeed(selectedWorld));
+            }
+            previewGen = new FacetLayerPreview(environment, worldGenerator);
+            updatePreview();
+        } catch (UnresolvedWorldGeneratorException e) {
+            e.getMessage();
+        }
     }
 
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -21,6 +21,7 @@ import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.math.TeraMath;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
@@ -33,6 +34,7 @@ import org.terasology.rendering.nui.layers.mainMenu.preview.FacetLayerPreview;
 import org.terasology.rendering.nui.layers.mainMenu.preview.PreviewGenerator;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.nui.widgets.UIImage;
+import org.terasology.rendering.nui.widgets.UISlider;
 import org.terasology.rendering.world.World;
 import org.terasology.utilities.Assets;
 import org.terasology.world.generator.UnresolvedWorldGeneratorException;
@@ -66,6 +68,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     private List<World> worldList;
     private String selectedWorld;
     private List<String> worldNames;
+    private UISlider zoomSlider;
 
 
     public WorldPreGenerationScreen() {
@@ -104,6 +107,11 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+
+        zoomSlider = find("zoomSlider", UISlider.class);
+        if (zoomSlider != null) {
+            zoomSlider.setValue(2f);
+        }
 
         final UIDropdownScrollable worldsDropdown = find("worlds", UIDropdownScrollable.class);
         worldsDropdown.bindSelection(new Binding<String>() {
@@ -180,7 +188,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
                 popup.setMessage("Updating Preview", String.format("Please wait ... %d%%", (int) (progress * 100f)));
 
         Callable<TextureData> operation = () -> {
-            int zoom = 8;
+            int zoom = TeraMath.floorToInt(zoomSlider.getValue());
             TextureData data = texture.getData();
 
             previewGen.render(data, zoom, progressListener);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -157,7 +157,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
 
         StartPlayingScreen startPlayingScreen = getManager().createScreen(StartPlayingScreen.ASSET_URI, StartPlayingScreen.class);
         WidgetUtil.trySubscribe(this, "continue", button -> {
-            startPlayingScreen.setTargetWorld(findWorldByName(), texture);
+            startPlayingScreen.setTargetWorld(findWorldByName(), texture, context);
             triggerForwardAnimation(startPlayingScreen);
         });
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -72,10 +72,6 @@ public class WorldPreGenerationScreen extends CoreScreenLayer {
     private int seedNumber = 0;
     private float zoomValue = 2f;
 
-
-    public WorldPreGenerationScreen() {
-    }
-
     /**
      * A function called before the screen comes to the forefront to setup the environment
      * and extract necessary objects from the new Context.

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -43,6 +43,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Allows configuration of a single world.
+ */
 public class WorldSetupScreen extends CoreScreenLayer {
 
     public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldSetupScreen");
@@ -69,6 +72,14 @@ public class WorldSetupScreen extends CoreScreenLayer {
         });
     }
 
+    /**
+     * This method sets the world whose properties are to changed. This function is called before the screen comes
+     * to the forefront.
+     * @param subContext As there is a new environment created in the {@link UniverseSetupScreen}, it's passed to
+     *                   this screen instead of using the old Context.
+     * @param worldSelected the world whose configurations are to be changed.
+     * @throws UnresolvedWorldGeneratorException
+     */
     public void setWorld(Context subContext, WorldSetupWrapper worldSelected) throws UnresolvedWorldGeneratorException {
         world = worldSelected;
         context = subContext;
@@ -85,6 +96,10 @@ public class WorldSetupScreen extends CoreScreenLayer {
         configureProperties();
     }
 
+    /**
+     * Assigns a {@link WorldConfigurator} for every world if it doesn't exist. Using
+     * the WorldConfigurator it gets the properties associated with that world.
+     */
     private void configureProperties() {
 
         PropertyLayout propLayout = find("properties", PropertyLayout.class);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -131,7 +131,8 @@ public class WorldSetupScreen extends CoreScreenLayer {
             Class<? extends Component> clazz = params.get(key).getClass();
             Component comp = config.getModuleConfig(worldGenerator.getUri(), key, clazz);
             if (comp != null) {
-                worldConfig.setProperty(key, comp);       // use the data from the config instead of defaults
+                // use the data from the config instead of defaults
+                worldConfig.setProperty(key, comp);
             }
         }
 
@@ -206,11 +207,9 @@ public class WorldSetupScreen extends CoreScreenLayer {
         protected WorldConfigNumberBinding(WorldConfigurator config, String label, ComponentLibrary compLib, FieldMetadata<Object, ?> field) {
             Class<?> type = field.getType();
             if (type == Integer.TYPE || type == Integer.class) {
-                this.binding = new WorldSetupScreen.WorldConfigBinding<>(config, label, compLib,
-                        (FieldMetadata<Object, Integer>) field);
+                this.binding = new WorldSetupScreen.WorldConfigBinding<>(config, label, compLib, (FieldMetadata<Object, Integer>) field);
             } else if (type == Float.TYPE || type == Float.class) {
-                this.binding = new WorldSetupScreen.WorldConfigBinding<>(config, label, compLib,
-                        (FieldMetadata<Object, Float>) field);
+                this.binding = new WorldSetupScreen.WorldConfigBinding<>(config, label, compLib, (FieldMetadata<Object, Float>) field);
             }
         }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -104,7 +104,6 @@ public class WorldSetupScreen extends CoreScreenLayer {
         } else {
             worldGenerator = world.getWorldGenerator();
         }
-        //worldGenerator = WorldGeneratorManager.createWorldGenerator(worldGenUri, context, environment);
         configureProperties();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -31,7 +31,7 @@ import org.terasology.rendering.nui.layouts.PropertyLayout;
 import org.terasology.rendering.nui.properties.Property;
 import org.terasology.rendering.nui.properties.PropertyOrdering;
 import org.terasology.rendering.nui.properties.PropertyProvider;
-import org.terasology.rendering.world.World;
+import org.terasology.rendering.world.WorldSetupWrapper;
 import org.terasology.world.generator.UnresolvedWorldGeneratorException;
 import org.terasology.world.generator.WorldConfigurator;
 import org.terasology.world.generator.WorldGenerator;
@@ -51,7 +51,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
     @In
     private Config config;
     private WorldGenerator worldGenerator;
-    private World world;
+    private WorldSetupWrapper world;
     private ModuleEnvironment environment;
     private Context context;
     private WorldConfigurator oldWorldConfig;
@@ -69,7 +69,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
         });
     }
 
-    public void setWorld(Context subContext, World worldSelected) throws UnresolvedWorldGeneratorException {
+    public void setWorld(Context subContext, WorldSetupWrapper worldSelected) throws UnresolvedWorldGeneratorException {
         world = worldSelected;
         context = subContext;
         SimpleUri worldGenUri = worldSelected.getWorldGeneratorInfo().getUri();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -61,7 +61,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
     @Override
     public void initialise() {
 
-        WidgetUtil.trySubscribe(this, "accept", button -> {
+        WidgetUtil.trySubscribe(this, "apply", button -> {
             triggerBackAnimation();
         });
 
@@ -131,7 +131,6 @@ public class WorldSetupScreen extends CoreScreenLayer {
             List<Property<?, ?>> properties = provider.createProperties(target);
             propLayout.addProperties(label, properties);
         }
-        System.out.println();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -21,6 +21,7 @@ import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.metadata.ComponentLibrary;
+import org.terasology.i18n.TranslationSystem;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.reflection.metadata.FieldMetadata;
 import org.terasology.registry.In;
@@ -31,6 +32,7 @@ import org.terasology.rendering.nui.layouts.PropertyLayout;
 import org.terasology.rendering.nui.properties.Property;
 import org.terasology.rendering.nui.properties.PropertyOrdering;
 import org.terasology.rendering.nui.properties.PropertyProvider;
+import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.world.WorldSetupWrapper;
 import org.terasology.world.generator.UnresolvedWorldGeneratorException;
 import org.terasology.world.generator.WorldConfigurator;
@@ -53,6 +55,10 @@ public class WorldSetupScreen extends CoreScreenLayer {
     private WorldGeneratorManager worldGeneratorManager;
     @In
     private Config config;
+
+    @In
+    private TranslationSystem translationSystem;
+
     private WorldGenerator worldGenerator;
     private WorldSetupWrapper world;
     private ModuleEnvironment environment;
@@ -70,6 +76,12 @@ public class WorldSetupScreen extends CoreScreenLayer {
             world.setWorldConfigurator(oldWorldConfig);
             triggerBackAnimation();
         });
+    }
+
+    @Override
+    public void onOpened() {
+        UILabel subitle = find("subtitle", UILabel.class);
+        subitle.setText(translationSystem.translate("${engine:menu#world-setup}") + " for " + world.getWorldName().toString());
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -45,13 +45,11 @@ import java.util.Objects;
 
 public class WorldSetupScreen extends CoreScreenLayer {
 
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldSetupScreen");
     @In
     private WorldGeneratorManager worldGeneratorManager;
-
     @In
     private Config config;
-
-    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:worldSetupScreen");
     private WorldGenerator worldGenerator;
     private World world;
     private ModuleEnvironment environment;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/AdvancedGameSetupScreen.java
@@ -49,6 +49,7 @@ import org.terasology.rendering.nui.itemRendering.AbstractItemRenderer;
 import org.terasology.rendering.nui.layers.mainMenu.ConfirmPopup;
 import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
 import org.terasology.rendering.nui.layers.mainMenu.UniverseSetupScreen;
+import org.terasology.rendering.nui.layers.mainMenu.UniverseWrapper;
 import org.terasology.rendering.nui.layers.mainMenu.WaitPopup;
 import org.terasology.rendering.nui.widgets.ResettableUIText;
 import org.terasology.rendering.nui.widgets.TextChangeEventListener;
@@ -105,6 +106,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
     private boolean needsUpdate = true;
     private ResettableUIText moduleSearch;
     private SelectModulesConfig selectModulesConfig;
+    private UniverseWrapper universeWrapper;
 
     @Override
     public void onOpened() {
@@ -425,7 +427,8 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
         }
         UniverseSetupScreen universeSetupScreen = getManager().createScreen(UniverseSetupScreen.ASSET_URI, UniverseSetupScreen.class);
         WidgetUtil.trySubscribe(this, "continue", button -> {
-            universeSetupScreen.setEnvironment();
+            universeSetupScreen.setEnvironment(universeWrapper);
+            universeWrapper.setSeed(seed.getText());
             triggerForwardAnimation(universeSetupScreen);
         });
 
@@ -703,5 +706,9 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
         public StandardModuleExtension getStandardModuleExtension() {
             return standardModuleExtension;
         }
+    }
+
+    public void setUniverseWrapper(UniverseWrapper wrapper) {
+        universeWrapper = wrapper;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/selectModulesScreen/AdvancedGameSetupScreen.java
@@ -58,6 +58,7 @@ import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
 import org.terasology.rendering.nui.widgets.UIText;
 import org.terasology.utilities.random.FastRandom;
+import org.terasology.world.generator.UnresolvedWorldGeneratorException;
 import org.terasology.world.generator.internal.WorldGeneratorManager;
 
 import java.util.ArrayList;
@@ -424,7 +425,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
         }
         UniverseSetupScreen universeSetupScreen = getManager().createScreen(UniverseSetupScreen.ASSET_URI, UniverseSetupScreen.class);
         WidgetUtil.trySubscribe(this, "continue", button -> {
-            worldGenManager.refresh();
+            universeSetupScreen.setEnvironment();
             triggerForwardAnimation(universeSetupScreen);
         });
 

--- a/engine/src/main/java/org/terasology/rendering/world/World.java
+++ b/engine/src/main/java/org/terasology/rendering/world/World.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.world;
+
+import org.terasology.naming.Name;
+import org.terasology.world.generator.WorldConfigurator;
+import org.terasology.world.generator.internal.WorldGeneratorInfo;
+
+public class World {
+
+    private Name worldName;
+    private WorldGeneratorInfo worldGeneratorInfo;
+    private WorldConfigurator worldConfigurator;
+
+    public World(Name worldName, WorldGeneratorInfo worldGeneratorInfo) {
+        this.worldName = worldName;
+        this.worldGeneratorInfo = worldGeneratorInfo;
+    }
+
+    public WorldGeneratorInfo getWorldGeneratorInfo() {
+        return this.worldGeneratorInfo;
+    }
+
+    public Name getWorldName() {
+        return this.worldName;
+    }
+
+    public void setWorldConfigurator(WorldConfigurator worldConfigurator) {
+        this.worldConfigurator = worldConfigurator;
+    }
+
+    public WorldConfigurator getWorldConfigurator() {
+        return worldConfigurator;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/world/World.java
+++ b/engine/src/main/java/org/terasology/rendering/world/World.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.world;
 
 import org.terasology.naming.Name;
 import org.terasology.world.generator.WorldConfigurator;
+import org.terasology.world.generator.WorldGenerator;
 import org.terasology.world.generator.internal.WorldGeneratorInfo;
 
 public class World {
@@ -24,6 +25,7 @@ public class World {
     private Name worldName;
     private WorldGeneratorInfo worldGeneratorInfo;
     private WorldConfigurator worldConfigurator;
+    private WorldGenerator worldGenerator;
 
     public World(Name worldName, WorldGeneratorInfo worldGeneratorInfo) {
         this.worldName = worldName;
@@ -44,5 +46,13 @@ public class World {
 
     public WorldConfigurator getWorldConfigurator() {
         return worldConfigurator;
+    }
+
+    public void setWorldGenerator(WorldGenerator worldGenerator) {
+        this.worldGenerator = worldGenerator;
+    }
+
+    public WorldGenerator getWorldGenerator() {
+        return worldGenerator;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldSetupWrapper.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldSetupWrapper.java
@@ -20,14 +20,14 @@ import org.terasology.world.generator.WorldConfigurator;
 import org.terasology.world.generator.WorldGenerator;
 import org.terasology.world.generator.internal.WorldGeneratorInfo;
 
-public class World {
+public class WorldSetupWrapper {
 
     private Name worldName;
     private WorldGeneratorInfo worldGeneratorInfo;
     private WorldConfigurator worldConfigurator;
     private WorldGenerator worldGenerator;
 
-    public World(Name worldName, WorldGeneratorInfo worldGeneratorInfo) {
+    public WorldSetupWrapper(Name worldName, WorldGeneratorInfo worldGeneratorInfo) {
         this.worldName = worldName;
         this.worldGeneratorInfo = worldGeneratorInfo;
     }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldSetupWrapper.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldSetupWrapper.java
@@ -20,6 +20,10 @@ import org.terasology.world.generator.WorldConfigurator;
 import org.terasology.world.generator.WorldGenerator;
 import org.terasology.world.generator.internal.WorldGeneratorInfo;
 
+/**
+ * This class only has significance during the create game phase.
+ * Every world is a object of this class.
+ */
 public class WorldSetupWrapper {
 
     private Name worldName;
@@ -27,6 +31,11 @@ public class WorldSetupWrapper {
     private WorldConfigurator worldConfigurator;
     private WorldGenerator worldGenerator;
 
+    /**
+     * A constructor to initialise a world object.
+     * @param worldName The World Name which is displayed in the drop-downs.
+     * @param worldGeneratorInfo Contains the {@link WorldGeneratorInfo} object for that world.
+     */
     public WorldSetupWrapper(Name worldName, WorldGeneratorInfo worldGeneratorInfo) {
         this.worldName = worldName;
         this.worldGeneratorInfo = worldGeneratorInfo;

--- a/engine/src/main/resources/assets/ui/startPlayingScreen.ui
+++ b/engine/src/main/resources/assets/ui/startPlayingScreen.ui
@@ -102,7 +102,7 @@
           {
             "type": "UIButton",
             "text": "${engine:menu#start-game}",
-            "id": "continue"
+            "id": "play"
           }
         ],
         "layoutInfo": {

--- a/engine/src/main/resources/assets/ui/worldPreGenerationScreen.ui
+++ b/engine/src/main/resources/assets/ui/worldPreGenerationScreen.ui
@@ -114,7 +114,7 @@
               {
                 "type": "UILabel",
                 "text": "${engine:menu#game-worlds}:",
-                "id": "worldGenLabel",
+                "id": "worldLabel",
                 "family": "left-label",
                 "layoutInfo": {
                   "position-horizontal-center": {},
@@ -127,7 +127,7 @@
               },
               {
                 "type": "UIDropdown",
-                "id": "worldGenerators",
+                "id": "worlds",
                 "layoutInfo": {
                   "position-horizontal-center": {},
                   "position-top": {

--- a/engine/src/main/resources/assets/ui/worldPreGenerationScreen.ui
+++ b/engine/src/main/resources/assets/ui/worldPreGenerationScreen.ui
@@ -87,12 +87,12 @@
               {
                 "type": "UILabel",
                 "text": "${engine:menu#time-progression-during-pre-generation}:",
-                "id": "zoomLabel",
+                "id": "timeLabel",
                 "family": "left-label"
               },
               {
                 "type": "UISlider",
-                "id": "zoomSlider",
+                "id": "timeSlider",
                 "minimum": 0.0,
                 "range": 9.0,
                 "increment": 1.0,
@@ -102,14 +102,40 @@
                   "position-horizontal-center": {},
                   "position-top": {
                     "target": "BOTTOM",
-                    "widget": "zoomLabel",
+                    "widget": "timeLabel",
                     "offset": 0
                   }
                 }
               },
               {
-                "type": "UISpace",
-                "size": [1, 32]
+                "type": "UILabel",
+                "text": "${engine:menu#preview-zoom-factor}:",
+                "id": "zoomLabel",
+                "family": "left-label",
+                "layoutInfo": {
+                  "position-horizontal-center": {},
+                  "position-top": {
+                    "target": "BOTTOM",
+                    "widget": "timeSlider",
+                    "offset": 0
+                  }
+                }
+              },
+              {
+                "type": "UISlider",
+                "id": "zoomSlider",
+                "minimum": 1.0,
+                "range": 7.0,
+                "increment": 1.0,
+                "precision": 0,
+                "layoutInfo": {
+                  "use-content-height": true,
+                  "position-horizontal-center": {},
+                  "position-top": {
+                    "target": "BOTTOM",
+                    "widget": "zoomLabel"
+                  }
+                }
               },
               {
                 "type": "UILabel",

--- a/engine/src/main/resources/assets/ui/worldPreGenerationScreen.ui
+++ b/engine/src/main/resources/assets/ui/worldPreGenerationScreen.ui
@@ -126,7 +126,7 @@
                 }
               },
               {
-                "type": "UIDropdown",
+                "type": "UIDropdownScrollable",
                 "id": "worlds",
                 "layoutInfo": {
                   "position-horizontal-center": {},

--- a/engine/src/main/resources/assets/ui/worldSetupScreen.ui
+++ b/engine/src/main/resources/assets/ui/worldSetupScreen.ui
@@ -1,5 +1,5 @@
 {
-  "type": "WorldSetupScreen",
+  "type": "engine:worldSetupScreen",
   "skin": "engine:mainMenu",
   "contents": {
     "type": "relativeLayout",
@@ -34,100 +34,117 @@
       },
       {
         "type": "UIBox",
-        "id":"mainBox",
-        "content": {
-          "type": "ColumnLayout",
-          "columns": 1,
-          "verticalSpacing": 4,
-          "horizontalSpacing": 4,
-          "contents": [
-            {
-              "type": "RowLayout",
-              "verticalSpacing": 4,
-              "horizontalSpacing": 4,
-              "contents": [
-                {
-                  "type": "UILabel",
-                  "text": "World Shape:",
-                  "family": "left-label",
-                  "layoutInfo": {
-                    "relativeWidth": 0.20
-                  }
-                },
-                {
-                  "type": "UIDropdownScrollable",
-                  "id": "worlds",
-                  "layoutInfo": {
-                    "relativeWidth": 0.50
-                  }
-                }
-              ]
-            },
-            {
-              "type": "UISpace",
-              "size": [
-                1,
-                48
-              ]
-            },
-            {
-              "type": "ScrollableArea",
-              "content": {
-                "type": "propertyLayout",
-                "id": "properties",
-                "rowConstraints": "[min]"
-              },
-              "layoutInfo": {
-                "position-horizontal-center": {},
-                "position-top": {
-                  "target": "BOTTOM",
-                  "offset": 8,
-                  "widget": "seed"
-                },
-                "position-bottom": {
-                  "target": "TOP",
-                  "offset": 8,
-                  "widget": "apply"
-                }
-              }
-            }
-          ]
-        },
+        "id": "container",
         "layoutInfo": {
-          "width": 500,
-          "use-content-height": true,
+          "width": 520,
           "position-horizontal-center": {},
           "position-top": {
             "target": "BOTTOM",
             "offset": 16,
             "widget": "subtitle"
+          },
+          "position-bottom": {
+            "target": "TOP",
+            "widget": "close",
+            "offset": 16
           }
         }
       },
       {
-        "type": "RowLayout",
-        "id": "actionsRow",
-        "horizontalSpacing": 4,
+        "type": "ColumnLayout",
+        "columns": 1,
+        "verticalSpacing": 16,
+        "horizontalSpacing": 8,
+        "layoutInfo": {
+          "width": 504,
+          "position-horizontal-center": {},
+          "position-top": {
+            "target": "TOP",
+            "widget": "container",
+            "offset": 8
+          },
+          "position-bottom": {
+            "target": "TOP",
+            "widget": "close",
+            "offset": 24
+          }
+        },
         "contents": [
           {
-            "type": "UIButton",
-            "text": "${engine:menu#back}",
-            "id": "close"
-          },
-          {
-            "type": "UIButton",
-            "text": "${engine:menu#accept}",
-            "id": "accept"
+            "type": "RelativeLayout",
+            "family": "description",
+            "contents": [
+              {
+                "type": "RowLayout",
+                "id": "shape",
+                "layoutInfo": {
+                  "use-content-height": true,
+                  "position-horizontal-center": {},
+                  "position-top": {
+                    "target": "TOP"
+                  }
+                },
+                "contents": [
+                  {
+                    "type": "UILabel",
+                    "text": "World Shape:"
+                  },
+                  {
+                    "type": "UIDropdownScrollable",
+                    "id": "worlds"
+                  }
+                ]
+              },
+              {
+                "type": "ScrollableArea",
+                "content": {
+                  "type": "propertyLayout",
+                  "id": "properties",
+                  "rowConstraints": "[min]"
+                },
+                "layoutInfo": {
+                  "position-horizontal-center": {},
+                  "position-top": {
+                    "target": "BOTTOM",
+                    "offset": 8,
+                    "widget": "shape"
+                  },
+                  "position-bottom": {
+                    "target": "TOP",
+                    "offset": 8,
+                    "widget": "apply"
+                  }
+                }
+              },
+              {
+                "type": "UIButton",
+                "text": "${engine:menu#accept}",
+                "id": "apply",
+                "layoutInfo": {
+                  "height": 32,
+                  "width" : 100,
+                  "position-horizontal-center": {},
+                  "position-bottom": {
+                    "target": "BOTTOM",
+                    "offset": 4
+                  }
+                }
+              }
+            ]
           }
-        ],
+        ]
+      },
+      {
+        "type": "UIButton",
+        "text": "${engine:menu#back}",
+        "id": "close",
         "layoutInfo": {
-          "width": 400,
+          "width": 128,
           "height": 32,
           "position-horizontal-center": {},
           "position-bottom": {
             "target": "BOTTOM",
-            "offset": -48,
-            "widget": "mainBox"
+            "offset": 48
           }
         }
       }


### PR DESCRIPTION
### Contains
The backend of the [new create game flow](https://goo.gl/hizreb). The player can now select different world generators and add a number of worlds to the game. Each world has a unique seed and the seed you see on the `AdvanceGameSetupScreen` is for the Universe. Each world is previewable individually on the `WorldPreGenerationScreen`. You have the option to configure and change the properties of your world in both `UniverseSetupScreen` and `WorldPreGenerationScreen`. There is a configure button which leads you to the `WorldSetupScreen`  where properties can be edited and the changes are successfully previewed in the `WorldPreGenerationScreen`.

### Outstanding before merging
- [ ] Making a world with Height Map causes a crash.
- [x] Game title (?) 
 
A video of what's done: https://www.youtube.com/watch?v=qhKGQjEONmA
