### PR TITLE
Command line  string concatenation

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButtonWebBrowser.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButtonWebBrowser.java
@@ -86,11 +86,11 @@ public class UIButtonWebBrowser extends UIButton {
             Runtime runtime = Runtime.getRuntime();
             try {
                 if (os.contains("win")) {
-                    runtime.exec("rundll32 url.dll,FileProtocolHandler " + this.url);
+                    runtime.exec(new String[] {"rundll32 url.dll,FileProtocolHandler ", this.url});
                 } else if (os.contains("mac")) {
-                    runtime.exec("open " + this.url);
+                    runtime.exec(new String[] {"open ", this.url});
                 } else {
-                    runtime.exec("xdg-open " + this.url);
+                    runtime.exec(new String[] {"xdg-open ", this.url});
                 }
             } catch (IOException e) {
                 LOGGER.warn("Can't recognize your OS and open the url {}.", this.url);


### PR DESCRIPTION
### Contains

Fixes the LGTM "Command line is built with string concatenation" described in #3510. 

A simple switch from string concatenation to using an array of strings as recommended [here](https://lgtm.com/rules/7870097/) has been made.

### How to test

Start the game and go to the "Module Details" screen while creating a game using the Advanced option. Find the only usage of UIButtonWebBrowser when clicking "Open in browser". This should work as expected with the fix.

Side note: Clicking the "Module Details" button doesn't open up the module details screen when no module from the list is selected, producing this error:
```
java.lang.NullPointerException: null
	at org.terasology.rendering.nui.layers.mainMenu.advancedGameSetupScreen.AdvancedGameSetupScreen.lambda$null$13(AdvancedGameSetupScreen.java:493)
```


