### PR TITLE
Reduce memory allocations

### DIFF
--- a/engine-tests/src/test/java/org/terasology/math/RotationTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/RotationTest.java
@@ -82,7 +82,7 @@ public class RotationTest {
     public void testReverseRotation() {
         for (Rotation rotation : Rotation.allValues()) {
             Rotation reverseRotation = Rotation.findReverse(rotation);
-            for (Side side : Side.values()) {
+            for (Side side : Side.getAllSides()) {
                 assertEquals(side, reverseRotation.rotate(rotation.rotate(side)));
             }
         }

--- a/engine-tests/src/test/java/org/terasology/math/SideTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/SideTest.java
@@ -25,7 +25,7 @@ public class SideTest {
 
     @Test
     public void testSideInDirection() {
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             assertEquals(side, Side.inDirection(side.getVector3i().x, side.getVector3i().y, side.getVector3i().z));
         }
     }

--- a/engine/src/main/java/org/terasology/math/Side.java
+++ b/engine/src/main/java/org/terasology/math/Side.java
@@ -21,6 +21,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 
 import java.util.EnumMap;
+import java.util.EnumSet;
 
 /**
  * The six sides of a block and a slew of related utility.
@@ -36,6 +37,8 @@ public enum Side {
     RIGHT(new Vector3i(1, 0, 0), false, true, true),
     FRONT(new Vector3i(0, 0, -1), true, true, false),
     BACK(new Vector3i(0, 0, 1), true, true, false);
+
+    private static final EnumSet<Side> ALL_SIDES = EnumSet.allOf(Side.class);
 
     private static final EnumMap<Side, Side> reverseMap;
     private static final ImmutableList<Side> horizontalSides;
@@ -183,6 +186,17 @@ public enum Side {
             return (x > 0) ? RIGHT : LEFT;
         }
         return (z > 0) ? BACK : FRONT;
+    }
+
+    /**
+     * This provides a static EnumSet of all Sides defined in the enumeration. The result contains the same values as
+     * calling {@code Side#values} but this does not create a new copy on every call.
+     * <br/>
+     * <b>Warning:</b> Do not change the content of the returned enum set! It will be reflected on all calls to this method.
+     * @return All available sides
+     */
+    public static EnumSet<Side> getAllSides() {
+        return ALL_SIDES;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -35,7 +35,6 @@ import java.util.Map;
 public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(BlockMeshGeneratorSingleShape.class);
-    private static final Side[] BLOCK_SIDES = Side.values();
 
     private Block block;
     private Mesh mesh;
@@ -67,7 +66,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
         // Gather adjacent blocks
         Map<Side, Block> adjacentBlocks = Maps.newEnumMap(Side.class);
-        for (Side side : BLOCK_SIDES) {
+        for (Side side : Side.getAllSides()) {
             Vector3i offset = side.getVector3i();
             Block blockToCheck = view.getBlock(x + offset.x, y + offset.y, z + offset.z);
             adjacentBlocks.put(side, blockToCheck);
@@ -98,7 +97,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
         boolean[] drawDir = new boolean[6];
 
-        for (Side side : BLOCK_SIDES) {
+        for (Side side : Side.getAllSides()) {
             drawDir[side.ordinal()] = blockAppearance.getPart(BlockPart.fromSide(side)) != null && isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side);
         }
 
@@ -122,7 +121,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             drawDir[Side.TOP.ordinal()] |= !blockToCheck.isLiquid();
 
             if (bottomBlock.isLiquid() || bottomBlock.getMeshGenerator() == null) {
-                for (Side dir : BLOCK_SIDES) {
+                for (Side dir : Side.getAllSides()) {
                     if (drawDir[dir.ordinal()]) {
                         Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(dir), selfBiome);
                         selfBlock.getLoweredLiquidMesh(dir).appendTo(chunkMesh, x, y, z, colorOffset, renderType, vertexFlag);
@@ -132,7 +131,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             }
         }
 
-        for (Side dir : BLOCK_SIDES) {
+        for (Side dir : Side.getAllSides()) {
             if (drawDir[dir.ordinal()]) {
                 Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(dir), selfBiome);
                 // TODO: Needs review since the new per-vertex flags introduce a lot of special scenarios - probably a per-side setting?

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -33,7 +33,9 @@ import org.terasology.world.block.shapes.BlockMeshPart;
 import java.util.Map;
 
 public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
+
     private static final Logger logger = LoggerFactory.getLogger(BlockMeshGeneratorSingleShape.class);
+    private static final Side[] BLOCK_SIDES = Side.values();
 
     private Block block;
     private Mesh mesh;
@@ -65,7 +67,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
         // Gather adjacent blocks
         Map<Side, Block> adjacentBlocks = Maps.newEnumMap(Side.class);
-        for (Side side : Side.values()) {
+        for (Side side : BLOCK_SIDES) {
             Vector3i offset = side.getVector3i();
             Block blockToCheck = view.getBlock(x + offset.x, y + offset.y, z + offset.z);
             adjacentBlocks.put(side, blockToCheck);
@@ -96,7 +98,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
         boolean[] drawDir = new boolean[6];
 
-        for (Side side : Side.values()) {
+        for (Side side : BLOCK_SIDES) {
             drawDir[side.ordinal()] = blockAppearance.getPart(BlockPart.fromSide(side)) != null && isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side);
         }
 
@@ -120,7 +122,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             drawDir[Side.TOP.ordinal()] |= !blockToCheck.isLiquid();
 
             if (bottomBlock.isLiquid() || bottomBlock.getMeshGenerator() == null) {
-                for (Side dir : Side.values()) {
+                for (Side dir : BLOCK_SIDES) {
                     if (drawDir[dir.ordinal()]) {
                         Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(dir), selfBiome);
                         selfBlock.getLoweredLiquidMesh(dir).appendTo(chunkMesh, x, y, z, colorOffset, renderType, vertexFlag);
@@ -130,7 +132,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             }
         }
 
-        for (Side dir : Side.values()) {
+        for (Side dir : BLOCK_SIDES) {
             if (drawDir[dir.ordinal()]) {
                 Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(dir), selfBiome);
                 // TODO: Needs review since the new per-vertex flags introduce a lot of special scenarios - probably a per-side setting?

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
@@ -109,7 +109,7 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
     }
 
     private void processUpdateForBlockLocation(Vector3i blockLocation) {
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             Vector3i neighborLocation = new Vector3i(blockLocation);
             neighborLocation.add(side.getVector3i());
             if (worldProvider.isBlockRelevant(neighborLocation)) {

--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -69,7 +69,7 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
             blockMap.put(Side.BOTTOM, block);
         }
 
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             Block block = blockMap.get(side);
             if (block != null) {
                 blocks.put(side, block);

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
@@ -201,14 +201,14 @@ public class BlockBuilder implements BlockBuilderHelper {
     }
 
     private void setBlockFullSides(Block block, BlockShape shape, Rotation rot) {
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             BlockPart targetPart = BlockPart.fromSide(rot.rotate(side));
             block.setFullSide(targetPart.getSide(), shape.isBlockingSide(side));
         }
     }
 
     private void applyLoweredShape(Block block, BlockShape shape, Map<BlockPart, BlockTile> tiles) {
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             BlockPart part = BlockPart.fromSide(side);
             BlockTile blockTile = tiles.get(part);
             if (blockTile != null) {

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
@@ -73,7 +73,7 @@ public class BlockShapeImpl extends BlockShape {
         for (BlockPart part : BlockPart.values()) {
             this.meshParts.put(part, data.getMeshPart(part));
         }
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             this.fullSide.put(side, data.isBlockingSide(side));
         }
         this.baseCollisionShape = data.getCollisionShape();

--- a/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
@@ -62,7 +62,7 @@ public class AttachSupportRequired implements BlockStructuralSupport {
         final AttachSupportRequiredComponent component = getComponent(location, blockOverrides);
         if (component != null) {
             final Block block = getBlockWithOverrides(location, blockOverrides);
-            for (Side side : Side.values()) {
+            for (Side side : Side.getAllSides()) {
                 if (hasRequiredSupportOnSideForBlock(location, side, block)) {
                     return true;
                 }

--- a/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupportSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupportSystem.java
@@ -81,7 +81,7 @@ public class BlockStructuralSupportSystem extends BaseComponentSystem implements
     public void checkForSupportRemoved(OnChangedBlock event, EntityRef entity) {
         PerformanceMonitor.startActivity("StructuralCheck");
         try {
-            for (Side side : Side.values()) {
+            for (Side side : Side.getAllSides()) {
                 validateSupportForBlockOnSide(event.getBlockPosition(), side);
             }
         } finally {

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -467,7 +467,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
     private List<Chunk> listAdjacentChunks(Chunk chunk) {
         final Vector3i centerChunkPosition = chunk.getPosition();
         List<Chunk> adjacentChunks = new ArrayList<>(6);
-        for (Side side : Side.values()) {
+        for (Side side : Side.getAllSides()) {
             final Vector3i adjacentChunkPosition = side.getAdjacentPos(centerChunkPosition);
             final Chunk adjacentChunk = chunkCache.get(adjacentChunkPosition);
             if (adjacentChunk != null) {

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -201,8 +201,8 @@ public class StandardBatchPropagator implements BatchPropagator {
         Block block = world.getBlockAt(pos);
         for (Side side : BLOCK_SIDES) {
             byte spreadValue = rules.propagateValue(value, side, block);
-            Vector3i adjPos = side.getAdjacentPos(pos);
             if (rules.canSpreadOutOf(block, side)) {
+                Vector3i adjPos = side.getAdjacentPos(pos);
                 byte adjValue = world.getValueAt(adjPos);
                 if (adjValue < spreadValue && adjValue != PropagatorWorldView.UNAVAILABLE) {
                     Block adjBlock = world.getBlockAt(adjPos);

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -28,7 +28,6 @@ import org.terasology.world.chunks.LitChunk;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Batch propagator that works on a set of changed blocks

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -36,7 +36,6 @@ import java.util.Set;
 public class StandardBatchPropagator implements BatchPropagator {
 
     private static final byte NO_VALUE = 0;
-    private static final Side[] BLOCK_SIDES = Side.values();
 
     private PropagationRules rules;
     private PropagatorWorldView world;
@@ -50,7 +49,7 @@ public class StandardBatchPropagator implements BatchPropagator {
         this.world = world;
         this.rules = rules;
 
-        for (Side side : BLOCK_SIDES) {
+        for (Side side : Side.getAllSides()) {
             Vector3i delta = new Vector3i(side.getVector3i());
             if (delta.x < 0) {
                 delta.x += ChunkConstants.SIZE_X;
@@ -107,7 +106,7 @@ public class StandardBatchPropagator implements BatchPropagator {
             reduce(blockChange.getPosition(), oldValue);
         }
 
-        for (Side side : BLOCK_SIDES) {
+        for (Side side : Side.getAllSides()) {
             PropagationComparison comparison = rules.comparePropagation(blockChange.getTo(), blockChange.getFrom(), side);
             if (comparison.isRestricting() && existingValue > 0) {
                 reduce(blockChange.getPosition(), existingValue);
@@ -159,7 +158,7 @@ public class StandardBatchPropagator implements BatchPropagator {
             world.setValueAt(pos, NO_VALUE);
         }
 
-        for (Side side : BLOCK_SIDES) {
+        for (Side side : Side.getAllSides()) {
             byte expectedValue = rules.propagateValue(oldValue, side, block);
             Vector3i adjPos = side.getAdjacentPos(pos);
             if (rules.canSpreadOutOf(block, side)) {
@@ -198,7 +197,7 @@ public class StandardBatchPropagator implements BatchPropagator {
 
     private void push(Vector3i pos, byte value) {
         Block block = world.getBlockAt(pos);
-        for (Side side : BLOCK_SIDES) {
+        for (Side side : Side.getAllSides()) {
             byte spreadValue = rules.propagateValue(value, side, block);
             if (rules.canSpreadOutOf(block, side)) {
                 Vector3i adjPos = side.getAdjacentPos(pos);

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -28,6 +28,7 @@ import org.terasology.world.chunks.LitChunk;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Batch propagator that works on a set of changed blocks
@@ -36,6 +37,7 @@ import java.util.Set;
 public class StandardBatchPropagator implements BatchPropagator {
 
     private static final byte NO_VALUE = 0;
+    private static final Side[] BLOCK_SIDES = Side.values();
 
     private PropagationRules rules;
     private PropagatorWorldView world;
@@ -49,7 +51,7 @@ public class StandardBatchPropagator implements BatchPropagator {
         this.world = world;
         this.rules = rules;
 
-        for (Side side : Side.values()) {
+        for (Side side : BLOCK_SIDES) {
             Vector3i delta = new Vector3i(side.getVector3i());
             if (delta.x < 0) {
                 delta.x += ChunkConstants.SIZE_X;
@@ -106,7 +108,7 @@ public class StandardBatchPropagator implements BatchPropagator {
             reduce(blockChange.getPosition(), oldValue);
         }
 
-        for (Side side : Side.values()) {
+        for (Side side : BLOCK_SIDES) {
             PropagationComparison comparison = rules.comparePropagation(blockChange.getTo(), blockChange.getFrom(), side);
             if (comparison.isRestricting() && existingValue > 0) {
                 reduce(blockChange.getPosition(), existingValue);
@@ -158,7 +160,7 @@ public class StandardBatchPropagator implements BatchPropagator {
             world.setValueAt(pos, NO_VALUE);
         }
 
-        for (Side side : Side.values()) {
+        for (Side side : BLOCK_SIDES) {
             byte expectedValue = rules.propagateValue(oldValue, side, block);
             Vector3i adjPos = side.getAdjacentPos(pos);
             if (rules.canSpreadOutOf(block, side)) {
@@ -197,7 +199,7 @@ public class StandardBatchPropagator implements BatchPropagator {
 
     private void push(Vector3i pos, byte value) {
         Block block = world.getBlockAt(pos);
-        for (Side side : Side.values()) {
+        for (Side side : BLOCK_SIDES) {
             byte spreadValue = rules.propagateValue(value, side, block);
             Vector3i adjPos = side.getAdjacentPos(pos);
             if (rules.canSpreadOutOf(block, side)) {

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightMerger.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightMerger.java
@@ -89,7 +89,7 @@ public class LightMerger<T> {
 
         for (BatchPropagator propagator : propagators) {
             // Propagate Inwards
-            for (Side side : Side.values()) {
+            for (Side side : Side.getAllSides()) {
                 Vector3i adjChunkPos = side.getAdjacentPos(chunk.getPosition());
                 LitChunk adjChunk = chunkProvider.getChunkUnready(adjChunkPos);
                 if (adjChunk != null) {
@@ -98,7 +98,7 @@ public class LightMerger<T> {
             }
 
             // Propagate Outwards
-            for (Side side : Side.values()) {
+            for (Side side : Side.getAllSides()) {
                 Vector3i adjChunkPos = side.getAdjacentPos(chunk.getPosition());
                 LitChunk adjChunk = chunkProvider.getChunk(adjChunkPos);
                 if (adjChunk != null) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Reduction of memory allocations while playing the game. As result this will lead to fewer garbage collections.  
Found this while recording a view minutes of gameply with Java Mission Control.

### How to test

Run the game with the debug information displayed and compare the memory information.  
Alternatively check the allocations with some profiler.

### Outstanding before merging

Maybe replace all occurences of Sides.values() in the codebase with a static variable?