### PR TITLE
Vector pool

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -20,6 +20,7 @@ import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayerSystem;
 import org.terasology.math.Region3i;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
@@ -217,6 +218,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
                 chunksInProximity.clear();
                 for (Vector3i chunkPosition : viewRegion) {
                     RenderableChunk c = chunkProvider.getChunk(chunkPosition);
+                    VectorPools.free(chunkPosition);
                     if (c != null && worldProvider.getLocalView(c.getPosition()) != null) {
                         chunksInProximity.add(c);
                     } else {
@@ -240,6 +242,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
                 // add
                 for (Vector3i chunkPosition : viewRegion) {
                     RenderableChunk c = chunkProvider.getChunk(chunkPosition);
+                    VectorPools.free(chunkPosition);
                     if (c != null && worldProvider.getLocalView(c.getPosition()) != null) {
                         chunksInProximity.add(c);
                     } else {

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -111,7 +111,7 @@ public final class ChunkMath {
         for (int x = minX; x <= maxX; x++) {
             for (int y = minY; y <= maxY; y++) {
                 for (int z = minZ; z <= maxZ; z++) {
-                    result[index++] = new Vector3i(x, y, z);
+                    result[index++] = VectorPools.getVector3i(x, y, z);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/math/Region3i.java
+++ b/engine/src/main/java/org/terasology/math/Region3i.java
@@ -341,7 +341,7 @@ public final class Region3i implements Iterable<Vector3i> {
 
         @Override
         public Vector3i next() {
-            Vector3i result = new Vector3i(pos.x + min.x, pos.y + min.y, pos.z + min.z);
+            Vector3i result = VectorPools.getVector3i(pos.x + min.x, pos.y + min.y, pos.z + min.z);
             pos.z++;
             if (pos.z >= size.z) {
                 pos.z = 0;

--- a/engine/src/main/java/org/terasology/math/VectorPools.java
+++ b/engine/src/main/java/org/terasology/math/VectorPools.java
@@ -19,7 +19,7 @@ import org.terasology.math.geom.Vector3i;
 
 public class VectorPools {
 
-    private static final int POOL_SIZE = 100;
+    private static final int POOL_SIZE = 100_000; //Might be a bit overkill, but some might methods return array of all Vectors in chunk
 
     private static int currentVector3isAvailable;
     private static final Vector3i[] VECTOR_3I_POOL = new Vector3i[POOL_SIZE];

--- a/engine/src/main/java/org/terasology/math/VectorPools.java
+++ b/engine/src/main/java/org/terasology/math/VectorPools.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.math;
+
+import org.terasology.math.geom.Vector3i;
+
+public class VectorPools {
+
+    private static final int POOL_SIZE = 100;
+
+    private static int currentVector3isAvailable;
+    private static final Vector3i[] VECTOR_3I_POOL = new Vector3i[POOL_SIZE];
+
+    private VectorPools() { }
+
+    public static synchronized Vector3i getVector3i() {
+        if (currentVector3isAvailable > 0) {
+            VECTOR_3I_POOL[currentVector3isAvailable - 1].set(0, 0, 0);
+            return VECTOR_3I_POOL[--currentVector3isAvailable];
+        }
+        return new Vector3i();
+    }
+
+    public static synchronized Vector3i getVector3i(Vector3i other) {
+        if (currentVector3isAvailable > 0) {
+            VECTOR_3I_POOL[currentVector3isAvailable - 1].set(other);
+            return VECTOR_3I_POOL[--currentVector3isAvailable];
+        }
+        return new Vector3i(other);
+    }
+
+    public static synchronized Vector3i getVector3i(int x, int y, int z) {
+        if (currentVector3isAvailable > 0) {
+            VECTOR_3I_POOL[currentVector3isAvailable - 1].set(x, y, z);
+            return VECTOR_3I_POOL[--currentVector3isAvailable];
+        }
+        return new Vector3i(x, y, z);
+    }
+
+    public static synchronized void free(Vector3i v) {
+        if (currentVector3isAvailable < POOL_SIZE) {
+            VECTOR_3I_POOL[currentVector3isAvailable++] = v;
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/math/VectorPools.java
+++ b/engine/src/main/java/org/terasology/math/VectorPools.java
@@ -21,12 +21,17 @@ public class VectorPools {
 
     private static final int POOL_SIZE = 100_000; //Might be a bit overkill, but some might methods return array of all Vectors in chunk
 
+    // debug purpose
+    public static long freed3is = 0;
+    public static long drawn3is = 0;
+
     private static int currentVector3isAvailable;
     private static final Vector3i[] VECTOR_3I_POOL = new Vector3i[POOL_SIZE];
 
     private VectorPools() { }
 
     public static synchronized Vector3i getVector3i() {
+        drawn3is++;
         if (currentVector3isAvailable > 0) {
             VECTOR_3I_POOL[currentVector3isAvailable - 1].set(0, 0, 0);
             return VECTOR_3I_POOL[--currentVector3isAvailable];
@@ -35,6 +40,7 @@ public class VectorPools {
     }
 
     public static synchronized Vector3i getVector3i(Vector3i other) {
+        drawn3is++;
         if (currentVector3isAvailable > 0) {
             VECTOR_3I_POOL[currentVector3isAvailable - 1].set(other);
             return VECTOR_3I_POOL[--currentVector3isAvailable];
@@ -43,6 +49,7 @@ public class VectorPools {
     }
 
     public static synchronized Vector3i getVector3i(int x, int y, int z) {
+        drawn3is++;
         if (currentVector3isAvailable > 0) {
             VECTOR_3I_POOL[currentVector3isAvailable - 1].set(x, y, z);
             return VECTOR_3I_POOL[--currentVector3isAvailable];
@@ -51,6 +58,7 @@ public class VectorPools {
     }
 
     public static synchronized void free(Vector3i v) {
+        freed3is++;
         if (currentVector3isAvailable < POOL_SIZE) {
             VECTOR_3I_POOL[currentVector3isAvailable++] = v;
         }

--- a/engine/src/main/java/org/terasology/math/VectorPoolsCommands.java
+++ b/engine/src/main/java/org/terasology/math/VectorPoolsCommands.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.math;
+
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.console.commandSystem.annotations.Command;
+
+@RegisterSystem
+public class VectorPoolsCommands extends BaseComponentSystem {
+    @Command
+    public void reportVectorUsage() {
+        System.out.println("Reporting vector3i usage (vectors drawn, vectors freed)");
+        System.out.println(VectorPools.drawn3is);
+        System.out.println(VectorPools.freed3is);
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -24,6 +24,7 @@ import org.terasology.config.RenderingConfig;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
@@ -145,8 +146,10 @@ class RenderableWorldImpl implements RenderableWorld {
             chunk = chunkProvider.getChunk(chunkCoordinates);
             if (chunk == null) {
                 pregenerationIsComplete = false;
+                VectorPools.free(chunkCoordinates);
             } else if (chunk.isDirty()) {
                 localView = worldProvider.getLocalView(chunkCoordinates);
+                VectorPools.free(chunkCoordinates);
                 if (localView == null) {
                     continue;
                 }

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -29,6 +29,7 @@ import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.inventory.events.DropItemEvent;
 import org.terasology.logic.inventory.events.GiveItemEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.events.ImpulseEvent;
 import org.terasology.registry.In;
@@ -104,6 +105,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
                     for (Vector3i location : blockRegion.region) {
                         Block blockInWorld = worldProvider.getBlock(location);
                         commonDefaultDropsHandling(event, entity, location, blockInWorld.getBlockFamily().getArchetypeBlock());
+                        VectorPools.free(location);
                     }
                 } else {
                     // just drop the ActAsBlock block

--- a/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.health.DoDestroyEvent;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
@@ -43,6 +44,7 @@ public class BlockRegionSystem extends BaseComponentSystem {
     public void onDestroyed(DoDestroyEvent event, EntityRef entity, BlockRegionComponent blockRegion) {
         for (Vector3i blockPosition : blockRegion.region) {
             worldProvider.setBlock(blockPosition, blockManager.getBlock(BlockManager.AIR_ID));
+            VectorPools.free(blockPosition);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -35,6 +35,7 @@ import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.TeraMath;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.monitoring.chunk.ChunkMonitor;
@@ -187,6 +188,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
             chunkPos.sub(region.minX(), region.minY(), region.minZ());
             int index = TeraMath.calculate3DArrayIndex(chunkPos, region.size());
             chunks[index] = chunk;
+            VectorPools.free(chunkPos);
         }
         return new ChunkViewCoreImpl(chunks, region, offset, blockManager.getBlock(BlockManager.AIR_ID));
     }
@@ -233,6 +235,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
             } else {
                 createOrLoadChunk(pos);
             }
+            VectorPools.free(pos);
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -27,6 +27,7 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldComponent;
@@ -180,6 +181,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             if (!chunkProvider.isChunkReady(chunkPos)) {
                 return false;
             }
+            VectorPools.free(chunkPos);
         }
         return true;
     }
@@ -204,6 +206,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 }
                 for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
                     RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+                    VectorPools.free(pos);
                     if (dirtiedChunk != null) {
                         dirtiedChunk.setDirty(true);
                     }
@@ -244,6 +247,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                     }
                     for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
                         RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+                        VectorPools.free(pos);
                         if (dirtiedChunk != null) {
                             dirtiedChunks.add(dirtiedChunk);
                         }
@@ -348,6 +352,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 }
                 for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
                     RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+                    VectorPools.free(pos);
                     if (dirtiedChunk != null) {
                         dirtiedChunk.setDirty(true);
                     }

--- a/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
@@ -16,6 +16,7 @@
 package org.terasology.world.propagation;
 
 import org.terasology.math.ChunkMath;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.Chunk;
@@ -63,6 +64,7 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
         setValueAt(getChunk(pos), ChunkMath.calcBlockPos(pos.x, pos.y, pos.z), value);
         for (Vector3i affectedChunkPos : ChunkMath.getChunkRegionAroundWorldPos(pos, 1)) {
             Chunk dirtiedChunk = chunkProvider.getChunk(affectedChunkPos);
+            VectorPools.free(affectedChunkPos);
             if (dirtiedChunk != null) {
                 dirtiedChunk.setDirty(true);
             }

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
+import org.terasology.math.VectorPools;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.ChunkConstants;
@@ -280,6 +281,7 @@ public class StandardBatchPropagator implements BatchPropagator {
                     queueSpreadValue(adjChunk.chunkToWorldPosition(adjPos), value);
                 }
             }
+            VectorPools.free(pos);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Creates a Vector(3i) memory management model to lower a bit usage of memory and ease the work for garbage collector.

### How to test

Launch game, ideally create new world, let it run for a little while, then use console command `reportVectorUsage`. You should see logs from VectorPool dumped to stdout, the first number being amount of vectors drawn from vectorPool, and the second amount of vectors returned to it. Amount of vectors drawn is higher than amount of vectors freed, that is because not everything returns its vectors (yet). With Perlin worldGen, I was able to get to about 7_000_000L vectors freed in about 10 seconds, which makes about 100 MBytes of memory saved, that gc has not to free himself.

### Outstanding before merging

Not everything (actually, only a bit of things) use VectorPools now, and amount of vectors drawn is way higher than the amount of vectors freed. This however serves as a nice proof of concept.
