### PR TITLE
Add rendering enums as API

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkMesh.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkMesh.java
@@ -25,6 +25,7 @@ import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL15;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.module.sandbox.API;
 import org.terasology.rendering.VertexBufferObjectUtil;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.world.chunks.ChunkConstants;
@@ -56,6 +57,7 @@ public class ChunkMesh {
     /**
      * Possible rendering types.
      */
+    @API
     public enum RenderType {
         OPAQUE(0),
         TRANSLUCENT(1),

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkVertexFlag.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkVertexFlag.java
@@ -15,8 +15,11 @@
  */
 package org.terasology.rendering.primitives;
 
+import org.terasology.module.sandbox.API;
+
 /**
  */
+@API
 public enum ChunkVertexFlag {
     NORMAL(0, "BLOCK_HINT_NORMAL"),
     WATER(1, "BLOCK_HINT_WATER"),


### PR DESCRIPTION
Since #3476 renders most of #3309 obsolete, this is the remaining parts, revealing the bits of API necessary for a custom implementation of BlockMeshGenerator, such as FlowingLiquids uses for making meshes for liquid blocks.

Although this is not currently necessary due to the module access restrictions being disabled, it still seems desirable to have this marked as API as it's actually used in a module (and harmless).

The things revealed do relate to some rather ad-hoc internals of rendering which may be changed at some point, but if that's a problem, it indicates that changes need to be made elsewhere so that access to these isn't necessary.

### Contains

Reveals ChunkVertexFlag and ChunkMesh.RenderType as API
