### PR TITLE
Record & Replay - Fix issue of holding left click

### DIFF
--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -39,7 +39,9 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.network.internal.NetworkSystemImpl;
 import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.internal.ReadWriteStorageManager;
+import org.terasology.recording.DirectionAndOriginPosRecorder;
 import org.terasology.recording.CharacterStateEventPositionMap;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.recording.RecordAndReplaySerializer;
 import org.terasology.recording.RecordAndReplayUtils;
@@ -102,7 +104,9 @@ public abstract class TerasologyTestingEnvironment {
         context.put(RecordAndReplayUtils.class, recordAndReplayUtils);
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
         context.put(CharacterStateEventPositionMap.class, characterStateEventPositionMap);
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(engineEntityManager, recordedEventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap);
+        DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
+        context.put(DirectionAndOriginPosRecorderList.class, directionAndOriginPosRecorderList);
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(engineEntityManager, recordedEventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
         context.put(RecordAndReplaySerializer.class, recordAndReplaySerializer);
 
         Path savePath = PathManager.getInstance().getSavePath("world1");

--- a/engine-tests/src/test/java/org/terasology/input/InputSystemTests.java
+++ b/engine-tests/src/test/java/org/terasology/input/InputSystemTests.java
@@ -22,6 +22,7 @@ import org.terasology.input.events.KeyEvent;
 import org.terasology.input.internal.BindableButtonImpl;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.ClientComponent;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.registry.InjectionHelper;
 
@@ -76,7 +77,7 @@ public class InputSystemTests {
 
     private void setUpLocalPlayer(Context context) {
         LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setEntityIdMap(new EntityIdMap());
+        localPlayer.setRecordAndReplayClasses(new EntityIdMap(), new DirectionAndOriginPosRecorderList());
         clientEntity = mock(EntityRef.class);
         ClientComponent clientComponent = new ClientComponent();
         characterEntity = mock(EntityRef.class);

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -44,7 +44,9 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.ChunkStore;
 import org.terasology.persistence.PlayerStore;
 import org.terasology.persistence.StorageManager;
+import org.terasology.recording.DirectionAndOriginPosRecorder;
 import org.terasology.recording.CharacterStateEventPositionMap;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.recording.RecordAndReplaySerializer;
 import org.terasology.recording.RecordAndReplayUtils;
@@ -116,7 +118,8 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         EntityIdMap entityIdMap = new EntityIdMap();
         recordAndReplayUtils = new RecordAndReplayUtils();
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
-        recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap);
+        DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
+        recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
 
 
         esm = new ReadWriteStorageManager(savePath, moduleEnvironment, entityManager, blockManager, biomeManager,

--- a/engine-tests/src/test/java/org/terasology/recording/EventSystemReplayImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/recording/EventSystemReplayImplTest.java
@@ -72,7 +72,8 @@ public class EventSystemReplayImplTest {
         EntityIdMap entityIdMap = new EntityIdMap();
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, eventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap);
+        DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, eventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
         RecordAndReplayStatus.setCurrentStatus(RecordAndReplayStatus.REPLAYING);
         entity = entityManager.create();
         Long id = entity.getId();

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -57,6 +57,7 @@ import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.recording.CharacterStateEventPositionMap;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.RecordAndReplayUtils;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectFactory;
@@ -153,10 +154,14 @@ public class TerasologyEngine implements GameEngine {
         this.rootContext = new ContextImpl();
         rootContext.put(GameEngine.class, this);
         this.timeSubsystem = timeSubsystem;
+
+        //Record and Replay classes
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
         rootContext.put(RecordAndReplayUtils.class, recordAndReplayUtils);
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
         rootContext.put(CharacterStateEventPositionMap.class, characterStateEventPositionMap);
+        DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
+        rootContext.put(DirectionAndOriginPosRecorderList.class, directionAndOriginPosRecorderList);
         /*
          * We can't load the engine without core registry yet.
          * e.g. the statically created MaterialLoader needs the CoreRegistry to get the AssetManager.

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -43,6 +43,7 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.extensionTypes.EntityRefTypeHandler;
 import org.terasology.recording.CharacterStateEventPositionMap;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.recording.EventCatcher;
 import org.terasology.recording.RecordAndReplayUtils;
@@ -126,10 +127,11 @@ public final class EntitySystemSetupUtil {
         //Record and Replay
         RecordAndReplayUtils recordAndReplayUtils = context.get(RecordAndReplayUtils.class);
         CharacterStateEventPositionMap characterStateEventPositionMap = context.get(CharacterStateEventPositionMap.class);
+        DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = context.get(DirectionAndOriginPosRecorderList.class);
         RecordedEventStore recordedEventStore = new RecordedEventStore();
         EntityIdMap entityIdMap = new EntityIdMap();
         context.put(EntityIdMap.class, entityIdMap);
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap);
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, entityIdMap, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
         context.put(RecordAndReplaySerializer.class, recordAndReplaySerializer);
 
 
@@ -183,6 +185,7 @@ public final class EntitySystemSetupUtil {
         selectedClassesToRecord.add(PlaySoundEvent.class);
         selectedClassesToRecord.add(CameraTargetChangedEvent.class);
         selectedClassesToRecord.add(CharacterMoveInputEvent.class);
+        //selectedClassesToRecord.add(AttackEvent.class);
         //selectedClassesToRecord.add(GetMaxSpeedEvent.class);
         return selectedClassesToRecord;
     }

--- a/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateMainMenu.java
@@ -37,6 +37,7 @@ import org.terasology.logic.console.ConsoleSystem;
 import org.terasology.logic.console.commands.CoreCommands;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.ClientComponent;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
@@ -122,7 +123,7 @@ public class StateMainMenu implements GameState {
 
         EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
         LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setEntityIdMap(context.get(EntityIdMap.class));
+        localPlayer.setRecordAndReplayClasses(context.get(EntityIdMap.class), context.get(DirectionAndOriginPosRecorderList.class));
         context.put(LocalPlayer.class, localPlayer);
         localPlayer.setClientEntity(localPlayerEntity);
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -23,6 +23,7 @@ import org.terasology.engine.subsystem.RenderingSubsystemFactory;
 import org.terasology.game.GameManifest;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.NetworkSystem;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.rendering.backdrop.BackdropProvider;
 import org.terasology.rendering.backdrop.BackdropRenderer;
@@ -60,7 +61,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer
         LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setEntityIdMap(context.get(EntityIdMap.class));
+        localPlayer.setRecordAndReplayClasses(context.get(EntityIdMap.class), context.get(DirectionAndOriginPosRecorderList.class));
         context.put(LocalPlayer.class, localPlayer);
         BlockManager blockManager = context.get(BlockManager.class);
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseWorld.java
@@ -35,6 +35,7 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.persistence.StorageManager;
 import org.terasology.persistence.internal.ReadOnlyStorageManager;
 import org.terasology.persistence.internal.ReadWriteStorageManager;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.recording.RecordAndReplaySerializer;
 import org.terasology.recording.RecordAndReplayStatus;
@@ -162,7 +163,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
 
         // TODO: These shouldn't be done here, nor so strongly tied to the world renderer
         LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setEntityIdMap(context.get(EntityIdMap.class));
+        localPlayer.setRecordAndReplayClasses(context.get(EntityIdMap.class), context.get(DirectionAndOriginPosRecorderList.class));
         context.put(LocalPlayer.class, localPlayer);
         context.put(Camera.class, worldRenderer.getActiveCamera());
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -42,6 +42,7 @@ import org.terasology.module.Module;
 import org.terasology.naming.Name;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkMode;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.NUIManager;
@@ -92,7 +93,7 @@ public class StateHeadlessSetup implements GameState {
 
         EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
         LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setEntityIdMap(context.get(EntityIdMap.class));
+        localPlayer.setRecordAndReplayClasses(context.get(EntityIdMap.class), context.get(DirectionAndOriginPosRecorderList.class));
         context.put(LocalPlayer.class, localPlayer);
         localPlayer.setClientEntity(localPlayerEntity);
 

--- a/engine/src/main/java/org/terasology/input/events/KeyDownEvent.java
+++ b/engine/src/main/java/org/terasology/input/events/KeyDownEvent.java
@@ -32,4 +32,8 @@ public final class KeyDownEvent extends KeyEvent {
         event.setKey(key, keyChar);
         return event;
     }
+
+    public static KeyDownEvent createCopy(KeyDownEvent toBeCopied) {
+        return new KeyDownEvent(toBeCopied.getKey(), toBeCopied.getKeyCharacter(), toBeCopied.getDelta());
+    }
 }

--- a/engine/src/main/java/org/terasology/input/events/KeyRepeatEvent.java
+++ b/engine/src/main/java/org/terasology/input/events/KeyRepeatEvent.java
@@ -33,5 +33,9 @@ public final class KeyRepeatEvent extends KeyEvent {
         return event;
     }
 
+    public static KeyRepeatEvent createCopy(KeyRepeatEvent toBeCopied) {
+        return new KeyRepeatEvent(toBeCopied.getKey(), toBeCopied.getKeyCharacter(), toBeCopied.getDelta());
+    }
+
 
 }

--- a/engine/src/main/java/org/terasology/input/events/KeyUpEvent.java
+++ b/engine/src/main/java/org/terasology/input/events/KeyUpEvent.java
@@ -32,4 +32,8 @@ public final class KeyUpEvent extends KeyEvent {
         event.setKey(key, keyChar);
         return event;
     }
+
+    public static KeyUpEvent createCopy(KeyUpEvent toBeCopied) {
+        return new KeyUpEvent(toBeCopied.getKey(), toBeCopied.getKeyCharacter(), toBeCopied.getDelta());
+    }
 }

--- a/engine/src/main/java/org/terasology/input/events/MouseAxisEvent.java
+++ b/engine/src/main/java/org/terasology/input/events/MouseAxisEvent.java
@@ -52,4 +52,8 @@ public class MouseAxisEvent extends AxisEvent {
         event.value = value;
         return event;
     }
+
+    public static MouseAxisEvent createCopy(MouseAxisEvent toBeCopied) {
+        return new MouseAxisEvent(toBeCopied.getMouseAxis(), toBeCopied.getValue(), toBeCopied.getDelta());
+    }
 }

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterSystem.java
@@ -224,6 +224,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
             }
 
             HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
+
             if (result.isHit()) {
                 result.getEntity().send(new AttackEvent(character, event.getItem()));
             }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -29,6 +29,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.physics.HitResult;
 import org.terasology.physics.Physics;
+import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.EntityIdMap;
 import org.terasology.recording.RecordAndReplayStatus;
 import org.terasology.registry.CoreRegistry;
@@ -37,7 +38,10 @@ public class LocalPlayer {
 
     private EntityRef clientEntity = EntityRef.NULL;
     private int nextActivationId;
+
+    //Record and Replay classes
     private EntityIdMap entityIdMap;
+    private DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList;
 
     public LocalPlayer() {
 
@@ -63,8 +67,10 @@ public class LocalPlayer {
         }
     }
 
-    public void setEntityIdMap(EntityIdMap entityIdMap) {
-        this.entityIdMap = entityIdMap;
+    public void setRecordAndReplayClasses(EntityIdMap idMap, DirectionAndOriginPosRecorderList list) {
+        this.entityIdMap = idMap;
+        this.directionAndOriginPosRecorderList = list;
+
     }
 
     public EntityRef getClientEntity() {
@@ -206,6 +212,13 @@ public class LocalPlayer {
         CharacterComponent characterComponent = character.getComponent(CharacterComponent.class);
         Vector3f direction = getViewDirection();
         Vector3f originPos = getViewPosition();
+        if (RecordAndReplayStatus.getCurrentStatus() == RecordAndReplayStatus.RECORDING) {
+            this.directionAndOriginPosRecorderList.getTargetOrOwnedEntityDirectionAndOriginPosRecorder().add(direction, originPos);
+        } else if (RecordAndReplayStatus.getCurrentStatus() == RecordAndReplayStatus.REPLAYING) {
+            Vector3f[] data = this.directionAndOriginPosRecorderList.getTargetOrOwnedEntityDirectionAndOriginPosRecorder().poll();
+            direction = data[0];
+            originPos = data[1];
+        }
         boolean ownedEntityUsage = usedOwnedEntity.exists();
         int activationId = nextActivationId++;
         Physics physics = CoreRegistry.get(Physics.class);

--- a/engine/src/main/java/org/terasology/recording/DirectionAndOriginPosRecorder.java
+++ b/engine/src/main/java/org/terasology/recording/DirectionAndOriginPosRecorder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.recording;
+
+import org.terasology.math.geom.Vector3f;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Saves the variables 'direction' and 'originData' to be used on replays since holding the mouse buttons can cause weird
+ * behavior during replays.
+ */
+public class DirectionAndOriginPosRecorder {
+
+    private Deque<Vector3f[]> directionAndOriginData;
+
+    DirectionAndOriginPosRecorder() {
+        this.directionAndOriginData = new ArrayDeque<>();
+    }
+
+    public void add(Vector3f direction, Vector3f originPos) {
+        Vector3f[] data = new Vector3f[2];
+        data[0] = new Vector3f(direction);
+        data[1] = new Vector3f(originPos);
+        this.directionAndOriginData.addLast(data);
+    }
+
+    public Vector3f[] poll() {
+        return this.directionAndOriginData.pollFirst();
+    }
+
+    public Deque<Vector3f[]> getDirectionAndOriginData() {
+        return directionAndOriginData;
+    }
+
+    public void setDirectionAndOriginData(Deque<Vector3f[]> directionAndOriginData) {
+        this.directionAndOriginData = directionAndOriginData;
+    }
+
+    public void reset() {
+        this.directionAndOriginData = new ArrayDeque<>();
+    }
+}

--- a/engine/src/main/java/org/terasology/recording/DirectionAndOriginPosRecorderList.java
+++ b/engine/src/main/java/org/terasology/recording/DirectionAndOriginPosRecorderList.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.recording;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Saves DirectionAndOriginPosRecorders used in LocalPlayer and CharacterSystem.
+ */
+public class DirectionAndOriginPosRecorderList {
+
+    private List<DirectionAndOriginPosRecorder> list;
+
+    public DirectionAndOriginPosRecorderList() {
+        list = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            list.add(new DirectionAndOriginPosRecorder());
+        }
+    }
+
+    public DirectionAndOriginPosRecorder getAttackEventDirectionAndOriginPosRecorder() {
+        return this.list.get(0);
+    }
+
+    public DirectionAndOriginPosRecorder getTargetOrOwnedEntityDirectionAndOriginPosRecorder() {
+        return this.list.get(1);
+    }
+
+    public void reset() {
+        list = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            list.add(new DirectionAndOriginPosRecorder());
+        }
+    }
+
+    public List<DirectionAndOriginPosRecorder> getList() {
+        return list;
+    }
+
+    public void setList(List<DirectionAndOriginPosRecorder> list) {
+        this.list = list;
+    }
+}

--- a/engine/src/main/java/org/terasology/recording/EventCatcher.java
+++ b/engine/src/main/java/org/terasology/recording/EventCatcher.java
@@ -17,7 +17,6 @@ package org.terasology.recording;
 
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.event.PendingEvent;
-import org.terasology.input.events.MouseButtonEvent;
 
 import java.util.List;
 

--- a/engine/src/main/java/org/terasology/recording/EventCatcher.java
+++ b/engine/src/main/java/org/terasology/recording/EventCatcher.java
@@ -17,6 +17,7 @@ package org.terasology.recording;
 
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.event.PendingEvent;
+import org.terasology.input.events.MouseButtonEvent;
 
 import java.util.List;
 

--- a/engine/src/main/java/org/terasology/recording/EventCopier.java
+++ b/engine/src/main/java/org/terasology/recording/EventCopier.java
@@ -59,6 +59,7 @@ import org.terasology.input.events.MouseWheelEvent;
 import org.terasology.logic.behavior.nui.BTEditorButton;
 import org.terasology.logic.characters.CharacterMoveInputEvent;
 import org.terasology.logic.characters.GetMaxSpeedEvent;
+import org.terasology.logic.characters.events.AttackEvent;
 import org.terasology.logic.players.DecreaseViewDistanceButton;
 import org.terasology.logic.players.IncreaseViewDistanceButton;
 import org.terasology.rendering.nui.editor.binds.NUIEditorButton;
@@ -126,6 +127,10 @@ class EventCopier {
             newEvent.setModifiers(originalEvent.getModifiers());
             newEvent.setMultipliers(originalEvent.getMultipliers());
             newEvent.setPostModifiers(originalEvent.getPostModifiers());
+            return newEvent;
+        } else if (e instanceof AttackEvent) {
+            AttackEvent originalEvent = (AttackEvent) e;
+            AttackEvent  newEvent = new AttackEvent(originalEvent.getInstigator(), originalEvent.getDirectCause());
             return newEvent;
         } else {
             return null;
@@ -201,11 +206,11 @@ class EventCopier {
         Class eventClass = originalEvent.getClass();
 
         if (eventClass.equals(KeyDownEvent.class)) {
-            newEvent = KeyDownEvent.create(originalEvent.getKey(), originalEvent.getKeyCharacter(), originalEvent.getDelta());
+            newEvent = KeyDownEvent.createCopy((KeyDownEvent) originalEvent);
         } else if (eventClass.equals(KeyRepeatEvent.class)) {
-            newEvent = KeyRepeatEvent.create(originalEvent.getKey(), originalEvent.getKeyCharacter(), originalEvent.getDelta());
+            newEvent = KeyRepeatEvent.createCopy((KeyRepeatEvent) originalEvent);
         } else if (eventClass.equals(KeyUpEvent.class)) {
-            newEvent = KeyUpEvent.create(originalEvent.getKey(), originalEvent.getKeyCharacter(), originalEvent.getDelta());
+            newEvent = KeyUpEvent.createCopy((KeyUpEvent) originalEvent);
         } else {
             logger.error("ERROR!!! Event not Identified");
         }
@@ -239,7 +244,7 @@ class EventCopier {
     }
 
     private MouseAxisEvent createNewMouseAxisEvent(MouseAxisEvent originalEvent) {
-        return MouseAxisEvent.create(originalEvent.getMouseAxis(), originalEvent.getValue(), originalEvent.getDelta());
+        return MouseAxisEvent.createCopy(originalEvent);
     }
 
 }

--- a/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
@@ -200,8 +200,7 @@ public final class RecordAndReplaySerializer {
             logger.error("Error while serializing AttackEvent extras:", e);
         }
     }
-
-    //check this out
+    
     private void deserializeAttackEventExtraRecorder(Gson gson, String recordingPath) {
         try {
             JsonParser parser = new JsonParser();

--- a/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
@@ -31,6 +31,7 @@ import org.terasology.math.geom.Vector3f;
 import java.io.FileWriter;
 import java.io.FileReader;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,20 +46,24 @@ public final class RecordAndReplaySerializer {
     private static final String REF_ID_MAP = "/ref_id_map" + JSON;
     private static final String FILE_AMOUNT = "/file_amount" + JSON;
     private static final String STATE_EVENT_POSITION = "/state_event_position" + JSON;
+    private static final String DIRECTION_ORIGIN_LIST = "/direction_origin_list" + JSON;
 
     private EntityManager entityManager;
     private RecordedEventStore recordedEventStore;
     private EntityIdMap entityIdMap;
     private RecordAndReplayUtils recordAndReplayUtils;
     private CharacterStateEventPositionMap characterStateEventPositionMap;
+    private DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList;
 
     public RecordAndReplaySerializer(EntityManager manager, RecordedEventStore store, EntityIdMap idMap,
-                                     RecordAndReplayUtils recordAndReplayUtils, CharacterStateEventPositionMap characterStateEventPositionMap) {
+                                     RecordAndReplayUtils recordAndReplayUtils, CharacterStateEventPositionMap characterStateEventPositionMap,
+                                     DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList) {
         this.entityManager = manager;
         this.recordedEventStore = store;
         this.entityIdMap = idMap;
         this.recordAndReplayUtils = recordAndReplayUtils;
         this.characterStateEventPositionMap = characterStateEventPositionMap;
+        this.directionAndOriginPosRecorderList = directionAndOriginPosRecorderList;
     }
 
     /**
@@ -71,6 +76,7 @@ public final class RecordAndReplaySerializer {
         serializeRefIdMap(gson, recordingPath);
         serializeFileAmount(gson, recordingPath);
         serializeCharacterStateEventPositonMap(gson, recordingPath);
+        serializeAttackEventExtraRecorder(gson, recordingPath);
     }
 
     /**
@@ -96,6 +102,7 @@ public final class RecordAndReplaySerializer {
         deserializeRefIdMap(gson, recordingPath);
         deserializeFileAmount(gson, recordingPath);
         deserializeCharacterStateEventPositonMap(gson, recordingPath);
+        deserializeAttackEventExtraRecorder(gson, recordingPath);
     }
 
     /**
@@ -179,6 +186,32 @@ public final class RecordAndReplaySerializer {
             logger.info("CharacterStateEvent positions Deserialization completed!");
         } catch (Exception e) {
             logger.error("Error while deserializing CharacterStateEvent positions:", e);
+        }
+    }
+
+    private void serializeAttackEventExtraRecorder(Gson gson, String recordingPath) {
+        try {
+            JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + DIRECTION_ORIGIN_LIST));
+            gson.toJson(directionAndOriginPosRecorderList.getList(), ArrayList.class, writer);
+            writer.close();
+            directionAndOriginPosRecorderList.reset();
+            logger.info("AttackEvent extras serialization completed!");
+        } catch( Exception e) {
+            logger.error("Error while serializing AttackEvent extras:", e);
+        }
+    }
+
+    //check this out
+    private void deserializeAttackEventExtraRecorder(Gson gson, String recordingPath) {
+        try {
+            JsonParser parser = new JsonParser();
+            JsonElement jsonElement = parser.parse(new FileReader(recordingPath + DIRECTION_ORIGIN_LIST));
+            Type type = new TypeToken<ArrayList<DirectionAndOriginPosRecorder>>() {}.getType();
+            ArrayList<DirectionAndOriginPosRecorder> list = gson.fromJson(jsonElement, type);
+            directionAndOriginPosRecorderList.setList(list);
+            logger.info("AttackEvent extras deserialization completed!");
+        } catch( Exception e) {
+            logger.error("Error while deserializing AttackEvent extras:", e);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes the issue in which holding left click during a recording was causing replays to not reproduce block destruction correctly.

### How to test

Record a game in which you destroy blocks by holding left click and then watch its replay to check that everything was destroyed correctly.

### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [ ] This PR fixes the "left click" problem, but the same issue exists when holding "right click".
