### PR TITLE
Creation of a LoadProcess for Record and Replay

### DIFF
--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -104,7 +104,7 @@ public abstract class TerasologyTestingEnvironment {
         context.put(CharacterStateEventPositionMap.class, characterStateEventPositionMap);
         DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
         context.put(DirectionAndOriginPosRecorderList.class, directionAndOriginPosRecorderList);
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(engineEntityManager, recordedEventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(engineEntityManager, recordedEventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList, moduleManager.getEnvironment());
         context.put(RecordAndReplaySerializer.class, recordAndReplaySerializer);
 
         Path savePath = PathManager.getInstance().getSavePath("world1");

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -118,7 +118,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         recordAndReplayUtils = new RecordAndReplayUtils();
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
         DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
-        recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
+        recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList, moduleEnvironment);
         recordAndReplayCurrentStatus = context.get(RecordAndReplayCurrentStatus.class);
 
 

--- a/engine-tests/src/test/java/org/terasology/recording/EventSystemReplayImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/recording/EventSystemReplayImplTest.java
@@ -68,13 +68,12 @@ public class EventSystemReplayImplTest {
         entityManager.setPrefabManager(new PojoPrefabManager(context));
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
-
         recordAndReplayCurrentStatus = new RecordAndReplayCurrentStatus();
         RecordedEventStore eventStore = new RecordedEventStore();
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
         DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, eventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, eventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList, null);
         recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.REPLAYING);
         entity = entityManager.create();
         Long id = entity.getId();

--- a/engine/src/main/java/org/terasology/engine/GameThread.java
+++ b/engine/src/main/java/org/terasology/engine/GameThread.java
@@ -108,6 +108,13 @@ public final class GameThread {
     }
 
     /**
+     * Sets the game thread to null. Should called after a test that calls engine.initialise() is finished.
+     */
+    public static void reset() {
+        gameThread = null;
+    }
+
+    /**
      * A process decorated allowing a thread to block until the process has been run.
      */
     private static class BlockingProcess implements Runnable {

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -130,7 +130,7 @@ public final class EntitySystemSetupUtil {
         CharacterStateEventPositionMap characterStateEventPositionMap = context.get(CharacterStateEventPositionMap.class);
         DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = context.get(DirectionAndOriginPosRecorderList.class);
         RecordedEventStore recordedEventStore = new RecordedEventStore();
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList);
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, recordedEventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList, environment);
         context.put(RecordAndReplaySerializer.class, recordAndReplaySerializer);
 
 

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -36,6 +36,7 @@ import org.terasology.engine.modes.loadProcesses.InitialiseComponentSystemManage
 import org.terasology.engine.modes.loadProcesses.InitialiseEntitySystem;
 import org.terasology.engine.modes.loadProcesses.InitialiseGraphics;
 import org.terasology.engine.modes.loadProcesses.InitialisePhysics;
+import org.terasology.engine.modes.loadProcesses.InitialiseRecordAndReplay;
 import org.terasology.engine.modes.loadProcesses.InitialiseRemoteWorld;
 import org.terasology.engine.modes.loadProcesses.InitialiseSystems;
 import org.terasology.engine.modes.loadProcesses.InitialiseWorld;
@@ -188,6 +189,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new InitialiseBlockTypeEntities(context));
         loadProcesses.add(new CreateWorldEntity(context, gameManifest));
         loadProcesses.add(new InitialiseWorldGenerator(context));
