### PR TITLE
Blockfamily library handler

### DIFF
--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -81,10 +81,8 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.family.AttachedToSurfaceFamily;
 import org.terasology.world.block.family.BlockFamily;
-import org.terasology.world.block.family.BlockFamilyRegistry;
-import org.terasology.world.block.family.HorizontalFamily;
+import org.terasology.world.block.family.BlockFamilyLibrary;
 import org.terasology.world.block.internal.BlockManagerImpl;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.loader.BlockFamilyDefinitionFormat;
@@ -137,6 +135,9 @@ public class HeadlessEnvironment extends Environment {
         RecordAndReplaySerializer recordAndReplaySerializer = context.get(RecordAndReplaySerializer.class);
         Path savePath = PathManager.getInstance().getSavePath("world1");
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
+
+        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
+        context.put(BlockFamilyLibrary.class, new BlockFamilyLibrary(environment,context));
 
         context.put(StorageManager.class, new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(),
                 engineEntityManager, blockManager, biomeManager, recordAndReplaySerializer, recordAndReplayUtils));
@@ -201,11 +202,8 @@ public class HeadlessEnvironment extends Environment {
         assetTypeManager.registerCoreAssetType(StaticSound.class, NullSound::new, "sounds");
         assetTypeManager.registerCoreAssetType(StreamingSound.class, NullStreamingSound::new, "music");
 
-        BlockFamilyRegistry blockFamilyFactoryRegistry = new BlockFamilyRegistry();
-        blockFamilyFactoryRegistry.setBlockFamily("horizontal", HorizontalFamily.class);
-        blockFamilyFactoryRegistry.setBlockFamily("alignToSurface", AttachedToSurfaceFamily.class);
         assetTypeManager.registerCoreFormat(BlockFamilyDefinition.class,
-                new BlockFamilyDefinitionFormat(assetTypeManager.getAssetManager(), blockFamilyFactoryRegistry));
+                new BlockFamilyDefinitionFormat(assetTypeManager.getAssetManager()));
 
         assetTypeManager.registerCoreAssetType(UISkin.class,
                 UISkin::new, "skins");

--- a/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/TerasologyEngine.java
@@ -67,7 +67,6 @@ import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.rendering.nui.skin.UISkinData;
 import org.terasology.version.TerasologyVersion;
-import org.terasology.world.block.family.BlockFamilyRegistry;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.loader.BlockFamilyDefinitionData;
 import org.terasology.world.block.loader.BlockFamilyDefinitionFormat;
