### PR TITLE
Upgrade to Gradle 4.7 for Java 10 compatibility (version parsing issue)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Relates to #3407 - at least on MacOS you can run the game seemingly OK with Java 10, but without this PR you couldn't *build* the game on Java 10 due to a trivial version parsing change in how Gradle detects the Java version.

Still would be good with more research to see if there are any other obvious issues with 9 or 10, this just allows you to use Gradle again.

I recall having noted several potential issues in upgrading Gradle beyond 3.3 or so. So it might not be ideal to merge this yet - especially as I believe one relates to how Gradle outputs when running in CI (the logging changes and can end up deducing the wrong mode to run in)

Anyway, anybody else able to test out this simple change on Win + Linux? Try out a few Gradle commands (like `gradlew idea`, check, jar, clean, etc) and try to re-open the game in IntelliJ after regenerating project files.