### PR TITLE
hotfix that fixes the rotation issue with structured templates

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 @RegisterBlockFamily("freeform")
 @FreeFormSupported(true)
-public class FreeformFamily extends AbstractBlockFamily {
+public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBlockFamily{
     private static final Logger logger = LoggerFactory.getLogger(FreeformFamily.class);
 
     private Map<Side, Block> blocks = Maps.newEnumMap(Side.class);
@@ -124,4 +124,23 @@ public class FreeformFamily extends AbstractBlockFamily {
         return Arrays.asList(archetypeBlock);
     }
 
+    @Override
+    public Block getBlockForSide(Side side) {
+        if(archetypeBlock == null) {
+            return blocks.get(side);
+        }
+        return archetypeBlock;
+    }
+
+    @Override
+    public Side getSide(Block block) {
+        if(archetypeBlock == null) {
+            for (Map.Entry<Side, Block> sideBlockEntry : blocks.entrySet()) {
+                if (block == sideBlockEntry.getValue()) {
+                    return sideBlockEntry.getKey();
+                }
+            }
+        }
+        return archetypeBlock.getDirection();
+    }
 }

--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -46,7 +46,7 @@ import java.util.Set;
  * - Fence
  */
 public abstract class MultiConnectFamily extends AbstractBlockFamily implements UpdatesWithNeighboursFamily {
-    private static final Logger logger = LoggerFactory.getLogger(FreeformFamily.class);
+    private static final Logger logger = LoggerFactory.getLogger(MultiConnectFamily.class);
 
     @In
     protected WorldProvider worldProvider;


### PR DESCRIPTION
this is a quick hot-fix that fixes the block building in structured templates. A freeformfamily is now considered a side-defined family. this can be verified by building a structured template shape with stairs and verifying that the stairs are in the right direction.