### PR TITLE
Add new run configuration for Java FlightRecorder

### DIFF
--- a/config/gradle/ide.gradle
+++ b/config/gradle/ide.gradle
@@ -212,6 +212,38 @@ ext {
             </configuration>
         '''))
 
+        // Run config for a client with activated Java FlightRecorder recording. Recording will be dumped when the application is closed
+        runManager.append(new XmlParser().parseText('''
+            <configuration default="false" name="TerasologyPC (Java FlightRecorder)" type="Application" factoryName="Application">
+              <extension name="coverage" enabled="false" merge="false" runner="idea">
+                <pattern>
+                  <option name="PATTERN" value="org.terasology.engine.*"/>
+                  <option name="ENABLED" value="true"/>
+                </pattern>
+              </extension>
+              <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology"/>
+              <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m -XX:+UnlockCommercialFeatures -XX:+FlightRecorder -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:StartFlightRecording=filename=terasology.jfr,dumponexit=true"/>
+              <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport"/>
+              <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$"/>
+              <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
+              <option name="ALTERNATIVE_JRE_PATH" value=""/>
+              <option name="ENABLE_SWING_INSPECTOR" value="false"/>
+              <option name="ENV_VARIABLES"/>
+              <option name="PASS_PARENT_ENVS" value="true"/>
+              <module name="PC"/>
+              <envs/>
+              <RunnerSettings RunnerId="Debug">
+                <option name="DEBUG_PORT" value=""/>
+                <option name="TRANSPORT" value="0"/>
+                <option name="LOCAL" value="true"/>
+              </RunnerSettings>
+              <RunnerSettings RunnerId="Run"/>
+              <ConfigurationWrapper RunnerId="Debug"/>
+              <ConfigurationWrapper RunnerId="Run"/>
+              <method/>
+            </configuration>
+        '''))
+
         // Run config for a second client in its own data dir (for easy multiplayer testing)
         runManager.append(new XmlParser().parseText('''
             <configuration default="false" name="TerasologyPC (2nd client)" type="Application" factoryName="Application">


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Follow up of PR #3469 
Provides a new run configuration with enabled Java FlightRecorder. The provided configuration will only work until Java 9 (didn't worked on Java 10+ for me).
 
### How to test

Run Terasology with the new configuration. After closing the program a new file called `terasology.jfr` should be in the project root directory.

### Outstanding before merging

Maybe the wiki entry @Cervator mentioned in the original PR. But I think the run configuration should be enough to start with. An entry for the analysis of the recording is IMHO out of scope.
