### PR TITLE
Add fully qualified name (module:name) for biomes

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -193,7 +193,7 @@ public class GameDetailsScreen extends CoreScreenLayer {
 
         biomes.setItemRenderer(new AbstractItemRenderer<Biome>() {
             String getString(Biome biome) {
-                return biome.getName();
+                return biome.getId();
             }
 
             @Override


### PR DESCRIPTION
### Contains

Small fix for GameDetails screen. Actually, only adds fully qualified name for biomes.

### How to test

Open details of any saved game (better with PolyWorld module enabled). Check that we have full names on Worlds & Biomes tab now.

Should be something like this... 
![pic](https://i.gyazo.com/7b46b9479e0561aab9639f4735448a39.png)