+        loadProcesses.add(new InitialiseRecordAndReplay(context));
         if (netMode.isServer()) {
             boolean dedicated;
             if (netMode == NetworkMode.DEDICATED_SERVER) {

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRecordAndReplay.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRecordAndReplay.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.modes.loadProcesses;
+
+import org.terasology.context.Context;
+import org.terasology.engine.modes.LoadProcess;
+import org.terasology.recording.RecordAndReplayCurrentStatus;
+import org.terasology.recording.RecordAndReplaySerializer;
+import org.terasology.recording.RecordAndReplayStatus;
+
+/**
+ * Initialises Record and Replay if they were selected in the main menu.
+ */
+public class InitialiseRecordAndReplay implements LoadProcess {
+
+    private Context context;
+    private RecordAndReplaySerializer recordAndReplaySerializer;
+    private RecordAndReplayCurrentStatus recordAndReplayCurrentStatus;
+
+    public InitialiseRecordAndReplay(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Initialising Record and Replay...";
+    }
+
+    @Override
+    public boolean step() {
+        //Activate record when the preparations are ready
+        if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_RECORD) {
+            recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.RECORDING);
+        }
+
+        //Activate the replay when the preparations are ready
+        if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_REPLAY) {
+            recordAndReplaySerializer.deserializeRecordAndReplayData();
+            recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.REPLAYING);
+        }
+        return true;
+    }
+
+    @Override
+    public void begin() {
+        this.recordAndReplayCurrentStatus = context.get(RecordAndReplayCurrentStatus.class);
+        this.recordAndReplaySerializer = context.get(RecordAndReplaySerializer.class);
+    }
+
+    @Override
+    public float getProgress() {
+        return 0;
+    }
+
+    @Override
+    public int getExpectedCost() {
+        return 1;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
@@ -18,6 +18,7 @@ package org.terasology.engine.subsystem.headless;
 import org.terasology.assets.AssetFactory;
 import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.context.Context;
+import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.engine.subsystem.RenderingSubsystemFactory;
@@ -89,6 +90,11 @@ public class HeadlessGraphics implements EngineSubsystem {
 
     private void initHeadless(Context context) {
         context.put(ShaderManager.class, new ShaderManagerHeadless());
+    }
+
+    @Override
+    public void postUpdate(GameState currentState, float delta) {
+        currentState.render();
     }
 
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/HeadlessGraphics.java
@@ -18,7 +18,6 @@ package org.terasology.engine.subsystem.headless;
 import org.terasology.assets.AssetFactory;
 import org.terasology.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.context.Context;
-import org.terasology.engine.modes.GameState;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.EngineSubsystem;
 import org.terasology.engine.subsystem.RenderingSubsystemFactory;
@@ -92,9 +91,5 @@ public class HeadlessGraphics implements EngineSubsystem {
         context.put(ShaderManager.class, new ShaderManagerHeadless());
     }
 
-    @Override
-    public void postUpdate(GameState currentState, float delta) {
-        currentState.render();
-    }
 
 }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -23,6 +23,9 @@ import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.recording.RecordAndReplayCurrentStatus;
+import org.terasology.recording.RecordAndReplaySerializer;
+import org.terasology.recording.RecordAndReplayStatus;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
@@ -54,10 +57,14 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     private Vector3i chunkPos = new Vector3i();
 
     private Config config;
+    private RecordAndReplayCurrentStatus recordAndReplayCurrentStatus;
+    private RecordAndReplaySerializer recordAndReplaySerializer;
 
     public HeadlessWorldRenderer(Context context) {
         this.worldProvider = context.get(WorldProvider.class);
         this.chunkProvider = context.get(ChunkProvider.class);
+        this.recordAndReplayCurrentStatus = context.get(RecordAndReplayCurrentStatus.class);
+        this.recordAndReplaySerializer = context.get(RecordAndReplaySerializer.class);
         LocalPlayerSystem localPlayerSystem = context.get(LocalPlayerSystem.class);
         localPlayerSystem.setPlayerCamera(noCamera);
         config = context.get(Config.class);
@@ -126,7 +133,16 @@ public class HeadlessWorldRenderer implements WorldRenderer {
 
     @Override
     public void render(RenderingStage mono) {
-        // TODO Auto-generated method stub
+        //Activate record when the preparations are ready
+        if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_RECORD) {
+            recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.RECORDING);
+        }
+
+        //Activate the replay when the preparations are ready
+        if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_REPLAY) {
+            recordAndReplaySerializer.deserializeRecordAndReplayData();
+            recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.REPLAYING);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -23,9 +23,6 @@ import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
-import org.terasology.recording.RecordAndReplayCurrentStatus;
-import org.terasology.recording.RecordAndReplaySerializer;
-import org.terasology.recording.RecordAndReplayStatus;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
@@ -57,14 +54,10 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     private Vector3i chunkPos = new Vector3i();
 
     private Config config;
-    private RecordAndReplayCurrentStatus recordAndReplayCurrentStatus;
-    private RecordAndReplaySerializer recordAndReplaySerializer;
 
     public HeadlessWorldRenderer(Context context) {
         this.worldProvider = context.get(WorldProvider.class);
         this.chunkProvider = context.get(ChunkProvider.class);
-        this.recordAndReplayCurrentStatus = context.get(RecordAndReplayCurrentStatus.class);
-        this.recordAndReplaySerializer = context.get(RecordAndReplaySerializer.class);
         LocalPlayerSystem localPlayerSystem = context.get(LocalPlayerSystem.class);
         localPlayerSystem.setPlayerCamera(noCamera);
         config = context.get(Config.class);
@@ -133,16 +126,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
 
     @Override
     public void render(RenderingStage mono) {
-        //Activate record when the preparations are ready
-        if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_RECORD) {
-            recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.RECORDING);
-        }
-
-        //Activate the replay when the preparations are ready
-        if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_REPLAY) {
-            recordAndReplaySerializer.deserializeRecordAndReplayData();
-            recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.REPLAYING);
-        }
+        // TODO Auto-generated method stub
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/recording/EventSystemReplayImpl.java
+++ b/engine/src/main/java/org/terasology/recording/EventSystemReplayImpl.java
@@ -114,7 +114,7 @@ public class EventSystemReplayImpl implements EventSystem {
     /** The current Status of Record And Replay */
     private RecordAndReplayCurrentStatus recordAndReplayCurrentStatus;
     /** The position of the last recorded event processed */
-    private long lastRecordedEventPosition;
+    private long lastRecordedEventIndex;
 
 
     public EventSystemReplayImpl(EventLibrary eventLibrary, NetworkSystem networkSystem, EngineEntityManager entityManager,
@@ -261,7 +261,7 @@ public class EventSystemReplayImpl implements EventSystem {
             } else {
                 originalSend(entity, re.getEvent());
             }
-            this.lastRecordedEventPosition = re.getPosition();
+            this.lastRecordedEventIndex = re.getIndex();
             // Check if time is up.
             if ((System.currentTimeMillis() - beginTime) >= maxDuration) {
                 return;
@@ -580,8 +580,8 @@ public class EventSystemReplayImpl implements EventSystem {
         return result;
     }
 
-    public long getLastRecordedEventPosition() {
-        return lastRecordedEventPosition;
+    public long getLastRecordedEventIndex() {
+        return lastRecordedEventIndex;
     }
 
     private static class EventHandlerPriorityComparator implements Comparator<EventSystemReplayImpl.EventHandlerInfo> {

--- a/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.module.ModuleEnvironment;
 
 import java.io.FileWriter;
 import java.io.FileReader;
@@ -51,15 +52,17 @@ public final class RecordAndReplaySerializer {
     private RecordAndReplayUtils recordAndReplayUtils;
     private CharacterStateEventPositionMap characterStateEventPositionMap;
     private DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList;
+    private RecordedEventSerializer recordedEventSerializer;
 
     public RecordAndReplaySerializer(EntityManager manager, RecordedEventStore store,
                                      RecordAndReplayUtils recordAndReplayUtils, CharacterStateEventPositionMap characterStateEventPositionMap,
-                                     DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList) {
+                                     DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList, ModuleEnvironment moduleEnvironment) {
         this.entityManager = manager;
         this.recordedEventStore = store;
         this.recordAndReplayUtils = recordAndReplayUtils;
         this.characterStateEventPositionMap = characterStateEventPositionMap;
         this.directionAndOriginPosRecorderList = directionAndOriginPosRecorderList;
+        this.recordedEventSerializer = new RecordedEventSerializer(entityManager, moduleEnvironment);
     }
 
     /**
@@ -79,11 +82,10 @@ public final class RecordAndReplaySerializer {
      * @param recordingPath path where the data should be saved.
      */
     public void serializeRecordedEvents(String recordingPath) {
-        RecordedEventSerializer serializer = new RecordedEventSerializer(entityManager);
         String filepath = recordingPath + EVENT_DIR + recordAndReplayUtils.getFileCount() + JSON;
         recordAndReplayUtils.setFileAmount(recordAndReplayUtils.getFileAmount() + 1);
         recordAndReplayUtils.setFileCount(recordAndReplayUtils.getFileCount() + 1);
-        serializer.serializeRecordedEvents(recordedEventStore.popEvents(), filepath);
+        recordedEventSerializer.serializeRecordedEvents(recordedEventStore.popEvents(), filepath);
         logger.info("RecordedEvents Serialization completed!");
     }
 
@@ -104,10 +106,9 @@ public final class RecordAndReplaySerializer {
      * @param recordingPath path where the data was saved.
      */
     void deserializeRecordedEvents(String recordingPath) {
-        RecordedEventSerializer serializer = new RecordedEventSerializer(entityManager);
         String filepath = recordingPath + EVENT_DIR + recordAndReplayUtils.getFileCount() + JSON;
         recordAndReplayUtils.setFileCount(recordAndReplayUtils.getFileCount() + 1);
-        recordedEventStore.setEvents(serializer.deserializeRecordedEvents(filepath));
+        recordedEventStore.setEvents(recordedEventSerializer.deserializeRecordedEvents(filepath));
         logger.info("RecordedEvents Deserialization completed!");
     }
 

--- a/engine/src/main/java/org/terasology/recording/RecordedEvent.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEvent.java
@@ -27,20 +27,20 @@ public class RecordedEvent {
     private Event event;
     private Component component;
     private long timestamp;
-    private long position;
+    private long index;
 
     /**
      *
      * @param entityId Id of the EntityRef which the event was sent against.
      * @param event The event to be recorded.
      * @param timestamp The timestamp in which the event was sent.
-     * @param position The position of the RecordedEvent.
+     * @param index The index of the RecordedEvent.
      */
-    RecordedEvent(long entityId, Event event, long timestamp, long position) {
+    RecordedEvent(long entityId, Event event, long timestamp, long index) {
         this.entityId = entityId;
         this.event = event;
         this.timestamp = timestamp;
-        this.position = position;
+        this.index = index;
     }
 
     /**
@@ -49,14 +49,14 @@ public class RecordedEvent {
      * @param event The event to be recorded.
      * @param component The component that was sent with the event
      * @param timestamp The timestamp in which the event was sent.
-     * @param position The position of the RecordedEvent.
+     * @param index The index of the RecordedEvent.
      */
-    RecordedEvent(long entityId, Event event, Component component, long timestamp, long position) {
+    RecordedEvent(long entityId, Event event, Component component, long timestamp, long index) {
         this.entityId = entityId;
         this.event = event;
         this.component = component;
         this.timestamp = timestamp;
-        this.position = position;
+        this.index = index;
     }
 
 
@@ -65,8 +65,8 @@ public class RecordedEvent {
         return timestamp;
     }
 
-    public long getPosition() {
-        return position;
+    public long getIndex() {
+        return index;
     }
 
     long getEntityId() {

--- a/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
@@ -42,6 +42,7 @@ import org.terasology.logic.characters.events.AttackEvent;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.module.ModuleEnvironment;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -72,7 +73,9 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Serializes and deserializes RecordedEvents.
@@ -83,9 +86,11 @@ class RecordedEventSerializer {
     private static final double DEFAULT_DOUBLE_VALUE = 0.0;
     private TypeSerializationLibrary typeSerializationLibrary;
     private EntityManager entityManager;
+    private ModuleEnvironment moduleEnvironment;
+    private Map<String, Class<? extends InputEvent>> inputEventClassMap;
 
 
-    RecordedEventSerializer(EntityManager entityManager) {
+    RecordedEventSerializer(EntityManager entityManager, ModuleEnvironment moduleEnvironment) {
         ReflectionReflectFactory reflectFactory = new ReflectionReflectFactory();
         CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);
         this.typeSerializationLibrary = TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
@@ -96,6 +101,7 @@ class RecordedEventSerializer {
         typeSerializationLibrary.add(MouseInput.class, new EnumTypeHandler<>(MouseInput.class));
         typeSerializationLibrary.add(MovementMode.class, new EnumTypeHandler<>(MovementMode.class));
         this.entityManager = entityManager;
+        this.moduleEnvironment = moduleEnvironment;
     }
 
     void serializeRecordedEvents(List<RecordedEvent> events, String filePath) {
@@ -324,6 +330,7 @@ class RecordedEventSerializer {
 
     List<RecordedEvent> deserializeRecordedEvents(String path) {
         List<RecordedEvent> events = new ArrayList<>();
+        createInputEventClassMap();
         JsonObject jsonObject;
         try {
             JsonParser parser = new JsonParser();
@@ -345,6 +352,14 @@ class RecordedEventSerializer {
         }
 
         return events;
+    }
+
+    private void createInputEventClassMap() {
+        this.inputEventClassMap = new HashMap<>();
+        Iterable<Class<? extends InputEvent>> classes = moduleEnvironment.getSubtypesOf(InputEvent.class);
+        for (Class<? extends InputEvent> c : classes) {
+            this.inputEventClassMap.put(c.getName(), c);
+        }
     }
 
     private Event deserializeSpecificEventData(JsonObject jsonObject, String className) {
@@ -402,7 +417,7 @@ class RecordedEventSerializer {
     private InputEvent getInputEventSpecificType(JsonObject jsonObject, String className, GsonDeserializationContext deserializationContext) {
         InputEvent newEvent = null;
         try {
-            Class clazz = Class.forName(className);
+            Class clazz = this.inputEventClassMap.get(className);
             if (BindButtonEvent.class.isAssignableFrom(clazz) || BindAxisEvent.class.isAssignableFrom(clazz)) {
                 newEvent = (InputEvent) clazz.getConstructor().newInstance();
             } else if (clazz.equals(KeyDownEvent.class) || clazz.equals(KeyRepeatEvent.class) || clazz.equals(KeyUpEvent.class)) { //KeyEvent

--- a/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
@@ -114,7 +114,7 @@ class RecordedEventSerializer {
                 writer.beginObject();
                 writer.name("entityRef_ID").value(event.getEntityId());
                 writer.name("timestamp").value(event.getTimestamp());
-                writer.name("position").value(event.getPosition());
+                writer.name("index").value(event.getIndex());
                 writer.name("event_class").value(event.getEvent().getClass().getName());
                 writer.name("event_data");
                 writer.beginObject();
@@ -341,10 +341,10 @@ class RecordedEventSerializer {
                 jsonObject = element.getAsJsonObject();
                 String className = jsonObject.get("event_class").getAsString();
                 long refId = jsonObject.get("entityRef_ID").getAsLong();
-                long position = jsonObject.get("position").getAsLong();
+                long index = jsonObject.get("index").getAsLong();
                 long timestamp = jsonObject.get("timestamp").getAsLong();
                 Event event = deserializeSpecificEventData(jsonObject.get("event_data").getAsJsonObject(), className);
-                RecordedEvent re = new RecordedEvent(refId, event, timestamp, position);
+                RecordedEvent re = new RecordedEvent(refId, event, timestamp, index);
                 events.add(re);
             }
         } catch (Exception e) {

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -32,9 +32,6 @@ import org.terasology.logic.players.LocalPlayerSystem;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.recording.RecordAndReplayCurrentStatus;
-import org.terasology.recording.RecordAndReplaySerializer;
-import org.terasology.recording.RecordAndReplayStatus;
 import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
@@ -639,18 +636,6 @@ public final class WorldRendererImpl implements WorldRenderer {
             List<Node> orderedNodes = renderGraph.getNodesInTopologicalOrder();
             renderPipelineTaskList = renderTaskListGenerator.generateFrom(orderedNodes);
             requestedTaskListRefresh = false;
-            RecordAndReplayCurrentStatus recordAndReplayCurrentStatus = context.get(RecordAndReplayCurrentStatus.class);
-            //Activate record when the preparations are ready
-            if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_RECORD) {
-                recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.RECORDING);
-            }
-
-            //Activate the replay when the preparations are ready
-            if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.PREPARING_REPLAY) {
-                RecordAndReplaySerializer recordAndReplaySerializer = context.get(RecordAndReplaySerializer.class);
-                recordAndReplaySerializer.deserializeRecordAndReplayData();
-                recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.REPLAYING);
-            }
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Refactor that removed the Record and Replay initialization from the WorldRendererImpl and put it in a new LoadProcess. This also made it possible to run a replay in a headless client.

### How to test

Replay a recording and everything should work the same way as before.

### Outstanding before merging

- [ ] TestReplayModule wasn't updated yet to support Headless ReplayTests.
- [ ] This PR should be merged after PR 3455