### PR TITLE
Fix module details NPE

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -475,7 +475,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
                     moduleDetails.bindEnabled(new ReadOnlyBinding<Boolean>() {
                         @Override
                         public Boolean get() {
-                            return !sortedModules.isEmpty() && sortedModules.stream().anyMatch(ModuleSelectionInfo::isPresent);
+                            return moduleInfoBinding.get() != null;
                         }
                     });
                     moduleDetails.subscribe(b -> {


### PR DESCRIPTION
### Contains
Fixes #3507 by disabling "Module details" button on "Advanced Game Setup" screen until a valid module is selected.

