### PR TITLE
Deprecate LegacyGsonTypeHandlerAdapter

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/LegacyGsonTypeHandlerAdapter.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/LegacyGsonTypeHandlerAdapter.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Type;
  * object, can be used to (de)serialize objects to JSON (via Gson) with the rules specified by
  * the {@link #typeHandler}.
  */
+@Deprecated
 public class LegacyGsonTypeHandlerAdapter<T> implements JsonDeserializer<T>, JsonSerializer<T> {
 
     private TypeHandler<T> typeHandler;

--- a/engine/src/main/java/org/terasology/rendering/nui/asset/UIFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/asset/UIFormat.java
@@ -17,17 +17,16 @@ package org.terasology.rendering.nui.asset;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonElement;
-import com.google.gson.GsonBuilder;
 import com.google.gson.Gson;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonObject;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
@@ -39,7 +38,7 @@ import org.terasology.math.Border;
 import org.terasology.persistence.ModuleContext;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.extensionTypes.AssetTypeHandler;
-import org.terasology.persistence.typeHandling.gson.LegacyGsonTypeHandlerAdapter;
+import org.terasology.persistence.typeHandling.gson.GsonTypeSerializationLibraryAdapterFactory;
 import org.terasology.persistence.typeHandling.mathTypes.BorderTypeHandler;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.reflection.metadata.FieldMetadata;
@@ -102,12 +101,10 @@ public class UIFormat extends AbstractAssetFileFormat<UIData> {
         library.add(Border.class, new BorderTypeHandler());
 
         GsonBuilder gsonBuilder = new GsonBuilder()
-            .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
-            .registerTypeAdapter(UIData.class, new UIDataTypeAdapter())
-            .registerTypeHierarchyAdapter(UIWidget.class, new UIWidgetTypeAdapter(nuiManager));
-        for (Class<?> handledType : library.getCoreTypes()) {
-            gsonBuilder.registerTypeAdapter(handledType, new LegacyGsonTypeHandlerAdapter<>(library.getHandlerFor(handledType)));
-        }
+                .registerTypeAdapterFactory(new GsonTypeSerializationLibraryAdapterFactory(library))
+                .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+                .registerTypeAdapter(UIData.class, new UIDataTypeAdapter())
+                .registerTypeHierarchyAdapter(UIWidget.class, new UIWidgetTypeAdapter(nuiManager));
 
         // override the String TypeAdapter from the serialization library
         gsonBuilder.registerTypeAdapter(String.class, new I18nStringTypeAdapter(translationSystem, otherLocale));

--- a/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java
@@ -31,7 +31,7 @@ import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.persistence.ModuleContext;
 import org.terasology.persistence.typeHandling.extensionTypes.ColorTypeHandler;
-import org.terasology.persistence.typeHandling.gson.LegacyGsonTypeHandlerAdapter;
+import org.terasology.persistence.typeHandling.gson.GsonTypeHandlerAdapterFactory;
 import org.terasology.reflection.metadata.ClassLibrary;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.registry.CoreRegistry;
@@ -66,7 +66,11 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
             .registerTypeAdapter(Font.class, new AssetTypeAdapter<>(Font.class))
             .registerTypeAdapter(UISkinData.class, new UISkinTypeAdapter())
             .registerTypeAdapter(TextureRegion.class, new TextureRegionTypeAdapter())
-            .registerTypeAdapter(Color.class, new LegacyGsonTypeHandlerAdapter<>(new ColorTypeHandler()))
+            .registerTypeAdapterFactory(new GsonTypeHandlerAdapterFactory() {
+                {
+                    addTypeHandler(Color.class, new ColorTypeHandler());
+                }
+            })
             .registerTypeAdapter(Optional.class, new OptionalTextureRegionTypeAdapter())
             .create();
     }


### PR DESCRIPTION
Deprecates `LegacyGsonTypeHandlerAdapter` and removes its usages.

The following usage(s) in `UIFormat`

https://github.com/MovingBlocks/Terasology/blob/5d17468a400f9335ec36fff4beeee348848adcf8/engine/src/main/java/org/terasology/rendering/nui/asset/UIFormat.java#L108-L110

are replaced with a single `GsonTypeSerializationLibraryAdapterFactory`.

The usage in `UISkinFormat`

https://github.com/MovingBlocks/Terasology/blob/5d17468a400f9335ec36fff4beeee348848adcf8/engine/src/main/java/org/terasology/rendering/nui/skin/UISkinFormat.java#L69

is replaced with a `GsonTypeHandlerAdapterFactory` with a `ColorTypeHandler`.

# Known issues
`TypeSerializationLibrary` logs a few errors when the UI is loaded, but these errors are irrelevant and everything functions as expected (needs confirmation). This error logging will be stopped in a future PR.