### PR TITLE
Improvements for UIImageSlideshow widget

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -99,7 +99,7 @@ public class SelectGameScreen extends SelectionScreen {
             if (gameInfo != null) {
                 final GameDetailsScreen detailsScreen = getManager().createScreen(GameDetailsScreen.ASSET_URI, GameDetailsScreen.class);
                 detailsScreen.setGameInfo(gameInfo);
-                detailsScreen.setPreviewImage(previewImage.getImage());
+                detailsScreen.setPreviews(previewSlideshow.getImages());
                 getManager().pushScreen(detailsScreen);
             }
         });

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectionScreen.java
@@ -30,9 +30,9 @@ import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
-import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
+import org.terasology.rendering.nui.widgets.UIImageSlideshow;
 import org.terasology.utilities.Assets;
 import org.terasology.utilities.FilesUtil;
 
@@ -52,7 +52,7 @@ public abstract class SelectionScreen extends CoreScreenLayer {
 
     private static final Logger logger = LoggerFactory.getLogger(SelectionScreen.class);
 
-    protected UIImage previewImage;
+    protected UIImageSlideshow previewSlideshow;
 
     @In
     protected Config config;
@@ -75,21 +75,21 @@ public abstract class SelectionScreen extends CoreScreenLayer {
         super.onOpened();
     }
 
-    void updateDescription(GameInfo item) {
-        if (item == null) {
+    void updateDescription(final GameInfo gameInfo) {
+        if (gameInfo == null) {
             worldGenerator.setText("");
             moduleNames.setText("");
             loadPreviewImage(null);
             return;
         }
 
-        final String mainWorldGenerator = item.getManifest()
+        final String mainWorldGenerator = gameInfo.getManifest()
                 .getWorldInfo(TerasologyConstants.MAIN_WORLD)
                 .getWorldGenerator()
                 .getObjectName()
                 .toString();
 
-        final String commaSeparatedModules = item.getManifest()
+        final String commaSeparatedModules = gameInfo.getManifest()
                 .getModules()
                 .stream()
                 .map(NameVersion::getName)
@@ -100,15 +100,15 @@ public abstract class SelectionScreen extends CoreScreenLayer {
         worldGenerator.setText(mainWorldGenerator);
         moduleNames.setText(commaSeparatedModules.length() > MODULES_LINE_LIMIT ? commaSeparatedModules.substring(0, MODULES_LINE_LIMIT) + "..." : commaSeparatedModules);
 
-        loadPreviewImage(item);
+        loadPreviewImage(gameInfo);
     }
 
-    private void loadPreviewImage(GameInfo item) {
+    private void loadPreviewImage(final GameInfo gameInfo) {
         Texture texture;
-        if (item != null && item.getPreviewImage() != null) {
+        if (gameInfo != null && gameInfo.getPreviewImage() != null) {
             TextureData textureData = null;
             try {
-                textureData = AWTTextureFormat.convertToTextureData(item.getPreviewImage(), Texture.FilterMode.LINEAR);
+                textureData = AWTTextureFormat.convertToTextureData(gameInfo.getPreviewImage(), Texture.FilterMode.LINEAR);
             } catch (IOException e) {
                 logger.error("Converting preview image to texture data {} failed", e);
             }
@@ -116,8 +116,8 @@ public abstract class SelectionScreen extends CoreScreenLayer {
         } else {
             texture = Assets.getTexture(DEFAULT_PREVIEW_IMAGE_URI).get();
         }
-
-        previewImage.setImage(texture);
+        previewSlideshow.clean();
+        previewSlideshow.addImage(texture);
     }
 
     protected void remove(final UIList<GameInfo> gameList, Path world, String removeString) {
@@ -146,10 +146,10 @@ public abstract class SelectionScreen extends CoreScreenLayer {
     private boolean initScreenWidgets() {
         worldGenerator = find("worldGenerator", UILabel.class);
         moduleNames = find("moduleNames", UILabel.class);
-        previewImage = find("previewImage", UIImage.class);
+        previewSlideshow = find("previewImage", UIImageSlideshow.class);
         gameInfos = find("gameList", UIList.class);
-        if (worldGenerator == null || moduleNames == null || gameInfos == null || previewImage == null) {
-            logger.error("Screen can't be initialized correctly, because required widgets are missed!\nworldGenerator = {}, moduleNames = {}, previewImage = {}, gameList = {}", worldGenerator, moduleNames, previewImage, gameInfos);
+        if (worldGenerator == null || moduleNames == null || gameInfos == null || previewSlideshow == null) {
+            logger.error("Screen can't be initialized correctly, because required widgets are missed!\nworldGenerator = {}, moduleNames = {}, previewSlideshow = {}, gameList = {}", worldGenerator, moduleNames, previewSlideshow, gameInfos);
             return false;
         }
         return true;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -35,7 +35,6 @@ import org.terasology.module.ResolutionResult;
 import org.terasology.naming.Name;
 import org.terasology.naming.NameVersion;
 import org.terasology.registry.In;
-import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
@@ -49,11 +48,12 @@ import org.terasology.rendering.nui.layers.mainMenu.moduleDetailsScreen.ModuleDe
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layouts.ScrollableArea;
 import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
 import org.terasology.rendering.nui.widgets.UITabBox;
 import org.terasology.rendering.nui.widgets.UIText;
-import org.terasology.rendering.nui.widgets.slideshow.UITimedImageSlideshow;
+import org.terasology.rendering.nui.widgets.UIImageSlideshow;
 import org.terasology.utilities.time.DateTimeHelper;
 import org.terasology.world.biomes.Biome;
 import org.terasology.world.biomes.BiomeManager;
@@ -103,6 +103,7 @@ public class GameDetailsScreen extends CoreScreenLayer {
     private Map<String, List<String>> blockFamilyIds;
     private List<String> errors;
     private UIButton openModuleDetails;
+    private UIImageSlideshow previewSlideshow;
 
     @Override
     public void initialise() {
@@ -118,14 +119,17 @@ public class GameDetailsScreen extends CoreScreenLayer {
         worldDescription = find("worldDescription", ScrollableArea.class);
         descriptionContainer = find("descriptionContainer", ScrollableArea.class);
         openModuleDetails = find("openModuleDetails", UIButton.class);
+        previewSlideshow = find("preview", UIImageSlideshow.class);
 
         if (descriptionContainer != null && worldDescription != null && descriptionTitle != null &&
-                gameModules != null && gameWorlds != null && biomes != null && blocks != null && openModuleDetails != null) {
+                gameModules != null && gameWorlds != null && biomes != null && blocks != null && openModuleDetails != null ||
+                previewSlideshow != null) {
 
             setUpGameModules();
             setUpGameWorlds();
             setUpBlocks();
             setUpBiomes();
+            setUpPreviewSlideshow();
 
             openModuleDetails.subscribe(button -> openModuleDetailsScreen());
 
@@ -276,6 +280,31 @@ public class GameDetailsScreen extends CoreScreenLayer {
             descriptionContainer.setVisible(false);
             worldDescription.setVisible(true);
         });
+    }
+
+    private void setUpPreviewSlideshow() {
+        tryFind("slideLeft", UIButton.class).ifPresent(
+                slideLeft -> {
+                    slideLeft.subscribe(b -> previewSlideshow.prevImage());
+                    slideLeft.bindEnabled(new ReadOnlyBinding<Boolean>() {
+                        @Override
+                        public Boolean get() {
+                            return previewSlideshow.getImages().size() > 1;
+                        }
+                    });
+                }
+        );
+        tryFind("slideRight", UIButton.class).ifPresent(
+                slideRight -> {
+                    slideRight.subscribe(b -> previewSlideshow.nextImage());
+                    slideRight.bindEnabled(new ReadOnlyBinding<Boolean>() {
+                        @Override
+                        public Boolean get() {
+                            return previewSlideshow.getImages().size() > 1;
+                        }
+                    });
+                }
+        );
     }
 
     private void setUpGameModules() {
@@ -519,10 +548,10 @@ public class GameDetailsScreen extends CoreScreenLayer {
         this.gameInfo = gameInfo;
     }
 
-    public void setPreviewImage(TextureRegion texture) {
-        UITimedImageSlideshow slider = find("preview", UITimedImageSlideshow.class);
-        if (slider != null) {
-            slider.addImage(texture);
+    public void setPreviews(final List<UIImage> textures) {
+        if (textures != null && !textures.isEmpty()) {
+            previewSlideshow.clean();
+            textures.forEach(previewSlideshow::addImage);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -122,7 +122,7 @@ public class GameDetailsScreen extends CoreScreenLayer {
         previewSlideshow = find("preview", UIImageSlideshow.class);
 
         if (descriptionContainer != null && worldDescription != null && descriptionTitle != null &&
-                gameModules != null && gameWorlds != null && biomes != null && blocks != null && openModuleDetails != null ||
+                gameModules != null && gameWorlds != null && biomes != null && blocks != null && openModuleDetails != null &&
                 previewSlideshow != null) {
 
             setUpGameModules();
@@ -548,10 +548,10 @@ public class GameDetailsScreen extends CoreScreenLayer {
         this.gameInfo = gameInfo;
     }
 
-    public void setPreviews(final List<UIImage> textures) {
-        if (textures != null && !textures.isEmpty()) {
+    public void setPreviews(final List<UIImage> images) {
+        if (images != null && !images.isEmpty()) {
             previewSlideshow.clean();
-            textures.forEach(previewSlideshow::addImage);
+            images.forEach(previewSlideshow::addImage);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImageSlideshow.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImageSlideshow.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.widgets.slideshow;
+package org.terasology.rendering.nui.widgets;
 
 import org.terasology.math.geom.Vector2i;
 import org.terasology.rendering.assets.texture.TextureRegion;
@@ -29,15 +29,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This widget displays images in sequence in an image slideshow. Switching images automatically after a time period.
+ * This widget displays images in sequence in an image slideshow.
+ * Switching images automatically after a time period or manually.
  */
-public class UITimedImageSlideshow extends CoreWidget {
+public class UIImageSlideshow extends CoreWidget {
 
     private Binding<UIWidget> currentImage = new DefaultBinding<>();
     private List<UIImage> images = new ArrayList<>();
     private boolean active = true;
-    private float imageDisplayTime = 0f;
     private int index = 0;
+    private float imageDisplayTime = 0f;
 
     /**
      * Speed of slideshow (in seconds).
@@ -51,41 +52,16 @@ public class UITimedImageSlideshow extends CoreWidget {
     @LayoutConfig
     private boolean infinite = true;
 
+    /**
+     * Whether the slideshow automatically switch images.
+     */
+    @LayoutConfig
+    private boolean auto = true;
+
     @Override
     public void onDraw(Canvas canvas) {
         if (currentImage.get() != null) {
             currentImage.get().onDraw(canvas);
-        }
-    }
-
-    @Override
-    public void update(float delta) {
-        if (isActive()) {
-            imageDisplayTime += delta;
-            if (imageDisplayTime >= speed) {
-                imageDisplayTime = 0f;
-                nextImage();
-            }
-        }
-        super.update(delta);
-    }
-
-    private void nextImage() {
-        int size = images.size();
-        int prevIndex = index;
-        if (size > 0) {
-            if (index == size - 1) {
-                if (infinite) {
-                    index = 0;
-                } else {
-                    stop();
-                }
-            } else {
-                index++;
-            }
-            if (prevIndex != index) {
-                currentImage.set(images.get(index));
-            }
         }
     }
 
@@ -95,6 +71,18 @@ public class UITimedImageSlideshow extends CoreWidget {
             return currentImage.get().getPreferredContentSize(canvas, sizeHint);
         }
         return Vector2i.zero();
+    }
+
+    @Override
+    public void update(float delta) {
+        if (auto && active) {
+            imageDisplayTime += delta;
+            if (imageDisplayTime >= speed) {
+                imageDisplayTime = 0f;
+                nextImage();
+            }
+        }
+        super.update(delta);
     }
 
     /**
@@ -128,22 +116,73 @@ public class UITimedImageSlideshow extends CoreWidget {
         images = new ArrayList<>();
     }
 
-    protected boolean isActive() {
-        return active;
-    }
-
     /**
-     * Starts the slideshow.
+     * Starts automatic slideshow.
      */
     public void start() {
         active = true;
     }
 
     /**
-     * Stops the slideshow.
+     * Stops automatic slideshow.
      */
     public void stop() {
         active = false;
     }
 
+    /**
+     * Switches to next image of list.
+     */
+    public void nextImage() {
+        int size = images.size();
+        int prevIndex = index;
+        if (size > 0) {
+            if (index == size - 1) {
+                if (infinite) {
+                    index = 0;
+                } else {
+                    stop();
+                }
+            } else {
+                index++;
+            }
+            if (prevIndex != index) {
+                currentImage.set(images.get(index));
+            }
+        }
+    }
+
+    /**
+     * Switches to previous image of list.
+     */
+    public void prevImage() {
+        int size = images.size();
+        int prevIndex = index;
+        if (size > 0) {
+            if (index == 0) {
+                if (infinite) {
+                    index = size - 1;
+                } else {
+                    stop();
+                }
+            } else {
+                index--;
+            }
+            if (prevIndex != index) {
+                currentImage.set(images.get(index));
+            }
+        }
+    }
+
+    public float getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(float speed) {
+        this.speed = speed;
+    }
+
+    public List<UIImage> getImages() {
+        return images;
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImageSlideshow.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImageSlideshow.java
@@ -20,10 +20,6 @@ import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreWidget;
 import org.terasology.rendering.nui.LayoutConfig;
-import org.terasology.rendering.nui.UIWidget;
-import org.terasology.rendering.nui.databinding.Binding;
-import org.terasology.rendering.nui.databinding.DefaultBinding;
-import org.terasology.rendering.nui.widgets.UIImage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,11 +30,16 @@ import java.util.List;
  */
 public class UIImageSlideshow extends CoreWidget {
 
-    private Binding<UIWidget> currentImage = new DefaultBinding<>();
-    private List<UIImage> images = new ArrayList<>();
+    private UIImage currentImage;
     private boolean active = true;
     private int index = 0;
     private float imageDisplayTime = 0f;
+
+    /**
+     * List of images to show.
+     */
+    @LayoutConfig
+    private List<UIImage> images = new ArrayList<>();
 
     /**
      * Speed of slideshow (in seconds).
@@ -60,15 +61,15 @@ public class UIImageSlideshow extends CoreWidget {
 
     @Override
     public void onDraw(Canvas canvas) {
-        if (currentImage.get() != null) {
-            currentImage.get().onDraw(canvas);
+        if (currentImage != null) {
+            currentImage.onDraw(canvas);
         }
     }
 
     @Override
     public Vector2i getPreferredContentSize(Canvas canvas, Vector2i sizeHint) {
-        if (currentImage.get() != null) {
-            return currentImage.get().getPreferredContentSize(canvas, sizeHint);
+        if (currentImage != null) {
+            return currentImage.getPreferredContentSize(canvas, sizeHint);
         }
         return Vector2i.zero();
     }
@@ -92,8 +93,8 @@ public class UIImageSlideshow extends CoreWidget {
      */
     public void addImage(final UIImage image) {
         images.add(image);
-        if (currentImage.get() == null) {
-            currentImage.set(images.get(index));
+        if (currentImage == null) {
+            currentImage = images.get(index);
         }
     }
 
@@ -112,7 +113,7 @@ public class UIImageSlideshow extends CoreWidget {
     public void clean() {
         index = 0;
         imageDisplayTime = 0f;
-        currentImage.set(null);
+        currentImage = null;
         images = new ArrayList<>();
     }
 
@@ -147,7 +148,7 @@ public class UIImageSlideshow extends CoreWidget {
                 index++;
             }
             if (prevIndex != index) {
-                currentImage.set(images.get(index));
+                currentImage = images.get(index);
             }
         }
     }
@@ -169,7 +170,7 @@ public class UIImageSlideshow extends CoreWidget {
                 index--;
             }
             if (prevIndex != index) {
-                currentImage.set(images.get(index));
+                currentImage = images.get(index);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImageSlideshow.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImageSlideshow.java
@@ -30,7 +30,6 @@ import java.util.List;
  */
 public class UIImageSlideshow extends CoreWidget {
 
-    private UIImage currentImage;
     private boolean active = true;
     private int index = 0;
     private float imageDisplayTime = 0f;
@@ -61,15 +60,15 @@ public class UIImageSlideshow extends CoreWidget {
 
     @Override
     public void onDraw(Canvas canvas) {
-        if (currentImage != null) {
-            currentImage.onDraw(canvas);
+        if (images.get(index) != null) {
+            images.get(index).onDraw(canvas);
         }
     }
 
     @Override
     public Vector2i getPreferredContentSize(Canvas canvas, Vector2i sizeHint) {
-        if (currentImage != null) {
-            return currentImage.getPreferredContentSize(canvas, sizeHint);
+        if (images.get(index) != null) {
+            return images.get(index).getPreferredContentSize(canvas, sizeHint);
         }
         return Vector2i.zero();
     }
@@ -92,9 +91,8 @@ public class UIImageSlideshow extends CoreWidget {
      * @param image the image to show.
      */
     public void addImage(final UIImage image) {
-        images.add(image);
-        if (currentImage == null) {
-            currentImage = images.get(index);
+        if (image != null) {
+            images.add(image);
         }
     }
 
@@ -113,7 +111,6 @@ public class UIImageSlideshow extends CoreWidget {
     public void clean() {
         index = 0;
         imageDisplayTime = 0f;
-        currentImage = null;
         images = new ArrayList<>();
     }
 
@@ -136,7 +133,6 @@ public class UIImageSlideshow extends CoreWidget {
      */
     public void nextImage() {
         int size = images.size();
-        int prevIndex = index;
         if (size > 0) {
             if (index == size - 1) {
                 if (infinite) {
@@ -147,9 +143,6 @@ public class UIImageSlideshow extends CoreWidget {
             } else {
                 index++;
             }
-            if (prevIndex != index) {
-                currentImage = images.get(index);
-            }
         }
     }
 
@@ -158,7 +151,6 @@ public class UIImageSlideshow extends CoreWidget {
      */
     public void prevImage() {
         int size = images.size();
-        int prevIndex = index;
         if (size > 0) {
             if (index == 0) {
                 if (infinite) {
@@ -168,9 +160,6 @@ public class UIImageSlideshow extends CoreWidget {
                 }
             } else {
                 index--;
-            }
-            if (prevIndex != index) {
-                currentImage = images.get(index);
             }
         }
     }

--- a/engine/src/main/resources/assets/skins/default.skin
+++ b/engine/src/main/resources/assets/skins/default.skin
@@ -79,7 +79,7 @@
         "UIImage": {
             "texture-scale-mode": "scale fit"
         },
-        "UITimedImageSlideshow": {
+        "UIImageSlideshow": {
             "texture-scale-mode": "scale fit"
         },
         "RowLayout": {

--- a/engine/src/main/resources/assets/skins/framed_image.skin
+++ b/engine/src/main/resources/assets/skins/framed_image.skin
@@ -16,7 +16,7 @@
                 "right": 4
             }
         },
-        "UITimedImageSlideshow": {
+        "UIImageSlideshow": {
             "background": "engine:box",
             "background-border": {
                 "top": 4,

--- a/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
@@ -82,7 +82,7 @@
                                 },
                                 "contents": [
                                     {
-                                        "type": "UITimedImageSlideshow",
+                                        "type": "UIImageSlideshow",
                                         "id": "preview",
                                         "skin": "framed_image",
                                         "layoutInfo": {
@@ -90,6 +90,33 @@
                                             "position-horizontal-center": {},
                                             "position-top": {
                                                 "target": "TOP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "RowLayout",
+                                        "id": "sliderActions",
+                                        "horizontalSpacing": 8,
+                                        "contents": [
+                                            {
+                                                "type": "UIButton",
+                                                "text": "Prev",
+                                                "id": "slideLeft"
+                                            },
+                                            {
+                                                "type": "UIButton",
+                                                "text": "Next",
+                                                "id": "slideRight"
+                                            }
+                                        ],
+                                        "layoutInfo": {
+                                            "width": 400,
+                                            "height": 32,
+                                            "position-horizontal-center": {},
+                                            "position-bottom": {
+                                                "target": "BOTTOM",
+                                                "widget": "preview",
+                                                "offset": 3
                                             }
                                         }
                                     },
@@ -103,7 +130,7 @@
                                             "position-horizontal-center": {},
                                             "position-top": {
                                                 "target": "BOTTOM",
-                                                "widget": "preview"
+                                                "widget": "sliderActions"
                                             }
                                         }
                                     },

--- a/engine/src/main/resources/assets/ui/menu/selectGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/selectGameScreen.ui
@@ -99,7 +99,7 @@
                         "family": "description",
                         "contents": [
                             {
-                                "type": "UIImage",
+                                "type": "UIImageSlideshow",
                                 "skin": "framed_image",
                                 "id": "previewImage",
                                 "layoutInfo": {


### PR DESCRIPTION
### Contains

I redid slideshow widget, now images can be switched manually or by time period, or even both methods.

### How to test

_GameDetailsScreen.java_
```
    public void setPreviews(final List<UIImage> textures) {
        if (textures != null && !textures.isEmpty()) {
            previewSlideshow.clean();
            textures.forEach(previewSlideshow::addImage);

            // ADD RANDOM IMAGES
            previewSlideshow.addImage(Assets.getTexture("engine:defaultPreview").get());
            previewSlideshow.addImage(Assets.getTexture("engine:default").get());
            previewSlideshow.addImage(Assets.getTexture("engine:char").get());
            previewSlideshow.addImage(Assets.getTexture("engine:openbook").get());
        }
    }
```
![PIC](https://i.gyazo.com/f373df1f90f63b376e1ab1efcc9393b4.png)

### Outstanding before merging

Nothing.