### PR TITLE
Remove old useless attributes from ui files

### DIFF
--- a/engine/src/main/resources/assets/ui/hud/toolbar.ui
+++ b/engine/src/main/resources/assets/ui/hud/toolbar.ui
@@ -9,7 +9,6 @@
                 "id": "breathBar",
                 "icon": "engine:icons#bubble",
                 "family": "breathBar",
-                "emptyIcon": "engine:icons#burstBubble",
                 "halfIconMode": "shrink",
                 "spacing": 2,
                 "maxIcons": 10,
@@ -33,7 +32,6 @@
             {
                 "type": "UICrosshair",
                 "id": "crosshair",
-                "crosshairIcon": "engine:gui#crosshair",
                 "layoutInfo": {
                     "use-content-width": true,
                     "use-content-height": true,

--- a/modules/Core/assets/ui/hud/inventoryHud.ui
+++ b/modules/Core/assets/ui/hud/inventoryHud.ui
@@ -61,7 +61,6 @@
             {
                 "type": "UICrosshair",
                 "id": "crosshair",
-                "crosshairIcon": "engine:gui#crosshair",
                 "chargeStages": [
                     "engine:gui#crosshairCharge1",
                     "engine:gui#crosshairCharge2",


### PR DESCRIPTION
### Contains

When you have started new game you may find in log next warnings. So, I've fixed them. 

For UICrosshair, inventoryDefault skin already has background "engine:gui#crosshair". So we can safely remove them.
For UIIconBar, I'm not sure what "emptyIcon" means in HUD context. We still have "engine:icons#burstBubble" in atlas, but I believe it hasn't worked since 2015 or never.

```
20:00:22.620 [main] WARN  o.t.rendering.nui.asset.UIFormat - Field 'emptyIcon' not recognized for interface org.terasology.rendering.nui.UIWidget in {"type":"UIIconBar","id":"breathBar","icon":"engine:icons#bubble","family":"breathBar","emptyIcon":"engine:icons#burstBubble","halfIconMode":"shrink","spacing":2,"maxIcons":10,"layoutInfo":{"use-content-width":true,"use-content-height":true,"position-left":{"target":"CENTER"},"position-right":{"target":"RIGHT","widget":"healthBar"},"position-bottom":{"target":"TOP","widget":"healthBar","offset":1}}}
20:00:22.621 [main] WARN  o.t.rendering.nui.asset.UIFormat - Field 'crosshairIcon' not recognized for interface org.terasology.rendering.nui.UIWidget in {"type":"UICrosshair","id":"crosshair","crosshairIcon":"engine:gui#crosshair","layoutInfo":{"use-content-width":true,"use-content-height":true,"position-horizontal-center":{},"position-vertical-center":{}}}
20:00:22.708 [main] WARN  o.t.rendering.nui.asset.UIFormat - Field 'crosshairIcon' not recognized for interface org.terasology.rendering.nui.UIWidget in {"type":"UICrosshair","id":"crosshair","crosshairIcon":"engine:gui#crosshair","chargeStages":["engine:gui#crosshairCharge1","engine:gui#crosshairCharge2","engine:gui#crosshairCharge3","engine:gui#crosshairCharge4","engine:gui#crosshairCharge5","engine:gui#crosshairCharge6","engine:gui#crosshairCharge7","engine:gui#crosshairCharge8"],"layoutInfo":{"use-content-width":true,"use-content-height":true,"position-horizontal-center":{},"position-vertical-center":{}}}

```

### How to test

1. Start new game or load saved.
2. Check that log is clear.

### Outstanding before merging

Nothing.