### PR TITLE
Up-Down-Enter keys support for UIList widget

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIList.java
@@ -16,6 +16,7 @@
 package org.terasology.rendering.nui.widgets;
 
 import com.google.common.collect.Lists;
+import org.terasology.input.Keyboard;
 import org.terasology.input.MouseInput;
 import org.terasology.math.Border;
 import org.terasology.math.geom.Rect2i;
@@ -25,8 +26,10 @@ import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
+import org.terasology.rendering.nui.events.NUIKeyEvent;
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
 import org.terasology.rendering.nui.events.NUIMouseDoubleClickEvent;
+import org.terasology.rendering.nui.events.NUIMouseOverEvent;
 import org.terasology.rendering.nui.itemRendering.ItemRenderer;
 import org.terasology.rendering.nui.itemRendering.ToStringTextRenderer;
 
@@ -306,6 +309,38 @@ public class UIList<T> extends CoreWidget {
             }
             return false;
         }
+
+        @Override
+        public void onMouseOver(NUIMouseOverEvent event) {
+            super.onMouseOver(event);
+            if (isMouseOver()) {
+                focusManager.setFocus(UIList.this);
+            }
+        }
     }
 
+    private int getCurrentIndex() {
+        return list.get().indexOf(selection.get());
+    }
+
+    @Override
+    public boolean onKeyEvent(NUIKeyEvent event) {
+        if (event.isDown()) {
+            int keyId = event.getKey().getId();
+            int currentIndex = getCurrentIndex();
+            if (currentIndex != -1) {
+                if (keyId == Keyboard.KeyId.UP) {
+                    select(currentIndex - 1);
+                    return true;
+                } else if (keyId == Keyboard.KeyId.DOWN) {
+                    select(currentIndex + 1);
+                    return true;
+                } else if (keyId == Keyboard.KeyId.ENTER || keyId == Keyboard.KeyId.SPACE) {
+                    activate(currentIndex);
+                    return true;
+                }
+            }
+        }
+        return super.onKeyEvent(event);
+    }
 }

--- a/engine/src/main/resources/assets/ui/menu/selectGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectGameScreen.ui
@@ -105,49 +105,47 @@
                                 "layoutInfo": {
                                     "position-top": {
                                         "target": "TOP"
-                                     },
-                                     "position-bottom": {
+                                    },
+                                    "position-bottom": {
                                         "target": "BOTTOM",
                                         "offset": 130
-                                     }
+                                    }
                                 }
                             },
                             {
                                 "type": "ScrollableArea",
                                 "family": "shortDescription",
-                                "contents": [
-                                    {
-                                        "type": "ColumnLayout",
-                                        "id": "shortDescriptionItems",
-                                        "columns": 2,
-                                        "column-widths": [0.2, 0.8],
-                                        "verticalSpacing": 16,
-                                        "horizontalSpacing": 4,
-                                        "fillVerticalSpace": false,
-                                        "contents": [
-                                            {
-                                                "type": "UILabel",
-                                                "text": "${engine:menu#world-generator}: ",
-                                                "family": "description"
-                                            },
-                                            {
-                                                "type": "UILabel",
-                                                "id": "worldGenerator",
-                                                "family": "description"
-                                            },
-                                            {
-                                                "type": "UILabel",
-                                                "text": "${engine:menu#module-list}: ",
-                                                "family": "description"
-                                            },
-                                            {
-                                                "type": "UILabel",
-                                                "id": "moduleNames",
-                                                "family": "description"
-                                            }
-                                        ]
-                                    }
-                                ],
+                                "content": {
+                                    "type": "ColumnLayout",
+                                    "id": "shortDescriptionItems",
+                                    "columns": 2,
+                                    "column-widths": [0.2, 0.8],
+                                    "verticalSpacing": 16,
+                                    "horizontalSpacing": 4,
+                                    "fillVerticalSpace": false,
+                                    "contents": [
+                                        {
+                                            "type": "UILabel",
+                                            "text": "${engine:menu#world-generator}: ",
+                                            "family": "description"
+                                        },
+                                        {
+                                            "type": "UILabel",
+                                            "id": "worldGenerator",
+                                            "family": "description"
+                                        },
+                                        {
+                                            "type": "UILabel",
+                                            "text": "${engine:menu#module-list}: ",
+                                            "family": "description"
+                                        },
+                                        {
+                                            "type": "UILabel",
+                                            "id": "moduleNames",
+                                            "family": "description"
+                                        }
+                                    ]
+                                },
                                 "layoutInfo": {
                                     "position-top": {
                                         "target": "BOTTOM",


### PR DESCRIPTION
### Contains

IMHO, it might be useful. At present, you can't switch list items by up and down keys, you can use mouse only. 

### How to test

1. Open any screen with UIList widget (e.g. SelectGameScreen). 
2. Select any item from list (focus should be on UIList), and check that **Up**, **Down** and **Enter** keys work properly.

### Outstanding before merging

Nothing.