@@ -318,8 +317,7 @@ public class TerasologyEngine implements GameEngine {
     }
 
     private void initAssets() {
-        BlockFamilyRegistry familyFactoryRegistry = new BlockFamilyRegistry();
-        rootContext.put(BlockFamilyRegistry.class, familyFactoryRegistry);
+
 
         // cast lambdas explicitly to avoid inconsistent compiler behavior wrt. type inference
         assetTypeManager.registerCoreAssetType(Prefab.class,
@@ -333,7 +331,7 @@ public class TerasologyEngine implements GameEngine {
         assetTypeManager.registerCoreAssetType(BlockFamilyDefinition.class,
                 (AssetFactory<BlockFamilyDefinition, BlockFamilyDefinitionData>) BlockFamilyDefinition::new, "blocks");
         assetTypeManager.registerCoreFormat(BlockFamilyDefinition.class,
-                new BlockFamilyDefinitionFormat(assetTypeManager.getAssetManager(), familyFactoryRegistry));
+                new BlockFamilyDefinitionFormat(assetTypeManager.getAssetManager()));
         assetTypeManager.registerCoreAssetType(UISkin.class,
                 (AssetFactory<UISkin, UISkinData>) UISkin::new, "skins");
         assetTypeManager.registerCoreAssetType(BehaviorTree.class,

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -47,10 +47,6 @@ import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.util.reflection.GenericsUtil;
 import org.terasology.utilities.ReflectionUtil;
-import org.terasology.world.block.family.AbstractBlockFamily;
-import org.terasology.world.block.family.BlockFamily;
-import org.terasology.world.block.family.BlockFamilyRegistry;
-import org.terasology.world.block.family.RegisterBlockFamily;
 
 /**
  * Handles an environment switch by updating the asset manager, component library, and other context objects.
@@ -97,9 +93,6 @@ public final class EnvironmentSwitchHandler {
 
         registerComponents(componentLibrary, moduleManager.getEnvironment());
         registerTypeHandlers(context, typeSerializationLibrary, moduleManager.getEnvironment());
-
-        BlockFamilyRegistry blockFamilyFactoryRegistry = context.get(BlockFamilyRegistry.class);
-        loadFamilies((BlockFamilyRegistry) blockFamilyFactoryRegistry, moduleManager.getEnvironment());
 
         ModuleAwareAssetTypeManager assetTypeManager = context.get(ModuleAwareAssetTypeManager.class);
 
@@ -174,20 +167,6 @@ public final class EnvironmentSwitchHandler {
         }
     }
 
-    private static void loadFamilies(BlockFamilyRegistry registry, ModuleEnvironment environment) {
-        registry.clear();
-        for (Class<?> blockFamily : environment.getTypesAnnotatedWith(RegisterBlockFamily.class)) {
-            if (!BlockFamily.class.isAssignableFrom(blockFamily)) {
-                logger.error("Cannot load {}, must be a subclass of BlockFamily", blockFamily.getSimpleName());
-                continue;
-            }
-            RegisterBlockFamily registerInfo = blockFamily.getAnnotation(RegisterBlockFamily.class);
-            String id = registerInfo.value();
-            logger.debug("Registering blockFamily {}", id);
-            registry.setBlockFamily(id, (Class<? extends AbstractBlockFamily>) blockFamily);
-        }
-
-    }
 
     private static void registerComponents(ComponentLibrary library, ModuleEnvironment environment) {
         for (Class<? extends Component> componentType : environment.getSubtypesOf(Component.class)) {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBlocks.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/RegisterBlocks.java
@@ -19,7 +19,9 @@ package org.terasology.engine.modes.loadProcesses;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.config.Config;
 import org.terasology.context.Context;
+import org.terasology.engine.module.ModuleManager;
 import org.terasology.game.GameManifest;
+import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.extensionTypes.BlockFamilyTypeHandler;
@@ -27,6 +29,7 @@ import org.terasology.persistence.typeHandling.extensionTypes.BlockTypeHandler;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.family.BlockFamily;
+import org.terasology.world.block.family.BlockFamilyLibrary;
 import org.terasology.world.block.internal.BlockManagerImpl;
 import org.terasology.world.block.tiles.WorldAtlas;
 import org.terasology.world.block.tiles.WorldAtlasImpl;
@@ -52,6 +55,10 @@ public class RegisterBlocks extends SingleStepLoadProcess {
         NetworkSystem networkSystem = context.get(NetworkSystem.class);
         WorldAtlas atlas = new WorldAtlasImpl(context.get(Config.class).getRendering().getMaxTextureAtlasResolution());
         context.put(WorldAtlas.class, atlas);
+
+        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
+        context.put(BlockFamilyLibrary.class,new BlockFamilyLibrary(environment,context));
+
 
         BlockManagerImpl blockManager;
         if (networkSystem.getMode().isAuthority()) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -55,7 +55,7 @@ import org.terasology.rendering.nui.skin.UISkin;
 import org.terasology.rendering.nui.skin.UISkinData;
 import org.terasology.rendering.nui.widgets.UIDropdownScrollable;
 import org.terasology.rendering.world.WorldSetupWrapper;
-import org.terasology.world.block.family.BlockFamilyRegistry;
+import org.terasology.world.block.family.BlockFamilyLibrary;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.loader.BlockFamilyDefinitionData;
 import org.terasology.world.block.loader.BlockFamilyDefinitionFormat;
@@ -298,8 +298,9 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     }
 
     private void initAssets() {
-        BlockFamilyRegistry familyFactoryRegistry = new BlockFamilyRegistry();
-        context.put(BlockFamilyRegistry.class, familyFactoryRegistry);
+
+        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
+        BlockFamilyLibrary library =  new BlockFamilyLibrary(environment,context);
 
         // cast lambdas explicitly to avoid inconsistent compiler behavior wrt. type inference
         assetTypeManager.registerCoreAssetType(Prefab.class,
@@ -313,7 +314,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         assetTypeManager.registerCoreAssetType(BlockFamilyDefinition.class,
                 (AssetFactory<BlockFamilyDefinition, BlockFamilyDefinitionData>) BlockFamilyDefinition::new, "blocks");
         assetTypeManager.registerCoreFormat(BlockFamilyDefinition.class,
-                new BlockFamilyDefinitionFormat(assetTypeManager.getAssetManager(), familyFactoryRegistry));
+                new BlockFamilyDefinitionFormat(assetTypeManager.getAssetManager()));
         assetTypeManager.registerCoreAssetType(UISkin.class,
                 (AssetFactory<UISkin, UISkinData>) UISkin::new, "skins");
         assetTypeManager.registerCoreAssetType(BehaviorTree.class,

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamilyLibrary.java
@@ -15,9 +15,13 @@
  */
 package org.terasology.world.block.family;
 
-import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
+import org.terasology.engine.SimpleUri;
+import org.terasology.module.ModuleEnvironment;
+import org.terasology.reflection.metadata.ClassLibrary;
+import org.terasology.reflection.metadata.DefaultClassLibrary;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.util.reflection.ParameterProvider;
 import org.terasology.util.reflection.SimpleClassFactory;
@@ -25,7 +29,6 @@ import org.terasology.world.block.BlockBuilderHelper;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.shapes.BlockShape;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -34,10 +37,40 @@ import java.util.Optional;
  * The Registry maps a string id to an associated class implementation of a block Family.
  * </p>
  */
-public class BlockFamilyRegistry {
-    private static final Logger logger = LoggerFactory.getLogger(BlockFamilyRegistry.class);
-    private Map<String, Class<? extends AbstractBlockFamily>> registryMap = Maps.newHashMap();
-    
+public class BlockFamilyLibrary {
+    private static final Logger logger = LoggerFactory.getLogger(BlockFamilyLibrary.class);
+
+    private ClassLibrary<BlockFamily> library;
+
+    public BlockFamilyLibrary(ModuleEnvironment moduleEnvironment, Context context) {
+        library = new DefaultClassLibrary<>(context);
+        for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterBlockFamily.class)) {
+
+            if (!BlockFamily.class.isAssignableFrom(entry)) {
+                logger.error("Cannot load {}, must be a subclass of BlockFamily", entry.getSimpleName());
+                continue;
+            }
+            RegisterBlockFamily registerInfo = entry.getAnnotation(RegisterBlockFamily.class);
+            String id = registerInfo.value();
+            logger.debug("Registering blockFamily {}", id);
+            library.register(new SimpleUri(moduleEnvironment.getModuleProviding(entry),registerInfo.value()), (Class<? extends BlockFamily>) entry);
+
+        }
+    }
+
+    /**
+     * returns the class representing the block family based off the registered id.
+     *
+     * @param uri
+     * @return
+     */
+    public Class<? extends BlockFamily> getBlockFamily(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return SymmetricFamily.class;
+        }
+        return library.resolve(uri).getType();
+    }
+
     /**
      * Create a family based on the type and instantiate from the the family definition of the block and builder
      *
@@ -64,14 +97,14 @@ public class BlockFamilyRegistry {
             if (result.getURI() == null) {
                 throw new Exception("Family Is missng a BlockUri");
             }
-    
+
             return result;
         } catch (Exception e) {
             logger.error("Failed to load blockFamily {}", blockFamily, e);
         }
         return null;
     }
-    
+
     /**
      * Create a family based on the type and instantiate from the the family definition of the block and builder
      *
@@ -98,7 +131,7 @@ public class BlockFamilyRegistry {
             });
             BlockFamily result = simpleClassFactory.instantiateClass(blockFamily).get();
             InjectionHelper.inject(result);
-    
+
             if (result.getURI() == null) {
                 throw new Exception("Family Is missng a BlockUri");
             }
@@ -108,8 +141,9 @@ public class BlockFamilyRegistry {
         }
         return null;
     }
-    
-    
+
+
+
     public static String[] getSections(Class<? extends AbstractBlockFamily> blockFamily) {
         if (blockFamily == null) {
             return new String[]{};
@@ -120,7 +154,7 @@ public class BlockFamilyRegistry {
         }
         return sections.value();
     }
-    
+
     public static MultiSection[] getMultiSections(Class<? extends AbstractBlockFamily> blockFamily) {
         if (blockFamily == null) {
             return new MultiSection[]{};
@@ -131,7 +165,7 @@ public class BlockFamilyRegistry {
         }
         return sections.value();
     }
-    
+
     public static boolean isFreeformSupported(Class<? extends AbstractBlockFamily> blockFamily) {
         if (blockFamily == null) {
             return false;
@@ -142,31 +176,8 @@ public class BlockFamilyRegistry {
         }
         return freeFormSupported.value();
     }
-    
-    /**
-     * attach the block to the registry
-     *
-     * @param id
-     * @param blockFamily
-     */
-    public void setBlockFamily(String id, Class<? extends AbstractBlockFamily> blockFamily) {
-        registryMap.put(id.toLowerCase(), blockFamily);
-    }
-    
-    /**
-     * returns the class representing the block family based off the registered id.
-     *
-     * @param blockFamilyId
-     * @return
-     */
-    public Class<? extends AbstractBlockFamily> getBlockFamily(String blockFamilyId) {
-        if (blockFamilyId == null || blockFamilyId.isEmpty()) {
-            return SymmetricFamily.class;
-        }
-        return registryMap.get(blockFamilyId.toLowerCase());
-    }
-    
-    public void clear() {
-        registryMap.clear();
-    }
+
+
+
+
 }

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamilyLibrary.java
@@ -21,6 +21,7 @@ import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.reflection.metadata.ClassLibrary;
+import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.reflection.metadata.DefaultClassLibrary;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.util.reflection.ParameterProvider;
@@ -65,10 +66,13 @@ public class BlockFamilyLibrary {
      * @return
      */
     public Class<? extends BlockFamily> getBlockFamily(String uri) {
-        if (uri == null || uri.isEmpty()) {
+        ClassMetadata<? extends BlockFamily, ?> resolved = library.resolve(uri);
+
+        if (uri == null || uri.isEmpty() || resolved == null) {
+            logger.error(" Failed to resolve Blockfamily {}",uri);
             return SymmetricFamily.class;
         }
-        return library.resolve(uri).getType();
+        return resolved.getType();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamilyLibrary.java
@@ -54,7 +54,7 @@ public class BlockFamilyLibrary {
             RegisterBlockFamily registerInfo = entry.getAnnotation(RegisterBlockFamily.class);
             String id = registerInfo.value();
             logger.debug("Registering blockFamily {}", id);
-            library.register(new SimpleUri(moduleEnvironment.getModuleProviding(entry),registerInfo.value()), (Class<? extends BlockFamily>) entry);
+            library.register(new SimpleUri(moduleEnvironment.getModuleProviding(entry), registerInfo.value()), (Class<? extends BlockFamily>) entry);
 
         }
     }
@@ -69,7 +69,7 @@ public class BlockFamilyLibrary {
         ClassMetadata<? extends BlockFamily, ?> resolved = library.resolve(uri);
 
         if (uri == null || uri.isEmpty() || resolved == null) {
-            logger.error(" Failed to resolve Blockfamily {}",uri);
+            logger.error(" Failed to resolve Blockfamily {}", uri);
             return SymmetricFamily.class;
         }
         return resolved.getType();
@@ -147,7 +147,6 @@ public class BlockFamilyLibrary {
     }
 
 
-
     public static String[] getSections(Class<? extends AbstractBlockFamily> blockFamily) {
         if (blockFamily == null) {
             return new String[]{};
@@ -180,8 +179,4 @@ public class BlockFamilyLibrary {
         }
         return freeFormSupported.value();
     }
-
-
-
-
 }

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinition.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinition.java
@@ -22,7 +22,7 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.module.sandbox.API;
 import org.terasology.world.block.BlockBuilderHelper;
 import org.terasology.world.block.family.BlockFamily;
-import org.terasology.world.block.family.BlockFamilyRegistry;
+import org.terasology.world.block.family.BlockFamilyLibrary;
 import org.terasology.world.block.shapes.BlockShape;
 
 import java.util.Collections;
@@ -48,17 +48,17 @@ public class BlockFamilyDefinition extends Asset<BlockFamilyDefinitionData> {
     }
 
     public boolean isFreeform() {
-        return BlockFamilyRegistry.isFreeformSupported(getData().getBlockFamily());
+        return BlockFamilyLibrary.isFreeformSupported(getData().getBlockFamily());
     }
 
     public BlockFamily createFamily(BlockBuilderHelper blockBuilderHelper) {
         Preconditions.checkState(!isFreeform());
-        return BlockFamilyRegistry.createFamily(getData().getBlockFamily(), this, blockBuilderHelper);
+        return BlockFamilyLibrary.createFamily(getData().getBlockFamily(), this, blockBuilderHelper);
     }
 
     public BlockFamily createFamily(BlockShape shape, BlockBuilderHelper blockBuilderHelper) {
         Preconditions.checkState(isFreeform());
-        return BlockFamilyRegistry.createFamily(getData().getBlockFamily(), this, shape, blockBuilderHelper);
+        return BlockFamilyLibrary.createFamily(getData().getBlockFamily(), this, shape, blockBuilderHelper);
     }
 
 

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
@@ -38,13 +38,14 @@ import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.gson.CaseInsensitiveEnumTypeAdapterFactory;
 import org.terasology.utilities.gson.Vector3fTypeAdapter;
 import org.terasology.utilities.gson.Vector4fTypeAdapter;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.DefaultColorSource;
-import org.terasology.world.block.family.AbstractBlockFamily;
-import org.terasology.world.block.family.BlockFamilyRegistry;
+import org.terasology.world.block.family.BlockFamily;
+import org.terasology.world.block.family.BlockFamilyLibrary;
 import org.terasology.world.block.family.FreeformFamily;
 import org.terasology.world.block.family.HorizontalFamily;
 import org.terasology.world.block.family.MultiSection;
@@ -74,7 +75,7 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
     private final AssetManager assetManager;
     private final Gson gson;
 
-    public BlockFamilyDefinitionFormat(AssetManager assetManager, BlockFamilyRegistry blockFamilyRegistry) {
+    public BlockFamilyDefinitionFormat(AssetManager assetManager) {
         super("block");
         this.assetManager = assetManager;
         gson = new GsonBuilder()
@@ -83,7 +84,7 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
                 .registerTypeAdapter(BlockFamilyDefinitionData.class, new BlockFamilyDefinitionDataHandler())
                 .registerTypeAdapter(Vector3f.class, new Vector3fTypeAdapter())
                 .registerTypeAdapter(Vector4f.class, new Vector4fTypeAdapter())
-                .registerTypeAdapter(Class.class, new BlockFamilyHandler(blockFamilyRegistry))
+                .registerTypeAdapter(Class.class, new BlockFamilyHandler())
                 .create();
     }
 
@@ -146,7 +147,7 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
 
 
             if (result.getBlockFamily() != null) {
-                for (MultiSection multiSection : BlockFamilyRegistry.getMultiSections(result.getBlockFamily())) {
+                for (MultiSection multiSection : BlockFamilyLibrary.getMultiSections(result.getBlockFamily())) {
                     if (jsonObject.has(multiSection.name()) && jsonObject.get(multiSection.name()).isJsonObject()) {
                         JsonObject jsonMultiSection = jsonObject.getAsJsonObject(multiSection.name());
                         for (String section : multiSection.appliesToSections()) {
@@ -160,7 +161,7 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
                         }
                     }
                 }
-                for (String section : BlockFamilyRegistry.getSections(result.getBlockFamily())) {
+                for (String section : BlockFamilyLibrary.getSections(result.getBlockFamily())) {
                     if (jsonObject.has(section) && jsonObject.get(section).isJsonObject()) {
                         SectionDefinitionData sectionData = result.getSections().get(section);
                         if (sectionData == null) {
@@ -323,17 +324,15 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
         }
     }
 
-    private static class BlockFamilyHandler implements JsonDeserializer<Class<? extends AbstractBlockFamily>> {
-
-        private final BlockFamilyRegistry blockFamilyRegistry;
-
-        BlockFamilyHandler(BlockFamilyRegistry blockFamilyRegistry) {
-            this.blockFamilyRegistry = blockFamilyRegistry;
+    private static class BlockFamilyHandler implements JsonDeserializer<Class<? extends BlockFamily>> {
+        BlockFamilyHandler() {
         }
 
         @Override
-        public Class<? extends AbstractBlockFamily> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-            return blockFamilyRegistry.getBlockFamily(json.getAsString());
+        public Class<? extends BlockFamily> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+
+            BlockFamilyLibrary library = CoreRegistry.get(BlockFamilyLibrary.class);
+            return library.getBlockFamily(json.getAsString());
         }
     }
 


### PR DESCRIPTION
I replaced BlockFamilyRegistry with a block family library type. The idea behind this change is to allow a block family to be mapped to the module vs just the name. This is more specific and should avoid problems in the future where a family is named the same in two separate modules. There are currently some block families that follow the module:family type. This can be tested with some of the blocks under the additional rails module where some of the special rail blocks use the family type from the base rails module.