### PR TITLE
Deprecated getters and setters in BlockComponent and removed all usages.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/health/EntityDestructionAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/health/EntityDestructionAuthoritySystem.java
@@ -44,7 +44,7 @@ public class EntityDestructionAuthoritySystem extends BaseComponentSystem {
         if (instigator != null) {
             if (entityRef.hasComponent(BlockComponent.class)) {
                 BlockComponent blockComponent = entityRef.getComponent(BlockComponent.class);
-                String blockName = blockComponent.getBlock().getDisplayName();
+                String blockName = blockComponent.block.getDisplayName();
                 if (instigator.hasComponent(GamePlayStatsComponent.class)) {
                     GamePlayStatsComponent gamePlayStatsComponent = instigator.getComponent(GamePlayStatsComponent.class);
                     Map<String, Integer> blockDestroyedMap = gamePlayStatsComponent.blockDestroyedMap;

--- a/engine/src/main/java/org/terasology/network/internal/NetClient.java
+++ b/engine/src/main/java/org/terasology/network/internal/NetClient.java
@@ -347,9 +347,9 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
         try {
             BlockComponent blockComp = target.getComponent(BlockComponent.class);
             if (blockComp != null) {
-                if (relevantChunks.contains(ChunkMath.calcChunkPos(blockComp.getPosition()))) {
+                if (relevantChunks.contains(ChunkMath.calcChunkPos(blockComp.position))) {
                     queuedOutgoingEvents.add(NetData.EventMessage.newBuilder()
-                            .setTargetBlockPos(NetMessageUtil.convert(blockComp.getPosition()))
+                            .setTargetBlockPos(NetMessageUtil.convert(blockComp.position))
                             .setEvent(eventSerializer.serialize(event)).build());
                 }
             } else {
@@ -500,7 +500,7 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
             NetData.CreateEntityMessage.Builder createMessage = NetData.CreateEntityMessage.newBuilder().setEntity(entityData);
             BlockComponent blockComponent = entity.getComponent(BlockComponent.class);
             if (blockComponent != null) {
-                createMessage.setBlockPos(NetMessageUtil.convert(blockComponent.getPosition()));
+                createMessage.setBlockPos(NetMessageUtil.convert(blockComponent.position));
             }
             message.addCreateEntity(createMessage);
         }

--- a/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
@@ -375,7 +375,7 @@ public class ServerImpl implements Server {
             entitySerializer.deserializeOnto(currentEntity, updateEntity.getEntity());
             BlockComponent blockComponent = currentEntity.getComponent(BlockComponent.class);
             if (blockComponent != null && !blockEntityBefore) {
-                if (!blockEntityRegistry.getExistingBlockEntityAt(blockComponent.getPosition()).equals(currentEntity)) {
+                if (!blockEntityRegistry.getExistingBlockEntityAt(blockComponent.position).equals(currentEntity)) {
                     logger.error("Failed to associated new block entity");
                 }
             }

--- a/engine/src/main/java/org/terasology/network/serialization/NetEntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/network/serialization/NetEntityRefTypeHandler.java
@@ -47,8 +47,7 @@ public class NetEntityRefTypeHandler implements TypeHandler<EntityRef> {
     public PersistedData serialize(EntityRef value, SerializationContext context) {
         BlockComponent blockComponent = value.getComponent(BlockComponent.class);
         if (blockComponent != null) {
-            Vector3i pos = blockComponent.getPosition();
-            return context.create(pos.x, pos.y, pos.z);
+            return context.create(blockComponent.position.x, blockComponent.position.y, blockComponent.position.z);
         }
         NetworkComponent netComponent = value.getComponent(NetworkComponent.class);
         if (netComponent != null) {

--- a/engine/src/main/java/org/terasology/world/block/BlockComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockComponent.java
@@ -25,9 +25,9 @@ import org.terasology.network.Replicate;
  */
 public final class BlockComponent implements Component {
     @Replicate
-    Vector3i position = new Vector3i();
+    public Vector3i position = new Vector3i();
     @Replicate
-    Block block;
+    public Block block;
 
     public BlockComponent() {
     }
@@ -37,18 +37,34 @@ public final class BlockComponent implements Component {
         this.position.set(pos);
     }
 
+    /**
+     * @deprecated Deprecated on 21/Sep/2018, because it is error prone (no defensive copy) and needlessly verbose.
+     */
+    @Deprecated
     public Vector3i getPosition() {
         return position;
     }
 
+    /**
+     * @deprecated Deprecated on 21/Sep/2018, because it is needlessly verbose.
+     */
+    @Deprecated
     public void setPosition(Vector3i pos) {
         position.set(pos);
     }
 
+    /**
+     * @deprecated Deprecated on 21/Sep/2018, because it is error prone (no defensive copy) and needlessly verbose.
+     */
+    @Deprecated
     public void setBlock(Block block) {
         this.block = block;
     }
 
+    /**
+     * @deprecated Deprecated on 21/Sep/2018, because it is error prone (no defensive copy) and needlessly verbose.
+     */
+    @Deprecated
     public Block getBlock() {
         return block;
     }

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -210,7 +210,7 @@ public class BlockCommands extends BaseComponentSystem {
             if (def.isPresent()) {
                 BlockFamily blockFamily = blockManager.getBlockFamily(uri);
                 Block block = blockManager.getBlock(blockFamily.getURI());
-                world.setBlock(targetLocation.getPosition(), block);
+                world.setBlock(targetLocation.position, block);
             } else if (matchingUris.size() > 1) {
                 StringBuilder builder = new StringBuilder();
                 builder.append("Non-unique shape name, possible matches: ");

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -84,14 +84,14 @@ public class BlockEntitySystem extends BaseComponentSystem {
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
     public void doDestroy(DoDestroyEvent event, EntityRef entity, BlockComponent blockComponent) {
-        commonDestroyed(event, entity, blockComponent.getBlock());
-        worldProvider.setBlock(blockComponent.getPosition(), blockManager.getBlock(BlockManager.AIR_ID));
+        commonDestroyed(event, entity, blockComponent.block);
+        worldProvider.setBlock(blockComponent.position, blockManager.getBlock(BlockManager.AIR_ID));
     }
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
     public void defaultDropsHandling(CreateBlockDropsEvent event, EntityRef entity, BlockComponent blockComponent) {
-        Vector3i location = blockComponent.getPosition();
-        commonDefaultDropsHandling(event, entity, location, blockComponent.getBlock());
+        Vector3i location = new Vector3i(blockComponent.position);
+        commonDefaultDropsHandling(event, entity, location, blockComponent.block);
     }
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
@@ -25,6 +25,7 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.math.Side;
+import org.terasology.math.geom.BaseVector3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
@@ -80,8 +81,7 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
             return;
         }
 
-        Vector3i targetBlock = blockComponent.getPosition();
-        processUpdateForBlockLocation(targetBlock);
+        processUpdateForBlockLocation(blockComponent.position);
     }
 
     private void notifyNeighboursOfChangedBlocks() {

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -86,7 +86,7 @@ public class BlockItemSystem extends BaseComponentSystem {
             event.consume();
             return;
         }
-        Vector3i targetBlock = blockComponent.getPosition();
+        Vector3i targetBlock = new Vector3i(blockComponent.position);
         Vector3i placementPos = new Vector3i(targetBlock);
         placementPos.add(surfaceSide.getVector3i());
 

--- a/engine/src/main/java/org/terasology/world/block/structure/SideBlockSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/SideBlockSupportRequired.java
@@ -63,7 +63,7 @@ public class SideBlockSupportRequired implements BlockStructuralSupport {
     @ReceiveEvent
     public void checkForSupport(DelayedActionTriggeredEvent event, EntityRef entity, BlockComponent block, SideBlockSupportRequiredComponent supportRequired) {
         if (event.getActionId().equals(SUPPORT_CHECK_ACTION_ID)) {
-            if (!isSufficientlySupported(block.getPosition(), null, Collections.<Vector3i, Block>emptyMap(), supportRequired)) {
+            if (!isSufficientlySupported(block.position, null, Collections.<Vector3i, Block>emptyMap(), supportRequired)) {
                 PrefabManager prefabManager = CoreRegistry.get(PrefabManager.class);
                 entity.send(new DestroyEvent(entity, EntityRef.NULL, prefabManager.getPrefab("engine:supportRemovedDamage")));
             }

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -242,7 +242,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
 
         Optional<Prefab> oldPrefab = oldType.getPrefab();
         EntityBuilder oldEntityBuilder = entityManager.newBuilder(oldPrefab.orElse(null));
-        oldEntityBuilder.addComponent(new BlockComponent(oldType, new Vector3i(blockComponent.getPosition())));
+        oldEntityBuilder.addComponent(new BlockComponent(oldType, blockComponent.position));
         BeforeEntityCreated oldEntityEvent = new BeforeEntityCreated(oldPrefab.orElse(null), oldEntityBuilder.iterateComponents());
         blockEntity.send(oldEntityEvent);
         for (Component comp : oldEntityEvent.getResultComponents()) {
@@ -251,7 +251,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
 
         Optional<Prefab> newPrefab = type.getPrefab();
         EntityBuilder newEntityBuilder = entityManager.newBuilder(newPrefab.orElse(null));
-        newEntityBuilder.addComponent(new BlockComponent(type, new Vector3i(blockComponent.getPosition())));
+        newEntityBuilder.addComponent(new BlockComponent(type, blockComponent.position));
         BeforeEntityCreated newEntityEvent = new BeforeEntityCreated(newPrefab.orElse(null), newEntityBuilder.iterateComponents());
         blockEntity.send(newEntityEvent);
         for (Component comp : newEntityEvent.getResultComponents()) {
@@ -267,7 +267,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
         }
 
 
-        blockComponent.setBlock(type);
+        blockComponent.block = type;
         blockEntity.saveComponent(blockComponent);
 
         for (Component comp : newEntityBuilder.iterateComponents()) {
@@ -362,7 +362,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     @ReceiveEvent(components = {BlockComponent.class})
     public void onActivateBlock(OnActivatedComponent event, EntityRef entity) {
         BlockComponent block = entity.getComponent(BlockComponent.class);
-        EntityRef oldEntity = blockEntityLookup.put(new Vector3i(block.getPosition()), entity);
+        EntityRef oldEntity = blockEntityLookup.put(new Vector3i(block.position), entity);
         // If this is a client, then an existing block entity may exist. Destroy it.
         if (oldEntity != null && !Objects.equal(oldEntity, entity)) {
             oldEntity.destroy();
@@ -372,9 +372,8 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     @ReceiveEvent(components = {BlockComponent.class})
     public void onDeactivateBlock(BeforeDeactivateComponent event, EntityRef entity) {
         BlockComponent block = entity.getComponent(BlockComponent.class);
-        Vector3i pos = new Vector3i(block.getPosition());
-        if (blockEntityLookup.get(pos) == entity) {
-            blockEntityLookup.remove(pos);
+        if (blockEntityLookup.get(block.position) == entity) {
+            blockEntityLookup.remove(block.position);
         }
     }
 
@@ -472,7 +471,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
         if (entityManager.getComponentLibrary().getMetadata(component).isForceBlockActive()) {
             BlockComponent blockComp = entity.getComponent(BlockComponent.class);
             if (blockComp != null) {
-                Block block = getBlock(blockComp.getPosition().x, blockComp.getPosition().y, blockComp.getPosition().z);
+                Block block = getBlock(blockComp.position.x, blockComp.position.y, blockComp.position.z);
                 if (isTemporaryBlock(entity, block, component)) {
                     temporaryBlockEntities.add(entity);
                 }

--- a/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
@@ -83,10 +83,10 @@ public class DoorSystem extends BaseComponentSystem {
         }
 
         Vector3f offset = new Vector3f(event.getHitPosition());
-        offset.sub(targetBlockComp.getPosition().toVector3f());
+        offset.sub(targetBlockComp.position.toVector3f());
         Side offsetDir = Side.inDirection(offset);
 
-        Vector3i primePos = new Vector3i(targetBlockComp.getPosition());
+        Vector3i primePos = new Vector3i(targetBlockComp.position);
         primePos.add(offsetDir.getVector3i());
         Block primeBlock = worldProvider.getBlock(primePos);
         if (!primeBlock.isReplacementAllowed()) {

--- a/modules/Core/src/main/java/org/terasology/logic/actions/ExplosionAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/ExplosionAuthoritySystem.java
@@ -163,9 +163,9 @@ public class ExplosionAuthoritySystem extends BaseComponentSystem {
             if (entityRef.hasComponent(BlockComponent.class)) {
                 BlockComponent blockComponent = entityRef.getComponent(BlockComponent.class);
                 // always destroy the block that caused the explosion
-                worldProvider.setBlock(blockComponent.getPosition(), blockManager.getBlock(BlockManager.AIR_ID));
+                worldProvider.setBlock(blockComponent.position, blockManager.getBlock(BlockManager.AIR_ID));
                 // create the explosion from the block's location
-                doExplosion(explosionActionComponent, blockComponent.getPosition().toVector3f(), entityRef);
+                doExplosion(explosionActionComponent, blockComponent.position.toVector3f(), entityRef);
             } else if (entityRef.hasComponent(LocationComponent.class)) {
                 // get the position of the non-block entity to make it explode from there
                 Vector3f position = entityRef.getComponent(LocationComponent.class).getWorldPosition();

--- a/modules/Core/src/main/java/org/terasology/logic/health/BlockDamageAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/BlockDamageAuthoritySystem.java
@@ -78,7 +78,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void beforeDamaged(BeforeDamagedEvent event, EntityRef blockEntity, BlockComponent blockComp) {
-        if (!blockComp.getBlock().isDestructible()) {
+        if (!blockComp.block.isDestructible()) {
             event.consume();
         }
     }
@@ -97,7 +97,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onDamaged(OnDamagedEvent event, EntityRef entity, BlockComponent blockComponent, LocationComponent locComp) {
-        onDamagedCommon(event, blockComponent.getBlock().getBlockFamily(), locComp.getWorldPosition(), entity);
+        onDamagedCommon(event, blockComponent.block.getBlockFamily(), locComp.getWorldPosition(), entity);
         if (!entity.hasComponent(BlockDamagedComponent.class)) {
             entity.addComponent(new BlockDamagedComponent());
         }
@@ -191,7 +191,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
 
     @ReceiveEvent(netFilter = RegisterMode.AUTHORITY)
     public void beforeDamage(BeforeDamagedEvent event, EntityRef entity, BlockComponent blockComp) {
-        beforeDamageCommon(event, blockComp.getBlock());
+        beforeDamageCommon(event, blockComp.block);
     }
 
     @ReceiveEvent(netFilter = RegisterMode.AUTHORITY)
@@ -232,7 +232,7 @@ public class BlockDamageAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void beforeDamagedEnsureHealthPresent(BeforeDamagedEvent event, EntityRef blockEntity, BlockComponent blockComponent) {
         if (!blockEntity.hasComponent(HealthComponent.class)) {
-            Block type = blockComponent.getBlock();
+            Block type = blockComponent.block;
             if (type.isDestructible()) {
                 HealthComponent healthComponent = new HealthComponent(type.getHardness(), type.getHardness() / BLOCK_REGEN_SECONDS, 1.0f);
                 healthComponent.destroyEntityOnNoHealth = true;

--- a/modules/Core/src/main/java/org/terasology/logic/health/BlockDamageRenderer.java
+++ b/modules/Core/src/main/java/org/terasology/logic/health/BlockDamageRenderer.java
@@ -61,7 +61,7 @@ public class BlockDamageRenderer extends BaseComponentSystem implements RenderSy
                 continue;
             }
             BlockComponent blockComponent = entity.getComponent(BlockComponent.class);
-            groupedEntitiesByEffect.put(getEffectsNumber(health), blockComponent.getPosition());
+            groupedEntitiesByEffect.put(getEffectsNumber(health), blockComponent.position);
         }
         for (EntityRef entity : entityManager.getEntitiesWith(BlockRegionComponent.class, HealthComponent.class)) {
             HealthComponent health = entity.getComponent(HealthComponent.class);


### PR DESCRIPTION
The getters and setters made the code more verbose without any benefit.
The getters and setters where also error prone, because they did not do
any defense copying, while that should be the expected behaviour.

### Contains
- Deprecated BlockComponent getters/setters.
- BlockComponent fields made public instead of package private.
- Removed all calls to BlockComponent getters/setters from engine and core.
- Removed defensive copies at calling locations, where they weren't necessary.

### How to test
- Run the game
- Run the engine tests