### PR TITLE
Change InventoryScreen.class so movingItem not lost on exit

### DIFF
--- a/modules/Core/src/main/java/org/terasology/logic/inventory/InventoryUIClientSystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/InventoryUIClientSystem.java
@@ -155,7 +155,14 @@ public class InventoryUIClientSystem extends BaseComponentSystem {
     }
 
     @Override
-    public void postSave() {
+    public void postAutoSave() {
+        EntityRef playerEntity = CoreRegistry.get(LocalPlayer.class).getCharacterEntity();
+        EntityRef movingItem = playerEntity.getComponent(CharacterComponent.class).movingItem;
 
+        EntityRef targetEntity = movingItem;
+        EntityRef fromEntity = playerEntity;
+        int fromSlot = 0;
+
+        CoreRegistry.get(InventoryManager.class).switchItem(fromEntity, getTransferEntity(), fromSlot, targetEntity, 0);
     }
 }

--- a/modules/Core/src/main/java/org/terasology/logic/inventory/InventoryUIClientSystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/inventory/InventoryUIClientSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.logic.inventory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
@@ -24,14 +26,23 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.ButtonState;
 import org.terasology.input.binds.inventory.InventoryButton;
+import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.interactions.InteractionUtil;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.network.ClientComponent;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.ControlWidget;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.layers.ingame.inventory.InventoryCell;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class InventoryUIClientSystem extends BaseComponentSystem {
+
+    private static final Logger logger = LoggerFactory.getLogger(InventoryCell.class);
 
     @In
     private NUIManager nuiManager;
@@ -68,5 +79,83 @@ public class InventoryUIClientSystem extends BaseComponentSystem {
             InteractionUtil.cancelInteractionAsClient(character);
             // do not consume the event, so that the inventory will still open
         }
+    }
+
+
+    /*
+      The numbersBetween() and getTransferEntity() methods were
+      originally in the InventoryCell class. They were copied over
+      to here because they are private functions that the
+      moveItemSmartly() method needs to function. The first section
+      of code in onClosed() is based on the moveItemSmartly() method.
+    */
+    private List<Integer> numbersBetween(int start, int exclusiveEnd) {
+        List<Integer> numbers = new ArrayList<>();
+        for (int number = start; number < exclusiveEnd; number++) {
+            numbers.add(number);
+        }
+        return numbers;
+    }
+
+    private EntityRef getTransferEntity() {
+        return CoreRegistry.get(LocalPlayer.class).getCharacterEntity().getComponent(CharacterComponent.class).movingItem;
+    }
+
+    @Override
+    public void preAutoSave(){
+        /*
+          The code below was originally taken from moveItemSmartly() in
+          InventoryCell.class and slightly modified to work here.
+
+          The way items are being moved to and from the hotbar is really
+          similar to what was needed here to take them out of the transfer
+          slot and sort them into the inventory.
+        */
+        EntityRef playerEntity = CoreRegistry.get(LocalPlayer.class).getCharacterEntity();
+        EntityRef movingItem = playerEntity.getComponent(CharacterComponent.class).movingItem;
+
+        EntityRef fromEntity = movingItem;
+        int fromSlot = 0;
+
+        InventoryComponent playerInventory = playerEntity.getComponent(InventoryComponent.class);
+        if (playerInventory == null) {
+            return;
+        }
+        CharacterComponent characterComponent = playerEntity.getComponent(CharacterComponent.class);
+        if (characterComponent == null) {
+            logger.error("Character entity of player had no character component");
+            return;
+        }
+        int totalSlotCount = playerInventory.itemSlots.size();
+
+        EntityRef interactionTarget = characterComponent.predictedInteractionTarget;
+        InventoryComponent interactionTargetInventory = interactionTarget.getComponent(InventoryComponent.class);
+
+
+        EntityRef targetEntity;
+        List<Integer> toSlots = new ArrayList<>(totalSlotCount);
+        if (fromEntity.equals(playerEntity)) {
+
+            if (interactionTarget.exists() && interactionTargetInventory != null) {
+                targetEntity = interactionTarget;
+                toSlots = numbersBetween(0, interactionTargetInventory.itemSlots.size());
+            } else {
+                targetEntity = playerEntity;
+
+                toSlots = numbersBetween(0, totalSlotCount);
+
+            }
+        } else {
+            targetEntity = playerEntity;
+            toSlots = numbersBetween(0, totalSlotCount);
+        }
+
+        CoreRegistry.get(InventoryManager.class).moveItemToSlots(getTransferEntity(), fromEntity, fromSlot, targetEntity, toSlots);
+
+    }
+
+    @Override
+    public void postSave() {
+
     }
 }

--- a/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
+++ b/modules/Core/src/main/java/org/terasology/rendering/nui/layers/ingame/inventory/InventoryScreen.java
@@ -15,17 +15,35 @@
  */
 package org.terasology.rendering.nui.layers.ingame.inventory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.engine.Time;
