### PR TITLE
Polymorphic Gson

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeHandlerAdapterTest.java
@@ -30,9 +30,10 @@ public class GsonTypeHandlerAdapterTest {
     private static final String OBJECT_JSON_HEX = "{\"color\":DEADBEEF,\"i\":-123}";
     private static final TestClass OBJECT = new TestClass(new Color(0xDEADBEEF), -123);
 
-    private final Gson gson = GsonFactory.createGsonWithTypeHandlers(
+    private final Gson gson = GsonBuilderFactory.createGsonBuilderWithTypeHandlers(
             TypeHandlerEntry.of(Color.class, new ColorTypeHandler())
-    );
+    )
+            .create();
 
     /**
      * {@link GsonTypeHandlerAdapter#read(JsonReader)} is tested by deserializing an object from JSON

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactoryTest.java
@@ -51,7 +51,9 @@ public class GsonTypeSerializationLibraryAdapterFactoryTest {
     private final TypeSerializationLibrary typeSerializationLibrary =
             TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
 
-    private final Gson gson = GsonFactory.createGsonWithTypeSerializationLibrary(typeSerializationLibrary);
+    private final Gson gson =
+            GsonBuilderFactory.createGsonBuilderWithTypeSerializationLibrary(typeSerializationLibrary)
+            .create();
 
     @Test
     public void testSerialize() {

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactoryTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+public class PolymorphicTypeAdapterFactoryTest {
+    private static final Dog DOG = new Dog(1.25f);
+    private static final Animal CAT = new Animal("Cat");
+    private static final Cheetah CHEETAH = new Cheetah(21);
+
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(PolymorphicTypeAdapterFactory.of(Animal.class))
+            .create();
+
+    @Test
+    public void testBaseClass() {
+        Animal animal = CHEETAH;
+
+        String json = gson.toJson(animal);
+
+        Animal newAnimal = gson.fromJson(json, Animal.class);
+
+        Assert.assertTrue(newAnimal instanceof Cheetah);
+    }
+
+    @Test
+    public void testInnerField() {
+        Capsule capsule = new Capsule(DOG);
+
+        String json = gson.toJson(capsule);
+
+        Capsule newCapsule = gson.fromJson(json, Capsule.class);
+        Assert.assertTrue(newCapsule.animal instanceof Dog);
+    }
+
+    @Test
+    public void testPolymorphicList() {
+        List<Animal> animals = Lists.newArrayList(CAT, DOG, CHEETAH);
+
+        String json = gson.toJson(animals);
+
+        List<Animal> newAnimals = gson.fromJson(json, new TypeToken<List<Animal>>(){}.getType());
+
+        Assert.assertTrue(newAnimals.get(1) instanceof Dog);
+        Assert.assertTrue(newAnimals.get(2) instanceof Cheetah);
+    }
+
+    private static class Capsule {
+        private final Animal animal;
+
+        private Capsule(Animal animal) {
+            this.animal = animal;
+        }
+    }
+
+    private static class Animal {
+        private final String name;
+
+        private Animal(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Animal animal = (Animal) o;
+            return Objects.equals(name, animal.name);
+        }
+    }
+
+    private static class Dog extends Animal {
+        private final float tailLength;
+
+        private Dog(float tailLength) {
+            super("Dog");
+            this.tailLength = tailLength;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Dog dog = (Dog) o;
+            return Float.compare(dog.tailLength, tailLength) == 0;
+        }
+    }
+
+    private static class Cheetah extends Animal {
+        private final int spotCount;
+
+        private Cheetah(int spotCount) {
+            super("Cheetah");
+            this.spotCount = spotCount;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            Cheetah cheetah = (Cheetah) o;
+            return spotCount == cheetah.spotCount;
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonBuilderFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonBuilderFactory.java
@@ -21,10 +21,10 @@ import com.google.gson.TypeAdapterFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 
 /**
- * Class containing static factory methods for generating {@link Gson} objects that follow Terasology
+ * Class containing static factory methods for generating {@link GsonBuilder} objects that follow Terasology
  * serialization rules and support Terasology TypeHandlers.
  */
-public class GsonFactory {
+public class GsonBuilderFactory {
     /**
      * Create a {@link GsonBuilder} with options set to comply with Terasology JSON serialization rules.
      */
@@ -34,29 +34,28 @@ public class GsonFactory {
     }
 
     /**
-     * Create a {@link Gson} object which uses type handlers loaded from the given
+     * Create a {@link GsonBuilder} which uses type handlers loaded from the given
      * {@link TypeSerializationLibrary} and complies with Terasology JSON serialization rules.
      *
      * @param typeSerializationLibrary The {@link TypeSerializationLibrary} to load type handler
      *                                 definitions from
      */
-    public static Gson createGsonWithTypeSerializationLibrary(TypeSerializationLibrary typeSerializationLibrary) {
+    public static GsonBuilder createGsonBuilderWithTypeSerializationLibrary(TypeSerializationLibrary typeSerializationLibrary) {
         TypeAdapterFactory typeAdapterFactory =
                 new GsonTypeSerializationLibraryAdapterFactory(typeSerializationLibrary);
 
         return createDefaultGsonBuilder()
-                .registerTypeAdapterFactory(typeAdapterFactory)
-                .create();
+                .registerTypeAdapterFactory(typeAdapterFactory);
     }
 
     /**
-     * Create a {@link Gson} object which uses the given type handlers and complies with Terasology
+     * Create a {@link GsonBuilder} which uses the given type handlers and complies with Terasology
      * JSON serialization rules.
      *
      * @param typeHandlerEntries The type handlers to use during serialization.
      */
     @SuppressWarnings("unchecked")
-    public static Gson createGsonWithTypeHandlers(TypeHandlerEntry<?>... typeHandlerEntries) {
+    public static GsonBuilder createGsonBuilderWithTypeHandlers(TypeHandlerEntry<?>... typeHandlerEntries) {
         GsonTypeHandlerAdapterFactory typeAdapterFactory = new GsonTypeHandlerAdapterFactory();
 
         for (TypeHandlerEntry typeHandlerEntry : typeHandlerEntries) {
@@ -64,7 +63,6 @@ public class GsonFactory {
         }
 
         return createDefaultGsonBuilder()
-                .registerTypeAdapterFactory(typeAdapterFactory)
-                .create();
+                .registerTypeAdapterFactory(typeAdapterFactory);
     }
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactory.java
@@ -30,6 +30,13 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Map;
 
+/**
+ * A {@link TypeAdapterFactory} that generates type adapters which read and write type information for
+ * sub-types of the given base type. The type information allows the generated type adapters to dynamically
+ * identify which sub-type instance is being read or written when it is given a base type reference.
+ *
+ * @param <T> The base type.
+ */
 public class PolymorphicTypeAdapterFactory<T> implements TypeAdapterFactory {
     private static final String TYPE_FIELD_NAME = "@type";
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactory.java
@@ -113,6 +113,10 @@ public class PolymorphicTypeAdapterFactory<T> implements TypeAdapterFactory {
                     valueClass = baseClass;
                 }
 
+                if (!baseClass.isAssignableFrom(valueClass)) {
+                    throw new JsonParseException(valueClass.getName() + " does not derive from " + baseClass.getName());
+                }
+
                 TypeToken<?> valueType = TypeToken.get(valueClass);
                 TypeAdapter<R> delegate = (TypeAdapter<R>)
                         gson.getDelegateAdapter(PolymorphicTypeAdapterFactory.this, valueType);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/PolymorphicTypeAdapterFactory.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class PolymorphicTypeAdapterFactory<T> implements TypeAdapterFactory {
+    private static final String TYPE_FIELD_NAME = "@type";
+
+    private final Class<T> baseClass;
+
+    private PolymorphicTypeAdapterFactory(Class<T> baseClass) {
+        this.baseClass = baseClass;
+    }
+
+    public static <T> PolymorphicTypeAdapterFactory<T> of(Class<T> baseClass) {
+        return new PolymorphicTypeAdapterFactory<>(baseClass);
+    }
+
+    @Override
+    public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+        if (!baseClass.isAssignableFrom(type.getRawType())) {
+            return null;
+        }
+
+        return new TypeAdapter<R>() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public void write(JsonWriter out, R value) throws IOException {
+                Class<?> valueClass = value.getClass();
+                String valueTypeName = valueClass.getName();
+
+                TypeToken<?> valueType = TypeToken.get(valueClass);
+                TypeAdapter<R> delegate = (TypeAdapter<R>)
+                        gson.getDelegateAdapter(PolymorphicTypeAdapterFactory.this, valueType);
+
+                if (delegate == null) {
+                    throw new JsonParseException("Could not serialize " + valueClass.getName());
+                }
+
+                JsonElement jsonElement = delegate.toJsonTree(value);
+
+                if (valueClass != baseClass) {
+                    JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+                    JsonObject clone = new JsonObject();
+                    clone.add(TYPE_FIELD_NAME, new JsonPrimitive(valueTypeName));
+
+                    for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
+                        clone.add(e.getKey(), e.getValue());
+                    }
+
+                    Streams.write(clone, out);
+                } else {
+                    Streams.write(jsonElement, out);
+                }
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public R read(JsonReader in) throws IOException {
+                JsonElement jsonElement = Streams.parse(in);
+                Class<?> valueClass;
+
+                if (jsonElement.isJsonObject()) {
+                    JsonElement typeNameJsonElement = jsonElement.getAsJsonObject().remove(TYPE_FIELD_NAME);
+
+                    if (typeNameJsonElement != null) {
+                        String typeName = typeNameJsonElement.getAsString();
+
+                        try {
+                            valueClass = Class.forName(typeName);
+                        } catch (ClassNotFoundException e) {
+                            throw new JsonParseException("Could not find class " + typeName);
+                        }
+                    } else {
+                        valueClass = baseClass;
+                    }
+                } else {
+                    valueClass = baseClass;
+                }
+
+                TypeToken<?> valueType = TypeToken.get(valueClass);
+                TypeAdapter<R> delegate = (TypeAdapter<R>)
+                        gson.getDelegateAdapter(PolymorphicTypeAdapterFactory.this, valueType);
+
+                if (delegate == null) {
+                    throw new JsonParseException("Could not deserialize " + valueClass.getName());
+                }
+
+                return delegate.fromJsonTree(jsonElement);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Gson by default does not allow serialization of polymorphic references (e.g. base type references to a sub-type instance). This PR introduces the `PolymorphicTypeAdapterFactory`, which serializes type metadata for types deriving from the given base type.

# Changes
- Add `PolymorphicTypeAdapterFactory`
- Rename `GsonFactory` to `GsonBuilderFactory`

# Usage
- Create a `GsonBuilder` from a factory method in `GsonBuilderFactory`.
- Register instances of `PolymorphicTypeAdapterFactory` in the `GsonBuilder` for each base type you wish to support (e.g. `gsonBuilder.registerTypeAdapterFactory(PolymorphicTypeAdapterFactory.of(Event.class))`)
- Serialize base type references of sub-type instances (like `Event event = new AttackEvent()`) with ease