### PR TITLE
Make render logging a little quieter

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/dag/RenderTaskListGeneratorTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/dag/RenderTaskListGeneratorTest.java
@@ -17,11 +17,11 @@ package org.terasology.rendering.dag;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import java.util.Set;
 import org.junit.Test;
 import org.terasology.engine.SimpleUri;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,14 +41,11 @@ public class RenderTaskListGeneratorTest {
 
         List<RenderPipelineTask> taskList = renderTaskListGenerator.generateFrom(orderedNodes);
 
-        assertEquals("----- test:alphaNode (AlphaNode)",        taskList.get(0).toString().trim()); // Strictly speaking we don't need
-        assertEquals("SetName: foo",       taskList.get(1).toString().trim()); // trimming MarkerTask.toString(),
-        assertEquals("test:alphaNode (AlphaNode)",   taskList.get(2).toString().trim()); // resulting in "----- <NodeName>"
-        assertEquals("----- test:bravoNode (BravoNode)",        taskList.get(3).toString().trim()); // We just do it to avoid attracting
-        assertEquals("test:bravoNode (BravoNode)",   taskList.get(4).toString().trim()); // too much attention to it.
-        assertEquals("----- test:charlieNode (CharlieNode)",      taskList.get(5).toString().trim());
-        assertEquals("test:charlieNode (CharlieNode)", taskList.get(6).toString().trim());
-        assertEquals("SetName: bar",       taskList.get(7).toString().trim());
+        assertEquals("SetName: foo",       taskList.get(0).toString().trim()); // trimming MarkerTask.toString(),
+        assertEquals("test:alphaNode (AlphaNode)",   taskList.get(1).toString().trim()); // resulting in "----- <NodeName>"
+        assertEquals("test:bravoNode (BravoNode)",   taskList.get(2).toString().trim()); // too much attention to it.
+        assertEquals("test:charlieNode (CharlieNode)", taskList.get(3).toString().trim());
+        assertEquals("SetName: bar",       taskList.get(4).toString().trim());
     }
 
     @Test
@@ -66,17 +63,13 @@ public class RenderTaskListGeneratorTest {
 
         List<RenderPipelineTask> taskList = renderTaskListGenerator.generateFrom(orderedNodes);
 
-        assertEquals("----- test:alphaNode (AlphaNode)",        taskList.get(0).toString().trim());
-        assertEquals("SetName: foo",       taskList.get(1).toString().trim());
-        assertEquals("test:alphaNode (AlphaNode)",   taskList.get(2).toString().trim());
-        assertEquals("----- test:bravoNode (BravoNode)",        taskList.get(3).toString().trim());
-        assertEquals("test:bravoNode (BravoNode)",   taskList.get(4).toString().trim());
-        assertEquals("----- test:charlieNode (CharlieNode)",      taskList.get(5).toString().trim());
-        assertEquals("test:charlieNode (CharlieNode)", taskList.get(6).toString().trim());
-        assertEquals("----- test:deltaNode (DeltaNode)",        taskList.get(7).toString().trim());
-        assertEquals("SetName: bar",     taskList.get(8).toString().trim());
-        assertEquals("test:deltaNode (DeltaNode)",   taskList.get(9).toString().trim());
-        assertEquals("SetName: bar",       taskList.get(10).toString().trim());
+        assertEquals("SetName: foo",       taskList.get(0).toString().trim());
+        assertEquals("test:alphaNode (AlphaNode)",   taskList.get(1).toString().trim());
+        assertEquals("test:bravoNode (BravoNode)",   taskList.get(2).toString().trim());
+        assertEquals("test:charlieNode (CharlieNode)", taskList.get(3).toString().trim());
+        assertEquals("SetName: bar",     taskList.get(4).toString().trim());
+        assertEquals("test:deltaNode (DeltaNode)",   taskList.get(5).toString().trim());
+        assertEquals("SetName: bar",       taskList.get(6).toString().trim());
     }
 
     @Test
