### PR TITLE
Add custom per-block data fields

### DIFF
--- a/engine-tests/src/main/java/org/terasology/Environment.java
+++ b/engine-tests/src/main/java/org/terasology/Environment.java
@@ -72,6 +72,8 @@ public class Environment {
         AssetManager assetManager = setupAssetManager();
 
         setupBlockManager(assetManager);
+        
+        setupExtraDataManager(context);
 
         setupCollisionManager();
 
@@ -129,6 +131,10 @@ public class Environment {
     }
 
     protected void setupBlockManager(AssetManager assetManager) {
+        // empty
+    }
+    
+    protected void setupExtraDataManager(Context context) {
         // empty
     }
 

--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -29,6 +29,7 @@ import org.terasology.audio.nullAudio.NullAudioManager;
 import org.terasology.audio.nullAudio.NullSound;
 import org.terasology.audio.nullAudio.NullStreamingSound;
 import org.terasology.config.Config;
+import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.Time;
@@ -93,6 +94,7 @@ import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.block.tiles.BlockTile;
 import org.terasology.world.block.tiles.NullWorldAtlas;
 import org.terasology.world.block.tiles.WorldAtlas;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.internal.WorldInfo;
 import org.terasology.world.sun.BasicCelestialModel;
 import org.terasology.world.sun.CelestialSystem;
@@ -140,9 +142,11 @@ public class HeadlessEnvironment extends Environment {
 
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         context.put(BlockFamilyLibrary.class, new BlockFamilyLibrary(environment,context));
+        
+        ExtraBlockDataManager extraDataManager = context.get(ExtraBlockDataManager.class);
 
         context.put(StorageManager.class, new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(),
-                engineEntityManager, blockManager, biomeManager, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus));
+                engineEntityManager, blockManager, biomeManager, extraDataManager, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus));
     }
 
     @Override
@@ -173,6 +177,11 @@ public class HeadlessEnvironment extends Environment {
         TypeSerializationLibrary typeSerializationLibrary = context.get(TypeSerializationLibrary.class);
         typeSerializationLibrary.addTypeHandler(BlockFamily.class, new BlockFamilyTypeHandler(blockManager));
         typeSerializationLibrary.addTypeHandler(Block.class, new BlockTypeHandler(blockManager));
+    }
+    
+    @Override
+    protected void setupExtraDataManager(Context context) {
+        context.put(ExtraBlockDataManager.class, new ExtraBlockDataManager(context));
     }
 
     @Override

--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -26,6 +26,7 @@ import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.generation.impl.EntityBufferImpl;
 import org.terasology.world.generator.WorldGenerator;
@@ -50,12 +51,14 @@ public class MapWorldProvider implements WorldProviderCore {
     private WorldGenerator worldGenerator;
     private BlockManager blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
     private EntityBufferImpl entityBuffer;
 
-    public MapWorldProvider(WorldGenerator worldGenerator, BlockManager blockManager, BiomeManager biomeManager) {
+    public MapWorldProvider(WorldGenerator worldGenerator, BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
         this.worldGenerator = worldGenerator;
         this.blockManager = blockManager;
         this.biomeManager = biomeManager;
+        this.extraDataManager = extraDataManager;
         entityBuffer = new EntityBufferImpl();
     }
 
@@ -113,7 +116,7 @@ public class MapWorldProvider implements WorldProviderCore {
         Vector3i chunkPos = ChunkMath.calcChunkPos(pos);
         Chunk chunk = chunks.get(chunkPos);
         if (chunk == null && worldGenerator != null) {
-            chunk = new ChunkImpl(chunkPos, blockManager, biomeManager);
+            chunk = new ChunkImpl(chunkPos, blockManager, biomeManager, extraDataManager);
             worldGenerator.createChunk(chunk, entityBuffer);
             chunks.put(chunkPos, chunk);
         }
@@ -171,6 +174,16 @@ public class MapWorldProvider implements WorldProviderCore {
 
     @Override
     public byte getTotalLight(int x, int y, int z) {
+        return 0;
+    }
+    
+    @Override
+    public int setExtraData(int i, Vector3i pos, int value) {
+        return 0;
+    }
+    
+    @Override
+    public int getExtraData(int i, int x, int y, int z) {
         return 0;
     }
 

--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -178,12 +178,12 @@ public class MapWorldProvider implements WorldProviderCore {
     }
     
     @Override
-    public int setExtraData(int i, Vector3i pos, int value) {
+    public int setExtraData(int index, Vector3i pos, int value) {
         return 0;
     }
     
     @Override
-    public int getExtraData(int i, int x, int y, int z) {
+    public int getExtraData(int index, int x, int y, int z) {
         return 0;
     }
 

--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -47,6 +47,7 @@ import org.terasology.recording.RecordAndReplayUtils;
 import org.terasology.recording.RecordedEventStore;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
@@ -97,6 +98,7 @@ public abstract class TerasologyTestingEnvironment {
         engineEntityManager = context.get(EngineEntityManager.class);
         BlockManager mockBlockManager = context.get(BlockManager.class); // 'mock' added to avoid hiding a field
         BiomeManager biomeManager = context.get(BiomeManager.class);
+        ExtraBlockDataManager extraDataManager = context.get(ExtraBlockDataManager.class);
         RecordedEventStore recordedEventStore = new RecordedEventStore();
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
         context.put(RecordAndReplayUtils.class, recordAndReplayUtils);
@@ -109,7 +111,7 @@ public abstract class TerasologyTestingEnvironment {
 
         Path savePath = PathManager.getInstance().getSavePath("world1");
         context.put(StorageManager.class, new ReadWriteStorageManager(savePath, moduleManager.getEnvironment(),
-                engineEntityManager, mockBlockManager, biomeManager, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus));
+                engineEntityManager, mockBlockManager, biomeManager, extraDataManager, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus));
 
         ComponentSystemManager componentSystemManager = new ComponentSystemManager(context);
         context.put(ComponentSystemManager.class, componentSystemManager);

--- a/engine-tests/src/main/java/org/terasology/WorldProvidingHeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/WorldProvidingHeadlessEnvironment.java
@@ -22,6 +22,7 @@ import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.generator.WorldGenerator;
 import org.terasology.world.internal.EntityAwareWorldProvider;
 import org.terasology.world.internal.WorldProviderCore;
@@ -38,8 +39,8 @@ public class WorldProvidingHeadlessEnvironment extends HeadlessEnvironment {
 
     public void setupWorldProvider(WorldGenerator generator) {
         generator.initialize();
-        WorldProviderCore stub = new MapWorldProvider(generator, context.get(BlockManager.class), Mockito.mock(BiomeManager.class));
-        WorldProvider world = new WorldProviderWrapper(stub);
+        WorldProviderCore stub = new MapWorldProvider(generator, context.get(BlockManager.class), Mockito.mock(BiomeManager.class), context.get(ExtraBlockDataManager.class));
+        WorldProvider world = new WorldProviderWrapper(stub, context.get(ExtraBlockDataManager.class));
         CoreRegistry.put(WorldProvider.class, world);
         CoreRegistry.put(BlockEntityRegistry.class, new EntityAwareWorldProvider(stub, context));
     }

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -177,29 +177,20 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
-        extendExtraDataTo(index);
-        Integer prevValue = extraData.get(index).get(pos);
-        extraData.get(index).put(pos, value);
-        if (prevValue == null) {
-            return 0;
-        }
-        return prevValue;
+        Integer prevValue = getExtraDataLayer(index).put(pos, value);
+        return prevValue == null ? 0 : prevValue;
     }
     
     @Override
     public int getExtraData(int index, int x, int y, int z) {
-        extendExtraDataTo(index);
-        Integer prevValue = extraData.get(index).get(new Vector3i(x, y, z));
-        if (prevValue == null) {
-            return 0;
-        }
-        return prevValue;
+        return getExtraDataLayer(index).getOrDefault(new Vector3i(x, y, z), 0);
     }
     
-    private void extendExtraDataTo(int i) {
-        while (extraData.size() <= i) {
+    private Map<Vector3i, Integer> getExtraDataLayer(int index) {
+        while (extraData.size() <= index) {
             extraData.add(Maps.newHashMap());
         }
+        return extraData.get(index);
     }
 
     @Override

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -17,6 +17,7 @@
 package org.terasology.testUtil;
 
 import com.google.common.collect.Maps;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +41,7 @@ public class WorldProviderCoreStub implements WorldProviderCore {
 
     private Map<Vector3i, Block> blocks = Maps.newHashMap();
     private Map<Vector3i, Biome> biomes = Maps.newHashMap();
+    private ArrayList<Map<Vector3i, Integer>> extraData = new ArrayList<>();
     private Block air;
     private Biome defaultBiome;
 
@@ -171,6 +173,33 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     @Override
     public byte getTotalLight(int x, int y, int z) {
         return 0;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+    
+    @Override
+    public int setExtraData(int i, Vector3i pos, int value) {
+        extendExtraDataTo(i);
+        Integer prevValue = extraData.get(i).get(pos);
+        extraData.get(i).put(pos, value);
+        if (prevValue == null) {
+            return 0;
+        }
+        return prevValue;
+    }
+    
+    @Override
+    public int getExtraData(int i, int x, int y, int z) {
+        extendExtraDataTo(i);
+        Integer prevValue = extraData.get(i).get(new Vector3i(x, y, z));
+        if (prevValue == null) {
+            return 0;
+        }
+        return prevValue;
+    }
+    
+    private void extendExtraDataTo(int i) {
+        while (extraData.size() <= i) {
+            extraData.add(Maps.newHashMap());
+        }
     }
 
     @Override

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -176,10 +176,10 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     }
     
     @Override
-    public int setExtraData(int i, Vector3i pos, int value) {
-        extendExtraDataTo(i);
-        Integer prevValue = extraData.get(i).get(pos);
-        extraData.get(i).put(pos, value);
+    public int setExtraData(int index, Vector3i pos, int value) {
+        extendExtraDataTo(index);
+        Integer prevValue = extraData.get(index).get(pos);
+        extraData.get(index).put(pos, value);
         if (prevValue == null) {
             return 0;
         }
@@ -187,9 +187,9 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     }
     
     @Override
-    public int getExtraData(int i, int x, int y, int z) {
-        extendExtraDataTo(i);
-        Integer prevValue = extraData.get(i).get(new Vector3i(x, y, z));
+    public int getExtraData(int index, int x, int y, int z) {
+        extendExtraDataTo(index);
+        Integer prevValue = extraData.get(index).get(new Vector3i(x, y, z));
         if (prevValue == null) {
             return 0;
         }

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -61,6 +61,7 @@ import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.loader.BlockFamilyDefinitionData;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkProvider;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.internal.WorldInfo;
 
@@ -91,6 +92,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
     private EngineEntityManager entityManager;
     private BlockManager blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
     private Block testBlock;
     private Block testBlock2;
     private EntityRef character;
@@ -113,6 +115,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         moduleEnvironment = context.get(ModuleEnvironment.class);
         blockManager = context.get(BlockManager.class);
         biomeManager = context.get(BiomeManager.class);
+        extraDataManager = context.get(ExtraBlockDataManager.class);
 
         RecordedEventStore recordedEventStore = new RecordedEventStore();
         recordAndReplayUtils = new RecordAndReplayUtils();
@@ -122,7 +125,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         recordAndReplayCurrentStatus = context.get(RecordAndReplayCurrentStatus.class);
 
 
-        esm = new ReadWriteStorageManager(savePath, moduleEnvironment, entityManager, blockManager, biomeManager,
+        esm = new ReadWriteStorageManager(savePath, moduleEnvironment, entityManager, blockManager, biomeManager, extraDataManager,
                 false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
         context.put(StorageManager.class, esm);
 
@@ -225,7 +228,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
 
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleEnvironment, newEntityManager, blockManager,
-                biomeManager, false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
+                biomeManager, extraDataManager, false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
         newSM.loadGlobalStore();
 
         List<EntityRef> entities = Lists.newArrayList(newEntityManager.getEntitiesWith(StringComponent.class));
@@ -246,7 +249,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
         EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleEnvironment, newEntityManager, blockManager,
-                biomeManager, false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
+                biomeManager, extraDataManager, false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
         newSM.loadGlobalStore();
 
         PlayerStore restored = newSM.loadPlayerStore(PLAYER_ID);
@@ -261,7 +264,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testStoreAndRestoreChunkStore() {
-        Chunk chunk = new ChunkImpl(CHUNK_POS, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(CHUNK_POS, blockManager, biomeManager, extraDataManager);
         chunk.setBlock(0, 0, 0, testBlock);
         chunk.markReady();
         ChunkProvider chunkProvider = mock(ChunkProvider.class);
@@ -280,7 +283,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testChunkSurvivesStorageSaveAndRestore() throws Exception {
-        Chunk chunk = new ChunkImpl(CHUNK_POS, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(CHUNK_POS, blockManager, biomeManager, extraDataManager);
         chunk.setBlock(0, 0, 0, testBlock);
         chunk.setBlock(0, 4, 2, testBlock2);
         chunk.markReady();
@@ -298,7 +301,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
         EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleEnvironment, newEntityManager, blockManager,
-                biomeManager, storeChunkInZips, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
+                biomeManager, extraDataManager, storeChunkInZips, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
         newSM.loadGlobalStore();
 
         ChunkStore restored = newSM.loadChunkStore(CHUNK_POS);
@@ -311,7 +314,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testEntitySurvivesStorageInChunkStore() throws Exception {
-        Chunk chunk = new ChunkImpl(CHUNK_POS, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(CHUNK_POS, blockManager, biomeManager, extraDataManager);
         chunk.setBlock(0, 0, 0, testBlock);
         chunk.markReady();
         ChunkProvider chunkProvider = mock(ChunkProvider.class);
@@ -333,7 +336,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
         EngineEntityManager newEntityManager = context.get(EngineEntityManager.class);
         StorageManager newSM = new ReadWriteStorageManager(savePath, moduleEnvironment, newEntityManager, blockManager,
-                biomeManager, false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
+                biomeManager, extraDataManager, false, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
         newSM.loadGlobalStore();
 
         ChunkStore restored = newSM.loadChunkStore(CHUNK_POS);

--- a/engine-tests/src/test/java/org/terasology/world/ChunkTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/ChunkTest.java
@@ -36,6 +36,7 @@ import org.terasology.world.block.shapes.BlockShape;
 import org.terasology.world.block.tiles.NullWorldAtlas;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 
 import static org.junit.Assert.assertEquals;
@@ -54,8 +55,10 @@ public class ChunkTest extends TerasologyTestingEnvironment {
         CoreRegistry.put(BlockManager.class, blockManager);
 
         BiomeManager biomeManager = Mockito.mock(BiomeManager.class);
+        
+        ExtraBlockDataManager extraDataManager = new ExtraBlockDataManager();
 
-        chunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager);
+        chunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager, extraDataManager);
 
         BlockFamilyDefinitionData solidData = new BlockFamilyDefinitionData();
         solidData.getBaseSection().setDisplayName("Stone");

--- a/engine-tests/src/test/java/org/terasology/world/ChunkViewTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/ChunkViewTest.java
@@ -36,6 +36,7 @@ import org.terasology.world.block.shapes.BlockShape;
 import org.terasology.world.block.tiles.NullWorldAtlas;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.internal.ChunkViewCore;
 import org.terasology.world.internal.ChunkViewCoreImpl;
@@ -50,6 +51,7 @@ public class ChunkViewTest extends TerasologyTestingEnvironment {
     Block solidBlock;
     private BlockManager blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
 
     @Before
     public void setup() throws IOException {
@@ -59,6 +61,8 @@ public class ChunkViewTest extends TerasologyTestingEnvironment {
         airBlock = blockManager.getBlock(BlockManager.AIR_ID);
 
         biomeManager = Mockito.mock(BiomeManager.class);
+        
+        extraDataManager = new ExtraBlockDataManager();
 
         BlockFamilyDefinitionData solidData = new BlockFamilyDefinitionData();
         solidData.getBaseSection().setDisplayName("Stone");
@@ -149,6 +153,6 @@ public class ChunkViewTest extends TerasologyTestingEnvironment {
     }
 
     private Chunk createChunk(int x, int y, int z) {
-        return new ChunkImpl(new Vector3i(x, y, z), blockManager, biomeManager);
+        return new ChunkImpl(new Vector3i(x, y, z), blockManager, biomeManager, extraDataManager);
     }
 }

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -36,6 +36,7 @@ import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.OnActivatedBlocks;
 import org.terasology.world.block.OnAddedBlocks;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.event.OnChunkGenerated;
 import org.terasology.world.chunks.event.OnChunkLoaded;
 import org.terasology.world.chunks.internal.ReadyChunkInfo;
@@ -62,6 +63,7 @@ public class LocalChunkProviderTest {
     private ChunkFinalizer chunkFinalizer;
     private EntityManager entityManager;
     private BlockManager blockManager;
+    private ExtraBlockDataManager extraDataManager;
     private BlockEntityRegistry blockEntityRegistry;
     private EntityRef worldEntity;
     private ChunkCache chunkCache;
@@ -71,11 +73,12 @@ public class LocalChunkProviderTest {
         entityManager = mock(EntityManager.class);
         chunkFinalizer = mock(ChunkFinalizer.class);
         blockManager = mock(BlockManager.class);
+        extraDataManager = new ExtraBlockDataManager();
         blockEntityRegistry = mock(BlockEntityRegistry.class);
         worldEntity = mock(EntityRef.class);
         chunkCache = new ConcurrentMapChunkCache();
         chunkProvider = new LocalChunkProvider(null,
-                entityManager, null, blockManager, null, chunkFinalizer, null, chunkCache);
+                entityManager, null, blockManager, null, extraDataManager, chunkFinalizer, null, chunkCache);
         chunkProvider.setBlockEntityRegistry(blockEntityRegistry);
         chunkProvider.setWorldEntity(worldEntity);
     }

--- a/engine-tests/src/test/java/org/terasology/world/generator/InternalLightGeneratorTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/generator/InternalLightGeneratorTest.java
@@ -37,6 +37,7 @@ import org.terasology.world.block.shapes.BlockShape;
 import org.terasology.world.block.tiles.NullWorldAtlas;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.propagation.light.InternalLightProcessor;
 
@@ -50,6 +51,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     private BlockManager blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
 
 
     @Before
@@ -61,6 +63,8 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
         airBlock = blockManager.getBlock(BlockManager.AIR_ID);
 
         biomeManager = Mockito.mock(BiomeManager.class);
+        
+        extraDataManager = new ExtraBlockDataManager();
 
         BlockFamilyDefinitionData solidData = new BlockFamilyDefinitionData();
         solidData.getBaseSection().setDisplayName("Stone");
@@ -81,7 +85,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testUnblockedSunlightRegenPropagation() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         InternalLightProcessor.generateInternalLighting(chunk);
 
         for (Vector3i pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z))) {
@@ -92,7 +96,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testBlockedSunlightRegenPropagationResets() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 60, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
             chunk.setBlock(pos, solidBlock);
         }
@@ -113,7 +117,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testBlockedAtTopSunlightRegenPropagationResets() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 63, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
             chunk.setBlock(pos, solidBlock);
         }
@@ -127,7 +131,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testUnblockedSunlightPropagationAfterHittingMaxRegen() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         InternalLightProcessor.generateInternalLighting(chunk);
 
         for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - 15,
@@ -144,7 +148,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testBlockedSunlightPropagation() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 4, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
             chunk.setBlock(pos, solidBlock);
         }
@@ -158,7 +162,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testUnblockedSunlightPropagation() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         InternalLightProcessor.generateInternalLighting(chunk);
 
         for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 15,
@@ -169,7 +173,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testHorizontalSunlightPropagation() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 4, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
             chunk.setBlock(pos, solidBlock);
         }
@@ -190,7 +194,7 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testLightPropagation() {
-        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager);
+        Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, biomeManager, extraDataManager);
         chunk.setBlock(16, 32, 16, fullLight);
 
         InternalLightProcessor.generateInternalLighting(chunk);

--- a/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
@@ -41,6 +41,7 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.ChunkRegionListener;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.internal.ChunkViewCore;
 import org.terasology.world.propagation.light.InternalLightProcessor;
@@ -58,6 +59,7 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
 
     private BlockManagerImpl blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
     private Block solid;
     private SunlightPropagationRules lightRules;
     private SunlightRegenPropagationRules regenRules;
@@ -80,6 +82,7 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         blockManager = new BlockManagerImpl(new NullWorldAtlas(), assetManager, true);
         biomeManager = Mockito.mock(BiomeManager.class);
         CoreRegistry.put(BlockManager.class, blockManager);
+        extraDataManager = new ExtraBlockDataManager();
 
         BlockFamilyDefinitionData solidData = new BlockFamilyDefinitionData();
         solidData.getBaseSection().setDisplayName("Stone");
@@ -99,8 +102,8 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testBetweenChunksSimple() {
-        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager);
-        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager);
+        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager, extraDataManager);
+        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager, extraDataManager);
 
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
@@ -121,8 +124,8 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testBetweenChunksSimpleSunlightRegenOnly() {
-        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager);
-        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager);
+        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager, extraDataManager);
+        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager, extraDataManager);
 
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
@@ -141,8 +144,8 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testBetweenChunksWithOverhang() {
-        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager);
-        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager);
+        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager, extraDataManager);
+        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager, extraDataManager);
 
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
@@ -169,8 +172,8 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testPropagateSunlightAppearingMidChunk() {
-        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager);
-        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager);
+        Chunk topChunk = new ChunkImpl(new Vector3i(0, 1, 0), blockManager, biomeManager, extraDataManager);
+        Chunk bottomChunk = new ChunkImpl(new Vector3i(0, 0, 0), blockManager, biomeManager, extraDataManager);
 
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -43,6 +43,7 @@ import org.terasology.engine.modes.loadProcesses.InitialiseWorld;
 import org.terasology.engine.modes.loadProcesses.InitialiseWorldGenerator;
 import org.terasology.engine.modes.loadProcesses.JoinServer;
 import org.terasology.engine.modes.loadProcesses.LoadEntities;
+import org.terasology.engine.modes.loadProcesses.LoadExtraBlockData;
 import org.terasology.engine.modes.loadProcesses.LoadPrefabs;
 import org.terasology.engine.modes.loadProcesses.PostBeginSystems;
 import org.terasology.engine.modes.loadProcesses.PreBeginSystems;
@@ -149,6 +150,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new CacheBlocks(context));
         loadProcesses.add(new LoadPrefabs(context));
         loadProcesses.add(new ProcessBlockPrefabs(context));
+        loadProcesses.add(new LoadExtraBlockData(context));
         loadProcesses.add(new InitialiseComponentSystemManager(context));
         loadProcesses.add(new RegisterInputSystem(context));
         loadProcesses.add(new RegisterSystems(context, netMode));
@@ -179,6 +181,7 @@ public class StateLoading implements GameState {
         loadProcesses.add(new RegisterInputSystem(context));
         loadProcesses.add(new RegisterSystems(context, netMode));
         loadProcesses.add(new InitialiseCommandSystem(context));
+        loadProcesses.add(new LoadExtraBlockData(context));
         loadProcesses.add(new InitialiseWorld(gameManifest, context));
         loadProcesses.add(new RegisterBlockFamilies(context));
         loadProcesses.add(new EnsureSaveGameConsistency(context));

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -34,6 +34,7 @@ import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.remoteChunkProvider.RemoteChunkProvider;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.internal.EntityAwareWorldProvider;
 import org.terasology.world.internal.WorldProviderCoreImpl;
 import org.terasology.world.internal.WorldProviderWrapper;
@@ -64,13 +65,14 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         localPlayer.setRecordAndReplayClasses(context.get(DirectionAndOriginPosRecorderList.class), context.get(RecordAndReplayCurrentStatus.class));
         context.put(LocalPlayer.class, localPlayer);
         BlockManager blockManager = context.get(BlockManager.class);
+        ExtraBlockDataManager extraDataManager = context.get(ExtraBlockDataManager.class);
 
         RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager, localPlayer);
 
         WorldProviderCoreImpl worldProviderCore = new WorldProviderCoreImpl(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD), chunkProvider,
                 blockManager.getBlock(BlockManager.UNLOADED_ID), context);
         EntityAwareWorldProvider entityWorldProvider = new EntityAwareWorldProvider(worldProviderCore, context);
-        WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider);
+        WorldProvider worldProvider = new WorldProviderWrapper(entityWorldProvider, extraDataManager);
         context.put(WorldProvider.class, worldProvider);
         context.put(BlockEntityRegistry.class, entityWorldProvider);
         context.get(ComponentSystemManager.class).register(entityWorldProvider, "engine:BlockEntityRegistry");

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadExtraBlockData.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadExtraBlockData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.engine.modes.loadProcesses;
+
+import org.terasology.context.Context;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
+
+public class LoadExtraBlockData extends SingleStepLoadProcess {
+    private final Context context;
+    
+    public LoadExtraBlockData(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Loading extra block data fields...";
+    }
+    
+    @Override
+    public boolean step() {
+        context.put(ExtraBlockDataManager.class, new ExtraBlockDataManager(context));
+        return true;
+    }
+    
+    @Override
+    public int getExpectedCost() {
+        return 1;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadExtraBlockData.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadExtraBlockData.java
@@ -19,6 +19,10 @@ package org.terasology.engine.modes.loadProcesses;
 import org.terasology.context.Context;
 import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 
+/**
+ * Sets up an ExtraBlockDataManager based on @ExtraBlockSystem classes from the loaded modules.
+ * Depends on block definitions and module classes already being loaded.
+ */
 public class LoadExtraBlockData extends SingleStepLoadProcess {
     private final Context context;
     

--- a/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
@@ -60,6 +60,7 @@ import org.terasology.world.block.BlockUri;
 import org.terasology.world.block.BlockUriParseException;
 import org.terasology.world.block.internal.BlockManagerImpl;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkSerializer;
 import org.terasology.world.chunks.remoteChunkProvider.RemoteChunkProvider;
 
@@ -92,6 +93,7 @@ public class ServerImpl implements Server {
     private EventSerializer eventSerializer;
     private BlockManagerImpl blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
 
     private BlockEntityRegistry blockEntityRegistry;
     private RemoteChunkProvider remoteWorldProvider;
@@ -100,6 +102,7 @@ public class ServerImpl implements Server {
     private SetMultimap<Integer, Class<? extends Component>> changedComponents = HashMultimap.create();
     private ListMultimap<Vector3i, NetData.BlockChangeMessage> awaitingChunkReadyBlockUpdates = ArrayListMultimap.create();
     private ListMultimap<Vector3i, NetData.BiomeChangeMessage> awaitingChunkReadyBiomeUpdates = ArrayListMultimap.create();
+    private ListMultimap<Vector3i, NetData.ExtraDataChangeMessage> awaitingChunkReadyExtraDataUpdates = ArrayListMultimap.create();
 
     private EngineTime time;
 
@@ -119,6 +122,7 @@ public class ServerImpl implements Server {
         this.blockEntityRegistry = newBlockEntityRegistry;
         blockManager = (BlockManagerImpl) CoreRegistry.get(BlockManager.class);
         biomeManager = CoreRegistry.get(BiomeManager.class);
+        extraDataManager = CoreRegistry.get(ExtraBlockDataManager.class);
     }
 
     void setServerInfo(NetData.ServerInfoMessage serverInfo) {
@@ -268,6 +272,7 @@ public class ServerImpl implements Server {
             processInvalidatedChunks(message);
             processBlockChanges(message);
             processBiomeChanges(message);
+            processExtraDataChanges(message);
             processRemoveEntities(message);
             message.getCreateEntityList().forEach(this::createEntityMessage);
             message.getUpdateEntityList().forEach(this::updateEntity);
@@ -322,6 +327,18 @@ public class ServerImpl implements Server {
             }
         }
     }
+    
+    private void processExtraDataChanges(NetData.NetMessage message) {
+        for (NetData.ExtraDataChangeMessage extraDataChange : message.getExtraDataChangeList()) {
+            WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);
+            Vector3i pos = NetMessageUtil.convert(extraDataChange.getPos());
+            if (worldProvider.isBlockRelevant(pos)) {
+                worldProvider.setExtraData(extraDataChange.getIndex(), pos, extraDataChange.getNewData());
+            } else {
+                awaitingChunkReadyExtraDataUpdates.put(ChunkMath.calcChunkPos(pos), extraDataChange);
+            }
+        }
+    }
 
     private void processInvalidatedChunks(NetData.NetMessage message) {
         for (NetData.InvalidateChunkMessage chunk : message.getInvalidateChunkList()) {
@@ -329,12 +346,13 @@ public class ServerImpl implements Server {
             remoteWorldProvider.invalidateChunks(chunkPos);
             awaitingChunkReadyBlockUpdates.removeAll(chunkPos);
             awaitingChunkReadyBiomeUpdates.removeAll(chunkPos);
+            awaitingChunkReadyExtraDataUpdates.removeAll(chunkPos);
         }
     }
 
     private void processReceivedChunks(NetData.NetMessage message) {
         for (EntityData.ChunkStore chunkInfo : message.getChunkInfoList()) {
-            Chunk chunk = ChunkSerializer.decode(chunkInfo, blockManager, biomeManager);
+            Chunk chunk = ChunkSerializer.decode(chunkInfo, blockManager, biomeManager, extraDataManager);
             chunkQueue.offer(chunk);
         }
     }
@@ -423,6 +441,14 @@ public class ServerImpl implements Server {
             Vector3i pos = NetMessageUtil.convert(message.getPos());
             Biome newBiome = biomeManager.getBiomeByShortId((short) message.getNewBiome());
             worldProvider.setBiome(pos, newBiome);
+        }
+        
+        List<NetData.ExtraDataChangeMessage> updateExtraDataMessages = awaitingChunkReadyExtraDataUpdates.removeAll(chunkPos);
+        for (NetData.ExtraDataChangeMessage message : updateExtraDataMessages) {
+            Vector3i pos = NetMessageUtil.convert(message.getPos());
+            int newValue = message.getNewData();
+            int i = message.getIndex();
+            worldProvider.setExtraData(i, pos, newValue);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
@@ -297,7 +297,10 @@ public class ServerImpl implements Server {
             }
         }
     }
-
+    
+    /**
+     * Apply the block changes from the message to the local world.
+     */
     private void processBlockChanges(NetData.NetMessage message) {
         for (NetData.BlockChangeMessage blockChange : message.getBlockChangeList()) {
             Block newBlock = blockManager.getBlock((short) blockChange.getNewBlock());
@@ -312,7 +315,10 @@ public class ServerImpl implements Server {
             }
         }
     }
-
+    
+    /**
+     * Apply the biome changes from the message to the local world.
+     */
     private void processBiomeChanges(NetData.NetMessage message) {
         for (NetData.BiomeChangeMessage biomeChange : message.getBiomeChangeList()) {
             logger.debug("Received block change to {}", blockManager.getBlock((short) biomeChange.getNewBiome()));
@@ -328,6 +334,9 @@ public class ServerImpl implements Server {
         }
     }
     
+    /**
+     * Apply the extra-data changes from the message to the local world.
+     */
     private void processExtraDataChanges(NetData.NetMessage message) {
         for (NetData.ExtraDataChangeMessage extraDataChange : message.getExtraDataChangeList()) {
             WorldProvider worldProvider = CoreRegistry.get(WorldProvider.class);

--- a/engine/src/main/java/org/terasology/persistence/internal/AbstractStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/AbstractStorageManager.java
@@ -35,6 +35,7 @@ import org.terasology.protobuf.EntityData;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -60,6 +61,7 @@ public abstract class AbstractStorageManager implements StorageManager {
     private final StoragePathProvider storagePathProvider;
     private final BlockManager blockManager;
     private final BiomeManager biomeManager;
+    private final ExtraBlockDataManager extraDataManager;
 
     private final ModuleEnvironment environment;
     private final EngineEntityManager entityManager;
@@ -69,13 +71,14 @@ public abstract class AbstractStorageManager implements StorageManager {
     private boolean storeChunksInZips = true;
 
     public AbstractStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,
-                                  BlockManager blockManager, BiomeManager biomeManager, boolean storeChunksInZips) {
+                                  BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager, boolean storeChunksInZips) {
         this.entityManager = entityManager;
         this.environment = environment;
         this.storeChunksInZips = storeChunksInZips;
         this.prefabSerializer = new PrefabSerializer(entityManager.getComponentLibrary(), entityManager.getTypeSerializerLibrary());
         this.blockManager = blockManager;
         this.biomeManager = biomeManager;
+        this.extraDataManager = extraDataManager;
 
         this.storagePathProvider = new StoragePathProvider(savePath);
         this.helper = new OwnershipHelper(entityManager.getComponentLibrary());
@@ -110,7 +113,7 @@ public abstract class AbstractStorageManager implements StorageManager {
             ByteArrayInputStream bais = new ByteArrayInputStream(chunkData);
             try (GZIPInputStream gzipIn = new GZIPInputStream(bais)) {
                 EntityData.ChunkStore storeData = EntityData.ChunkStore.parseFrom(gzipIn);
-                store = new ChunkStoreInternal(storeData, entityManager, blockManager, biomeManager);
+                store = new ChunkStoreInternal(storeData, entityManager, blockManager, biomeManager, extraDataManager);
             } catch (IOException e) {
                 logger.error("Failed to read existing saved chunk {}", chunkPos);
             }

--- a/engine/src/main/java/org/terasology/persistence/internal/ChunkStoreInternal.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ChunkStoreInternal.java
@@ -22,6 +22,7 @@ import org.terasology.protobuf.EntityData;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkSerializer;
 
 /**
@@ -35,11 +36,11 @@ final class ChunkStoreInternal implements ChunkStore {
     private EntityData.EntityStore entityStore;
 
     ChunkStoreInternal(EntityData.ChunkStore chunkData, EngineEntityManager entityManager,
-            BlockManager blockManager, BiomeManager biomeManager) {
+            BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
         this.chunkPosition = new Vector3i(chunkData.getX(), chunkData.getY(), chunkData.getZ());
         this.entityManager = entityManager;
 
-        this.chunk = ChunkSerializer.decode(chunkData, blockManager, biomeManager);
+        this.chunk = ChunkSerializer.decode(chunkData, blockManager, biomeManager, extraDataManager);
         this.entityStore = chunkData.getStore();
     }
 

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadOnlyStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadOnlyStorageManager.java
@@ -24,6 +24,7 @@ import org.terasology.network.ClientComponent;
 import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -35,13 +36,13 @@ import java.util.Collection;
 public final class ReadOnlyStorageManager extends AbstractStorageManager {
 
     public ReadOnlyStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,
-                                  BlockManager blockManager, BiomeManager biomeManager) {
-        this(savePath, environment, entityManager, blockManager, biomeManager, true);
+                                  BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
+        this(savePath, environment, entityManager, blockManager, biomeManager, extraDataManager, true);
     }
 
     public ReadOnlyStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,
-                                  BlockManager blockManager, BiomeManager biomeManager, boolean storeChunksInZips) {
-        super(savePath, environment, entityManager, blockManager, biomeManager, storeChunksInZips);
+                                  BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager, boolean storeChunksInZips) {
+        super(savePath, environment, entityManager, blockManager, biomeManager, extraDataManager, storeChunksInZips);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
@@ -64,6 +64,7 @@ import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.ManagedChunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.internal.WorldInfo;
 
@@ -124,16 +125,16 @@ public final class ReadWriteStorageManager extends AbstractStorageManager implem
     private ComponentLibrary entityRefReplacingComponentLibrary;
 
     public ReadWriteStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,
-                                   BlockManager blockManager, BiomeManager biomeManager, RecordAndReplaySerializer recordAndReplaySerializer,
+                                   BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager, RecordAndReplaySerializer recordAndReplaySerializer,
                                    RecordAndReplayUtils recordAndReplayUtils, RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) throws IOException {
-        this(savePath, environment, entityManager, blockManager, biomeManager, true, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
+        this(savePath, environment, entityManager, blockManager, biomeManager, extraDataManager, true, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
     }
 
     ReadWriteStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,
-                                   BlockManager blockManager, BiomeManager biomeManager, boolean storeChunksInZips,
+                                   BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager, boolean storeChunksInZips,
                                    RecordAndReplaySerializer recordAndReplaySerializer, RecordAndReplayUtils recordAndReplayUtils,
                             RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) throws IOException {
-        super(savePath, environment, entityManager, blockManager, biomeManager, storeChunksInZips);
+        super(savePath, environment, entityManager, blockManager, biomeManager, extraDataManager, storeChunksInZips);
 
         entityManager.subscribeForDestruction(this);
         entityManager.subscribeForChanges(this);

--- a/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/ReadWriteStorageManager.java
@@ -124,10 +124,11 @@ public final class ReadWriteStorageManager extends AbstractStorageManager implem
      */
     private ComponentLibrary entityRefReplacingComponentLibrary;
 
-    public ReadWriteStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,
-                                   BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager, RecordAndReplaySerializer recordAndReplaySerializer,
+    public ReadWriteStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager, BlockManager blockManager,
+                                   BiomeManager biomeManager, ExtraBlockDataManager extraDataManager, RecordAndReplaySerializer recordAndReplaySerializer,
                                    RecordAndReplayUtils recordAndReplayUtils, RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) throws IOException {
-        this(savePath, environment, entityManager, blockManager, biomeManager, extraDataManager, true, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
+        this(savePath, environment, entityManager, blockManager, biomeManager, extraDataManager,
+            true, recordAndReplaySerializer, recordAndReplayUtils, recordAndReplayCurrentStatus);
     }
 
     ReadWriteStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager,

--- a/engine/src/main/java/org/terasology/protobuf/EntityData.java
+++ b/engine/src/main/java/org/terasology/protobuf/EntityData.java
@@ -91,10 +91,10 @@ public final class EntityData {
   }
 
   public interface ValueOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Value)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<Value> {
 
+    // repeated double double = 1 [packed = true];
     /**
      * <code>repeated double double = 1 [packed = true];</code>
      */
@@ -108,6 +108,7 @@ public final class EntityData {
      */
     double getDouble(int index);
 
+    // repeated float float = 2 [packed = true];
     /**
      * <code>repeated float float = 2 [packed = true];</code>
      */
@@ -121,6 +122,7 @@ public final class EntityData {
      */
     float getFloat(int index);
 
+    // repeated sint32 integer = 3 [packed = true];
     /**
      * <code>repeated sint32 integer = 3 [packed = true];</code>
      */
@@ -134,6 +136,7 @@ public final class EntityData {
      */
     int getInteger(int index);
 
+    // repeated sint64 long = 4 [packed = true];
     /**
      * <code>repeated sint64 long = 4 [packed = true];</code>
      */
@@ -147,6 +150,7 @@ public final class EntityData {
      */
     long getLong(int index);
 
+    // repeated bool boolean = 5 [packed = true];
     /**
      * <code>repeated bool boolean = 5 [packed = true];</code>
      */
@@ -160,11 +164,12 @@ public final class EntityData {
      */
     boolean getBoolean(int index);
 
+    // repeated string string = 6;
     /**
      * <code>repeated string string = 6;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getStringList();
+    java.util.List<java.lang.String>
+    getStringList();
     /**
      * <code>repeated string string = 6;</code>
      */
@@ -179,6 +184,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getStringBytes(int index);
 
+    // optional bytes bytes = 7;
     /**
      * <code>optional bytes bytes = 7;</code>
      */
@@ -188,6 +194,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getBytes();
 
+    // repeated .Value value = 8;
     /**
      * <code>repeated .Value value = 8;</code>
      */
@@ -212,6 +219,7 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.ValueOrBuilder getValueOrBuilder(
         int index);
 
+    // repeated .NameValue name_value = 9;
     /**
      * <code>repeated .NameValue name_value = 9;</code>
      *
@@ -261,9 +269,7 @@ public final class EntityData {
    */
   public static final class Value extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        Value> implements
-      // @@protoc_insertion_point(message_implements:Value)
-      ValueOrBuilder {
+        Value> implements ValueOrBuilder {
     // Use Value.newBuilder() to construct.
     private Value(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.Value, ?> builder) {
       super(builder);
@@ -415,12 +421,11 @@ public final class EntityData {
               break;
             }
             case 50: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
                 string_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000020;
               }
-              string_.add(bs);
+              string_.add(input.readBytes());
               break;
             }
             case 58: {
@@ -468,7 +473,7 @@ public final class EntityData {
           boolean_ = java.util.Collections.unmodifiableList(boolean_);
         }
         if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-          string_ = string_.getUnmodifiableView();
+          string_ = new com.google.protobuf.UnmodifiableLazyStringList(string_);
         }
         if (((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
           value_ = java.util.Collections.unmodifiableList(value_);
@@ -508,6 +513,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // repeated double double = 1 [packed = true];
     public static final int DOUBLE_FIELD_NUMBER = 1;
     private java.util.List<java.lang.Double> double_;
     /**
@@ -531,6 +537,7 @@ public final class EntityData {
     }
     private int doubleMemoizedSerializedSize = -1;
 
+    // repeated float float = 2 [packed = true];
     public static final int FLOAT_FIELD_NUMBER = 2;
     private java.util.List<java.lang.Float> float_;
     /**
@@ -554,6 +561,7 @@ public final class EntityData {
     }
     private int floatMemoizedSerializedSize = -1;
 
+    // repeated sint32 integer = 3 [packed = true];
     public static final int INTEGER_FIELD_NUMBER = 3;
     private java.util.List<java.lang.Integer> integer_;
     /**
@@ -577,6 +585,7 @@ public final class EntityData {
     }
     private int integerMemoizedSerializedSize = -1;
 
+    // repeated sint64 long = 4 [packed = true];
     public static final int LONG_FIELD_NUMBER = 4;
     private java.util.List<java.lang.Long> long_;
     /**
@@ -600,6 +609,7 @@ public final class EntityData {
     }
     private int longMemoizedSerializedSize = -1;
 
+    // repeated bool boolean = 5 [packed = true];
     public static final int BOOLEAN_FIELD_NUMBER = 5;
     private java.util.List<java.lang.Boolean> boolean_;
     /**
@@ -623,12 +633,13 @@ public final class EntityData {
     }
     private int booleanMemoizedSerializedSize = -1;
 
+    // repeated string string = 6;
     public static final int STRING_FIELD_NUMBER = 6;
     private com.google.protobuf.LazyStringList string_;
     /**
      * <code>repeated string string = 6;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getStringList() {
       return string_;
     }
@@ -652,6 +663,7 @@ public final class EntityData {
       return string_.getByteString(index);
     }
 
+    // optional bytes bytes = 7;
     public static final int BYTES_FIELD_NUMBER = 7;
     private com.google.protobuf.ByteString bytes_;
     /**
@@ -667,6 +679,7 @@ public final class EntityData {
       return bytes_;
     }
 
+    // repeated .Value value = 8;
     public static final int VALUE_FIELD_NUMBER = 8;
     private java.util.List<org.terasology.protobuf.EntityData.Value> value_;
     /**
@@ -702,6 +715,7 @@ public final class EntityData {
       return value_.get(index);
     }
 
+    // repeated .NameValue name_value = 9;
     public static final int NAME_VALUE_FIELD_NUMBER = 9;
     private java.util.List<org.terasology.protobuf.EntityData.NameValue> nameValue_;
     /**
@@ -771,8 +785,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getValueCount(); i++) {
         if (!getValue(i).isInitialized()) {
@@ -1023,9 +1036,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.Value, Builder> implements
-        // @@protoc_insertion_point(builder_implements:Value)
-        org.terasology.protobuf.EntityData.ValueOrBuilder {
+          org.terasology.protobuf.EntityData.Value, Builder> implements org.terasology.protobuf.EntityData.ValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_Value_descriptor;
@@ -1140,7 +1151,8 @@ public final class EntityData {
         }
         result.boolean_ = boolean_;
         if (((bitField0_ & 0x00000020) == 0x00000020)) {
-          string_ = string_.getUnmodifiableView();
+          string_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              string_);
           bitField0_ = (bitField0_ & ~0x00000020);
         }
         result.string_ = string_;
@@ -1341,6 +1353,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // repeated double double = 1 [packed = true];
       private java.util.List<java.lang.Double> double_ = java.util.Collections.emptyList();
       private void ensureDoubleIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -1392,8 +1405,7 @@ public final class EntityData {
       public Builder addAllDouble(
           java.lang.Iterable<? extends java.lang.Double> values) {
         ensureDoubleIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, double_);
+        super.addAll(values, double_);
         onChanged();
         return this;
       }
@@ -1407,6 +1419,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated float float = 2 [packed = true];
       private java.util.List<java.lang.Float> float_ = java.util.Collections.emptyList();
       private void ensureFloatIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -1458,8 +1471,7 @@ public final class EntityData {
       public Builder addAllFloat(
           java.lang.Iterable<? extends java.lang.Float> values) {
         ensureFloatIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, float_);
+        super.addAll(values, float_);
         onChanged();
         return this;
       }
@@ -1473,6 +1485,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated sint32 integer = 3 [packed = true];
       private java.util.List<java.lang.Integer> integer_ = java.util.Collections.emptyList();
       private void ensureIntegerIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -1524,8 +1537,7 @@ public final class EntityData {
       public Builder addAllInteger(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureIntegerIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, integer_);
+        super.addAll(values, integer_);
         onChanged();
         return this;
       }
@@ -1539,6 +1551,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated sint64 long = 4 [packed = true];
       private java.util.List<java.lang.Long> long_ = java.util.Collections.emptyList();
       private void ensureLongIsMutable() {
         if (!((bitField0_ & 0x00000008) == 0x00000008)) {
@@ -1590,8 +1603,7 @@ public final class EntityData {
       public Builder addAllLong(
           java.lang.Iterable<? extends java.lang.Long> values) {
         ensureLongIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, long_);
+        super.addAll(values, long_);
         onChanged();
         return this;
       }
@@ -1605,6 +1617,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated bool boolean = 5 [packed = true];
       private java.util.List<java.lang.Boolean> boolean_ = java.util.Collections.emptyList();
       private void ensureBooleanIsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
@@ -1656,8 +1669,7 @@ public final class EntityData {
       public Builder addAllBoolean(
           java.lang.Iterable<? extends java.lang.Boolean> values) {
         ensureBooleanIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, boolean_);
+        super.addAll(values, boolean_);
         onChanged();
         return this;
       }
@@ -1671,6 +1683,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated string string = 6;
       private com.google.protobuf.LazyStringList string_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureStringIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -1681,9 +1694,9 @@ public final class EntityData {
       /**
        * <code>repeated string string = 6;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getStringList() {
-        return string_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(string_);
       }
       /**
        * <code>repeated string string = 6;</code>
@@ -1736,8 +1749,7 @@ public final class EntityData {
       public Builder addAllString(
           java.lang.Iterable<java.lang.String> values) {
         ensureStringIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, string_);
+        super.addAll(values, string_);
         onChanged();
         return this;
       }
@@ -1764,6 +1776,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes bytes = 7;
       private com.google.protobuf.ByteString bytes_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes bytes = 7;</code>
@@ -1799,6 +1812,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated .Value value = 8;
       private java.util.List<org.terasology.protobuf.EntityData.Value> value_ =
         java.util.Collections.emptyList();
       private void ensureValueIsMutable() {
@@ -1940,8 +1954,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Value> values) {
         if (valueBuilder_ == null) {
           ensureValueIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, value_);
+          super.addAll(values, value_);
           onChanged();
         } else {
           valueBuilder_.addAllMessages(values);
@@ -2039,6 +2052,7 @@ public final class EntityData {
         return valueBuilder_;
       }
 
+      // repeated .NameValue name_value = 9;
       private java.util.List<org.terasology.protobuf.EntityData.NameValue> nameValue_ =
         java.util.Collections.emptyList();
       private void ensureNameValueIsMutable() {
@@ -2220,8 +2234,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.NameValue> values) {
         if (nameValueBuilder_ == null) {
           ensureNameValueIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, nameValue_);
+          super.addAll(values, nameValue_);
           onChanged();
         } else {
           nameValueBuilder_.addAllMessages(values);
@@ -2362,10 +2375,10 @@ public final class EntityData {
     // @@protoc_insertion_point(class_scope:Value)
   }
 
-  public interface NameValueOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:NameValue)
-      com.google.protobuf.MessageOrBuilder {
+  public interface NameValueOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -2380,6 +2393,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // optional .Value value = 2;
     /**
      * <code>optional .Value value = 2;</code>
      */
@@ -2393,6 +2407,7 @@ public final class EntityData {
      */
     org.terasology.protobuf.EntityData.ValueOrBuilder getValueOrBuilder();
 
+    // optional int32 name_index = 3;
     /**
      * <code>optional int32 name_index = 3;</code>
      */
@@ -2406,9 +2421,8 @@ public final class EntityData {
    * Protobuf type {@code NameValue}
    */
   public static final class NameValue extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:NameValue)
-      NameValueOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements NameValueOrBuilder {
     // Use NameValue.newBuilder() to construct.
     private NameValue(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -2455,9 +2469,8 @@ public final class EntityData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 18: {
@@ -2518,6 +2531,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -2560,6 +2574,7 @@ public final class EntityData {
       }
     }
 
+    // optional .Value value = 2;
     public static final int VALUE_FIELD_NUMBER = 2;
     private org.terasology.protobuf.EntityData.Value value_;
     /**
@@ -2581,6 +2596,7 @@ public final class EntityData {
       return value_;
     }
 
+    // optional int32 name_index = 3;
     public static final int NAME_INDEX_FIELD_NUMBER = 3;
     private int nameIndex_;
     /**
@@ -2604,8 +2620,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasValue()) {
         if (!getValue().isInitialized()) {
@@ -2732,9 +2747,8 @@ public final class EntityData {
      * Protobuf type {@code NameValue}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:NameValue)
-        org.terasology.protobuf.EntityData.NameValueOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.terasology.protobuf.EntityData.NameValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_NameValue_descriptor;
@@ -2882,6 +2896,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -2895,12 +2910,9 @@ public final class EntityData {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -2958,6 +2970,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional .Value value = 2;
       private org.terasology.protobuf.EntityData.Value value_ = org.terasology.protobuf.EntityData.Value.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.Value, org.terasology.protobuf.EntityData.Value.Builder, org.terasology.protobuf.EntityData.ValueOrBuilder> valueBuilder_;
@@ -3066,7 +3079,7 @@ public final class EntityData {
         if (valueBuilder_ == null) {
           valueBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.Value, org.terasology.protobuf.EntityData.Value.Builder, org.terasology.protobuf.EntityData.ValueOrBuilder>(
-                  getValue(),
+                  value_,
                   getParentForChildren(),
                   isClean());
           value_ = null;
@@ -3074,6 +3087,7 @@ public final class EntityData {
         return valueBuilder_;
       }
 
+      // optional int32 name_index = 3;
       private int nameIndex_ ;
       /**
        * <code>optional int32 name_index = 3;</code>
@@ -3118,10 +3132,10 @@ public final class EntityData {
   }
 
   public interface ComponentOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Component)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<Component> {
 
+    // optional int32 type_index = 1;
     /**
      * <code>optional int32 type_index = 1;</code>
      *
@@ -3139,6 +3153,7 @@ public final class EntityData {
      */
     int getTypeIndex();
 
+    // optional string type = 15;
     /**
      * <code>optional string type = 15;</code>
      *
@@ -3165,6 +3180,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getTypeBytes();
 
+    // repeated .NameValue field = 2;
     /**
      * <code>repeated .NameValue field = 2;</code>
      */
@@ -3194,9 +3210,7 @@ public final class EntityData {
    */
   public static final class Component extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        Component> implements
-      // @@protoc_insertion_point(message_implements:Component)
-      ComponentOrBuilder {
+        Component> implements ComponentOrBuilder {
     // Use Component.newBuilder() to construct.
     private Component(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.Component, ?> builder) {
       super(builder);
@@ -3256,9 +3270,8 @@ public final class EntityData {
               break;
             }
             case 122: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              type_ = bs;
+              type_ = input.readBytes();
               break;
             }
           }
@@ -3304,6 +3317,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional int32 type_index = 1;
     public static final int TYPE_INDEX_FIELD_NUMBER = 1;
     private int typeIndex_;
     /**
@@ -3327,6 +3341,7 @@ public final class EntityData {
       return typeIndex_;
     }
 
+    // optional string type = 15;
     public static final int TYPE_FIELD_NUMBER = 15;
     private java.lang.Object type_;
     /**
@@ -3381,6 +3396,7 @@ public final class EntityData {
       }
     }
 
+    // repeated .NameValue field = 2;
     public static final int FIELD_FIELD_NUMBER = 2;
     private java.util.List<org.terasology.protobuf.EntityData.NameValue> field_;
     /**
@@ -3424,8 +3440,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getFieldCount(); i++) {
         if (!getField(i).isInitialized()) {
@@ -3562,9 +3577,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.Component, Builder> implements
-        // @@protoc_insertion_point(builder_implements:Component)
-        org.terasology.protobuf.EntityData.ComponentOrBuilder {
+          org.terasology.protobuf.EntityData.Component, Builder> implements org.terasology.protobuf.EntityData.ComponentOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_Component_descriptor;
@@ -3741,6 +3754,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional int32 type_index = 1;
       private int typeIndex_ ;
       /**
        * <code>optional int32 type_index = 1;</code>
@@ -3789,6 +3803,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional string type = 15;
       private java.lang.Object type_ = "";
       /**
        * <code>optional string type = 15;</code>
@@ -3810,12 +3825,9 @@ public final class EntityData {
       public java.lang.String getType() {
         java.lang.Object ref = type_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            type_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          type_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3889,6 +3901,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated .NameValue field = 2;
       private java.util.List<org.terasology.protobuf.EntityData.NameValue> field_ =
         java.util.Collections.emptyList();
       private void ensureFieldIsMutable() {
@@ -4030,8 +4043,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.NameValue> values) {
         if (fieldBuilder_ == null) {
           ensureFieldIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, field_);
+          super.addAll(values, field_);
           onChanged();
         } else {
           fieldBuilder_.addAllMessages(values);
@@ -4141,10 +4153,10 @@ public final class EntityData {
   }
 
   public interface EntityOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Entity)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<Entity> {
 
+    // optional int64 id = 1;
     /**
      * <code>optional int64 id = 1;</code>
      */
@@ -4154,6 +4166,7 @@ public final class EntityData {
      */
     long getId();
 
+    // repeated .Component component = 2;
     /**
      * <code>repeated .Component component = 2;</code>
      */
@@ -4178,6 +4191,7 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.ComponentOrBuilder getComponentOrBuilder(
         int index);
 
+    // repeated int32 removed_component_index = 3 [packed = true];
     /**
      * <code>repeated int32 removed_component_index = 3 [packed = true];</code>
      */
@@ -4191,6 +4205,7 @@ public final class EntityData {
      */
     int getRemovedComponentIndex(int index);
 
+    // optional string parent_prefab = 4;
     /**
      * <code>optional string parent_prefab = 4;</code>
      */
@@ -4205,6 +4220,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getParentPrefabBytes();
 
+    // optional bool alwaysRelevant = 5;
     /**
      * <code>optional bool alwaysRelevant = 5;</code>
      */
@@ -4214,6 +4230,7 @@ public final class EntityData {
      */
     boolean getAlwaysRelevant();
 
+    // optional int64 owner = 6;
     /**
      * <code>optional int64 owner = 6;</code>
      */
@@ -4223,11 +4240,12 @@ public final class EntityData {
      */
     long getOwner();
 
+    // repeated string removed_component = 15;
     /**
      * <code>repeated string removed_component = 15;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getRemovedComponentList();
+    java.util.List<java.lang.String>
+    getRemovedComponentList();
     /**
      * <code>repeated string removed_component = 15;</code>
      */
@@ -4242,6 +4260,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getRemovedComponentBytes(int index);
 
+    // optional .Entity.Scope scope = 7;
     /**
      * <code>optional .Entity.Scope scope = 7;</code>
      */
@@ -4256,9 +4275,7 @@ public final class EntityData {
    */
   public static final class Entity extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        Entity> implements
-      // @@protoc_insertion_point(message_implements:Entity)
-      EntityOrBuilder {
+        Entity> implements EntityOrBuilder {
     // Use Entity.newBuilder() to construct.
     private Entity(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.Entity, ?> builder) {
       super(builder);
@@ -4339,9 +4356,8 @@ public final class EntityData {
               break;
             }
             case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              parentPrefab_ = bs;
+              parentPrefab_ = input.readBytes();
               break;
             }
             case 40: {
@@ -4366,12 +4382,11 @@ public final class EntityData {
               break;
             }
             case 122: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
                 removedComponent_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000040;
               }
-              removedComponent_.add(bs);
+              removedComponent_.add(input.readBytes());
               break;
             }
           }
@@ -4389,7 +4404,7 @@ public final class EntityData {
           removedComponentIndex_ = java.util.Collections.unmodifiableList(removedComponentIndex_);
         }
         if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-          removedComponent_ = removedComponent_.getUnmodifiableView();
+          removedComponent_ = new com.google.protobuf.UnmodifiableLazyStringList(removedComponent_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -4514,6 +4529,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional int64 id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private long id_;
     /**
@@ -4529,6 +4545,7 @@ public final class EntityData {
       return id_;
     }
 
+    // repeated .Component component = 2;
     public static final int COMPONENT_FIELD_NUMBER = 2;
     private java.util.List<org.terasology.protobuf.EntityData.Component> component_;
     /**
@@ -4564,6 +4581,7 @@ public final class EntityData {
       return component_.get(index);
     }
 
+    // repeated int32 removed_component_index = 3 [packed = true];
     public static final int REMOVED_COMPONENT_INDEX_FIELD_NUMBER = 3;
     private java.util.List<java.lang.Integer> removedComponentIndex_;
     /**
@@ -4587,6 +4605,7 @@ public final class EntityData {
     }
     private int removedComponentIndexMemoizedSerializedSize = -1;
 
+    // optional string parent_prefab = 4;
     public static final int PARENT_PREFAB_FIELD_NUMBER = 4;
     private java.lang.Object parentPrefab_;
     /**
@@ -4629,6 +4648,7 @@ public final class EntityData {
       }
     }
 
+    // optional bool alwaysRelevant = 5;
     public static final int ALWAYSRELEVANT_FIELD_NUMBER = 5;
     private boolean alwaysRelevant_;
     /**
@@ -4644,6 +4664,7 @@ public final class EntityData {
       return alwaysRelevant_;
     }
 
+    // optional int64 owner = 6;
     public static final int OWNER_FIELD_NUMBER = 6;
     private long owner_;
     /**
@@ -4659,12 +4680,13 @@ public final class EntityData {
       return owner_;
     }
 
+    // repeated string removed_component = 15;
     public static final int REMOVED_COMPONENT_FIELD_NUMBER = 15;
     private com.google.protobuf.LazyStringList removedComponent_;
     /**
      * <code>repeated string removed_component = 15;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getRemovedComponentList() {
       return removedComponent_;
     }
@@ -4688,6 +4710,7 @@ public final class EntityData {
       return removedComponent_.getByteString(index);
     }
 
+    // optional .Entity.Scope scope = 7;
     public static final int SCOPE_FIELD_NUMBER = 7;
     private org.terasology.protobuf.EntityData.Entity.Scope scope_;
     /**
@@ -4716,8 +4739,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getComponentCount(); i++) {
         if (!getComponent(i).isInitialized()) {
@@ -4908,9 +4930,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.Entity, Builder> implements
-        // @@protoc_insertion_point(builder_implements:Entity)
-        org.terasology.protobuf.EntityData.EntityOrBuilder {
+          org.terasology.protobuf.EntityData.Entity, Builder> implements org.terasology.protobuf.EntityData.EntityOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_Entity_descriptor;
@@ -5023,7 +5043,8 @@ public final class EntityData {
         }
         result.owner_ = owner_;
         if (((bitField0_ & 0x00000040) == 0x00000040)) {
-          removedComponent_ = removedComponent_.getUnmodifiableView();
+          removedComponent_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              removedComponent_);
           bitField0_ = (bitField0_ & ~0x00000040);
         }
         result.removedComponent_ = removedComponent_;
@@ -5148,6 +5169,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional int64 id = 1;
       private long id_ ;
       /**
        * <code>optional int64 id = 1;</code>
@@ -5180,6 +5202,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated .Component component = 2;
       private java.util.List<org.terasology.protobuf.EntityData.Component> component_ =
         java.util.Collections.emptyList();
       private void ensureComponentIsMutable() {
@@ -5321,8 +5344,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Component> values) {
         if (componentBuilder_ == null) {
           ensureComponentIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, component_);
+          super.addAll(values, component_);
           onChanged();
         } else {
           componentBuilder_.addAllMessages(values);
@@ -5420,6 +5442,7 @@ public final class EntityData {
         return componentBuilder_;
       }
 
+      // repeated int32 removed_component_index = 3 [packed = true];
       private java.util.List<java.lang.Integer> removedComponentIndex_ = java.util.Collections.emptyList();
       private void ensureRemovedComponentIndexIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -5471,8 +5494,7 @@ public final class EntityData {
       public Builder addAllRemovedComponentIndex(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureRemovedComponentIndexIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, removedComponentIndex_);
+        super.addAll(values, removedComponentIndex_);
         onChanged();
         return this;
       }
@@ -5486,6 +5508,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional string parent_prefab = 4;
       private java.lang.Object parentPrefab_ = "";
       /**
        * <code>optional string parent_prefab = 4;</code>
@@ -5499,12 +5522,9 @@ public final class EntityData {
       public java.lang.String getParentPrefab() {
         java.lang.Object ref = parentPrefab_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            parentPrefab_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          parentPrefab_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -5562,6 +5582,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bool alwaysRelevant = 5;
       private boolean alwaysRelevant_ ;
       /**
        * <code>optional bool alwaysRelevant = 5;</code>
@@ -5594,6 +5615,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional int64 owner = 6;
       private long owner_ ;
       /**
        * <code>optional int64 owner = 6;</code>
@@ -5626,6 +5648,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated string removed_component = 15;
       private com.google.protobuf.LazyStringList removedComponent_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureRemovedComponentIsMutable() {
         if (!((bitField0_ & 0x00000040) == 0x00000040)) {
@@ -5636,9 +5659,9 @@ public final class EntityData {
       /**
        * <code>repeated string removed_component = 15;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getRemovedComponentList() {
-        return removedComponent_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(removedComponent_);
       }
       /**
        * <code>repeated string removed_component = 15;</code>
@@ -5691,8 +5714,7 @@ public final class EntityData {
       public Builder addAllRemovedComponent(
           java.lang.Iterable<java.lang.String> values) {
         ensureRemovedComponentIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, removedComponent_);
+        super.addAll(values, removedComponent_);
         onChanged();
         return this;
       }
@@ -5719,6 +5741,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional .Entity.Scope scope = 7;
       private org.terasology.protobuf.EntityData.Entity.Scope scope_ = org.terasology.protobuf.EntityData.Entity.Scope.GLOBAL;
       /**
        * <code>optional .Entity.Scope scope = 7;</code>
@@ -5766,10 +5789,10 @@ public final class EntityData {
   }
 
   public interface PackedEntityOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:PackedEntity)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<PackedEntity> {
 
+    // optional int64 id = 1;
     /**
      * <code>optional int64 id = 1;</code>
      */
@@ -5779,6 +5802,7 @@ public final class EntityData {
      */
     long getId();
 
+    // repeated int32 componentId = 2 [packed = true];
     /**
      * <code>repeated int32 componentId = 2 [packed = true];</code>
      */
@@ -5792,6 +5816,7 @@ public final class EntityData {
      */
     int getComponentId(int index);
 
+    // optional bytes componentFieldCounts = 3;
     /**
      * <code>optional bytes componentFieldCounts = 3;</code>
      */
@@ -5801,6 +5826,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getComponentFieldCounts();
 
+    // optional bytes fieldIds = 4;
     /**
      * <code>optional bytes fieldIds = 4;</code>
      */
@@ -5810,6 +5836,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getFieldIds();
 
+    // repeated .Value fieldValue = 5;
     /**
      * <code>repeated .Value fieldValue = 5;</code>
      */
@@ -5834,6 +5861,7 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.ValueOrBuilder getFieldValueOrBuilder(
         int index);
 
+    // repeated int32 removedComponent = 6 [packed = true];
     /**
      * <code>repeated int32 removedComponent = 6 [packed = true];</code>
      */
@@ -5847,6 +5875,7 @@ public final class EntityData {
      */
     int getRemovedComponent(int index);
 
+    // optional int64 owner = 7;
     /**
      * <code>optional int64 owner = 7;</code>
      */
@@ -5856,6 +5885,7 @@ public final class EntityData {
      */
     long getOwner();
 
+    // optional string parentPrefabUri = 16;
     /**
      * <code>optional string parentPrefabUri = 16;</code>
      */
@@ -5875,9 +5905,7 @@ public final class EntityData {
    */
   public static final class PackedEntity extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        PackedEntity> implements
-      // @@protoc_insertion_point(message_implements:PackedEntity)
-      PackedEntityOrBuilder {
+        PackedEntity> implements PackedEntityOrBuilder {
     // Use PackedEntity.newBuilder() to construct.
     private PackedEntity(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.PackedEntity, ?> builder) {
       super(builder);
@@ -5994,9 +6022,8 @@ public final class EntityData {
               break;
             }
             case 130: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              parentPrefabUri_ = bs;
+              parentPrefabUri_ = input.readBytes();
               break;
             }
           }
@@ -6048,6 +6075,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional int64 id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private long id_;
     /**
@@ -6063,6 +6091,7 @@ public final class EntityData {
       return id_;
     }
 
+    // repeated int32 componentId = 2 [packed = true];
     public static final int COMPONENTID_FIELD_NUMBER = 2;
     private java.util.List<java.lang.Integer> componentId_;
     /**
@@ -6086,6 +6115,7 @@ public final class EntityData {
     }
     private int componentIdMemoizedSerializedSize = -1;
 
+    // optional bytes componentFieldCounts = 3;
     public static final int COMPONENTFIELDCOUNTS_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString componentFieldCounts_;
     /**
@@ -6101,6 +6131,7 @@ public final class EntityData {
       return componentFieldCounts_;
     }
 
+    // optional bytes fieldIds = 4;
     public static final int FIELDIDS_FIELD_NUMBER = 4;
     private com.google.protobuf.ByteString fieldIds_;
     /**
@@ -6116,6 +6147,7 @@ public final class EntityData {
       return fieldIds_;
     }
 
+    // repeated .Value fieldValue = 5;
     public static final int FIELDVALUE_FIELD_NUMBER = 5;
     private java.util.List<org.terasology.protobuf.EntityData.Value> fieldValue_;
     /**
@@ -6151,6 +6183,7 @@ public final class EntityData {
       return fieldValue_.get(index);
     }
 
+    // repeated int32 removedComponent = 6 [packed = true];
     public static final int REMOVEDCOMPONENT_FIELD_NUMBER = 6;
     private java.util.List<java.lang.Integer> removedComponent_;
     /**
@@ -6174,6 +6207,7 @@ public final class EntityData {
     }
     private int removedComponentMemoizedSerializedSize = -1;
 
+    // optional int64 owner = 7;
     public static final int OWNER_FIELD_NUMBER = 7;
     private long owner_;
     /**
@@ -6189,6 +6223,7 @@ public final class EntityData {
       return owner_;
     }
 
+    // optional string parentPrefabUri = 16;
     public static final int PARENTPREFABURI_FIELD_NUMBER = 16;
     private java.lang.Object parentPrefabUri_;
     /**
@@ -6244,8 +6279,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getFieldValueCount(); i++) {
         if (!getFieldValue(i).isInitialized()) {
@@ -6445,9 +6479,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.PackedEntity, Builder> implements
-        // @@protoc_insertion_point(builder_implements:PackedEntity)
-        org.terasology.protobuf.EntityData.PackedEntityOrBuilder {
+          org.terasology.protobuf.EntityData.PackedEntity, Builder> implements org.terasology.protobuf.EntityData.PackedEntityOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_PackedEntity_descriptor;
@@ -6685,6 +6717,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional int64 id = 1;
       private long id_ ;
       /**
        * <code>optional int64 id = 1;</code>
@@ -6717,6 +6750,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated int32 componentId = 2 [packed = true];
       private java.util.List<java.lang.Integer> componentId_ = java.util.Collections.emptyList();
       private void ensureComponentIdIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -6768,8 +6802,7 @@ public final class EntityData {
       public Builder addAllComponentId(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureComponentIdIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, componentId_);
+        super.addAll(values, componentId_);
         onChanged();
         return this;
       }
@@ -6783,6 +6816,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes componentFieldCounts = 3;
       private com.google.protobuf.ByteString componentFieldCounts_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes componentFieldCounts = 3;</code>
@@ -6818,6 +6852,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes fieldIds = 4;
       private com.google.protobuf.ByteString fieldIds_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes fieldIds = 4;</code>
@@ -6853,6 +6888,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated .Value fieldValue = 5;
       private java.util.List<org.terasology.protobuf.EntityData.Value> fieldValue_ =
         java.util.Collections.emptyList();
       private void ensureFieldValueIsMutable() {
@@ -6994,8 +7030,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Value> values) {
         if (fieldValueBuilder_ == null) {
           ensureFieldValueIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, fieldValue_);
+          super.addAll(values, fieldValue_);
           onChanged();
         } else {
           fieldValueBuilder_.addAllMessages(values);
@@ -7093,6 +7128,7 @@ public final class EntityData {
         return fieldValueBuilder_;
       }
 
+      // repeated int32 removedComponent = 6 [packed = true];
       private java.util.List<java.lang.Integer> removedComponent_ = java.util.Collections.emptyList();
       private void ensureRemovedComponentIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -7144,8 +7180,7 @@ public final class EntityData {
       public Builder addAllRemovedComponent(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureRemovedComponentIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, removedComponent_);
+        super.addAll(values, removedComponent_);
         onChanged();
         return this;
       }
@@ -7159,6 +7194,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional int64 owner = 7;
       private long owner_ ;
       /**
        * <code>optional int64 owner = 7;</code>
@@ -7191,6 +7227,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional string parentPrefabUri = 16;
       private java.lang.Object parentPrefabUri_ = "";
       /**
        * <code>optional string parentPrefabUri = 16;</code>
@@ -7204,12 +7241,9 @@ public final class EntityData {
       public java.lang.String getParentPrefabUri() {
         java.lang.Object ref = parentPrefabUri_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            parentPrefabUri_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          parentPrefabUri_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -7279,10 +7313,10 @@ public final class EntityData {
   }
 
   public interface PrefabOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Prefab)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<Prefab> {
 
+    // optional int32 name_index = 1;
     /**
      * <code>optional int32 name_index = 1;</code>
      */
@@ -7292,6 +7326,7 @@ public final class EntityData {
      */
     int getNameIndex();
 
+    // repeated .Component component = 2;
     /**
      * <code>repeated .Component component = 2;</code>
      */
@@ -7316,6 +7351,7 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.ComponentOrBuilder getComponentOrBuilder(
         int index);
 
+    // repeated int32 deprecated = 3 [packed = true];
     /**
      * <code>repeated int32 deprecated = 3 [packed = true];</code>
      */
@@ -7329,6 +7365,7 @@ public final class EntityData {
      */
     int getDeprecated(int index);
 
+    // optional bool persisted = 4 [default = true];
     /**
      * <code>optional bool persisted = 4 [default = true];</code>
      */
@@ -7338,11 +7375,12 @@ public final class EntityData {
      */
     boolean getPersisted();
 
+    // repeated string removedComponent = 5;
     /**
      * <code>repeated string removedComponent = 5;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getRemovedComponentList();
+    java.util.List<java.lang.String>
+    getRemovedComponentList();
     /**
      * <code>repeated string removedComponent = 5;</code>
      */
@@ -7357,6 +7395,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getRemovedComponentBytes(int index);
 
+    // optional bool alwaysRelevant = 6;
     /**
      * <code>optional bool alwaysRelevant = 6;</code>
      */
@@ -7366,6 +7405,7 @@ public final class EntityData {
      */
     boolean getAlwaysRelevant();
 
+    // optional string name = 15;
     /**
      * <code>optional string name = 15;</code>
      */
@@ -7380,6 +7420,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // optional string parent_name = 16;
     /**
      * <code>optional string parent_name = 16;</code>
      */
@@ -7399,9 +7440,7 @@ public final class EntityData {
    */
   public static final class Prefab extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        Prefab> implements
-      // @@protoc_insertion_point(message_implements:Prefab)
-      PrefabOrBuilder {
+        Prefab> implements PrefabOrBuilder {
     // Use Prefab.newBuilder() to construct.
     private Prefab(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.Prefab, ?> builder) {
       super(builder);
@@ -7487,12 +7526,11 @@ public final class EntityData {
               break;
             }
             case 42: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
                 removedComponent_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000010;
               }
-              removedComponent_.add(bs);
+              removedComponent_.add(input.readBytes());
               break;
             }
             case 48: {
@@ -7501,15 +7539,13 @@ public final class EntityData {
               break;
             }
             case 122: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 130: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              parentName_ = bs;
+              parentName_ = input.readBytes();
               break;
             }
           }
@@ -7527,7 +7563,7 @@ public final class EntityData {
           deprecated_ = java.util.Collections.unmodifiableList(deprecated_);
         }
         if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          removedComponent_ = removedComponent_.getUnmodifiableView();
+          removedComponent_ = new com.google.protobuf.UnmodifiableLazyStringList(removedComponent_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -7561,6 +7597,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional int32 name_index = 1;
     public static final int NAME_INDEX_FIELD_NUMBER = 1;
     private int nameIndex_;
     /**
@@ -7576,6 +7613,7 @@ public final class EntityData {
       return nameIndex_;
     }
 
+    // repeated .Component component = 2;
     public static final int COMPONENT_FIELD_NUMBER = 2;
     private java.util.List<org.terasology.protobuf.EntityData.Component> component_;
     /**
@@ -7611,6 +7649,7 @@ public final class EntityData {
       return component_.get(index);
     }
 
+    // repeated int32 deprecated = 3 [packed = true];
     public static final int DEPRECATED_FIELD_NUMBER = 3;
     private java.util.List<java.lang.Integer> deprecated_;
     /**
@@ -7634,6 +7673,7 @@ public final class EntityData {
     }
     private int deprecatedMemoizedSerializedSize = -1;
 
+    // optional bool persisted = 4 [default = true];
     public static final int PERSISTED_FIELD_NUMBER = 4;
     private boolean persisted_;
     /**
@@ -7649,12 +7689,13 @@ public final class EntityData {
       return persisted_;
     }
 
+    // repeated string removedComponent = 5;
     public static final int REMOVEDCOMPONENT_FIELD_NUMBER = 5;
     private com.google.protobuf.LazyStringList removedComponent_;
     /**
      * <code>repeated string removedComponent = 5;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getRemovedComponentList() {
       return removedComponent_;
     }
@@ -7678,6 +7719,7 @@ public final class EntityData {
       return removedComponent_.getByteString(index);
     }
 
+    // optional bool alwaysRelevant = 6;
     public static final int ALWAYSRELEVANT_FIELD_NUMBER = 6;
     private boolean alwaysRelevant_;
     /**
@@ -7693,6 +7735,7 @@ public final class EntityData {
       return alwaysRelevant_;
     }
 
+    // optional string name = 15;
     public static final int NAME_FIELD_NUMBER = 15;
     private java.lang.Object name_;
     /**
@@ -7735,6 +7778,7 @@ public final class EntityData {
       }
     }
 
+    // optional string parent_name = 16;
     public static final int PARENT_NAME_FIELD_NUMBER = 16;
     private java.lang.Object parentName_;
     /**
@@ -7790,8 +7834,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getComponentCount(); i++) {
         if (!getComponent(i).isInitialized()) {
@@ -7982,9 +8025,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.Prefab, Builder> implements
-        // @@protoc_insertion_point(builder_implements:Prefab)
-        org.terasology.protobuf.EntityData.PrefabOrBuilder {
+          org.terasology.protobuf.EntityData.Prefab, Builder> implements org.terasology.protobuf.EntityData.PrefabOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_Prefab_descriptor;
@@ -8089,7 +8130,8 @@ public final class EntityData {
         }
         result.persisted_ = persisted_;
         if (((bitField0_ & 0x00000010) == 0x00000010)) {
-          removedComponent_ = removedComponent_.getUnmodifiableView();
+          removedComponent_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              removedComponent_);
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.removedComponent_ = removedComponent_;
@@ -8224,6 +8266,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional int32 name_index = 1;
       private int nameIndex_ ;
       /**
        * <code>optional int32 name_index = 1;</code>
@@ -8256,6 +8299,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated .Component component = 2;
       private java.util.List<org.terasology.protobuf.EntityData.Component> component_ =
         java.util.Collections.emptyList();
       private void ensureComponentIsMutable() {
@@ -8397,8 +8441,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Component> values) {
         if (componentBuilder_ == null) {
           ensureComponentIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, component_);
+          super.addAll(values, component_);
           onChanged();
         } else {
           componentBuilder_.addAllMessages(values);
@@ -8496,6 +8539,7 @@ public final class EntityData {
         return componentBuilder_;
       }
 
+      // repeated int32 deprecated = 3 [packed = true];
       private java.util.List<java.lang.Integer> deprecated_ = java.util.Collections.emptyList();
       private void ensureDeprecatedIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -8547,8 +8591,7 @@ public final class EntityData {
       public Builder addAllDeprecated(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureDeprecatedIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, deprecated_);
+        super.addAll(values, deprecated_);
         onChanged();
         return this;
       }
@@ -8562,6 +8605,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bool persisted = 4 [default = true];
       private boolean persisted_ = true;
       /**
        * <code>optional bool persisted = 4 [default = true];</code>
@@ -8594,6 +8638,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated string removedComponent = 5;
       private com.google.protobuf.LazyStringList removedComponent_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureRemovedComponentIsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
@@ -8604,9 +8649,9 @@ public final class EntityData {
       /**
        * <code>repeated string removedComponent = 5;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getRemovedComponentList() {
-        return removedComponent_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(removedComponent_);
       }
       /**
        * <code>repeated string removedComponent = 5;</code>
@@ -8659,8 +8704,7 @@ public final class EntityData {
       public Builder addAllRemovedComponent(
           java.lang.Iterable<java.lang.String> values) {
         ensureRemovedComponentIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, removedComponent_);
+        super.addAll(values, removedComponent_);
         onChanged();
         return this;
       }
@@ -8687,6 +8731,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bool alwaysRelevant = 6;
       private boolean alwaysRelevant_ ;
       /**
        * <code>optional bool alwaysRelevant = 6;</code>
@@ -8719,6 +8764,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional string name = 15;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 15;</code>
@@ -8732,12 +8778,9 @@ public final class EntityData {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -8795,6 +8838,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional string parent_name = 16;
       private java.lang.Object parentName_ = "";
       /**
        * <code>optional string parent_name = 16;</code>
@@ -8808,12 +8852,9 @@ public final class EntityData {
       public java.lang.String getParentName() {
         java.lang.Object ref = parentName_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            parentName_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          parentName_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -8883,10 +8924,10 @@ public final class EntityData {
   }
 
   public interface EventOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Event)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<Event> {
 
+    // optional int32 type = 1;
     /**
      * <code>optional int32 type = 1;</code>
      */
@@ -8896,6 +8937,7 @@ public final class EntityData {
      */
     int getType();
 
+    // optional bytes fieldIds = 2;
     /**
      * <code>optional bytes fieldIds = 2;</code>
      */
@@ -8905,6 +8947,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getFieldIds();
 
+    // repeated .Value fieldValue = 3;
     /**
      * <code>repeated .Value fieldValue = 3;</code>
      */
@@ -8934,9 +8977,7 @@ public final class EntityData {
    */
   public static final class Event extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        Event> implements
-      // @@protoc_insertion_point(message_implements:Event)
-      EventOrBuilder {
+        Event> implements EventOrBuilder {
     // Use Event.newBuilder() to construct.
     private Event(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.Event, ?> builder) {
       super(builder);
@@ -9043,6 +9084,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional int32 type = 1;
     public static final int TYPE_FIELD_NUMBER = 1;
     private int type_;
     /**
@@ -9058,6 +9100,7 @@ public final class EntityData {
       return type_;
     }
 
+    // optional bytes fieldIds = 2;
     public static final int FIELDIDS_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString fieldIds_;
     /**
@@ -9073,6 +9116,7 @@ public final class EntityData {
       return fieldIds_;
     }
 
+    // repeated .Value fieldValue = 3;
     public static final int FIELDVALUE_FIELD_NUMBER = 3;
     private java.util.List<org.terasology.protobuf.EntityData.Value> fieldValue_;
     /**
@@ -9116,8 +9160,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getFieldValueCount(); i++) {
         if (!getFieldValue(i).isInitialized()) {
@@ -9254,9 +9297,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.Event, Builder> implements
-        // @@protoc_insertion_point(builder_implements:Event)
-        org.terasology.protobuf.EntityData.EventOrBuilder {
+          org.terasology.protobuf.EntityData.Event, Builder> implements org.terasology.protobuf.EntityData.EventOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_Event_descriptor;
@@ -9431,6 +9472,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional int32 type = 1;
       private int type_ ;
       /**
        * <code>optional int32 type = 1;</code>
@@ -9463,6 +9505,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes fieldIds = 2;
       private com.google.protobuf.ByteString fieldIds_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes fieldIds = 2;</code>
@@ -9498,6 +9541,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated .Value fieldValue = 3;
       private java.util.List<org.terasology.protobuf.EntityData.Value> fieldValue_ =
         java.util.Collections.emptyList();
       private void ensureFieldValueIsMutable() {
@@ -9639,8 +9683,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Value> values) {
         if (fieldValueBuilder_ == null) {
           ensureFieldValueIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, fieldValue_);
+          super.addAll(values, fieldValue_);
           onChanged();
         } else {
           fieldValueBuilder_.addAllMessages(values);
@@ -9750,10 +9793,10 @@ public final class EntityData {
   }
 
   public interface EntityStoreOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:EntityStore)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<EntityStore> {
 
+    // repeated .Entity entity = 1;
     /**
      * <code>repeated .Entity entity = 1;</code>
      */
@@ -9778,11 +9821,12 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.EntityOrBuilder getEntityOrBuilder(
         int index);
 
+    // repeated string component_class = 3;
     /**
      * <code>repeated string component_class = 3;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getComponentClassList();
+    java.util.List<java.lang.String>
+    getComponentClassList();
     /**
      * <code>repeated string component_class = 3;</code>
      */
@@ -9797,6 +9841,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getComponentClassBytes(int index);
 
+    // repeated string entityName = 2;
     /**
      * <code>repeated string entityName = 2;</code>
      *
@@ -9804,8 +9849,8 @@ public final class EntityData {
      * These are paired, with entityNamed referencing entity id
      * </pre>
      */
-    com.google.protobuf.ProtocolStringList
-        getEntityNameList();
+    java.util.List<java.lang.String>
+    getEntityNameList();
     /**
      * <code>repeated string entityName = 2;</code>
      *
@@ -9832,6 +9877,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getEntityNameBytes(int index);
 
+    // repeated int64 entityNamed = 4 [packed = true];
     /**
      * <code>repeated int64 entityNamed = 4 [packed = true];</code>
      */
@@ -9850,9 +9896,7 @@ public final class EntityData {
    */
   public static final class EntityStore extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        EntityStore> implements
-      // @@protoc_insertion_point(message_implements:EntityStore)
-      EntityStoreOrBuilder {
+        EntityStore> implements EntityStoreOrBuilder {
     // Use EntityStore.newBuilder() to construct.
     private EntityStore(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.EntityStore, ?> builder) {
       super(builder);
@@ -9907,21 +9951,19 @@ public final class EntityData {
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 entityName_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000004;
               }
-              entityName_.add(bs);
+              entityName_.add(input.readBytes());
               break;
             }
             case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
                 componentClass_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000002;
               }
-              componentClass_.add(bs);
+              componentClass_.add(input.readBytes());
               break;
             }
             case 32: {
@@ -9957,10 +9999,10 @@ public final class EntityData {
           entity_ = java.util.Collections.unmodifiableList(entity_);
         }
         if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-          entityName_ = entityName_.getUnmodifiableView();
+          entityName_ = new com.google.protobuf.UnmodifiableLazyStringList(entityName_);
         }
         if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-          componentClass_ = componentClass_.getUnmodifiableView();
+          componentClass_ = new com.google.protobuf.UnmodifiableLazyStringList(componentClass_);
         }
         if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
           entityNamed_ = java.util.Collections.unmodifiableList(entityNamed_);
@@ -9996,6 +10038,7 @@ public final class EntityData {
       return PARSER;
     }
 
+    // repeated .Entity entity = 1;
     public static final int ENTITY_FIELD_NUMBER = 1;
     private java.util.List<org.terasology.protobuf.EntityData.Entity> entity_;
     /**
@@ -10031,12 +10074,13 @@ public final class EntityData {
       return entity_.get(index);
     }
 
+    // repeated string component_class = 3;
     public static final int COMPONENT_CLASS_FIELD_NUMBER = 3;
     private com.google.protobuf.LazyStringList componentClass_;
     /**
      * <code>repeated string component_class = 3;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getComponentClassList() {
       return componentClass_;
     }
@@ -10060,6 +10104,7 @@ public final class EntityData {
       return componentClass_.getByteString(index);
     }
 
+    // repeated string entityName = 2;
     public static final int ENTITYNAME_FIELD_NUMBER = 2;
     private com.google.protobuf.LazyStringList entityName_;
     /**
@@ -10069,7 +10114,7 @@ public final class EntityData {
      * These are paired, with entityNamed referencing entity id
      * </pre>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getEntityNameList() {
       return entityName_;
     }
@@ -10105,6 +10150,7 @@ public final class EntityData {
       return entityName_.getByteString(index);
     }
 
+    // repeated int64 entityNamed = 4 [packed = true];
     public static final int ENTITYNAMED_FIELD_NUMBER = 4;
     private java.util.List<java.lang.Long> entityNamed_;
     /**
@@ -10137,8 +10183,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getEntityCount(); i++) {
         if (!getEntity(i).isInitialized()) {
@@ -10306,9 +10351,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.EntityStore, Builder> implements
-        // @@protoc_insertion_point(builder_implements:EntityStore)
-        org.terasology.protobuf.EntityData.EntityStoreOrBuilder {
+          org.terasology.protobuf.EntityData.EntityStore, Builder> implements org.terasology.protobuf.EntityData.EntityStoreOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_EntityStore_descriptor;
@@ -10391,12 +10434,14 @@ public final class EntityData {
           result.entity_ = entityBuilder_.build();
         }
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          componentClass_ = componentClass_.getUnmodifiableView();
+          componentClass_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              componentClass_);
           bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.componentClass_ = componentClass_;
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
-          entityName_ = entityName_.getUnmodifiableView();
+          entityName_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              entityName_);
           bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.entityName_ = entityName_;
@@ -10514,6 +10559,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // repeated .Entity entity = 1;
       private java.util.List<org.terasology.protobuf.EntityData.Entity> entity_ =
         java.util.Collections.emptyList();
       private void ensureEntityIsMutable() {
@@ -10655,8 +10701,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Entity> values) {
         if (entityBuilder_ == null) {
           ensureEntityIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, entity_);
+          super.addAll(values, entity_);
           onChanged();
         } else {
           entityBuilder_.addAllMessages(values);
@@ -10754,6 +10799,7 @@ public final class EntityData {
         return entityBuilder_;
       }
 
+      // repeated string component_class = 3;
       private com.google.protobuf.LazyStringList componentClass_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureComponentClassIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -10764,9 +10810,9 @@ public final class EntityData {
       /**
        * <code>repeated string component_class = 3;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getComponentClassList() {
-        return componentClass_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(componentClass_);
       }
       /**
        * <code>repeated string component_class = 3;</code>
@@ -10819,8 +10865,7 @@ public final class EntityData {
       public Builder addAllComponentClass(
           java.lang.Iterable<java.lang.String> values) {
         ensureComponentClassIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, componentClass_);
+        super.addAll(values, componentClass_);
         onChanged();
         return this;
       }
@@ -10847,6 +10892,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated string entityName = 2;
       private com.google.protobuf.LazyStringList entityName_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureEntityNameIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -10861,9 +10907,9 @@ public final class EntityData {
        * These are paired, with entityNamed referencing entity id
        * </pre>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getEntityNameList() {
-        return entityName_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(entityName_);
       }
       /**
        * <code>repeated string entityName = 2;</code>
@@ -10940,8 +10986,7 @@ public final class EntityData {
       public Builder addAllEntityName(
           java.lang.Iterable<java.lang.String> values) {
         ensureEntityNameIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, entityName_);
+        super.addAll(values, entityName_);
         onChanged();
         return this;
       }
@@ -10976,6 +11021,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated int64 entityNamed = 4 [packed = true];
       private java.util.List<java.lang.Long> entityNamed_ = java.util.Collections.emptyList();
       private void ensureEntityNamedIsMutable() {
         if (!((bitField0_ & 0x00000008) == 0x00000008)) {
@@ -11027,8 +11073,7 @@ public final class EntityData {
       public Builder addAllEntityNamed(
           java.lang.Iterable<? extends java.lang.Long> values) {
         ensureEntityNamedIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, entityNamed_);
+        super.addAll(values, entityNamed_);
         onChanged();
         return this;
       }
@@ -11054,10 +11099,10 @@ public final class EntityData {
   }
 
   public interface PlayerStoreOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:PlayerStore)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<PlayerStore> {
 
+    // optional .EntityStore store = 1;
     /**
      * <code>optional .EntityStore store = 1;</code>
      */
@@ -11071,6 +11116,7 @@ public final class EntityData {
      */
     org.terasology.protobuf.EntityData.EntityStoreOrBuilder getStoreOrBuilder();
 
+    // optional float characterPosX = 15;
     /**
      * <code>optional float characterPosX = 15;</code>
      */
@@ -11080,6 +11126,7 @@ public final class EntityData {
      */
     float getCharacterPosX();
 
+    // optional float characterPosY = 16;
     /**
      * <code>optional float characterPosY = 16;</code>
      */
@@ -11089,6 +11136,7 @@ public final class EntityData {
      */
     float getCharacterPosY();
 
+    // optional float characterPosZ = 17;
     /**
      * <code>optional float characterPosZ = 17;</code>
      */
@@ -11098,6 +11146,7 @@ public final class EntityData {
      */
     float getCharacterPosZ();
 
+    // optional bool hasCharacter = 18;
     /**
      * <code>optional bool hasCharacter = 18;</code>
      */
@@ -11112,9 +11161,7 @@ public final class EntityData {
    */
   public static final class PlayerStore extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        PlayerStore> implements
-      // @@protoc_insertion_point(message_implements:PlayerStore)
-      PlayerStoreOrBuilder {
+        PlayerStore> implements PlayerStoreOrBuilder {
     // Use PlayerStore.newBuilder() to construct.
     private PlayerStore(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.PlayerStore, ?> builder) {
       super(builder);
@@ -11233,6 +11280,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional .EntityStore store = 1;
     public static final int STORE_FIELD_NUMBER = 1;
     private org.terasology.protobuf.EntityData.EntityStore store_;
     /**
@@ -11254,6 +11302,7 @@ public final class EntityData {
       return store_;
     }
 
+    // optional float characterPosX = 15;
     public static final int CHARACTERPOSX_FIELD_NUMBER = 15;
     private float characterPosX_;
     /**
@@ -11269,6 +11318,7 @@ public final class EntityData {
       return characterPosX_;
     }
 
+    // optional float characterPosY = 16;
     public static final int CHARACTERPOSY_FIELD_NUMBER = 16;
     private float characterPosY_;
     /**
@@ -11284,6 +11334,7 @@ public final class EntityData {
       return characterPosY_;
     }
 
+    // optional float characterPosZ = 17;
     public static final int CHARACTERPOSZ_FIELD_NUMBER = 17;
     private float characterPosZ_;
     /**
@@ -11299,6 +11350,7 @@ public final class EntityData {
       return characterPosZ_;
     }
 
+    // optional bool hasCharacter = 18;
     public static final int HASCHARACTER_FIELD_NUMBER = 18;
     private boolean hasCharacter_;
     /**
@@ -11324,8 +11376,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasStore()) {
         if (!getStore().isInitialized()) {
@@ -11476,9 +11527,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.PlayerStore, Builder> implements
-        // @@protoc_insertion_point(builder_implements:PlayerStore)
-        org.terasology.protobuf.EntityData.PlayerStoreOrBuilder {
+          org.terasology.protobuf.EntityData.PlayerStore, Builder> implements org.terasology.protobuf.EntityData.PlayerStoreOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_PlayerStore_descriptor;
@@ -11647,6 +11696,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional .EntityStore store = 1;
       private org.terasology.protobuf.EntityData.EntityStore store_ = org.terasology.protobuf.EntityData.EntityStore.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.EntityStore, org.terasology.protobuf.EntityData.EntityStore.Builder, org.terasology.protobuf.EntityData.EntityStoreOrBuilder> storeBuilder_;
@@ -11755,7 +11805,7 @@ public final class EntityData {
         if (storeBuilder_ == null) {
           storeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.EntityStore, org.terasology.protobuf.EntityData.EntityStore.Builder, org.terasology.protobuf.EntityData.EntityStoreOrBuilder>(
-                  getStore(),
+                  store_,
                   getParentForChildren(),
                   isClean());
           store_ = null;
@@ -11763,6 +11813,7 @@ public final class EntityData {
         return storeBuilder_;
       }
 
+      // optional float characterPosX = 15;
       private float characterPosX_ ;
       /**
        * <code>optional float characterPosX = 15;</code>
@@ -11795,6 +11846,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional float characterPosY = 16;
       private float characterPosY_ ;
       /**
        * <code>optional float characterPosY = 16;</code>
@@ -11827,6 +11879,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional float characterPosZ = 17;
       private float characterPosZ_ ;
       /**
        * <code>optional float characterPosZ = 17;</code>
@@ -11859,6 +11912,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bool hasCharacter = 18;
       private boolean hasCharacter_ ;
       /**
        * <code>optional bool hasCharacter = 18;</code>
@@ -11903,10 +11957,10 @@ public final class EntityData {
   }
 
   public interface ChunkStoreOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ChunkStore)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ChunkStore> {
 
+    // optional .EntityStore store = 1;
     /**
      * <code>optional .EntityStore store = 1;</code>
      */
@@ -11920,6 +11974,7 @@ public final class EntityData {
      */
     org.terasology.protobuf.EntityData.EntityStoreOrBuilder getStoreOrBuilder();
 
+    // optional sint32 x = 2;
     /**
      * <code>optional sint32 x = 2;</code>
      */
@@ -11929,6 +11984,7 @@ public final class EntityData {
      */
     int getX();
 
+    // optional sint32 y = 3;
     /**
      * <code>optional sint32 y = 3;</code>
      */
@@ -11938,6 +11994,7 @@ public final class EntityData {
      */
     int getY();
 
+    // optional sint32 z = 4;
     /**
      * <code>optional sint32 z = 4;</code>
      */
@@ -11947,6 +12004,7 @@ public final class EntityData {
      */
     int getZ();
 
+    // optional int32 deprecated_data_3 = 5;
     /**
      * <code>optional int32 deprecated_data_3 = 5;</code>
      */
@@ -11956,6 +12014,7 @@ public final class EntityData {
      */
     int getDeprecatedData3();
 
+    // optional bytes deprecated_data_4 = 6;
     /**
      * <code>optional bytes deprecated_data_4 = 6;</code>
      */
@@ -11965,6 +12024,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getDeprecatedData4();
 
+    // optional bytes deprecated_data_1 = 7;
     /**
      * <code>optional bytes deprecated_data_1 = 7;</code>
      */
@@ -11974,6 +12034,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getDeprecatedData1();
 
+    // optional bytes deprecated_data_2 = 8;
     /**
      * <code>optional bytes deprecated_data_2 = 8;</code>
      */
@@ -11983,6 +12044,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getDeprecatedData2();
 
+    // optional bytes deprecated_data_5 = 9;
     /**
      * <code>optional bytes deprecated_data_5 = 9;</code>
      */
@@ -11992,6 +12054,7 @@ public final class EntityData {
      */
     com.google.protobuf.ByteString getDeprecatedData5();
 
+    // optional .RunLengthEncoding16 block_data = 10;
     /**
      * <code>optional .RunLengthEncoding16 block_data = 10;</code>
      */
@@ -12005,6 +12068,7 @@ public final class EntityData {
      */
     org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder getBlockDataOrBuilder();
 
+    // optional .RunLengthEncoding8 liquid_data = 11;
     /**
      * <code>optional .RunLengthEncoding8 liquid_data = 11;</code>
      */
@@ -12018,6 +12082,7 @@ public final class EntityData {
      */
     org.terasology.protobuf.EntityData.RunLengthEncoding8OrBuilder getLiquidDataOrBuilder();
 
+    // optional .RunLengthEncoding16 biome_data = 12;
     /**
      * <code>optional .RunLengthEncoding16 biome_data = 12;</code>
      */
@@ -12030,15 +12095,38 @@ public final class EntityData {
      * <code>optional .RunLengthEncoding16 biome_data = 12;</code>
      */
     org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder getBiomeDataOrBuilder();
+
+    // repeated .RunLengthEncoding16 extra_data = 13;
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    java.util.List<org.terasology.protobuf.EntityData.RunLengthEncoding16> 
+        getExtraDataList();
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    org.terasology.protobuf.EntityData.RunLengthEncoding16 getExtraData(int index);
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    int getExtraDataCount();
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    java.util.List<? extends org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> 
+        getExtraDataOrBuilderList();
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder getExtraDataOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code ChunkStore}
    */
   public static final class ChunkStore extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ChunkStore> implements
-      // @@protoc_insertion_point(message_implements:ChunkStore)
-      ChunkStoreOrBuilder {
+        ChunkStore> implements ChunkStoreOrBuilder {
     // Use ChunkStore.newBuilder() to construct.
     private ChunkStore(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.ChunkStore, ?> builder) {
       super(builder);
@@ -12176,6 +12264,14 @@ public final class EntityData {
               bitField0_ |= 0x00000800;
               break;
             }
+            case 106: {
+              if (!((mutable_bitField0_ & 0x00001000) == 0x00001000)) {
+                extraData_ = new java.util.ArrayList<org.terasology.protobuf.EntityData.RunLengthEncoding16>();
+                mutable_bitField0_ |= 0x00001000;
+              }
+              extraData_.add(input.readMessage(org.terasology.protobuf.EntityData.RunLengthEncoding16.PARSER, extensionRegistry));
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -12184,6 +12280,9 @@ public final class EntityData {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00001000) == 0x00001000)) {
+          extraData_ = java.util.Collections.unmodifiableList(extraData_);
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -12216,6 +12315,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // optional .EntityStore store = 1;
     public static final int STORE_FIELD_NUMBER = 1;
     private org.terasology.protobuf.EntityData.EntityStore store_;
     /**
@@ -12237,6 +12337,7 @@ public final class EntityData {
       return store_;
     }
 
+    // optional sint32 x = 2;
     public static final int X_FIELD_NUMBER = 2;
     private int x_;
     /**
@@ -12252,6 +12353,7 @@ public final class EntityData {
       return x_;
     }
 
+    // optional sint32 y = 3;
     public static final int Y_FIELD_NUMBER = 3;
     private int y_;
     /**
@@ -12267,6 +12369,7 @@ public final class EntityData {
       return y_;
     }
 
+    // optional sint32 z = 4;
     public static final int Z_FIELD_NUMBER = 4;
     private int z_;
     /**
@@ -12282,6 +12385,7 @@ public final class EntityData {
       return z_;
     }
 
+    // optional int32 deprecated_data_3 = 5;
     public static final int DEPRECATED_DATA_3_FIELD_NUMBER = 5;
     private int deprecatedData3_;
     /**
@@ -12297,6 +12401,7 @@ public final class EntityData {
       return deprecatedData3_;
     }
 
+    // optional bytes deprecated_data_4 = 6;
     public static final int DEPRECATED_DATA_4_FIELD_NUMBER = 6;
     private com.google.protobuf.ByteString deprecatedData4_;
     /**
@@ -12312,6 +12417,7 @@ public final class EntityData {
       return deprecatedData4_;
     }
 
+    // optional bytes deprecated_data_1 = 7;
     public static final int DEPRECATED_DATA_1_FIELD_NUMBER = 7;
     private com.google.protobuf.ByteString deprecatedData1_;
     /**
@@ -12327,6 +12433,7 @@ public final class EntityData {
       return deprecatedData1_;
     }
 
+    // optional bytes deprecated_data_2 = 8;
     public static final int DEPRECATED_DATA_2_FIELD_NUMBER = 8;
     private com.google.protobuf.ByteString deprecatedData2_;
     /**
@@ -12342,6 +12449,7 @@ public final class EntityData {
       return deprecatedData2_;
     }
 
+    // optional bytes deprecated_data_5 = 9;
     public static final int DEPRECATED_DATA_5_FIELD_NUMBER = 9;
     private com.google.protobuf.ByteString deprecatedData5_;
     /**
@@ -12357,6 +12465,7 @@ public final class EntityData {
       return deprecatedData5_;
     }
 
+    // optional .RunLengthEncoding16 block_data = 10;
     public static final int BLOCK_DATA_FIELD_NUMBER = 10;
     private org.terasology.protobuf.EntityData.RunLengthEncoding16 blockData_;
     /**
@@ -12378,6 +12487,7 @@ public final class EntityData {
       return blockData_;
     }
 
+    // optional .RunLengthEncoding8 liquid_data = 11;
     public static final int LIQUID_DATA_FIELD_NUMBER = 11;
     private org.terasology.protobuf.EntityData.RunLengthEncoding8 liquidData_;
     /**
@@ -12399,6 +12509,7 @@ public final class EntityData {
       return liquidData_;
     }
 
+    // optional .RunLengthEncoding16 biome_data = 12;
     public static final int BIOME_DATA_FIELD_NUMBER = 12;
     private org.terasology.protobuf.EntityData.RunLengthEncoding16 biomeData_;
     /**
@@ -12420,6 +12531,42 @@ public final class EntityData {
       return biomeData_;
     }
 
+    // repeated .RunLengthEncoding16 extra_data = 13;
+    public static final int EXTRA_DATA_FIELD_NUMBER = 13;
+    private java.util.List<org.terasology.protobuf.EntityData.RunLengthEncoding16> extraData_;
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    public java.util.List<org.terasology.protobuf.EntityData.RunLengthEncoding16> getExtraDataList() {
+      return extraData_;
+    }
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    public java.util.List<? extends org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> 
+        getExtraDataOrBuilderList() {
+      return extraData_;
+    }
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    public int getExtraDataCount() {
+      return extraData_.size();
+    }
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    public org.terasology.protobuf.EntityData.RunLengthEncoding16 getExtraData(int index) {
+      return extraData_.get(index);
+    }
+    /**
+     * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+     */
+    public org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder getExtraDataOrBuilder(
+        int index) {
+      return extraData_.get(index);
+    }
+
     private void initFields() {
       store_ = org.terasology.protobuf.EntityData.EntityStore.getDefaultInstance();
       x_ = 0;
@@ -12433,12 +12580,12 @@ public final class EntityData {
       blockData_ = org.terasology.protobuf.EntityData.RunLengthEncoding16.getDefaultInstance();
       liquidData_ = org.terasology.protobuf.EntityData.RunLengthEncoding8.getDefaultInstance();
       biomeData_ = org.terasology.protobuf.EntityData.RunLengthEncoding16.getDefaultInstance();
+      extraData_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasStore()) {
         if (!getStore().isInitialized()) {
@@ -12460,6 +12607,12 @@ public final class EntityData {
       }
       if (hasBiomeData()) {
         if (!getBiomeData().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      for (int i = 0; i < getExtraDataCount(); i++) {
+        if (!getExtraData(i).isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -12513,6 +12666,9 @@ public final class EntityData {
       }
       if (((bitField0_ & 0x00000800) == 0x00000800)) {
         output.writeMessage(12, biomeData_);
+      }
+      for (int i = 0; i < extraData_.size(); i++) {
+        output.writeMessage(13, extraData_.get(i));
       }
       extensionWriter.writeUntil(536870912, output);
       getUnknownFields().writeTo(output);
@@ -12571,6 +12727,10 @@ public final class EntityData {
       if (((bitField0_ & 0x00000800) == 0x00000800)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(12, biomeData_);
+      }
+      for (int i = 0; i < extraData_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(13, extraData_.get(i));
       }
       size += extensionsSerializedSize();
       size += getUnknownFields().getSerializedSize();
@@ -12656,9 +12816,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.ChunkStore, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ChunkStore)
-        org.terasology.protobuf.EntityData.ChunkStoreOrBuilder {
+          org.terasology.protobuf.EntityData.ChunkStore, Builder> implements org.terasology.protobuf.EntityData.ChunkStoreOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_ChunkStore_descriptor;
@@ -12687,6 +12845,7 @@ public final class EntityData {
           getBlockDataFieldBuilder();
           getLiquidDataFieldBuilder();
           getBiomeDataFieldBuilder();
+          getExtraDataFieldBuilder();
         }
       }
       private static Builder create() {
@@ -12735,6 +12894,12 @@ public final class EntityData {
           biomeDataBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000800);
+        if (extraDataBuilder_ == null) {
+          extraData_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00001000);
+        } else {
+          extraDataBuilder_.clear();
+        }
         return this;
       }
 
@@ -12827,6 +12992,15 @@ public final class EntityData {
         } else {
           result.biomeData_ = biomeDataBuilder_.build();
         }
+        if (extraDataBuilder_ == null) {
+          if (((bitField0_ & 0x00001000) == 0x00001000)) {
+            extraData_ = java.util.Collections.unmodifiableList(extraData_);
+            bitField0_ = (bitField0_ & ~0x00001000);
+          }
+          result.extraData_ = extraData_;
+        } else {
+          result.extraData_ = extraDataBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -12879,6 +13053,32 @@ public final class EntityData {
         if (other.hasBiomeData()) {
           mergeBiomeData(other.getBiomeData());
         }
+        if (extraDataBuilder_ == null) {
+          if (!other.extraData_.isEmpty()) {
+            if (extraData_.isEmpty()) {
+              extraData_ = other.extraData_;
+              bitField0_ = (bitField0_ & ~0x00001000);
+            } else {
+              ensureExtraDataIsMutable();
+              extraData_.addAll(other.extraData_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.extraData_.isEmpty()) {
+            if (extraDataBuilder_.isEmpty()) {
+              extraDataBuilder_.dispose();
+              extraDataBuilder_ = null;
+              extraData_ = other.extraData_;
+              bitField0_ = (bitField0_ & ~0x00001000);
+              extraDataBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getExtraDataFieldBuilder() : null;
+            } else {
+              extraDataBuilder_.addAllMessages(other.extraData_);
+            }
+          }
+        }
         this.mergeExtensionFields(other);
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -12909,6 +13109,12 @@ public final class EntityData {
             return false;
           }
         }
+        for (int i = 0; i < getExtraDataCount(); i++) {
+          if (!getExtraData(i).isInitialized()) {
+            
+            return false;
+          }
+        }
         if (!extensionsAreInitialized()) {
           
           return false;
@@ -12935,6 +13141,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // optional .EntityStore store = 1;
       private org.terasology.protobuf.EntityData.EntityStore store_ = org.terasology.protobuf.EntityData.EntityStore.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.EntityStore, org.terasology.protobuf.EntityData.EntityStore.Builder, org.terasology.protobuf.EntityData.EntityStoreOrBuilder> storeBuilder_;
@@ -13043,7 +13250,7 @@ public final class EntityData {
         if (storeBuilder_ == null) {
           storeBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.EntityStore, org.terasology.protobuf.EntityData.EntityStore.Builder, org.terasology.protobuf.EntityData.EntityStoreOrBuilder>(
-                  getStore(),
+                  store_,
                   getParentForChildren(),
                   isClean());
           store_ = null;
@@ -13051,6 +13258,7 @@ public final class EntityData {
         return storeBuilder_;
       }
 
+      // optional sint32 x = 2;
       private int x_ ;
       /**
        * <code>optional sint32 x = 2;</code>
@@ -13083,6 +13291,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional sint32 y = 3;
       private int y_ ;
       /**
        * <code>optional sint32 y = 3;</code>
@@ -13115,6 +13324,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional sint32 z = 4;
       private int z_ ;
       /**
        * <code>optional sint32 z = 4;</code>
@@ -13147,6 +13357,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional int32 deprecated_data_3 = 5;
       private int deprecatedData3_ ;
       /**
        * <code>optional int32 deprecated_data_3 = 5;</code>
@@ -13179,6 +13390,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes deprecated_data_4 = 6;
       private com.google.protobuf.ByteString deprecatedData4_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes deprecated_data_4 = 6;</code>
@@ -13214,6 +13426,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes deprecated_data_1 = 7;
       private com.google.protobuf.ByteString deprecatedData1_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes deprecated_data_1 = 7;</code>
@@ -13249,6 +13462,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes deprecated_data_2 = 8;
       private com.google.protobuf.ByteString deprecatedData2_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes deprecated_data_2 = 8;</code>
@@ -13284,6 +13498,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes deprecated_data_5 = 9;
       private com.google.protobuf.ByteString deprecatedData5_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes deprecated_data_5 = 9;</code>
@@ -13319,6 +13534,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional .RunLengthEncoding16 block_data = 10;
       private org.terasology.protobuf.EntityData.RunLengthEncoding16 blockData_ = org.terasology.protobuf.EntityData.RunLengthEncoding16.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> blockDataBuilder_;
@@ -13427,7 +13643,7 @@ public final class EntityData {
         if (blockDataBuilder_ == null) {
           blockDataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder>(
-                  getBlockData(),
+                  blockData_,
                   getParentForChildren(),
                   isClean());
           blockData_ = null;
@@ -13435,6 +13651,7 @@ public final class EntityData {
         return blockDataBuilder_;
       }
 
+      // optional .RunLengthEncoding8 liquid_data = 11;
       private org.terasology.protobuf.EntityData.RunLengthEncoding8 liquidData_ = org.terasology.protobuf.EntityData.RunLengthEncoding8.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.RunLengthEncoding8, org.terasology.protobuf.EntityData.RunLengthEncoding8.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding8OrBuilder> liquidDataBuilder_;
@@ -13543,7 +13760,7 @@ public final class EntityData {
         if (liquidDataBuilder_ == null) {
           liquidDataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.RunLengthEncoding8, org.terasology.protobuf.EntityData.RunLengthEncoding8.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding8OrBuilder>(
-                  getLiquidData(),
+                  liquidData_,
                   getParentForChildren(),
                   isClean());
           liquidData_ = null;
@@ -13551,6 +13768,7 @@ public final class EntityData {
         return liquidDataBuilder_;
       }
 
+      // optional .RunLengthEncoding16 biome_data = 12;
       private org.terasology.protobuf.EntityData.RunLengthEncoding16 biomeData_ = org.terasology.protobuf.EntityData.RunLengthEncoding16.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> biomeDataBuilder_;
@@ -13659,12 +13877,252 @@ public final class EntityData {
         if (biomeDataBuilder_ == null) {
           biomeDataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder>(
-                  getBiomeData(),
+                  biomeData_,
                   getParentForChildren(),
                   isClean());
           biomeData_ = null;
         }
         return biomeDataBuilder_;
+      }
+
+      // repeated .RunLengthEncoding16 extra_data = 13;
+      private java.util.List<org.terasology.protobuf.EntityData.RunLengthEncoding16> extraData_ =
+        java.util.Collections.emptyList();
+      private void ensureExtraDataIsMutable() {
+        if (!((bitField0_ & 0x00001000) == 0x00001000)) {
+          extraData_ = new java.util.ArrayList<org.terasology.protobuf.EntityData.RunLengthEncoding16>(extraData_);
+          bitField0_ |= 0x00001000;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> extraDataBuilder_;
+
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public java.util.List<org.terasology.protobuf.EntityData.RunLengthEncoding16> getExtraDataList() {
+        if (extraDataBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(extraData_);
+        } else {
+          return extraDataBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public int getExtraDataCount() {
+        if (extraDataBuilder_ == null) {
+          return extraData_.size();
+        } else {
+          return extraDataBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public org.terasology.protobuf.EntityData.RunLengthEncoding16 getExtraData(int index) {
+        if (extraDataBuilder_ == null) {
+          return extraData_.get(index);
+        } else {
+          return extraDataBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder setExtraData(
+          int index, org.terasology.protobuf.EntityData.RunLengthEncoding16 value) {
+        if (extraDataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExtraDataIsMutable();
+          extraData_.set(index, value);
+          onChanged();
+        } else {
+          extraDataBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder setExtraData(
+          int index, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder builderForValue) {
+        if (extraDataBuilder_ == null) {
+          ensureExtraDataIsMutable();
+          extraData_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          extraDataBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder addExtraData(org.terasology.protobuf.EntityData.RunLengthEncoding16 value) {
+        if (extraDataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExtraDataIsMutable();
+          extraData_.add(value);
+          onChanged();
+        } else {
+          extraDataBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder addExtraData(
+          int index, org.terasology.protobuf.EntityData.RunLengthEncoding16 value) {
+        if (extraDataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExtraDataIsMutable();
+          extraData_.add(index, value);
+          onChanged();
+        } else {
+          extraDataBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder addExtraData(
+          org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder builderForValue) {
+        if (extraDataBuilder_ == null) {
+          ensureExtraDataIsMutable();
+          extraData_.add(builderForValue.build());
+          onChanged();
+        } else {
+          extraDataBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder addExtraData(
+          int index, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder builderForValue) {
+        if (extraDataBuilder_ == null) {
+          ensureExtraDataIsMutable();
+          extraData_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          extraDataBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder addAllExtraData(
+          java.lang.Iterable<? extends org.terasology.protobuf.EntityData.RunLengthEncoding16> values) {
+        if (extraDataBuilder_ == null) {
+          ensureExtraDataIsMutable();
+          super.addAll(values, extraData_);
+          onChanged();
+        } else {
+          extraDataBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder clearExtraData() {
+        if (extraDataBuilder_ == null) {
+          extraData_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00001000);
+          onChanged();
+        } else {
+          extraDataBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public Builder removeExtraData(int index) {
+        if (extraDataBuilder_ == null) {
+          ensureExtraDataIsMutable();
+          extraData_.remove(index);
+          onChanged();
+        } else {
+          extraDataBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder getExtraDataBuilder(
+          int index) {
+        return getExtraDataFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder getExtraDataOrBuilder(
+          int index) {
+        if (extraDataBuilder_ == null) {
+          return extraData_.get(index);  } else {
+          return extraDataBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public java.util.List<? extends org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> 
+           getExtraDataOrBuilderList() {
+        if (extraDataBuilder_ != null) {
+          return extraDataBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(extraData_);
+        }
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder addExtraDataBuilder() {
+        return getExtraDataFieldBuilder().addBuilder(
+            org.terasology.protobuf.EntityData.RunLengthEncoding16.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder addExtraDataBuilder(
+          int index) {
+        return getExtraDataFieldBuilder().addBuilder(
+            index, org.terasology.protobuf.EntityData.RunLengthEncoding16.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .RunLengthEncoding16 extra_data = 13;</code>
+       */
+      public java.util.List<org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder> 
+           getExtraDataBuilderList() {
+        return getExtraDataFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder> 
+          getExtraDataFieldBuilder() {
+        if (extraDataBuilder_ == null) {
+          extraDataBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.terasology.protobuf.EntityData.RunLengthEncoding16, org.terasology.protobuf.EntityData.RunLengthEncoding16.Builder, org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder>(
+                  extraData_,
+                  ((bitField0_ & 0x00001000) == 0x00001000),
+                  getParentForChildren(),
+                  isClean());
+          extraData_ = null;
+        }
+        return extraDataBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:ChunkStore)
@@ -13679,10 +14137,10 @@ public final class EntityData {
   }
 
   public interface RunLengthEncoding16OrBuilder extends
-      // @@protoc_insertion_point(interface_extends:RunLengthEncoding16)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<RunLengthEncoding16> {
 
+    // repeated sint32 runLengths = 1 [packed = true];
     /**
      * <code>repeated sint32 runLengths = 1 [packed = true];</code>
      */
@@ -13696,6 +14154,7 @@ public final class EntityData {
      */
     int getRunLengths(int index);
 
+    // repeated sint32 values = 2 [packed = true];
     /**
      * <code>repeated sint32 values = 2 [packed = true];</code>
      */
@@ -13714,9 +14173,7 @@ public final class EntityData {
    */
   public static final class RunLengthEncoding16 extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        RunLengthEncoding16> implements
-      // @@protoc_insertion_point(message_implements:RunLengthEncoding16)
-      RunLengthEncoding16OrBuilder {
+        RunLengthEncoding16> implements RunLengthEncoding16OrBuilder {
     // Use RunLengthEncoding16.newBuilder() to construct.
     private RunLengthEncoding16(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.RunLengthEncoding16, ?> builder) {
       super(builder);
@@ -13849,6 +14306,7 @@ public final class EntityData {
       return PARSER;
     }
 
+    // repeated sint32 runLengths = 1 [packed = true];
     public static final int RUNLENGTHS_FIELD_NUMBER = 1;
     private java.util.List<java.lang.Integer> runLengths_;
     /**
@@ -13872,6 +14330,7 @@ public final class EntityData {
     }
     private int runLengthsMemoizedSerializedSize = -1;
 
+    // repeated sint32 values = 2 [packed = true];
     public static final int VALUES_FIELD_NUMBER = 2;
     private java.util.List<java.lang.Integer> values_;
     /**
@@ -13902,8 +14361,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -14055,9 +14513,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.RunLengthEncoding16, Builder> implements
-        // @@protoc_insertion_point(builder_implements:RunLengthEncoding16)
-        org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder {
+          org.terasology.protobuf.EntityData.RunLengthEncoding16, Builder> implements org.terasology.protobuf.EntityData.RunLengthEncoding16OrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_RunLengthEncoding16_descriptor;
@@ -14198,6 +14654,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // repeated sint32 runLengths = 1 [packed = true];
       private java.util.List<java.lang.Integer> runLengths_ = java.util.Collections.emptyList();
       private void ensureRunLengthsIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -14249,8 +14706,7 @@ public final class EntityData {
       public Builder addAllRunLengths(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureRunLengthsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, runLengths_);
+        super.addAll(values, runLengths_);
         onChanged();
         return this;
       }
@@ -14264,6 +14720,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated sint32 values = 2 [packed = true];
       private java.util.List<java.lang.Integer> values_ = java.util.Collections.emptyList();
       private void ensureValuesIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -14315,8 +14772,7 @@ public final class EntityData {
       public Builder addAllValues(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureValuesIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, values_);
+        super.addAll(values, values_);
         onChanged();
         return this;
       }
@@ -14342,10 +14798,10 @@ public final class EntityData {
   }
 
   public interface RunLengthEncoding8OrBuilder extends
-      // @@protoc_insertion_point(interface_extends:RunLengthEncoding8)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<RunLengthEncoding8> {
 
+    // repeated sint32 runLengths = 1 [packed = true];
     /**
      * <code>repeated sint32 runLengths = 1 [packed = true];</code>
      */
@@ -14359,6 +14815,7 @@ public final class EntityData {
      */
     int getRunLengths(int index);
 
+    // optional bytes values = 2;
     /**
      * <code>optional bytes values = 2;</code>
      */
@@ -14373,9 +14830,7 @@ public final class EntityData {
    */
   public static final class RunLengthEncoding8 extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        RunLengthEncoding8> implements
-      // @@protoc_insertion_point(message_implements:RunLengthEncoding8)
-      RunLengthEncoding8OrBuilder {
+        RunLengthEncoding8> implements RunLengthEncoding8OrBuilder {
     // Use RunLengthEncoding8.newBuilder() to construct.
     private RunLengthEncoding8(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.RunLengthEncoding8, ?> builder) {
       super(builder);
@@ -14490,6 +14945,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // repeated sint32 runLengths = 1 [packed = true];
     public static final int RUNLENGTHS_FIELD_NUMBER = 1;
     private java.util.List<java.lang.Integer> runLengths_;
     /**
@@ -14513,6 +14969,7 @@ public final class EntityData {
     }
     private int runLengthsMemoizedSerializedSize = -1;
 
+    // optional bytes values = 2;
     public static final int VALUES_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString values_;
     /**
@@ -14535,8 +14992,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -14674,9 +15130,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.RunLengthEncoding8, Builder> implements
-        // @@protoc_insertion_point(builder_implements:RunLengthEncoding8)
-        org.terasology.protobuf.EntityData.RunLengthEncoding8OrBuilder {
+          org.terasology.protobuf.EntityData.RunLengthEncoding8, Builder> implements org.terasology.protobuf.EntityData.RunLengthEncoding8OrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_RunLengthEncoding8_descriptor;
@@ -14811,6 +15265,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // repeated sint32 runLengths = 1 [packed = true];
       private java.util.List<java.lang.Integer> runLengths_ = java.util.Collections.emptyList();
       private void ensureRunLengthsIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -14862,8 +15317,7 @@ public final class EntityData {
       public Builder addAllRunLengths(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureRunLengthsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, runLengths_);
+        super.addAll(values, runLengths_);
         onChanged();
         return this;
       }
@@ -14877,6 +15331,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional bytes values = 2;
       private com.google.protobuf.ByteString values_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes values = 2;</code>
@@ -14924,10 +15379,10 @@ public final class EntityData {
   }
 
   public interface GlobalStoreOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:GlobalStore)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<GlobalStore> {
 
+    // repeated .Entity entity = 1;
     /**
      * <code>repeated .Entity entity = 1;</code>
      */
@@ -14952,6 +15407,7 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.EntityOrBuilder getEntityOrBuilder(
         int index);
 
+    // repeated .Prefab prefab = 2;
     /**
      * <code>repeated .Prefab prefab = 2;</code>
      */
@@ -14976,11 +15432,12 @@ public final class EntityData {
     org.terasology.protobuf.EntityData.PrefabOrBuilder getPrefabOrBuilder(
         int index);
 
+    // repeated string component_class = 3;
     /**
      * <code>repeated string component_class = 3;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getComponentClassList();
+    java.util.List<java.lang.String>
+    getComponentClassList();
     /**
      * <code>repeated string component_class = 3;</code>
      */
@@ -14995,6 +15452,7 @@ public final class EntityData {
     com.google.protobuf.ByteString
         getComponentClassBytes(int index);
 
+    // optional int64 next_entity_id = 16;
     /**
      * <code>optional int64 next_entity_id = 16;</code>
      */
@@ -15004,6 +15462,7 @@ public final class EntityData {
      */
     long getNextEntityId();
 
+    // repeated int64 deprecated_data_17 = 17 [packed = true];
     /**
      * <code>repeated int64 deprecated_data_17 = 17 [packed = true];</code>
      */
@@ -15017,6 +15476,7 @@ public final class EntityData {
      */
     long getDeprecatedData17(int index);
 
+    // repeated string prefab_name = 18;
     /**
      * <code>repeated string prefab_name = 18;</code>
      *
@@ -15024,8 +15484,8 @@ public final class EntityData {
      * Table of prefabs, the index of which corresponds to Prefab's type_index
      * </pre>
      */
-    com.google.protobuf.ProtocolStringList
-        getPrefabNameList();
+    java.util.List<java.lang.String>
+    getPrefabNameList();
     /**
      * <code>repeated string prefab_name = 18;</code>
      *
@@ -15057,9 +15517,7 @@ public final class EntityData {
    */
   public static final class GlobalStore extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        GlobalStore> implements
-      // @@protoc_insertion_point(message_implements:GlobalStore)
-      GlobalStoreOrBuilder {
+        GlobalStore> implements GlobalStoreOrBuilder {
     // Use GlobalStore.newBuilder() to construct.
     private GlobalStore(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.EntityData.GlobalStore, ?> builder) {
       super(builder);
@@ -15122,12 +15580,11 @@ public final class EntityData {
               break;
             }
             case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 componentClass_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000004;
               }
-              componentClass_.add(bs);
+              componentClass_.add(input.readBytes());
               break;
             }
             case 128: {
@@ -15157,12 +15614,11 @@ public final class EntityData {
               break;
             }
             case 146: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
                 prefabName_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000020;
               }
-              prefabName_.add(bs);
+              prefabName_.add(input.readBytes());
               break;
             }
           }
@@ -15180,13 +15636,13 @@ public final class EntityData {
           prefab_ = java.util.Collections.unmodifiableList(prefab_);
         }
         if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-          componentClass_ = componentClass_.getUnmodifiableView();
+          componentClass_ = new com.google.protobuf.UnmodifiableLazyStringList(componentClass_);
         }
         if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
           deprecatedData17_ = java.util.Collections.unmodifiableList(deprecatedData17_);
         }
         if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-          prefabName_ = prefabName_.getUnmodifiableView();
+          prefabName_ = new com.google.protobuf.UnmodifiableLazyStringList(prefabName_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -15220,6 +15676,7 @@ public final class EntityData {
     }
 
     private int bitField0_;
+    // repeated .Entity entity = 1;
     public static final int ENTITY_FIELD_NUMBER = 1;
     private java.util.List<org.terasology.protobuf.EntityData.Entity> entity_;
     /**
@@ -15255,6 +15712,7 @@ public final class EntityData {
       return entity_.get(index);
     }
 
+    // repeated .Prefab prefab = 2;
     public static final int PREFAB_FIELD_NUMBER = 2;
     private java.util.List<org.terasology.protobuf.EntityData.Prefab> prefab_;
     /**
@@ -15290,12 +15748,13 @@ public final class EntityData {
       return prefab_.get(index);
     }
 
+    // repeated string component_class = 3;
     public static final int COMPONENT_CLASS_FIELD_NUMBER = 3;
     private com.google.protobuf.LazyStringList componentClass_;
     /**
      * <code>repeated string component_class = 3;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getComponentClassList() {
       return componentClass_;
     }
@@ -15319,6 +15778,7 @@ public final class EntityData {
       return componentClass_.getByteString(index);
     }
 
+    // optional int64 next_entity_id = 16;
     public static final int NEXT_ENTITY_ID_FIELD_NUMBER = 16;
     private long nextEntityId_;
     /**
@@ -15334,6 +15794,7 @@ public final class EntityData {
       return nextEntityId_;
     }
 
+    // repeated int64 deprecated_data_17 = 17 [packed = true];
     public static final int DEPRECATED_DATA_17_FIELD_NUMBER = 17;
     private java.util.List<java.lang.Long> deprecatedData17_;
     /**
@@ -15357,6 +15818,7 @@ public final class EntityData {
     }
     private int deprecatedData17MemoizedSerializedSize = -1;
 
+    // repeated string prefab_name = 18;
     public static final int PREFAB_NAME_FIELD_NUMBER = 18;
     private com.google.protobuf.LazyStringList prefabName_;
     /**
@@ -15366,7 +15828,7 @@ public final class EntityData {
      * Table of prefabs, the index of which corresponds to Prefab's type_index
      * </pre>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getPrefabNameList() {
       return prefabName_;
     }
@@ -15413,8 +15875,7 @@ public final class EntityData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getEntityCount(); i++) {
         if (!getEntity(i).isInitialized()) {
@@ -15602,9 +16063,7 @@ public final class EntityData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.EntityData.GlobalStore, Builder> implements
-        // @@protoc_insertion_point(builder_implements:GlobalStore)
-        org.terasology.protobuf.EntityData.GlobalStoreOrBuilder {
+          org.terasology.protobuf.EntityData.GlobalStore, Builder> implements org.terasology.protobuf.EntityData.GlobalStoreOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.EntityData.internal_static_GlobalStore_descriptor;
@@ -15706,7 +16165,8 @@ public final class EntityData {
           result.prefab_ = prefabBuilder_.build();
         }
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
-          componentClass_ = componentClass_.getUnmodifiableView();
+          componentClass_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              componentClass_);
           bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.componentClass_ = componentClass_;
@@ -15720,7 +16180,8 @@ public final class EntityData {
         }
         result.deprecatedData17_ = deprecatedData17_;
         if (((bitField0_ & 0x00000020) == 0x00000020)) {
-          prefabName_ = prefabName_.getUnmodifiableView();
+          prefabName_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              prefabName_);
           bitField0_ = (bitField0_ & ~0x00000020);
         }
         result.prefabName_ = prefabName_;
@@ -15869,6 +16330,7 @@ public final class EntityData {
       }
       private int bitField0_;
 
+      // repeated .Entity entity = 1;
       private java.util.List<org.terasology.protobuf.EntityData.Entity> entity_ =
         java.util.Collections.emptyList();
       private void ensureEntityIsMutable() {
@@ -16010,8 +16472,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Entity> values) {
         if (entityBuilder_ == null) {
           ensureEntityIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, entity_);
+          super.addAll(values, entity_);
           onChanged();
         } else {
           entityBuilder_.addAllMessages(values);
@@ -16109,6 +16570,7 @@ public final class EntityData {
         return entityBuilder_;
       }
 
+      // repeated .Prefab prefab = 2;
       private java.util.List<org.terasology.protobuf.EntityData.Prefab> prefab_ =
         java.util.Collections.emptyList();
       private void ensurePrefabIsMutable() {
@@ -16250,8 +16712,7 @@ public final class EntityData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.Prefab> values) {
         if (prefabBuilder_ == null) {
           ensurePrefabIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, prefab_);
+          super.addAll(values, prefab_);
           onChanged();
         } else {
           prefabBuilder_.addAllMessages(values);
@@ -16349,6 +16810,7 @@ public final class EntityData {
         return prefabBuilder_;
       }
 
+      // repeated string component_class = 3;
       private com.google.protobuf.LazyStringList componentClass_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureComponentClassIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -16359,9 +16821,9 @@ public final class EntityData {
       /**
        * <code>repeated string component_class = 3;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getComponentClassList() {
-        return componentClass_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(componentClass_);
       }
       /**
        * <code>repeated string component_class = 3;</code>
@@ -16414,8 +16876,7 @@ public final class EntityData {
       public Builder addAllComponentClass(
           java.lang.Iterable<java.lang.String> values) {
         ensureComponentClassIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, componentClass_);
+        super.addAll(values, componentClass_);
         onChanged();
         return this;
       }
@@ -16442,6 +16903,7 @@ public final class EntityData {
         return this;
       }
 
+      // optional int64 next_entity_id = 16;
       private long nextEntityId_ ;
       /**
        * <code>optional int64 next_entity_id = 16;</code>
@@ -16474,6 +16936,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated int64 deprecated_data_17 = 17 [packed = true];
       private java.util.List<java.lang.Long> deprecatedData17_ = java.util.Collections.emptyList();
       private void ensureDeprecatedData17IsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
@@ -16525,8 +16988,7 @@ public final class EntityData {
       public Builder addAllDeprecatedData17(
           java.lang.Iterable<? extends java.lang.Long> values) {
         ensureDeprecatedData17IsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, deprecatedData17_);
+        super.addAll(values, deprecatedData17_);
         onChanged();
         return this;
       }
@@ -16540,6 +17002,7 @@ public final class EntityData {
         return this;
       }
 
+      // repeated string prefab_name = 18;
       private com.google.protobuf.LazyStringList prefabName_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensurePrefabNameIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -16554,9 +17017,9 @@ public final class EntityData {
        * Table of prefabs, the index of which corresponds to Prefab's type_index
        * </pre>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getPrefabNameList() {
-        return prefabName_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(prefabName_);
       }
       /**
        * <code>repeated string prefab_name = 18;</code>
@@ -16633,8 +17096,7 @@ public final class EntityData {
       public Builder addAllPrefabName(
           java.lang.Iterable<java.lang.String> values) {
         ensurePrefabNameIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, prefabName_);
+        super.addAll(values, prefabName_);
         onChanged();
         return this;
       }
@@ -16680,67 +17142,67 @@ public final class EntityData {
     // @@protoc_insertion_point(class_scope:GlobalStore)
   }
 
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Value_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Value_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_NameValue_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_NameValue_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Component_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Component_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Entity_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Entity_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_PackedEntity_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_PackedEntity_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Prefab_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Prefab_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Event_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Event_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_EntityStore_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_EntityStore_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_PlayerStore_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_PlayerStore_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ChunkStore_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ChunkStore_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_RunLengthEncoding16_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_RunLengthEncoding16_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_RunLengthEncoding8_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_RunLengthEncoding8_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_GlobalStore_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -16789,7 +17251,7 @@ public final class EntityData {
       "\033\n\005store\030\001 \001(\0132\014.EntityStore\022\025\n\rcharacte" +
       "rPosX\030\017 \001(\002\022\025\n\rcharacterPosY\030\020 \001(\002\022\025\n\rch" +
       "aracterPosZ\030\021 \001(\002\022\024\n\014hasCharacter\030\022 \001(\010*" +
-      "\t\010\210\'\020\200\200\200\200\002\"\332\002\n\nChunkStore\022\033\n\005store\030\001 \001(\013" +
+      "\t\010\210\'\020\200\200\200\200\002\"\204\003\n\nChunkStore\022\033\n\005store\030\001 \001(\013" +
       "2\014.EntityStore\022\t\n\001x\030\002 \001(\021\022\t\n\001y\030\003 \001(\021\022\t\n\001" +
       "z\030\004 \001(\021\022\031\n\021deprecated_data_3\030\005 \001(\005\022\031\n\021de" +
       "precated_data_4\030\006 \001(\014\022\031\n\021deprecated_data" +
@@ -16797,109 +17259,110 @@ public final class EntityData {
       "eprecated_data_5\030\t \001(\014\022(\n\nblock_data\030\n \001" +
       "(\0132\024.RunLengthEncoding16\022(\n\013liquid_data\030" +
       "\013 \001(\0132\023.RunLengthEncoding8\022(\n\nbiome_data" +
-      "\030\014 \001(\0132\024.RunLengthEncoding16*\t\010\210\'\020\200\200\200\200\002\"" +
-      "L\n\023RunLengthEncoding16\022\026\n\nrunLengths\030\001 \003" +
-      "(\021B\002\020\001\022\022\n\006values\030\002 \003(\021B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"G\n" +
-      "\022RunLengthEncoding8\022\026\n\nrunLengths\030\001 \003(\021B" +
-      "\002\020\001\022\016\n\006values\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"\260\001\n\013Globa" +
-      "lStore\022\027\n\006entity\030\001 \003(\0132\007.Entity\022\027\n\006prefa" +
-      "b\030\002 \003(\0132\007.Prefab\022\027\n\017component_class\030\003 \003(",
-      "\t\022\026\n\016next_entity_id\030\020 \001(\003\022\036\n\022deprecated_" +
-      "data_17\030\021 \003(\003B\002\020\001\022\023\n\013prefab_name\030\022 \003(\t*\t" +
-      "\010\210\'\020\200\200\200\200\002*4\n\tStoreType\022\023\n\017PlayerStoreTyp" +
-      "e\020\001\022\022\n\016ChunkStoreType\020\002B\'\n\027org.terasolog" +
-      "y.protobufB\nEntityDataH\001"
+      "\030\014 \001(\0132\024.RunLengthEncoding16\022(\n\nextra_da" +
+      "ta\030\r \003(\0132\024.RunLengthEncoding16*\t\010\210\'\020\200\200\200\200" +
+      "\002\"L\n\023RunLengthEncoding16\022\026\n\nrunLengths\030\001" +
+      " \003(\021B\002\020\001\022\022\n\006values\030\002 \003(\021B\002\020\001*\t\010\210\'\020\200\200\200\200\002\"" +
+      "G\n\022RunLengthEncoding8\022\026\n\nrunLengths\030\001 \003(" +
+      "\021B\002\020\001\022\016\n\006values\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"\260\001\n\013Glo" +
+      "balStore\022\027\n\006entity\030\001 \003(\0132\007.Entity\022\027\n\006pre",
+      "fab\030\002 \003(\0132\007.Prefab\022\027\n\017component_class\030\003 " +
+      "\003(\t\022\026\n\016next_entity_id\030\020 \001(\003\022\036\n\022deprecate" +
+      "d_data_17\030\021 \003(\003B\002\020\001\022\023\n\013prefab_name\030\022 \003(\t" +
+      "*\t\010\210\'\020\200\200\200\200\002*4\n\tStoreType\022\023\n\017PlayerStoreT" +
+      "ype\020\001\022\022\n\016ChunkStoreType\020\002B\'\n\027org.terasol" +
+      "ogy.protobufB\nEntityDataH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
+      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
+        public com.google.protobuf.ExtensionRegistry assignDescriptors(
+            com.google.protobuf.Descriptors.FileDescriptor root) {
+          descriptor = root;
+          internal_static_Value_descriptor =
+            getDescriptor().getMessageTypes().get(0);
+          internal_static_Value_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Value_descriptor,
+              new java.lang.String[] { "Double", "Float", "Integer", "Long", "Boolean", "String", "Bytes", "Value", "NameValue", });
+          internal_static_NameValue_descriptor =
+            getDescriptor().getMessageTypes().get(1);
+          internal_static_NameValue_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_NameValue_descriptor,
+              new java.lang.String[] { "Name", "Value", "NameIndex", });
+          internal_static_Component_descriptor =
+            getDescriptor().getMessageTypes().get(2);
+          internal_static_Component_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Component_descriptor,
+              new java.lang.String[] { "TypeIndex", "Type", "Field", });
+          internal_static_Entity_descriptor =
+            getDescriptor().getMessageTypes().get(3);
+          internal_static_Entity_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Entity_descriptor,
+              new java.lang.String[] { "Id", "Component", "RemovedComponentIndex", "ParentPrefab", "AlwaysRelevant", "Owner", "RemovedComponent", "Scope", });
+          internal_static_PackedEntity_descriptor =
+            getDescriptor().getMessageTypes().get(4);
+          internal_static_PackedEntity_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_PackedEntity_descriptor,
+              new java.lang.String[] { "Id", "ComponentId", "ComponentFieldCounts", "FieldIds", "FieldValue", "RemovedComponent", "Owner", "ParentPrefabUri", });
+          internal_static_Prefab_descriptor =
+            getDescriptor().getMessageTypes().get(5);
+          internal_static_Prefab_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Prefab_descriptor,
+              new java.lang.String[] { "NameIndex", "Component", "Deprecated", "Persisted", "RemovedComponent", "AlwaysRelevant", "Name", "ParentName", });
+          internal_static_Event_descriptor =
+            getDescriptor().getMessageTypes().get(6);
+          internal_static_Event_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Event_descriptor,
+              new java.lang.String[] { "Type", "FieldIds", "FieldValue", });
+          internal_static_EntityStore_descriptor =
+            getDescriptor().getMessageTypes().get(7);
+          internal_static_EntityStore_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_EntityStore_descriptor,
+              new java.lang.String[] { "Entity", "ComponentClass", "EntityName", "EntityNamed", });
+          internal_static_PlayerStore_descriptor =
+            getDescriptor().getMessageTypes().get(8);
+          internal_static_PlayerStore_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_PlayerStore_descriptor,
+              new java.lang.String[] { "Store", "CharacterPosX", "CharacterPosY", "CharacterPosZ", "HasCharacter", });
+          internal_static_ChunkStore_descriptor =
+            getDescriptor().getMessageTypes().get(9);
+          internal_static_ChunkStore_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ChunkStore_descriptor,
+              new java.lang.String[] { "Store", "X", "Y", "Z", "DeprecatedData3", "DeprecatedData4", "DeprecatedData1", "DeprecatedData2", "DeprecatedData5", "BlockData", "LiquidData", "BiomeData", "ExtraData", });
+          internal_static_RunLengthEncoding16_descriptor =
+            getDescriptor().getMessageTypes().get(10);
+          internal_static_RunLengthEncoding16_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_RunLengthEncoding16_descriptor,
+              new java.lang.String[] { "RunLengths", "Values", });
+          internal_static_RunLengthEncoding8_descriptor =
+            getDescriptor().getMessageTypes().get(11);
+          internal_static_RunLengthEncoding8_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_RunLengthEncoding8_descriptor,
+              new java.lang.String[] { "RunLengths", "Values", });
+          internal_static_GlobalStore_descriptor =
+            getDescriptor().getMessageTypes().get(12);
+          internal_static_GlobalStore_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_GlobalStore_descriptor,
+              new java.lang.String[] { "Entity", "Prefab", "ComponentClass", "NextEntityId", "DeprecatedData17", "PrefabName", });
+          return null;
+        }
+      };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_Value_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_Value_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Value_descriptor,
-        new java.lang.String[] { "Double", "Float", "Integer", "Long", "Boolean", "String", "Bytes", "Value", "NameValue", });
-    internal_static_NameValue_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_NameValue_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_NameValue_descriptor,
-        new java.lang.String[] { "Name", "Value", "NameIndex", });
-    internal_static_Component_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_Component_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Component_descriptor,
-        new java.lang.String[] { "TypeIndex", "Type", "Field", });
-    internal_static_Entity_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_Entity_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Entity_descriptor,
-        new java.lang.String[] { "Id", "Component", "RemovedComponentIndex", "ParentPrefab", "AlwaysRelevant", "Owner", "RemovedComponent", "Scope", });
-    internal_static_PackedEntity_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_PackedEntity_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_PackedEntity_descriptor,
-        new java.lang.String[] { "Id", "ComponentId", "ComponentFieldCounts", "FieldIds", "FieldValue", "RemovedComponent", "Owner", "ParentPrefabUri", });
-    internal_static_Prefab_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_Prefab_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Prefab_descriptor,
-        new java.lang.String[] { "NameIndex", "Component", "Deprecated", "Persisted", "RemovedComponent", "AlwaysRelevant", "Name", "ParentName", });
-    internal_static_Event_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_Event_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Event_descriptor,
-        new java.lang.String[] { "Type", "FieldIds", "FieldValue", });
-    internal_static_EntityStore_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_EntityStore_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_EntityStore_descriptor,
-        new java.lang.String[] { "Entity", "ComponentClass", "EntityName", "EntityNamed", });
-    internal_static_PlayerStore_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_PlayerStore_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_PlayerStore_descriptor,
-        new java.lang.String[] { "Store", "CharacterPosX", "CharacterPosY", "CharacterPosZ", "HasCharacter", });
-    internal_static_ChunkStore_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_ChunkStore_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ChunkStore_descriptor,
-        new java.lang.String[] { "Store", "X", "Y", "Z", "DeprecatedData3", "DeprecatedData4", "DeprecatedData1", "DeprecatedData2", "DeprecatedData5", "BlockData", "LiquidData", "BiomeData", });
-    internal_static_RunLengthEncoding16_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_RunLengthEncoding16_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_RunLengthEncoding16_descriptor,
-        new java.lang.String[] { "RunLengths", "Values", });
-    internal_static_RunLengthEncoding8_descriptor =
-      getDescriptor().getMessageTypes().get(11);
-    internal_static_RunLengthEncoding8_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_RunLengthEncoding8_descriptor,
-        new java.lang.String[] { "RunLengths", "Values", });
-    internal_static_GlobalStore_descriptor =
-      getDescriptor().getMessageTypes().get(12);
-    internal_static_GlobalStore_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_GlobalStore_descriptor,
-        new java.lang.String[] { "Entity", "Prefab", "ComponentClass", "NextEntityId", "DeprecatedData17", "PrefabName", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/engine/src/main/java/org/terasology/protobuf/NetData.java
+++ b/engine/src/main/java/org/terasology/protobuf/NetData.java
@@ -9,10 +9,10 @@ public final class NetData {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface NetMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:NetMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<NetMessage> {
 
+    // repeated .ChunkStore chunkInfo = 2;
     /**
      * <code>repeated .ChunkStore chunkInfo = 2;</code>
      */
@@ -37,6 +37,7 @@ public final class NetData {
     org.terasology.protobuf.EntityData.ChunkStoreOrBuilder getChunkInfoOrBuilder(
         int index);
 
+    // repeated .InvalidateChunkMessage invalidateChunk = 3;
     /**
      * <code>repeated .InvalidateChunkMessage invalidateChunk = 3;</code>
      */
@@ -61,6 +62,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.InvalidateChunkMessageOrBuilder getInvalidateChunkOrBuilder(
         int index);
 
+    // repeated .BlockChangeMessage blockChange = 4;
     /**
      * <code>repeated .BlockChangeMessage blockChange = 4;</code>
      */
@@ -85,6 +87,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.BlockChangeMessageOrBuilder getBlockChangeOrBuilder(
         int index);
 
+    // repeated .CreateEntityMessage createEntity = 5;
     /**
      * <code>repeated .CreateEntityMessage createEntity = 5;</code>
      */
@@ -109,6 +112,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.CreateEntityMessageOrBuilder getCreateEntityOrBuilder(
         int index);
 
+    // repeated .RemoveEntityMessage removeEntity = 6;
     /**
      * <code>repeated .RemoveEntityMessage removeEntity = 6;</code>
      */
@@ -133,6 +137,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.RemoveEntityMessageOrBuilder getRemoveEntityOrBuilder(
         int index);
 
+    // repeated .UpdateEntityMessage updateEntity = 7;
     /**
      * <code>repeated .UpdateEntityMessage updateEntity = 7;</code>
      */
@@ -157,6 +162,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.UpdateEntityMessageOrBuilder getUpdateEntityOrBuilder(
         int index);
 
+    // repeated .EventMessage event = 8;
     /**
      * <code>repeated .EventMessage event = 8;</code>
      */
@@ -181,6 +187,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.EventMessageOrBuilder getEventOrBuilder(
         int index);
 
+    // optional int64 time = 9;
     /**
      * <code>optional int64 time = 9;</code>
      */
@@ -190,6 +197,7 @@ public final class NetData {
      */
     long getTime();
 
+    // repeated .BiomeChangeMessage biomeChange = 10;
     /**
      * <code>repeated .BiomeChangeMessage biomeChange = 10;</code>
      */
@@ -214,6 +222,32 @@ public final class NetData {
     org.terasology.protobuf.NetData.BiomeChangeMessageOrBuilder getBiomeChangeOrBuilder(
         int index);
 
+    // repeated .ExtraDataChangeMessage extraDataChange = 11;
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    java.util.List<org.terasology.protobuf.NetData.ExtraDataChangeMessage> 
+        getExtraDataChangeList();
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    org.terasology.protobuf.NetData.ExtraDataChangeMessage getExtraDataChange(int index);
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    int getExtraDataChangeCount();
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    java.util.List<? extends org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder> 
+        getExtraDataChangeOrBuilderList();
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder getExtraDataChangeOrBuilder(
+        int index);
+
+    // optional .ServerInfoRequest serverInfoRequest = 15;
     /**
      * <code>optional .ServerInfoRequest serverInfoRequest = 15;</code>
      */
@@ -227,6 +261,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.ServerInfoRequestOrBuilder getServerInfoRequestOrBuilder();
 
+    // optional .ServerInfoMessage serverInfo = 16;
     /**
      * <code>optional .ServerInfoMessage serverInfo = 16;</code>
      */
@@ -240,6 +275,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.ServerInfoMessageOrBuilder getServerInfoOrBuilder();
 
+    // repeated .BlockFamilyRegisteredMessage blockFamilyRegistered = 17;
     /**
      * <code>repeated .BlockFamilyRegisteredMessage blockFamilyRegistered = 17;</code>
      */
@@ -264,6 +300,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.BlockFamilyRegisteredMessageOrBuilder getBlockFamilyRegisteredOrBuilder(
         int index);
 
+    // optional .JoinMessage join = 18;
     /**
      * <code>optional .JoinMessage join = 18;</code>
      */
@@ -277,6 +314,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.JoinMessageOrBuilder getJoinOrBuilder();
 
+    // repeated .ModuleRequest moduleRequest = 19;
     /**
      * <code>repeated .ModuleRequest moduleRequest = 19;</code>
      */
@@ -301,6 +339,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.ModuleRequestOrBuilder getModuleRequestOrBuilder(
         int index);
 
+    // optional .ModuleDataHeader moduleDataHeader = 20;
     /**
      * <code>optional .ModuleDataHeader moduleDataHeader = 20;</code>
      */
@@ -314,6 +353,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.ModuleDataHeaderOrBuilder getModuleDataHeaderOrBuilder();
 
+    // optional .ModuleData moduleData = 21;
     /**
      * <code>optional .ModuleData moduleData = 21;</code>
      */
@@ -327,6 +367,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.ModuleDataOrBuilder getModuleDataOrBuilder();
 
+    // optional .JoinCompleteMessage joinComplete = 22;
     /**
      * <code>optional .JoinCompleteMessage joinComplete = 22;</code>
      */
@@ -340,6 +381,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.JoinCompleteMessageOrBuilder getJoinCompleteOrBuilder();
 
+    // optional .HandshakeHello handshakeHello = 100;
     /**
      * <code>optional .HandshakeHello handshakeHello = 100;</code>
      *
@@ -365,6 +407,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.HandshakeHelloOrBuilder getHandshakeHelloOrBuilder();
 
+    // optional .NewIdentityRequest newIdentityRequest = 101;
     /**
      * <code>optional .NewIdentityRequest newIdentityRequest = 101;</code>
      */
@@ -378,6 +421,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.NewIdentityRequestOrBuilder getNewIdentityRequestOrBuilder();
 
+    // optional .ProvisionIdentity provisionIdentity = 102;
     /**
      * <code>optional .ProvisionIdentity provisionIdentity = 102;</code>
      */
@@ -391,6 +435,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.ProvisionIdentityOrBuilder getProvisionIdentityOrBuilder();
 
+    // optional .HandshakeVerification handshakeVerification = 103;
     /**
      * <code>optional .HandshakeVerification handshakeVerification = 103;</code>
      */
@@ -409,9 +454,7 @@ public final class NetData {
    */
   public static final class NetMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        NetMessage> implements
-      // @@protoc_insertion_point(message_implements:NetMessage)
-      NetMessageOrBuilder {
+        NetMessage> implements NetMessageOrBuilder {
     // Use NetMessage.newBuilder() to construct.
     private NetMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.NetMessage, ?> builder) {
       super(builder);
@@ -526,6 +569,14 @@ public final class NetData {
               biomeChange_.add(input.readMessage(org.terasology.protobuf.NetData.BiomeChangeMessage.PARSER, extensionRegistry));
               break;
             }
+            case 90: {
+              if (!((mutable_bitField0_ & 0x00000200) == 0x00000200)) {
+                extraDataChange_ = new java.util.ArrayList<org.terasology.protobuf.NetData.ExtraDataChangeMessage>();
+                mutable_bitField0_ |= 0x00000200;
+              }
+              extraDataChange_.add(input.readMessage(org.terasology.protobuf.NetData.ExtraDataChangeMessage.PARSER, extensionRegistry));
+              break;
+            }
             case 122: {
               org.terasology.protobuf.NetData.ServerInfoRequest.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -553,9 +604,9 @@ public final class NetData {
               break;
             }
             case 138: {
-              if (!((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
+              if (!((mutable_bitField0_ & 0x00001000) == 0x00001000)) {
                 blockFamilyRegistered_ = new java.util.ArrayList<org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage>();
-                mutable_bitField0_ |= 0x00000800;
+                mutable_bitField0_ |= 0x00001000;
               }
               blockFamilyRegistered_.add(input.readMessage(org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage.PARSER, extensionRegistry));
               break;
@@ -574,9 +625,9 @@ public final class NetData {
               break;
             }
             case 154: {
-              if (!((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
+              if (!((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
                 moduleRequest_ = new java.util.ArrayList<org.terasology.protobuf.NetData.ModuleRequest>();
-                mutable_bitField0_ |= 0x00002000;
+                mutable_bitField0_ |= 0x00004000;
               }
               moduleRequest_.add(input.readMessage(org.terasology.protobuf.NetData.ModuleRequest.PARSER, extensionRegistry));
               break;
@@ -704,10 +755,13 @@ public final class NetData {
         if (((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
           biomeChange_ = java.util.Collections.unmodifiableList(biomeChange_);
         }
-        if (((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
+        if (((mutable_bitField0_ & 0x00000200) == 0x00000200)) {
+          extraDataChange_ = java.util.Collections.unmodifiableList(extraDataChange_);
+        }
+        if (((mutable_bitField0_ & 0x00001000) == 0x00001000)) {
           blockFamilyRegistered_ = java.util.Collections.unmodifiableList(blockFamilyRegistered_);
         }
-        if (((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
+        if (((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
           moduleRequest_ = java.util.Collections.unmodifiableList(moduleRequest_);
         }
         this.unknownFields = unknownFields.build();
@@ -742,6 +796,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // repeated .ChunkStore chunkInfo = 2;
     public static final int CHUNKINFO_FIELD_NUMBER = 2;
     private java.util.List<org.terasology.protobuf.EntityData.ChunkStore> chunkInfo_;
     /**
@@ -777,6 +832,7 @@ public final class NetData {
       return chunkInfo_.get(index);
     }
 
+    // repeated .InvalidateChunkMessage invalidateChunk = 3;
     public static final int INVALIDATECHUNK_FIELD_NUMBER = 3;
     private java.util.List<org.terasology.protobuf.NetData.InvalidateChunkMessage> invalidateChunk_;
     /**
@@ -812,6 +868,7 @@ public final class NetData {
       return invalidateChunk_.get(index);
     }
 
+    // repeated .BlockChangeMessage blockChange = 4;
     public static final int BLOCKCHANGE_FIELD_NUMBER = 4;
     private java.util.List<org.terasology.protobuf.NetData.BlockChangeMessage> blockChange_;
     /**
@@ -847,6 +904,7 @@ public final class NetData {
       return blockChange_.get(index);
     }
 
+    // repeated .CreateEntityMessage createEntity = 5;
     public static final int CREATEENTITY_FIELD_NUMBER = 5;
     private java.util.List<org.terasology.protobuf.NetData.CreateEntityMessage> createEntity_;
     /**
@@ -882,6 +940,7 @@ public final class NetData {
       return createEntity_.get(index);
     }
 
+    // repeated .RemoveEntityMessage removeEntity = 6;
     public static final int REMOVEENTITY_FIELD_NUMBER = 6;
     private java.util.List<org.terasology.protobuf.NetData.RemoveEntityMessage> removeEntity_;
     /**
@@ -917,6 +976,7 @@ public final class NetData {
       return removeEntity_.get(index);
     }
 
+    // repeated .UpdateEntityMessage updateEntity = 7;
     public static final int UPDATEENTITY_FIELD_NUMBER = 7;
     private java.util.List<org.terasology.protobuf.NetData.UpdateEntityMessage> updateEntity_;
     /**
@@ -952,6 +1012,7 @@ public final class NetData {
       return updateEntity_.get(index);
     }
 
+    // repeated .EventMessage event = 8;
     public static final int EVENT_FIELD_NUMBER = 8;
     private java.util.List<org.terasology.protobuf.NetData.EventMessage> event_;
     /**
@@ -987,6 +1048,7 @@ public final class NetData {
       return event_.get(index);
     }
 
+    // optional int64 time = 9;
     public static final int TIME_FIELD_NUMBER = 9;
     private long time_;
     /**
@@ -1002,6 +1064,7 @@ public final class NetData {
       return time_;
     }
 
+    // repeated .BiomeChangeMessage biomeChange = 10;
     public static final int BIOMECHANGE_FIELD_NUMBER = 10;
     private java.util.List<org.terasology.protobuf.NetData.BiomeChangeMessage> biomeChange_;
     /**
@@ -1037,6 +1100,43 @@ public final class NetData {
       return biomeChange_.get(index);
     }
 
+    // repeated .ExtraDataChangeMessage extraDataChange = 11;
+    public static final int EXTRADATACHANGE_FIELD_NUMBER = 11;
+    private java.util.List<org.terasology.protobuf.NetData.ExtraDataChangeMessage> extraDataChange_;
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    public java.util.List<org.terasology.protobuf.NetData.ExtraDataChangeMessage> getExtraDataChangeList() {
+      return extraDataChange_;
+    }
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    public java.util.List<? extends org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder> 
+        getExtraDataChangeOrBuilderList() {
+      return extraDataChange_;
+    }
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    public int getExtraDataChangeCount() {
+      return extraDataChange_.size();
+    }
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    public org.terasology.protobuf.NetData.ExtraDataChangeMessage getExtraDataChange(int index) {
+      return extraDataChange_.get(index);
+    }
+    /**
+     * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+     */
+    public org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder getExtraDataChangeOrBuilder(
+        int index) {
+      return extraDataChange_.get(index);
+    }
+
+    // optional .ServerInfoRequest serverInfoRequest = 15;
     public static final int SERVERINFOREQUEST_FIELD_NUMBER = 15;
     private org.terasology.protobuf.NetData.ServerInfoRequest serverInfoRequest_;
     /**
@@ -1058,6 +1158,7 @@ public final class NetData {
       return serverInfoRequest_;
     }
 
+    // optional .ServerInfoMessage serverInfo = 16;
     public static final int SERVERINFO_FIELD_NUMBER = 16;
     private org.terasology.protobuf.NetData.ServerInfoMessage serverInfo_;
     /**
@@ -1079,6 +1180,7 @@ public final class NetData {
       return serverInfo_;
     }
 
+    // repeated .BlockFamilyRegisteredMessage blockFamilyRegistered = 17;
     public static final int BLOCKFAMILYREGISTERED_FIELD_NUMBER = 17;
     private java.util.List<org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage> blockFamilyRegistered_;
     /**
@@ -1114,6 +1216,7 @@ public final class NetData {
       return blockFamilyRegistered_.get(index);
     }
 
+    // optional .JoinMessage join = 18;
     public static final int JOIN_FIELD_NUMBER = 18;
     private org.terasology.protobuf.NetData.JoinMessage join_;
     /**
@@ -1135,6 +1238,7 @@ public final class NetData {
       return join_;
     }
 
+    // repeated .ModuleRequest moduleRequest = 19;
     public static final int MODULEREQUEST_FIELD_NUMBER = 19;
     private java.util.List<org.terasology.protobuf.NetData.ModuleRequest> moduleRequest_;
     /**
@@ -1170,6 +1274,7 @@ public final class NetData {
       return moduleRequest_.get(index);
     }
 
+    // optional .ModuleDataHeader moduleDataHeader = 20;
     public static final int MODULEDATAHEADER_FIELD_NUMBER = 20;
     private org.terasology.protobuf.NetData.ModuleDataHeader moduleDataHeader_;
     /**
@@ -1191,6 +1296,7 @@ public final class NetData {
       return moduleDataHeader_;
     }
 
+    // optional .ModuleData moduleData = 21;
     public static final int MODULEDATA_FIELD_NUMBER = 21;
     private org.terasology.protobuf.NetData.ModuleData moduleData_;
     /**
@@ -1212,6 +1318,7 @@ public final class NetData {
       return moduleData_;
     }
 
+    // optional .JoinCompleteMessage joinComplete = 22;
     public static final int JOINCOMPLETE_FIELD_NUMBER = 22;
     private org.terasology.protobuf.NetData.JoinCompleteMessage joinComplete_;
     /**
@@ -1233,6 +1340,7 @@ public final class NetData {
       return joinComplete_;
     }
 
+    // optional .HandshakeHello handshakeHello = 100;
     public static final int HANDSHAKEHELLO_FIELD_NUMBER = 100;
     private org.terasology.protobuf.NetData.HandshakeHello handshakeHello_;
     /**
@@ -1266,6 +1374,7 @@ public final class NetData {
       return handshakeHello_;
     }
 
+    // optional .NewIdentityRequest newIdentityRequest = 101;
     public static final int NEWIDENTITYREQUEST_FIELD_NUMBER = 101;
     private org.terasology.protobuf.NetData.NewIdentityRequest newIdentityRequest_;
     /**
@@ -1287,6 +1396,7 @@ public final class NetData {
       return newIdentityRequest_;
     }
 
+    // optional .ProvisionIdentity provisionIdentity = 102;
     public static final int PROVISIONIDENTITY_FIELD_NUMBER = 102;
     private org.terasology.protobuf.NetData.ProvisionIdentity provisionIdentity_;
     /**
@@ -1308,6 +1418,7 @@ public final class NetData {
       return provisionIdentity_;
     }
 
+    // optional .HandshakeVerification handshakeVerification = 103;
     public static final int HANDSHAKEVERIFICATION_FIELD_NUMBER = 103;
     private org.terasology.protobuf.NetData.HandshakeVerification handshakeVerification_;
     /**
@@ -1339,6 +1450,7 @@ public final class NetData {
       event_ = java.util.Collections.emptyList();
       time_ = 0L;
       biomeChange_ = java.util.Collections.emptyList();
+      extraDataChange_ = java.util.Collections.emptyList();
       serverInfoRequest_ = org.terasology.protobuf.NetData.ServerInfoRequest.getDefaultInstance();
       serverInfo_ = org.terasology.protobuf.NetData.ServerInfoMessage.getDefaultInstance();
       blockFamilyRegistered_ = java.util.Collections.emptyList();
@@ -1355,8 +1467,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getChunkInfoCount(); i++) {
         if (!getChunkInfo(i).isInitialized()) {
@@ -1402,6 +1513,12 @@ public final class NetData {
       }
       for (int i = 0; i < getBiomeChangeCount(); i++) {
         if (!getBiomeChange(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      for (int i = 0; i < getExtraDataChangeCount(); i++) {
+        if (!getExtraDataChange(i).isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -1519,6 +1636,9 @@ public final class NetData {
       for (int i = 0; i < biomeChange_.size(); i++) {
         output.writeMessage(10, biomeChange_.get(i));
       }
+      for (int i = 0; i < extraDataChange_.size(); i++) {
+        output.writeMessage(11, extraDataChange_.get(i));
+      }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeMessage(15, serverInfoRequest_);
       }
@@ -1600,6 +1720,10 @@ public final class NetData {
       for (int i = 0; i < biomeChange_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(10, biomeChange_.get(i));
+      }
+      for (int i = 0; i < extraDataChange_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(11, extraDataChange_.get(i));
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
@@ -1733,9 +1857,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.NetMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:NetMessage)
-        org.terasology.protobuf.NetData.NetMessageOrBuilder {
+          org.terasology.protobuf.NetData.NetMessage, Builder> implements org.terasology.protobuf.NetData.NetMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_NetMessage_descriptor;
@@ -1768,6 +1890,7 @@ public final class NetData {
           getUpdateEntityFieldBuilder();
           getEventFieldBuilder();
           getBiomeChangeFieldBuilder();
+          getExtraDataChangeFieldBuilder();
           getServerInfoRequestFieldBuilder();
           getServerInfoFieldBuilder();
           getBlockFamilyRegisteredFieldBuilder();
@@ -1838,21 +1961,27 @@ public final class NetData {
         } else {
           biomeChangeBuilder_.clear();
         }
+        if (extraDataChangeBuilder_ == null) {
+          extraDataChange_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000200);
+        } else {
+          extraDataChangeBuilder_.clear();
+        }
         if (serverInfoRequestBuilder_ == null) {
           serverInfoRequest_ = org.terasology.protobuf.NetData.ServerInfoRequest.getDefaultInstance();
         } else {
           serverInfoRequestBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000200);
+        bitField0_ = (bitField0_ & ~0x00000400);
         if (serverInfoBuilder_ == null) {
           serverInfo_ = org.terasology.protobuf.NetData.ServerInfoMessage.getDefaultInstance();
         } else {
           serverInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000400);
+        bitField0_ = (bitField0_ & ~0x00000800);
         if (blockFamilyRegisteredBuilder_ == null) {
           blockFamilyRegistered_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000800);
+          bitField0_ = (bitField0_ & ~0x00001000);
         } else {
           blockFamilyRegisteredBuilder_.clear();
         }
@@ -1861,10 +1990,10 @@ public final class NetData {
         } else {
           joinBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00001000);
+        bitField0_ = (bitField0_ & ~0x00002000);
         if (moduleRequestBuilder_ == null) {
           moduleRequest_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00002000);
+          bitField0_ = (bitField0_ & ~0x00004000);
         } else {
           moduleRequestBuilder_.clear();
         }
@@ -1873,43 +2002,43 @@ public final class NetData {
         } else {
           moduleDataHeaderBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00004000);
+        bitField0_ = (bitField0_ & ~0x00008000);
         if (moduleDataBuilder_ == null) {
           moduleData_ = org.terasology.protobuf.NetData.ModuleData.getDefaultInstance();
         } else {
           moduleDataBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00008000);
+        bitField0_ = (bitField0_ & ~0x00010000);
         if (joinCompleteBuilder_ == null) {
           joinComplete_ = org.terasology.protobuf.NetData.JoinCompleteMessage.getDefaultInstance();
         } else {
           joinCompleteBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00010000);
+        bitField0_ = (bitField0_ & ~0x00020000);
         if (handshakeHelloBuilder_ == null) {
           handshakeHello_ = org.terasology.protobuf.NetData.HandshakeHello.getDefaultInstance();
         } else {
           handshakeHelloBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00020000);
+        bitField0_ = (bitField0_ & ~0x00040000);
         if (newIdentityRequestBuilder_ == null) {
           newIdentityRequest_ = org.terasology.protobuf.NetData.NewIdentityRequest.getDefaultInstance();
         } else {
           newIdentityRequestBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00040000);
+        bitField0_ = (bitField0_ & ~0x00080000);
         if (provisionIdentityBuilder_ == null) {
           provisionIdentity_ = org.terasology.protobuf.NetData.ProvisionIdentity.getDefaultInstance();
         } else {
           provisionIdentityBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00080000);
+        bitField0_ = (bitField0_ & ~0x00100000);
         if (handshakeVerificationBuilder_ == null) {
           handshakeVerification_ = org.terasology.protobuf.NetData.HandshakeVerification.getDefaultInstance();
         } else {
           handshakeVerificationBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00100000);
+        bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
 
@@ -2014,7 +2143,16 @@ public final class NetData {
         } else {
           result.biomeChange_ = biomeChangeBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+        if (extraDataChangeBuilder_ == null) {
+          if (((bitField0_ & 0x00000200) == 0x00000200)) {
+            extraDataChange_ = java.util.Collections.unmodifiableList(extraDataChange_);
+            bitField0_ = (bitField0_ & ~0x00000200);
+          }
+          result.extraDataChange_ = extraDataChange_;
+        } else {
+          result.extraDataChange_ = extraDataChangeBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
           to_bitField0_ |= 0x00000002;
         }
         if (serverInfoRequestBuilder_ == null) {
@@ -2022,7 +2160,7 @@ public final class NetData {
         } else {
           result.serverInfoRequest_ = serverInfoRequestBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
+        if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
           to_bitField0_ |= 0x00000004;
         }
         if (serverInfoBuilder_ == null) {
@@ -2031,15 +2169,15 @@ public final class NetData {
           result.serverInfo_ = serverInfoBuilder_.build();
         }
         if (blockFamilyRegisteredBuilder_ == null) {
-          if (((bitField0_ & 0x00000800) == 0x00000800)) {
+          if (((bitField0_ & 0x00001000) == 0x00001000)) {
             blockFamilyRegistered_ = java.util.Collections.unmodifiableList(blockFamilyRegistered_);
-            bitField0_ = (bitField0_ & ~0x00000800);
+            bitField0_ = (bitField0_ & ~0x00001000);
           }
           result.blockFamilyRegistered_ = blockFamilyRegistered_;
         } else {
           result.blockFamilyRegistered_ = blockFamilyRegisteredBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+        if (((from_bitField0_ & 0x00002000) == 0x00002000)) {
           to_bitField0_ |= 0x00000008;
         }
         if (joinBuilder_ == null) {
@@ -2048,15 +2186,15 @@ public final class NetData {
           result.join_ = joinBuilder_.build();
         }
         if (moduleRequestBuilder_ == null) {
-          if (((bitField0_ & 0x00002000) == 0x00002000)) {
+          if (((bitField0_ & 0x00004000) == 0x00004000)) {
             moduleRequest_ = java.util.Collections.unmodifiableList(moduleRequest_);
-            bitField0_ = (bitField0_ & ~0x00002000);
+            bitField0_ = (bitField0_ & ~0x00004000);
           }
           result.moduleRequest_ = moduleRequest_;
         } else {
           result.moduleRequest_ = moduleRequestBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00004000) == 0x00004000)) {
+        if (((from_bitField0_ & 0x00008000) == 0x00008000)) {
           to_bitField0_ |= 0x00000010;
         }
         if (moduleDataHeaderBuilder_ == null) {
@@ -2064,7 +2202,7 @@ public final class NetData {
         } else {
           result.moduleDataHeader_ = moduleDataHeaderBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00008000) == 0x00008000)) {
+        if (((from_bitField0_ & 0x00010000) == 0x00010000)) {
           to_bitField0_ |= 0x00000020;
         }
         if (moduleDataBuilder_ == null) {
@@ -2072,7 +2210,7 @@ public final class NetData {
         } else {
           result.moduleData_ = moduleDataBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00010000) == 0x00010000)) {
+        if (((from_bitField0_ & 0x00020000) == 0x00020000)) {
           to_bitField0_ |= 0x00000040;
         }
         if (joinCompleteBuilder_ == null) {
@@ -2080,7 +2218,7 @@ public final class NetData {
         } else {
           result.joinComplete_ = joinCompleteBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00020000) == 0x00020000)) {
+        if (((from_bitField0_ & 0x00040000) == 0x00040000)) {
           to_bitField0_ |= 0x00000080;
         }
         if (handshakeHelloBuilder_ == null) {
@@ -2088,7 +2226,7 @@ public final class NetData {
         } else {
           result.handshakeHello_ = handshakeHelloBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00040000) == 0x00040000)) {
+        if (((from_bitField0_ & 0x00080000) == 0x00080000)) {
           to_bitField0_ |= 0x00000100;
         }
         if (newIdentityRequestBuilder_ == null) {
@@ -2096,7 +2234,7 @@ public final class NetData {
         } else {
           result.newIdentityRequest_ = newIdentityRequestBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00080000) == 0x00080000)) {
+        if (((from_bitField0_ & 0x00100000) == 0x00100000)) {
           to_bitField0_ |= 0x00000200;
         }
         if (provisionIdentityBuilder_ == null) {
@@ -2104,7 +2242,7 @@ public final class NetData {
         } else {
           result.provisionIdentity_ = provisionIdentityBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00100000) == 0x00100000)) {
+        if (((from_bitField0_ & 0x00200000) == 0x00200000)) {
           to_bitField0_ |= 0x00000400;
         }
         if (handshakeVerificationBuilder_ == null) {
@@ -2339,6 +2477,32 @@ public final class NetData {
             }
           }
         }
+        if (extraDataChangeBuilder_ == null) {
+          if (!other.extraDataChange_.isEmpty()) {
+            if (extraDataChange_.isEmpty()) {
+              extraDataChange_ = other.extraDataChange_;
+              bitField0_ = (bitField0_ & ~0x00000200);
+            } else {
+              ensureExtraDataChangeIsMutable();
+              extraDataChange_.addAll(other.extraDataChange_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.extraDataChange_.isEmpty()) {
+            if (extraDataChangeBuilder_.isEmpty()) {
+              extraDataChangeBuilder_.dispose();
+              extraDataChangeBuilder_ = null;
+              extraDataChange_ = other.extraDataChange_;
+              bitField0_ = (bitField0_ & ~0x00000200);
+              extraDataChangeBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getExtraDataChangeFieldBuilder() : null;
+            } else {
+              extraDataChangeBuilder_.addAllMessages(other.extraDataChange_);
+            }
+          }
+        }
         if (other.hasServerInfoRequest()) {
           mergeServerInfoRequest(other.getServerInfoRequest());
         }
@@ -2349,7 +2513,7 @@ public final class NetData {
           if (!other.blockFamilyRegistered_.isEmpty()) {
             if (blockFamilyRegistered_.isEmpty()) {
               blockFamilyRegistered_ = other.blockFamilyRegistered_;
-              bitField0_ = (bitField0_ & ~0x00000800);
+              bitField0_ = (bitField0_ & ~0x00001000);
             } else {
               ensureBlockFamilyRegisteredIsMutable();
               blockFamilyRegistered_.addAll(other.blockFamilyRegistered_);
@@ -2362,7 +2526,7 @@ public final class NetData {
               blockFamilyRegisteredBuilder_.dispose();
               blockFamilyRegisteredBuilder_ = null;
               blockFamilyRegistered_ = other.blockFamilyRegistered_;
-              bitField0_ = (bitField0_ & ~0x00000800);
+              bitField0_ = (bitField0_ & ~0x00001000);
               blockFamilyRegisteredBuilder_ = 
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getBlockFamilyRegisteredFieldBuilder() : null;
@@ -2378,7 +2542,7 @@ public final class NetData {
           if (!other.moduleRequest_.isEmpty()) {
             if (moduleRequest_.isEmpty()) {
               moduleRequest_ = other.moduleRequest_;
-              bitField0_ = (bitField0_ & ~0x00002000);
+              bitField0_ = (bitField0_ & ~0x00004000);
             } else {
               ensureModuleRequestIsMutable();
               moduleRequest_.addAll(other.moduleRequest_);
@@ -2391,7 +2555,7 @@ public final class NetData {
               moduleRequestBuilder_.dispose();
               moduleRequestBuilder_ = null;
               moduleRequest_ = other.moduleRequest_;
-              bitField0_ = (bitField0_ & ~0x00002000);
+              bitField0_ = (bitField0_ & ~0x00004000);
               moduleRequestBuilder_ = 
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getModuleRequestFieldBuilder() : null;
@@ -2471,6 +2635,12 @@ public final class NetData {
         }
         for (int i = 0; i < getBiomeChangeCount(); i++) {
           if (!getBiomeChange(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        for (int i = 0; i < getExtraDataChangeCount(); i++) {
+          if (!getExtraDataChange(i).isInitialized()) {
             
             return false;
           }
@@ -2573,6 +2743,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // repeated .ChunkStore chunkInfo = 2;
       private java.util.List<org.terasology.protobuf.EntityData.ChunkStore> chunkInfo_ =
         java.util.Collections.emptyList();
       private void ensureChunkInfoIsMutable() {
@@ -2714,8 +2885,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.EntityData.ChunkStore> values) {
         if (chunkInfoBuilder_ == null) {
           ensureChunkInfoIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, chunkInfo_);
+          super.addAll(values, chunkInfo_);
           onChanged();
         } else {
           chunkInfoBuilder_.addAllMessages(values);
@@ -2813,6 +2983,7 @@ public final class NetData {
         return chunkInfoBuilder_;
       }
 
+      // repeated .InvalidateChunkMessage invalidateChunk = 3;
       private java.util.List<org.terasology.protobuf.NetData.InvalidateChunkMessage> invalidateChunk_ =
         java.util.Collections.emptyList();
       private void ensureInvalidateChunkIsMutable() {
@@ -2954,8 +3125,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.InvalidateChunkMessage> values) {
         if (invalidateChunkBuilder_ == null) {
           ensureInvalidateChunkIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, invalidateChunk_);
+          super.addAll(values, invalidateChunk_);
           onChanged();
         } else {
           invalidateChunkBuilder_.addAllMessages(values);
@@ -3053,6 +3223,7 @@ public final class NetData {
         return invalidateChunkBuilder_;
       }
 
+      // repeated .BlockChangeMessage blockChange = 4;
       private java.util.List<org.terasology.protobuf.NetData.BlockChangeMessage> blockChange_ =
         java.util.Collections.emptyList();
       private void ensureBlockChangeIsMutable() {
@@ -3194,8 +3365,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.BlockChangeMessage> values) {
         if (blockChangeBuilder_ == null) {
           ensureBlockChangeIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, blockChange_);
+          super.addAll(values, blockChange_);
           onChanged();
         } else {
           blockChangeBuilder_.addAllMessages(values);
@@ -3293,6 +3463,7 @@ public final class NetData {
         return blockChangeBuilder_;
       }
 
+      // repeated .CreateEntityMessage createEntity = 5;
       private java.util.List<org.terasology.protobuf.NetData.CreateEntityMessage> createEntity_ =
         java.util.Collections.emptyList();
       private void ensureCreateEntityIsMutable() {
@@ -3434,8 +3605,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.CreateEntityMessage> values) {
         if (createEntityBuilder_ == null) {
           ensureCreateEntityIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, createEntity_);
+          super.addAll(values, createEntity_);
           onChanged();
         } else {
           createEntityBuilder_.addAllMessages(values);
@@ -3533,6 +3703,7 @@ public final class NetData {
         return createEntityBuilder_;
       }
 
+      // repeated .RemoveEntityMessage removeEntity = 6;
       private java.util.List<org.terasology.protobuf.NetData.RemoveEntityMessage> removeEntity_ =
         java.util.Collections.emptyList();
       private void ensureRemoveEntityIsMutable() {
@@ -3674,8 +3845,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.RemoveEntityMessage> values) {
         if (removeEntityBuilder_ == null) {
           ensureRemoveEntityIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, removeEntity_);
+          super.addAll(values, removeEntity_);
           onChanged();
         } else {
           removeEntityBuilder_.addAllMessages(values);
@@ -3773,6 +3943,7 @@ public final class NetData {
         return removeEntityBuilder_;
       }
 
+      // repeated .UpdateEntityMessage updateEntity = 7;
       private java.util.List<org.terasology.protobuf.NetData.UpdateEntityMessage> updateEntity_ =
         java.util.Collections.emptyList();
       private void ensureUpdateEntityIsMutable() {
@@ -3914,8 +4085,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.UpdateEntityMessage> values) {
         if (updateEntityBuilder_ == null) {
           ensureUpdateEntityIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, updateEntity_);
+          super.addAll(values, updateEntity_);
           onChanged();
         } else {
           updateEntityBuilder_.addAllMessages(values);
@@ -4013,6 +4183,7 @@ public final class NetData {
         return updateEntityBuilder_;
       }
 
+      // repeated .EventMessage event = 8;
       private java.util.List<org.terasology.protobuf.NetData.EventMessage> event_ =
         java.util.Collections.emptyList();
       private void ensureEventIsMutable() {
@@ -4154,8 +4325,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.EventMessage> values) {
         if (eventBuilder_ == null) {
           ensureEventIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, event_);
+          super.addAll(values, event_);
           onChanged();
         } else {
           eventBuilder_.addAllMessages(values);
@@ -4253,6 +4423,7 @@ public final class NetData {
         return eventBuilder_;
       }
 
+      // optional int64 time = 9;
       private long time_ ;
       /**
        * <code>optional int64 time = 9;</code>
@@ -4285,6 +4456,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated .BiomeChangeMessage biomeChange = 10;
       private java.util.List<org.terasology.protobuf.NetData.BiomeChangeMessage> biomeChange_ =
         java.util.Collections.emptyList();
       private void ensureBiomeChangeIsMutable() {
@@ -4426,8 +4598,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.BiomeChangeMessage> values) {
         if (biomeChangeBuilder_ == null) {
           ensureBiomeChangeIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, biomeChange_);
+          super.addAll(values, biomeChange_);
           onChanged();
         } else {
           biomeChangeBuilder_.addAllMessages(values);
@@ -4525,6 +4696,247 @@ public final class NetData {
         return biomeChangeBuilder_;
       }
 
+      // repeated .ExtraDataChangeMessage extraDataChange = 11;
+      private java.util.List<org.terasology.protobuf.NetData.ExtraDataChangeMessage> extraDataChange_ =
+        java.util.Collections.emptyList();
+      private void ensureExtraDataChangeIsMutable() {
+        if (!((bitField0_ & 0x00000200) == 0x00000200)) {
+          extraDataChange_ = new java.util.ArrayList<org.terasology.protobuf.NetData.ExtraDataChangeMessage>(extraDataChange_);
+          bitField0_ |= 0x00000200;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.terasology.protobuf.NetData.ExtraDataChangeMessage, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder, org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder> extraDataChangeBuilder_;
+
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public java.util.List<org.terasology.protobuf.NetData.ExtraDataChangeMessage> getExtraDataChangeList() {
+        if (extraDataChangeBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(extraDataChange_);
+        } else {
+          return extraDataChangeBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public int getExtraDataChangeCount() {
+        if (extraDataChangeBuilder_ == null) {
+          return extraDataChange_.size();
+        } else {
+          return extraDataChangeBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage getExtraDataChange(int index) {
+        if (extraDataChangeBuilder_ == null) {
+          return extraDataChange_.get(index);
+        } else {
+          return extraDataChangeBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder setExtraDataChange(
+          int index, org.terasology.protobuf.NetData.ExtraDataChangeMessage value) {
+        if (extraDataChangeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.set(index, value);
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder setExtraDataChange(
+          int index, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder builderForValue) {
+        if (extraDataChangeBuilder_ == null) {
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder addExtraDataChange(org.terasology.protobuf.NetData.ExtraDataChangeMessage value) {
+        if (extraDataChangeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.add(value);
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder addExtraDataChange(
+          int index, org.terasology.protobuf.NetData.ExtraDataChangeMessage value) {
+        if (extraDataChangeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.add(index, value);
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder addExtraDataChange(
+          org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder builderForValue) {
+        if (extraDataChangeBuilder_ == null) {
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.add(builderForValue.build());
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder addExtraDataChange(
+          int index, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder builderForValue) {
+        if (extraDataChangeBuilder_ == null) {
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder addAllExtraDataChange(
+          java.lang.Iterable<? extends org.terasology.protobuf.NetData.ExtraDataChangeMessage> values) {
+        if (extraDataChangeBuilder_ == null) {
+          ensureExtraDataChangeIsMutable();
+          super.addAll(values, extraDataChange_);
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder clearExtraDataChange() {
+        if (extraDataChangeBuilder_ == null) {
+          extraDataChange_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000200);
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public Builder removeExtraDataChange(int index) {
+        if (extraDataChangeBuilder_ == null) {
+          ensureExtraDataChangeIsMutable();
+          extraDataChange_.remove(index);
+          onChanged();
+        } else {
+          extraDataChangeBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder getExtraDataChangeBuilder(
+          int index) {
+        return getExtraDataChangeFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder getExtraDataChangeOrBuilder(
+          int index) {
+        if (extraDataChangeBuilder_ == null) {
+          return extraDataChange_.get(index);  } else {
+          return extraDataChangeBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public java.util.List<? extends org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder> 
+           getExtraDataChangeOrBuilderList() {
+        if (extraDataChangeBuilder_ != null) {
+          return extraDataChangeBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(extraDataChange_);
+        }
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder addExtraDataChangeBuilder() {
+        return getExtraDataChangeFieldBuilder().addBuilder(
+            org.terasology.protobuf.NetData.ExtraDataChangeMessage.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder addExtraDataChangeBuilder(
+          int index) {
+        return getExtraDataChangeFieldBuilder().addBuilder(
+            index, org.terasology.protobuf.NetData.ExtraDataChangeMessage.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .ExtraDataChangeMessage extraDataChange = 11;</code>
+       */
+      public java.util.List<org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder> 
+           getExtraDataChangeBuilderList() {
+        return getExtraDataChangeFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.terasology.protobuf.NetData.ExtraDataChangeMessage, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder, org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder> 
+          getExtraDataChangeFieldBuilder() {
+        if (extraDataChangeBuilder_ == null) {
+          extraDataChangeBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.terasology.protobuf.NetData.ExtraDataChangeMessage, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder, org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder>(
+                  extraDataChange_,
+                  ((bitField0_ & 0x00000200) == 0x00000200),
+                  getParentForChildren(),
+                  isClean());
+          extraDataChange_ = null;
+        }
+        return extraDataChangeBuilder_;
+      }
+
+      // optional .ServerInfoRequest serverInfoRequest = 15;
       private org.terasology.protobuf.NetData.ServerInfoRequest serverInfoRequest_ = org.terasology.protobuf.NetData.ServerInfoRequest.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.ServerInfoRequest, org.terasology.protobuf.NetData.ServerInfoRequest.Builder, org.terasology.protobuf.NetData.ServerInfoRequestOrBuilder> serverInfoRequestBuilder_;
@@ -4532,7 +4944,7 @@ public final class NetData {
        * <code>optional .ServerInfoRequest serverInfoRequest = 15;</code>
        */
       public boolean hasServerInfoRequest() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return ((bitField0_ & 0x00000400) == 0x00000400);
       }
       /**
        * <code>optional .ServerInfoRequest serverInfoRequest = 15;</code>
@@ -4557,7 +4969,7 @@ public final class NetData {
         } else {
           serverInfoRequestBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000200;
+        bitField0_ |= 0x00000400;
         return this;
       }
       /**
@@ -4571,7 +4983,7 @@ public final class NetData {
         } else {
           serverInfoRequestBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000200;
+        bitField0_ |= 0x00000400;
         return this;
       }
       /**
@@ -4579,7 +4991,7 @@ public final class NetData {
        */
       public Builder mergeServerInfoRequest(org.terasology.protobuf.NetData.ServerInfoRequest value) {
         if (serverInfoRequestBuilder_ == null) {
-          if (((bitField0_ & 0x00000200) == 0x00000200) &&
+          if (((bitField0_ & 0x00000400) == 0x00000400) &&
               serverInfoRequest_ != org.terasology.protobuf.NetData.ServerInfoRequest.getDefaultInstance()) {
             serverInfoRequest_ =
               org.terasology.protobuf.NetData.ServerInfoRequest.newBuilder(serverInfoRequest_).mergeFrom(value).buildPartial();
@@ -4590,7 +5002,7 @@ public final class NetData {
         } else {
           serverInfoRequestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000200;
+        bitField0_ |= 0x00000400;
         return this;
       }
       /**
@@ -4603,14 +5015,14 @@ public final class NetData {
         } else {
           serverInfoRequestBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000200);
+        bitField0_ = (bitField0_ & ~0x00000400);
         return this;
       }
       /**
        * <code>optional .ServerInfoRequest serverInfoRequest = 15;</code>
        */
       public org.terasology.protobuf.NetData.ServerInfoRequest.Builder getServerInfoRequestBuilder() {
-        bitField0_ |= 0x00000200;
+        bitField0_ |= 0x00000400;
         onChanged();
         return getServerInfoRequestFieldBuilder().getBuilder();
       }
@@ -4633,7 +5045,7 @@ public final class NetData {
         if (serverInfoRequestBuilder_ == null) {
           serverInfoRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.ServerInfoRequest, org.terasology.protobuf.NetData.ServerInfoRequest.Builder, org.terasology.protobuf.NetData.ServerInfoRequestOrBuilder>(
-                  getServerInfoRequest(),
+                  serverInfoRequest_,
                   getParentForChildren(),
                   isClean());
           serverInfoRequest_ = null;
@@ -4641,6 +5053,7 @@ public final class NetData {
         return serverInfoRequestBuilder_;
       }
 
+      // optional .ServerInfoMessage serverInfo = 16;
       private org.terasology.protobuf.NetData.ServerInfoMessage serverInfo_ = org.terasology.protobuf.NetData.ServerInfoMessage.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.ServerInfoMessage, org.terasology.protobuf.NetData.ServerInfoMessage.Builder, org.terasology.protobuf.NetData.ServerInfoMessageOrBuilder> serverInfoBuilder_;
@@ -4648,7 +5061,7 @@ public final class NetData {
        * <code>optional .ServerInfoMessage serverInfo = 16;</code>
        */
       public boolean hasServerInfo() {
-        return ((bitField0_ & 0x00000400) == 0x00000400);
+        return ((bitField0_ & 0x00000800) == 0x00000800);
       }
       /**
        * <code>optional .ServerInfoMessage serverInfo = 16;</code>
@@ -4673,7 +5086,7 @@ public final class NetData {
         } else {
           serverInfoBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000400;
+        bitField0_ |= 0x00000800;
         return this;
       }
       /**
@@ -4687,7 +5100,7 @@ public final class NetData {
         } else {
           serverInfoBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000400;
+        bitField0_ |= 0x00000800;
         return this;
       }
       /**
@@ -4695,7 +5108,7 @@ public final class NetData {
        */
       public Builder mergeServerInfo(org.terasology.protobuf.NetData.ServerInfoMessage value) {
         if (serverInfoBuilder_ == null) {
-          if (((bitField0_ & 0x00000400) == 0x00000400) &&
+          if (((bitField0_ & 0x00000800) == 0x00000800) &&
               serverInfo_ != org.terasology.protobuf.NetData.ServerInfoMessage.getDefaultInstance()) {
             serverInfo_ =
               org.terasology.protobuf.NetData.ServerInfoMessage.newBuilder(serverInfo_).mergeFrom(value).buildPartial();
@@ -4706,7 +5119,7 @@ public final class NetData {
         } else {
           serverInfoBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000400;
+        bitField0_ |= 0x00000800;
         return this;
       }
       /**
@@ -4719,14 +5132,14 @@ public final class NetData {
         } else {
           serverInfoBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000400);
+        bitField0_ = (bitField0_ & ~0x00000800);
         return this;
       }
       /**
        * <code>optional .ServerInfoMessage serverInfo = 16;</code>
        */
       public org.terasology.protobuf.NetData.ServerInfoMessage.Builder getServerInfoBuilder() {
-        bitField0_ |= 0x00000400;
+        bitField0_ |= 0x00000800;
         onChanged();
         return getServerInfoFieldBuilder().getBuilder();
       }
@@ -4749,7 +5162,7 @@ public final class NetData {
         if (serverInfoBuilder_ == null) {
           serverInfoBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.ServerInfoMessage, org.terasology.protobuf.NetData.ServerInfoMessage.Builder, org.terasology.protobuf.NetData.ServerInfoMessageOrBuilder>(
-                  getServerInfo(),
+                  serverInfo_,
                   getParentForChildren(),
                   isClean());
           serverInfo_ = null;
@@ -4757,12 +5170,13 @@ public final class NetData {
         return serverInfoBuilder_;
       }
 
+      // repeated .BlockFamilyRegisteredMessage blockFamilyRegistered = 17;
       private java.util.List<org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage> blockFamilyRegistered_ =
         java.util.Collections.emptyList();
       private void ensureBlockFamilyRegisteredIsMutable() {
-        if (!((bitField0_ & 0x00000800) == 0x00000800)) {
+        if (!((bitField0_ & 0x00001000) == 0x00001000)) {
           blockFamilyRegistered_ = new java.util.ArrayList<org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage>(blockFamilyRegistered_);
-          bitField0_ |= 0x00000800;
+          bitField0_ |= 0x00001000;
          }
       }
 
@@ -4898,8 +5312,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage> values) {
         if (blockFamilyRegisteredBuilder_ == null) {
           ensureBlockFamilyRegisteredIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, blockFamilyRegistered_);
+          super.addAll(values, blockFamilyRegistered_);
           onChanged();
         } else {
           blockFamilyRegisteredBuilder_.addAllMessages(values);
@@ -4912,7 +5325,7 @@ public final class NetData {
       public Builder clearBlockFamilyRegistered() {
         if (blockFamilyRegisteredBuilder_ == null) {
           blockFamilyRegistered_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000800);
+          bitField0_ = (bitField0_ & ~0x00001000);
           onChanged();
         } else {
           blockFamilyRegisteredBuilder_.clear();
@@ -4989,7 +5402,7 @@ public final class NetData {
           blockFamilyRegisteredBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
               org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage, org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage.Builder, org.terasology.protobuf.NetData.BlockFamilyRegisteredMessageOrBuilder>(
                   blockFamilyRegistered_,
-                  ((bitField0_ & 0x00000800) == 0x00000800),
+                  ((bitField0_ & 0x00001000) == 0x00001000),
                   getParentForChildren(),
                   isClean());
           blockFamilyRegistered_ = null;
@@ -4997,6 +5410,7 @@ public final class NetData {
         return blockFamilyRegisteredBuilder_;
       }
 
+      // optional .JoinMessage join = 18;
       private org.terasology.protobuf.NetData.JoinMessage join_ = org.terasology.protobuf.NetData.JoinMessage.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.JoinMessage, org.terasology.protobuf.NetData.JoinMessage.Builder, org.terasology.protobuf.NetData.JoinMessageOrBuilder> joinBuilder_;
@@ -5004,7 +5418,7 @@ public final class NetData {
        * <code>optional .JoinMessage join = 18;</code>
        */
       public boolean hasJoin() {
-        return ((bitField0_ & 0x00001000) == 0x00001000);
+        return ((bitField0_ & 0x00002000) == 0x00002000);
       }
       /**
        * <code>optional .JoinMessage join = 18;</code>
@@ -5029,7 +5443,7 @@ public final class NetData {
         } else {
           joinBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00001000;
+        bitField0_ |= 0x00002000;
         return this;
       }
       /**
@@ -5043,7 +5457,7 @@ public final class NetData {
         } else {
           joinBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00001000;
+        bitField0_ |= 0x00002000;
         return this;
       }
       /**
@@ -5051,7 +5465,7 @@ public final class NetData {
        */
       public Builder mergeJoin(org.terasology.protobuf.NetData.JoinMessage value) {
         if (joinBuilder_ == null) {
-          if (((bitField0_ & 0x00001000) == 0x00001000) &&
+          if (((bitField0_ & 0x00002000) == 0x00002000) &&
               join_ != org.terasology.protobuf.NetData.JoinMessage.getDefaultInstance()) {
             join_ =
               org.terasology.protobuf.NetData.JoinMessage.newBuilder(join_).mergeFrom(value).buildPartial();
@@ -5062,7 +5476,7 @@ public final class NetData {
         } else {
           joinBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00001000;
+        bitField0_ |= 0x00002000;
         return this;
       }
       /**
@@ -5075,14 +5489,14 @@ public final class NetData {
         } else {
           joinBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00001000);
+        bitField0_ = (bitField0_ & ~0x00002000);
         return this;
       }
       /**
        * <code>optional .JoinMessage join = 18;</code>
        */
       public org.terasology.protobuf.NetData.JoinMessage.Builder getJoinBuilder() {
-        bitField0_ |= 0x00001000;
+        bitField0_ |= 0x00002000;
         onChanged();
         return getJoinFieldBuilder().getBuilder();
       }
@@ -5105,7 +5519,7 @@ public final class NetData {
         if (joinBuilder_ == null) {
           joinBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.JoinMessage, org.terasology.protobuf.NetData.JoinMessage.Builder, org.terasology.protobuf.NetData.JoinMessageOrBuilder>(
-                  getJoin(),
+                  join_,
                   getParentForChildren(),
                   isClean());
           join_ = null;
@@ -5113,12 +5527,13 @@ public final class NetData {
         return joinBuilder_;
       }
 
+      // repeated .ModuleRequest moduleRequest = 19;
       private java.util.List<org.terasology.protobuf.NetData.ModuleRequest> moduleRequest_ =
         java.util.Collections.emptyList();
       private void ensureModuleRequestIsMutable() {
-        if (!((bitField0_ & 0x00002000) == 0x00002000)) {
+        if (!((bitField0_ & 0x00004000) == 0x00004000)) {
           moduleRequest_ = new java.util.ArrayList<org.terasology.protobuf.NetData.ModuleRequest>(moduleRequest_);
-          bitField0_ |= 0x00002000;
+          bitField0_ |= 0x00004000;
          }
       }
 
@@ -5254,8 +5669,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.ModuleRequest> values) {
         if (moduleRequestBuilder_ == null) {
           ensureModuleRequestIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, moduleRequest_);
+          super.addAll(values, moduleRequest_);
           onChanged();
         } else {
           moduleRequestBuilder_.addAllMessages(values);
@@ -5268,7 +5682,7 @@ public final class NetData {
       public Builder clearModuleRequest() {
         if (moduleRequestBuilder_ == null) {
           moduleRequest_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00002000);
+          bitField0_ = (bitField0_ & ~0x00004000);
           onChanged();
         } else {
           moduleRequestBuilder_.clear();
@@ -5345,7 +5759,7 @@ public final class NetData {
           moduleRequestBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
               org.terasology.protobuf.NetData.ModuleRequest, org.terasology.protobuf.NetData.ModuleRequest.Builder, org.terasology.protobuf.NetData.ModuleRequestOrBuilder>(
                   moduleRequest_,
-                  ((bitField0_ & 0x00002000) == 0x00002000),
+                  ((bitField0_ & 0x00004000) == 0x00004000),
                   getParentForChildren(),
                   isClean());
           moduleRequest_ = null;
@@ -5353,6 +5767,7 @@ public final class NetData {
         return moduleRequestBuilder_;
       }
 
+      // optional .ModuleDataHeader moduleDataHeader = 20;
       private org.terasology.protobuf.NetData.ModuleDataHeader moduleDataHeader_ = org.terasology.protobuf.NetData.ModuleDataHeader.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.ModuleDataHeader, org.terasology.protobuf.NetData.ModuleDataHeader.Builder, org.terasology.protobuf.NetData.ModuleDataHeaderOrBuilder> moduleDataHeaderBuilder_;
@@ -5360,7 +5775,7 @@ public final class NetData {
        * <code>optional .ModuleDataHeader moduleDataHeader = 20;</code>
        */
       public boolean hasModuleDataHeader() {
-        return ((bitField0_ & 0x00004000) == 0x00004000);
+        return ((bitField0_ & 0x00008000) == 0x00008000);
       }
       /**
        * <code>optional .ModuleDataHeader moduleDataHeader = 20;</code>
@@ -5385,7 +5800,7 @@ public final class NetData {
         } else {
           moduleDataHeaderBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00004000;
+        bitField0_ |= 0x00008000;
         return this;
       }
       /**
@@ -5399,7 +5814,7 @@ public final class NetData {
         } else {
           moduleDataHeaderBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00004000;
+        bitField0_ |= 0x00008000;
         return this;
       }
       /**
@@ -5407,7 +5822,7 @@ public final class NetData {
        */
       public Builder mergeModuleDataHeader(org.terasology.protobuf.NetData.ModuleDataHeader value) {
         if (moduleDataHeaderBuilder_ == null) {
-          if (((bitField0_ & 0x00004000) == 0x00004000) &&
+          if (((bitField0_ & 0x00008000) == 0x00008000) &&
               moduleDataHeader_ != org.terasology.protobuf.NetData.ModuleDataHeader.getDefaultInstance()) {
             moduleDataHeader_ =
               org.terasology.protobuf.NetData.ModuleDataHeader.newBuilder(moduleDataHeader_).mergeFrom(value).buildPartial();
@@ -5418,7 +5833,7 @@ public final class NetData {
         } else {
           moduleDataHeaderBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00004000;
+        bitField0_ |= 0x00008000;
         return this;
       }
       /**
@@ -5431,14 +5846,14 @@ public final class NetData {
         } else {
           moduleDataHeaderBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00004000);
+        bitField0_ = (bitField0_ & ~0x00008000);
         return this;
       }
       /**
        * <code>optional .ModuleDataHeader moduleDataHeader = 20;</code>
        */
       public org.terasology.protobuf.NetData.ModuleDataHeader.Builder getModuleDataHeaderBuilder() {
-        bitField0_ |= 0x00004000;
+        bitField0_ |= 0x00008000;
         onChanged();
         return getModuleDataHeaderFieldBuilder().getBuilder();
       }
@@ -5461,7 +5876,7 @@ public final class NetData {
         if (moduleDataHeaderBuilder_ == null) {
           moduleDataHeaderBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.ModuleDataHeader, org.terasology.protobuf.NetData.ModuleDataHeader.Builder, org.terasology.protobuf.NetData.ModuleDataHeaderOrBuilder>(
-                  getModuleDataHeader(),
+                  moduleDataHeader_,
                   getParentForChildren(),
                   isClean());
           moduleDataHeader_ = null;
@@ -5469,6 +5884,7 @@ public final class NetData {
         return moduleDataHeaderBuilder_;
       }
 
+      // optional .ModuleData moduleData = 21;
       private org.terasology.protobuf.NetData.ModuleData moduleData_ = org.terasology.protobuf.NetData.ModuleData.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.ModuleData, org.terasology.protobuf.NetData.ModuleData.Builder, org.terasology.protobuf.NetData.ModuleDataOrBuilder> moduleDataBuilder_;
@@ -5476,7 +5892,7 @@ public final class NetData {
        * <code>optional .ModuleData moduleData = 21;</code>
        */
       public boolean hasModuleData() {
-        return ((bitField0_ & 0x00008000) == 0x00008000);
+        return ((bitField0_ & 0x00010000) == 0x00010000);
       }
       /**
        * <code>optional .ModuleData moduleData = 21;</code>
@@ -5501,7 +5917,7 @@ public final class NetData {
         } else {
           moduleDataBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00008000;
+        bitField0_ |= 0x00010000;
         return this;
       }
       /**
@@ -5515,7 +5931,7 @@ public final class NetData {
         } else {
           moduleDataBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00008000;
+        bitField0_ |= 0x00010000;
         return this;
       }
       /**
@@ -5523,7 +5939,7 @@ public final class NetData {
        */
       public Builder mergeModuleData(org.terasology.protobuf.NetData.ModuleData value) {
         if (moduleDataBuilder_ == null) {
-          if (((bitField0_ & 0x00008000) == 0x00008000) &&
+          if (((bitField0_ & 0x00010000) == 0x00010000) &&
               moduleData_ != org.terasology.protobuf.NetData.ModuleData.getDefaultInstance()) {
             moduleData_ =
               org.terasology.protobuf.NetData.ModuleData.newBuilder(moduleData_).mergeFrom(value).buildPartial();
@@ -5534,7 +5950,7 @@ public final class NetData {
         } else {
           moduleDataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00008000;
+        bitField0_ |= 0x00010000;
         return this;
       }
       /**
@@ -5547,14 +5963,14 @@ public final class NetData {
         } else {
           moduleDataBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00008000);
+        bitField0_ = (bitField0_ & ~0x00010000);
         return this;
       }
       /**
        * <code>optional .ModuleData moduleData = 21;</code>
        */
       public org.terasology.protobuf.NetData.ModuleData.Builder getModuleDataBuilder() {
-        bitField0_ |= 0x00008000;
+        bitField0_ |= 0x00010000;
         onChanged();
         return getModuleDataFieldBuilder().getBuilder();
       }
@@ -5577,7 +5993,7 @@ public final class NetData {
         if (moduleDataBuilder_ == null) {
           moduleDataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.ModuleData, org.terasology.protobuf.NetData.ModuleData.Builder, org.terasology.protobuf.NetData.ModuleDataOrBuilder>(
-                  getModuleData(),
+                  moduleData_,
                   getParentForChildren(),
                   isClean());
           moduleData_ = null;
@@ -5585,6 +6001,7 @@ public final class NetData {
         return moduleDataBuilder_;
       }
 
+      // optional .JoinCompleteMessage joinComplete = 22;
       private org.terasology.protobuf.NetData.JoinCompleteMessage joinComplete_ = org.terasology.protobuf.NetData.JoinCompleteMessage.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.JoinCompleteMessage, org.terasology.protobuf.NetData.JoinCompleteMessage.Builder, org.terasology.protobuf.NetData.JoinCompleteMessageOrBuilder> joinCompleteBuilder_;
@@ -5592,7 +6009,7 @@ public final class NetData {
        * <code>optional .JoinCompleteMessage joinComplete = 22;</code>
        */
       public boolean hasJoinComplete() {
-        return ((bitField0_ & 0x00010000) == 0x00010000);
+        return ((bitField0_ & 0x00020000) == 0x00020000);
       }
       /**
        * <code>optional .JoinCompleteMessage joinComplete = 22;</code>
@@ -5617,7 +6034,7 @@ public final class NetData {
         } else {
           joinCompleteBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00010000;
+        bitField0_ |= 0x00020000;
         return this;
       }
       /**
@@ -5631,7 +6048,7 @@ public final class NetData {
         } else {
           joinCompleteBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00010000;
+        bitField0_ |= 0x00020000;
         return this;
       }
       /**
@@ -5639,7 +6056,7 @@ public final class NetData {
        */
       public Builder mergeJoinComplete(org.terasology.protobuf.NetData.JoinCompleteMessage value) {
         if (joinCompleteBuilder_ == null) {
-          if (((bitField0_ & 0x00010000) == 0x00010000) &&
+          if (((bitField0_ & 0x00020000) == 0x00020000) &&
               joinComplete_ != org.terasology.protobuf.NetData.JoinCompleteMessage.getDefaultInstance()) {
             joinComplete_ =
               org.terasology.protobuf.NetData.JoinCompleteMessage.newBuilder(joinComplete_).mergeFrom(value).buildPartial();
@@ -5650,7 +6067,7 @@ public final class NetData {
         } else {
           joinCompleteBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00010000;
+        bitField0_ |= 0x00020000;
         return this;
       }
       /**
@@ -5663,14 +6080,14 @@ public final class NetData {
         } else {
           joinCompleteBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00010000);
+        bitField0_ = (bitField0_ & ~0x00020000);
         return this;
       }
       /**
        * <code>optional .JoinCompleteMessage joinComplete = 22;</code>
        */
       public org.terasology.protobuf.NetData.JoinCompleteMessage.Builder getJoinCompleteBuilder() {
-        bitField0_ |= 0x00010000;
+        bitField0_ |= 0x00020000;
         onChanged();
         return getJoinCompleteFieldBuilder().getBuilder();
       }
@@ -5693,7 +6110,7 @@ public final class NetData {
         if (joinCompleteBuilder_ == null) {
           joinCompleteBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.JoinCompleteMessage, org.terasology.protobuf.NetData.JoinCompleteMessage.Builder, org.terasology.protobuf.NetData.JoinCompleteMessageOrBuilder>(
-                  getJoinComplete(),
+                  joinComplete_,
                   getParentForChildren(),
                   isClean());
           joinComplete_ = null;
@@ -5701,6 +6118,7 @@ public final class NetData {
         return joinCompleteBuilder_;
       }
 
+      // optional .HandshakeHello handshakeHello = 100;
       private org.terasology.protobuf.NetData.HandshakeHello handshakeHello_ = org.terasology.protobuf.NetData.HandshakeHello.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.HandshakeHello, org.terasology.protobuf.NetData.HandshakeHello.Builder, org.terasology.protobuf.NetData.HandshakeHelloOrBuilder> handshakeHelloBuilder_;
@@ -5712,7 +6130,7 @@ public final class NetData {
        * </pre>
        */
       public boolean hasHandshakeHello() {
-        return ((bitField0_ & 0x00020000) == 0x00020000);
+        return ((bitField0_ & 0x00040000) == 0x00040000);
       }
       /**
        * <code>optional .HandshakeHello handshakeHello = 100;</code>
@@ -5745,7 +6163,7 @@ public final class NetData {
         } else {
           handshakeHelloBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00020000;
+        bitField0_ |= 0x00040000;
         return this;
       }
       /**
@@ -5763,7 +6181,7 @@ public final class NetData {
         } else {
           handshakeHelloBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00020000;
+        bitField0_ |= 0x00040000;
         return this;
       }
       /**
@@ -5775,7 +6193,7 @@ public final class NetData {
        */
       public Builder mergeHandshakeHello(org.terasology.protobuf.NetData.HandshakeHello value) {
         if (handshakeHelloBuilder_ == null) {
-          if (((bitField0_ & 0x00020000) == 0x00020000) &&
+          if (((bitField0_ & 0x00040000) == 0x00040000) &&
               handshakeHello_ != org.terasology.protobuf.NetData.HandshakeHello.getDefaultInstance()) {
             handshakeHello_ =
               org.terasology.protobuf.NetData.HandshakeHello.newBuilder(handshakeHello_).mergeFrom(value).buildPartial();
@@ -5786,7 +6204,7 @@ public final class NetData {
         } else {
           handshakeHelloBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00020000;
+        bitField0_ |= 0x00040000;
         return this;
       }
       /**
@@ -5803,7 +6221,7 @@ public final class NetData {
         } else {
           handshakeHelloBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00020000);
+        bitField0_ = (bitField0_ & ~0x00040000);
         return this;
       }
       /**
@@ -5814,7 +6232,7 @@ public final class NetData {
        * </pre>
        */
       public org.terasology.protobuf.NetData.HandshakeHello.Builder getHandshakeHelloBuilder() {
-        bitField0_ |= 0x00020000;
+        bitField0_ |= 0x00040000;
         onChanged();
         return getHandshakeHelloFieldBuilder().getBuilder();
       }
@@ -5845,7 +6263,7 @@ public final class NetData {
         if (handshakeHelloBuilder_ == null) {
           handshakeHelloBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.HandshakeHello, org.terasology.protobuf.NetData.HandshakeHello.Builder, org.terasology.protobuf.NetData.HandshakeHelloOrBuilder>(
-                  getHandshakeHello(),
+                  handshakeHello_,
                   getParentForChildren(),
                   isClean());
           handshakeHello_ = null;
@@ -5853,6 +6271,7 @@ public final class NetData {
         return handshakeHelloBuilder_;
       }
 
+      // optional .NewIdentityRequest newIdentityRequest = 101;
       private org.terasology.protobuf.NetData.NewIdentityRequest newIdentityRequest_ = org.terasology.protobuf.NetData.NewIdentityRequest.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.NewIdentityRequest, org.terasology.protobuf.NetData.NewIdentityRequest.Builder, org.terasology.protobuf.NetData.NewIdentityRequestOrBuilder> newIdentityRequestBuilder_;
@@ -5860,7 +6279,7 @@ public final class NetData {
        * <code>optional .NewIdentityRequest newIdentityRequest = 101;</code>
        */
       public boolean hasNewIdentityRequest() {
-        return ((bitField0_ & 0x00040000) == 0x00040000);
+        return ((bitField0_ & 0x00080000) == 0x00080000);
       }
       /**
        * <code>optional .NewIdentityRequest newIdentityRequest = 101;</code>
@@ -5885,7 +6304,7 @@ public final class NetData {
         } else {
           newIdentityRequestBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00040000;
+        bitField0_ |= 0x00080000;
         return this;
       }
       /**
@@ -5899,7 +6318,7 @@ public final class NetData {
         } else {
           newIdentityRequestBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00040000;
+        bitField0_ |= 0x00080000;
         return this;
       }
       /**
@@ -5907,7 +6326,7 @@ public final class NetData {
        */
       public Builder mergeNewIdentityRequest(org.terasology.protobuf.NetData.NewIdentityRequest value) {
         if (newIdentityRequestBuilder_ == null) {
-          if (((bitField0_ & 0x00040000) == 0x00040000) &&
+          if (((bitField0_ & 0x00080000) == 0x00080000) &&
               newIdentityRequest_ != org.terasology.protobuf.NetData.NewIdentityRequest.getDefaultInstance()) {
             newIdentityRequest_ =
               org.terasology.protobuf.NetData.NewIdentityRequest.newBuilder(newIdentityRequest_).mergeFrom(value).buildPartial();
@@ -5918,7 +6337,7 @@ public final class NetData {
         } else {
           newIdentityRequestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00040000;
+        bitField0_ |= 0x00080000;
         return this;
       }
       /**
@@ -5931,14 +6350,14 @@ public final class NetData {
         } else {
           newIdentityRequestBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00040000);
+        bitField0_ = (bitField0_ & ~0x00080000);
         return this;
       }
       /**
        * <code>optional .NewIdentityRequest newIdentityRequest = 101;</code>
        */
       public org.terasology.protobuf.NetData.NewIdentityRequest.Builder getNewIdentityRequestBuilder() {
-        bitField0_ |= 0x00040000;
+        bitField0_ |= 0x00080000;
         onChanged();
         return getNewIdentityRequestFieldBuilder().getBuilder();
       }
@@ -5961,7 +6380,7 @@ public final class NetData {
         if (newIdentityRequestBuilder_ == null) {
           newIdentityRequestBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.NewIdentityRequest, org.terasology.protobuf.NetData.NewIdentityRequest.Builder, org.terasology.protobuf.NetData.NewIdentityRequestOrBuilder>(
-                  getNewIdentityRequest(),
+                  newIdentityRequest_,
                   getParentForChildren(),
                   isClean());
           newIdentityRequest_ = null;
@@ -5969,6 +6388,7 @@ public final class NetData {
         return newIdentityRequestBuilder_;
       }
 
+      // optional .ProvisionIdentity provisionIdentity = 102;
       private org.terasology.protobuf.NetData.ProvisionIdentity provisionIdentity_ = org.terasology.protobuf.NetData.ProvisionIdentity.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.ProvisionIdentity, org.terasology.protobuf.NetData.ProvisionIdentity.Builder, org.terasology.protobuf.NetData.ProvisionIdentityOrBuilder> provisionIdentityBuilder_;
@@ -5976,7 +6396,7 @@ public final class NetData {
        * <code>optional .ProvisionIdentity provisionIdentity = 102;</code>
        */
       public boolean hasProvisionIdentity() {
-        return ((bitField0_ & 0x00080000) == 0x00080000);
+        return ((bitField0_ & 0x00100000) == 0x00100000);
       }
       /**
        * <code>optional .ProvisionIdentity provisionIdentity = 102;</code>
@@ -6001,7 +6421,7 @@ public final class NetData {
         } else {
           provisionIdentityBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00080000;
+        bitField0_ |= 0x00100000;
         return this;
       }
       /**
@@ -6015,7 +6435,7 @@ public final class NetData {
         } else {
           provisionIdentityBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00080000;
+        bitField0_ |= 0x00100000;
         return this;
       }
       /**
@@ -6023,7 +6443,7 @@ public final class NetData {
        */
       public Builder mergeProvisionIdentity(org.terasology.protobuf.NetData.ProvisionIdentity value) {
         if (provisionIdentityBuilder_ == null) {
-          if (((bitField0_ & 0x00080000) == 0x00080000) &&
+          if (((bitField0_ & 0x00100000) == 0x00100000) &&
               provisionIdentity_ != org.terasology.protobuf.NetData.ProvisionIdentity.getDefaultInstance()) {
             provisionIdentity_ =
               org.terasology.protobuf.NetData.ProvisionIdentity.newBuilder(provisionIdentity_).mergeFrom(value).buildPartial();
@@ -6034,7 +6454,7 @@ public final class NetData {
         } else {
           provisionIdentityBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00080000;
+        bitField0_ |= 0x00100000;
         return this;
       }
       /**
@@ -6047,14 +6467,14 @@ public final class NetData {
         } else {
           provisionIdentityBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00080000);
+        bitField0_ = (bitField0_ & ~0x00100000);
         return this;
       }
       /**
        * <code>optional .ProvisionIdentity provisionIdentity = 102;</code>
        */
       public org.terasology.protobuf.NetData.ProvisionIdentity.Builder getProvisionIdentityBuilder() {
-        bitField0_ |= 0x00080000;
+        bitField0_ |= 0x00100000;
         onChanged();
         return getProvisionIdentityFieldBuilder().getBuilder();
       }
@@ -6077,7 +6497,7 @@ public final class NetData {
         if (provisionIdentityBuilder_ == null) {
           provisionIdentityBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.ProvisionIdentity, org.terasology.protobuf.NetData.ProvisionIdentity.Builder, org.terasology.protobuf.NetData.ProvisionIdentityOrBuilder>(
-                  getProvisionIdentity(),
+                  provisionIdentity_,
                   getParentForChildren(),
                   isClean());
           provisionIdentity_ = null;
@@ -6085,6 +6505,7 @@ public final class NetData {
         return provisionIdentityBuilder_;
       }
 
+      // optional .HandshakeVerification handshakeVerification = 103;
       private org.terasology.protobuf.NetData.HandshakeVerification handshakeVerification_ = org.terasology.protobuf.NetData.HandshakeVerification.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.HandshakeVerification, org.terasology.protobuf.NetData.HandshakeVerification.Builder, org.terasology.protobuf.NetData.HandshakeVerificationOrBuilder> handshakeVerificationBuilder_;
@@ -6092,7 +6513,7 @@ public final class NetData {
        * <code>optional .HandshakeVerification handshakeVerification = 103;</code>
        */
       public boolean hasHandshakeVerification() {
-        return ((bitField0_ & 0x00100000) == 0x00100000);
+        return ((bitField0_ & 0x00200000) == 0x00200000);
       }
       /**
        * <code>optional .HandshakeVerification handshakeVerification = 103;</code>
@@ -6117,7 +6538,7 @@ public final class NetData {
         } else {
           handshakeVerificationBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00100000;
+        bitField0_ |= 0x00200000;
         return this;
       }
       /**
@@ -6131,7 +6552,7 @@ public final class NetData {
         } else {
           handshakeVerificationBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00100000;
+        bitField0_ |= 0x00200000;
         return this;
       }
       /**
@@ -6139,7 +6560,7 @@ public final class NetData {
        */
       public Builder mergeHandshakeVerification(org.terasology.protobuf.NetData.HandshakeVerification value) {
         if (handshakeVerificationBuilder_ == null) {
-          if (((bitField0_ & 0x00100000) == 0x00100000) &&
+          if (((bitField0_ & 0x00200000) == 0x00200000) &&
               handshakeVerification_ != org.terasology.protobuf.NetData.HandshakeVerification.getDefaultInstance()) {
             handshakeVerification_ =
               org.terasology.protobuf.NetData.HandshakeVerification.newBuilder(handshakeVerification_).mergeFrom(value).buildPartial();
@@ -6150,7 +6571,7 @@ public final class NetData {
         } else {
           handshakeVerificationBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00100000;
+        bitField0_ |= 0x00200000;
         return this;
       }
       /**
@@ -6163,14 +6584,14 @@ public final class NetData {
         } else {
           handshakeVerificationBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00100000);
+        bitField0_ = (bitField0_ & ~0x00200000);
         return this;
       }
       /**
        * <code>optional .HandshakeVerification handshakeVerification = 103;</code>
        */
       public org.terasology.protobuf.NetData.HandshakeVerification.Builder getHandshakeVerificationBuilder() {
-        bitField0_ |= 0x00100000;
+        bitField0_ |= 0x00200000;
         onChanged();
         return getHandshakeVerificationFieldBuilder().getBuilder();
       }
@@ -6193,7 +6614,7 @@ public final class NetData {
         if (handshakeVerificationBuilder_ == null) {
           handshakeVerificationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.HandshakeVerification, org.terasology.protobuf.NetData.HandshakeVerification.Builder, org.terasology.protobuf.NetData.HandshakeVerificationOrBuilder>(
-                  getHandshakeVerification(),
+                  handshakeVerification_,
                   getParentForChildren(),
                   isClean());
           handshakeVerification_ = null;
@@ -6213,10 +6634,10 @@ public final class NetData {
   }
 
   public interface HandshakeHelloOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:HandshakeHello)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<HandshakeHello> {
 
+    // optional bytes random = 1;
     /**
      * <code>optional bytes random = 1;</code>
      */
@@ -6226,6 +6647,7 @@ public final class NetData {
      */
     com.google.protobuf.ByteString getRandom();
 
+    // optional .Certificate certificate = 2;
     /**
      * <code>optional .Certificate certificate = 2;</code>
      */
@@ -6239,6 +6661,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.CertificateOrBuilder getCertificateOrBuilder();
 
+    // optional sint64 timestamp = 3;
     /**
      * <code>optional sint64 timestamp = 3;</code>
      */
@@ -6253,9 +6676,7 @@ public final class NetData {
    */
   public static final class HandshakeHello extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        HandshakeHello> implements
-      // @@protoc_insertion_point(message_implements:HandshakeHello)
-      HandshakeHelloOrBuilder {
+        HandshakeHello> implements HandshakeHelloOrBuilder {
     // Use HandshakeHello.newBuilder() to construct.
     private HandshakeHello(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.HandshakeHello, ?> builder) {
       super(builder);
@@ -6364,6 +6785,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional bytes random = 1;
     public static final int RANDOM_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString random_;
     /**
@@ -6379,6 +6801,7 @@ public final class NetData {
       return random_;
     }
 
+    // optional .Certificate certificate = 2;
     public static final int CERTIFICATE_FIELD_NUMBER = 2;
     private org.terasology.protobuf.NetData.Certificate certificate_;
     /**
@@ -6400,6 +6823,7 @@ public final class NetData {
       return certificate_;
     }
 
+    // optional sint64 timestamp = 3;
     public static final int TIMESTAMP_FIELD_NUMBER = 3;
     private long timestamp_;
     /**
@@ -6423,8 +6847,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasCertificate()) {
         if (!getCertificate().isInitialized()) {
@@ -6561,9 +6984,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.HandshakeHello, Builder> implements
-        // @@protoc_insertion_point(builder_implements:HandshakeHello)
-        org.terasology.protobuf.NetData.HandshakeHelloOrBuilder {
+          org.terasology.protobuf.NetData.HandshakeHello, Builder> implements org.terasology.protobuf.NetData.HandshakeHelloOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_HandshakeHello_descriptor;
@@ -6714,6 +7135,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional bytes random = 1;
       private com.google.protobuf.ByteString random_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes random = 1;</code>
@@ -6749,6 +7171,7 @@ public final class NetData {
         return this;
       }
 
+      // optional .Certificate certificate = 2;
       private org.terasology.protobuf.NetData.Certificate certificate_ = org.terasology.protobuf.NetData.Certificate.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Certificate, org.terasology.protobuf.NetData.Certificate.Builder, org.terasology.protobuf.NetData.CertificateOrBuilder> certificateBuilder_;
@@ -6857,7 +7280,7 @@ public final class NetData {
         if (certificateBuilder_ == null) {
           certificateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Certificate, org.terasology.protobuf.NetData.Certificate.Builder, org.terasology.protobuf.NetData.CertificateOrBuilder>(
-                  getCertificate(),
+                  certificate_,
                   getParentForChildren(),
                   isClean());
           certificate_ = null;
@@ -6865,6 +7288,7 @@ public final class NetData {
         return certificateBuilder_;
       }
 
+      // optional sint64 timestamp = 3;
       private long timestamp_ ;
       /**
        * <code>optional sint64 timestamp = 3;</code>
@@ -6909,10 +7333,10 @@ public final class NetData {
   }
 
   public interface NewIdentityRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:NewIdentityRequest)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<NewIdentityRequest> {
 
+    // optional bytes preMasterSecret = 1;
     /**
      * <code>optional bytes preMasterSecret = 1;</code>
      */
@@ -6922,6 +7346,7 @@ public final class NetData {
      */
     com.google.protobuf.ByteString getPreMasterSecret();
 
+    // optional bytes random = 2;
     /**
      * <code>optional bytes random = 2;</code>
      */
@@ -6936,9 +7361,7 @@ public final class NetData {
    */
   public static final class NewIdentityRequest extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        NewIdentityRequest> implements
-      // @@protoc_insertion_point(message_implements:NewIdentityRequest)
-      NewIdentityRequestOrBuilder {
+        NewIdentityRequest> implements NewIdentityRequestOrBuilder {
     // Use NewIdentityRequest.newBuilder() to construct.
     private NewIdentityRequest(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.NewIdentityRequest, ?> builder) {
       super(builder);
@@ -7034,6 +7457,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional bytes preMasterSecret = 1;
     public static final int PREMASTERSECRET_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString preMasterSecret_;
     /**
@@ -7049,6 +7473,7 @@ public final class NetData {
       return preMasterSecret_;
     }
 
+    // optional bytes random = 2;
     public static final int RANDOM_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString random_;
     /**
@@ -7071,8 +7496,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -7196,9 +7620,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.NewIdentityRequest, Builder> implements
-        // @@protoc_insertion_point(builder_implements:NewIdentityRequest)
-        org.terasology.protobuf.NetData.NewIdentityRequestOrBuilder {
+          org.terasology.protobuf.NetData.NewIdentityRequest, Builder> implements org.terasology.protobuf.NetData.NewIdentityRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_NewIdentityRequest_descriptor;
@@ -7325,6 +7747,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional bytes preMasterSecret = 1;
       private com.google.protobuf.ByteString preMasterSecret_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes preMasterSecret = 1;</code>
@@ -7360,6 +7783,7 @@ public final class NetData {
         return this;
       }
 
+      // optional bytes random = 2;
       private com.google.protobuf.ByteString random_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes random = 2;</code>
@@ -7407,10 +7831,10 @@ public final class NetData {
   }
 
   public interface ProvisionIdentityOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ProvisionIdentity)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ProvisionIdentity> {
 
+    // optional bytes encryptedCertificates = 1;
     /**
      * <code>optional bytes encryptedCertificates = 1;</code>
      */
@@ -7425,9 +7849,7 @@ public final class NetData {
    */
   public static final class ProvisionIdentity extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ProvisionIdentity> implements
-      // @@protoc_insertion_point(message_implements:ProvisionIdentity)
-      ProvisionIdentityOrBuilder {
+        ProvisionIdentity> implements ProvisionIdentityOrBuilder {
     // Use ProvisionIdentity.newBuilder() to construct.
     private ProvisionIdentity(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ProvisionIdentity, ?> builder) {
       super(builder);
@@ -7518,6 +7940,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional bytes encryptedCertificates = 1;
     public static final int ENCRYPTEDCERTIFICATES_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString encryptedCertificates_;
     /**
@@ -7539,8 +7962,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -7657,9 +8079,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ProvisionIdentity, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ProvisionIdentity)
-        org.terasology.protobuf.NetData.ProvisionIdentityOrBuilder {
+          org.terasology.protobuf.NetData.ProvisionIdentity, Builder> implements org.terasology.protobuf.NetData.ProvisionIdentityOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ProvisionIdentity_descriptor;
@@ -7777,6 +8197,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional bytes encryptedCertificates = 1;
       private com.google.protobuf.ByteString encryptedCertificates_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes encryptedCertificates = 1;</code>
@@ -7824,10 +8245,10 @@ public final class NetData {
   }
 
   public interface CertificateSetOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:CertificateSet)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<CertificateSet> {
 
+    // optional .Certificate publicCertificate = 1;
     /**
      * <code>optional .Certificate publicCertificate = 1;</code>
      */
@@ -7841,6 +8262,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.CertificateOrBuilder getPublicCertificateOrBuilder();
 
+    // optional bytes privateExponent = 2;
     /**
      * <code>optional bytes privateExponent = 2;</code>
      */
@@ -7855,9 +8277,7 @@ public final class NetData {
    */
   public static final class CertificateSet extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        CertificateSet> implements
-      // @@protoc_insertion_point(message_implements:CertificateSet)
-      CertificateSetOrBuilder {
+        CertificateSet> implements CertificateSetOrBuilder {
     // Use CertificateSet.newBuilder() to construct.
     private CertificateSet(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.CertificateSet, ?> builder) {
       super(builder);
@@ -7961,6 +8381,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional .Certificate publicCertificate = 1;
     public static final int PUBLICCERTIFICATE_FIELD_NUMBER = 1;
     private org.terasology.protobuf.NetData.Certificate publicCertificate_;
     /**
@@ -7982,6 +8403,7 @@ public final class NetData {
       return publicCertificate_;
     }
 
+    // optional bytes privateExponent = 2;
     public static final int PRIVATEEXPONENT_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString privateExponent_;
     /**
@@ -8004,8 +8426,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasPublicCertificate()) {
         if (!getPublicCertificate().isInitialized()) {
@@ -8135,9 +8556,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.CertificateSet, Builder> implements
-        // @@protoc_insertion_point(builder_implements:CertificateSet)
-        org.terasology.protobuf.NetData.CertificateSetOrBuilder {
+          org.terasology.protobuf.NetData.CertificateSet, Builder> implements org.terasology.protobuf.NetData.CertificateSetOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_CertificateSet_descriptor;
@@ -8279,6 +8698,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional .Certificate publicCertificate = 1;
       private org.terasology.protobuf.NetData.Certificate publicCertificate_ = org.terasology.protobuf.NetData.Certificate.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Certificate, org.terasology.protobuf.NetData.Certificate.Builder, org.terasology.protobuf.NetData.CertificateOrBuilder> publicCertificateBuilder_;
@@ -8387,7 +8807,7 @@ public final class NetData {
         if (publicCertificateBuilder_ == null) {
           publicCertificateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Certificate, org.terasology.protobuf.NetData.Certificate.Builder, org.terasology.protobuf.NetData.CertificateOrBuilder>(
-                  getPublicCertificate(),
+                  publicCertificate_,
                   getParentForChildren(),
                   isClean());
           publicCertificate_ = null;
@@ -8395,6 +8815,7 @@ public final class NetData {
         return publicCertificateBuilder_;
       }
 
+      // optional bytes privateExponent = 2;
       private com.google.protobuf.ByteString privateExponent_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes privateExponent = 2;</code>
@@ -8442,10 +8863,10 @@ public final class NetData {
   }
 
   public interface HandshakeVerificationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:HandshakeVerification)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<HandshakeVerification> {
 
+    // optional bytes signature = 1;
     /**
      * <code>optional bytes signature = 1;</code>
      */
@@ -8460,9 +8881,7 @@ public final class NetData {
    */
   public static final class HandshakeVerification extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        HandshakeVerification> implements
-      // @@protoc_insertion_point(message_implements:HandshakeVerification)
-      HandshakeVerificationOrBuilder {
+        HandshakeVerification> implements HandshakeVerificationOrBuilder {
     // Use HandshakeVerification.newBuilder() to construct.
     private HandshakeVerification(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.HandshakeVerification, ?> builder) {
       super(builder);
@@ -8553,6 +8972,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional bytes signature = 1;
     public static final int SIGNATURE_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString signature_;
     /**
@@ -8574,8 +8994,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -8692,9 +9111,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.HandshakeVerification, Builder> implements
-        // @@protoc_insertion_point(builder_implements:HandshakeVerification)
-        org.terasology.protobuf.NetData.HandshakeVerificationOrBuilder {
+          org.terasology.protobuf.NetData.HandshakeVerification, Builder> implements org.terasology.protobuf.NetData.HandshakeVerificationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_HandshakeVerification_descriptor;
@@ -8812,6 +9229,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional bytes signature = 1;
       private com.google.protobuf.ByteString signature_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes signature = 1;</code>
@@ -8859,10 +9277,10 @@ public final class NetData {
   }
 
   public interface CertificateOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Certificate)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<Certificate> {
 
+    // optional string id = 1;
     /**
      * <code>optional string id = 1;</code>
      */
@@ -8877,6 +9295,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // optional bytes modulus = 2;
     /**
      * <code>optional bytes modulus = 2;</code>
      */
@@ -8886,6 +9305,7 @@ public final class NetData {
      */
     com.google.protobuf.ByteString getModulus();
 
+    // optional bytes exponent = 3;
     /**
      * <code>optional bytes exponent = 3;</code>
      */
@@ -8895,6 +9315,7 @@ public final class NetData {
      */
     com.google.protobuf.ByteString getExponent();
 
+    // optional bytes signature = 4;
     /**
      * <code>optional bytes signature = 4;</code>
      */
@@ -8909,9 +9330,7 @@ public final class NetData {
    */
   public static final class Certificate extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        Certificate> implements
-      // @@protoc_insertion_point(message_implements:Certificate)
-      CertificateOrBuilder {
+        Certificate> implements CertificateOrBuilder {
     // Use Certificate.newBuilder() to construct.
     private Certificate(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.Certificate, ?> builder) {
       super(builder);
@@ -8958,9 +9377,8 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
@@ -9018,6 +9436,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -9060,6 +9479,7 @@ public final class NetData {
       }
     }
 
+    // optional bytes modulus = 2;
     public static final int MODULUS_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString modulus_;
     /**
@@ -9075,6 +9495,7 @@ public final class NetData {
       return modulus_;
     }
 
+    // optional bytes exponent = 3;
     public static final int EXPONENT_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString exponent_;
     /**
@@ -9090,6 +9511,7 @@ public final class NetData {
       return exponent_;
     }
 
+    // optional bytes signature = 4;
     public static final int SIGNATURE_FIELD_NUMBER = 4;
     private com.google.protobuf.ByteString signature_;
     /**
@@ -9114,8 +9536,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -9253,9 +9674,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.Certificate, Builder> implements
-        // @@protoc_insertion_point(builder_implements:Certificate)
-        org.terasology.protobuf.NetData.CertificateOrBuilder {
+          org.terasology.protobuf.NetData.Certificate, Builder> implements org.terasology.protobuf.NetData.CertificateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_Certificate_descriptor;
@@ -9402,6 +9821,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>optional string id = 1;</code>
@@ -9415,12 +9835,9 @@ public final class NetData {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9478,6 +9895,7 @@ public final class NetData {
         return this;
       }
 
+      // optional bytes modulus = 2;
       private com.google.protobuf.ByteString modulus_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes modulus = 2;</code>
@@ -9513,6 +9931,7 @@ public final class NetData {
         return this;
       }
 
+      // optional bytes exponent = 3;
       private com.google.protobuf.ByteString exponent_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes exponent = 3;</code>
@@ -9548,6 +9967,7 @@ public final class NetData {
         return this;
       }
 
+      // optional bytes signature = 4;
       private com.google.protobuf.ByteString signature_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes signature = 4;</code>
@@ -9595,15 +10015,15 @@ public final class NetData {
   }
 
   public interface BlockFamilyRegisteredMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:BlockFamilyRegisteredMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<BlockFamilyRegisteredMessage> {
 
+    // repeated string blockUri = 1;
     /**
      * <code>repeated string blockUri = 1;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getBlockUriList();
+    java.util.List<java.lang.String>
+    getBlockUriList();
     /**
      * <code>repeated string blockUri = 1;</code>
      */
@@ -9618,6 +10038,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getBlockUriBytes(int index);
 
+    // repeated int32 blockId = 2;
     /**
      * <code>repeated int32 blockId = 2;</code>
      */
@@ -9636,9 +10057,7 @@ public final class NetData {
    */
   public static final class BlockFamilyRegisteredMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        BlockFamilyRegisteredMessage> implements
-      // @@protoc_insertion_point(message_implements:BlockFamilyRegisteredMessage)
-      BlockFamilyRegisteredMessageOrBuilder {
+        BlockFamilyRegisteredMessage> implements BlockFamilyRegisteredMessageOrBuilder {
     // Use BlockFamilyRegisteredMessage.newBuilder() to construct.
     private BlockFamilyRegisteredMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage, ?> builder) {
       super(builder);
@@ -9685,12 +10104,11 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 blockUri_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              blockUri_.add(bs);
+              blockUri_.add(input.readBytes());
               break;
             }
             case 16: {
@@ -9723,7 +10141,7 @@ public final class NetData {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          blockUri_ = blockUri_.getUnmodifiableView();
+          blockUri_ = new com.google.protobuf.UnmodifiableLazyStringList(blockUri_);
         }
         if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
           blockId_ = java.util.Collections.unmodifiableList(blockId_);
@@ -9759,12 +10177,13 @@ public final class NetData {
       return PARSER;
     }
 
+    // repeated string blockUri = 1;
     public static final int BLOCKURI_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList blockUri_;
     /**
      * <code>repeated string blockUri = 1;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getBlockUriList() {
       return blockUri_;
     }
@@ -9788,6 +10207,7 @@ public final class NetData {
       return blockUri_.getByteString(index);
     }
 
+    // repeated int32 blockId = 2;
     public static final int BLOCKID_FIELD_NUMBER = 2;
     private java.util.List<java.lang.Integer> blockId_;
     /**
@@ -9817,8 +10237,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -9952,9 +10371,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:BlockFamilyRegisteredMessage)
-        org.terasology.protobuf.NetData.BlockFamilyRegisteredMessageOrBuilder {
+          org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage, Builder> implements org.terasology.protobuf.NetData.BlockFamilyRegisteredMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_BlockFamilyRegisteredMessage_descriptor;
@@ -10019,7 +10436,8 @@ public final class NetData {
         org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage result = new org.terasology.protobuf.NetData.BlockFamilyRegisteredMessage(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          blockUri_ = blockUri_.getUnmodifiableView();
+          blockUri_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              blockUri_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.blockUri_ = blockUri_;
@@ -10095,6 +10513,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // repeated string blockUri = 1;
       private com.google.protobuf.LazyStringList blockUri_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureBlockUriIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -10105,9 +10524,9 @@ public final class NetData {
       /**
        * <code>repeated string blockUri = 1;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getBlockUriList() {
-        return blockUri_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(blockUri_);
       }
       /**
        * <code>repeated string blockUri = 1;</code>
@@ -10160,8 +10579,7 @@ public final class NetData {
       public Builder addAllBlockUri(
           java.lang.Iterable<java.lang.String> values) {
         ensureBlockUriIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, blockUri_);
+        super.addAll(values, blockUri_);
         onChanged();
         return this;
       }
@@ -10188,6 +10606,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated int32 blockId = 2;
       private java.util.List<java.lang.Integer> blockId_ = java.util.Collections.emptyList();
       private void ensureBlockIdIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -10239,8 +10658,7 @@ public final class NetData {
       public Builder addAllBlockId(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureBlockIdIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, blockId_);
+        super.addAll(values, blockId_);
         onChanged();
         return this;
       }
@@ -10266,10 +10684,10 @@ public final class NetData {
   }
 
   public interface InvalidateChunkMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:InvalidateChunkMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<InvalidateChunkMessage> {
 
+    // optional .Vector3iData pos = 1;
     /**
      * <code>optional .Vector3iData pos = 1;</code>
      */
@@ -10288,9 +10706,7 @@ public final class NetData {
    */
   public static final class InvalidateChunkMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        InvalidateChunkMessage> implements
-      // @@protoc_insertion_point(message_implements:InvalidateChunkMessage)
-      InvalidateChunkMessageOrBuilder {
+        InvalidateChunkMessage> implements InvalidateChunkMessageOrBuilder {
     // Use InvalidateChunkMessage.newBuilder() to construct.
     private InvalidateChunkMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.InvalidateChunkMessage, ?> builder) {
       super(builder);
@@ -10389,6 +10805,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional .Vector3iData pos = 1;
     public static final int POS_FIELD_NUMBER = 1;
     private org.terasology.protobuf.NetData.Vector3iData pos_;
     /**
@@ -10416,8 +10833,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -10534,9 +10950,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.InvalidateChunkMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:InvalidateChunkMessage)
-        org.terasology.protobuf.NetData.InvalidateChunkMessageOrBuilder {
+          org.terasology.protobuf.NetData.InvalidateChunkMessage, Builder> implements org.terasology.protobuf.NetData.InvalidateChunkMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_InvalidateChunkMessage_descriptor;
@@ -10663,6 +11077,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional .Vector3iData pos = 1;
       private org.terasology.protobuf.NetData.Vector3iData pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> posBuilder_;
@@ -10771,7 +11186,7 @@ public final class NetData {
         if (posBuilder_ == null) {
           posBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder>(
-                  getPos(),
+                  pos_,
                   getParentForChildren(),
                   isClean());
           pos_ = null;
@@ -10791,10 +11206,10 @@ public final class NetData {
   }
 
   public interface BlockChangeMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:BlockChangeMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<BlockChangeMessage> {
 
+    // optional .Vector3iData pos = 1;
     /**
      * <code>optional .Vector3iData pos = 1;</code>
      */
@@ -10808,6 +11223,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.Vector3iDataOrBuilder getPosOrBuilder();
 
+    // optional int32 newBlock = 2;
     /**
      * <code>optional int32 newBlock = 2;</code>
      */
@@ -10822,9 +11238,7 @@ public final class NetData {
    */
   public static final class BlockChangeMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        BlockChangeMessage> implements
-      // @@protoc_insertion_point(message_implements:BlockChangeMessage)
-      BlockChangeMessageOrBuilder {
+        BlockChangeMessage> implements BlockChangeMessageOrBuilder {
     // Use BlockChangeMessage.newBuilder() to construct.
     private BlockChangeMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.BlockChangeMessage, ?> builder) {
       super(builder);
@@ -10928,6 +11342,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional .Vector3iData pos = 1;
     public static final int POS_FIELD_NUMBER = 1;
     private org.terasology.protobuf.NetData.Vector3iData pos_;
     /**
@@ -10949,6 +11364,7 @@ public final class NetData {
       return pos_;
     }
 
+    // optional int32 newBlock = 2;
     public static final int NEWBLOCK_FIELD_NUMBER = 2;
     private int newBlock_;
     /**
@@ -10971,8 +11387,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -11096,9 +11511,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.BlockChangeMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:BlockChangeMessage)
-        org.terasology.protobuf.NetData.BlockChangeMessageOrBuilder {
+          org.terasology.protobuf.NetData.BlockChangeMessage, Builder> implements org.terasology.protobuf.NetData.BlockChangeMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_BlockChangeMessage_descriptor;
@@ -11234,6 +11647,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional .Vector3iData pos = 1;
       private org.terasology.protobuf.NetData.Vector3iData pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> posBuilder_;
@@ -11342,7 +11756,7 @@ public final class NetData {
         if (posBuilder_ == null) {
           posBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder>(
-                  getPos(),
+                  pos_,
                   getParentForChildren(),
                   isClean());
           pos_ = null;
@@ -11350,6 +11764,7 @@ public final class NetData {
         return posBuilder_;
       }
 
+      // optional int32 newBlock = 2;
       private int newBlock_ ;
       /**
        * <code>optional int32 newBlock = 2;</code>
@@ -11394,10 +11809,10 @@ public final class NetData {
   }
 
   public interface BiomeChangeMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:BiomeChangeMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<BiomeChangeMessage> {
 
+    // optional .Vector3iData pos = 1;
     /**
      * <code>optional .Vector3iData pos = 1;</code>
      */
@@ -11411,6 +11826,7 @@ public final class NetData {
      */
     org.terasology.protobuf.NetData.Vector3iDataOrBuilder getPosOrBuilder();
 
+    // optional int32 newBiome = 2;
     /**
      * <code>optional int32 newBiome = 2;</code>
      */
@@ -11425,9 +11841,7 @@ public final class NetData {
    */
   public static final class BiomeChangeMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        BiomeChangeMessage> implements
-      // @@protoc_insertion_point(message_implements:BiomeChangeMessage)
-      BiomeChangeMessageOrBuilder {
+        BiomeChangeMessage> implements BiomeChangeMessageOrBuilder {
     // Use BiomeChangeMessage.newBuilder() to construct.
     private BiomeChangeMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.BiomeChangeMessage, ?> builder) {
       super(builder);
@@ -11531,6 +11945,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional .Vector3iData pos = 1;
     public static final int POS_FIELD_NUMBER = 1;
     private org.terasology.protobuf.NetData.Vector3iData pos_;
     /**
@@ -11552,6 +11967,7 @@ public final class NetData {
       return pos_;
     }
 
+    // optional int32 newBiome = 2;
     public static final int NEWBIOME_FIELD_NUMBER = 2;
     private int newBiome_;
     /**
@@ -11574,8 +11990,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -11699,9 +12114,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.BiomeChangeMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:BiomeChangeMessage)
-        org.terasology.protobuf.NetData.BiomeChangeMessageOrBuilder {
+          org.terasology.protobuf.NetData.BiomeChangeMessage, Builder> implements org.terasology.protobuf.NetData.BiomeChangeMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_BiomeChangeMessage_descriptor;
@@ -11837,6 +12250,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional .Vector3iData pos = 1;
       private org.terasology.protobuf.NetData.Vector3iData pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> posBuilder_;
@@ -11945,7 +12359,7 @@ public final class NetData {
         if (posBuilder_ == null) {
           posBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder>(
-                  getPos(),
+                  pos_,
                   getParentForChildren(),
                   isClean());
           pos_ = null;
@@ -11953,6 +12367,7 @@ public final class NetData {
         return posBuilder_;
       }
 
+      // optional int32 newBiome = 2;
       private int newBiome_ ;
       /**
        * <code>optional int32 newBiome = 2;</code>
@@ -11996,10 +12411,694 @@ public final class NetData {
     // @@protoc_insertion_point(class_scope:BiomeChangeMessage)
   }
 
-  public interface Vector3iDataOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Vector3iData)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ExtraDataChangeMessageOrBuilder extends
+      com.google.protobuf.GeneratedMessage.
+          ExtendableMessageOrBuilder<ExtraDataChangeMessage> {
 
+    // optional int32 index = 1;
+    /**
+     * <code>optional int32 index = 1;</code>
+     */
+    boolean hasIndex();
+    /**
+     * <code>optional int32 index = 1;</code>
+     */
+    int getIndex();
+
+    // optional .Vector3iData pos = 2;
+    /**
+     * <code>optional .Vector3iData pos = 2;</code>
+     */
+    boolean hasPos();
+    /**
+     * <code>optional .Vector3iData pos = 2;</code>
+     */
+    org.terasology.protobuf.NetData.Vector3iData getPos();
+    /**
+     * <code>optional .Vector3iData pos = 2;</code>
+     */
+    org.terasology.protobuf.NetData.Vector3iDataOrBuilder getPosOrBuilder();
+
+    // optional int32 newData = 3;
+    /**
+     * <code>optional int32 newData = 3;</code>
+     */
+    boolean hasNewData();
+    /**
+     * <code>optional int32 newData = 3;</code>
+     */
+    int getNewData();
+  }
+  /**
+   * Protobuf type {@code ExtraDataChangeMessage}
+   */
+  public static final class ExtraDataChangeMessage extends
+      com.google.protobuf.GeneratedMessage.ExtendableMessage<
+        ExtraDataChangeMessage> implements ExtraDataChangeMessageOrBuilder {
+    // Use ExtraDataChangeMessage.newBuilder() to construct.
+    private ExtraDataChangeMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ExtraDataChangeMessage, ?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private ExtraDataChangeMessage(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final ExtraDataChangeMessage defaultInstance;
+    public static ExtraDataChangeMessage getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public ExtraDataChangeMessage getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ExtraDataChangeMessage(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              index_ = input.readInt32();
+              break;
+            }
+            case 18: {
+              org.terasology.protobuf.NetData.Vector3iData.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                subBuilder = pos_.toBuilder();
+              }
+              pos_ = input.readMessage(org.terasology.protobuf.NetData.Vector3iData.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(pos_);
+                pos_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              newData_ = input.readInt32();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.terasology.protobuf.NetData.internal_static_ExtraDataChangeMessage_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.terasology.protobuf.NetData.internal_static_ExtraDataChangeMessage_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.terasology.protobuf.NetData.ExtraDataChangeMessage.class, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<ExtraDataChangeMessage> PARSER =
+        new com.google.protobuf.AbstractParser<ExtraDataChangeMessage>() {
+      public ExtraDataChangeMessage parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ExtraDataChangeMessage(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ExtraDataChangeMessage> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    // optional int32 index = 1;
+    public static final int INDEX_FIELD_NUMBER = 1;
+    private int index_;
+    /**
+     * <code>optional int32 index = 1;</code>
+     */
+    public boolean hasIndex() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int32 index = 1;</code>
+     */
+    public int getIndex() {
+      return index_;
+    }
+
+    // optional .Vector3iData pos = 2;
+    public static final int POS_FIELD_NUMBER = 2;
+    private org.terasology.protobuf.NetData.Vector3iData pos_;
+    /**
+     * <code>optional .Vector3iData pos = 2;</code>
+     */
+    public boolean hasPos() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .Vector3iData pos = 2;</code>
+     */
+    public org.terasology.protobuf.NetData.Vector3iData getPos() {
+      return pos_;
+    }
+    /**
+     * <code>optional .Vector3iData pos = 2;</code>
+     */
+    public org.terasology.protobuf.NetData.Vector3iDataOrBuilder getPosOrBuilder() {
+      return pos_;
+    }
+
+    // optional int32 newData = 3;
+    public static final int NEWDATA_FIELD_NUMBER = 3;
+    private int newData_;
+    /**
+     * <code>optional int32 newData = 3;</code>
+     */
+    public boolean hasNewData() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional int32 newData = 3;</code>
+     */
+    public int getNewData() {
+      return newData_;
+    }
+
+    private void initFields() {
+      index_ = 0;
+      pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
+      newData_ = 0;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      if (!extensionsAreInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      com.google.protobuf.GeneratedMessage
+        .ExtendableMessage<org.terasology.protobuf.NetData.ExtraDataChangeMessage>.ExtensionWriter extensionWriter =
+          newExtensionWriter();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt32(1, index_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeMessage(2, pos_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt32(3, newData_);
+      }
+      extensionWriter.writeUntil(536870912, output);
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, index_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, pos_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, newData_);
+      }
+      size += extensionsSerializedSize();
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.terasology.protobuf.NetData.ExtraDataChangeMessage parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.terasology.protobuf.NetData.ExtraDataChangeMessage prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code ExtraDataChangeMessage}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.ExtendableBuilder<
+          org.terasology.protobuf.NetData.ExtraDataChangeMessage, Builder> implements org.terasology.protobuf.NetData.ExtraDataChangeMessageOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.terasology.protobuf.NetData.internal_static_ExtraDataChangeMessage_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.terasology.protobuf.NetData.internal_static_ExtraDataChangeMessage_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.terasology.protobuf.NetData.ExtraDataChangeMessage.class, org.terasology.protobuf.NetData.ExtraDataChangeMessage.Builder.class);
+      }
+
+      // Construct using org.terasology.protobuf.NetData.ExtraDataChangeMessage.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getPosFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        index_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (posBuilder_ == null) {
+          pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
+        } else {
+          posBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        newData_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.terasology.protobuf.NetData.internal_static_ExtraDataChangeMessage_descriptor;
+      }
+
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage getDefaultInstanceForType() {
+        return org.terasology.protobuf.NetData.ExtraDataChangeMessage.getDefaultInstance();
+      }
+
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage build() {
+        org.terasology.protobuf.NetData.ExtraDataChangeMessage result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.terasology.protobuf.NetData.ExtraDataChangeMessage buildPartial() {
+        org.terasology.protobuf.NetData.ExtraDataChangeMessage result = new org.terasology.protobuf.NetData.ExtraDataChangeMessage(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.index_ = index_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        if (posBuilder_ == null) {
+          result.pos_ = pos_;
+        } else {
+          result.pos_ = posBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.newData_ = newData_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.terasology.protobuf.NetData.ExtraDataChangeMessage) {
+          return mergeFrom((org.terasology.protobuf.NetData.ExtraDataChangeMessage)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.terasology.protobuf.NetData.ExtraDataChangeMessage other) {
+        if (other == org.terasology.protobuf.NetData.ExtraDataChangeMessage.getDefaultInstance()) return this;
+        if (other.hasIndex()) {
+          setIndex(other.getIndex());
+        }
+        if (other.hasPos()) {
+          mergePos(other.getPos());
+        }
+        if (other.hasNewData()) {
+          setNewData(other.getNewData());
+        }
+        this.mergeExtensionFields(other);
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!extensionsAreInitialized()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.terasology.protobuf.NetData.ExtraDataChangeMessage parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.terasology.protobuf.NetData.ExtraDataChangeMessage) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // optional int32 index = 1;
+      private int index_ ;
+      /**
+       * <code>optional int32 index = 1;</code>
+       */
+      public boolean hasIndex() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int32 index = 1;</code>
+       */
+      public int getIndex() {
+        return index_;
+      }
+      /**
+       * <code>optional int32 index = 1;</code>
+       */
+      public Builder setIndex(int value) {
+        bitField0_ |= 0x00000001;
+        index_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 index = 1;</code>
+       */
+      public Builder clearIndex() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        index_ = 0;
+        onChanged();
+        return this;
+      }
+
+      // optional .Vector3iData pos = 2;
+      private org.terasology.protobuf.NetData.Vector3iData pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> posBuilder_;
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public boolean hasPos() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public org.terasology.protobuf.NetData.Vector3iData getPos() {
+        if (posBuilder_ == null) {
+          return pos_;
+        } else {
+          return posBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public Builder setPos(org.terasology.protobuf.NetData.Vector3iData value) {
+        if (posBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          pos_ = value;
+          onChanged();
+        } else {
+          posBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public Builder setPos(
+          org.terasology.protobuf.NetData.Vector3iData.Builder builderForValue) {
+        if (posBuilder_ == null) {
+          pos_ = builderForValue.build();
+          onChanged();
+        } else {
+          posBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public Builder mergePos(org.terasology.protobuf.NetData.Vector3iData value) {
+        if (posBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+              pos_ != org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance()) {
+            pos_ =
+              org.terasology.protobuf.NetData.Vector3iData.newBuilder(pos_).mergeFrom(value).buildPartial();
+          } else {
+            pos_ = value;
+          }
+          onChanged();
+        } else {
+          posBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public Builder clearPos() {
+        if (posBuilder_ == null) {
+          pos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
+          onChanged();
+        } else {
+          posBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public org.terasology.protobuf.NetData.Vector3iData.Builder getPosBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getPosFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      public org.terasology.protobuf.NetData.Vector3iDataOrBuilder getPosOrBuilder() {
+        if (posBuilder_ != null) {
+          return posBuilder_.getMessageOrBuilder();
+        } else {
+          return pos_;
+        }
+      }
+      /**
+       * <code>optional .Vector3iData pos = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> 
+          getPosFieldBuilder() {
+        if (posBuilder_ == null) {
+          posBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder>(
+                  pos_,
+                  getParentForChildren(),
+                  isClean());
+          pos_ = null;
+        }
+        return posBuilder_;
+      }
+
+      // optional int32 newData = 3;
+      private int newData_ ;
+      /**
+       * <code>optional int32 newData = 3;</code>
+       */
+      public boolean hasNewData() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional int32 newData = 3;</code>
+       */
+      public int getNewData() {
+        return newData_;
+      }
+      /**
+       * <code>optional int32 newData = 3;</code>
+       */
+      public Builder setNewData(int value) {
+        bitField0_ |= 0x00000004;
+        newData_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 newData = 3;</code>
+       */
+      public Builder clearNewData() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        newData_ = 0;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:ExtraDataChangeMessage)
+    }
+
+    static {
+      defaultInstance = new ExtraDataChangeMessage(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:ExtraDataChangeMessage)
+  }
+
+  public interface Vector3iDataOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // optional int32 x = 1;
     /**
      * <code>optional int32 x = 1;</code>
      */
@@ -12009,6 +13108,7 @@ public final class NetData {
      */
     int getX();
 
+    // optional int32 y = 2;
     /**
      * <code>optional int32 y = 2;</code>
      */
@@ -12018,6 +13118,7 @@ public final class NetData {
      */
     int getY();
 
+    // optional int32 z = 3;
     /**
      * <code>optional int32 z = 3;</code>
      */
@@ -12031,9 +13132,8 @@ public final class NetData {
    * Protobuf type {@code Vector3iData}
    */
   public static final class Vector3iData extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Vector3iData)
-      Vector3iDataOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements Vector3iDataOrBuilder {
     // Use Vector3iData.newBuilder() to construct.
     private Vector3iData(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -12134,6 +13234,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional int32 x = 1;
     public static final int X_FIELD_NUMBER = 1;
     private int x_;
     /**
@@ -12149,6 +13250,7 @@ public final class NetData {
       return x_;
     }
 
+    // optional int32 y = 2;
     public static final int Y_FIELD_NUMBER = 2;
     private int y_;
     /**
@@ -12164,6 +13266,7 @@ public final class NetData {
       return y_;
     }
 
+    // optional int32 z = 3;
     public static final int Z_FIELD_NUMBER = 3;
     private int z_;
     /**
@@ -12187,8 +13290,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       memoizedIsInitialized = 1;
       return true;
@@ -12309,9 +13411,8 @@ public final class NetData {
      * Protobuf type {@code Vector3iData}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Vector3iData)
-        org.terasology.protobuf.NetData.Vector3iDataOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.terasology.protobuf.NetData.Vector3iDataOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_Vector3iData_descriptor;
@@ -12442,6 +13543,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional int32 x = 1;
       private int x_ ;
       /**
        * <code>optional int32 x = 1;</code>
@@ -12474,6 +13576,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int32 y = 2;
       private int y_ ;
       /**
        * <code>optional int32 y = 2;</code>
@@ -12506,6 +13609,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int32 z = 3;
       private int z_ ;
       /**
        * <code>optional int32 z = 3;</code>
@@ -12550,7 +13654,6 @@ public final class NetData {
   }
 
   public interface ServerInfoRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ServerInfoRequest)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ServerInfoRequest> {
   }
@@ -12559,9 +13662,7 @@ public final class NetData {
    */
   public static final class ServerInfoRequest extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ServerInfoRequest> implements
-      // @@protoc_insertion_point(message_implements:ServerInfoRequest)
-      ServerInfoRequestOrBuilder {
+        ServerInfoRequest> implements ServerInfoRequestOrBuilder {
     // Use ServerInfoRequest.newBuilder() to construct.
     private ServerInfoRequest(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ServerInfoRequest, ?> builder) {
       super(builder);
@@ -12650,8 +13751,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -12761,9 +13861,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ServerInfoRequest, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ServerInfoRequest)
-        org.terasology.protobuf.NetData.ServerInfoRequestOrBuilder {
+          org.terasology.protobuf.NetData.ServerInfoRequest, Builder> implements org.terasology.protobuf.NetData.ServerInfoRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ServerInfoRequest_descriptor;
@@ -12880,10 +13978,10 @@ public final class NetData {
   }
 
   public interface JoinMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:JoinMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<JoinMessage> {
 
+    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -12898,6 +13996,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // optional string version = 2;
     /**
      * <code>optional string version = 2;</code>
      */
@@ -12912,6 +14011,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // optional sint32 viewDistanceLevel = 3;
     /**
      * <code>optional sint32 viewDistanceLevel = 3;</code>
      */
@@ -12921,6 +14021,7 @@ public final class NetData {
      */
     int getViewDistanceLevel();
 
+    // optional .Color color = 4;
     /**
      * <code>optional .Color color = 4;</code>
      */
@@ -12939,9 +14040,7 @@ public final class NetData {
    */
   public static final class JoinMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        JoinMessage> implements
-      // @@protoc_insertion_point(message_implements:JoinMessage)
-      JoinMessageOrBuilder {
+        JoinMessage> implements JoinMessageOrBuilder {
     // Use JoinMessage.newBuilder() to construct.
     private JoinMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.JoinMessage, ?> builder) {
       super(builder);
@@ -12988,15 +14087,13 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 24: {
@@ -13057,6 +14154,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -13099,6 +14197,7 @@ public final class NetData {
       }
     }
 
+    // optional string version = 2;
     public static final int VERSION_FIELD_NUMBER = 2;
     private java.lang.Object version_;
     /**
@@ -13141,6 +14240,7 @@ public final class NetData {
       }
     }
 
+    // optional sint32 viewDistanceLevel = 3;
     public static final int VIEWDISTANCELEVEL_FIELD_NUMBER = 3;
     private int viewDistanceLevel_;
     /**
@@ -13156,6 +14256,7 @@ public final class NetData {
       return viewDistanceLevel_;
     }
 
+    // optional .Color color = 4;
     public static final int COLOR_FIELD_NUMBER = 4;
     private org.terasology.protobuf.NetData.Color color_;
     /**
@@ -13186,8 +14287,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -13325,9 +14425,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.JoinMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:JoinMessage)
-        org.terasology.protobuf.NetData.JoinMessageOrBuilder {
+          org.terasology.protobuf.NetData.JoinMessage, Builder> implements org.terasology.protobuf.NetData.JoinMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_JoinMessage_descriptor;
@@ -13485,6 +14583,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -13498,12 +14597,9 @@ public final class NetData {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -13561,6 +14657,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string version = 2;
       private java.lang.Object version_ = "";
       /**
        * <code>optional string version = 2;</code>
@@ -13574,12 +14671,9 @@ public final class NetData {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -13637,6 +14731,7 @@ public final class NetData {
         return this;
       }
 
+      // optional sint32 viewDistanceLevel = 3;
       private int viewDistanceLevel_ ;
       /**
        * <code>optional sint32 viewDistanceLevel = 3;</code>
@@ -13669,6 +14764,7 @@ public final class NetData {
         return this;
       }
 
+      // optional .Color color = 4;
       private org.terasology.protobuf.NetData.Color color_ = org.terasology.protobuf.NetData.Color.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Color, org.terasology.protobuf.NetData.Color.Builder, org.terasology.protobuf.NetData.ColorOrBuilder> colorBuilder_;
@@ -13777,7 +14873,7 @@ public final class NetData {
         if (colorBuilder_ == null) {
           colorBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Color, org.terasology.protobuf.NetData.Color.Builder, org.terasology.protobuf.NetData.ColorOrBuilder>(
-                  getColor(),
+                  color_,
                   getParentForChildren(),
                   isClean());
           color_ = null;
@@ -13796,10 +14892,10 @@ public final class NetData {
     // @@protoc_insertion_point(class_scope:JoinMessage)
   }
 
-  public interface ColorOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:Color)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ColorOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // optional uint32 rgba = 1;
     /**
      * <code>optional uint32 rgba = 1;</code>
      */
@@ -13813,9 +14909,8 @@ public final class NetData {
    * Protobuf type {@code Color}
    */
   public static final class Color extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:Color)
-      ColorOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ColorOrBuilder {
     // Use Color.newBuilder() to construct.
     private Color(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -13906,6 +15001,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional uint32 rgba = 1;
     public static final int RGBA_FIELD_NUMBER = 1;
     private int rgba_;
     /**
@@ -13927,8 +15023,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       memoizedIsInitialized = 1;
       return true;
@@ -14035,9 +15130,8 @@ public final class NetData {
      * Protobuf type {@code Color}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:Color)
-        org.terasology.protobuf.NetData.ColorOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.terasology.protobuf.NetData.ColorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_Color_descriptor;
@@ -14150,6 +15244,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional uint32 rgba = 1;
       private int rgba_ ;
       /**
        * <code>optional uint32 rgba = 1;</code>
@@ -14194,10 +15289,10 @@ public final class NetData {
   }
 
   public interface JoinCompleteMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:JoinCompleteMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<JoinCompleteMessage> {
 
+    // optional int32 clientId = 1;
     /**
      * <code>optional int32 clientId = 1;</code>
      */
@@ -14212,9 +15307,7 @@ public final class NetData {
    */
   public static final class JoinCompleteMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        JoinCompleteMessage> implements
-      // @@protoc_insertion_point(message_implements:JoinCompleteMessage)
-      JoinCompleteMessageOrBuilder {
+        JoinCompleteMessage> implements JoinCompleteMessageOrBuilder {
     // Use JoinCompleteMessage.newBuilder() to construct.
     private JoinCompleteMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.JoinCompleteMessage, ?> builder) {
       super(builder);
@@ -14305,6 +15398,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional int32 clientId = 1;
     public static final int CLIENTID_FIELD_NUMBER = 1;
     private int clientId_;
     /**
@@ -14326,8 +15420,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -14444,9 +15537,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.JoinCompleteMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:JoinCompleteMessage)
-        org.terasology.protobuf.NetData.JoinCompleteMessageOrBuilder {
+          org.terasology.protobuf.NetData.JoinCompleteMessage, Builder> implements org.terasology.protobuf.NetData.JoinCompleteMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_JoinCompleteMessage_descriptor;
@@ -14564,6 +15655,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional int32 clientId = 1;
       private int clientId_ ;
       /**
        * <code>optional int32 clientId = 1;</code>
@@ -14608,10 +15700,10 @@ public final class NetData {
   }
 
   public interface ServerInfoMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ServerInfoMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ServerInfoMessage> {
 
+    // repeated .ModuleInfo module = 1;
     /**
      * <code>repeated .ModuleInfo module = 1;</code>
      */
@@ -14636,6 +15728,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.ModuleInfoOrBuilder getModuleOrBuilder(
         int index);
 
+    // repeated sint32 blockId = 2 [packed = true];
     /**
      * <code>repeated sint32 blockId = 2 [packed = true];</code>
      */
@@ -14649,11 +15742,12 @@ public final class NetData {
      */
     int getBlockId(int index);
 
+    // repeated string blockName = 3;
     /**
      * <code>repeated string blockName = 3;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getBlockNameList();
+    java.util.List<java.lang.String>
+    getBlockNameList();
     /**
      * <code>repeated string blockName = 3;</code>
      */
@@ -14668,6 +15762,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getBlockNameBytes(int index);
 
+    // repeated .SerializationInfo component = 4;
     /**
      * <code>repeated .SerializationInfo component = 4;</code>
      */
@@ -14692,6 +15787,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.SerializationInfoOrBuilder getComponentOrBuilder(
         int index);
 
+    // repeated .SerializationInfo event = 5;
     /**
      * <code>repeated .SerializationInfo event = 5;</code>
      */
@@ -14716,6 +15812,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.SerializationInfoOrBuilder getEventOrBuilder(
         int index);
 
+    // repeated int32 assetId = 6 [packed = true];
     /**
      * <code>repeated int32 assetId = 6 [packed = true];</code>
      */
@@ -14729,11 +15826,12 @@ public final class NetData {
      */
     int getAssetId(int index);
 
+    // repeated string assetUri = 7;
     /**
      * <code>repeated string assetUri = 7;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getAssetUriList();
+    java.util.List<java.lang.String>
+    getAssetUriList();
     /**
      * <code>repeated string assetUri = 7;</code>
      */
@@ -14748,11 +15846,12 @@ public final class NetData {
     com.google.protobuf.ByteString
         getAssetUriBytes(int index);
 
+    // repeated string registerBlockFamily = 8;
     /**
      * <code>repeated string registerBlockFamily = 8;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getRegisterBlockFamilyList();
+    java.util.List<java.lang.String>
+    getRegisterBlockFamilyList();
     /**
      * <code>repeated string registerBlockFamily = 8;</code>
      */
@@ -14767,6 +15866,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getRegisterBlockFamilyBytes(int index);
 
+    // repeated .WorldInfo worldInfo = 9;
     /**
      * <code>repeated .WorldInfo worldInfo = 9;</code>
      */
@@ -14791,6 +15891,7 @@ public final class NetData {
     org.terasology.protobuf.NetData.WorldInfoOrBuilder getWorldInfoOrBuilder(
         int index);
 
+    // repeated sint32 biomeShortId = 10 [packed = true];
     /**
      * <code>repeated sint32 biomeShortId = 10 [packed = true];</code>
      */
@@ -14804,11 +15905,12 @@ public final class NetData {
      */
     int getBiomeShortId(int index);
 
+    // repeated string biomeId = 11;
     /**
      * <code>repeated string biomeId = 11;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getBiomeIdList();
+    java.util.List<java.lang.String>
+    getBiomeIdList();
     /**
      * <code>repeated string biomeId = 11;</code>
      */
@@ -14823,6 +15925,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getBiomeIdBytes(int index);
 
+    // optional string errorMessage = 12;
     /**
      * <code>optional string errorMessage = 12;</code>
      */
@@ -14837,6 +15940,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getErrorMessageBytes();
 
+    // optional string version = 15;
     /**
      * <code>optional string version = 15;</code>
      */
@@ -14851,6 +15955,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // optional string gameName = 16;
     /**
      * <code>optional string gameName = 16;</code>
      */
@@ -14865,6 +15970,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getGameNameBytes();
 
+    // optional int64 time = 17;
     /**
      * <code>optional int64 time = 17;</code>
      */
@@ -14874,6 +15980,7 @@ public final class NetData {
      */
     long getTime();
 
+    // optional float reflectionHeight = 18;
     /**
      * <code>optional float reflectionHeight = 18;</code>
      */
@@ -14883,6 +15990,7 @@ public final class NetData {
      */
     float getReflectionHeight();
 
+    // optional string MOTD = 19;
     /**
      * <code>optional string MOTD = 19;</code>
      */
@@ -14897,6 +16005,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getMOTDBytes();
 
+    // optional int32 onlinePlayersAmount = 20;
     /**
      * <code>optional int32 onlinePlayersAmount = 20;</code>
      */
@@ -14911,9 +16020,7 @@ public final class NetData {
    */
   public static final class ServerInfoMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ServerInfoMessage> implements
-      // @@protoc_insertion_point(message_implements:ServerInfoMessage)
-      ServerInfoMessageOrBuilder {
+        ServerInfoMessage> implements ServerInfoMessageOrBuilder {
     // Use ServerInfoMessage.newBuilder() to construct.
     private ServerInfoMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ServerInfoMessage, ?> builder) {
       super(builder);
@@ -14989,12 +16096,11 @@ public final class NetData {
               break;
             }
             case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 blockName_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000004;
               }
-              blockName_.add(bs);
+              blockName_.add(input.readBytes());
               break;
             }
             case 34: {
@@ -15035,21 +16141,19 @@ public final class NetData {
               break;
             }
             case 58: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
                 assetUri_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000040;
               }
-              assetUri_.add(bs);
+              assetUri_.add(input.readBytes());
               break;
             }
             case 66: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
                 registerBlockFamily_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000080;
               }
-              registerBlockFamily_.add(bs);
+              registerBlockFamily_.add(input.readBytes());
               break;
             }
             case 74: {
@@ -15082,30 +16186,26 @@ public final class NetData {
               break;
             }
             case 90: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
                 biomeId_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000400;
               }
-              biomeId_.add(bs);
+              biomeId_.add(input.readBytes());
               break;
             }
             case 98: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              errorMessage_ = bs;
+              errorMessage_ = input.readBytes();
               break;
             }
             case 122: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 130: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              gameName_ = bs;
+              gameName_ = input.readBytes();
               break;
             }
             case 136: {
@@ -15119,9 +16219,8 @@ public final class NetData {
               break;
             }
             case 154: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              mOTD_ = bs;
+              mOTD_ = input.readBytes();
               break;
             }
             case 160: {
@@ -15144,7 +16243,7 @@ public final class NetData {
           blockId_ = java.util.Collections.unmodifiableList(blockId_);
         }
         if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-          blockName_ = blockName_.getUnmodifiableView();
+          blockName_ = new com.google.protobuf.UnmodifiableLazyStringList(blockName_);
         }
         if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
           component_ = java.util.Collections.unmodifiableList(component_);
@@ -15156,10 +16255,10 @@ public final class NetData {
           assetId_ = java.util.Collections.unmodifiableList(assetId_);
         }
         if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-          assetUri_ = assetUri_.getUnmodifiableView();
+          assetUri_ = new com.google.protobuf.UnmodifiableLazyStringList(assetUri_);
         }
         if (((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
-          registerBlockFamily_ = registerBlockFamily_.getUnmodifiableView();
+          registerBlockFamily_ = new com.google.protobuf.UnmodifiableLazyStringList(registerBlockFamily_);
         }
         if (((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
           worldInfo_ = java.util.Collections.unmodifiableList(worldInfo_);
@@ -15168,7 +16267,7 @@ public final class NetData {
           biomeShortId_ = java.util.Collections.unmodifiableList(biomeShortId_);
         }
         if (((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
-          biomeId_ = biomeId_.getUnmodifiableView();
+          biomeId_ = new com.google.protobuf.UnmodifiableLazyStringList(biomeId_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -15202,6 +16301,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // repeated .ModuleInfo module = 1;
     public static final int MODULE_FIELD_NUMBER = 1;
     private java.util.List<org.terasology.protobuf.NetData.ModuleInfo> module_;
     /**
@@ -15237,6 +16337,7 @@ public final class NetData {
       return module_.get(index);
     }
 
+    // repeated sint32 blockId = 2 [packed = true];
     public static final int BLOCKID_FIELD_NUMBER = 2;
     private java.util.List<java.lang.Integer> blockId_;
     /**
@@ -15260,12 +16361,13 @@ public final class NetData {
     }
     private int blockIdMemoizedSerializedSize = -1;
 
+    // repeated string blockName = 3;
     public static final int BLOCKNAME_FIELD_NUMBER = 3;
     private com.google.protobuf.LazyStringList blockName_;
     /**
      * <code>repeated string blockName = 3;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getBlockNameList() {
       return blockName_;
     }
@@ -15289,6 +16391,7 @@ public final class NetData {
       return blockName_.getByteString(index);
     }
 
+    // repeated .SerializationInfo component = 4;
     public static final int COMPONENT_FIELD_NUMBER = 4;
     private java.util.List<org.terasology.protobuf.NetData.SerializationInfo> component_;
     /**
@@ -15324,6 +16427,7 @@ public final class NetData {
       return component_.get(index);
     }
 
+    // repeated .SerializationInfo event = 5;
     public static final int EVENT_FIELD_NUMBER = 5;
     private java.util.List<org.terasology.protobuf.NetData.SerializationInfo> event_;
     /**
@@ -15359,6 +16463,7 @@ public final class NetData {
       return event_.get(index);
     }
 
+    // repeated int32 assetId = 6 [packed = true];
     public static final int ASSETID_FIELD_NUMBER = 6;
     private java.util.List<java.lang.Integer> assetId_;
     /**
@@ -15382,12 +16487,13 @@ public final class NetData {
     }
     private int assetIdMemoizedSerializedSize = -1;
 
+    // repeated string assetUri = 7;
     public static final int ASSETURI_FIELD_NUMBER = 7;
     private com.google.protobuf.LazyStringList assetUri_;
     /**
      * <code>repeated string assetUri = 7;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getAssetUriList() {
       return assetUri_;
     }
@@ -15411,12 +16517,13 @@ public final class NetData {
       return assetUri_.getByteString(index);
     }
 
+    // repeated string registerBlockFamily = 8;
     public static final int REGISTERBLOCKFAMILY_FIELD_NUMBER = 8;
     private com.google.protobuf.LazyStringList registerBlockFamily_;
     /**
      * <code>repeated string registerBlockFamily = 8;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getRegisterBlockFamilyList() {
       return registerBlockFamily_;
     }
@@ -15440,6 +16547,7 @@ public final class NetData {
       return registerBlockFamily_.getByteString(index);
     }
 
+    // repeated .WorldInfo worldInfo = 9;
     public static final int WORLDINFO_FIELD_NUMBER = 9;
     private java.util.List<org.terasology.protobuf.NetData.WorldInfo> worldInfo_;
     /**
@@ -15475,6 +16583,7 @@ public final class NetData {
       return worldInfo_.get(index);
     }
 
+    // repeated sint32 biomeShortId = 10 [packed = true];
     public static final int BIOMESHORTID_FIELD_NUMBER = 10;
     private java.util.List<java.lang.Integer> biomeShortId_;
     /**
@@ -15498,12 +16607,13 @@ public final class NetData {
     }
     private int biomeShortIdMemoizedSerializedSize = -1;
 
+    // repeated string biomeId = 11;
     public static final int BIOMEID_FIELD_NUMBER = 11;
     private com.google.protobuf.LazyStringList biomeId_;
     /**
      * <code>repeated string biomeId = 11;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getBiomeIdList() {
       return biomeId_;
     }
@@ -15527,6 +16637,7 @@ public final class NetData {
       return biomeId_.getByteString(index);
     }
 
+    // optional string errorMessage = 12;
     public static final int ERRORMESSAGE_FIELD_NUMBER = 12;
     private java.lang.Object errorMessage_;
     /**
@@ -15569,6 +16680,7 @@ public final class NetData {
       }
     }
 
+    // optional string version = 15;
     public static final int VERSION_FIELD_NUMBER = 15;
     private java.lang.Object version_;
     /**
@@ -15611,6 +16723,7 @@ public final class NetData {
       }
     }
 
+    // optional string gameName = 16;
     public static final int GAMENAME_FIELD_NUMBER = 16;
     private java.lang.Object gameName_;
     /**
@@ -15653,6 +16766,7 @@ public final class NetData {
       }
     }
 
+    // optional int64 time = 17;
     public static final int TIME_FIELD_NUMBER = 17;
     private long time_;
     /**
@@ -15668,6 +16782,7 @@ public final class NetData {
       return time_;
     }
 
+    // optional float reflectionHeight = 18;
     public static final int REFLECTIONHEIGHT_FIELD_NUMBER = 18;
     private float reflectionHeight_;
     /**
@@ -15683,6 +16798,7 @@ public final class NetData {
       return reflectionHeight_;
     }
 
+    // optional string MOTD = 19;
     public static final int MOTD_FIELD_NUMBER = 19;
     private java.lang.Object mOTD_;
     /**
@@ -15725,6 +16841,7 @@ public final class NetData {
       }
     }
 
+    // optional int32 onlinePlayersAmount = 20;
     public static final int ONLINEPLAYERSAMOUNT_FIELD_NUMBER = 20;
     private int onlinePlayersAmount_;
     /**
@@ -15763,8 +16880,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getModuleCount(); i++) {
         if (!getModule(i).isInitialized()) {
@@ -16086,9 +17202,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ServerInfoMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ServerInfoMessage)
-        org.terasology.protobuf.NetData.ServerInfoMessageOrBuilder {
+          org.terasology.protobuf.NetData.ServerInfoMessage, Builder> implements org.terasology.protobuf.NetData.ServerInfoMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ServerInfoMessage_descriptor;
@@ -16220,7 +17334,8 @@ public final class NetData {
         }
         result.blockId_ = blockId_;
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
-          blockName_ = blockName_.getUnmodifiableView();
+          blockName_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              blockName_);
           bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.blockName_ = blockName_;
@@ -16248,12 +17363,14 @@ public final class NetData {
         }
         result.assetId_ = assetId_;
         if (((bitField0_ & 0x00000040) == 0x00000040)) {
-          assetUri_ = assetUri_.getUnmodifiableView();
+          assetUri_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              assetUri_);
           bitField0_ = (bitField0_ & ~0x00000040);
         }
         result.assetUri_ = assetUri_;
         if (((bitField0_ & 0x00000080) == 0x00000080)) {
-          registerBlockFamily_ = registerBlockFamily_.getUnmodifiableView();
+          registerBlockFamily_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              registerBlockFamily_);
           bitField0_ = (bitField0_ & ~0x00000080);
         }
         result.registerBlockFamily_ = registerBlockFamily_;
@@ -16272,7 +17389,8 @@ public final class NetData {
         }
         result.biomeShortId_ = biomeShortId_;
         if (((bitField0_ & 0x00000400) == 0x00000400)) {
-          biomeId_ = biomeId_.getUnmodifiableView();
+          biomeId_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              biomeId_);
           bitField0_ = (bitField0_ & ~0x00000400);
         }
         result.biomeId_ = biomeId_;
@@ -16579,6 +17697,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // repeated .ModuleInfo module = 1;
       private java.util.List<org.terasology.protobuf.NetData.ModuleInfo> module_ =
         java.util.Collections.emptyList();
       private void ensureModuleIsMutable() {
@@ -16720,8 +17839,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.ModuleInfo> values) {
         if (moduleBuilder_ == null) {
           ensureModuleIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, module_);
+          super.addAll(values, module_);
           onChanged();
         } else {
           moduleBuilder_.addAllMessages(values);
@@ -16819,6 +17937,7 @@ public final class NetData {
         return moduleBuilder_;
       }
 
+      // repeated sint32 blockId = 2 [packed = true];
       private java.util.List<java.lang.Integer> blockId_ = java.util.Collections.emptyList();
       private void ensureBlockIdIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -16870,8 +17989,7 @@ public final class NetData {
       public Builder addAllBlockId(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureBlockIdIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, blockId_);
+        super.addAll(values, blockId_);
         onChanged();
         return this;
       }
@@ -16885,6 +18003,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated string blockName = 3;
       private com.google.protobuf.LazyStringList blockName_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureBlockNameIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -16895,9 +18014,9 @@ public final class NetData {
       /**
        * <code>repeated string blockName = 3;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getBlockNameList() {
-        return blockName_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(blockName_);
       }
       /**
        * <code>repeated string blockName = 3;</code>
@@ -16950,8 +18069,7 @@ public final class NetData {
       public Builder addAllBlockName(
           java.lang.Iterable<java.lang.String> values) {
         ensureBlockNameIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, blockName_);
+        super.addAll(values, blockName_);
         onChanged();
         return this;
       }
@@ -16978,6 +18096,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated .SerializationInfo component = 4;
       private java.util.List<org.terasology.protobuf.NetData.SerializationInfo> component_ =
         java.util.Collections.emptyList();
       private void ensureComponentIsMutable() {
@@ -17119,8 +18238,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.SerializationInfo> values) {
         if (componentBuilder_ == null) {
           ensureComponentIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, component_);
+          super.addAll(values, component_);
           onChanged();
         } else {
           componentBuilder_.addAllMessages(values);
@@ -17218,6 +18336,7 @@ public final class NetData {
         return componentBuilder_;
       }
 
+      // repeated .SerializationInfo event = 5;
       private java.util.List<org.terasology.protobuf.NetData.SerializationInfo> event_ =
         java.util.Collections.emptyList();
       private void ensureEventIsMutable() {
@@ -17359,8 +18478,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.SerializationInfo> values) {
         if (eventBuilder_ == null) {
           ensureEventIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, event_);
+          super.addAll(values, event_);
           onChanged();
         } else {
           eventBuilder_.addAllMessages(values);
@@ -17458,6 +18576,7 @@ public final class NetData {
         return eventBuilder_;
       }
 
+      // repeated int32 assetId = 6 [packed = true];
       private java.util.List<java.lang.Integer> assetId_ = java.util.Collections.emptyList();
       private void ensureAssetIdIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -17509,8 +18628,7 @@ public final class NetData {
       public Builder addAllAssetId(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureAssetIdIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, assetId_);
+        super.addAll(values, assetId_);
         onChanged();
         return this;
       }
@@ -17524,6 +18642,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated string assetUri = 7;
       private com.google.protobuf.LazyStringList assetUri_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureAssetUriIsMutable() {
         if (!((bitField0_ & 0x00000040) == 0x00000040)) {
@@ -17534,9 +18653,9 @@ public final class NetData {
       /**
        * <code>repeated string assetUri = 7;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getAssetUriList() {
-        return assetUri_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(assetUri_);
       }
       /**
        * <code>repeated string assetUri = 7;</code>
@@ -17589,8 +18708,7 @@ public final class NetData {
       public Builder addAllAssetUri(
           java.lang.Iterable<java.lang.String> values) {
         ensureAssetUriIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, assetUri_);
+        super.addAll(values, assetUri_);
         onChanged();
         return this;
       }
@@ -17617,6 +18735,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated string registerBlockFamily = 8;
       private com.google.protobuf.LazyStringList registerBlockFamily_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureRegisterBlockFamilyIsMutable() {
         if (!((bitField0_ & 0x00000080) == 0x00000080)) {
@@ -17627,9 +18746,9 @@ public final class NetData {
       /**
        * <code>repeated string registerBlockFamily = 8;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getRegisterBlockFamilyList() {
-        return registerBlockFamily_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(registerBlockFamily_);
       }
       /**
        * <code>repeated string registerBlockFamily = 8;</code>
@@ -17682,8 +18801,7 @@ public final class NetData {
       public Builder addAllRegisterBlockFamily(
           java.lang.Iterable<java.lang.String> values) {
         ensureRegisterBlockFamilyIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, registerBlockFamily_);
+        super.addAll(values, registerBlockFamily_);
         onChanged();
         return this;
       }
@@ -17710,6 +18828,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated .WorldInfo worldInfo = 9;
       private java.util.List<org.terasology.protobuf.NetData.WorldInfo> worldInfo_ =
         java.util.Collections.emptyList();
       private void ensureWorldInfoIsMutable() {
@@ -17851,8 +18970,7 @@ public final class NetData {
           java.lang.Iterable<? extends org.terasology.protobuf.NetData.WorldInfo> values) {
         if (worldInfoBuilder_ == null) {
           ensureWorldInfoIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, worldInfo_);
+          super.addAll(values, worldInfo_);
           onChanged();
         } else {
           worldInfoBuilder_.addAllMessages(values);
@@ -17950,6 +19068,7 @@ public final class NetData {
         return worldInfoBuilder_;
       }
 
+      // repeated sint32 biomeShortId = 10 [packed = true];
       private java.util.List<java.lang.Integer> biomeShortId_ = java.util.Collections.emptyList();
       private void ensureBiomeShortIdIsMutable() {
         if (!((bitField0_ & 0x00000200) == 0x00000200)) {
@@ -18001,8 +19120,7 @@ public final class NetData {
       public Builder addAllBiomeShortId(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureBiomeShortIdIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, biomeShortId_);
+        super.addAll(values, biomeShortId_);
         onChanged();
         return this;
       }
@@ -18016,6 +19134,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated string biomeId = 11;
       private com.google.protobuf.LazyStringList biomeId_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureBiomeIdIsMutable() {
         if (!((bitField0_ & 0x00000400) == 0x00000400)) {
@@ -18026,9 +19145,9 @@ public final class NetData {
       /**
        * <code>repeated string biomeId = 11;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getBiomeIdList() {
-        return biomeId_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(biomeId_);
       }
       /**
        * <code>repeated string biomeId = 11;</code>
@@ -18081,8 +19200,7 @@ public final class NetData {
       public Builder addAllBiomeId(
           java.lang.Iterable<java.lang.String> values) {
         ensureBiomeIdIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, biomeId_);
+        super.addAll(values, biomeId_);
         onChanged();
         return this;
       }
@@ -18109,6 +19227,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string errorMessage = 12;
       private java.lang.Object errorMessage_ = "";
       /**
        * <code>optional string errorMessage = 12;</code>
@@ -18122,12 +19241,9 @@ public final class NetData {
       public java.lang.String getErrorMessage() {
         java.lang.Object ref = errorMessage_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            errorMessage_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          errorMessage_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -18185,6 +19301,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string version = 15;
       private java.lang.Object version_ = "";
       /**
        * <code>optional string version = 15;</code>
@@ -18198,12 +19315,9 @@ public final class NetData {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -18261,6 +19375,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string gameName = 16;
       private java.lang.Object gameName_ = "";
       /**
        * <code>optional string gameName = 16;</code>
@@ -18274,12 +19389,9 @@ public final class NetData {
       public java.lang.String getGameName() {
         java.lang.Object ref = gameName_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            gameName_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          gameName_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -18337,6 +19449,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int64 time = 17;
       private long time_ ;
       /**
        * <code>optional int64 time = 17;</code>
@@ -18369,6 +19482,7 @@ public final class NetData {
         return this;
       }
 
+      // optional float reflectionHeight = 18;
       private float reflectionHeight_ ;
       /**
        * <code>optional float reflectionHeight = 18;</code>
@@ -18401,6 +19515,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string MOTD = 19;
       private java.lang.Object mOTD_ = "";
       /**
        * <code>optional string MOTD = 19;</code>
@@ -18414,12 +19529,9 @@ public final class NetData {
       public java.lang.String getMOTD() {
         java.lang.Object ref = mOTD_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            mOTD_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          mOTD_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -18477,6 +19589,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int32 onlinePlayersAmount = 20;
       private int onlinePlayersAmount_ ;
       /**
        * <code>optional int32 onlinePlayersAmount = 20;</code>
@@ -18521,10 +19634,10 @@ public final class NetData {
   }
 
   public interface WorldInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:WorldInfo)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<WorldInfo> {
 
+    // optional string title = 1;
     /**
      * <code>optional string title = 1;</code>
      */
@@ -18539,6 +19652,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getTitleBytes();
 
+    // optional int64 time = 2;
     /**
      * <code>optional int64 time = 2;</code>
      */
@@ -18553,9 +19667,7 @@ public final class NetData {
    */
   public static final class WorldInfo extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        WorldInfo> implements
-      // @@protoc_insertion_point(message_implements:WorldInfo)
-      WorldInfoOrBuilder {
+        WorldInfo> implements WorldInfoOrBuilder {
     // Use WorldInfo.newBuilder() to construct.
     private WorldInfo(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.WorldInfo, ?> builder) {
       super(builder);
@@ -18602,9 +19714,8 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              title_ = bs;
+              title_ = input.readBytes();
               break;
             }
             case 16: {
@@ -18652,6 +19763,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string title = 1;
     public static final int TITLE_FIELD_NUMBER = 1;
     private java.lang.Object title_;
     /**
@@ -18694,6 +19806,7 @@ public final class NetData {
       }
     }
 
+    // optional int64 time = 2;
     public static final int TIME_FIELD_NUMBER = 2;
     private long time_;
     /**
@@ -18716,8 +19829,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -18841,9 +19953,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.WorldInfo, Builder> implements
-        // @@protoc_insertion_point(builder_implements:WorldInfo)
-        org.terasology.protobuf.NetData.WorldInfoOrBuilder {
+          org.terasology.protobuf.NetData.WorldInfo, Builder> implements org.terasology.protobuf.NetData.WorldInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_WorldInfo_descriptor;
@@ -18972,6 +20082,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string title = 1;
       private java.lang.Object title_ = "";
       /**
        * <code>optional string title = 1;</code>
@@ -18985,12 +20096,9 @@ public final class NetData {
       public java.lang.String getTitle() {
         java.lang.Object ref = title_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            title_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          title_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -19048,6 +20156,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int64 time = 2;
       private long time_ ;
       /**
        * <code>optional int64 time = 2;</code>
@@ -19092,10 +20201,10 @@ public final class NetData {
   }
 
   public interface SerializationInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:SerializationInfo)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<SerializationInfo> {
 
+    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -19110,6 +20219,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // optional int32 id = 2;
     /**
      * <code>optional int32 id = 2;</code>
      */
@@ -19119,11 +20229,12 @@ public final class NetData {
      */
     int getId();
 
+    // repeated string fieldName = 3;
     /**
      * <code>repeated string fieldName = 3;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getFieldNameList();
+    java.util.List<java.lang.String>
+    getFieldNameList();
     /**
      * <code>repeated string fieldName = 3;</code>
      */
@@ -19138,6 +20249,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getFieldNameBytes(int index);
 
+    // optional bytes fieldIds = 4;
     /**
      * <code>optional bytes fieldIds = 4;</code>
      */
@@ -19152,9 +20264,7 @@ public final class NetData {
    */
   public static final class SerializationInfo extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        SerializationInfo> implements
-      // @@protoc_insertion_point(message_implements:SerializationInfo)
-      SerializationInfoOrBuilder {
+        SerializationInfo> implements SerializationInfoOrBuilder {
     // Use SerializationInfo.newBuilder() to construct.
     private SerializationInfo(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.SerializationInfo, ?> builder) {
       super(builder);
@@ -19201,9 +20311,8 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 16: {
@@ -19212,12 +20321,11 @@ public final class NetData {
               break;
             }
             case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
                 fieldName_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000004;
               }
-              fieldName_.add(bs);
+              fieldName_.add(input.readBytes());
               break;
             }
             case 34: {
@@ -19234,7 +20342,7 @@ public final class NetData {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-          fieldName_ = fieldName_.getUnmodifiableView();
+          fieldName_ = new com.google.protobuf.UnmodifiableLazyStringList(fieldName_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -19268,6 +20376,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -19310,6 +20419,7 @@ public final class NetData {
       }
     }
 
+    // optional int32 id = 2;
     public static final int ID_FIELD_NUMBER = 2;
     private int id_;
     /**
@@ -19325,12 +20435,13 @@ public final class NetData {
       return id_;
     }
 
+    // repeated string fieldName = 3;
     public static final int FIELDNAME_FIELD_NUMBER = 3;
     private com.google.protobuf.LazyStringList fieldName_;
     /**
      * <code>repeated string fieldName = 3;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getFieldNameList() {
       return fieldName_;
     }
@@ -19354,6 +20465,7 @@ public final class NetData {
       return fieldName_.getByteString(index);
     }
 
+    // optional bytes fieldIds = 4;
     public static final int FIELDIDS_FIELD_NUMBER = 4;
     private com.google.protobuf.ByteString fieldIds_;
     /**
@@ -19378,8 +20490,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -19522,9 +20633,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.SerializationInfo, Builder> implements
-        // @@protoc_insertion_point(builder_implements:SerializationInfo)
-        org.terasology.protobuf.NetData.SerializationInfoOrBuilder {
+          org.terasology.protobuf.NetData.SerializationInfo, Builder> implements org.terasology.protobuf.NetData.SerializationInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_SerializationInfo_descriptor;
@@ -19602,7 +20711,8 @@ public final class NetData {
         }
         result.id_ = id_;
         if (((bitField0_ & 0x00000004) == 0x00000004)) {
-          fieldName_ = fieldName_.getUnmodifiableView();
+          fieldName_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              fieldName_);
           bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.fieldName_ = fieldName_;
@@ -19679,6 +20789,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -19692,12 +20803,9 @@ public final class NetData {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -19755,6 +20863,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int32 id = 2;
       private int id_ ;
       /**
        * <code>optional int32 id = 2;</code>
@@ -19787,6 +20896,7 @@ public final class NetData {
         return this;
       }
 
+      // repeated string fieldName = 3;
       private com.google.protobuf.LazyStringList fieldName_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureFieldNameIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -19797,9 +20907,9 @@ public final class NetData {
       /**
        * <code>repeated string fieldName = 3;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getFieldNameList() {
-        return fieldName_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(fieldName_);
       }
       /**
        * <code>repeated string fieldName = 3;</code>
@@ -19852,8 +20962,7 @@ public final class NetData {
       public Builder addAllFieldName(
           java.lang.Iterable<java.lang.String> values) {
         ensureFieldNameIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, fieldName_);
+        super.addAll(values, fieldName_);
         onChanged();
         return this;
       }
@@ -19880,6 +20989,7 @@ public final class NetData {
         return this;
       }
 
+      // optional bytes fieldIds = 4;
       private com.google.protobuf.ByteString fieldIds_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes fieldIds = 4;</code>
@@ -19927,10 +21037,10 @@ public final class NetData {
   }
 
   public interface ModuleInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ModuleInfo)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ModuleInfo> {
 
+    // optional string moduleId = 1;
     /**
      * <code>optional string moduleId = 1;</code>
      */
@@ -19945,6 +21055,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getModuleIdBytes();
 
+    // optional string moduleVersion = 2;
     /**
      * <code>optional string moduleVersion = 2;</code>
      */
@@ -19964,9 +21075,7 @@ public final class NetData {
    */
   public static final class ModuleInfo extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ModuleInfo> implements
-      // @@protoc_insertion_point(message_implements:ModuleInfo)
-      ModuleInfoOrBuilder {
+        ModuleInfo> implements ModuleInfoOrBuilder {
     // Use ModuleInfo.newBuilder() to construct.
     private ModuleInfo(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ModuleInfo, ?> builder) {
       super(builder);
@@ -20013,15 +21122,13 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              moduleId_ = bs;
+              moduleId_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              moduleVersion_ = bs;
+              moduleVersion_ = input.readBytes();
               break;
             }
           }
@@ -20064,6 +21171,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string moduleId = 1;
     public static final int MODULEID_FIELD_NUMBER = 1;
     private java.lang.Object moduleId_;
     /**
@@ -20106,6 +21214,7 @@ public final class NetData {
       }
     }
 
+    // optional string moduleVersion = 2;
     public static final int MODULEVERSION_FIELD_NUMBER = 2;
     private java.lang.Object moduleVersion_;
     /**
@@ -20155,8 +21264,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -20280,9 +21388,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ModuleInfo, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ModuleInfo)
-        org.terasology.protobuf.NetData.ModuleInfoOrBuilder {
+          org.terasology.protobuf.NetData.ModuleInfo, Builder> implements org.terasology.protobuf.NetData.ModuleInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ModuleInfo_descriptor;
@@ -20413,6 +21519,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string moduleId = 1;
       private java.lang.Object moduleId_ = "";
       /**
        * <code>optional string moduleId = 1;</code>
@@ -20426,12 +21533,9 @@ public final class NetData {
       public java.lang.String getModuleId() {
         java.lang.Object ref = moduleId_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            moduleId_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          moduleId_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -20489,6 +21593,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string moduleVersion = 2;
       private java.lang.Object moduleVersion_ = "";
       /**
        * <code>optional string moduleVersion = 2;</code>
@@ -20502,12 +21607,9 @@ public final class NetData {
       public java.lang.String getModuleVersion() {
         java.lang.Object ref = moduleVersion_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            moduleVersion_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          moduleVersion_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -20577,10 +21679,10 @@ public final class NetData {
   }
 
   public interface ModuleRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ModuleRequest)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ModuleRequest> {
 
+    // optional string moduleId = 1;
     /**
      * <code>optional string moduleId = 1;</code>
      */
@@ -20600,9 +21702,7 @@ public final class NetData {
    */
   public static final class ModuleRequest extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ModuleRequest> implements
-      // @@protoc_insertion_point(message_implements:ModuleRequest)
-      ModuleRequestOrBuilder {
+        ModuleRequest> implements ModuleRequestOrBuilder {
     // Use ModuleRequest.newBuilder() to construct.
     private ModuleRequest(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ModuleRequest, ?> builder) {
       super(builder);
@@ -20649,9 +21749,8 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              moduleId_ = bs;
+              moduleId_ = input.readBytes();
               break;
             }
           }
@@ -20694,6 +21793,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string moduleId = 1;
     public static final int MODULEID_FIELD_NUMBER = 1;
     private java.lang.Object moduleId_;
     /**
@@ -20742,8 +21842,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -20860,9 +21959,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ModuleRequest, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ModuleRequest)
-        org.terasology.protobuf.NetData.ModuleRequestOrBuilder {
+          org.terasology.protobuf.NetData.ModuleRequest, Builder> implements org.terasology.protobuf.NetData.ModuleRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ModuleRequest_descriptor;
@@ -20982,6 +22079,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string moduleId = 1;
       private java.lang.Object moduleId_ = "";
       /**
        * <code>optional string moduleId = 1;</code>
@@ -20995,12 +22093,9 @@ public final class NetData {
       public java.lang.String getModuleId() {
         java.lang.Object ref = moduleId_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            moduleId_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          moduleId_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -21070,10 +22165,10 @@ public final class NetData {
   }
 
   public interface ModuleDataHeaderOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ModuleDataHeader)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ModuleDataHeader> {
 
+    // optional string id = 1;
     /**
      * <code>optional string id = 1;</code>
      */
@@ -21088,6 +22183,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // optional string version = 2;
     /**
      * <code>optional string version = 2;</code>
      */
@@ -21102,6 +22198,7 @@ public final class NetData {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // optional int64 size = 3;
     /**
      * <code>optional int64 size = 3;</code>
      */
@@ -21111,6 +22208,7 @@ public final class NetData {
      */
     long getSize();
 
+    // optional string error = 15;
     /**
      * <code>optional string error = 15;</code>
      */
@@ -21130,9 +22228,7 @@ public final class NetData {
    */
   public static final class ModuleDataHeader extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ModuleDataHeader> implements
-      // @@protoc_insertion_point(message_implements:ModuleDataHeader)
-      ModuleDataHeaderOrBuilder {
+        ModuleDataHeader> implements ModuleDataHeaderOrBuilder {
     // Use ModuleDataHeader.newBuilder() to construct.
     private ModuleDataHeader(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ModuleDataHeader, ?> builder) {
       super(builder);
@@ -21179,15 +22275,13 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 24: {
@@ -21196,9 +22290,8 @@ public final class NetData {
               break;
             }
             case 122: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              error_ = bs;
+              error_ = input.readBytes();
               break;
             }
           }
@@ -21241,6 +22334,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -21283,6 +22377,7 @@ public final class NetData {
       }
     }
 
+    // optional string version = 2;
     public static final int VERSION_FIELD_NUMBER = 2;
     private java.lang.Object version_;
     /**
@@ -21325,6 +22420,7 @@ public final class NetData {
       }
     }
 
+    // optional int64 size = 3;
     public static final int SIZE_FIELD_NUMBER = 3;
     private long size_;
     /**
@@ -21340,6 +22436,7 @@ public final class NetData {
       return size_;
     }
 
+    // optional string error = 15;
     public static final int ERROR_FIELD_NUMBER = 15;
     private java.lang.Object error_;
     /**
@@ -21391,8 +22488,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -21530,9 +22626,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ModuleDataHeader, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ModuleDataHeader)
-        org.terasology.protobuf.NetData.ModuleDataHeaderOrBuilder {
+          org.terasology.protobuf.NetData.ModuleDataHeader, Builder> implements org.terasology.protobuf.NetData.ModuleDataHeaderOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ModuleDataHeader_descriptor;
@@ -21683,6 +22777,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>optional string id = 1;</code>
@@ -21696,12 +22791,9 @@ public final class NetData {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -21759,6 +22851,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string version = 2;
       private java.lang.Object version_ = "";
       /**
        * <code>optional string version = 2;</code>
@@ -21772,12 +22865,9 @@ public final class NetData {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -21835,6 +22925,7 @@ public final class NetData {
         return this;
       }
 
+      // optional int64 size = 3;
       private long size_ ;
       /**
        * <code>optional int64 size = 3;</code>
@@ -21867,6 +22958,7 @@ public final class NetData {
         return this;
       }
 
+      // optional string error = 15;
       private java.lang.Object error_ = "";
       /**
        * <code>optional string error = 15;</code>
@@ -21880,12 +22972,9 @@ public final class NetData {
       public java.lang.String getError() {
         java.lang.Object ref = error_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            error_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          error_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -21955,10 +23044,10 @@ public final class NetData {
   }
 
   public interface ModuleDataOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ModuleData)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ModuleData> {
 
+    // optional bytes module = 1;
     /**
      * <code>optional bytes module = 1;</code>
      */
@@ -21973,9 +23062,7 @@ public final class NetData {
    */
   public static final class ModuleData extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ModuleData> implements
-      // @@protoc_insertion_point(message_implements:ModuleData)
-      ModuleDataOrBuilder {
+        ModuleData> implements ModuleDataOrBuilder {
     // Use ModuleData.newBuilder() to construct.
     private ModuleData(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ModuleData, ?> builder) {
       super(builder);
@@ -22066,6 +23153,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional bytes module = 1;
     public static final int MODULE_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString module_;
     /**
@@ -22087,8 +23175,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -22205,9 +23292,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ModuleData, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ModuleData)
-        org.terasology.protobuf.NetData.ModuleDataOrBuilder {
+          org.terasology.protobuf.NetData.ModuleData, Builder> implements org.terasology.protobuf.NetData.ModuleDataOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ModuleData_descriptor;
@@ -22325,6 +23410,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional bytes module = 1;
       private com.google.protobuf.ByteString module_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>optional bytes module = 1;</code>
@@ -22372,10 +23458,10 @@ public final class NetData {
   }
 
   public interface ModuleSendErrorOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:ModuleSendError)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<ModuleSendError> {
 
+    // optional string message = 1;
     /**
      * <code>optional string message = 1;</code>
      */
@@ -22395,9 +23481,7 @@ public final class NetData {
    */
   public static final class ModuleSendError extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        ModuleSendError> implements
-      // @@protoc_insertion_point(message_implements:ModuleSendError)
-      ModuleSendErrorOrBuilder {
+        ModuleSendError> implements ModuleSendErrorOrBuilder {
     // Use ModuleSendError.newBuilder() to construct.
     private ModuleSendError(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.ModuleSendError, ?> builder) {
       super(builder);
@@ -22444,9 +23528,8 @@ public final class NetData {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              message_ = bs;
+              message_ = input.readBytes();
               break;
             }
           }
@@ -22489,6 +23572,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional string message = 1;
     public static final int MESSAGE_FIELD_NUMBER = 1;
     private java.lang.Object message_;
     /**
@@ -22537,8 +23621,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -22655,9 +23738,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.ModuleSendError, Builder> implements
-        // @@protoc_insertion_point(builder_implements:ModuleSendError)
-        org.terasology.protobuf.NetData.ModuleSendErrorOrBuilder {
+          org.terasology.protobuf.NetData.ModuleSendError, Builder> implements org.terasology.protobuf.NetData.ModuleSendErrorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_ModuleSendError_descriptor;
@@ -22777,6 +23858,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional string message = 1;
       private java.lang.Object message_ = "";
       /**
        * <code>optional string message = 1;</code>
@@ -22790,12 +23872,9 @@ public final class NetData {
       public java.lang.String getMessage() {
         java.lang.Object ref = message_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            message_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          message_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -22865,10 +23944,10 @@ public final class NetData {
   }
 
   public interface CreateEntityMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:CreateEntityMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<CreateEntityMessage> {
 
+    // optional .PackedEntity entity = 1;
     /**
      * <code>optional .PackedEntity entity = 1;</code>
      */
@@ -22882,6 +23961,7 @@ public final class NetData {
      */
     org.terasology.protobuf.EntityData.PackedEntityOrBuilder getEntityOrBuilder();
 
+    // optional .Vector3iData blockPos = 2;
     /**
      * <code>optional .Vector3iData blockPos = 2;</code>
      */
@@ -22900,9 +23980,7 @@ public final class NetData {
    */
   public static final class CreateEntityMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        CreateEntityMessage> implements
-      // @@protoc_insertion_point(message_implements:CreateEntityMessage)
-      CreateEntityMessageOrBuilder {
+        CreateEntityMessage> implements CreateEntityMessageOrBuilder {
     // Use CreateEntityMessage.newBuilder() to construct.
     private CreateEntityMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.CreateEntityMessage, ?> builder) {
       super(builder);
@@ -23014,6 +24092,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional .PackedEntity entity = 1;
     public static final int ENTITY_FIELD_NUMBER = 1;
     private org.terasology.protobuf.EntityData.PackedEntity entity_;
     /**
@@ -23035,6 +24114,7 @@ public final class NetData {
       return entity_;
     }
 
+    // optional .Vector3iData blockPos = 2;
     public static final int BLOCKPOS_FIELD_NUMBER = 2;
     private org.terasology.protobuf.NetData.Vector3iData blockPos_;
     /**
@@ -23063,8 +24143,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasEntity()) {
         if (!getEntity().isInitialized()) {
@@ -23194,9 +24273,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.CreateEntityMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:CreateEntityMessage)
-        org.terasology.protobuf.NetData.CreateEntityMessageOrBuilder {
+          org.terasology.protobuf.NetData.CreateEntityMessage, Builder> implements org.terasology.protobuf.NetData.CreateEntityMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_CreateEntityMessage_descriptor;
@@ -23347,6 +24424,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional .PackedEntity entity = 1;
       private org.terasology.protobuf.EntityData.PackedEntity entity_ = org.terasology.protobuf.EntityData.PackedEntity.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.PackedEntity, org.terasology.protobuf.EntityData.PackedEntity.Builder, org.terasology.protobuf.EntityData.PackedEntityOrBuilder> entityBuilder_;
@@ -23455,7 +24533,7 @@ public final class NetData {
         if (entityBuilder_ == null) {
           entityBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.PackedEntity, org.terasology.protobuf.EntityData.PackedEntity.Builder, org.terasology.protobuf.EntityData.PackedEntityOrBuilder>(
-                  getEntity(),
+                  entity_,
                   getParentForChildren(),
                   isClean());
           entity_ = null;
@@ -23463,6 +24541,7 @@ public final class NetData {
         return entityBuilder_;
       }
 
+      // optional .Vector3iData blockPos = 2;
       private org.terasology.protobuf.NetData.Vector3iData blockPos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> blockPosBuilder_;
@@ -23571,7 +24650,7 @@ public final class NetData {
         if (blockPosBuilder_ == null) {
           blockPosBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder>(
-                  getBlockPos(),
+                  blockPos_,
                   getParentForChildren(),
                   isClean());
           blockPos_ = null;
@@ -23591,10 +24670,10 @@ public final class NetData {
   }
 
   public interface UpdateEntityMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:UpdateEntityMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<UpdateEntityMessage> {
 
+    // optional .PackedEntity entity = 1;
     /**
      * <code>optional .PackedEntity entity = 1;</code>
      */
@@ -23608,6 +24687,7 @@ public final class NetData {
      */
     org.terasology.protobuf.EntityData.PackedEntityOrBuilder getEntityOrBuilder();
 
+    // optional int32 netId = 2;
     /**
      * <code>optional int32 netId = 2;</code>
      */
@@ -23622,9 +24702,7 @@ public final class NetData {
    */
   public static final class UpdateEntityMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        UpdateEntityMessage> implements
-      // @@protoc_insertion_point(message_implements:UpdateEntityMessage)
-      UpdateEntityMessageOrBuilder {
+        UpdateEntityMessage> implements UpdateEntityMessageOrBuilder {
     // Use UpdateEntityMessage.newBuilder() to construct.
     private UpdateEntityMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.UpdateEntityMessage, ?> builder) {
       super(builder);
@@ -23728,6 +24806,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional .PackedEntity entity = 1;
     public static final int ENTITY_FIELD_NUMBER = 1;
     private org.terasology.protobuf.EntityData.PackedEntity entity_;
     /**
@@ -23749,6 +24828,7 @@ public final class NetData {
       return entity_;
     }
 
+    // optional int32 netId = 2;
     public static final int NETID_FIELD_NUMBER = 2;
     private int netId_;
     /**
@@ -23771,8 +24851,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasEntity()) {
         if (!getEntity().isInitialized()) {
@@ -23902,9 +24981,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.UpdateEntityMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:UpdateEntityMessage)
-        org.terasology.protobuf.NetData.UpdateEntityMessageOrBuilder {
+          org.terasology.protobuf.NetData.UpdateEntityMessage, Builder> implements org.terasology.protobuf.NetData.UpdateEntityMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_UpdateEntityMessage_descriptor;
@@ -24046,6 +25123,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional .PackedEntity entity = 1;
       private org.terasology.protobuf.EntityData.PackedEntity entity_ = org.terasology.protobuf.EntityData.PackedEntity.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.PackedEntity, org.terasology.protobuf.EntityData.PackedEntity.Builder, org.terasology.protobuf.EntityData.PackedEntityOrBuilder> entityBuilder_;
@@ -24154,7 +25232,7 @@ public final class NetData {
         if (entityBuilder_ == null) {
           entityBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.PackedEntity, org.terasology.protobuf.EntityData.PackedEntity.Builder, org.terasology.protobuf.EntityData.PackedEntityOrBuilder>(
-                  getEntity(),
+                  entity_,
                   getParentForChildren(),
                   isClean());
           entity_ = null;
@@ -24162,6 +25240,7 @@ public final class NetData {
         return entityBuilder_;
       }
 
+      // optional int32 netId = 2;
       private int netId_ ;
       /**
        * <code>optional int32 netId = 2;</code>
@@ -24206,10 +25285,10 @@ public final class NetData {
   }
 
   public interface RemoveEntityMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:RemoveEntityMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<RemoveEntityMessage> {
 
+    // optional int32 netId = 1;
     /**
      * <code>optional int32 netId = 1;</code>
      */
@@ -24224,9 +25303,7 @@ public final class NetData {
    */
   public static final class RemoveEntityMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        RemoveEntityMessage> implements
-      // @@protoc_insertion_point(message_implements:RemoveEntityMessage)
-      RemoveEntityMessageOrBuilder {
+        RemoveEntityMessage> implements RemoveEntityMessageOrBuilder {
     // Use RemoveEntityMessage.newBuilder() to construct.
     private RemoveEntityMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.RemoveEntityMessage, ?> builder) {
       super(builder);
@@ -24317,6 +25394,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional int32 netId = 1;
     public static final int NETID_FIELD_NUMBER = 1;
     private int netId_;
     /**
@@ -24338,8 +25416,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!extensionsAreInitialized()) {
         memoizedIsInitialized = 0;
@@ -24456,9 +25533,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.RemoveEntityMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:RemoveEntityMessage)
-        org.terasology.protobuf.NetData.RemoveEntityMessageOrBuilder {
+          org.terasology.protobuf.NetData.RemoveEntityMessage, Builder> implements org.terasology.protobuf.NetData.RemoveEntityMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_RemoveEntityMessage_descriptor;
@@ -24576,6 +25651,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional int32 netId = 1;
       private int netId_ ;
       /**
        * <code>optional int32 netId = 1;</code>
@@ -24620,10 +25696,10 @@ public final class NetData {
   }
 
   public interface EventMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:EventMessage)
       com.google.protobuf.GeneratedMessage.
           ExtendableMessageOrBuilder<EventMessage> {
 
+    // optional int32 targetId = 1;
     /**
      * <code>optional int32 targetId = 1;</code>
      */
@@ -24633,6 +25709,7 @@ public final class NetData {
      */
     int getTargetId();
 
+    // optional .Event event = 2;
     /**
      * <code>optional .Event event = 2;</code>
      */
@@ -24646,6 +25723,7 @@ public final class NetData {
      */
     org.terasology.protobuf.EntityData.EventOrBuilder getEventOrBuilder();
 
+    // optional .Vector3iData targetBlockPos = 3;
     /**
      * <code>optional .Vector3iData targetBlockPos = 3;</code>
      */
@@ -24664,9 +25742,7 @@ public final class NetData {
    */
   public static final class EventMessage extends
       com.google.protobuf.GeneratedMessage.ExtendableMessage<
-        EventMessage> implements
-      // @@protoc_insertion_point(message_implements:EventMessage)
-      EventMessageOrBuilder {
+        EventMessage> implements EventMessageOrBuilder {
     // Use EventMessage.newBuilder() to construct.
     private EventMessage(com.google.protobuf.GeneratedMessage.ExtendableBuilder<org.terasology.protobuf.NetData.EventMessage, ?> builder) {
       super(builder);
@@ -24783,6 +25859,7 @@ public final class NetData {
     }
 
     private int bitField0_;
+    // optional int32 targetId = 1;
     public static final int TARGETID_FIELD_NUMBER = 1;
     private int targetId_;
     /**
@@ -24798,6 +25875,7 @@ public final class NetData {
       return targetId_;
     }
 
+    // optional .Event event = 2;
     public static final int EVENT_FIELD_NUMBER = 2;
     private org.terasology.protobuf.EntityData.Event event_;
     /**
@@ -24819,6 +25897,7 @@ public final class NetData {
       return event_;
     }
 
+    // optional .Vector3iData targetBlockPos = 3;
     public static final int TARGETBLOCKPOS_FIELD_NUMBER = 3;
     private org.terasology.protobuf.NetData.Vector3iData targetBlockPos_;
     /**
@@ -24848,8 +25927,7 @@ public final class NetData {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (hasEvent()) {
         if (!getEvent().isInitialized()) {
@@ -24986,9 +26064,7 @@ public final class NetData {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.ExtendableBuilder<
-          org.terasology.protobuf.NetData.EventMessage, Builder> implements
-        // @@protoc_insertion_point(builder_implements:EventMessage)
-        org.terasology.protobuf.NetData.EventMessageOrBuilder {
+          org.terasology.protobuf.NetData.EventMessage, Builder> implements org.terasology.protobuf.NetData.EventMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return org.terasology.protobuf.NetData.internal_static_EventMessage_descriptor;
@@ -25148,6 +26224,7 @@ public final class NetData {
       }
       private int bitField0_;
 
+      // optional int32 targetId = 1;
       private int targetId_ ;
       /**
        * <code>optional int32 targetId = 1;</code>
@@ -25180,6 +26257,7 @@ public final class NetData {
         return this;
       }
 
+      // optional .Event event = 2;
       private org.terasology.protobuf.EntityData.Event event_ = org.terasology.protobuf.EntityData.Event.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.EntityData.Event, org.terasology.protobuf.EntityData.Event.Builder, org.terasology.protobuf.EntityData.EventOrBuilder> eventBuilder_;
@@ -25288,7 +26366,7 @@ public final class NetData {
         if (eventBuilder_ == null) {
           eventBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.EntityData.Event, org.terasology.protobuf.EntityData.Event.Builder, org.terasology.protobuf.EntityData.EventOrBuilder>(
-                  getEvent(),
+                  event_,
                   getParentForChildren(),
                   isClean());
           event_ = null;
@@ -25296,6 +26374,7 @@ public final class NetData {
         return eventBuilder_;
       }
 
+      // optional .Vector3iData targetBlockPos = 3;
       private org.terasology.protobuf.NetData.Vector3iData targetBlockPos_ = org.terasology.protobuf.NetData.Vector3iData.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder> targetBlockPosBuilder_;
@@ -25404,7 +26483,7 @@ public final class NetData {
         if (targetBlockPosBuilder_ == null) {
           targetBlockPosBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.terasology.protobuf.NetData.Vector3iData, org.terasology.protobuf.NetData.Vector3iData.Builder, org.terasology.protobuf.NetData.Vector3iDataOrBuilder>(
-                  getTargetBlockPos(),
+                  targetBlockPos_,
                   getParentForChildren(),
                   isClean());
           targetBlockPos_ = null;
@@ -25423,142 +26502,147 @@ public final class NetData {
     // @@protoc_insertion_point(class_scope:EventMessage)
   }
 
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_NetMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_NetMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_HandshakeHello_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_HandshakeHello_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_NewIdentityRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_NewIdentityRequest_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ProvisionIdentity_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ProvisionIdentity_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_CertificateSet_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_CertificateSet_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_HandshakeVerification_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_HandshakeVerification_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Certificate_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Certificate_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_BlockFamilyRegisteredMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_BlockFamilyRegisteredMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_InvalidateChunkMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_InvalidateChunkMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_BlockChangeMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_BlockChangeMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_BiomeChangeMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_BiomeChangeMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_ExtraDataChangeMessage_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_ExtraDataChangeMessage_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Vector3iData_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Vector3iData_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ServerInfoRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ServerInfoRequest_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_JoinMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_JoinMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_Color_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_Color_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_JoinCompleteMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_JoinCompleteMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ServerInfoMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ServerInfoMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_WorldInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_WorldInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_SerializationInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_SerializationInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ModuleInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ModuleInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ModuleRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ModuleRequest_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ModuleDataHeader_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ModuleDataHeader_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ModuleData_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ModuleData_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ModuleSendError_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_ModuleSendError_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_CreateEntityMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_CreateEntityMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_UpdateEntityMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_UpdateEntityMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_RemoveEntityMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_RemoveEntityMessage_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_EventMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -25572,7 +26656,7 @@ public final class NetData {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\020NetMessage.proto\032\020EntityData.proto\"\377\006\n" +
+      "\n\020NetMessage.proto\032\020EntityData.proto\"\261\007\n" +
       "\nNetMessage\022\036\n\tchunkInfo\030\002 \003(\0132\013.ChunkSt" +
       "ore\0220\n\017invalidateChunk\030\003 \003(\0132\027.Invalidat" +
       "eChunkMessage\022(\n\013blockChange\030\004 \003(\0132\023.Blo" +
@@ -25581,262 +26665,270 @@ public final class NetData {
       "\0132\024.RemoveEntityMessage\022*\n\014updateEntity\030" +
       "\007 \003(\0132\024.UpdateEntityMessage\022\034\n\005event\030\010 \003" +
       "(\0132\r.EventMessage\022\014\n\004time\030\t \001(\003\022(\n\013biome" +
-      "Change\030\n \003(\0132\023.BiomeChangeMessage\022-\n\021ser",
-      "verInfoRequest\030\017 \001(\0132\022.ServerInfoRequest" +
-      "\022&\n\nserverInfo\030\020 \001(\0132\022.ServerInfoMessage" +
-      "\022<\n\025blockFamilyRegistered\030\021 \003(\0132\035.BlockF" +
-      "amilyRegisteredMessage\022\032\n\004join\030\022 \001(\0132\014.J" +
-      "oinMessage\022%\n\rmoduleRequest\030\023 \003(\0132\016.Modu" +
-      "leRequest\022+\n\020moduleDataHeader\030\024 \001(\0132\021.Mo" +
-      "duleDataHeader\022\037\n\nmoduleData\030\025 \001(\0132\013.Mod" +
-      "uleData\022*\n\014joinComplete\030\026 \001(\0132\024.JoinComp" +
-      "leteMessage\022\'\n\016handshakeHello\030d \001(\0132\017.Ha" +
-      "ndshakeHello\022/\n\022newIdentityRequest\030e \001(\013",
-      "2\023.NewIdentityRequest\022-\n\021provisionIdenti" +
-      "ty\030f \001(\0132\022.ProvisionIdentity\0225\n\025handshak" +
-      "eVerification\030g \001(\0132\026.HandshakeVerificat" +
-      "ion*\t\010\210\'\020\200\200\200\200\002\"a\n\016HandshakeHello\022\016\n\006rand" +
-      "om\030\001 \001(\014\022!\n\013certificate\030\002 \001(\0132\014.Certific" +
-      "ate\022\021\n\ttimestamp\030\003 \001(\022*\t\010\210\'\020\200\200\200\200\002\"H\n\022New" +
-      "IdentityRequest\022\027\n\017preMasterSecret\030\001 \001(\014" +
-      "\022\016\n\006random\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"=\n\021Provision" +
-      "Identity\022\035\n\025encryptedCertificates\030\001 \001(\014*" +
-      "\t\010\210\'\020\200\200\200\200\002\"]\n\016CertificateSet\022\'\n\021publicCe",
-      "rtificate\030\001 \001(\0132\014.Certificate\022\027\n\017private" +
-      "Exponent\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"5\n\025HandshakeVe" +
-      "rification\022\021\n\tsignature\030\001 \001(\014*\t\010\210\'\020\200\200\200\200\002" +
-      "\"Z\n\013Certificate\022\n\n\002id\030\001 \001(\t\022\017\n\007modulus\030\002" +
-      " \001(\014\022\020\n\010exponent\030\003 \001(\014\022\021\n\tsignature\030\004 \001(" +
-      "\014*\t\010\210\'\020\200\200\200\200\002\"L\n\034BlockFamilyRegisteredMes" +
-      "sage\022\020\n\010blockUri\030\001 \003(\t\022\017\n\007blockId\030\002 \003(\005*" +
-      "\t\010\210\'\020\200\200\200\200\002\"?\n\026InvalidateChunkMessage\022\032\n\003" +
-      "pos\030\001 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002\"M\n\022B" +
-      "lockChangeMessage\022\032\n\003pos\030\001 \001(\0132\r.Vector3",
-      "iData\022\020\n\010newBlock\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"M\n\022Bi" +
-      "omeChangeMessage\022\032\n\003pos\030\001 \001(\0132\r.Vector3i" +
-      "Data\022\020\n\010newBiome\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/\n\014Vec" +
-      "tor3iData\022\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\022\t\n\001z\030\003 \001" +
-      "(\005\"\036\n\021ServerInfoRequest*\t\010\210\'\020\200\200\200\200\002\"i\n\013Jo" +
-      "inMessage\022\014\n\004name\030\001 \001(\t\022\017\n\007version\030\002 \001(\t" +
-      "\022\031\n\021viewDistanceLevel\030\003 \001(\021\022\025\n\005color\030\004 \001" +
-      "(\0132\006.Color*\t\010\210\'\020\200\200\200\200\002\"\025\n\005Color\022\014\n\004rgba\030\001" +
-      " \001(\r\"2\n\023JoinCompleteMessage\022\020\n\010clientId\030" +
-      "\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"\307\003\n\021ServerInfoMessage\022\033",
-      "\n\006module\030\001 \003(\0132\013.ModuleInfo\022\023\n\007blockId\030\002" +
-      " \003(\021B\002\020\001\022\021\n\tblockName\030\003 \003(\t\022%\n\tcomponent" +
-      "\030\004 \003(\0132\022.SerializationInfo\022!\n\005event\030\005 \003(" +
-      "\0132\022.SerializationInfo\022\023\n\007assetId\030\006 \003(\005B\002" +
-      "\020\001\022\020\n\010assetUri\030\007 \003(\t\022\033\n\023registerBlockFam" +
-      "ily\030\010 \003(\t\022\035\n\tworldInfo\030\t \003(\0132\n.WorldInfo" +
-      "\022\030\n\014biomeShortId\030\n \003(\021B\002\020\001\022\017\n\007biomeId\030\013 " +
-      "\003(\t\022\024\n\014errorMessage\030\014 \001(\t\022\017\n\007version\030\017 \001" +
-      "(\t\022\020\n\010gameName\030\020 \001(\t\022\014\n\004time\030\021 \001(\003\022\030\n\020re" +
-      "flectionHeight\030\022 \001(\002\022\014\n\004MOTD\030\023 \001(\t\022\033\n\023on",
-      "linePlayersAmount\030\024 \001(\005*\t\010\210\'\020\200\200\200\200\002\"3\n\tWo" +
-      "rldInfo\022\r\n\005title\030\001 \001(\t\022\014\n\004time\030\002 \001(\003*\t\010\210" +
-      "\'\020\200\200\200\200\002\"]\n\021SerializationInfo\022\014\n\004name\030\001 \001" +
-      "(\t\022\n\n\002id\030\002 \001(\005\022\021\n\tfieldName\030\003 \003(\t\022\020\n\010fie" +
-      "ldIds\030\004 \001(\014*\t\010\210\'\020\200\200\200\200\002\"@\n\nModuleInfo\022\020\n\010" +
-      "moduleId\030\001 \001(\t\022\025\n\rmoduleVersion\030\002 \001(\t*\t\010" +
-      "\210\'\020\200\200\200\200\002\",\n\rModuleRequest\022\020\n\010moduleId\030\001 " +
-      "\001(\t*\t\010\210\'\020\200\200\200\200\002\"W\n\020ModuleDataHeader\022\n\n\002id" +
-      "\030\001 \001(\t\022\017\n\007version\030\002 \001(\t\022\014\n\004size\030\003 \001(\003\022\r\n" +
-      "\005error\030\017 \001(\t*\t\010\210\'\020\200\200\200\200\002\"\'\n\nModuleData\022\016\n",
-      "\006module\030\001 \001(\014*\t\010\210\'\020\200\200\200\200\002\"-\n\017ModuleSendEr" +
-      "ror\022\017\n\007message\030\001 \001(\t*\t\010\210\'\020\200\200\200\200\002\"`\n\023Creat" +
-      "eEntityMessage\022\035\n\006entity\030\001 \001(\0132\r.PackedE" +
-      "ntity\022\037\n\010blockPos\030\002 \001(\0132\r.Vector3iData*\t" +
-      "\010\210\'\020\200\200\200\200\002\"N\n\023UpdateEntityMessage\022\035\n\006enti" +
-      "ty\030\001 \001(\0132\r.PackedEntity\022\r\n\005netId\030\002 \001(\005*\t" +
-      "\010\210\'\020\200\200\200\200\002\"/\n\023RemoveEntityMessage\022\r\n\005netI" +
-      "d\030\001 \001(\005*\t\010\210\'\020\200\200\200\200\002\"i\n\014EventMessage\022\020\n\010ta" +
-      "rgetId\030\001 \001(\005\022\025\n\005event\030\002 \001(\0132\006.Event\022%\n\016t" +
-      "argetBlockPos\030\003 \001(\0132\r.Vector3iData*\t\010\210\'\020",
-      "\200\200\200\200\002B$\n\027org.terasology.protobufB\007NetDat" +
-      "aH\001"
+      "Change\030\n \003(\0132\023.BiomeChangeMessage\0220\n\017ext",
+      "raDataChange\030\013 \003(\0132\027.ExtraDataChangeMess" +
+      "age\022-\n\021serverInfoRequest\030\017 \001(\0132\022.ServerI" +
+      "nfoRequest\022&\n\nserverInfo\030\020 \001(\0132\022.ServerI" +
+      "nfoMessage\022<\n\025blockFamilyRegistered\030\021 \003(" +
+      "\0132\035.BlockFamilyRegisteredMessage\022\032\n\004join" +
+      "\030\022 \001(\0132\014.JoinMessage\022%\n\rmoduleRequest\030\023 " +
+      "\003(\0132\016.ModuleRequest\022+\n\020moduleDataHeader\030" +
+      "\024 \001(\0132\021.ModuleDataHeader\022\037\n\nmoduleData\030\025" +
+      " \001(\0132\013.ModuleData\022*\n\014joinComplete\030\026 \001(\0132" +
+      "\024.JoinCompleteMessage\022\'\n\016handshakeHello\030",
+      "d \001(\0132\017.HandshakeHello\022/\n\022newIdentityReq" +
+      "uest\030e \001(\0132\023.NewIdentityRequest\022-\n\021provi" +
+      "sionIdentity\030f \001(\0132\022.ProvisionIdentity\0225" +
+      "\n\025handshakeVerification\030g \001(\0132\026.Handshak" +
+      "eVerification*\t\010\210\'\020\200\200\200\200\002\"a\n\016HandshakeHel" +
+      "lo\022\016\n\006random\030\001 \001(\014\022!\n\013certificate\030\002 \001(\0132" +
+      "\014.Certificate\022\021\n\ttimestamp\030\003 \001(\022*\t\010\210\'\020\200\200" +
+      "\200\200\002\"H\n\022NewIdentityRequest\022\027\n\017preMasterSe" +
+      "cret\030\001 \001(\014\022\016\n\006random\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"=\n" +
+      "\021ProvisionIdentity\022\035\n\025encryptedCertifica",
+      "tes\030\001 \001(\014*\t\010\210\'\020\200\200\200\200\002\"]\n\016CertificateSet\022\'" +
+      "\n\021publicCertificate\030\001 \001(\0132\014.Certificate\022" +
+      "\027\n\017privateExponent\030\002 \001(\014*\t\010\210\'\020\200\200\200\200\002\"5\n\025H" +
+      "andshakeVerification\022\021\n\tsignature\030\001 \001(\014*" +
+      "\t\010\210\'\020\200\200\200\200\002\"Z\n\013Certificate\022\n\n\002id\030\001 \001(\t\022\017\n" +
+      "\007modulus\030\002 \001(\014\022\020\n\010exponent\030\003 \001(\014\022\021\n\tsign" +
+      "ature\030\004 \001(\014*\t\010\210\'\020\200\200\200\200\002\"L\n\034BlockFamilyReg" +
+      "isteredMessage\022\020\n\010blockUri\030\001 \003(\t\022\017\n\007bloc" +
+      "kId\030\002 \003(\005*\t\010\210\'\020\200\200\200\200\002\"?\n\026InvalidateChunkM" +
+      "essage\022\032\n\003pos\030\001 \001(\0132\r.Vector3iData*\t\010\210\'\020",
+      "\200\200\200\200\002\"M\n\022BlockChangeMessage\022\032\n\003pos\030\001 \001(\013" +
+      "2\r.Vector3iData\022\020\n\010newBlock\030\002 \001(\005*\t\010\210\'\020\200" +
+      "\200\200\200\002\"M\n\022BiomeChangeMessage\022\032\n\003pos\030\001 \001(\0132" +
+      "\r.Vector3iData\022\020\n\010newBiome\030\002 \001(\005*\t\010\210\'\020\200\200" +
+      "\200\200\002\"_\n\026ExtraDataChangeMessage\022\r\n\005index\030\001" +
+      " \001(\005\022\032\n\003pos\030\002 \001(\0132\r.Vector3iData\022\017\n\007newD" +
+      "ata\030\003 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/\n\014Vector3iData\022\t\n\001" +
+      "x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\022\t\n\001z\030\003 \001(\005\"\036\n\021ServerI" +
+      "nfoRequest*\t\010\210\'\020\200\200\200\200\002\"i\n\013JoinMessage\022\014\n\004" +
+      "name\030\001 \001(\t\022\017\n\007version\030\002 \001(\t\022\031\n\021viewDista",
+      "nceLevel\030\003 \001(\021\022\025\n\005color\030\004 \001(\0132\006.Color*\t\010" +
+      "\210\'\020\200\200\200\200\002\"\025\n\005Color\022\014\n\004rgba\030\001 \001(\r\"2\n\023JoinC" +
+      "ompleteMessage\022\020\n\010clientId\030\001 \001(\005*\t\010\210\'\020\200\200" +
+      "\200\200\002\"\307\003\n\021ServerInfoMessage\022\033\n\006module\030\001 \003(" +
+      "\0132\013.ModuleInfo\022\023\n\007blockId\030\002 \003(\021B\002\020\001\022\021\n\tb" +
+      "lockName\030\003 \003(\t\022%\n\tcomponent\030\004 \003(\0132\022.Seri" +
+      "alizationInfo\022!\n\005event\030\005 \003(\0132\022.Serializa" +
+      "tionInfo\022\023\n\007assetId\030\006 \003(\005B\002\020\001\022\020\n\010assetUr" +
+      "i\030\007 \003(\t\022\033\n\023registerBlockFamily\030\010 \003(\t\022\035\n\t" +
+      "worldInfo\030\t \003(\0132\n.WorldInfo\022\030\n\014biomeShor",
+      "tId\030\n \003(\021B\002\020\001\022\017\n\007biomeId\030\013 \003(\t\022\024\n\014errorM" +
+      "essage\030\014 \001(\t\022\017\n\007version\030\017 \001(\t\022\020\n\010gameNam" +
+      "e\030\020 \001(\t\022\014\n\004time\030\021 \001(\003\022\030\n\020reflectionHeigh" +
+      "t\030\022 \001(\002\022\014\n\004MOTD\030\023 \001(\t\022\033\n\023onlinePlayersAm" +
+      "ount\030\024 \001(\005*\t\010\210\'\020\200\200\200\200\002\"3\n\tWorldInfo\022\r\n\005ti" +
+      "tle\030\001 \001(\t\022\014\n\004time\030\002 \001(\003*\t\010\210\'\020\200\200\200\200\002\"]\n\021Se" +
+      "rializationInfo\022\014\n\004name\030\001 \001(\t\022\n\n\002id\030\002 \001(" +
+      "\005\022\021\n\tfieldName\030\003 \003(\t\022\020\n\010fieldIds\030\004 \001(\014*\t" +
+      "\010\210\'\020\200\200\200\200\002\"@\n\nModuleInfo\022\020\n\010moduleId\030\001 \001(" +
+      "\t\022\025\n\rmoduleVersion\030\002 \001(\t*\t\010\210\'\020\200\200\200\200\002\",\n\rM",
+      "oduleRequest\022\020\n\010moduleId\030\001 \001(\t*\t\010\210\'\020\200\200\200\200" +
+      "\002\"W\n\020ModuleDataHeader\022\n\n\002id\030\001 \001(\t\022\017\n\007ver" +
+      "sion\030\002 \001(\t\022\014\n\004size\030\003 \001(\003\022\r\n\005error\030\017 \001(\t*" +
+      "\t\010\210\'\020\200\200\200\200\002\"\'\n\nModuleData\022\016\n\006module\030\001 \001(\014" +
+      "*\t\010\210\'\020\200\200\200\200\002\"-\n\017ModuleSendError\022\017\n\007messag" +
+      "e\030\001 \001(\t*\t\010\210\'\020\200\200\200\200\002\"`\n\023CreateEntityMessag" +
+      "e\022\035\n\006entity\030\001 \001(\0132\r.PackedEntity\022\037\n\010bloc" +
+      "kPos\030\002 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002\"N\n\023" +
+      "UpdateEntityMessage\022\035\n\006entity\030\001 \001(\0132\r.Pa" +
+      "ckedEntity\022\r\n\005netId\030\002 \001(\005*\t\010\210\'\020\200\200\200\200\002\"/\n\023",
+      "RemoveEntityMessage\022\r\n\005netId\030\001 \001(\005*\t\010\210\'\020" +
+      "\200\200\200\200\002\"i\n\014EventMessage\022\020\n\010targetId\030\001 \001(\005\022" +
+      "\025\n\005event\030\002 \001(\0132\006.Event\022%\n\016targetBlockPos" +
+      "\030\003 \001(\0132\r.Vector3iData*\t\010\210\'\020\200\200\200\200\002B$\n\027org." +
+      "terasology.protobufB\007NetDataH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
+      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
+        public com.google.protobuf.ExtensionRegistry assignDescriptors(
+            com.google.protobuf.Descriptors.FileDescriptor root) {
+          descriptor = root;
+          internal_static_NetMessage_descriptor =
+            getDescriptor().getMessageTypes().get(0);
+          internal_static_NetMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_NetMessage_descriptor,
+              new java.lang.String[] { "ChunkInfo", "InvalidateChunk", "BlockChange", "CreateEntity", "RemoveEntity", "UpdateEntity", "Event", "Time", "BiomeChange", "ExtraDataChange", "ServerInfoRequest", "ServerInfo", "BlockFamilyRegistered", "Join", "ModuleRequest", "ModuleDataHeader", "ModuleData", "JoinComplete", "HandshakeHello", "NewIdentityRequest", "ProvisionIdentity", "HandshakeVerification", });
+          internal_static_HandshakeHello_descriptor =
+            getDescriptor().getMessageTypes().get(1);
+          internal_static_HandshakeHello_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_HandshakeHello_descriptor,
+              new java.lang.String[] { "Random", "Certificate", "Timestamp", });
+          internal_static_NewIdentityRequest_descriptor =
+            getDescriptor().getMessageTypes().get(2);
+          internal_static_NewIdentityRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_NewIdentityRequest_descriptor,
+              new java.lang.String[] { "PreMasterSecret", "Random", });
+          internal_static_ProvisionIdentity_descriptor =
+            getDescriptor().getMessageTypes().get(3);
+          internal_static_ProvisionIdentity_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ProvisionIdentity_descriptor,
+              new java.lang.String[] { "EncryptedCertificates", });
+          internal_static_CertificateSet_descriptor =
+            getDescriptor().getMessageTypes().get(4);
+          internal_static_CertificateSet_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_CertificateSet_descriptor,
+              new java.lang.String[] { "PublicCertificate", "PrivateExponent", });
+          internal_static_HandshakeVerification_descriptor =
+            getDescriptor().getMessageTypes().get(5);
+          internal_static_HandshakeVerification_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_HandshakeVerification_descriptor,
+              new java.lang.String[] { "Signature", });
+          internal_static_Certificate_descriptor =
+            getDescriptor().getMessageTypes().get(6);
+          internal_static_Certificate_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Certificate_descriptor,
+              new java.lang.String[] { "Id", "Modulus", "Exponent", "Signature", });
+          internal_static_BlockFamilyRegisteredMessage_descriptor =
+            getDescriptor().getMessageTypes().get(7);
+          internal_static_BlockFamilyRegisteredMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_BlockFamilyRegisteredMessage_descriptor,
+              new java.lang.String[] { "BlockUri", "BlockId", });
+          internal_static_InvalidateChunkMessage_descriptor =
+            getDescriptor().getMessageTypes().get(8);
+          internal_static_InvalidateChunkMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_InvalidateChunkMessage_descriptor,
+              new java.lang.String[] { "Pos", });
+          internal_static_BlockChangeMessage_descriptor =
+            getDescriptor().getMessageTypes().get(9);
+          internal_static_BlockChangeMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_BlockChangeMessage_descriptor,
+              new java.lang.String[] { "Pos", "NewBlock", });
+          internal_static_BiomeChangeMessage_descriptor =
+            getDescriptor().getMessageTypes().get(10);
+          internal_static_BiomeChangeMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_BiomeChangeMessage_descriptor,
+              new java.lang.String[] { "Pos", "NewBiome", });
+          internal_static_ExtraDataChangeMessage_descriptor =
+            getDescriptor().getMessageTypes().get(11);
+          internal_static_ExtraDataChangeMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ExtraDataChangeMessage_descriptor,
+              new java.lang.String[] { "Index", "Pos", "NewData", });
+          internal_static_Vector3iData_descriptor =
+            getDescriptor().getMessageTypes().get(12);
+          internal_static_Vector3iData_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Vector3iData_descriptor,
+              new java.lang.String[] { "X", "Y", "Z", });
+          internal_static_ServerInfoRequest_descriptor =
+            getDescriptor().getMessageTypes().get(13);
+          internal_static_ServerInfoRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ServerInfoRequest_descriptor,
+              new java.lang.String[] { });
+          internal_static_JoinMessage_descriptor =
+            getDescriptor().getMessageTypes().get(14);
+          internal_static_JoinMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_JoinMessage_descriptor,
+              new java.lang.String[] { "Name", "Version", "ViewDistanceLevel", "Color", });
+          internal_static_Color_descriptor =
+            getDescriptor().getMessageTypes().get(15);
+          internal_static_Color_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_Color_descriptor,
+              new java.lang.String[] { "Rgba", });
+          internal_static_JoinCompleteMessage_descriptor =
+            getDescriptor().getMessageTypes().get(16);
+          internal_static_JoinCompleteMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_JoinCompleteMessage_descriptor,
+              new java.lang.String[] { "ClientId", });
+          internal_static_ServerInfoMessage_descriptor =
+            getDescriptor().getMessageTypes().get(17);
+          internal_static_ServerInfoMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ServerInfoMessage_descriptor,
+              new java.lang.String[] { "Module", "BlockId", "BlockName", "Component", "Event", "AssetId", "AssetUri", "RegisterBlockFamily", "WorldInfo", "BiomeShortId", "BiomeId", "ErrorMessage", "Version", "GameName", "Time", "ReflectionHeight", "MOTD", "OnlinePlayersAmount", });
+          internal_static_WorldInfo_descriptor =
+            getDescriptor().getMessageTypes().get(18);
+          internal_static_WorldInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_WorldInfo_descriptor,
+              new java.lang.String[] { "Title", "Time", });
+          internal_static_SerializationInfo_descriptor =
+            getDescriptor().getMessageTypes().get(19);
+          internal_static_SerializationInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_SerializationInfo_descriptor,
+              new java.lang.String[] { "Name", "Id", "FieldName", "FieldIds", });
+          internal_static_ModuleInfo_descriptor =
+            getDescriptor().getMessageTypes().get(20);
+          internal_static_ModuleInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ModuleInfo_descriptor,
+              new java.lang.String[] { "ModuleId", "ModuleVersion", });
+          internal_static_ModuleRequest_descriptor =
+            getDescriptor().getMessageTypes().get(21);
+          internal_static_ModuleRequest_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ModuleRequest_descriptor,
+              new java.lang.String[] { "ModuleId", });
+          internal_static_ModuleDataHeader_descriptor =
+            getDescriptor().getMessageTypes().get(22);
+          internal_static_ModuleDataHeader_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ModuleDataHeader_descriptor,
+              new java.lang.String[] { "Id", "Version", "Size", "Error", });
+          internal_static_ModuleData_descriptor =
+            getDescriptor().getMessageTypes().get(23);
+          internal_static_ModuleData_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ModuleData_descriptor,
+              new java.lang.String[] { "Module", });
+          internal_static_ModuleSendError_descriptor =
+            getDescriptor().getMessageTypes().get(24);
+          internal_static_ModuleSendError_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_ModuleSendError_descriptor,
+              new java.lang.String[] { "Message", });
+          internal_static_CreateEntityMessage_descriptor =
+            getDescriptor().getMessageTypes().get(25);
+          internal_static_CreateEntityMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_CreateEntityMessage_descriptor,
+              new java.lang.String[] { "Entity", "BlockPos", });
+          internal_static_UpdateEntityMessage_descriptor =
+            getDescriptor().getMessageTypes().get(26);
+          internal_static_UpdateEntityMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_UpdateEntityMessage_descriptor,
+              new java.lang.String[] { "Entity", "NetId", });
+          internal_static_RemoveEntityMessage_descriptor =
+            getDescriptor().getMessageTypes().get(27);
+          internal_static_RemoveEntityMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_RemoveEntityMessage_descriptor,
+              new java.lang.String[] { "NetId", });
+          internal_static_EventMessage_descriptor =
+            getDescriptor().getMessageTypes().get(28);
+          internal_static_EventMessage_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_EventMessage_descriptor,
+              new java.lang.String[] { "TargetId", "Event", "TargetBlockPos", });
+          return null;
+        }
+      };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           org.terasology.protobuf.EntityData.getDescriptor(),
         }, assigner);
-    internal_static_NetMessage_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_NetMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_NetMessage_descriptor,
-        new java.lang.String[] { "ChunkInfo", "InvalidateChunk", "BlockChange", "CreateEntity", "RemoveEntity", "UpdateEntity", "Event", "Time", "BiomeChange", "ServerInfoRequest", "ServerInfo", "BlockFamilyRegistered", "Join", "ModuleRequest", "ModuleDataHeader", "ModuleData", "JoinComplete", "HandshakeHello", "NewIdentityRequest", "ProvisionIdentity", "HandshakeVerification", });
-    internal_static_HandshakeHello_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_HandshakeHello_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_HandshakeHello_descriptor,
-        new java.lang.String[] { "Random", "Certificate", "Timestamp", });
-    internal_static_NewIdentityRequest_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_NewIdentityRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_NewIdentityRequest_descriptor,
-        new java.lang.String[] { "PreMasterSecret", "Random", });
-    internal_static_ProvisionIdentity_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_ProvisionIdentity_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ProvisionIdentity_descriptor,
-        new java.lang.String[] { "EncryptedCertificates", });
-    internal_static_CertificateSet_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_CertificateSet_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_CertificateSet_descriptor,
-        new java.lang.String[] { "PublicCertificate", "PrivateExponent", });
-    internal_static_HandshakeVerification_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_HandshakeVerification_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_HandshakeVerification_descriptor,
-        new java.lang.String[] { "Signature", });
-    internal_static_Certificate_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_Certificate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Certificate_descriptor,
-        new java.lang.String[] { "Id", "Modulus", "Exponent", "Signature", });
-    internal_static_BlockFamilyRegisteredMessage_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_BlockFamilyRegisteredMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_BlockFamilyRegisteredMessage_descriptor,
-        new java.lang.String[] { "BlockUri", "BlockId", });
-    internal_static_InvalidateChunkMessage_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_InvalidateChunkMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_InvalidateChunkMessage_descriptor,
-        new java.lang.String[] { "Pos", });
-    internal_static_BlockChangeMessage_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_BlockChangeMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_BlockChangeMessage_descriptor,
-        new java.lang.String[] { "Pos", "NewBlock", });
-    internal_static_BiomeChangeMessage_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_BiomeChangeMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_BiomeChangeMessage_descriptor,
-        new java.lang.String[] { "Pos", "NewBiome", });
-    internal_static_Vector3iData_descriptor =
-      getDescriptor().getMessageTypes().get(11);
-    internal_static_Vector3iData_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Vector3iData_descriptor,
-        new java.lang.String[] { "X", "Y", "Z", });
-    internal_static_ServerInfoRequest_descriptor =
-      getDescriptor().getMessageTypes().get(12);
-    internal_static_ServerInfoRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ServerInfoRequest_descriptor,
-        new java.lang.String[] { });
-    internal_static_JoinMessage_descriptor =
-      getDescriptor().getMessageTypes().get(13);
-    internal_static_JoinMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_JoinMessage_descriptor,
-        new java.lang.String[] { "Name", "Version", "ViewDistanceLevel", "Color", });
-    internal_static_Color_descriptor =
-      getDescriptor().getMessageTypes().get(14);
-    internal_static_Color_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_Color_descriptor,
-        new java.lang.String[] { "Rgba", });
-    internal_static_JoinCompleteMessage_descriptor =
-      getDescriptor().getMessageTypes().get(15);
-    internal_static_JoinCompleteMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_JoinCompleteMessage_descriptor,
-        new java.lang.String[] { "ClientId", });
-    internal_static_ServerInfoMessage_descriptor =
-      getDescriptor().getMessageTypes().get(16);
-    internal_static_ServerInfoMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ServerInfoMessage_descriptor,
-        new java.lang.String[] { "Module", "BlockId", "BlockName", "Component", "Event", "AssetId", "AssetUri", "RegisterBlockFamily", "WorldInfo", "BiomeShortId", "BiomeId", "ErrorMessage", "Version", "GameName", "Time", "ReflectionHeight", "MOTD", "OnlinePlayersAmount", });
-    internal_static_WorldInfo_descriptor =
-      getDescriptor().getMessageTypes().get(17);
-    internal_static_WorldInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_WorldInfo_descriptor,
-        new java.lang.String[] { "Title", "Time", });
-    internal_static_SerializationInfo_descriptor =
-      getDescriptor().getMessageTypes().get(18);
-    internal_static_SerializationInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_SerializationInfo_descriptor,
-        new java.lang.String[] { "Name", "Id", "FieldName", "FieldIds", });
-    internal_static_ModuleInfo_descriptor =
-      getDescriptor().getMessageTypes().get(19);
-    internal_static_ModuleInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ModuleInfo_descriptor,
-        new java.lang.String[] { "ModuleId", "ModuleVersion", });
-    internal_static_ModuleRequest_descriptor =
-      getDescriptor().getMessageTypes().get(20);
-    internal_static_ModuleRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ModuleRequest_descriptor,
-        new java.lang.String[] { "ModuleId", });
-    internal_static_ModuleDataHeader_descriptor =
-      getDescriptor().getMessageTypes().get(21);
-    internal_static_ModuleDataHeader_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ModuleDataHeader_descriptor,
-        new java.lang.String[] { "Id", "Version", "Size", "Error", });
-    internal_static_ModuleData_descriptor =
-      getDescriptor().getMessageTypes().get(22);
-    internal_static_ModuleData_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ModuleData_descriptor,
-        new java.lang.String[] { "Module", });
-    internal_static_ModuleSendError_descriptor =
-      getDescriptor().getMessageTypes().get(23);
-    internal_static_ModuleSendError_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_ModuleSendError_descriptor,
-        new java.lang.String[] { "Message", });
-    internal_static_CreateEntityMessage_descriptor =
-      getDescriptor().getMessageTypes().get(24);
-    internal_static_CreateEntityMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_CreateEntityMessage_descriptor,
-        new java.lang.String[] { "Entity", "BlockPos", });
-    internal_static_UpdateEntityMessage_descriptor =
-      getDescriptor().getMessageTypes().get(25);
-    internal_static_UpdateEntityMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_UpdateEntityMessage_descriptor,
-        new java.lang.String[] { "Entity", "NetId", });
-    internal_static_RemoveEntityMessage_descriptor =
-      getDescriptor().getMessageTypes().get(26);
-    internal_static_RemoveEntityMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_RemoveEntityMessage_descriptor,
-        new java.lang.String[] { "NetId", });
-    internal_static_EventMessage_descriptor =
-      getDescriptor().getMessageTypes().get(27);
-    internal_static_EventMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_EventMessage_descriptor,
-        new java.lang.String[] { "TargetId", "Event", "TargetBlockPos", });
-    org.terasology.protobuf.EntityData.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -189,42 +189,42 @@ public interface ChunkView {
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param x
      * @param y
      * @param z
-     * @return The ith extra-data value at the given position
+     * @return The (index)th extra-data value at the given position
      */
-    int getExtraData(int i, int x, int y, int z);
+    int getExtraData(int index, int x, int y, int z);
     
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param pos
-     * @return The ith extra-data value at the given position
+     * @return The (index)th extra-data value at the given position
      */
-    int getExtraData(int i, Vector3i pos);
+    int getExtraData(int index, Vector3i pos);
     
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param x
      * @param y
      * @param z
      * @param value
      */
-    void setExtraData(int i, int x, int y, int z, int value);
+    void setExtraData(int index, int x, int y, int z, int value);
     
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param pos
      * @param value
      */
-    void setExtraData(int i, Vector3i pos, int value);
+    void setExtraData(int index, Vector3i pos, int value);
 
     /**
      * Converts a coordinate from view-space to world space.

--- a/engine/src/main/java/org/terasology/world/ChunkView.java
+++ b/engine/src/main/java/org/terasology/world/ChunkView.java
@@ -185,6 +185,46 @@ public interface ChunkView {
      * @param newState
      */
     void setLiquid(int x, int y, int z, LiquidData newState);
+    
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param i The index of the extra data field
+     * @param x
+     * @param y
+     * @param z
+     * @return The ith extra-data value at the given position
+     */
+    int getExtraData(int i, int x, int y, int z);
+    
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param i The index of the extra data field
+     * @param pos
+     * @return The ith extra-data value at the given position
+     */
+    int getExtraData(int i, Vector3i pos);
+    
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param i The index of the extra data field
+     * @param x
+     * @param y
+     * @param z
+     * @param value
+     */
+    void setExtraData(int i, int x, int y, int z, int value);
+    
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param i The index of the extra data field
+     * @param pos
+     * @param value
+     */
+    void setExtraData(int i, Vector3i pos, int value);
 
     /**
      * Converts a coordinate from view-space to world space.

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -104,5 +104,67 @@ public interface WorldProvider extends WorldProviderCore {
     byte getSunlight(Vector3i pos);
 
     byte getTotalLight(Vector3i pos);
-
+    
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param i The index of the extra data field
+     * @param pos
+     * @return The ith extra-data value at the given position
+     */
+    int getExtraData(int i, Vector3i pos);
+    
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param i The index of the extra data field
+     * @param x
+     * @param y
+     * @param z
+     * @param value
+     * @return The replaced value
+     */
+    int setExtraData(int i, int x, int y, int z, int value);
+    
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param fieldName The name of the extra-data field
+     * @param x
+     * @param y
+     * @param z
+     * @return The named extra-data value at the given position
+     */
+    int getExtraData(String fieldName, int x, int y, int z);
+    
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param fieldName The name of the extra-data field
+     * @param pos
+     * @return The named extra-data value at the given position
+     */
+    int getExtraData(String fieldName, Vector3i pos);
+    
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param fieldName The name of the extra-data field
+     * @param x
+     * @param y
+     * @param z
+     * @param value
+     * @return The replaced value
+     */
+    int setExtraData(String fieldName, int x, int y, int z, int value);
+    
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param fieldName The name of the extra-data field
+     * @param pos
+     * @param value
+     * @return The replaced value
+     */
+    int setExtraData(String fieldName, Vector3i pos, int value);
 }

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -108,23 +108,23 @@ public interface WorldProvider extends WorldProviderCore {
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param pos
-     * @return The ith extra-data value at the given position
+     * @return The (index)th extra-data value at the given position
      */
-    int getExtraData(int i, Vector3i pos);
+    int getExtraData(int index, Vector3i pos);
     
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param x
      * @param y
      * @param z
      * @param value
      * @return The replaced value
      */
-    int setExtraData(int i, int x, int y, int z, int value);
+    int setExtraData(int index, int x, int y, int z, int value);
     
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -160,44 +160,44 @@ public interface CoreChunk {
      * The given value is downcast from int to the appropriate type for the array. It is not
      * checked for overflow.
      *
-     * @param i     Index of the extra data array
+     * @param index Index of the extra data array
      * @param x     X offset from the corner of the chunk
      * @param y     Y offset from the corner of the chunk
      * @param z     Z offset from the corner of the chunk
      * @param value New value to set the block to
      */
-    void setExtraData(int i, int x, int y, int z, int value);
+    void setExtraData(int index, int x, int y, int z, int value);
     
     /**
      * Sets one of the per-block custom data values at a given position relative to the chunk.
      * The given value is downcast from int to the appropriate type for the array. It is not
      * checked for overflow.
      *
-     * @param i     Index of the extra data array
+     * @param index Index of the extra data array
      * @param pos   Position of the block relative to the corner of the chunk
      * @param value New value to set the block to
      */
-    void setExtraData(int i, BaseVector3i pos, int value);
+    void setExtraData(int index, BaseVector3i pos, int value);
     
     /**
      * Returns one of the per-block custom data values at a given position relative to the chunk.
      *
-     * @param i Index of the extra data array
-     * @param x X offset from the corner of the chunk
-     * @param y Y offset from the corner of the chunk
-     * @param z Z offset from the corner of the chunk
+     * @param index Index of the extra data array
+     * @param x     X offset from the corner of the chunk
+     * @param y     Y offset from the corner of the chunk
+     * @param z     Z offset from the corner of the chunk
      * @return Selected extra data value at the given location
      */
-    int getExtraData(int i, int x, int y, int z);
+    int getExtraData(int index, int x, int y, int z);
     
     /**
      * Returns one of the per-block custom data values at a given position relative to the chunk.
      *
-     * @param i     Index of the extra data array
+     * @param index Index of the extra data array
      * @param pos   Position of the block relative to the corner of the chunk
      * @return Selected extra data value at the given location
      */
-    int getExtraData(int i, BaseVector3i pos);
+    int getExtraData(int index, BaseVector3i pos);
 
     /**
      * Returns offset of this chunk to the world center (0:0:0), with one unit being one chunk.

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -29,6 +29,7 @@ import org.terasology.world.liquid.LiquidData;
  * <li>Chunk position</li>
  * <li>Block read/write</li>
  * <li>Liquid read/write</li>
+ * <li>Extra data read/write</li>
  * <li>Chunk to world position conversion</li>
  * <li>Chunk size and region</li>
  * <li>Locking</li>
@@ -153,6 +154,50 @@ public interface CoreChunk {
      * @return Liquid state currently assigned to the block
      */
     LiquidData getLiquid(int x, int y, int z);
+    
+    /**
+     * Sets one of the per-block custom data values at a given position relative to the chunk.
+     * The given value is downcast from int to the appropriate type for the array. It is not
+     * checked for overflow.
+     *
+     * @param i     Index of the extra data array
+     * @param x     X offset from the corner of the chunk
+     * @param y     Y offset from the corner of the chunk
+     * @param z     Z offset from the corner of the chunk
+     * @param value New value to set the block to
+     */
+    void setExtraData(int i, int x, int y, int z, int value);
+    
+    /**
+     * Sets one of the per-block custom data values at a given position relative to the chunk.
+     * The given value is downcast from int to the appropriate type for the array. It is not
+     * checked for overflow.
+     *
+     * @param i     Index of the extra data array
+     * @param pos   Position of the block relative to the corner of the chunk
+     * @param value New value to set the block to
+     */
+    void setExtraData(int i, BaseVector3i pos, int value);
+    
+    /**
+     * Returns one of the per-block custom data values at a given position relative to the chunk.
+     *
+     * @param i Index of the extra data array
+     * @param x X offset from the corner of the chunk
+     * @param y Y offset from the corner of the chunk
+     * @param z Z offset from the corner of the chunk
+     * @return Selected extra data value at the given location
+     */
+    int getExtraData(int i, int x, int y, int z);
+    
+    /**
+     * Returns one of the per-block custom data values at a given position relative to the chunk.
+     *
+     * @param i     Index of the extra data array
+     * @param pos   Position of the block relative to the corner of the chunk
+     * @return Selected extra data value at the given location
+     */
+    int getExtraData(int i, BaseVector3i pos);
 
     /**
      * Returns offset of this chunk to the world center (0:0:0), with one unit being one chunk.

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/ExtraBlockDataManager.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/ExtraBlockDataManager.java
@@ -67,6 +67,12 @@ public class ExtraBlockDataManager {
     private Map<String,Integer> slots;
     private TeraArray.Factory<? extends TeraArray>[] slotFactories;
     
+    // For testing purposes: don't add any fields.
+    public ExtraBlockDataManager() {
+        slots = new HashMap<>();
+        slotFactories = new TeraArray.Factory[0];
+    }
+    
     public ExtraBlockDataManager(Context context) {
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         Collection<Block> blocks = context.get(BlockManager.class).listRegisteredBlocks();

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/ExtraBlockDataManager.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/ExtraBlockDataManager.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.world.chunks.blockdata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.module.ModuleEnvironment;
+import org.terasology.module.sandbox.API;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Keeps track of the extra per-block storage fields which may be registered by mods for
+ * their own use. If multiple fields of the same size are registered for disjoint sets
+ * of blocks, they may be made aliases of the same field, to save space.
+ *
+ * To register extra data fields, annotate a class with @ExtraDataSystem, and include a
+ * public static method annotated with @RegisterExtraData which determines, for each block,
+ * whether the field is applicable for that block. For example:
+ *
+ * {@code
+ * @ExtraDataSystem
+ * public class ExampleExtraDataSystem {
+ *     @RegisterExtraData(name="exampleModule.grassNutrients", bitSize=8)
+ *     public static boolean shouldHaveNutrients(Block block) {
+ *         return block.isGrass();
+ *     }
+ *  }
+ *  }
+ */
+@API
+public class ExtraBlockDataManager {
+    private static final Logger logger = LoggerFactory.getLogger(ExtraBlockDataManager.class);
+    private static final Map<Integer,TeraArray.Factory<? extends TeraArray>> teraArrayFactories = new HashMap<>();
+    static {
+        teraArrayFactories.put(4, new TeraSparseArray4Bit.Factory());
+        teraArrayFactories.put(8, new TeraSparseArray8Bit.Factory());
+        teraArrayFactories.put(16,new TeraSparseArray16Bit.Factory());
+    }
+    
+    private Map<String,Integer> slots;
+    private TeraArray.Factory<? extends TeraArray>[] slotFactories;
+    
+    public ExtraBlockDataManager(Context context) {
+        ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
+        Collection<Block> blocks = context.get(BlockManager.class).listRegisteredBlocks();
+        
+        HashMap<Integer, HashMap<String, HashSet<Block>>> fieldss = new HashMap<>();
+        teraArrayFactories.forEach((size, fac) -> fieldss.put(size, new HashMap<>()));
+        
+        for (Class<?> type : environment.getTypesAnnotatedWith(ExtraDataSystem.class)) {
+            for (Method method : type.getMethods()) {
+                RegisterExtraData registerAnnotation = method.getAnnotation(RegisterExtraData.class);
+                if (registerAnnotation != null) {
+                    String errorType = validRegistrationMethod(method, registerAnnotation);
+                    if (errorType != null) {
+                        logger.error("Unable to register extra block data: "+errorType+" for {}.{}: should be \"public static boolean {}(Block block)\", and bitSize should be 4, 8 or 16.", type.getName(), method.getName(), method.getName());
+                        continue;
+                    }
+                    method.setAccessible(true);
+                    HashSet<Block> includedBlocks = new HashSet<>();
+                    for (Block block : blocks) {
+                        try {
+                            if ((boolean) method.invoke(null, block)) {
+                                includedBlocks.add(block);
+                            }
+                        } catch(IllegalAccessException e) {
+                            // This should not get to this point.
+                            throw new RuntimeException("Incorrect access modifier on register extra data method", e);
+                        } catch(InvocationTargetException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    fieldss.get(registerAnnotation.bitSize()).put(registerAnnotation.name(), includedBlocks);
+                }
+            }
+        }
+        
+        slots = new HashMap<>();
+        ArrayList<TeraArray.Factory<?>> tempSlotTypes = new ArrayList<>();
+        fieldss.forEach((size, fields) -> {
+            Graph disjointnessGraph = getDisjointnessGraph(fields);
+            ArrayList<ArrayList<String>> cliques = findCliqueCover(disjointnessGraph);
+            for (ArrayList<String> clique : cliques) {
+                for (String label : clique) {
+                    slots.put(label, tempSlotTypes.size());
+                }
+                tempSlotTypes.add(teraArrayFactories.get(size));
+            }
+        });
+        slotFactories = tempSlotTypes.toArray(new TeraArray.Factory<?>[0]);
+        String loggingOutput = "Extra data slots registered:";
+        boolean first = true;
+        for (Map.Entry<String, Integer> entry : slots.entrySet()) {
+            loggingOutput += (first ? " " : ", ") + entry.getKey() + " -> " + entry.getValue();
+            first = false;
+        }
+        logger.info(loggingOutput);
+    }
+    
+    private static String validRegistrationMethod(Method method, RegisterExtraData annotation) {
+        Class<?>[] argumentTypes = method.getParameterTypes();
+        return method.getReturnType() != boolean.class ? "incorrect return type" :
+               //! method.isAccessible() ? "method not accessible" :
+               ! teraArrayFactories.containsKey(annotation.bitSize()) ? "invalid bitSize" :
+               ! Modifier.isStatic(method.getModifiers()) ? "method not static" :
+               argumentTypes.length != 1 ? "arguments list has wrong length" :
+               argumentTypes[0] != Block.class ? "incorrect argument type" :
+               null;
+    }
+    
+    private static class Graph {
+        public String[] verts;
+        public HashMap<String, Set<String>> edges;
+        
+        public Graph(String[] verts, HashMap<String, Set<String>> edges) {
+            this.verts = verts;
+            this.edges = edges;
+        }
+        
+        public Graph(String[] verts) {
+            this.verts = verts;
+            this.edges = new HashMap<>();
+            for (String vert : verts) {
+                edges.put(vert, new HashSet());
+            }
+        }
+        
+        public Graph addEdge(String s0, String s1) {
+            edges.get(s0).add(s1);
+            edges.get(s1).add(s0);
+            return this;
+        }
+        
+        public Graph removeEdge(String s0, String s1) {
+            edges.get(s0).remove(s1);
+            edges.get(s1).remove(s0);
+            return this;
+        }
+        
+        // Creates a new graph containing the complement of the contraction of the complement.
+        public Graph ntract(String s0, String s1) {
+            int v0, v1 = -1;
+            for (int i=0; i<verts.length; i++) {
+                if (verts[i].equals(s0)) {
+                    v0 = i;
+                }
+                if (verts[i].equals(s1)) {
+                    v1 = i;
+                }
+            }
+            String[] newVerts = new String[verts.length-1];
+            System.arraycopy(verts, 0, newVerts, 0, v1);
+            System.arraycopy(verts, v1+1, newVerts, v1, verts.length-v1-1);
+            HashMap<String, Set<String>> newEdges = new HashMap<>();
+            for (String s : verts) {
+                newEdges.put(s, new HashSet<>(edges.get(s)));
+            }
+            newEdges.remove(s1);
+            Set<String> e0 = newEdges.get(s0);
+            Set<String> e1 = edges.get(s1);
+            for (String s2 : verts) {
+                if (e0.contains(s2) && !e1.contains(s2)) {
+                    e0.remove(s2);
+                    newEdges.get(s2).remove(s0);
+                }
+                if (e1.contains(s2)) {
+                    newEdges.get(s2).remove(s1);
+                }
+            }
+            return new Graph(newVerts, newEdges);
+        }
+        
+        public String toString() {
+            String result = "Graph:";
+            for (int i=0; i<verts.length; i++) {
+                result += " (" + verts[i] + " ->";
+                for (String v : edges.get(verts[i])) {
+                    result += " " + v;
+                }
+                result += ")";
+            }
+            return result;
+        }
+    }
+    
+    private static Graph getDisjointnessGraph(Map<String, HashSet<Block>> fields) {
+        Graph graph = new Graph(fields.keySet().toArray(new String[0]));
+        fields.forEach((name0, blockSet0) ->
+            fields.forEach((name1, blockSet1) -> {
+                if (name0.compareTo(name1) < 0 && isDisjoint(blockSet0, blockSet1)) {
+                    graph.addEdge(name0, name1);
+                }
+            })
+        );
+        return graph;
+    }
+    
+    private static <T> boolean isDisjoint(Set<T> s0, Set<T> s1) {
+        for (T t : s0) {
+            if (s1.contains(t)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    //This is exponential time, but the problem is known to be NP-hard in general and large cases are unlikely to come up.
+    private static ArrayList<ArrayList<String>> findCliqueCover(Graph graph) {
+        return findCliqueCover(graph, Integer.MAX_VALUE, "");
+    }
+    
+    private static ArrayList<ArrayList<String>> findCliqueCover(Graph graph, int bestSize, String tabs) {
+        verboseLog(tabs+"findCliqueCover up to "+bestSize+", "+graph.toString());
+        for (int i=0; i<graph.verts.length; i++) {
+            if (i >= bestSize-1) {
+                verboseLog(tabs+"giving up");
+                return null;
+            }
+            String v0 = graph.verts[i];
+            if (!graph.edges.get(v0).isEmpty()) {
+                verboseLog(tabs+"Selected vertex "+v0);
+                String v1 = graph.edges.get(v0).iterator().next();
+                ArrayList<ArrayList<String>> bestCover0 = findCliqueCover(graph.ntract(v0,v1), bestSize, tabs+"----");
+                int bestSize0 = bestCover0 == null ? bestSize : bestCover0.size();
+                graph.removeEdge(v0,v1);
+                ArrayList<ArrayList<String>> bestCover1 = findCliqueCover(graph, bestSize0, tabs+"    ");
+                graph.addEdge(v0,v1);
+                if (bestCover1 != null) {
+                    return bestCover1;
+                } else {
+                    if (bestCover0 != null) {
+                        bestCover0.get(i).add(v1);
+                    }
+                    return bestCover0;
+                }
+            }
+        }
+        verboseLog(tabs+"done, "+graph.verts.length);
+        ArrayList<ArrayList<String>> bestCover = new ArrayList<>();
+        for (int i=0; i<graph.verts.length; i++) {
+            ArrayList<String> singleton = new ArrayList<>();
+            singleton.add(graph.verts[i]);
+            bestCover.add(singleton);
+        }
+        return bestCover;
+    }
+    
+    // Log something, but only when this class is being tested.
+    private static void verboseLog(String string) {
+        //logger.info(string);
+    }
+    
+    /**
+     * Get the numerical index associated with the extra data field name.
+     * This numerical index is needed for most extra-data access methods.
+     */
+    public int getSlotNumber(String name) {
+        Integer index = slots.get(name);
+        if (index == null) {
+            throw new IllegalArgumentException("Extra-data name not registered: " + name);
+        }
+        return index;
+    }
+    
+    public TeraArray[] makeDataArrays(int sizeX, int sizeY, int sizeZ) {
+        TeraArray[] extraData = new TeraArray[slotFactories.length];
+        for (int i=0; i<extraData.length; i++) {
+            extraData[i] = slotFactories[i].create(sizeX, sizeY, sizeZ);
+        }
+        return extraData;
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/ExtraDataSystem.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/ExtraDataSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package org.terasology.world;
+package org.terasology.world.chunks.blockdata;
 
-import org.terasology.math.geom.Vector3i;
-import org.terasology.world.biomes.Biome;
-import org.terasology.world.block.Block;
+import org.terasology.module.sandbox.API;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
+ * Annotation for classes which register extra per-block data fields.
+ * Methods for this purpose must also be annotated with {@link org.terasology.world.chunks.blockdata.RegisterExtraData}.
  */
-public interface WorldChangeListener {
-
-    void onBlockChanged(Vector3i pos, Block newBlock, Block originalBlock);
-
-    void onBiomeChanged(Vector3i pos, Biome newBiome, Biome originalBiome);
-    
-    void onExtraDataChanged(int i, Vector3i pos, int newData, int oldData);
+@API
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ExtraDataSystem {
 }

--- a/engine/src/main/java/org/terasology/world/chunks/blockdata/RegisterExtraData.java
+++ b/engine/src/main/java/org/terasology/world/chunks/blockdata/RegisterExtraData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.world.chunks.blockdata;
+
+import org.terasology.module.sandbox.API;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for methods to register extra per-block data fields.
+ * These must be inside classes annotated with {@link org.terasology.world.chunks.blockdata.ExtraDataSystem}.
+ * The valid values for bitSize are 4, 8 and 16.
+ * The correct format is
+ * {@code
+ * @RegisterExtraData(name="exampleModule.grassNutrients", bitSize=8)
+ * public static boolean shouldHaveNutrients(Block block) {
+ *     return block.isGrass();
+ * }
+ * }.
+ */
+@API
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RegisterExtraData {
+    String name();
+    int bitSize();
+}

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -139,7 +139,7 @@ public class ChunkImpl implements Chunk {
     @Override
     public int getEstimatedMemoryConsumptionInBytes() {
         int extraDataSize = 0;
-        for (int i=0; i<extraData.length; i++) {
+        for (int i = 0; i < extraData.length; i++) {
             extraDataSize += extraData[i].getEstimatedMemoryConsumptionInBytes();
         }
         return blockData.getEstimatedMemoryConsumptionInBytes()
@@ -163,7 +163,9 @@ public class ChunkImpl implements Chunk {
         return blockManager.getBlock(id);
     }
 
-    // This could be made to check for and clear extraData fields as appropriate, but that could take an excessive amount of time, so whatever sets a block to something extraData sensitive should also initialise the extra data.
+    // This could be made to check for and clear extraData fields as appropriate,
+    // but that could take an excessive amount of time,
+    // so whatever sets a block to something extraData sensitive should also initialise the extra data.
     @Override
     public Block setBlock(int x, int y, int z, Block block) {
         if (blockData == blockDataSnapshot) {
@@ -386,7 +388,7 @@ public class ChunkImpl implements Chunk {
             int liquidSize = liquidData.getEstimatedMemoryConsumptionInBytes();
             int biomeSize = biomeData.getEstimatedMemoryConsumptionInBytes();
             int extraSize = 0;
-            for (int i=0; i<extraData.length; i++) {
+            for (int i = 0; i < extraData.length; i++) {
                 extraSize += extraData[i].getEstimatedMemoryConsumptionInBytes();
             }
             int totalSize = blocksSize + sunlightRegenSize + sunlightSize + lightSize + liquidSize + biomeSize + extraSize;
@@ -395,7 +397,7 @@ public class ChunkImpl implements Chunk {
             lightData = def.deflate(lightData);
             liquidData = def.deflate(liquidData);
             biomeData = def.deflate(biomeData);
-            for (int i=0; i<extraData.length; i++) {
+            for (int i = 0; i < extraData.length; i++) {
                 extraData[i] = def.deflate(extraData[i]);
             }
 
@@ -404,7 +406,7 @@ public class ChunkImpl implements Chunk {
             int liquidReduced = liquidData.getEstimatedMemoryConsumptionInBytes();
             int biomeReduced = biomeData.getEstimatedMemoryConsumptionInBytes();
             int extraReduced = 0;
-            for (int i=0; i<extraData.length; i++) {
+            for (int i = 0; i < extraData.length; i++) {
                 extraReduced += extraData[i].getEstimatedMemoryConsumptionInBytes();
             }
             int totalReduced = blocksReduced + sunlightRegenSize + sunlightSize + lightReduced + liquidReduced + biomeReduced + extraReduced;
@@ -441,7 +443,7 @@ public class ChunkImpl implements Chunk {
             lightData = def.deflate(lightData);
             liquidData = def.deflate(liquidData);
             biomeData = def.deflate(biomeData);
-            for (int i=0; i<extraData.length; i++) {
+            for (int i = 0; i < extraData.length; i++) {
                 extraData[i] = def.deflate(extraData[i]);
             }
             ChunkMonitor.fireChunkDeflated(this, oldSize, getEstimatedMemoryConsumptionInBytes());

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -298,26 +298,26 @@ public class ChunkImpl implements Chunk {
     }
     
     @Override
-    public int getExtraData(int i, int x, int y, int z) {
-        return extraData[i].get(x, y, z);
+    public int getExtraData(int index, int x, int y, int z) {
+        return extraData[index].get(x, y, z);
     }
     
     @Override
-    public int getExtraData(int i, BaseVector3i pos) {
-        return getExtraData(i, pos.x(), pos.y(), pos.z());
+    public int getExtraData(int index, BaseVector3i pos) {
+        return getExtraData(index, pos.x(), pos.y(), pos.z());
     }
     
     @Override
-    public void setExtraData(int i, int x, int y, int z, int value) {
-        if (extraDataSnapshots != null && extraData[i] == extraDataSnapshots[i]) {
-            extraData[i] = extraData[i].copy();
+    public void setExtraData(int index, int x, int y, int z, int value) {
+        if (extraDataSnapshots != null && extraData[index] == extraDataSnapshots[index]) {
+            extraData[index] = extraData[index].copy();
         }
-        extraData[i].set(x, y, z, value);
+        extraData[index].set(x, y, z, value);
     }
     
     @Override
-    public void setExtraData(int i, BaseVector3i pos, int value) {
-        setExtraData(i, pos.x(), pos.y(), pos.z(), value);
+    public void setExtraData(int index, BaseVector3i pos, int value) {
+        setExtraData(index, pos.x(), pos.y(), pos.z(), value);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -35,6 +35,7 @@ import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkBlockIterator;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.blockdata.TeraArray;
 import org.terasology.world.chunks.blockdata.TeraDenseArray16Bit;
 import org.terasology.world.chunks.blockdata.TeraDenseArray8Bit;
@@ -70,10 +71,12 @@ public class ChunkImpl implements Chunk {
 
     private TeraArray blockData;
     private volatile TeraArray blockDataSnapshot;
-    private TeraArray extraData;
-    private volatile TeraArray extraDataSnapshot;
+    private TeraArray liquidData;
+    private volatile TeraArray liquidDataSnapshot;
     private TeraArray biomeData;
     private volatile TeraArray biomeDataSnapshot;
+    private TeraArray[] extraData;
+    private volatile TeraArray[] extraDataSnapshots;
 
     private AABB aabb;
     private Region3i region;
@@ -88,23 +91,25 @@ public class ChunkImpl implements Chunk {
     private ChunkMesh pendingMesh;
     private boolean adjacentChunksReady;
 
-    public ChunkImpl(int x, int y, int z, BlockManager blockManager, BiomeManager biomeManager) {
-        this(new Vector3i(x, y, z), blockManager, biomeManager);
+    public ChunkImpl(int x, int y, int z, BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
+        this(new Vector3i(x, y, z), blockManager, biomeManager, extraDataManager);
     }
 
-    public ChunkImpl(Vector3i chunkPos, BlockManager blockManager, BiomeManager biomeManager) {
+    public ChunkImpl(Vector3i chunkPos, BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
         this(chunkPos, new TeraDenseArray16Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
                 new TeraDenseArray8Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
                 new TeraDenseArray8Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
+                extraDataManager.makeDataArrays(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
                 blockManager, biomeManager);
     }
 
-    public ChunkImpl(Vector3i chunkPos, TeraArray blocks, TeraArray liquid, TeraArray biome, BlockManager blockManager,
+    public ChunkImpl(Vector3i chunkPos, TeraArray blocks, TeraArray liquid, TeraArray biome, TeraArray[] extra, BlockManager blockManager,
                      BiomeManager biomeManager) {
         this.chunkPos.set(Preconditions.checkNotNull(chunkPos));
         this.blockData = Preconditions.checkNotNull(blocks);
-        this.extraData = Preconditions.checkNotNull(liquid);
+        this.liquidData = Preconditions.checkNotNull(liquid);
         this.biomeData = Preconditions.checkNotNull(biome);
+        this.extraData = Preconditions.checkNotNull(extra);
         sunlightData = new TeraDenseArray8Bit(getChunkSizeX(), getChunkSizeY(), getChunkSizeZ());
         sunlightRegenData = new TeraDenseArray8Bit(getChunkSizeX(), getChunkSizeY(), getChunkSizeZ());
         lightData = new TeraDenseArray8Bit(getChunkSizeX(), getChunkSizeY(), getChunkSizeZ());
@@ -133,12 +138,17 @@ public class ChunkImpl implements Chunk {
 
     @Override
     public int getEstimatedMemoryConsumptionInBytes() {
+        int extraDataSize = 0;
+        for (int i=0; i<extraData.length; i++) {
+            extraDataSize += extraData[i].getEstimatedMemoryConsumptionInBytes();
+        }
         return blockData.getEstimatedMemoryConsumptionInBytes()
                 + sunlightData.getEstimatedMemoryConsumptionInBytes()
                 + sunlightRegenData.getEstimatedMemoryConsumptionInBytes()
                 + lightData.getEstimatedMemoryConsumptionInBytes()
-                + extraData.getEstimatedMemoryConsumptionInBytes()
-                + biomeData.getEstimatedMemoryConsumptionInBytes();
+                + liquidData.getEstimatedMemoryConsumptionInBytes()
+                + biomeData.getEstimatedMemoryConsumptionInBytes()
+                + extraDataSize;
     }
 
     @Override
@@ -153,6 +163,7 @@ public class ChunkImpl implements Chunk {
         return blockManager.getBlock(id);
     }
 
+    // This could be made to check for and clear extraData fields as appropriate, but that could take an excessive amount of time, so whatever sets a block to something extraData sensitive should also initialise the extra data.
     @Override
     public Block setBlock(int x, int y, int z, Block block) {
         if (blockData == blockDataSnapshot) {
@@ -243,10 +254,10 @@ public class ChunkImpl implements Chunk {
     @Override
     public void setLiquid(int x, int y, int z, LiquidData newState) {
         byte newValue = newState.toByte();
-        if (extraData == extraDataSnapshot) {
-            extraData = extraData.copy();
+        if (liquidData == liquidDataSnapshot) {
+            liquidData = liquidData.copy();
         }
-        extraData.set(x, y, z, newValue);
+        liquidData.set(x, y, z, newValue);
     }
 
     @Override
@@ -256,7 +267,7 @@ public class ChunkImpl implements Chunk {
 
     @Override
     public LiquidData getLiquid(int x, int y, int z) {
-        return new LiquidData((byte) extraData.get(x, y, z));
+        return new LiquidData((byte) liquidData.get(x, y, z));
     }
 
     @Override
@@ -282,6 +293,29 @@ public class ChunkImpl implements Chunk {
     @Override
     public Biome setBiome(BaseVector3i pos, Biome biome) {
         return setBiome(pos.x(), pos.y(), pos.z(), biome);
+    }
+    
+    @Override
+    public int getExtraData(int i, int x, int y, int z) {
+        return extraData[i].get(x, y, z);
+    }
+    
+    @Override
+    public int getExtraData(int i, BaseVector3i pos) {
+        return getExtraData(i, pos.x(), pos.y(), pos.z());
+    }
+    
+    @Override
+    public void setExtraData(int i, int x, int y, int z, int value) {
+        if (extraDataSnapshots != null && extraData[i] == extraDataSnapshots[i]) {
+            extraData[i] = extraData[i].copy();
+        }
+        extraData[i].set(x, y, z, value);
+    }
+    
+    @Override
+    public void setExtraData(int i, BaseVector3i pos, int value) {
+        setExtraData(i, pos.x(), pos.y(), pos.z(), value);
     }
 
     @Override
@@ -349,25 +383,37 @@ public class ChunkImpl implements Chunk {
             int sunlightSize = sunlightData.getEstimatedMemoryConsumptionInBytes();
             int sunlightRegenSize = sunlightRegenData.getEstimatedMemoryConsumptionInBytes();
             int lightSize = lightData.getEstimatedMemoryConsumptionInBytes();
-            int liquidSize = extraData.getEstimatedMemoryConsumptionInBytes();
+            int liquidSize = liquidData.getEstimatedMemoryConsumptionInBytes();
             int biomeSize = biomeData.getEstimatedMemoryConsumptionInBytes();
-            int totalSize = blocksSize + sunlightRegenSize + sunlightSize + lightSize + liquidSize + biomeSize;
+            int extraSize = 0;
+            for (int i=0; i<extraData.length; i++) {
+                extraSize += extraData[i].getEstimatedMemoryConsumptionInBytes();
+            }
+            int totalSize = blocksSize + sunlightRegenSize + sunlightSize + lightSize + liquidSize + biomeSize + extraSize;
 
             blockData = def.deflate(blockData);
             lightData = def.deflate(lightData);
-            extraData = def.deflate(extraData);
+            liquidData = def.deflate(liquidData);
             biomeData = def.deflate(biomeData);
+            for (int i=0; i<extraData.length; i++) {
+                extraData[i] = def.deflate(extraData[i]);
+            }
 
             int blocksReduced = blockData.getEstimatedMemoryConsumptionInBytes();
             int lightReduced = lightData.getEstimatedMemoryConsumptionInBytes();
-            int liquidReduced = extraData.getEstimatedMemoryConsumptionInBytes();
+            int liquidReduced = liquidData.getEstimatedMemoryConsumptionInBytes();
             int biomeReduced = biomeData.getEstimatedMemoryConsumptionInBytes();
-            int totalReduced = blocksReduced + sunlightRegenSize + sunlightSize + lightReduced + liquidReduced + biomeReduced;
+            int extraReduced = 0;
+            for (int i=0; i<extraData.length; i++) {
+                extraReduced += extraData[i].getEstimatedMemoryConsumptionInBytes();
+            }
+            int totalReduced = blocksReduced + sunlightRegenSize + sunlightSize + lightReduced + liquidReduced + biomeReduced + extraReduced;
 
             double blocksPercent = 100d - (100d / blocksSize * blocksReduced);
             double lightPercent = 100d - (100d / lightSize * lightReduced);
             double liquidPercent = 100d - (100d / liquidSize * liquidReduced);
             double biomePercent = 100d - (100d / biomeSize * biomeReduced);
+            double extraPercent = 100d - (100d / extraSize * extraReduced);
             double totalPercent = 100d - (100d / totalSize * totalReduced);
 
             logger.debug("chunk {}: " +
@@ -377,7 +423,8 @@ public class ChunkImpl implements Chunk {
                             "blocks-deflated-by={}%, " +
                             "light-deflated-by={}%, " +
                             "liquid-deflated-by={}%, " +
-                            "biome-deflated-by={}%",
+                            "biome-deflated-by={}%, " +
+                            "extra-data-deflated-by={}%",
                     chunkPos,
                     SIZE_FORMAT.format(totalSize),
                     SIZE_FORMAT.format(totalReduced),
@@ -385,14 +432,18 @@ public class ChunkImpl implements Chunk {
                     PERCENT_FORMAT.format(blocksPercent),
                     PERCENT_FORMAT.format(lightPercent),
                     PERCENT_FORMAT.format(liquidPercent),
-                    PERCENT_FORMAT.format(biomePercent));
+                    PERCENT_FORMAT.format(biomePercent),
+                    PERCENT_FORMAT.format(extraPercent));
             ChunkMonitor.fireChunkDeflated(this, totalSize, totalReduced);
         } else {
             final int oldSize = getEstimatedMemoryConsumptionInBytes();
             blockData = def.deflate(blockData);
             lightData = def.deflate(lightData);
-            extraData = def.deflate(extraData);
+            liquidData = def.deflate(liquidData);
             biomeData = def.deflate(biomeData);
+            for (int i=0; i<extraData.length; i++) {
+                extraData[i] = def.deflate(extraData[i]);
+            }
             ChunkMonitor.fireChunkDeflated(this, oldSize, getEstimatedMemoryConsumptionInBytes());
         }
     }
@@ -405,7 +456,7 @@ public class ChunkImpl implements Chunk {
             int sunlightSize = sunlightData.getEstimatedMemoryConsumptionInBytes();
             int sunlightRegenSize = sunlightRegenData.getEstimatedMemoryConsumptionInBytes();
             int lightSize = lightData.getEstimatedMemoryConsumptionInBytes();
-            int liquidSize = extraData.getEstimatedMemoryConsumptionInBytes();
+            int liquidSize = liquidData.getEstimatedMemoryConsumptionInBytes();
             int totalSize = blocksSize + sunlightRegenSize + sunlightSize + lightSize + liquidSize;
 
             sunlightData = def.deflate(sunlightData);
@@ -569,7 +620,7 @@ public class ChunkImpl implements Chunk {
 
     @Override
     public EntityData.ChunkStore.Builder encode() {
-        return ChunkSerializer.encode(chunkPos, blockData, extraData, biomeData);
+        return ChunkSerializer.encode(chunkPos, blockData, liquidData, biomeData, extraData);
     }
 
     /**
@@ -578,8 +629,10 @@ public class ChunkImpl implements Chunk {
      */
     public void createSnapshot() {
         this.blockDataSnapshot = this.blockData;
-        this.extraDataSnapshot = this.extraData;
+        this.liquidDataSnapshot = this.liquidData;
         this.biomeDataSnapshot = this.biomeData;
+        this.extraDataSnapshots = new TeraArray[extraData.length];
+        System.arraycopy(extraData, 0, extraDataSnapshots, 0, extraData.length);
     }
 
     /**
@@ -591,10 +644,11 @@ public class ChunkImpl implements Chunk {
      * @return an encoded version of the snapshot taken with {@link #createSnapshot()}.
      */
     public EntityData.ChunkStore.Builder encodeAndReleaseSnapshot() {
-        EntityData.ChunkStore.Builder result = ChunkSerializer.encode(chunkPos, blockDataSnapshot, extraDataSnapshot, biomeDataSnapshot);
+        EntityData.ChunkStore.Builder result = ChunkSerializer.encode(chunkPos, blockDataSnapshot, liquidDataSnapshot, biomeDataSnapshot, extraDataSnapshots);
         this.blockDataSnapshot = null;
-        this.extraDataSnapshot = null;
+        this.liquidDataSnapshot = null;
         this.biomeDataSnapshot = null;
+        this.extraDataSnapshots = null;
         return result;
     }
 

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkSerializer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkSerializer.java
@@ -168,10 +168,10 @@ public final class ChunkSerializer {
         for (int y = 0; y < array.getSizeY(); ++y) {
             for (int z = 0; z < array.getSizeZ(); ++z) {
                 for (int x = 0; x < array.getSizeX(); ++x) {
-                    if (index >= data.getRunLengthsCount()) {
-                        break outer;
-                    }
                     if (count == 0) {
+                        if (index >= data.getRunLengthsCount()) {
+                            break outer;
+                        }
                         count = data.getRunLengths(index);
                         value = data.getValues(index);
                         index++;

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkSerializer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkSerializer.java
@@ -25,6 +25,7 @@ import org.terasology.world.biomes.BiomeManager;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.blockdata.TeraArray;
 import org.terasology.world.chunks.blockdata.TeraDenseArray16Bit;
 import org.terasology.world.chunks.blockdata.TeraDenseArray8Bit;
@@ -36,17 +37,20 @@ public final class ChunkSerializer {
     private ChunkSerializer() {
     }
 
-    public static EntityData.ChunkStore.Builder encode(Vector3i pos, TeraArray blockData, TeraArray liquidData, TeraArray biomeData) {
+    public static EntityData.ChunkStore.Builder encode(Vector3i pos, TeraArray blockData, TeraArray liquidData, TeraArray biomeData, TeraArray[] extraData) {
         final EntityData.ChunkStore.Builder b = EntityData.ChunkStore.newBuilder()
                 .setX(pos.x).setY(pos.y).setZ(pos.z);
         b.setBlockData(runLengthEncode16(blockData));
         b.setLiquidData(runLengthEncode8(liquidData));
         b.setBiomeData(runLengthEncode16(biomeData));
+        for (int i=0; i<extraData.length; i++) {
+            b.addExtraData(runLengthEncode16(extraData[i]));
+        }
 
         return b;
     }
 
-    public static Chunk decode(EntityData.ChunkStore message, BlockManager blockManager, BiomeManager biomeManager) {
+    public static Chunk decode(EntityData.ChunkStore message, BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
         Preconditions.checkNotNull(message, "The parameter 'message' must not be null");
         if (!message.hasX() || !message.hasY() || !message.hasZ()) {
             throw new IllegalArgumentException("Ill-formed protobuf message. Missing chunk position.");
@@ -62,7 +66,11 @@ public final class ChunkSerializer {
         final TeraArray blockData = runLengthDecode(message.getBlockData());
         final TeraArray liquidData = runLengthDecode(message.getLiquidData());
         final TeraArray biomeData = runLengthDecode(message.getBiomeData());
-        return new ChunkImpl(pos, blockData, liquidData, biomeData, blockManager, biomeManager);
+        final TeraArray[] extraData = extraDataManager.makeDataArrays(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z);
+        for (int i=0; i<extraData.length; i++) {
+            runLengthDecode(message.getExtraData(i), extraData[i]);
+        }
+        return new ChunkImpl(pos, blockData, liquidData, biomeData, extraData, blockManager, biomeManager);
     }
 
     private static EntityData.RunLengthEncoding16 runLengthEncode16(TeraArray array) {
@@ -146,5 +154,28 @@ public final class ChunkSerializer {
             }
         }
         return new TeraDenseArray8Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z, decodedData);
+    }
+    
+    private static void runLengthDecode(EntityData.RunLengthEncoding16 data, TeraArray array) {
+        int index = 0;
+        int count = 0;
+        int value = 0;
+        outer:
+        for (int y = 0; y < array.getSizeY(); ++y) {
+            for (int z = 0; z < array.getSizeZ(); ++z) {
+                for (int x = 0; x < array.getSizeX(); ++x) {
+                    if (index >= data.getRunLengthsCount()) {
+                        break outer;
+                    }
+                    if (count == 0) {
+                        count = data.getRunLengths(index);
+                        value = data.getValues(index);
+                        index++;
+                    }
+                    count--;
+                    array.set(x, y, z, value);
+                }
+            }
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkSerializer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkSerializer.java
@@ -43,7 +43,7 @@ public final class ChunkSerializer {
         b.setBlockData(runLengthEncode16(blockData));
         b.setLiquidData(runLengthEncode8(liquidData));
         b.setBiomeData(runLengthEncode16(biomeData));
-        for (int i=0; i<extraData.length; i++) {
+        for (int i = 0; i < extraData.length; i++) {
             b.addExtraData(runLengthEncode16(extraData[i]));
         }
 
@@ -67,7 +67,7 @@ public final class ChunkSerializer {
         final TeraArray liquidData = runLengthDecode(message.getLiquidData());
         final TeraArray biomeData = runLengthDecode(message.getBiomeData());
         final TeraArray[] extraData = extraDataManager.makeDataArrays(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z);
-        for (int i=0; i<extraData.length; i++) {
+        for (int i = 0; i < extraData.length; i++) {
             runLengthDecode(message.getExtraData(i), extraData[i]);
         }
         return new ChunkImpl(pos, blockData, liquidData, biomeData, extraData, blockManager, biomeManager);
@@ -156,6 +156,10 @@ public final class ChunkSerializer {
         return new TeraDenseArray8Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z, decodedData);
     }
     
+    /**
+     * Decode compressed data into an existing TeraArray.
+     * Generic w.r.t. TeraArray subclasses, allowing the data to be used for any type of TeraArray.
+     */
     private static void runLengthDecode(EntityData.RunLengthEncoding16 data, TeraArray array) {
         int index = 0;
         int count = 0;

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -53,6 +53,7 @@ import org.terasology.world.chunks.ChunkBlockIterator;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkRegionListener;
 import org.terasology.world.chunks.ManagedChunk;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.event.BeforeChunkUnload;
 import org.terasology.world.chunks.event.OnChunkGenerated;
 import org.terasology.world.chunks.event.OnChunkLoaded;
@@ -112,6 +113,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
 
     private BlockManager blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
     private final ChunkCache chunkCache;
     private final Supplier<ChunkFinalizer> chunkFinalizerSupplier;
     private BlockEntityRegistry registry;
@@ -120,25 +122,28 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
 
     //TODO Remove this old constructor at the end of the chunk overhaul
     public LocalChunkProvider(StorageManager storageManager, EntityManager entityManager, WorldGenerator generator,
-                              BlockManager blockManager, BiomeManager biomeManager) {
+                              BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager) {
         this(storageManager,
                 entityManager,
                 generator,
                 blockManager,
                 biomeManager,
+                extraDataManager,
                 new LightMergingChunkFinalizer(),
                 LightMergingChunkFinalizer::new,
                 new ConcurrentMapChunkCache());
     }
 
     LocalChunkProvider(StorageManager storageManager, EntityManager entityManager, WorldGenerator generator,
-                       BlockManager blockManager, BiomeManager biomeManager, ChunkFinalizer chunkFinalizer,
-                       Supplier<ChunkFinalizer> chunkFinalizerSupplier, ChunkCache chunkCache) {
+                       BlockManager blockManager, BiomeManager biomeManager, ExtraBlockDataManager extraDataManager,
+                       ChunkFinalizer chunkFinalizer, Supplier<ChunkFinalizer> chunkFinalizerSupplier,
+                       ChunkCache chunkCache) {
         this.storageManager = storageManager;
         this.entityManager = entityManager;
         this.generator = generator;
         this.blockManager = blockManager;
         this.biomeManager = biomeManager;
+        this.extraDataManager = extraDataManager;
         this.pipeline = new ChunkGenerationPipeline(new ChunkTaskRelevanceComparator());
         this.unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 4);
         this.chunkFinalizer = chunkFinalizer;
@@ -648,7 +653,7 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
                     Chunk chunk;
                     EntityBufferImpl buffer = new EntityBufferImpl();
                     if (chunkStore == null) {
-                        chunk = new ChunkImpl(getPosition(), blockManager, biomeManager);
+                        chunk = new ChunkImpl(getPosition(), blockManager, biomeManager, extraDataManager);
                         generator.createChunk(chunk, buffer);
                     } else {
                         chunk = chunkStore.getChunk();

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -143,13 +143,13 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     }
     
     @Override
-    public int getExtraData(int i, int x, int y, int z) {
-        return base.getExtraData(i, x, y, z);
+    public int getExtraData(int index, int x, int y, int z) {
+        return base.getExtraData(index, x, y, z);
     }
     
     @Override
-    public int setExtraData(int i, Vector3i pos, int value) {
-        return base.setExtraData(i, pos, value);
+    public int setExtraData(int index, Vector3i pos, int value) {
+        return base.setExtraData(index, pos, value);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -141,6 +141,16 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return base.getTotalLight(x, y, z);
     }
+    
+    @Override
+    public int getExtraData(int i, int x, int y, int z) {
+        return base.getExtraData(i, x, y, z);
+    }
+    
+    @Override
+    public int setExtraData(int i, Vector3i pos, int value) {
+        return base.setExtraData(i, pos, value);
+    }
 
     @Override
     public void dispose() {

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -240,6 +240,36 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     }
 
     @Override
+    public int getExtraData(int i, Vector3i pos) {
+        return getExtraData(i, pos.x, pos.y, pos.z);
+    }
+
+    @Override
+    public int getExtraData(int i, int blockX, int blockY, int blockZ) {
+        if (!blockRegion.encompasses(blockX, blockY, blockZ)) {
+            return 0;
+        }
+
+        int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
+        return chunks[chunkIndex].getExtraData(i, ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
+    }
+
+    @Override
+    public void setExtraData(int i, Vector3i pos, int value) {
+        setExtraData(i, pos.x, pos.y, pos.z, value);
+    }
+
+    @Override
+    public void setExtraData(int i, int blockX, int blockY, int blockZ, int value) {
+        if (blockRegion.encompasses(blockX, blockY, blockZ)) {
+            int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
+            chunks[chunkIndex].setExtraData(i, ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), value);
+        } else {
+            throw new IllegalStateException("Attempted to modify extra data though an unlocked view");
+        }
+    }
+
+    @Override
     public void setDirtyAround(Vector3i blockPos) {
         for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(blockPos, 1)) {
             chunks[pos.x + offset.x + chunkRegion.size().x * (pos.z + offset.z)].setDirty(true);

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -240,30 +240,30 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     }
 
     @Override
-    public int getExtraData(int i, Vector3i pos) {
-        return getExtraData(i, pos.x, pos.y, pos.z);
+    public int getExtraData(int index, Vector3i pos) {
+        return getExtraData(index, pos.x, pos.y, pos.z);
     }
 
     @Override
-    public int getExtraData(int i, int blockX, int blockY, int blockZ) {
+    public int getExtraData(int index, int blockX, int blockY, int blockZ) {
         if (!blockRegion.encompasses(blockX, blockY, blockZ)) {
             return 0;
         }
 
         int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getExtraData(i, ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
+        return chunks[chunkIndex].getExtraData(index, ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize));
     }
 
     @Override
-    public void setExtraData(int i, Vector3i pos, int value) {
-        setExtraData(i, pos.x, pos.y, pos.z, value);
+    public void setExtraData(int index, Vector3i pos, int value) {
+        setExtraData(index, pos.x, pos.y, pos.z, value);
     }
 
     @Override
-    public void setExtraData(int i, int blockX, int blockY, int blockZ, int value) {
+    public void setExtraData(int index, int blockX, int blockY, int blockZ, int value) {
         if (blockRegion.encompasses(blockX, blockY, blockZ)) {
             int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setExtraData(i, ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), value);
+            chunks[chunkIndex].setExtraData(index, ChunkMath.calcBlockPos(blockX, blockY, blockZ, chunkFilterSize), value);
         } else {
             throw new IllegalStateException("Attempted to modify extra data though an unlocked view");
         }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -197,23 +197,23 @@ public interface WorldProviderCore {
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param x
      * @param y
      * @param z
-     * @return The ith extra-data value at the given position
+     * @return The (index)th extra-data value at the given position
      */
-    int getExtraData(int i, int x, int y, int z);
+    int getExtraData(int index, int x, int y, int z);
     
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
-     * @param i The index of the extra data field
+     * @param index The index of the extra data field
      * @param pos
      * @param value
      * @return The replaced value
      */
-    int setExtraData(int i, Vector3i pos, int value);
+    int setExtraData(int index, Vector3i pos, int value);
 
     /**
      * Disposes this world provider.

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -193,6 +193,27 @@ public interface WorldProviderCore {
     byte getSunlight(int x, int y, int z);
 
     byte getTotalLight(int x, int y, int z);
+    
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param i The index of the extra data field
+     * @param x
+     * @param y
+     * @param z
+     * @return The ith extra-data value at the given position
+     */
+    int getExtraData(int i, int x, int y, int z);
+    
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param i The index of the extra data field
+     * @param pos
+     * @param value
+     * @return The replaced value
+     */
+    int setExtraData(int i, Vector3i pos, int value);
 
     /**
      * Disposes this world provider.

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -281,11 +281,11 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         }
     }
     
-    private void notifyExtraDataChanged(int i, Vector3i pos, int newData, int oldData) {
+    private void notifyExtraDataChanged(int index, Vector3i pos, int newData, int oldData) {
         // TODO: Change to match block and biome, if those changes are made.
         synchronized (listeners) {
             for (WorldChangeListener listener : listeners) {
-                listener.onExtraDataChanged(i, pos, newData, oldData);
+                listener.onExtraDataChanged(index, pos, newData, oldData);
             }
         }
     }
@@ -393,25 +393,25 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     @Override
-    public int getExtraData(int i, int x, int y, int z) {
+    public int getExtraData(int index, int x, int y, int z) {
         CoreChunk chunk = chunkProvider.getChunk(ChunkMath.calcChunkPosX(x), ChunkMath.calcChunkPosY(y), ChunkMath.calcChunkPosZ(z));
         if (chunk != null) {
-            return chunk.getExtraData(i, ChunkMath.calcBlockPosX(x), ChunkMath.calcBlockPosY(y), ChunkMath.calcBlockPosZ(z));
+            return chunk.getExtraData(index, ChunkMath.calcBlockPosX(x), ChunkMath.calcBlockPosY(y), ChunkMath.calcBlockPosZ(z));
         }
         return 0;
     }
 
     @Override
-    public int setExtraData(int i, Vector3i worldPos, int value) {
+    public int setExtraData(int index, Vector3i worldPos, int value) {
         Vector3i chunkPos = ChunkMath.calcChunkPos(worldPos);
         CoreChunk chunk = chunkProvider.getChunk(chunkPos);
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
-            int oldValue = chunk.getExtraData(i, blockPos.x, blockPos.y, blockPos.z);
-            chunk.setExtraData(i, blockPos.x, blockPos.y, blockPos.z, value);
+            int oldValue = chunk.getExtraData(index, blockPos.x, blockPos.y, blockPos.z);
+            chunk.setExtraData(index, blockPos.x, blockPos.y, blockPos.z, value);
             if (oldValue != value) {
                 setDirtyChunksNear(worldPos);
-                notifyExtraDataChanged(i, worldPos, value, oldValue);
+                notifyExtraDataChanged(index, worldPos, value, oldValue);
             }
             return oldValue;
         }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -202,12 +202,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 } else {
                     oldChange.setTo(type);
                 }
-                for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
-                    RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
-                    if (dirtiedChunk != null) {
-                        dirtiedChunk.setDirty(true);
-                    }
-                }
+                setDirtyChunksNear(worldPos);
                 notifyBlockChanged(worldPos, type, oldBlockType);
             }
             return oldBlockType;
@@ -222,7 +217,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
          * Hint: This method has a benchmark available in the BenchmarkScreen, The screen can be opened ingame via the
          * command "showSCreen BenchmarkScreen".
          */
-        Set<RenderableChunk> dirtiedChunks = new HashSet<>();
         Set<BlockChange> changedBlocks = new HashSet<>();
         Map<Vector3i, Block> result = new HashMap<>(blocks.size());
 
@@ -242,12 +236,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                     } else {
                         oldChange.setTo(type);
                     }
-                    for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
-                        RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
-                        if (dirtiedChunk != null) {
-                            dirtiedChunks.add(dirtiedChunk);
-                        }
-                    }
+                    setDirtyChunksNear(worldPos);
                     changedBlocks.add(new BlockChange(worldPos, oldBlockType, type));
                 }
                 result.put(worldPos, oldBlockType);
@@ -256,14 +245,20 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             }
         }
 
-        for (RenderableChunk chunk : dirtiedChunks) {
-            chunk.setDirty(true);
-        }
         for (BlockChange change : changedBlocks) {
             notifyBlockChanged(change.getPosition(), change.getTo(), change.getFrom());
         }
 
         return result;
+    }
+    
+    private void setDirtyChunksNear(Vector3i pos0) {
+        for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(pos0, 1)) {
+            RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+            if (dirtiedChunk != null) {
+                dirtiedChunk.setDirty(true);
+            }
+        }
     }
 
     private void notifyBlockChanged(Vector3i pos, Block type, Block oldType) {
@@ -282,6 +277,15 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         synchronized (listeners) {
             for (WorldChangeListener listener : listeners) {
                 listener.onBiomeChanged(pos, newBiome, originalBiome);
+            }
+        }
+    }
+    
+    private void notifyExtraDataChanged(int i, Vector3i pos, int newData, int oldData) {
+        // TODO: Change to match block and biome, if those changes are made.
+        synchronized (listeners) {
+            for (WorldChangeListener listener : listeners) {
+                listener.onExtraDataChanged(i, pos, newData, oldData);
             }
         }
     }
@@ -346,12 +350,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 } else {
                     oldChange.setTo(biome);
                 }
-                for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(worldPos, 1)) {
-                    RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
-                    if (dirtiedChunk != null) {
-                        dirtiedChunk.setDirty(true);
-                    }
-                }
+                setDirtyChunksNear(worldPos);
                 notifyBiomeChanged(worldPos, biome, oldBiomeType);
             }
             return oldBiomeType;
@@ -389,6 +388,32 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
         if (chunk != null) {
             Vector3i blockPos = ChunkMath.calcBlockPos(x, y, z);
             return (byte) Math.max(chunk.getSunlight(blockPos), chunk.getLight(blockPos));
+        }
+        return 0;
+    }
+
+    @Override
+    public int getExtraData(int i, int x, int y, int z) {
+        CoreChunk chunk = chunkProvider.getChunk(ChunkMath.calcChunkPosX(x), ChunkMath.calcChunkPosY(y), ChunkMath.calcChunkPosZ(z));
+        if (chunk != null) {
+            return chunk.getExtraData(i, ChunkMath.calcBlockPosX(x), ChunkMath.calcBlockPosY(y), ChunkMath.calcBlockPosZ(z));
+        }
+        return 0;
+    }
+
+    @Override
+    public int setExtraData(int i, Vector3i worldPos, int value) {
+        Vector3i chunkPos = ChunkMath.calcChunkPos(worldPos);
+        CoreChunk chunk = chunkProvider.getChunk(chunkPos);
+        if (chunk != null) {
+            Vector3i blockPos = ChunkMath.calcBlockPos(worldPos);
+            int oldValue = chunk.getExtraData(i, blockPos.x, blockPos.y, blockPos.z);
+            chunk.setExtraData(i, blockPos.x, blockPos.y, blockPos.z, value);
+            if (oldValue != value) {
+                setDirtyChunksNear(worldPos);
+                notifyExtraDataChanged(i, worldPos, value, oldValue);
+            }
+            return oldValue;
         }
         return 0;
     }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -106,12 +106,12 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
         return core.getTotalLight(pos.x, pos.y, pos.z);
     }
     
-    public int getExtraData(int i, Vector3i pos) {
-        return core.getExtraData(i, pos.x, pos.y, pos.z);
+    public int getExtraData(int index, Vector3i pos) {
+        return core.getExtraData(index, pos.x, pos.y, pos.z);
     }
     
-    public int setExtraData(int i, int x, int y, int z, int value) {
-        return core.setExtraData(i, new Vector3i(x, y, z), value);
+    public int setExtraData(int index, int x, int y, int z, int value) {
+        return core.setExtraData(index, new Vector3i(x, y, z), value);
     }
     
     public int getExtraData(String fieldName, int x, int y, int z) {

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -22,6 +22,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.liquid.LiquidData;
 
 import java.math.RoundingMode;
@@ -31,10 +32,12 @@ import java.util.Collection;
  */
 public class WorldProviderWrapper extends AbstractWorldProviderDecorator implements WorldProvider {
     private WorldProviderCore core;
+    private ExtraBlockDataManager extraDataManager;
 
-    public WorldProviderWrapper(WorldProviderCore core) {
+    public WorldProviderWrapper(WorldProviderCore core, ExtraBlockDataManager extraDataManager) {
         super(core);
         this.core = core;
+        this.extraDataManager = extraDataManager;
     }
 
     @Override
@@ -101,6 +104,30 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     @Override
     public byte getTotalLight(Vector3i pos) {
         return core.getTotalLight(pos.x, pos.y, pos.z);
+    }
+    
+    public int getExtraData(int i, Vector3i pos) {
+        return core.getExtraData(i, pos.x, pos.y, pos.z);
+    }
+    
+    public int setExtraData(int i, int x, int y, int z, int value) {
+        return core.setExtraData(i, new Vector3i(x, y, z), value);
+    }
+    
+    public int getExtraData(String fieldName, int x, int y, int z) {
+        return core.getExtraData(extraDataManager.getSlotNumber(fieldName), x, y, z);
+    }
+    
+    public int getExtraData(String fieldName, Vector3i pos) {
+        return core.getExtraData(extraDataManager.getSlotNumber(fieldName), pos.x, pos.y, pos.z);
+    }
+    
+    public int setExtraData(String fieldName, int x, int y, int z, int value) {
+        return core.setExtraData(extraDataManager.getSlotNumber(fieldName), new Vector3i(x, y, z), value);
+    }
+    
+    public int setExtraData(String fieldName, Vector3i pos, int value) {
+        return core.setExtraData(extraDataManager.getSlotNumber(fieldName), pos, value);
     }
 
     @Override

--- a/engine/src/main/protobuf/EntityData.proto
+++ b/engine/src/main/protobuf/EntityData.proto
@@ -132,6 +132,7 @@ message ChunkStore {
     optional RunLengthEncoding16 block_data = 10;
     optional RunLengthEncoding8 liquid_data = 11;
     optional RunLengthEncoding16 biome_data = 12;
+    repeated RunLengthEncoding16 extra_data = 13;
 
     extensions 5000 to max;
 }

--- a/engine/src/main/protobuf/NetMessage.proto
+++ b/engine/src/main/protobuf/NetMessage.proto
@@ -14,6 +14,7 @@ message NetMessage {
     repeated EventMessage event = 8;
     optional int64 time = 9;
     repeated BiomeChangeMessage biomeChange = 10;
+    repeated ExtraDataChangeMessage extraDataChange = 11;
 
     optional ServerInfoRequest serverInfoRequest = 15;
     optional ServerInfoMessage serverInfo = 16;
@@ -101,6 +102,14 @@ message BiomeChangeMessage {
     optional Vector3iData pos = 1;
     optional int32 newBiome = 2;
 
+    extensions 5000 to max;
+}
+
+message ExtraDataChangeMessage {
+    optional int32 index = 1;
+    optional Vector3iData pos = 2;
+    optional int32 newData = 3;
+    
     extensions 5000 to max;
 }
 

--- a/modules/Core/src/test/java/org/terasology/world/generator/TreeTests.java
+++ b/modules/Core/src/test/java/org/terasology/world/generator/TreeTests.java
@@ -40,6 +40,7 @@ import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockUri;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 
 /**
@@ -51,6 +52,7 @@ public class TreeTests {
 
     private BlockManager blockManager;
     private BiomeManager biomeManager;
+    private ExtraBlockDataManager extraDataManager;
 
     @Before
     public void setup() {
@@ -64,6 +66,8 @@ public class TreeTests {
         Block air = blockManager.getBlock(BlockManager.AIR_ID);
 
         biomeManager = Mockito.mock(BiomeManager.class);
+        
+        extraDataManager = new ExtraBlockDataManager();
 
         Mockito.when(blockManager.getBlock(Matchers.<BlockUri>any())).thenReturn(air);
         Mockito.when(blockManager.getBlock(Matchers.<String>any())).thenReturn(air);
@@ -115,7 +119,7 @@ public class TreeTests {
 
         Rect2i chunks = Rect2i.createFromMinAndMax(-1, -1, 1, 1);
         for (BaseVector2i chunkPos : chunks.contents()) {
-            Chunk chunk = new ChunkImpl(chunkPos.getX(), 0, chunkPos.getY(), blockManager, biomeManager) {
+            Chunk chunk = new ChunkImpl(chunkPos.getX(), 0, chunkPos.getY(), blockManager, biomeManager, extraDataManager) {
                 @Override
                 public Block setBlock(int x, int y, int z, Block block) {
                     Vector3i world = chunkToWorldPosition(x, y, z);


### PR DESCRIPTION
### Contains

Allow mods to register additional 4, 8 or 16 bit data fields to be stored for each block along with the block IDs, biome data &ct. If data-fields of the same size are registered for disjoint sets of blocks, they may be made aliases of the same field, to save space.

This has a similar intent to #617, but there are several design changes:
  * Fields are registered in the java code, rather than module.txt.
  * The size may vary (all of the bit-sizes for which TeraArray implementations exist are available).
  * Every class for accessing block data has methods [get/set]ExtraData with an extra ID parameter to identify which extra data field, rather than having only one field accessible per worldProvider.

### How to test

As this is a framework rather than user-facing thing, the easiest way to test that it works would be to load FlowingLiquids, which (on the customDataStorage branch), uses a custom data field to store the liquid flow data. There are non-trivial interactions with networking stuff, too, so if you want to generally test things, doing it on multi-player as well could be worthwhile.

### Outstanding before merging
There's nothing I know of that needs to be changed before merging, but there are several things to be improved relating to this:
  * If there's leftover space in a large (8 or 16 bit) field, that may as well be combined with smaller fields like currently happens with fields of the same size.
  * If the built-in liquid data is relevant at all, it certainly at least deserves to be demoted to an extra data field, so it might as well be removed.
  * When 8 and 4 bit fields are serialised, they are padded to 16 bits for convenience. This could be avoided, with further effort.
