### PR TITLE
Fixes LGTM: Command line string concatenation

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButtonWebBrowser.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButtonWebBrowser.java
@@ -86,11 +86,11 @@ public class UIButtonWebBrowser extends UIButton {
             Runtime runtime = Runtime.getRuntime();
             try {
                 if (os.contains("win")) {
-                    runtime.exec("rundll32 url.dll,FileProtocolHandler " + this.url);
+                    runtime.exec(new String[] {"rundll32 url.dll,FileProtocolHandler ", this.url});
                 } else if (os.contains("mac")) {
-                    runtime.exec("open " + this.url);
+                    runtime.exec(new String[] {"open ", this.url});
                 } else {
-                    runtime.exec("xdg-open " + this.url);
+                    runtime.exec(new String[] {"xdg-open ", this.url});
                 }
             } catch (IOException e) {
                 LOGGER.warn("Can't recognize your OS and open the url {}.", this.url);


### PR DESCRIPTION
### Contains

Fixes the LGTM "Command line is built with string concatenation" error described in #3510. 

Fix as per rule described [here](https://lgtm.com/rules/7870097/).

### How to test

Create a game with the Advanced mode. Select the "Module Details" screen and hit the "Open in browser" button. This seems to be the only usage of `UIButtonWebBrowser` so far.
