### PR TITLE
Made UI screen styles consistent

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotSize.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/ScreenshotSize.java
@@ -22,10 +22,10 @@ import org.terasology.math.TeraMath;
  */
 public enum ScreenshotSize {
 
-    DOUBLE_SIZE("${engine:menu#screenshot-size-double}", 2.0F),
-    NORMAL_SIZE("${engine:menu#screenshot-size-normal}", 1.0F),
-    HALF_SIZE("${engine:menu#screenshot-size-half}", 0.5F),
     QUARTER_SIZE("${engine:menu#screenshot-size-quarter}", 0.25F),
+    HALF_SIZE("${engine:menu#screenshot-size-half}", 0.5F),
+    NORMAL_SIZE("${engine:menu#screenshot-size-normal}", 1.0F),
+    DOUBLE_SIZE("${engine:menu#screenshot-size-double}", 2.0F),
     HD720("720p", 1280, 720),
     HD1080("1080p", 1920, 1080),
     UHD_1("4K UHD", 3840, 2160); // see: https://en.wikipedia.org/wiki/4K_resolution

--- a/engine/src/main/resources/assets/skins/graypopup.skin
+++ b/engine/src/main/resources/assets/skins/graypopup.skin
@@ -1,0 +1,8 @@
+{
+	"inherit": "popup",
+	"elements": {
+		"UIBox": {
+			"background": "engine:box"
+		}
+	}
+}

--- a/engine/src/main/resources/assets/skins/settingsmenu.skin
+++ b/engine/src/main/resources/assets/skins/settingsmenu.skin
@@ -1,0 +1,13 @@
+{
+	"inherit": "mainmenu",
+	"elements": {
+		"ScrollableArea": {
+			"background": "engine:area"
+		}
+	},
+	"families": {
+		"subheading": {
+			"text-align-horizontal": "center"
+		}
+	}
+}

--- a/engine/src/main/resources/assets/ui/enterTextPopup.ui
+++ b/engine/src/main/resources/assets/ui/enterTextPopup.ui
@@ -1,5 +1,6 @@
 {
     "type": "enterTextPopup",
+    "skin": "graypopup",
     "contents": {
         "type": "relativeLayout",
         "contents": [

--- a/engine/src/main/resources/assets/ui/menu/addServerPopup.ui
+++ b/engine/src/main/resources/assets/ui/menu/addServerPopup.ui
@@ -1,6 +1,6 @@
 {
     "type": "addServerPopup",
-    "skin": "popup",
+    "skin": "graypopup",
     "contents": {
         "type": "relativeLayout",
         "contents": [

--- a/engine/src/main/resources/assets/ui/menu/audioMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/audioMenuScreen.ui
@@ -1,6 +1,6 @@
 {
     "type": "AudioSettingsScreen",
-    "skin": "mainmenu",
+    "skin": "settingsmenu",
     "contents": {
         "type": "relativeLayout",
         "contents": [

--- a/engine/src/main/resources/assets/ui/menu/inputSettingsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/inputSettingsScreen.ui
@@ -1,6 +1,6 @@
 {
     "type": "InputSettingsScreen",
-    "skin": "mainmenu",
+    "skin": "settingsmenu",
     "contents": {
         "type": "RelativeLayout",
         "contents": [

--- a/engine/src/main/resources/assets/ui/menu/playerMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/playerMenuScreen.ui
@@ -1,6 +1,6 @@
 {
     "type": "PlayerSettingsScreen",
-    "skin": "mainmenu",
+    "skin": "settingsmenu",
     "contents": {
         "type": "relativeLayout",
         "contents": [
@@ -126,11 +126,11 @@
                         },
                         {
                             "type": "UILabel",
-                            "text": ""
+                            "text": "${engine:menu#experimental}"
                         },
                         {
                             "type": "UILabel",
-                            "text": "${engine:menu#experimental}:                                                                        "
+                            "text": ""
                         },
                         {
                             "type": "UILabel",

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -1,6 +1,6 @@
 {
     "type": "VideoSettingsScreen",
-    "skin": "mainmenu",
+    "skin": "settingsmenu",
     "contents": {
         "type": "RelativeLayout",
         "contents": [

--- a/engine/src/main/resources/default.cfg
+++ b/engine/src/main/resources/default.cfg
@@ -61,7 +61,7 @@
     "fboScale": 100,
     "dumpShaders": false,
     "screenshotSize": "${engine:menu#screenshot-size-normal}",
-    "screenshotFormat": "jpg",
+    "screenshotFormat": "png",
     "cameraSettings": {
       "cameraSetting": "${engine:menu#camera-setting-normal}"
     },

--- a/modules/Core/assets/skins/inventoryDefault.skin
+++ b/modules/Core/assets/skins/inventoryDefault.skin
@@ -2,7 +2,7 @@
     "inherit": "default",
     "elements": {
         "InventoryCell": {
-            "background": "engine:box",
+            "background": "engine:area",
             "background-border": {
                 "top": 4,
                 "bottom": 4,


### PR DESCRIPTION

### Contains
Fixes #2927

Screens:
- engine:videoMenuScreen,
- engine:inputSettingsScreen,
- in-game inventory/backpack screen,

now have transparent background and centered titles.

- engine:addServerPopup now has strict gray background.

Also,
- screenshot size options are now sorted from smallest to biggest
- default screenshot format is png
- removed “:” at the end of “experimental” title in Player-Settings screen

### How to test

The changes can be seen on affected screens directly in-game.