+import org.terasology.logic.inventory.InventoryComponent;
+import org.terasology.logic.inventory.InventoryManager;
+import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.inventory.InventoryUtils;
+import org.terasology.logic.inventory.events.DropItemRequest;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class InventoryScreen extends CoreScreenLayer {
 
+    private static final Logger logger = LoggerFactory.getLogger(InventoryCell.class);
+
     @In
     private LocalPlayer localPlayer;
+
+    @In
+    private Time time;
 
     @Override
     public void initialise() {
@@ -42,5 +60,104 @@ public class InventoryScreen extends CoreScreenLayer {
     @Override
     public boolean isModal() {
         return false;
+    }
+
+    /*
+      The numbersBetween() and getTransferEntity() methods were
+      originally in the InventoryCell class. They were copied over
+      to here because they are private functions that the
+      moveItemSmartly() method needs to function. The first section
+      of code in onClosed() is based on the moveItemSmartly() method.
+    */
+    private List<Integer> numbersBetween(int start, int exclusiveEnd) {
+        List<Integer> numbers = new ArrayList<>();
+        for (int number = start; number < exclusiveEnd; number++) {
+            numbers.add(number);
+        }
+        return numbers;
+    }
+
+    private EntityRef getTransferEntity() {
+        return CoreRegistry.get(LocalPlayer.class).getCharacterEntity().getComponent(CharacterComponent.class).movingItem;
+    }
+
+
+    @Override
+    public void onClosed(){
+        /*
+          The code below was originally taken from moveItemSmartly() in
+          InventoryCell.class and slightly modified to work here.
+
+          The way items are being moved to and from the hotbar is really
+          similar to what was needed here to take them out of the transfer
+          slot and sort them into the inventory.
+        */
+        EntityRef playerEntity = CoreRegistry.get(LocalPlayer.class).getCharacterEntity();
+        EntityRef movingItem = playerEntity.getComponent(CharacterComponent.class).movingItem;
+
+        EntityRef fromEntity = movingItem;
+        int fromSlot = 0;
+
+        InventoryComponent playerInventory = playerEntity.getComponent(InventoryComponent.class);
+        if (playerInventory == null) {
+            return;
+        }
+        CharacterComponent characterComponent = playerEntity.getComponent(CharacterComponent.class);
+        if (characterComponent == null) {
+            logger.error("Character entity of player had no character component");
+            return;
+        }
+        int totalSlotCount = playerInventory.itemSlots.size();
+
+        EntityRef interactionTarget = characterComponent.predictedInteractionTarget;
+        InventoryComponent interactionTargetInventory = interactionTarget.getComponent(InventoryComponent.class);
+
+
+        EntityRef targetEntity;
+        List<Integer> toSlots = new ArrayList<>(totalSlotCount);
+        if (fromEntity.equals(playerEntity)) {
+
+            if (interactionTarget.exists() && interactionTargetInventory != null) {
+                targetEntity = interactionTarget;
+                toSlots = numbersBetween(0, interactionTargetInventory.itemSlots.size());
+            } else {
+                targetEntity = playerEntity;
+
+                toSlots = numbersBetween(0, totalSlotCount);
+
+            }
+        } else {
+            targetEntity = playerEntity;
+            toSlots = numbersBetween(0, totalSlotCount);
+        }
+
+        CoreRegistry.get(InventoryManager.class).moveItemToSlots(getTransferEntity(), fromEntity, fromSlot, targetEntity, toSlots);
+
+
+
+        /*
+         The code below was taken from the InteractionListener in the
+         DropItemRegion.class and slightly modified to work here.
+
+         The code to drop an item right in front of the player that
+         was in that class was almost exactly what was needed here.
+        */
+        EntityRef item  = InventoryUtils.getItemAt(movingItem, 0);
+
+        int count = InventoryUtils.getStackCount(item);
+
+        Vector3f position = localPlayer.getViewPosition();
+        Vector3f direction = localPlayer.getViewDirection();
+        Vector3f newPosition = new Vector3f(position.x + direction.x * 1.5f,
+                position.y + direction.y * 1.5f,
+                position.z + direction.z * 1.5f
+        );
+
+        //send DropItemRequest
+        Vector3f impulseVector = new Vector3f(direction);
+        playerEntity.send(new DropItemRequest(item, playerEntity,
+                impulseVector,
+                newPosition,
+                count));
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes issue [#3266](https://github.com/MovingBlocks/Terasology/issues/3266) by taking code from the InventoryCell and DropItem region classes and modifying it to work in the onClose() method of the InventoryScreen class.

Instead of the old behavior, the item in the transfer slot should now return to the player's inventory if there is space, or drop on the ground if the inventory is full.

### How to test

Create a world with the Core Gameplay template and open your inventory. Left click on an item so you have it grabbed and then press either escape or i to close your inventory. The item should have returned to your inventory with the same logic that shift+left-click uses to move items from the hotbar to the main inventory and back.

Now open your inventory again and fill every empty slot with a torch. Place the remaining torches in the slot where the pickaxe was so you have a pickaxe on your cursor and an inventory full of torches. Close your inventory. The pickaxe should drop on the ground in front of you with the same logic that drops an item when you left click with it off of an inventory cell.

### Outstanding before merging

- [ ] Currently does not have the same behavior applied to auto-save as suggested by @Maximetinu and @jellysnake.