@@ -96,21 +89,16 @@ public class RenderTaskListGeneratorTest {
 
         List<RenderPipelineTask> taskList = renderTaskListGenerator.generateFrom(orderedNodes);
 
-        assertEquals("----- test:alphaNode (AlphaNode)",        taskList.get(0).toString().trim());
-        assertEquals("SetName: foo",       taskList.get(1).toString().trim());
-        assertEquals("test:alphaNode (AlphaNode)",   taskList.get(2).toString().trim());
-        assertEquals("----- test:bravoNode (BravoNode)",        taskList.get(3).toString().trim());
-        assertEquals("test:bravoNode (BravoNode)",   taskList.get(4).toString().trim());
-        assertEquals("----- test:echoNode (EchoNode)",         taskList.get(5).toString().trim());
-        assertEquals("SetName: bar",       taskList.get(6).toString().trim());
-        assertEquals("test:echoNode (EchoNode)",    taskList.get(7).toString().trim());
-        assertEquals("----- test:charlieNode (CharlieNode)",      taskList.get(8).toString().trim());
-        assertEquals("SetName: foo",       taskList.get(9).toString().trim());
-        assertEquals("test:charlieNode (CharlieNode)", taskList.get(10).toString().trim());
-        assertEquals("----- test:deltaNode (DeltaNode)",        taskList.get(11).toString().trim());
-        assertEquals("SetName: bar",     taskList.get(12).toString().trim());
-        assertEquals("test:deltaNode (DeltaNode)",   taskList.get(13).toString().trim());
-        assertEquals("SetName: bar",   taskList.get(14).toString().trim());
+        assertEquals("SetName: foo",       taskList.get(0).toString().trim());
+        assertEquals("test:alphaNode (AlphaNode)",   taskList.get(1).toString().trim());
+        assertEquals("test:bravoNode (BravoNode)",   taskList.get(2).toString().trim());
+        assertEquals("SetName: bar",       taskList.get(3).toString().trim());
+        assertEquals("test:echoNode (EchoNode)",    taskList.get(4).toString().trim());
+        assertEquals("SetName: foo",       taskList.get(5).toString().trim());
+        assertEquals("test:charlieNode (CharlieNode)", taskList.get(6).toString().trim());
+        assertEquals("SetName: bar",     taskList.get(7).toString().trim());
+        assertEquals("test:deltaNode (DeltaNode)",   taskList.get(8).toString().trim());
+        assertEquals("SetName: bar",   taskList.get(9).toString().trim());
     }
 
     private abstract class DummyNode implements Node {

--- a/engine/src/main/java/org/terasology/rendering/dag/RenderTaskListGenerator.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/RenderTaskListGenerator.java
@@ -112,7 +112,7 @@ public final class RenderTaskListGenerator {
 
         for (Node node : orderedNodes) {
             if (node.isEnabled()) {
-                if (logger.isInfoEnabled()) {
+                if (logger.isDebugEnabled()) {
                     // Marker tasks just add a dividing line to the logger output
                     taskList.add(new MarkerTask(node.getUri() + " (" + node.getClass().getSimpleName() + ")"));
                     enabledNodes++; // we count them only for statistical purposes
@@ -180,16 +180,16 @@ public final class RenderTaskListGenerator {
 
         long endTimeInNanoSeconds = System.nanoTime();
 
-        if (logger.isInfoEnabled()) {
-            logger.info("===== INTERMEDIATE RENDERER LIST =========================");
+        if (logger.isDebugEnabled()) {
+            logger.debug("===== INTERMEDIATE RENDERER LIST =========================");
             logIntermediateRendererListForDebugging(orderedNodes);
-            logger.info("===== RENDERER TASK LIST =================================");
+            logger.debug("===== RENDERER TASK LIST =================================");
             logList(taskList);
-            logger.info("----------------------------------------------------------");
-            logger.info(String.format("Task list generated in %.3f ms", (endTimeInNanoSeconds - startTimeInNanoSeconds) / 1000000f));
-            logger.info(String.format("%s nodes, %s enabled - %s tasks (excluding marker tasks) out of %s potential tasks.",
+            logger.debug("----------------------------------------------------------");
+            logger.debug(String.format("Task list generated in %.3f ms", (endTimeInNanoSeconds - startTimeInNanoSeconds) / 1000000f));
+            logger.debug(String.format("%s nodes, %s enabled - %s tasks (excluding marker tasks) out of %s potential tasks.",
                     nodeList.size(), enabledNodes, taskList.size() - enabledNodes, potentialTasks));
-            logger.info("----------------------------------------------------------");
+            logger.debug("----------------------------------------------------------");
         }
 
         return taskList;
@@ -197,7 +197,7 @@ public final class RenderTaskListGenerator {
 
     private void logList(List<?> list) {
         for (Object object : list) {
-            logger.info(object.toString());
+            logger.debug(object.toString());
         }
     }
 


### PR DESCRIPTION
Currently the `RenderTaskListGenerator` class outputs the entire `INTERMEDIATE RENDERER LIST` which is really long. I've moved to to debug rather than info which makes the log easier to search through and use as this list can get very long