### PR TITLE
Correct block attribute top -> topBottom

### DIFF
--- a/modules/Core/assets/blocks/Torch.block
+++ b/modules/Core/assets/blocks/Torch.block
@@ -6,7 +6,7 @@
     "sides": {
         "shape": "TorchWall"
     },
-    "top": {
+    "topBottom": {
         "shape": "TorchGrounded"
     },
     "penetrable": true,


### PR DESCRIPTION
### Contains
Fixes #3390 
I corrected the blocks section attribute name of the torch from `top` -> `topBottom` as defined in its family AttachedToSurfaceFamily [here](https://github.com/MovingBlocks/Terasology/blob/d0c852d53788e92fc82a56fe0ef4b5347b85e148/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java#L37) .
### How to test
- Start the game with GooeysQuests
- Ask Gooey for a quest.
- If you got the DwarfHalls quest, check if they are constructed correctly.

