### PR TITLE
Gradle support for JNLua and its natives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,9 +78,12 @@ dependencies {
 
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
     codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.2.0', ext: 'zip'
+
+    // Natives for JNLua (Kallisti, KComputers)
+    natives group: 'org.terasology.jnlua', name: 'jnlua_natives', version: '0.1.0-SNAPSHOT', ext: 'zip'
 }
 
-task extractWindowsNatives(type:Sync) {
+task extractWindowsNatives(type:Copy) {
     description = "Extracts the Windows natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains('-natives-window') ? zipTree(it) : [] }
@@ -89,7 +92,7 @@ task extractWindowsNatives(type:Sync) {
     exclude ('META-INF/**')
 }
 
-task extractMacOSXNatives(type:Sync) {
+task extractMacOSXNatives(type:Copy) {
     description = "Extracts the OSX natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains('-natives-osx') ? zipTree(it) : [] }
@@ -98,7 +101,7 @@ task extractMacOSXNatives(type:Sync) {
     exclude ('META-INF/**')
 }
 
-task extractLinuxNatives(type:Sync) {
+task extractLinuxNatives(type:Copy) {
     description = "Extracts the Linux natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains('-natives-linux') ? zipTree(it) : [] }
@@ -107,11 +110,20 @@ task extractLinuxNatives(type:Sync) {
     exclude ('META-INF/**')
 }
 
+task extractJNLuaNatives(type:Copy) {
+    description = "Extracts the JNLua natives from the downloaded zip"
+    from {
+        configurations.natives.collect { it.getName().contains('jnlua') ? zipTree(it) : [] }
+    }
+    into ("$dirNatives")
+}
+
 task extractNatives {
     description = "Extracts all the native lwjgl libraries from the downloaded zip"
     dependsOn extractWindowsNatives
     dependsOn extractLinuxNatives
     dependsOn extractMacOSXNatives
+    dependsOn extractJNLuaNatives
 }
 
 // TODO: Test meta modules and other libs - not that there's really much to test other than being able to Git via Gradle

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -140,6 +140,7 @@ dependencies {
     compile group: 'org.terasology', name: 'TeraMath', version: '1.4.0'
     compile group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.3.1'
     compile group: 'org.terasology', name: 'splash-screen', version: '1.0.2'
+    compile group: 'org.terasology.jnlua', name: 'JNLua', version: '0.1.0-SNAPSHOT'
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     compile fileTree(dir: 'libs', include: '*.jar')


### PR DESCRIPTION
For @asiekierka's GSOC project. Should allow Kallisti to build as a module which then would allow KComputers to depend on it instead of having to embed it as source. Also should package up JNLua and its natives along with the game zip.

To test: merge this and try `gradlew idea` (which should trigger `extractNatives`)

https://github.com/MovingBlocks/JNLua/pull/2 included the part to deal with natives in Jenkins. Two jobs are now involved:

* http://jenkins.terasology.org/job/JNLua/ - builds the jar and Win/Linux natives. Runs on a Debian builder node I prepared manually. We should be able to automate that or just make a snapshot to restore as needed
* http://jenkins.terasology.org/job/JNLua_Mac/ - builds Mac natives then zips all of them and publishes to Artifactory. Runs on my Mac - the job will trigger after the first one finishes, but queue waiting for the Mac to become available. That's nice and visible in Jenkins so I should notice (or be poked if needed)

After this is merged we can build module-Kallisti then make KComputers depend on it.

Only remaining todo will be #3444 until we sort out the sandbox. Not sure if we also need some whitelisting but atm that won't be enough so gotta turn security permissive for now