### PR TITLE
[Defect] Not always all modules are available for filtering

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -640,16 +640,18 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
                 if (info == null) {
                     info = ModuleSelectionInfo.remote(remote);
                     modulesLookup.put(remote.getId(), info);
-                    int pos = Collections.binarySearch(sortedModules, info, moduleInfoComparator);
-                    if (pos < 0) { // not yet in the (sorted) list
-                        sortedModules.add(-pos - 1, info); // use "insertion point" to keep the list sorted
-                        allSortedModules.clear();
-                        allSortedModules.addAll(sortedModules);
-                    }
                 }
                 info.setOnlineVersion(remote);
             }
         }
+        sortedModules.clear();
+        allSortedModules.clear();
+
+        sortedModules.addAll(modulesLookup.values());
+        sortedModules.sort(moduleInfoComparator);
+
+        allSortedModules.addAll(sortedModules);
+
         filterModules();
     }
 


### PR DESCRIPTION
### Contains

I've spotted out that sometimes I can't find all existing modules on AdvancedGameSetup screen. After investigation, I understood that in this case I can see only "remote" and "filtered" modules from previous session. 

### How to test

1. Open AdvancedGameSetup screen.
2. Filter "libraries"
3. Exit game. 
4. Open AdvancedGameSetup screen.
5. Uncheck libraries.
6. Check that available only "libraries", even when you selected "local".

### Outstanding before merging

Nothing.