### PR TITLE
Make water-waves actually vertical

### DIFF
--- a/engine/src/main/resources/assets/shaders/chunk_vert.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_vert.glsl
@@ -159,7 +159,7 @@ void main()
         vec4 normalAndOffset = calcWaterNormalAndOffset(vertexWorldPos.xz);
 
         waterNormalViewSpace = gl_NormalMatrix * normalAndOffset.xyz;
-        vertexViewPos.y += normalAndOffset.w + waterOffsetY;
+        vertexViewPos += gl_ModelViewMatrix[1] * (normalAndOffset.w + waterOffsetY);
     }
 #else
     waterNormalViewSpace = gl_NormalMatrix * vec3(0.0, 1.0, 0.0);


### PR DESCRIPTION
### Contains

Change the offset for animated water from being vertical in view-space to being vertical in world-space. Resolves #2450.

It still doesn't look good, but it does look better.

### How to test

Turn on animated water in video settings. Look at it from various angles.