### PR TITLE
Small fix of margin on game details screen

### DIFF
--- a/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
@@ -44,7 +44,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "widget": "title",
-                        "offset": 24
+                        "offset": 32
                     },
                     "position-bottom": {
                         "target": "TOP",


### PR DESCRIPTION
### Contains

Before:
![pic](https://i.gyazo.com/822d9796adb2f8f0830c633d6699cc0f.png)
Now:
![pic](https://i.gyazo.com/8cbe5425b4e87e7e245d87fd146bc6ae.png)

### How to test

Open details of any saved game. And check that box looks better :) 

### Outstanding before merging

Nope.
