### PR TITLE
Cleaner Math: static Vector3i operators

### DIFF
--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -167,15 +167,10 @@ public final class ChunkMath {
     }
 
     public static Region3i getChunkRegionAroundWorldPos(Vector3i pos, int extent) {
-        Vector3i minPos = new Vector3i(-extent, -extent, -extent);
-        minPos.add(pos);
-        Vector3i maxPos = new Vector3i(extent, extent, extent);
-        maxPos.add(pos);
+        Vector3i minPos = Vector3i.one().mul(-extent).add(pos);
+        Vector3i maxPos = Vector3i.one().mul(+extent).add(pos);
 
-        Vector3i minChunk = calcChunkPos(minPos);
-        Vector3i maxChunk = calcChunkPos(maxPos);
-
-        return Region3i.createFromMinMax(minChunk, maxChunk);
+        return Region3i.createFromMinMax(calcChunkPos(minPos), calcChunkPos(maxPos));
     }
 
     // TODO: This doesn't belong in this class, move it.

--- a/engine/src/main/java/org/terasology/math/Side.java
+++ b/engine/src/main/java/org/terasology/math/Side.java
@@ -23,6 +23,8 @@ import org.terasology.math.geom.Vector3i;
 import java.util.EnumMap;
 import java.util.EnumSet;
 
