### PR TITLE
New button widget "Open In Browser"

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButtonWebBrowser.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButtonWebBrowser.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.widgets;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Button with predefined action - open the link in default web browser
+ */
+public class UIButtonWebBrowser extends UIButton {
+
+    private static final Logger logger = LoggerFactory.getLogger(UIButtonWebBrowser.class);
+
+    private String link = "";
+
+    public UIButtonWebBrowser() {
+        this.subscribe(openInDefaultBrowser);
+    }
+
+    private ActivateEventListener openInDefaultBrowser = button -> {
+        if (Desktop.isDesktopSupported()) {
+            Desktop desktop = Desktop.getDesktop();
+            try {
+                desktop.browse(new URI(this.link));
+            } catch (IOException | URISyntaxException e) {
+                logger.warn("Can't open {} in default browser of your system.", this.link);
+            }
+        } else {
+            String os = System.getProperty("os.name").toLowerCase();
+            Runtime runtime = Runtime.getRuntime();
+            try {
+                if (os.contains("win")) {
+                    runtime.exec("rundll32 url.dll,FileProtocolHandler " + this.link);
+                } else if (os.contains("mac")) {
+                    runtime.exec("open " + this.link);
+                } else {
+                    runtime.exec("xdg-open " + this.link);
+                }
+            } catch (IOException e) {
+                logger.warn("Can't recognize your system and open the link {}.", this.link);
+            }
+        }
+    };
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+}


### PR DESCRIPTION
### Contains

Add new button widget with predefined action opening default web browser.

### How to test

Add the button widget to some existing screen and set up a link.
Check that default web browser open the link.

e.g. `tryFind("openInBrowser", UIButtonWebBrowser.class).ifPresent( b -> b.setLink("https://github.com"));`

### Outstanding before merging

- [ ] Check on Windows.
- [ ] Check on Mac
- [ ] Check on *nix
