### PR TITLE
Fix NPE after releasing v2 Core

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameDetailsScreen.java
@@ -63,6 +63,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -309,8 +310,13 @@ public class GameDetailsScreen extends CoreScreenLayer {
                 .sorted(Comparator.comparing(NameVersion::getName))
                 .map(nameVersion -> {
                     Module module = moduleManager.getRegistry().getModule(nameVersion.getName(), nameVersion.getVersion());
+                    if (module == null) {
+                        logger.warn("Can't find module in your classpath - {}:{}", nameVersion.getName(), nameVersion.getVersion());
+                        return null;
+                    }
                     return ModuleSelectionInfo.local(module);
                 })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         gameModules.setList(sortedGameModules);

--- a/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectModsScreen.ui
@@ -92,7 +92,6 @@
                         {
                             "type": "RowLayout",
                             "id": "AdvanceFilterTitle",
-                            "verticalSpacing": 4,
                             "contents": [
                                 {
                                     "type": "UILabel",


### PR DESCRIPTION
### Contains

Fix NPE for DetailsGameScreen after releasing V2. 
After release we don't have an old version of some modules in our classpath. In this case all your saved game with the old core version can't be showed correctly on this screen.

See Core, BuilderSampleGameplay, CoreSampleGameplay.

### How to test

1. Open DetailsGameScreen for any save with old core version.
2. See log for appropriate message.
3. Check that they aren't in list of modules.

