### PR TITLE
Removed Behavior editor button from Main Screen

### DIFF
--- a/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/mainMenuScreen.ui
@@ -104,11 +104,6 @@
                         "text": "${engine:menu#credits}"
                     },
                     {
-                        "type" : "UIButton",
-                        "id" : "behavioreditor",
-                        "text" : "Behavior Editor"
-                    },
-                    {
                         "type" : "UISpace",
                         "size" : [1, 64]
                     },


### PR DESCRIPTION
### Contains

Removed Behavior Editor button, because it doesn't supposed to work without Behaviors module. 

See details in #3310 .

### How to test

Open MainMenu and check that we don't have this button anymore.