+import static org.terasology.math.Vector3iOperators.add;
+
 /**
  * The six sides of a block and a slew of related utility.
  * <br><br>
@@ -295,9 +297,7 @@ public enum Side {
     }
 
     public Vector3i getAdjacentPos(Vector3i position) {
-        Vector3i result = new Vector3i(position);
-        result.add(vector3iDir);
-        return result;
+        return add(position, vector3iDir);
     }
 
     public Side getRelativeSide(Direction direction) {

--- a/engine/src/main/java/org/terasology/math/Vector3iOperators.java
+++ b/engine/src/main/java/org/terasology/math/Vector3iOperators.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.math;
+
+import org.terasology.math.geom.BaseVector3i;
+import org.terasology.math.geom.Vector3i;
+
+/**
+ * Static Vector3i operators.
+ */
+public final class Vector3iOperators {
+    private Vector3iOperators() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static Vector3i add(BaseVector3i lhs, BaseVector3i rhs) {
+        return new Vector3i(lhs).add(rhs);
+    }
+
+    public static Vector3i sub(BaseVector3i lhs, BaseVector3i rhs) {
+        return new Vector3i(lhs).sub(rhs);
+    }
+
+    public static Vector3i mul(BaseVector3i lhs, int rhs) {
+        return new Vector3i(lhs).mul(rhs);
+    }
+
+    public static Vector3i mul(int lhs, BaseVector3i rhs) {
+        return new Vector3i(rhs).mul(lhs);
+    }
+
+    public static Vector3i div(BaseVector3i lhs, int rhs) {
+        return new Vector3i(lhs).div(rhs);
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/internal/StoragePathProvider.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/StoragePathProvider.java
@@ -21,6 +21,8 @@ import org.terasology.math.geom.Vector3i;
 
 import java.nio.file.Path;
 
+import static org.terasology.math.Vector3iOperators.div;
+
 /**
  */
 public class StoragePathProvider {
@@ -115,8 +117,7 @@ public class StoragePathProvider {
     }
 
     public Vector3i getChunkZipPosition(Vector3i chunkPos) {
-        Vector3i result = new Vector3i(chunkPos);
-        result.div(CHUNK_ZIP_DIM);
+        Vector3i result = div(chunkPos, CHUNK_ZIP_DIM);
         if (chunkPos.x < 0) {
             result.x -= 1;
         }

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
@@ -38,6 +38,8 @@ import org.terasology.world.block.items.OnBlockItemPlaced;
 
 import java.util.Set;
 
+import static org.terasology.math.Vector3iOperators.add;
+
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
     private static final Logger logger = LoggerFactory.getLogger(NeighbourBlockFamilyUpdateSystem.class);
@@ -110,8 +112,7 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
 
     private void processUpdateForBlockLocation(Vector3i blockLocation) {
         for (Side side : Side.getAllSides()) {
-            Vector3i neighborLocation = new Vector3i(blockLocation);
-            neighborLocation.add(side.getVector3i());
+            Vector3i neighborLocation = add(blockLocation, side.getVector3i());
             if (worldProvider.isBlockRelevant(neighborLocation)) {
                 Block neighborBlock = worldProvider.getBlock(neighborLocation);
                 final BlockFamily blockFamily = neighborBlock.getBlockFamily();

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -46,6 +46,8 @@ import org.terasology.world.block.family.BlockFamily;
 
 import java.util.Map;
 
+import static org.terasology.math.Vector3iOperators.add;
+
 // TODO: Predict placement client-side (and handle confirm/denial)
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class BlockItemSystem extends BaseComponentSystem {
@@ -87,8 +89,7 @@ public class BlockItemSystem extends BaseComponentSystem {
             return;
         }
         Vector3i targetBlock = blockComponent.getPosition();
-        Vector3i placementPos = new Vector3i(targetBlock);
-        placementPos.add(surfaceSide.getVector3i());
+        Vector3i placementPos = add(targetBlock, surfaceSide.getVector3i());
 
         Block block = type.getBlockForPlacement(placementPos, surfaceSide, secondaryDirection);
 

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -281,9 +281,7 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         this.chunkFilterSize = new Vector3i(TeraMath.ceilPowerOfTwo(chunkSize.x) - 1, TeraMath.ceilPowerOfTwo(chunkSize.y) - 1, TeraMath.ceilPowerOfTwo(chunkSize.z) - 1);
         this.chunkPower = new Vector3i(TeraMath.sizeOfPower(chunkSize.x), TeraMath.sizeOfPower(chunkSize.y), TeraMath.sizeOfPower(chunkSize.z));
 
-        Vector3i blockMin = new Vector3i();
-        blockMin.sub(offset);
-        blockMin.mul(chunkSize.x, chunkSize.y, chunkSize.z);
+        Vector3i blockMin = Vector3i.zero().sub(offset).mul(chunkSize.x, chunkSize.y, chunkSize.z);
         Vector3i blockSize = chunkRegion.size();
         blockSize.mul(chunkSize.x, chunkSize.y, chunkSize.z);
         this.blockRegion = Region3i.createFromMinAndSize(blockMin, blockSize);

--- a/modules/Core/src/main/java/org/terasology/core/debug/BenchmarkScreen.java
+++ b/modules/Core/src/main/java/org/terasology/core/debug/BenchmarkScreen.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.terasology.math.Vector3iOperators.sub;
+
 /**
  * This screen can be shown with the showScreen command in order to measure the performance of the block placement.
  */
@@ -147,8 +149,7 @@ public class BenchmarkScreen extends BaseInteractionScreen {
         Vector3i chunkAboveCharacter = ChunkMath.calcChunkPos(charecterPos);
         chunkAboveCharacter.addY(1);
         Vector3i chunkRelativePos = ChunkMath.calcBlockPos(charecterPos);
-        Vector3i characterChunkOriginPos = new Vector3i(charecterPos);
-        characterChunkOriginPos.sub(chunkRelativePos);
+        Vector3i characterChunkOriginPos = sub(charecterPos, chunkRelativePos);
 
         Vector3i chunkAboveOrigin = new Vector3i(characterChunkOriginPos);
         chunkAboveOrigin.addY(ChunkConstants.CHUNK_SIZE.getY());

--- a/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
@@ -48,6 +48,8 @@ import org.terasology.world.block.regions.BlockRegionComponent;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.terasology.math.Vector3iOperators.add;
+
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class DoorSystem extends BaseComponentSystem {
     private static final Logger logger = LoggerFactory.getLogger(DoorSystem.class);
@@ -86,8 +88,7 @@ public class DoorSystem extends BaseComponentSystem {
         offset.sub(targetBlockComp.getPosition().toVector3f());
         Side offsetDir = Side.inDirection(offset);
 
-        Vector3i primePos = new Vector3i(targetBlockComp.getPosition());
-        primePos.add(offsetDir.getVector3i());
+        Vector3i primePos = add(targetBlockComp.getPosition(), offsetDir.getVector3i());
         Block primeBlock = worldProvider.getBlock(primePos);
         if (!primeBlock.isReplacementAllowed()) {
             event.consume();
@@ -172,8 +173,7 @@ public class DoorSystem extends BaseComponentSystem {
     }
 
     private boolean canAttachTo(Vector3i doorPos, Side side) {
-        Vector3i adjacentBlockPos = new Vector3i(doorPos);
-        adjacentBlockPos.add(side.getVector3i());
+        Vector3i adjacentBlockPos = add(doorPos, side.getVector3i());
         Block adjacentBlock = worldProvider.getBlock(adjacentBlockPos);
         return adjacentBlock.isAttachmentAllowed();
     }

--- a/modules/Core/src/test/java/org/terasology/world/generator/TreeTests.java
+++ b/modules/Core/src/test/java/org/terasology/world/generator/TreeTests.java
@@ -42,6 +42,8 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.internal.ChunkImpl;
 
+import static org.terasology.math.Vector3iOperators.sub;
+
 /**
  * TODO: more flexibility for estimated extents
  */
@@ -132,7 +134,7 @@ public class TreeTests {
             treeGen.generate(blockManagerLocal, chunk, random, relPos.x, relPos.y, relPos.z);
         }
 
-        Vector3i ext = new Vector3i(max).sub(min);
+        Vector3i ext = sub(max, min);
 //        logger.info(String.format("Min: %12s  Max: %12s  Extent: %s", min, max, ext));
 
         return ext;


### PR DESCRIPTION
### Contains
- Adds static Vector3i operators.
- Replaces calls to member operator, where it makes code more concise and reduces clutter.
- Does _not_ increase the number of Vector3i constructor calls.

### How to test
- Run the game
- Run the engine tests 
- Can add Unit tests, if requested.