### PR TITLE
add byte array persistence type handler

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
@@ -39,6 +39,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.coreTypes.BooleanTypeHandler;
+import org.terasology.persistence.typeHandling.coreTypes.ByteArrayTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.ByteTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.DoubleTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.EnumTypeHandler;
@@ -125,6 +126,7 @@ public class TypeSerializationLibrary {
         add(Long.TYPE, new LongTypeHandler());
         add(String.class, new StringTypeHandler());
         add(Number.class, new NumberTypeHandler());
+        add(byte[].class, new ByteArrayTypeHandler());
     }
 
     /**

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ByteArrayTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ByteArrayTypeHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.coreTypes;
+
+import org.terasology.persistence.typeHandling.DeserializationContext;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.SerializationContext;
+import org.terasology.persistence.typeHandling.SimpleTypeHandler;
+
+public class ByteArrayTypeHandler extends SimpleTypeHandler<byte[]> {
+	@Override
+	public PersistedData serialize(byte[] value, SerializationContext context) {
+		if (value == null) {
+			return context.createNull();
+		} else {
+			return context.create(value);
+		}
+	}
+
+	@Override
+	public byte[] deserialize(PersistedData data, DeserializationContext context) {
+		if (data.isBytes()) {
+			return data.getAsBytes();
+		} else {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
### Contains

A persistence handler for byte[] objects, used by KComputers to proxy Kallisti synchronization packets.

### How to test

Already tested in KComputers, seems to [work fine](https://img.asie.pl/wUAV).

### Outstanding before merging

Nothing! I might write a generic persistence handler for array objects later, but one is not necessary yet.
