### PR TITLE
Additional TypeHandlers

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/TypeSerializationLibraryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/TypeSerializationLibraryTest.java
@@ -18,7 +18,7 @@ package org.terasology.persistence.typeHandling;
 import org.junit.Test;
 import org.terasology.persistence.typeHandling.coreTypes.CollectionTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.EnumTypeHandler;
-import org.terasology.persistence.typeHandling.coreTypes.MappedContainerTypeHandler;
+import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.StringMapTypeHandler;
 import org.terasology.reflection.MappedContainer;
 import org.terasology.reflection.TypeInfo;
@@ -55,7 +55,7 @@ public class TypeSerializationLibraryTest {
     public void testMappedContainerHandler() {
         TypeHandler<AMappedContainer> handler = typeSerializationLibrary.getTypeHandler(AMappedContainer.class);
 
-        assertTrue(handler instanceof MappedContainerTypeHandler);
+        assertTrue(handler instanceof ObjectFieldMapTypeHandler);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandlerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandlerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.coreTypes;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.Test;
+import org.terasology.persistence.typeHandling.DeserializationContext;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.SerializationContext;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+import org.terasology.persistence.typeHandling.coreTypes.factories.CollectionTypeHandlerFactory;
+import org.terasology.reflection.TypeInfo;
+import org.terasology.reflection.reflect.ConstructorLibrary;
+import org.terasology.reflection.reflect.ReflectionReflectFactory;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class RuntimeDelegatingTypeHandlerTest {
+    private final ConstructorLibrary constructorLibrary =
+            new ConstructorLibrary(Maps.newHashMap(), new ReflectionReflectFactory());
+
+    private final CollectionTypeHandlerFactory collectionHandlerFactory =
+            new CollectionTypeHandlerFactory(constructorLibrary);
+
+    private final TypeSerializationLibrary typeSerializationLibrary = mock(TypeSerializationLibrary.class);
+
+    private static class Base {
+        int x;
+    }
+
+    private static class Sub extends Base {
+        float y;
+    }
+
+    @Test
+    public void testSerialize() {
+        SerializationContext context = mock(SerializationContext.class);
+
+        Class<Sub> subType = Sub.class;
+        Type baseType = TypeInfo.of(Base.class).getType();
+
+        TypeHandler baseTypeHandler = mock(TypeHandler.class);
+        TypeHandler<Sub> subTypeHandler = mock(TypeHandler.class);
+
+        when(typeSerializationLibrary.getTypeHandler(eq(baseType))).thenReturn(baseTypeHandler);
+        when(typeSerializationLibrary.getTypeHandler(eq(subType))).thenReturn(subTypeHandler);
+
+        TypeHandler<List<Base>> listTypeHandler = collectionHandlerFactory.create(new TypeInfo<List<Base>>() {
+        }, typeSerializationLibrary).get();
+
+        ArrayList<Base> bases = Lists.newArrayList(new Sub(), new Base(), new Sub(), new Base(), new Sub());
+        listTypeHandler.serialize(bases, context);
+
+        verify(typeSerializationLibrary).getTypeHandler(baseType);
+        verify(typeSerializationLibrary, times(3)).getTypeHandler(subType);
+
+        verify(baseTypeHandler, times(2)).serialize(any(), any());
+        verify(subTypeHandler, times(3)).serialize(any(), any());
+    }
+
+    @Test
+    public void testDeserialize() {
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/CollectionTypeHandlerFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/CollectionTypeHandlerFactoryTest.java
@@ -25,6 +25,7 @@ import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.reflect.ConstructorLibrary;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -72,6 +73,20 @@ public class CollectionTypeHandlerFactoryTest {
 
         Optional<TypeHandler<Queue<Integer>>> typeHandler =
                 typeHandlerFactory.create(listTypeInfo, typeSerializationLibrary);
+
+        assertTrue(typeHandler.isPresent());
+        assertTrue(typeHandler.get() instanceof CollectionTypeHandler);
+
+        // Verify that the Integer TypeHandler was loaded from the TypeSerializationLibrary
+        verify(typeSerializationLibrary).getTypeHandler(ArgumentMatchers.eq(TypeInfo.of(Integer.class).getType()));
+    }
+
+    @Test
+    public void testNonGenericCollection() {
+        class IntList extends ArrayList<Integer> {}
+
+        Optional<TypeHandler<IntList>> typeHandler =
+                typeHandlerFactory.create(TypeInfo.of(IntList.class), typeSerializationLibrary);
 
         assertTrue(typeHandler.isPresent());
         assertTrue(typeHandler.get() instanceof CollectionTypeHandler);

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
@@ -20,7 +20,6 @@ import org.mockito.ArgumentMatchers;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
-import org.terasology.reflection.MappedContainer;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
@@ -40,16 +39,15 @@ public class ObjectFieldMapTypeHandlerFactoryTest {
             reflectFactory, copyStrategyLibrary
     );
 
-    @MappedContainer
-    public static class AMappedContainer {
+    public static class SomeClass {
         public int someInt;
         public String someString;
     }
 
     @Test
-    public void testMappedContainer() {
-        Optional<TypeHandler<AMappedContainer>> typeHandler =
-                typeHandlerFactory.create(TypeInfo.of(AMappedContainer.class), typeSerializationLibrary);
+    public void testObject() {
+        Optional<TypeHandler<SomeClass>> typeHandler =
+                typeHandlerFactory.create(TypeInfo.of(SomeClass.class), typeSerializationLibrary);
 
 
         assertTrue(typeHandler.isPresent());

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
-import org.terasology.persistence.typeHandling.coreTypes.MappedContainerTypeHandler;
+import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
 import org.terasology.reflection.MappedContainer;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
@@ -31,12 +31,12 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class MappedContainerTypeHandlerFactoryTest {
+public class ObjectFieldMapTypeHandlerFactoryTest {
     private final TypeSerializationLibrary typeSerializationLibrary = mock(TypeSerializationLibrary.class);
 
     private final ReflectionReflectFactory reflectFactory = new ReflectionReflectFactory();
     private final CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);
-    private final MappedContainerTypeHandlerFactory typeHandlerFactory = new MappedContainerTypeHandlerFactory(
+    private final ObjectFieldMapTypeHandlerFactory typeHandlerFactory = new ObjectFieldMapTypeHandlerFactory(
             reflectFactory, copyStrategyLibrary
     );
 
@@ -53,7 +53,7 @@ public class MappedContainerTypeHandlerFactoryTest {
 
 
         assertTrue(typeHandler.isPresent());
-        assertTrue(typeHandler.get() instanceof MappedContainerTypeHandler);
+        assertTrue(typeHandler.get() instanceof ObjectFieldMapTypeHandler);
 
         // Verify that the Integer and String TypeHandlers were loaded from the TypeSerializationLibrary
         verify(typeSerializationLibrary).getTypeHandler(ArgumentMatchers.eq(TypeInfo.of(Integer.TYPE).getType()));

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/StringMapTypeHandlerFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/StringMapTypeHandlerFactoryTest.java
@@ -22,6 +22,7 @@ import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.coreTypes.StringMapTypeHandler;
 import org.terasology.reflection.TypeInfo;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -56,4 +57,19 @@ public class StringMapTypeHandlerFactoryTest {
                 typeHandlerFactory.create(listTypeInfo, typeSerializationLibrary);
 
         assertFalse(typeHandler.isPresent());
-    }}
+    }
+
+    @Test
+    public void testNonGenericMap() {
+        class IntMap extends HashMap<String, Integer> {}
+
+        Optional<TypeHandler<IntMap>> typeHandler =
+                typeHandlerFactory.create(TypeInfo.of(IntMap.class), typeSerializationLibrary);
+
+        assertTrue(typeHandler.isPresent());
+        assertTrue(typeHandler.get() instanceof StringMapTypeHandler);
+
+        // Verify that the Integer TypeHandler was loaded from the TypeSerializationLibrary
+        verify(typeSerializationLibrary).getTypeHandler(ArgumentMatchers.eq(TypeInfo.of(Integer.class).getType()));
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/extensionTypes/factories/AssetTypeHandlerFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/extensionTypes/factories/AssetTypeHandlerFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.extensionTypes.factories;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+import org.terasology.assets.Asset;
+import org.terasology.audio.StaticSound;
+import org.terasology.audio.StreamingSound;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeHandlerFactory;
+import org.terasology.persistence.typeHandling.extensionTypes.AssetTypeHandler;
+import org.terasology.reflection.TypeInfo;
+import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.nui.asset.UIElement;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+
+public class AssetTypeHandlerFactoryTest {
+    @Test
+    public void testCreate() {
+        TypeHandlerFactory factory = new AssetTypeHandlerFactory();
+
+        List<TypeInfo<? extends Asset>> typesToTest = Lists.newArrayList(
+                TypeInfo.of(Texture.class),
+                TypeInfo.of(UIElement.class),
+                TypeInfo.of(StaticSound.class),
+                TypeInfo.of(StreamingSound.class)
+        );
+
+        for (TypeInfo<? extends Asset> typeInfo : typesToTest) {
+            Optional<? extends TypeHandler<? extends Asset>> typeHandler = factory.create(typeInfo, null);
+
+            assertTrue(typeHandler.isPresent());
+
+            assertTrue(typeHandler.get() instanceof AssetTypeHandler);
+        }
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
@@ -89,6 +89,56 @@ public class ReflectionUtilsTest {
     }
 
     @Test
+    public void testResolveRawParameterizedType() {
+        class SomeClass<T> {
+            private CopyStrategy<T> t;
+            private T o;
+        }
+
+        TypeInfo<SomeClass> typeInfo = new TypeInfo<SomeClass>() {
+        };
+
+        Type resolvedFieldType = ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
+        );
+
+        assertEquals(new TypeInfo<CopyStrategy<Object>>() {}.getType(), resolvedFieldType);
+
+        resolvedFieldType = ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[1].getGenericType()
+        );
+
+        assertEquals(TypeInfo.of(Object.class).getType(), resolvedFieldType);
+    }
+
+    @Test
+    public void testResolveNothing() {
+        class SomeClass {
+            private CopyStrategy<Integer> t;
+            private String o;
+        }
+
+        TypeInfo<SomeClass> typeInfo = new TypeInfo<SomeClass>() {
+        };
+
+        Type resolvedFieldType = ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
+        );
+
+        assertEquals(new TypeInfo<CopyStrategy<Integer>>() {}.getType(), resolvedFieldType);
+
+        resolvedFieldType = ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[1].getGenericType()
+        );
+
+        assertEquals(TypeInfo.of(String.class).getType(), resolvedFieldType);
+    }
+
+    @Test
     public void testResolveGenericArray() {
         class SomeClass<T> {
             private T[] t;

--- a/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
@@ -18,9 +18,12 @@ package org.terasology.utilities;
 import org.junit.Test;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategy;
 
+import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -36,7 +39,7 @@ public class ReflectionUtilsTest {
 
     @Test
     public void testGetParameterForGenericInterface() throws Exception {
-        assertEquals(Integer.class, ReflectionUtil.getTypeParameterForSuper(ParameterisedInterfaceImplementor.class, CopyStrategy.class, 0));
+        assertEquals(Integer.class, ReflectionUtil.getTypeParameterForSuper(SubInterfaceImplementor.class, CopyStrategy.class, 0));
     }
 
     @Test
@@ -47,6 +50,36 @@ public class ReflectionUtilsTest {
     @Test
     public void testGetParameterForUnboundGenericInterface() throws Exception {
         assertTrue(ReflectionUtil.getTypeParameterForSuper(UnboundInterfaceImplementor.class, CopyStrategy.class, 0) instanceof TypeVariable);
+    }
+
+    @Test
+    public void testResolveFieldType() {
+        class SomeClass<T> {
+            private T t;
+
+            SomeClass(T t) {
+                this.t = t;
+            }
+        }
+
+        TypeInfo<SomeClass<Float>> typeInfo = new TypeInfo<SomeClass<Float>>() {
+        };
+
+        Type resolvedFieldType = ReflectionUtil.resolveFieldType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
+        );
+
+        assertEquals(Float.class, resolvedFieldType);
+    }
+
+    interface GenericInterfaceSubInterface extends CopyStrategy<Integer> {}
+
+    class SubInterfaceImplementor implements GenericInterfaceSubInterface {
+        @Override
+        public Integer copy(Integer value) {
+            return null;
+        }
     }
 
     public static class ParameterisedInterfaceImplementor implements CopyStrategy<Integer> {

--- a/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
@@ -23,7 +23,6 @@ import org.terasology.reflection.copy.CopyStrategy;
 
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -53,7 +52,7 @@ public class ReflectionUtilsTest {
     }
 
     @Test
-    public void testResolveFieldType() {
+    public void testResolveType() {
         class SomeClass<T> {
             private T t;
 
@@ -65,7 +64,7 @@ public class ReflectionUtilsTest {
         TypeInfo<SomeClass<Float>> typeInfo = new TypeInfo<SomeClass<Float>>() {
         };
 
-        Type resolvedFieldType = ReflectionUtil.resolveFieldType(
+        Type resolvedFieldType = ReflectionUtil.resolveType(
                 typeInfo.getType(),
                 typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
         );

--- a/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
@@ -21,6 +21,7 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategy;
 
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 
@@ -52,13 +53,9 @@ public class ReflectionUtilsTest {
     }
 
     @Test
-    public void testResolveType() {
+    public void testResolveTypeVariable() {
         class SomeClass<T> {
             private T t;
-
-            SomeClass(T t) {
-                this.t = t;
-            }
         }
 
         TypeInfo<SomeClass<Float>> typeInfo = new TypeInfo<SomeClass<Float>>() {
@@ -70,6 +67,40 @@ public class ReflectionUtilsTest {
         );
 
         assertEquals(Float.class, resolvedFieldType);
+    }
+
+    @Test
+    public void testResolveParameterizedType() {
+        class SomeClass<T> {
+            private CopyStrategy<T> t;
+        }
+
+        TypeInfo<SomeClass<Float>> typeInfo = new TypeInfo<SomeClass<Float>>() {
+        };
+
+        Type resolvedFieldType = ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
+        );
+
+        assertEquals(new TypeInfo<CopyStrategy<Float>>() {}.getType(), resolvedFieldType);
+    }
+
+    @Test
+    public void testResolveGenericArray() {
+        class SomeClass<T> {
+            private T[] t;
+        }
+
+        TypeInfo<SomeClass<Float>> typeInfo = new TypeInfo<SomeClass<Float>>() {
+        };
+
+        GenericArrayType resolvedFieldType = (GenericArrayType) ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
+        );
+
+        assertEquals(Float[].class.getComponentType(), resolvedFieldType.getGenericComponentType());
     }
 
     interface GenericInterfaceSubInterface extends CopyStrategy<Integer> {}

--- a/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
+++ b/engine-tests/src/test/java/org/terasology/utilities/ReflectionUtilsTest.java
@@ -22,8 +22,10 @@ import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategy;
 
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -101,6 +103,35 @@ public class ReflectionUtilsTest {
         );
 
         assertEquals(Float[].class.getComponentType(), resolvedFieldType.getGenericComponentType());
+    }
+
+    @Test
+    public void testResolveWildcardType() {
+        class SomeClass<T, U> {
+            private CopyStrategy<? extends T> t;
+            private CopyStrategy<? super U> u;
+        }
+
+        TypeInfo<SomeClass<Float, Integer>> typeInfo = new TypeInfo<SomeClass<Float, Integer>>() {
+        };
+
+        ParameterizedType resolvedFieldType = (ParameterizedType) ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[0].getGenericType()
+        );
+
+        WildcardType resolvedWildcardType = (WildcardType) resolvedFieldType.getActualTypeArguments()[0];
+
+        assertEquals(Float.class, resolvedWildcardType.getUpperBounds()[0]);
+
+        resolvedFieldType = (ParameterizedType) ReflectionUtil.resolveType(
+                typeInfo.getType(),
+                typeInfo.getRawType().getDeclaredFields()[1].getGenericType()
+        );
+
+        resolvedWildcardType = (WildcardType) resolvedFieldType.getActualTypeArguments()[0];
+
+        assertEquals(Integer.class, resolvedWildcardType.getLowerBounds()[0]);
     }
 
     interface GenericInterfaceSubInterface extends CopyStrategy<Integer> {}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
@@ -114,6 +114,8 @@ public class TypeSerializationLibrary {
 
         constructorLibrary = new ConstructorLibrary(instanceCreators, reflectFactory);
 
+        addTypeHandlerFactory(new ObjectFieldMapTypeHandlerFactory(constructorLibrary));
+
         addTypeHandler(Boolean.class, new BooleanTypeHandler());
         addTypeHandler(Boolean.TYPE, new BooleanTypeHandler());
         addTypeHandler(Byte.class, new ByteTypeHandler());
@@ -133,7 +135,6 @@ public class TypeSerializationLibrary {
         addTypeHandlerFactory(new EnumTypeHandlerFactory());
         addTypeHandlerFactory(new CollectionTypeHandlerFactory(constructorLibrary));
         addTypeHandlerFactory(new StringMapTypeHandlerFactory());
-        addTypeHandlerFactory(new ObjectFieldMapTypeHandlerFactory(reflectFactory, this.copyStrategies));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
@@ -46,7 +46,7 @@ import org.terasology.persistence.typeHandling.coreTypes.NumberTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.StringTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.factories.CollectionTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.coreTypes.factories.EnumTypeHandlerFactory;
-import org.terasology.persistence.typeHandling.coreTypes.factories.MappedContainerTypeHandlerFactory;
+import org.terasology.persistence.typeHandling.coreTypes.factories.ObjectFieldMapTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.coreTypes.factories.StringMapTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.extensionTypes.AssetTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.ColorTypeHandler;
@@ -133,7 +133,7 @@ public class TypeSerializationLibrary {
         addTypeHandlerFactory(new EnumTypeHandlerFactory());
         addTypeHandlerFactory(new CollectionTypeHandlerFactory(constructorLibrary));
         addTypeHandlerFactory(new StringMapTypeHandlerFactory());
-        addTypeHandlerFactory(new MappedContainerTypeHandlerFactory(reflectFactory, this.copyStrategies));
+        addTypeHandlerFactory(new ObjectFieldMapTypeHandlerFactory(reflectFactory, this.copyStrategies));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeSerializationLibrary.java
@@ -53,6 +53,7 @@ import org.terasology.persistence.typeHandling.extensionTypes.ColorTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.NameTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.PrefabTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.TextureRegionTypeHandler;
+import org.terasology.persistence.typeHandling.extensionTypes.factories.AssetTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.extensionTypes.factories.TextureRegionAssetTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.mathTypes.IntegerRangeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Quat4fTypeHandler;
@@ -155,16 +156,10 @@ public class TypeSerializationLibrary {
 
         serializationLibrary.addTypeHandler(Color.class, new ColorTypeHandler());
         serializationLibrary.addTypeHandler(Quat4f.class, new Quat4fTypeHandler());
-        // TODO: Add AssetTypeHandlerFactory
-        serializationLibrary.addTypeHandler(Texture.class, new AssetTypeHandler<>(Texture.class));
-        serializationLibrary.addTypeHandler(UIElement.class, new AssetTypeHandler<>(UIElement.class));
-        serializationLibrary.addTypeHandler(Mesh.class, new AssetTypeHandler<>(Mesh.class));
-        serializationLibrary.addTypeHandler(StaticSound.class, new AssetTypeHandler<>(StaticSound.class));
-        serializationLibrary.addTypeHandler(StreamingSound.class, new AssetTypeHandler<>(StreamingSound.class));
-        serializationLibrary.addTypeHandler(Material.class, new AssetTypeHandler<>(Material.class));
+
+        serializationLibrary.addTypeHandlerFactory(new AssetTypeHandlerFactory());
+
         serializationLibrary.addTypeHandler(Name.class, new NameTypeHandler());
-        serializationLibrary.addTypeHandler(SkeletalMesh.class, new AssetTypeHandler<>(SkeletalMesh.class));
-        serializationLibrary.addTypeHandler(MeshAnimation.class, new AssetTypeHandler<>(MeshAnimation.class));
         serializationLibrary.addTypeHandler(TextureRegion.class, new TextureRegionTypeHandler());
 
         serializationLibrary.addTypeHandlerFactory(new TextureRegionAssetTypeHandlerFactory());
@@ -178,7 +173,6 @@ public class TypeSerializationLibrary {
         serializationLibrary.addTypeHandler(Rect2f.class, new Rect2fTypeHandler());
         serializationLibrary.addTypeHandler(Region3i.class, new Region3iTypeHandler());
         serializationLibrary.addTypeHandler(Prefab.class, new PrefabTypeHandler());
-        serializationLibrary.addTypeHandler(BehaviorTree.class, new AssetTypeHandler<>(BehaviorTree.class));
         serializationLibrary.addTypeHandler(IntegerRange.class, new IntegerRangeHandler());
 
         return serializationLibrary;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
@@ -29,15 +29,15 @@ import java.util.Map;
 
 /**
  */
-public class MappedContainerTypeHandler<T> implements TypeHandler<T> {
+public class ObjectFieldMapTypeHandler<T> implements TypeHandler<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MappedContainerTypeHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(ObjectFieldMapTypeHandler.class);
 
     private Map<String, FieldMetadata<T, ?>> fieldByName = Maps.newHashMap();
     private Map<FieldMetadata<T, ?>, TypeHandler<?>> mappedFields;
     private Class<T> clazz;
 
-    public MappedContainerTypeHandler(Class<T> clazz, Map<FieldMetadata<T, ?>, TypeHandler<?>> mappedFields) {
+    public ObjectFieldMapTypeHandler(Class<T> clazz, Map<FieldMetadata<T, ?>, TypeHandler<?>> mappedFields) {
         this.clazz = clazz;
         this.mappedFields = mappedFields;
         for (FieldMetadata<T, ?> field : mappedFields.keySet()) {

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
@@ -28,6 +28,8 @@ import java.lang.reflect.Field;
 import java.util.Map;
 
 /**
+ * Serializes objects as a fieldName -> fieldValue map. It is used as the last resort while serializing an
+ * object through a {@link org.terasology.persistence.typeHandling.TypeSerializationLibrary}.
  */
 public class ObjectFieldMapTypeHandler<T> implements TypeHandler<T> {
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
@@ -41,7 +41,7 @@ public class ObjectFieldMapTypeHandler<T> implements TypeHandler<T> {
         this.clazz = clazz;
         this.mappedFields = mappedFields;
         for (FieldMetadata<T, ?> field : mappedFields.keySet()) {
-            this.fieldByName.put(UriUtil.normalise(field.getName()), field);
+            this.fieldByName.put(field.getName(), field);
         }
     }
 
@@ -69,7 +69,7 @@ public class ObjectFieldMapTypeHandler<T> implements TypeHandler<T> {
         try {
             T result = clazz.newInstance();
             for (Map.Entry<String, PersistedData> entry : data.getAsValueMap().entrySet()) {
-                FieldMetadata fieldInfo = fieldByName.get(UriUtil.normalise(entry.getKey()));
+                FieldMetadata fieldInfo = fieldByName.get(entry.getKey());
                 if (fieldInfo != null) {
                     TypeHandler handler = mappedFields.get(fieldInfo);
                     Object val = handler.deserialize(entry.getValue(), context);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
@@ -81,12 +81,18 @@ public class ObjectFieldMapTypeHandler<T> implements TypeHandler<T> {
         try {
             T result = constructor.construct();
             for (Map.Entry<String, PersistedData> entry : data.getAsValueMap().entrySet()) {
-                Field field = fieldByName.get(entry.getKey());
-                if (field != null) {
-                    TypeHandler handler = mappedFields.get(field);
-                    Object val = handler.deserialize(entry.getValue(), context);
-                    field.set(result, val);
+                String fieldName = entry.getKey();
+                Field field = fieldByName.get(fieldName);
+
+                if (field == null) {
+                    logger.error("Cound not find field with name {}", fieldName);
+                    continue;
                 }
+
+                TypeHandler handler = mappedFields.get(field);
+                Object fieldValue = handler.deserialize(entry.getValue(), context);
+
+                field.set(result, fieldValue);
             }
             return result;
         } catch (Exception e) {
@@ -94,5 +100,4 @@ public class ObjectFieldMapTypeHandler<T> implements TypeHandler<T> {
         }
         return null;
     }
-
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandler.java
@@ -54,6 +54,11 @@ public class RuntimeDelegatingTypeHandler<T> implements TypeHandler<T> {
 
     @Override
     public PersistedData serialize(T value, SerializationContext context) {
+        // If primitive, don't go looking for the runtime type, serialize as is
+        if (typeInfo.getRawType().isPrimitive()) {
+            return delegateHandler.serialize(value, context);
+        }
+
         TypeHandler<T> chosenHandler = delegateHandler;
         Class<?> runtimeClass = value.getClass();
 
@@ -120,7 +125,7 @@ public class RuntimeDelegatingTypeHandler<T> implements TypeHandler<T> {
 
         PersistedData valueData = valueMap.get(VALUE_FIELD);
 
-        return typeHandler.deserialize(data, context);
+        return typeHandler.deserialize(valueData, context);
 
     }
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.coreTypes;
+
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.persistence.typeHandling.DeserializationContext;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.PersistedDataMap;
+import org.terasology.persistence.typeHandling.SerializationContext;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+import org.terasology.reflection.TypeInfo;
+
+import java.util.Map;
+
+public class RuntimeDelegatingTypeHandler<T> implements TypeHandler<T> {
+    private static final String TYPE_FIELD = "@type";
+    private static final String VALUE_FIELD = "@value";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeDelegatingTypeHandler.class);
+
+    private TypeHandler<T> delegateHandler;
+    private TypeInfo<T> typeInfo;
+    private TypeSerializationLibrary typeSerializationLibrary;
+
+    public RuntimeDelegatingTypeHandler(TypeHandler<T> delegateHandler, TypeInfo<T> typeInfo, TypeSerializationLibrary typeSerializationLibrary) {
+        this.delegateHandler = delegateHandler;
+        this.typeInfo = typeInfo;
+        this.typeSerializationLibrary = typeSerializationLibrary;
+    }
+
+    @Override
+    public PersistedData serialize(T value, SerializationContext context) {
+        TypeHandler<T> chosenHandler = delegateHandler;
+        Class<?> runtimeClass = value.getClass();
+
+        if (!typeInfo.getRawType().equals(runtimeClass)) {
+            TypeHandler<T> runtimeTypeHandler =
+                    (TypeHandler<T>) typeSerializationLibrary.getTypeHandler(runtimeClass);
+
+            if (!(runtimeTypeHandler instanceof ObjectFieldMapTypeHandler)) {
+                // Custom handler for runtime type
+                chosenHandler = runtimeTypeHandler;
+            } else if (!(delegateHandler instanceof ObjectFieldMapTypeHandler)) {
+                // Custom handler for specified type
+                chosenHandler = delegateHandler;
+            } else {
+                chosenHandler = runtimeTypeHandler;
+            }
+        }
+
+        if (chosenHandler == delegateHandler) {
+            return delegateHandler.serialize(value, context);
+        }
+
+        Map<String, PersistedData> typeValuePersistedDataMap = Maps.newHashMap();
+
+        typeValuePersistedDataMap.put(
+                TYPE_FIELD,
+                context.create(runtimeClass.getName())
+        );
+
+        typeValuePersistedDataMap.put(
+                VALUE_FIELD,
+                chosenHandler.serialize(value, context)
+        );
+
+        return context.create(typeValuePersistedDataMap);
+    }
+
+    @Override
+    public T deserialize(PersistedData data, DeserializationContext context) {
+        if (!data.isValueMap()) {
+            return delegateHandler.deserialize(data, context);
+        }
+
+        PersistedDataMap valueMap = data.getAsValueMap();
+
+        if (!valueMap.has(TYPE_FIELD) || !valueMap.has(VALUE_FIELD)) {
+            return delegateHandler.deserialize(data, context);
+        }
+
+        String typeName = valueMap.getAsString(TYPE_FIELD);
+
+        // TODO: Use context class loaders
+        Class<?> typeToDeserializeAs;
+
+        try {
+            typeToDeserializeAs = Class.forName(typeName);
+        } catch (ClassNotFoundException e) {
+            LOGGER.error("Cannot find class {}", typeName);
+            return null;
+        }
+
+        TypeHandler<T> typeHandler =
+                (TypeHandler<T>) typeSerializationLibrary.getTypeHandler(typeToDeserializeAs);
+
+        PersistedData valueData = valueMap.get(VALUE_FIELD);
+
+        return typeHandler.deserialize(data, context);
+
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/RuntimeDelegatingTypeHandler.java
@@ -28,6 +28,14 @@ import org.terasology.reflection.TypeInfo;
 
 import java.util.Map;
 
+/**
+ * Delegates serialization of a value to a handler of its runtime type if needed. It is used in
+ * cases where a subclass instance can be referred to as its supertype. As such, it is meant
+ * for internal use in another {@link TypeHandler} only, and is never directly registered
+ * in a {@link TypeSerializationLibrary}.
+ *
+ * @param <T> The base type whose instances may be delegated to a subtype's {@link TypeHandler} at runtime.
+ */
 public class RuntimeDelegatingTypeHandler<T> implements TypeHandler<T> {
     private static final String TYPE_FIELD = "@type";
     private static final String VALUE_FIELD = "@value";

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/CollectionTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/CollectionTypeHandlerFactory.java
@@ -51,8 +51,7 @@ public class CollectionTypeHandlerFactory implements TypeHandlerFactory {
             return Optional.empty();
         }
 
-        // TODO: Use getTypeParameterFromSuper
-        Type elementType = ReflectionUtil.getTypeParameter(typeInfo.getType(), 0);
+        Type elementType = ReflectionUtil.getTypeParameterForSuper(typeInfo.getType(), Collection.class, 0);
 
         if (elementType == null) {
             LOGGER.error("Collection is not parameterized and cannot be serialized");

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/CollectionTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/CollectionTypeHandlerFactory.java
@@ -21,6 +21,7 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeHandlerFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.coreTypes.CollectionTypeHandler;
+import org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.reflect.ConstructorLibrary;
 import org.terasology.reflection.reflect.ObjectConstructor;
@@ -50,6 +51,7 @@ public class CollectionTypeHandlerFactory implements TypeHandlerFactory {
             return Optional.empty();
         }
 
+        // TODO: Use getTypeParameterFromSuper
         Type elementType = ReflectionUtil.getTypeParameter(typeInfo.getType(), 0);
 
         if (elementType == null) {
@@ -57,7 +59,11 @@ public class CollectionTypeHandlerFactory implements TypeHandlerFactory {
             return Optional.empty();
         }
 
-        TypeHandler<?> elementTypeHandler = typeSerializationLibrary.getTypeHandler(elementType);
+        TypeHandler<?> elementTypeHandler = new RuntimeDelegatingTypeHandler(
+                typeSerializationLibrary.getTypeHandler(elementType),
+                TypeInfo.of(elementType),
+                typeSerializationLibrary
+        );
 
         ObjectConstructor<T> collectionConstructor = constructorLibrary.get(typeInfo);
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
@@ -23,7 +23,6 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeHandlerFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
-import org.terasology.reflection.MappedContainer;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.metadata.ClassMetadata;
@@ -50,11 +49,9 @@ public class ObjectFieldMapTypeHandlerFactory implements TypeHandlerFactory {
     public <T> Optional<TypeHandler<T>> create(TypeInfo<T> typeInfo, TypeSerializationLibrary typeSerializationLibrary) {
         Class<? super T> typeClass = typeInfo.getRawType();
 
-        if (typeClass.getAnnotation(MappedContainer.class) != null
-                && !Modifier.isAbstract(typeClass.getModifiers())
+        if (!Modifier.isAbstract(typeClass.getModifiers())
                 && !typeClass.isLocalClass()
-                && !(typeClass.isMemberClass()
-                && !Modifier.isStatic(typeClass.getModifiers()))) {
+                && !(typeClass.isMemberClass() && !Modifier.isStatic(typeClass.getModifiers()))) {
             try {
                 ClassMetadata<?, ?> metadata = new DefaultClassMetadata<>(new SimpleUri(), typeClass,
                         reflectFactory, copyStrategies);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
@@ -80,6 +80,10 @@ public class ObjectFieldMapTypeHandlerFactory implements TypeHandlerFactory {
 
         while (!Object.class.equals(rawType)) {
             for (Field field : rawType.getDeclaredFields()) {
+                if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+
                 field.setAccessible(true);
                 Type fieldType = ReflectionUtil.resolveType(type, field.getGenericType());
                 fields.put(field, fieldType);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
@@ -22,7 +22,7 @@ import org.terasology.engine.SimpleUri;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeHandlerFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
-import org.terasology.persistence.typeHandling.coreTypes.MappedContainerTypeHandler;
+import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
 import org.terasology.reflection.MappedContainer;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
@@ -35,13 +35,13 @@ import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Optional;
 
-public class MappedContainerTypeHandlerFactory implements TypeHandlerFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MappedContainerTypeHandlerFactory.class);
+public class ObjectFieldMapTypeHandlerFactory implements TypeHandlerFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ObjectFieldMapTypeHandlerFactory.class);
 
     private ReflectFactory reflectFactory;
     private CopyStrategyLibrary copyStrategies;
 
-    public MappedContainerTypeHandlerFactory(ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategies) {
+    public ObjectFieldMapTypeHandlerFactory(ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategies) {
         this.reflectFactory = reflectFactory;
         this.copyStrategies = copyStrategies;
     }
@@ -60,7 +60,7 @@ public class MappedContainerTypeHandlerFactory implements TypeHandlerFactory {
                         reflectFactory, copyStrategies);
 
                 @SuppressWarnings({"unchecked"})
-                MappedContainerTypeHandler<T> mappedHandler = new MappedContainerTypeHandler(typeClass,
+                ObjectFieldMapTypeHandler<T> mappedHandler = new ObjectFieldMapTypeHandler(typeClass,
                         getFieldHandlerMap(metadata, typeSerializationLibrary));
 
                 return Optional.of(mappedHandler);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactory.java
@@ -22,6 +22,7 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeHandlerFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
 import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
+import org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.reflect.ConstructorLibrary;
 import org.terasology.utilities.ReflectionUtil;
@@ -29,10 +30,8 @@ import org.terasology.utilities.ReflectionUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ObjectFieldMapTypeHandlerFactory implements TypeHandlerFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(ObjectFieldMapTypeHandlerFactory.class);
@@ -53,9 +52,15 @@ public class ObjectFieldMapTypeHandlerFactory implements TypeHandlerFactory {
             Map<Field, TypeHandler<?>> fieldTypeHandlerMap = Maps.newHashMap();
 
             getResolvedFields(typeInfo).forEach(
-                    (field, type) -> {
-                        fieldTypeHandlerMap.put(field, typeSerializationLibrary.getTypeHandler(type));
-                    }
+                    (field, fieldType) ->
+                            fieldTypeHandlerMap.put(
+                                    field,
+                                    new RuntimeDelegatingTypeHandler(
+                                            typeSerializationLibrary.getTypeHandler(fieldType),
+                                            TypeInfo.of(fieldType),
+                                            typeSerializationLibrary
+                                    )
+                            )
             );
 
             ObjectFieldMapTypeHandler<T> mappedHandler =

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/StringMapTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/StringMapTypeHandlerFactory.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeHandlerFactory;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+import org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.StringMapTypeHandler;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.utilities.ReflectionUtil;
@@ -38,6 +39,7 @@ public class StringMapTypeHandlerFactory implements TypeHandlerFactory {
             return Optional.empty();
         }
 
+        // TODO: Replace with getTypeParameterFromSuper
         Type keyType = ReflectionUtil.getTypeParameter(typeInfo.getType(), 0);
         Type valueType = ReflectionUtil.getTypeParameter(typeInfo.getType(), 1);
 
@@ -50,7 +52,11 @@ public class StringMapTypeHandlerFactory implements TypeHandlerFactory {
             return Optional.empty();
         }
 
-        TypeHandler<T> valueTypeHandler = (TypeHandler<T>) typeSerializationLibrary.getTypeHandler(valueType);
+        TypeHandler<T> valueTypeHandler = new RuntimeDelegatingTypeHandler(
+                typeSerializationLibrary.getTypeHandler(valueType),
+                TypeInfo.of(valueType),
+                typeSerializationLibrary
+        );
 
         return Optional.of((TypeHandler<T>) new StringMapTypeHandler<>(valueTypeHandler));
     }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/StringMapTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/factories/StringMapTypeHandlerFactory.java
@@ -39,9 +39,8 @@ public class StringMapTypeHandlerFactory implements TypeHandlerFactory {
             return Optional.empty();
         }
 
-        // TODO: Replace with getTypeParameterFromSuper
-        Type keyType = ReflectionUtil.getTypeParameter(typeInfo.getType(), 0);
-        Type valueType = ReflectionUtil.getTypeParameter(typeInfo.getType(), 1);
+        Type keyType = ReflectionUtil.getTypeParameterForSuper(typeInfo.getType(), Map.class, 0);
+        Type valueType = ReflectionUtil.getTypeParameterForSuper(typeInfo.getType(), Map.class, 1);
 
         if (!String.class.equals(keyType)) {
             return Optional.empty();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/factories/AssetTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/factories/AssetTypeHandlerFactory.java
@@ -24,6 +24,10 @@ import org.terasology.reflection.TypeInfo;
 
 import java.util.Optional;
 
+/**
+ * Generates an {@link AssetTypeHandler} for each type extending {@link Asset} so that an
+ * {@link AssetTypeHandler} does not have to be manually registered for each subtype of {@link Asset}.
+ */
 public class AssetTypeHandlerFactory implements TypeHandlerFactory {
     @Override
     public <T> Optional<TypeHandler<T>> create(TypeInfo<T> typeInfo, TypeSerializationLibrary typeSerializationLibrary) {

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/factories/AssetTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/factories/AssetTypeHandlerFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.extensionTypes.factories;
+
+import org.terasology.assets.Asset;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeHandlerFactory;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+import org.terasology.persistence.typeHandling.extensionTypes.AssetTypeHandler;
+import org.terasology.reflection.TypeInfo;
+
+import java.util.Optional;
+
+public class AssetTypeHandlerFactory implements TypeHandlerFactory {
+    @Override
+    public <T> Optional<TypeHandler<T>> create(TypeInfo<T> typeInfo, TypeSerializationLibrary typeSerializationLibrary) {
+        Class<? super T> rawType = typeInfo.getRawType();
+
+        if (!Asset.class.isAssignableFrom(rawType)) {
+            return Optional.empty();
+        }
+
+        @SuppressWarnings({"unchecked"})
+        TypeHandler<T> typeHandler = new AssetTypeHandler(rawType);
+
+        return Optional.of(typeHandler);
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/gson/GsonTypeSerializationLibraryAdapterFactory.java
@@ -21,6 +21,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+import org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler;
 
 import java.lang.reflect.Type;
 
@@ -43,7 +44,7 @@ public class GsonTypeSerializationLibraryAdapterFactory implements TypeAdapterFa
 
         TypeHandler<T> typeHandler = (TypeHandler<T>) typeSerializationLibrary.getTypeHandler(rawType);
 
-        if (typeHandler == null) {
+        if (typeHandler == null || typeHandler instanceof ObjectFieldMapTypeHandler) {
             return null;
         }
 

--- a/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
@@ -241,7 +241,8 @@ public final class ReflectionUtil {
     private static <T> Type getTypeParameterForSuperClass(Type target, Class<T> superClass, int index) {
         for (Class targetClass = getClassOfType(target);
              !Object.class.equals(targetClass);
-             target = targetClass.getGenericSuperclass(), targetClass = getClassOfType(target)) {
+             target = resolveType(target, targetClass.getGenericSuperclass()),
+                     targetClass = getClassOfType(target)) {
             if (superClass.equals(targetClass)) {
                 return getTypeParameter(target, index);
             }
@@ -261,13 +262,15 @@ public final class ReflectionUtil {
             return getTypeParameter(target, index);
         }
 
-        Type genericSuperclass = targetClass.getGenericSuperclass();
+        Type genericSuperclass = resolveType(target, targetClass.getGenericSuperclass());
 
         if (!Object.class.equals(genericSuperclass) && genericSuperclass != null) {
             return getTypeParameterForSuperInterface(genericSuperclass, superClass, index);
         }
 
         for (Type genericInterface : targetClass.getGenericInterfaces()) {
+            genericInterface = resolveType(target, genericInterface);
+
             Type typeParameter = getTypeParameterForSuperInterface(genericInterface, superClass, index);
 
             if (typeParameter != null) {

--- a/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
@@ -278,6 +278,34 @@ public final class ReflectionUtil {
         return null;
     }
 
+    public static Type resolveFieldType(Type classType, Type fieldType) {
+        Class<?> classClass = getClassOfType(classType);
+
+        if (fieldType instanceof TypeVariable<?>) {
+            TypeVariable<?> typeVariable = (TypeVariable<?>) fieldType;
+
+            Preconditions.checkArgument(typeVariable.getGenericDeclaration() instanceof Class,
+                    "fieldType has not been declared in a class and cannot be a field's type");
+
+            Class<?> declaringClass = (Class<?>) typeVariable.getGenericDeclaration();
+
+            Preconditions.checkArgument(declaringClass.isAssignableFrom(classClass),
+                    "Field was not declared in class " + classClass);
+
+            List<TypeVariable<?>> typeParameters =
+                    Arrays.asList(declaringClass.getTypeParameters());
+
+            int typeParameterIndex = typeParameters.indexOf(typeVariable);
+
+            if (!classClass.equals(declaringClass)) {
+                return getTypeParameterForSuper(classType, declaringClass, typeParameterIndex);
+            }
+            return getTypeParameter(classType, typeParameterIndex);
+        }
+
+        return fieldType;
+    }
+
     public static Object readField(Object object, String fieldName) {
         Class<?> cls = object.getClass();
         for (Class<?> c = cls; c != null; c = c.getSuperclass()) {

--- a/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
@@ -287,8 +287,13 @@ public final class ReflectionUtil {
 
             Type resolvedTypeVariable = resolveTypeVariable(contextType, typeVariable, contextClass);
 
-            if (resolvedTypeVariable == null || resolvedTypeVariable == typeVariable) {
+            if (resolvedTypeVariable == typeVariable) {
                 return typeVariable;
+            }
+
+            if (resolvedTypeVariable == null) {
+                // TypeVariable not specified (i.e. raw type), return Object
+                return Object.class;
             }
 
             return resolveType(contextType, resolvedTypeVariable);
@@ -313,9 +318,9 @@ public final class ReflectionUtil {
                 return parameterizedType;
             }
 
-            return new ParameterizedType() {
-                final Type rawType = parameterizedType.getRawType();
+            final Type rawType = parameterizedType.getRawType();
 
+            return new ParameterizedType() {
                 @Override
                 public Type[] getActualTypeArguments() {
                     return resolvedTypeArguments;
@@ -397,6 +402,7 @@ public final class ReflectionUtil {
             if (resolvedTypeArgument != types[i]) {
                 if (!changed) {
                     types = types.clone();
+                    changed = true;
                 }
 
                 types[i] = resolvedTypeArgument;
@@ -422,11 +428,7 @@ public final class ReflectionUtil {
 
         int typeParameterIndex = typeParameters.indexOf(typeVariable);
 
-        if (!contextClass.equals(declaringClass)) {
-            return getTypeParameterForSuper(contextType, declaringClass, typeParameterIndex);
-        }
-
-        return getTypeParameter(contextType, typeParameterIndex);
+        return getTypeParameterForSuper(contextType, declaringClass, typeParameterIndex);
     }
 
     public static Object readField(Object object, String fieldName) {

--- a/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
@@ -281,6 +281,16 @@ public final class ReflectionUtil {
         return null;
     }
 
+    /**
+     * Resolves all {@link TypeVariable}s in {@code type} to concrete types as per the type
+     * parameter definitions in {@code contextType}. All {@link TypeVariable}s in {@code type}
+     * should have been declared in {@code contextType} or one of its supertypes, otherwise an error
+     * will be thrown.
+     *
+     * @param contextType The {@link Type} which contains all type parameter definitions used in {@code type}.
+     * @param type The {@link Type} whose {@link TypeVariable}s are to be resolved.
+     * @return A copy of {@code type} with all {@link TypeVariable}s resolved.
+     */
     public static Type resolveType(Type contextType, Type type) {
         Class<?> contextClass = getClassOfType(contextType);
 

--- a/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/utilities/ReflectionUtil.java
@@ -281,6 +281,7 @@ public final class ReflectionUtil {
     public static Type resolveFieldType(Type classType, Type fieldType) {
         Class<?> classClass = getClassOfType(classType);
 
+        // T field;
         if (fieldType instanceof TypeVariable<?>) {
             TypeVariable<?> typeVariable = (TypeVariable<?>) fieldType;
 
@@ -301,6 +302,26 @@ public final class ReflectionUtil {
                 return getTypeParameterForSuper(classType, declaringClass, typeParameterIndex);
             }
             return getTypeParameter(classType, typeParameterIndex);
+        }
+
+        // T[] field || List<T>[] field;
+        if (fieldType instanceof GenericArrayType) {
+            GenericArrayType arrayType = (GenericArrayType) fieldType;
+
+            Type componentType = arrayType.getGenericComponentType();
+            Type resolvedComponentType = resolveFieldType(classType, componentType);
+
+            if (resolvedComponentType == componentType) {
+                return fieldType;
+            } else {
+                return new GenericArrayType() {
+                    final Type genericComponentType = resolvedComponentType;
+                    @Override
+                    public Type getGenericComponentType() {
+                        return genericComponentType;
+                    }
+                };
+            }
         }
 
         return fieldType;


### PR DESCRIPTION
This PR adds a number of additional TypeHandlers and TypeHandlerFactories to the engine for added functionality.

`TypeHandler`/`TypeHandlerFactory` | Description
--- | ---
`ObjectFieldMapTypeHandler` (and Factory) | Serializes objects as a fieldName -> fieldValue map. Used as the last resort. Replaces `MappedContainerTypeHandler` and makes `@MappedContainer` redundant.
`AssetTypeHandlerFactory` | Generates an `AssetTypeHandler` for each `T extends Asset` so that they do not need to be manually registered.
`RuntimeDelegatingTypeHandler` | Delegates serialization of a value to its runtime type if needed. Used in cases where a subclass instance is referred to as a supertype. Meant for internal use only, and is used in `Collection`, `Map`, and object as a field map serialization.

Minor changes:
- Add `ReflectionUtil.resolveType`
- Resolve types in `ReflectionUtil.getTypeParameterForSuper`
- Use `ReflectionUtil.getTypeParameterForSuper` in `Collection` and `StringMap` type handlers.