### PR TITLE
Rewrite modules tab

### DIFF
--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -149,6 +149,7 @@
     "game-details-no-description": "game-details-no-description",
     "game-details-version": "game-details-version",
     "game-details-last-play": "game-details-last-play",
+    "game-details-invalid-module-version-warning": "game-details-invalid-module-version-warning",
     "game-name": "game-name",
     "game-settings": "game-settings",
     "game-worlds": "game-worlds",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -152,6 +152,7 @@
     "game-details-no-description": "No description.",
     "game-details-version": "Version:",
     "game-details-last-play": "Last play",
+    "game-details-invalid-module-version-warning": "Warning: manifest.json contains not valid or not available version of module. This is description for the latest available version of module in your classpath.",
     "game-name": "Game name",
     "game-settings": "Settings",
     "game-worlds": "Worlds",

--- a/engine/src/main/resources/assets/i18n/menu_ru.lang
+++ b/engine/src/main/resources/assets/i18n/menu_ru.lang
@@ -118,6 +118,7 @@
     "game-details-no-description": "Нет описания.",
     "game-details-version": "Версия:",
     "game-details-last-play": "Последняя игра",
+    "game-details-invalid-module-version-warning": "Предупреждение: manifest.json содержит недопустимую или недоступную версию модуля. Это описание для последней доступной версии модуля в вашем classpath'e.",
     "game-name": "Название сохранения",
     "game-settings": "Настройки",
     "game-worlds": "Мир",

--- a/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
@@ -320,6 +320,8 @@
                                                         {
                                                             "type": "ScrollableArea",
                                                             "id": "moduleList",
+                                                            "family": "module-list",
+                                                            "skin": "mainmenu",
                                                             "content": {
                                                                 "type": "ColumnLayout",
                                                                 "columns": 1,


### PR DESCRIPTION
### Contains

Small changes for GameDetailsScreen. Includes highlighting for invalid modules (version from manifest.json isn't in user's classpath). 

### How to test

After release of V2 we increased Core version from 2.0.0-SNAPSHOT to 2.0.1-SNAPSHOT.
Basically, you need old save with previous version. In this case when you'll open the screen, you should see highlighted "Core Content" module on Modules tab and warning in description.
