### PR TITLE
Fix remotely held items @commands broken by #3379, brought by #3337

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/ThirdPersonRemoteClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/ThirdPersonRemoteClientSystem.java
@@ -121,39 +121,30 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
 
     @Command(shortDescription = "Sets the held item mount point translation for remote characters")
     public void setRemotePlayersHeldItemMountPointTranslations(@CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z) {
-        for (EntityRef remotePlayer : entityManager.getEntitiesWith(CharacterComponent.class, PlayerCharacterComponent.class)) {
-            if (relatesToLocalPlayer(remotePlayer)) {
-                RemotePersonHeldItemMountPointComponent newComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
-                if (newComponent != null) {
-                    newComponent.translate = new Vector3f(x, y, z);
-                    ensureClientSideEntityOnHeldItemMountPoint(OnActivatedComponent.newInstance(), remotePlayer, newComponent);
-                }
+        for (EntityRef remotePlayer : entityManager.getEntitiesWith(RemotePersonHeldItemMountPointComponent.class)) {
+            RemotePersonHeldItemMountPointComponent remoteMountPointComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
+            if (remoteMountPointComponent != null) {
+                remoteMountPointComponent.translate.set(x, y, z);
             }
         }
     }
 
     @Command(shortDescription = "Sets the held item mount point rotation for remote characters")
     public void setRemotePlayersHeldItemMountPointRotations(@CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z) {
-        for (EntityRef remotePlayer : entityManager.getEntitiesWith(CharacterComponent.class, PlayerCharacterComponent.class)) {
-            if (relatesToLocalPlayer(remotePlayer)) {
-                RemotePersonHeldItemMountPointComponent newComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
-                if (newComponent != null) {
-                    newComponent.rotateDegrees = new Vector3f(x, y, z);
-                    ensureClientSideEntityOnHeldItemMountPoint(OnActivatedComponent.newInstance(), remotePlayer, newComponent);
-                }
+        for (EntityRef remotePlayer : entityManager.getEntitiesWith(RemotePersonHeldItemMountPointComponent.class)) {
+            RemotePersonHeldItemMountPointComponent remoteMountPointComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
+            if (remoteMountPointComponent != null) {
+                remoteMountPointComponent.rotateDegrees.set(x, y, z);
             }
         }
     }
 
     @Command(shortDescription = "Sets the held item mount point scale for remote characters")
     public void setRemotePlayersHeldItemMountPointScale(@CommandParam("scale") float scale) {
-        for (EntityRef remotePlayer : entityManager.getEntitiesWith(CharacterComponent.class, PlayerCharacterComponent.class)) {
-            if (relatesToLocalPlayer(remotePlayer)) {
-                RemotePersonHeldItemMountPointComponent newComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
-                if (newComponent != null) {
-                    newComponent.scale = scale;
-                    ensureClientSideEntityOnHeldItemMountPoint(OnActivatedComponent.newInstance(), remotePlayer, newComponent);
-                }
+        for (EntityRef remotePlayer : entityManager.getEntitiesWith(RemotePersonHeldItemMountPointComponent.class)) {
+            RemotePersonHeldItemMountPointComponent remoteMountPointComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
+            if (remoteMountPointComponent != null) {
+                remoteMountPointComponent.scale = scale;
             }
         }
     }
@@ -190,8 +181,8 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
      */
     private void linkHeldItemLocationForRemotePlayer(EntityRef newItem, EntityRef player) {
         if (relatesToLocalPlayer(player)) {
-           logger.debug("linkHeldItemLocationForRemotePlayer called with an entity that relates to the local player, ignoring{}", player);
-           return;
+            logger.debug("linkHeldItemLocationForRemotePlayer called with an entity that relates to the local player, ignoring{}", player);
+            return;
         }
 
         // Find out if there is a current held item that maps to this player

--- a/engine/src/main/java/org/terasology/logic/players/ThirdPersonRemoteClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/ThirdPersonRemoteClientSystem.java
@@ -123,9 +123,7 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
     public void setRemotePlayersHeldItemMountPointTranslations(@CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z) {
         for (EntityRef remotePlayer : entityManager.getEntitiesWith(RemotePersonHeldItemMountPointComponent.class)) {
             RemotePersonHeldItemMountPointComponent remoteMountPointComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
-            if (remoteMountPointComponent != null) {
-                remoteMountPointComponent.translate.set(x, y, z);
-            }
+            remoteMountPointComponent.translate.set(x, y, z);
         }
     }
 
@@ -133,19 +131,7 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
     public void setRemotePlayersHeldItemMountPointRotations(@CommandParam("x") float x, @CommandParam("y") float y, @CommandParam("z") float z) {
         for (EntityRef remotePlayer : entityManager.getEntitiesWith(RemotePersonHeldItemMountPointComponent.class)) {
             RemotePersonHeldItemMountPointComponent remoteMountPointComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
-            if (remoteMountPointComponent != null) {
-                remoteMountPointComponent.rotateDegrees.set(x, y, z);
-            }
-        }
-    }
-
-    @Command(shortDescription = "Sets the held item mount point scale for remote characters")
-    public void setRemotePlayersHeldItemMountPointScale(@CommandParam("scale") float scale) {
-        for (EntityRef remotePlayer : entityManager.getEntitiesWith(RemotePersonHeldItemMountPointComponent.class)) {
-            RemotePersonHeldItemMountPointComponent remoteMountPointComponent = remotePlayer.getComponent(RemotePersonHeldItemMountPointComponent.class);
-            if (remoteMountPointComponent != null) {
-                remoteMountPointComponent.scale = scale;
-            }
+            remoteMountPointComponent.rotateDegrees.set(x, y, z);
         }
     }
 


### PR DESCRIPTION
### Commands brought with ThirdPersonRemoteClientSystem(#3337) were broken since #3379. This PR fixes them. These commands provide ability to set position and rotation of items held by remote players for local client trough ingame console. For debugging purposes

#3379
### Contains
Edited ingame commands for remote held item translation rotation and mountpoint scale (the 3rd one is probaly useless though, might as well get rid of it). These commands, introduced by #3337 stopped working after #3379 changed the code to suit the refactored logic. 

Changes: shortened, made it work. Redundant checks for _relatesToLocalPlayer(remotePlayer)_ removed as only real remote player entities should have _RemotePersonHeldItemMountPointComponent_ already (this check is performed when adding those). Unnecessary call to _ensureClientSideEntityOnHeldItemMountPoint()_ deleted.

### How to test

Start multiplayer game with 2 players minimum. Aim your screen at the other player/s. Fire up your console ("~") and use one of the commands:
*setRemotePlayersHeldItemMountPointTranslations \<Float x\> \<Float y\> \<Float z\>* for moving remote held items about. (in meters, 1 meter is one block i suppose?)
*setRemotePlayersHeldItemMountPointRotations \<Float x\> \<Float y\> \<Float z\>* for rotating remote held items about. (in degrees)

observe visual changes of items held by other players :)

### Outstanding before merging

Probably nothing.
