### PR TITLE
Permissive security flags with fixed formatting. Fixes #3444

### DIFF
--- a/engine/src/main/java/org/terasology/config/SystemConfig.java
+++ b/engine/src/main/java/org/terasology/config/SystemConfig.java
@@ -23,6 +23,7 @@ import java.util.Locale.Category;
  */
 public class SystemConfig {
     public static final String SAVED_GAMES_ENABLED_PROPERTY = "org.terasology.savedGamesEnabled";
+    public static final String PERMISSIVE_SECURITY_ENABLED_PEOPERTY = "org.terasology.permissiveSecurityEnabled";
 
     private long dayNightLengthInMs;
     private int maxThreads;

--- a/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.Asset;
 import org.terasology.config.Config;
+import org.terasology.config.SystemConfig;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.module.ClasspathModule;
@@ -40,7 +41,6 @@ import org.terasology.module.sandbox.PermissionProviderFactory;
 import org.terasology.module.sandbox.StandardPermissionProviderFactory;
 import org.terasology.module.sandbox.WarnOnlyProviderFactory;
 import org.terasology.naming.Name;
-
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -217,7 +217,13 @@ public class ModuleManagerImpl implements ModuleManager {
     public ModuleEnvironment loadEnvironment(Set<Module> modules, boolean asPrimary) {
         Set<Module> finalModules = Sets.newLinkedHashSet(modules);
         finalModules.addAll(registry.stream().filter(Module::isOnClasspath).collect(Collectors.toList()));
-        ModuleEnvironment newEnvironment = new ModuleEnvironment(finalModules, wrappingPermissionProviderFactory, Collections.<BytecodeInjector>emptyList());
+        ModuleEnvironment newEnvironment;
+        boolean permissiveSecurityEnabled = Boolean.parseBoolean(System.getProperty(SystemConfig.PERMISSIVE_SECURITY_ENABLED_PEOPERTY));
+        if (permissiveSecurityEnabled) {
+            newEnvironment = new ModuleEnvironment(finalModules, wrappingPermissionProviderFactory, Collections.<BytecodeInjector>emptyList());
+        } else {
+            newEnvironment = new ModuleEnvironment(finalModules, permissionProviderFactory, Collections.<BytecodeInjector>emptyList());
+        }
         if (asPrimary) {
             environment = newEnvironment;
         }

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -101,6 +101,7 @@ public final class Terasology {
     private static final String LOAD_LAST_GAME = "-loadlastgame";
     private static final String NO_CRASH_REPORT = "-noCrashReport";
     private static final String NO_SAVE_GAMES = "-noSaveGames";
+    private static final String PERMISSIVE_SECURITY = "-permissiveSecurity";
     private static final String NO_SOUND = "-noSound";
     private static final String NO_SPLASH = "-noSplash";
     private static final String SERVER_PORT = "-serverPort=";
@@ -251,6 +252,7 @@ public final class Terasology {
                 LOAD_LAST_GAME,
                 NO_CRASH_REPORT,
                 NO_SAVE_GAMES,
+                PERMISSIVE_SECURITY,
                 NO_SOUND,
                 NO_SPLASH,
                 OVERRIDE_DEFAULT_CONFIG + "<path>",
@@ -330,6 +332,8 @@ public final class Terasology {
                 splashEnabled = false;
             } else if (arg.equals(NO_SAVE_GAMES)) {
                 System.setProperty(SystemConfig.SAVED_GAMES_ENABLED_PROPERTY, "false");
+            } else if (arg.equals(PERMISSIVE_SECURITY)) {
+                System.setProperty(SystemConfig.PERMISSIVE_SECURITY_ENABLED_PEOPERTY, "true");
             } else if (arg.equals(NO_CRASH_REPORT)) {
                 crashReportEnabled = false;
             } else if (arg.equals(NO_SOUND)) {


### PR DESCRIPTION
Fixed formatting.

_Cerv edit_ : pasting in description from #3493 to close that one and merge this one:

Added permissive security flags fixes #3444

Description:
New permissive security flag, to test run the game and enter a world, when the permissive security ("-permissiveSecurity") flag is on security messages similar to this: "[main] ERROR o.t.m.s.WarnOnlyProviderFactory - Non-permitted permission..." will appear in the console.