### PR TITLE
Fixes the LGTM array out of bounds error

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/browser/data/basic/HTMLLikeParserParameterizedTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/browser/data/basic/HTMLLikeParserParameterizedTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.widgets.browser.data.basic;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(value = Parameterized.class)
+public class HTMLLikeParserParameterizedTest {
+    private final String encodedText;
+    private final String unencodedText;
+
+    public HTMLLikeParserParameterizedTest(String encodedText, String unencodedText) {
+        this.encodedText = encodedText;
+        this.unencodedText = unencodedText;
+    }
+
+    @Test
+    public void testEncodeHTMLLike() {
+        String actual = HTMLLikeParser.encodeHTMLLike(unencodedText);
+
+        assertEquals(encodedText, actual);
+    }
+
+    @Test
+    public void testUnencodeHTMLLike() {
+        String actual = HTMLLikeParser.unencodeHTMLLike(encodedText);
+
+        assertEquals(unencodedText, actual);
+    }
+
+    @Parameters
+    public static Collection data() {
+        Object[][] data = new Object[][]{
+                {"&amp;", "&"},
+                {"&lt;", "<"},
+                {"&gt;", ">"},
+                {"&lt;&gt;&amp;", "<>&"},
+                {"Leading text &lt;&gt;&amp;", "Leading text <>&"},
+                {"&lt;&gt;&amp; trailing text", "<>& trailing text"},
+                {"&lt;bold&gt;MovingBlocks &amp; Terasology&lt;/bold&gt;", "<bold>MovingBlocks & Terasology</bold>"}
+        };
+
+        return Arrays.asList(data);
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/browser/data/basic/HTMLLikeParserTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/widgets/browser/data/basic/HTMLLikeParserTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.widgets.browser.data.basic;
+
+import org.junit.Test;
+
+public class HTMLLikeParserTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnencodeUnsupportedEntities() {
+        HTMLLikeParser.unencodeHTMLLike("&invalid;");
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/data/basic/HTMLLikeParser.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/browser/data/basic/HTMLLikeParser.java
@@ -56,15 +56,14 @@ public final class HTMLLikeParser {
         int i = 0;
         while (i < chars.length) {
             char c = chars[i];
-            i++;
             if (c == '&') {
-                if (chars[i + 1] == 'a' && chars[i + 2] == 'm' && chars[i + 3] == 'p' && chars[i + 4] == ';') {
+                if (i + 4 < chars.length && chars[i + 1] == 'a' && chars[i + 2] == 'm' && chars[i + 3] == 'p' && chars[i + 4] == ';') {
                     result.append('&');
                     i += 4;
-                } else if (chars[i + 1] == 'l' && chars[i + 2] == 't' && chars[i + 3] == ';') {
+                } else if (i + 3 < chars.length && chars[i + 1] == 'l' && chars[i + 2] == 't' && chars[i + 3] == ';') {
                     result.append('<');
                     i += 3;
-                } else if (chars[i + 1] == 'g' && chars[i + 3] == 't' && chars[i + 3] == ';') {
+                } else if (i + 3 < chars.length && chars[i + 1] == 'g' && chars[i + 2] == 't' && chars[i + 3] == ';') {
                     result.append('>');
                     i += 3;
                 } else {
@@ -73,6 +72,8 @@ public final class HTMLLikeParser {
             } else {
                 result.append(c);
             }
+
+            i++;
         }
         return result.toString();
     }


### PR DESCRIPTION
### Contains

Fixes the LGTM array out of bounds error in #3510. When starting to work on this issue, I noticed that the method didn't work as intended so this has been fixed as part of this issue.

### How to test

Run the unit tests added as part of this PR. Verify that LGTM no longer flags this method as having errors (I was unable to test this locally since LGTM doesn't seem to support analyzing forks).

### Comments

I've tried keeping the fix as close to the original code as possible. In order to maintain the behavior of throwing an exception if an unsupported entity is encountered, I chose to add the length guard at each individual entity, since adding the check near `if (c == '&') {` would change this behavior. It would also need to check entities of length 3 and 4.