### PR TITLE
Gson TypeAdapters and Factories for TypeHandlers

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
@@ -16,7 +16,6 @@
 package org.terasology.persistence.typeHandling.gson;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.junit.Assert;
@@ -31,15 +30,9 @@ public class GsonTypeHandlerAdapterTest {
     private static final String OBJECT_JSON_HEX = "{\"color\":DEADBEEF,\"i\":-123}";
     private static final TestClass OBJECT = new TestClass(new Color(0xDEADBEEF), -123);
 
-    private final ColorTypeHandler typeHandler = new ColorTypeHandler();
-
-    private final GsonTypeHandlerAdapterFactory typeHandlerAdapterFactory = new GsonTypeHandlerAdapterFactory() {{
-        addTypeHandler(Color.class, typeHandler);
-    }};
-
-    private final Gson gson = new GsonBuilder()
-            .registerTypeAdapterFactory(typeHandlerAdapterFactory)
-            .create();
+    private final Gson gson = GsonUtility.createGsonWithTypeHandlers(
+            TypeHandlerEntry.of(Color.class, new ColorTypeHandler())
+    );
 
     /**
      * {@link GsonTypeHandlerAdapter#read(JsonReader)} is tested by deserializing an object from JSON

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.terasology.persistence.typeHandling.extensionTypes.ColorTypeHandler;
+import org.terasology.rendering.nui.Color;
+
+import java.util.Objects;
+
+public class GsonTypeHandlerAdapterTest {
+    private static final String OBJECT_JSON_ARRAY = "{\"color\":[222,173,190,239],\"i\":-123}";
+    private static final String OBJECT_JSON_HEX = "{\"color\":DEADBEEF,\"i\":-123}";
+    private static final TestClass OBJECT = new TestClass(new Color(0xDEADBEEF), -123);
+
+    private final ColorTypeHandler typeHandler = new ColorTypeHandler();
+
+    private final GsonTypeHandlerAdapterFactory typeHandlerAdapterFactory = new GsonTypeHandlerAdapterFactory() {{
+        addTypeHandler(Color.class, typeHandler);
+    }};
+
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(typeHandlerAdapterFactory)
+            .create();
+
+    /**
+     * {@link GsonTypeHandlerAdapter#read(JsonReader)} is tested by deserializing an object from JSON
+     * via Gson with a registered {@link GsonTypeHandlerAdapterFactory} which creates instances of
+     * {@link GsonTypeHandlerAdapter}.
+     */
+    @Test
+    public void testRead() {
+        // Deserialize object with color as JSON array
+        TestClass deserializedObject = gson.fromJson(OBJECT_JSON_ARRAY, TestClass.class);
+
+        Assert.assertEquals(OBJECT, deserializedObject);
+
+        // Deserialize object with color as hex string
+        deserializedObject = gson.fromJson(OBJECT_JSON_HEX, TestClass.class);
+
+        Assert.assertEquals(OBJECT, deserializedObject);
+    }
+
+    /**
+     * {@link GsonTypeHandlerAdapter#write(JsonWriter, Object)} is tested by serializing an object to JSON
+     * via Gson with a registered {@link GsonTypeHandlerAdapterFactory} which creates instances of
+     * {@link GsonTypeHandlerAdapter}.
+     */
+    @Test
+    public void testWrite() {
+        String serializedObject = gson.toJson(OBJECT);
+
+        Assert.assertEquals(OBJECT_JSON_ARRAY, serializedObject);
+    }
+
+    private static class TestClass {
+        private final Color color;
+        private final int i;
+
+        private TestClass(Color color, int i) {
+            this.color = color;
+            this.i = i;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestClass testClass = (TestClass) o;
+            return i == testClass.i &&
+                    Objects.equals(color, testClass.color);
+        }
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
@@ -30,7 +30,7 @@ public class GsonTypeHandlerAdapterTest {
     private static final String OBJECT_JSON_HEX = "{\"color\":DEADBEEF,\"i\":-123}";
     private static final TestClass OBJECT = new TestClass(new Color(0xDEADBEEF), -123);
 
-    private final Gson gson = GsonUtility.createGsonWithTypeHandlers(
+    private final Gson gson = GsonFactory.createGsonWithTypeHandlers(
             TypeHandlerEntry.of(Color.class, new ColorTypeHandler())
     );
 

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
@@ -22,9 +22,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.terasology.math.geom.Rect2i;
-import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector4f;
-import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
@@ -42,6 +40,7 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
                     "someRect",
                     Rect2i.createFromMinAndSize(-3, -3, 10, 10)
             ),
+            ImmutableMap.of(0, 1, 1, 0),
             -0xDECAF
     );
 
@@ -58,6 +57,7 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
 
     private final Gson gson = new GsonBuilder()
             .registerTypeAdapterFactory(typeAdapterFactory)
+            .setExclusionStrategies(new GsonMapExclusionStrategy())
             .create();
 
     @Test
@@ -78,12 +78,18 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
         private final Color color;
         private final Set<Vector4f> vector4fs;
         private final Map<String, Rect2i> rect2iMap;
+
+        // Will not be serialized
+        private final Map<Integer, Integer> intMap;
+        
         private final int i;
 
-        private TestClass(Color color, Set<Vector4f> vector4fs, Map<String, Rect2i> rect2iMap, int i) {
+        private TestClass(Color color, Set<Vector4f> vector4fs, Map<String, Rect2i> rect2iMap,
+                          Map<Integer, Integer> intMap, int i) {
             this.color = color;
             this.vector4fs = vector4fs;
             this.rect2iMap = rect2iMap;
+            this.intMap = intMap;
             this.i = i;
         }
 

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.terasology.math.geom.Rect2i;
+import org.terasology.math.geom.Vector4f;
+import org.terasology.naming.Name;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+import org.terasology.reflection.copy.CopyStrategyLibrary;
+import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.rendering.nui.Color;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class GsonTypeSerializationLibraryAdapterFactoryTest {
+    private static final TestClass OBJECT = new TestClass(
+            new Color(0xDEADBEEF),
+            ImmutableSet.of(Vector4f.zero(), Vector4f.one()),
+            ImmutableMap.of(
+                    new Name("someRect"),
+                    Rect2i.createFromMinAndSize(-3, -3, 10, 10)
+            ),
+            -0xDECAF
+    );
+
+    private static final String OBJECT_JSON = "{\"color\":[222,173,190,239],\"vector4fs\":[[0.0,0.0,0.0,0.0]," +
+            "[1.0,1.0,1.0,1.0]],\"rect2iMap\":{\"someRect\":{\"min\":[-3,-3],\"size\":[10,10]}},\"i\":-912559}";
+
+    private final ReflectionReflectFactory reflectFactory = new ReflectionReflectFactory();
+    private final CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);
+    private final TypeSerializationLibrary typeSerializationLibrary =
+            TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
+
+    private final GsonTypeSerializationLibraryAdapterFactory typeAdapterFactory =
+            new GsonTypeSerializationLibraryAdapterFactory(typeSerializationLibrary);
+
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(typeAdapterFactory)
+            .create();
+
+    @Test
+    public void testSerialize() {
+        String serializedObject = gson.toJson(OBJECT);
+
+        Assert.assertEquals(OBJECT_JSON, serializedObject);
+    }
+
+    @Test
+    public void testDeserialize() {
+        TestClass deserializedObject = gson.fromJson(OBJECT_JSON, TestClass.class);
+
+        Assert.assertEquals(OBJECT, deserializedObject);
+    }
+
+    private static class TestClass {
+        private final Color color;
+        private final Set<Vector4f> vector4fs;
+        private final Map<Name, Rect2i> rect2iMap;
+        private final int i;
+
+        private TestClass(Color color, Set<Vector4f> vector4fs, Map<Name, Rect2i> rect2iMap, int i) {
+            this.color = color;
+            this.vector4fs = vector4fs;
+            this.rect2iMap = rect2iMap;
+            this.i = i;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestClass testClass = (TestClass) o;
+            return i == testClass.i &&
+                    Objects.equals(color, testClass.color) &&
+                    Objects.equals(vector4fs, testClass.vector4fs) &&
+                    Objects.equals(rect2iMap, testClass.rect2iMap);
+        }
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
@@ -18,7 +18,6 @@ package org.terasology.persistence.typeHandling.gson;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.terasology.math.geom.Rect2i;
@@ -52,13 +51,7 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
     private final TypeSerializationLibrary typeSerializationLibrary =
             TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
 
-    private final GsonTypeSerializationLibraryAdapterFactory typeAdapterFactory =
-            new GsonTypeSerializationLibraryAdapterFactory(typeSerializationLibrary);
-
-    private final Gson gson = new GsonBuilder()
-            .registerTypeAdapterFactory(typeAdapterFactory)
-            .setExclusionStrategies(new GsonMapExclusionStrategy())
-            .create();
+    private final Gson gson = GsonUtility.createGsonWithTypeSerializationLibrary(typeSerializationLibrary);
 
     @Test
     public void testSerialize() {
@@ -81,7 +74,7 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
 
         // Will not be serialized
         private final Map<Integer, Integer> intMap;
-        
+
         private final int i;
 
         private TestClass(Color color, Set<Vector4f> vector4fs, Map<String, Rect2i> rect2iMap,

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
@@ -22,6 +22,7 @@ import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.terasology.math.geom.Rect2i;
+import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -38,7 +39,7 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
             new Color(0xDEADBEEF),
             ImmutableSet.of(Vector4f.zero(), Vector4f.one()),
             ImmutableMap.of(
-                    new Name("someRect"),
+                    "someRect",
                     Rect2i.createFromMinAndSize(-3, -3, 10, 10)
             ),
             -0xDECAF
@@ -76,10 +77,10 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
     private static class TestClass {
         private final Color color;
         private final Set<Vector4f> vector4fs;
-        private final Map<Name, Rect2i> rect2iMap;
+        private final Map<String, Rect2i> rect2iMap;
         private final int i;
 
-        private TestClass(Color color, Set<Vector4f> vector4fs, Map<Name, Rect2i> rect2iMap, int i) {
+        private TestClass(Color color, Set<Vector4f> vector4fs, Map<String, Rect2i> rect2iMap, int i) {
             this.color = color;
             this.vector4fs = vector4fs;
             this.rect2iMap = rect2iMap;

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
@@ -51,7 +51,7 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
     private final TypeSerializationLibrary typeSerializationLibrary =
             TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
 
-    private final Gson gson = GsonUtility.createGsonWithTypeSerializationLibrary(typeSerializationLibrary);
+    private final Gson gson = GsonFactory.createGsonWithTypeSerializationLibrary(typeSerializationLibrary);
 
     @Test
     public void testSerialize() {

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonFactory.java
@@ -20,7 +20,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapterFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
-public class GsonUtility {
+public class GsonFactory {
     public static GsonBuilder createDefaultGsonBuilder() {
         return new GsonBuilder()
                 .setExclusionStrategies(new GsonMapExclusionStrategy());

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonFactory.java
@@ -20,12 +20,26 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapterFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
+/**
+ * Class containing static factory methods for generating {@link Gson} objects that follow Terasology
+ * serialization rules and support Terasology TypeHandlers.
+ */
 public class GsonFactory {
+    /**
+     * Create a {@link GsonBuilder} with options set to comply with Terasology JSON serialization rules.
+     */
     public static GsonBuilder createDefaultGsonBuilder() {
         return new GsonBuilder()
                 .setExclusionStrategies(new GsonMapExclusionStrategy());
     }
 
+    /**
+     * Create a {@link Gson} object which uses type handlers loaded from the given
+     * {@link TypeSerializationLibrary} and complies with Terasology JSON serialization rules.
+     *
+     * @param typeSerializationLibrary The {@link TypeSerializationLibrary} to load type handler
+     *                                 definitions from
+     */
     public static Gson createGsonWithTypeSerializationLibrary(TypeSerializationLibrary typeSerializationLibrary) {
         TypeAdapterFactory typeAdapterFactory =
                 new GsonTypeSerializationLibraryAdapterFactory(typeSerializationLibrary);
@@ -35,11 +49,17 @@ public class GsonFactory {
                 .create();
     }
 
-    public static Gson createGsonWithTypeHandlers(TypeHandlerEntry<?>... typeHandlerPairs) {
+    /**
+     * Create a {@link Gson} object which uses the given type handlers and complies with Terasology
+     * JSON serialization rules.
+     *
+     * @param typeHandlerEntries The type handlers to use during serialization.
+     */
+    public static Gson createGsonWithTypeHandlers(TypeHandlerEntry<?>... typeHandlerEntries) {
         GsonTypeHandlerAdapterFactory typeAdapterFactory = new GsonTypeHandlerAdapterFactory();
 
-        for (TypeHandlerEntry typeHandlerPair : typeHandlerPairs) {
-            typeAdapterFactory.addTypeHandler(typeHandlerPair.type, typeHandlerPair.typeHandler);
+        for (TypeHandlerEntry typeHandlerEntry : typeHandlerEntries) {
+            typeAdapterFactory.addTypeHandler(typeHandlerEntry.type, typeHandlerEntry.typeHandler);
         }
 
         return createDefaultGsonBuilder()

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonFactory.java
@@ -55,11 +55,12 @@ public class GsonFactory {
      *
      * @param typeHandlerEntries The type handlers to use during serialization.
      */
+    @SuppressWarnings("unchecked")
     public static Gson createGsonWithTypeHandlers(TypeHandlerEntry<?>... typeHandlerEntries) {
         GsonTypeHandlerAdapterFactory typeAdapterFactory = new GsonTypeHandlerAdapterFactory();
 
         for (TypeHandlerEntry typeHandlerEntry : typeHandlerEntries) {
-            typeAdapterFactory.addTypeHandler(typeHandlerEntry.type, typeHandlerEntry.typeHandler);
+            typeAdapterFactory.addTypeHandler(typeHandlerEntry);
         }
 
         return createDefaultGsonBuilder()

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonMapExclusionStrategy.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonMapExclusionStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import org.terasology.utilities.ReflectionUtil;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class GsonMapExclusionStrategy implements ExclusionStrategy {
+    @Override
+    public boolean shouldSkipField(FieldAttributes f) {
+        Type fieldType = f.getDeclaredType();
+        Class<?> fieldClass = ReflectionUtil.getClassOfType(fieldType);
+
+        if (Map.class.isAssignableFrom(fieldClass)) {
+            Type mapKeyType = ReflectionUtil.getTypeParameter(fieldType, 0);
+
+            return String.class != mapKeyType;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean shouldSkipClass(Class<?> clazz) {
+        return false;
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapter.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 MovingBlocks
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GsonTypeHandlerAdapter is a less featureful clone of the package-private
+ * class TreeTypeAdapter in Gson 2.6.2.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.utilities.ReflectionUtil;
+
+import java.io.IOException;
+
+/**
+ * Adapts a {@link TypeHandler} as a Gson {@link TypeAdapter}. Instances of {@link GsonTypeHandlerAdapter},
+ * when registered as type adapters in a {@link Gson} object, can be used to (de)serialize objects
+ * to JSON (via Gson) with the rules specified by the {@link GsonTypeHandlerAdapter#typeHandler}.
+ *
+ * Since instances of {@link GsonTypeHandlerAdapter} require a {@link Gson} object and a
+ * {@link TypeToken}, it is recommended to register {@link GsonTypeHandlerAdapter} type adapters as a
+ * type adapter factory via a {@link com.google.gson.TypeAdapterFactory}.
+ */
+public final class GsonTypeHandlerAdapter<T> extends TypeAdapter<T> {
+
+    private final TypeHandler<T> typeHandler;
+    private final JsonSerializer<T> serializer;
+    private final JsonDeserializer<T> deserializer;
+    private final Gson gson;
+    private final TypeToken<T> typeToken;
+
+    GsonTypeHandlerAdapter(TypeHandler<T> typeHandler,
+                           Gson gson, TypeToken<T> typeToken) {
+        this.typeHandler = typeHandler;
+
+        this.serializer = (src, typeOfSrc, context) ->
+                ((GsonPersistedData) typeHandler.serialize(src, new GsonSerializationContext(context)))
+                .getElement();
+
+        this.deserializer = (json, typeOfT, context) ->
+                typeHandler.deserialize(new GsonPersistedData(json), new GsonDeserializationContext(context));
+
+        this.gson = gson;
+        this.typeToken = typeToken;
+    }
+
+    @Override
+    public T read(JsonReader in) throws IOException {
+        JsonElement value = Streams.parse(in);
+        if (value.isJsonNull()) {
+            return null;
+        }
+
+        return deserializer.deserialize(value, typeToken.getType(), (JsonDeserializationContext) ReflectionUtil.readField(gson, "deserializationContext"));
+    }
+
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+        JsonElement tree = serializer.serialize(value, typeToken.getType(), (JsonSerializationContext) ReflectionUtil.readField(gson, "serializationContext"));
+        Streams.write(tree, out);
+    }
+}
+

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapter.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapter.java
@@ -42,7 +42,8 @@ import java.io.IOException;
  *
  * Since instances of {@link GsonTypeHandlerAdapter} require a {@link Gson} object and a
  * {@link TypeToken}, it is recommended to register {@link GsonTypeHandlerAdapter} type adapters as a
- * type adapter factory via a {@link com.google.gson.TypeAdapterFactory}.
+ * type adapter factory via a {@link com.google.gson.TypeAdapterFactory} like
+ * {@link GsonTypeHandlerAdapterFactory}.
  */
 public final class GsonTypeHandlerAdapter<T> extends TypeAdapter<T> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterFactory.java
@@ -38,6 +38,16 @@ public class GsonTypeHandlerAdapterFactory implements TypeAdapterFactory {
 
     /**
      * Adds a {@link TypeHandler} to the {@link #typeHandlerMap} for the given type.
+     *
+     * @param typeHandlerEntry The {@link TypeHandlerEntry} encapsulating the {@link TypeHandler} for
+     *                         the given type.
+     */
+    public <T> void addTypeHandler(TypeHandlerEntry<T> typeHandlerEntry) {
+        addTypeHandler(typeHandlerEntry.type, typeHandlerEntry.typeHandler);
+    }
+
+    /**
+     * Adds a {@link TypeHandler} to the {@link #typeHandlerMap} for the given type.
      * @param type The {@link Class} of the type.
      * @param typeHandler The {@link TypeHandler} for the type.
      */

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterFactory.java
@@ -25,6 +25,10 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A Gson {@link TypeAdapterFactory} that creates a {@link GsonTypeHandlerAdapter} for each
+ * {@link TypeHandler} registered in the {@link #typeHandlerMap}.
+ */
 public class GsonTypeHandlerAdapterFactory implements TypeAdapterFactory {
     private Map<Class<?>, TypeHandler<?>> typeHandlerMap;
 
@@ -32,10 +36,19 @@ public class GsonTypeHandlerAdapterFactory implements TypeAdapterFactory {
         typeHandlerMap = new HashMap<>();
     }
 
+    /**
+     * Adds a {@link TypeHandler} to the {@link #typeHandlerMap} for the given type.
+     * @param type The {@link Class} of the type.
+     * @param typeHandler The {@link TypeHandler} for the type.
+     */
     public <T> void addTypeHandler(Class<T> type, TypeHandler<T> typeHandler) {
         typeHandlerMap.put(type, typeHandler);
     }
 
+    /**
+     * Returns a boolean stating whether the {@link #typeHandlerMap} contains a type handler for the given type.
+     * @param type The {@link Class} of the given type.
+     */
     public boolean containsTypeHandlerFor(Class<?> type) {
         return typeHandlerMap.containsKey(type);
     }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GsonTypeHandlerAdapterFactory implements TypeAdapterFactory {
+    private Map<Class<?>, TypeHandler<?>> typeHandlerMap;
+
+    public GsonTypeHandlerAdapterFactory() {
+        typeHandlerMap = new HashMap<>();
+    }
+
+    public <T> void addTypeHandler(Class<T> type, TypeHandler<T> typeHandler) {
+        typeHandlerMap.put(type, typeHandler);
+    }
+
+    public boolean containsTypeHandlerFor(Class<?> type) {
+        return typeHandlerMap.containsKey(type);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        Class<? super T> rawType = type.getRawType();
+
+        if (!containsTypeHandlerFor(rawType)) {
+            return null;
+        }
+
+        return new GsonTypeHandlerAdapter<>((TypeHandler<T>) typeHandlerMap.get(rawType), gson, type);
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactory.java
@@ -22,6 +22,8 @@ import com.google.gson.reflect.TypeToken;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
+import java.lang.reflect.Type;
+
 /**
  * A Gson {@link TypeAdapterFactory} that dynamically looks up the {@link TypeHandler} from a
  * {@link TypeSerializationLibrary} for each type encountered, and creates a {@link GsonTypeHandlerAdapter} with
@@ -37,7 +39,7 @@ public class GsonTypeSerializationLibraryAdapterFactory implements TypeAdapterFa
     @SuppressWarnings("unchecked")
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        Class<? super T> rawType = type.getRawType();
+        Type rawType = type.getType();
 
         TypeHandler<T> typeHandler = (TypeHandler<T>) typeSerializationLibrary.getHandlerFor(rawType);
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+
+/**
+ * A Gson {@link TypeAdapterFactory} that dynamically looks up the {@link TypeHandler} from a
+ * {@link TypeSerializationLibrary} for each type encountered, and creates a {@link GsonTypeHandlerAdapter} with
+ * the retrieved {@link TypeHandler}.
+ */
+public class GsonTypeSerializationLibraryAdapterFactory implements TypeAdapterFactory {
+    private final TypeSerializationLibrary typeSerializationLibrary;
+
+    public GsonTypeSerializationLibraryAdapterFactory(TypeSerializationLibrary typeSerializationLibrary) {
+        this.typeSerializationLibrary = typeSerializationLibrary;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        Class<? super T> rawType = type.getRawType();
+
+        TypeHandler<T> typeHandler = (TypeHandler<T>) typeSerializationLibrary.getHandlerFor(rawType);
+
+        if (typeHandler == null) {
+            return null;
+        }
+
+        return new GsonTypeHandlerAdapter<>(typeHandler, gson, type);
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonUtility.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonUtility.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapterFactory;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+
+public class GsonUtility {
+    public static GsonBuilder createDefaultGsonBuilder() {
+        return new GsonBuilder()
+                .setExclusionStrategies(new GsonMapExclusionStrategy());
+    }
+
+    public static Gson createGsonWithTypeSerializationLibrary(TypeSerializationLibrary typeSerializationLibrary) {
+        TypeAdapterFactory typeAdapterFactory =
+                new GsonTypeSerializationLibraryAdapterFactory(typeSerializationLibrary);
+
+        return createDefaultGsonBuilder()
+                .registerTypeAdapterFactory(typeAdapterFactory)
+                .create();
+    }
+
+    public static Gson createGsonWithTypeHandlers(TypeHandlerEntry<?>... typeHandlerPairs) {
+        GsonTypeHandlerAdapterFactory typeAdapterFactory = new GsonTypeHandlerAdapterFactory();
+
+        for (TypeHandlerEntry typeHandlerPair : typeHandlerPairs) {
+            typeAdapterFactory.addTypeHandler(typeHandlerPair.type, typeHandlerPair.typeHandler);
+        }
+
+        return createDefaultGsonBuilder()
+                .registerTypeAdapterFactory(typeAdapterFactory)
+                .create();
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/LegacyGsonTypeHandlerAdapter.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/LegacyGsonTypeHandlerAdapter.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.persistence.typeHandling.gson;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -26,6 +27,10 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import java.lang.reflect.Type;
 
 /**
+ * Adapts a {@link TypeHandler} as a legacy Gson {@link JsonSerializer} and {@link JsonDeserializer}.
+ * Instances of {@link LegacyGsonTypeHandlerAdapter}, when registered as type adapters in a {@link Gson}
+ * object, can be used to (de)serialize objects to JSON (via Gson) with the rules specified by
+ * the {@link #typeHandler}.
  */
 public class LegacyGsonTypeHandlerAdapter<T> implements JsonDeserializer<T>, JsonSerializer<T> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/LegacyGsonTypeHandlerAdapter.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/LegacyGsonTypeHandlerAdapter.java
@@ -27,11 +27,11 @@ import java.lang.reflect.Type;
 
 /**
  */
-public class JsonTypeHandlerAdapter<T> implements JsonDeserializer<T>, JsonSerializer<T> {
+public class LegacyGsonTypeHandlerAdapter<T> implements JsonDeserializer<T>, JsonSerializer<T> {
 
     private TypeHandler<T> typeHandler;
 
-    public JsonTypeHandlerAdapter(TypeHandler<T> handler) {
+    public LegacyGsonTypeHandlerAdapter(TypeHandler<T> handler) {
         this.typeHandler = handler;
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/TypeHandlerEntry.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/TypeHandlerEntry.java
@@ -17,6 +17,11 @@ package org.terasology.persistence.typeHandling.gson;
 
 import org.terasology.persistence.typeHandling.TypeHandler;
 
+/**
+ * A class containing a {@link TypeHandler} and the {@link Class} of the type it handles.
+ *
+ * @param <T> The type handled by the {@link TypeHandler} contained in the {@link TypeHandlerEntry}.
+ */
 public class TypeHandlerEntry<T> {
     public final Class<T> type;
     public final TypeHandler<T> typeHandler;
@@ -26,6 +31,9 @@ public class TypeHandlerEntry<T> {
         this.typeHandler = typeHandler;
     }
 
+    /**
+     * Creates a {@link TypeHandlerEntry} for a {@link TypeHandler} of the type {@link U}.
+     */
     public static <U> TypeHandlerEntry<U> of(Class<U> type, TypeHandler<U> typeHandler) {
         return new TypeHandlerEntry<>(type, typeHandler);
     }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/TypeHandlerEntry.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/TypeHandlerEntry.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import org.terasology.persistence.typeHandling.TypeHandler;
+
+public class TypeHandlerEntry<T> {
+    public Class<T> type;
+    public TypeHandler<T> typeHandler;
+
+    public static <U> TypeHandlerEntry<U> of(Class<U> type, TypeHandler<U> typeHandler) {
+        return new TypeHandlerEntry<>();
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/TypeHandlerEntry.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/TypeHandlerEntry.java
@@ -18,10 +18,15 @@ package org.terasology.persistence.typeHandling.gson;
 import org.terasology.persistence.typeHandling.TypeHandler;
 
 public class TypeHandlerEntry<T> {
-    public Class<T> type;
-    public TypeHandler<T> typeHandler;
+    public final Class<T> type;
+    public final TypeHandler<T> typeHandler;
+
+    private TypeHandlerEntry(Class<T> type, TypeHandler<T> typeHandler) {
+        this.type = type;
+        this.typeHandler = typeHandler;
+    }
 
     public static <U> TypeHandlerEntry<U> of(Class<U> type, TypeHandler<U> typeHandler) {
-        return new TypeHandlerEntry<>();
+        return new TypeHandlerEntry<>(type, typeHandler);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/asset/UIFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/asset/UIFormat.java
@@ -39,7 +39,7 @@ import org.terasology.math.Border;
 import org.terasology.persistence.ModuleContext;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.extensionTypes.AssetTypeHandler;
-import org.terasology.persistence.typeHandling.gson.JsonTypeHandlerAdapter;
+import org.terasology.persistence.typeHandling.gson.LegacyGsonTypeHandlerAdapter;
 import org.terasology.persistence.typeHandling.mathTypes.BorderTypeHandler;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.reflection.metadata.FieldMetadata;
@@ -106,7 +106,7 @@ public class UIFormat extends AbstractAssetFileFormat<UIData> {
             .registerTypeAdapter(UIData.class, new UIDataTypeAdapter())
             .registerTypeHierarchyAdapter(UIWidget.class, new UIWidgetTypeAdapter(nuiManager));
         for (Class<?> handledType : library.getCoreTypes()) {
-            gsonBuilder.registerTypeAdapter(handledType, new JsonTypeHandlerAdapter<>(library.getHandlerFor(handledType)));
+            gsonBuilder.registerTypeAdapter(handledType, new LegacyGsonTypeHandlerAdapter<>(library.getHandlerFor(handledType)));
         }
 
         // override the String TypeAdapter from the serialization library

--- a/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java
@@ -31,7 +31,7 @@ import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.persistence.ModuleContext;
 import org.terasology.persistence.typeHandling.extensionTypes.ColorTypeHandler;
-import org.terasology.persistence.typeHandling.gson.JsonTypeHandlerAdapter;
+import org.terasology.persistence.typeHandling.gson.LegacyGsonTypeHandlerAdapter;
 import org.terasology.reflection.metadata.ClassLibrary;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.registry.CoreRegistry;
@@ -66,7 +66,7 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
             .registerTypeAdapter(Font.class, new AssetTypeAdapter<>(Font.class))
             .registerTypeAdapter(UISkinData.class, new UISkinTypeAdapter())
             .registerTypeAdapter(TextureRegion.class, new TextureRegionTypeAdapter())
-            .registerTypeAdapter(Color.class, new JsonTypeHandlerAdapter<>(new ColorTypeHandler()))
+            .registerTypeAdapter(Color.class, new LegacyGsonTypeHandlerAdapter<>(new ColorTypeHandler()))
             .registerTypeAdapter(Optional.class, new OptionalTextureRegionTypeAdapter())
             .create();
     }

--- a/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
@@ -199,4 +199,21 @@ public final class ReflectionUtil {
         return getTypeParameterForSuperInterface(targetClass.getGenericSuperclass(), superClass, index);
     }
 
+    public static Object readField(Object object, String fieldName) {
+        Class<?> cls = object.getClass();
+        for (Class<?> c = cls; c != null; c = c.getSuperclass()) {
+            try {
+                final Field field = c.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field.get(object);
+            } catch (final NoSuchFieldException e) {
+                // Try parent
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Cannot access field " + cls.getName() + "." + fieldName, e);
+            }
+        }
+        throw new IllegalArgumentException(
+                "Cannot find field " + cls.getName() + "." + fieldName);
+    }
 }


### PR DESCRIPTION
# Motivation
Terasology uses a custom serialization system loosely based on the Gson 1.x architecture. To specify custom serialization for specific types, Terasology requires the use of implementations of `TypeHandler<T>` -- a Terasology-specific interface. As such, serialization handlers for Terasology-introduced types like `Vector3i` and `Color` implement `TypeHandler` and are only compatible with the Terasology serialization system.

To help use existing `TypeHandlers` for serializing Terasology types to JSON via Gson, the `JsonTypeHandlerAdapter` class, a legacy Gson 1.x serialization adapter, was created. `JsonTypeHandlerAdapter` can be used to register Gson type adapters for each type manually; however, this approach is suboptimal for reasons stated below.

Since manually registering a `TypeHandler`/`JsonTypeHandlerAdapter` for every possible generic variant of popularly serialized generic types like `Set`, `Map` and `List` is very cumbersome (if not downright impossible), Terasology uses a `TypeSerializationLibrary` to create/load `TypeHandler`s for types on the fly. This allows `TypeHandler`s for generic types like `Map` to be easily created on demand, rather than having to hardcode handlers for each generic variant.

Gson 2.x included the `TypeAdapterFactory` interface which, much like `TypeSerializationLibrary` creates `TypeAdapter`s for types on demand. However, it is currently not possible to levy the convenience of `TypeAdapterFactory`/`TypeSerializationLibrary` in Gson serialization with existing `TypeHandlers` because `JsonTypeHandlerAdapter`, a legacy Gson 1.x type adapter, is not supported by Gson 2.x `TypeAdapterFactory`.

To work around this, this PR introduces a new `GsonTypeHandlerAdapter` -- a Gson 2.x serialization adapter very similar in functionality to the old `JsonTypeHandlerAdapter` (renamed in this PR to `LegacyGsonTypeHandlerAdapter`) -- which allows the use of an existing `TypeHandler` as a Gson 2.x `TypeAdapter`. This PR also introduces two `TypeAdapterFactory` implementations -- `GsonTypeHandlerAdapterFactory` and `GsonTypeSerializationLibraryAdapterFactory` -- which create `GsonTypeHandlerAdapter` instances for types from their handlers on the fly.

Since `GsonTypeHandlerAdapter` instances are meant to be used only via a `TypeAdapterFactory` implementation, the `JsonTypeHandlerAdapter` is retained and renamed to `LegacyGsonTypeHandlerAdapter` in cases where individual `TypeHandler`s/`TypeAdapter`s are required.

# Impact
With the Terasology serialization system, there is no way to arbitrarily serialize objects of any compound type purely containing serializable data (like `class GameMap { Map<String, Rect2i> regions; }`) -- you must create a `TypeHandler` for the class (`GameMap` in our example) which manually (de)serializes all fields.

With the introduction of `JsonTypeHandlerAdapter`, you could levy the automagic of Gson by registering a `JsonTypeHandlerAdapter` in a `Gson` object for types having a `TypeHandler`. However, this would still be very restrictive as individual type handlers/adapters would not be able to handle all generic variants for a generic type like `Map` or `Set` (the very reason for which `TypeSerializationLibrary` was created).

With the introduction of the new `TypeAdapter` and `TypeAdapterFactory` implementations in this PR, it is now possible to levy the convenience of on-demand `TypeHandler` creation of `TypeSerializationLibrary` by using a `GsonTypeSerializationLibraryAdapterFactory`, which internally uses a `TypeSerializationLibrary` to create `TypeHandler`s for types on the fly (which are then wrapped by a `GsonTypeHandlerAdapter`). This also means that if a `TypeHandler` for the type of a given object is not found, the object will be serialized using the default Gson rules, allowing for more flexibility.

This makes serializing compound types using Terasology's handlers very easy:

```java
class GameMap { 
    Map<String, Rect2i> regions; 
    EntityRef mainEntity;
}

static Gson createGson(TypeSerializationLibrary typeSerializationLibrary) {
    return new GsonBuilder()
        .registerTypeAdapterFactory(
            new GsonTypeSerializationLibraryAdapterFactory(typeSerializationLibrary)
        )
        .create();
}

String serializeGameMap(GameMap gameMap) {
    Gson gson = createGson(entityManager.getTypeSerializerLibrary());    // Includes EntityRef handler
    return gson.toJson(gameMap);
}

GameMap deserializeGameMap(String json) {
    Gson gson = createGson(entityManager.getTypeSerializerLibrary());    // Includes EntityRef handler
    return gson.fromJson(json, GameMap.class);
}
```

# Changes
- Added `GsonTypeHandlerAdapter`
- Added `GsonTypeHandlerAdapterFactory`
- Added `GsonTypeSerializationLibraryAdapterFactory`
- Added `GsonMapExclusionStrategy`
- Added `GsonFactory`
- Added `TypeHandlerEntry`
- Added `ReflectionUtil.readField` helper
- Renamed `JsonTypeHandlerAdapter` to `LegacyGsonTypeHandlerAdapter`

# Caveats
- When `GsonTypeSerializationLibraryAdapterFactory` encounters a type which does not have a `TypeHandler` in `TypeSerializationLibrary`, the `TypeSerializationLibrary.getHandlerFor` logs errors. Logging errors, however, is unnecessary in this case because when a `TypeHandler` is not found, Gson switches to its default serialization handlers and is (more often than not) able to serialize the type correctly. This is specifically noticeable when serializing an object of a compound type with no existing `TypeHandler` (like `GameMap` in the above example). This can be worked around by making `getHandlerFor` log errors only on request.
- `TypeSerializationLibrary.getHandlerFor` returns null when a `Map` type with non-`String` keys is passed to it, raising an error in the stock Terasology serializer and ensuring that only `Map`s with `String` keys are serialized. In Gson, however, when a non-`String` keyed `Map` is serialized, the keys are serialized using `toString()`, effectively breaking deserialization. This can be prevented by either **a)** making Gson exclude non-String key Maps manually (using an `ExclusionStrategy` or similar); or **b)** [Enabling complex `Map` key serialization](https://google.github.io/gson/apidocs/com/google/gson/GsonBuilder.html#enableComplexMapKeySerialization--) in Gson, which serializes the `Map` to a list of key-value pairs (for non-primitive/complex key types), thus allowing deserialization.
- Deserialization of maps with primitive non-String key types does not work -- check [this comment](https://github.com/MovingBlocks/Terasology/pull/3403#issuecomment-401583540) on this PR for more details.

# Considerations
- [x] Add a static helper method (like in the example above) that creates a `Gson` object for a `TypeSerializationLibrary` while keeping in mind the following considerations.
- [x] Either **a)** make Gson exclude non-String key Maps manually (using an `ExclusionStrategy` or similar); ~or **b)** [enable complex `Map` key serialization](https://google.github.io/gson/apidocs/com/google/gson/GsonBuilder.html#enableComplexMapKeySerialization--) in Gson, which serializes the `Map` to a list of key-value pairs (for non-primitive/complex key types), thus allowing deserialization. Refer to the link for more details.
(Caveat 2)~
- [x] ~Extend primitive type handlers in Terasology to account for serialized values enclosed in a string/quotes _if_ option **b)** is chosen above
(Caveat 3)~

Comments and suggestions (especially on the **Caveats** and the **Considerations**) are welcome.