### PR TITLE
Remove "Terasology" logo image from unnecessary UI screens

### DIFF
--- a/engine/src/main/resources/assets/ui/menu/advancedGameSetupScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/advancedGameSetupScreen.ui
@@ -5,30 +5,16 @@
     "type": "relativeLayout",
     "contents": [
       {
-        "type": "UIImage",
-        "image": "engine:terasology",
-        "id": "title",
-        "layoutInfo": {
-          "width": 512,
-          "height": 128,
-          "position-horizontal-center": {},
-          "position-top": {
-            "target": "TOP",
-            "offset": 40
-          }
-        }
-      },
-      {
         "type": "UILabel",
-        "id": "subtitle",
+        "id": "title",
         "family": "title",
         "text": "${engine:menu#advanced-game-setup}",
         "layoutInfo": {
-          "height": 18,
+          "height": 48,
           "position-horizontal-center": {},
           "position-top": {
-            "target": "BOTTOM",
-            "widget": "title"
+            "target": "TOP",
+            "offset": 48
           }
         }
       },
@@ -42,7 +28,7 @@
           "position-horizontal-center": {},
           "position-top": {
             "target": "BOTTOM",
-            "widget": "subtitle",
+            "widget": "title",
             "offset": 36
           }
         }

--- a/engine/src/main/resources/assets/ui/menu/audioMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/audioMenuScreen.ui
@@ -5,30 +5,16 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "text": "${engine:menu#audio-settings-title}",
                 "family": "title",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -48,7 +34,7 @@
                         "position-top": {
                             "target": "BOTTOM",
                             "offset": 16,
-                            "widget": "subtitle"
+                            "widget": "title"
                         },
                         "position-bottom": {
                             "target": "TOP",
@@ -81,8 +67,7 @@
                     "position-horizontal-center": {},
                     "position-top": {
                         "target": "BOTTOM",
-                        "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/devToolsMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/devToolsMenuScreen.ui
@@ -5,30 +5,16 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "text": "${engine:menu#dev-tools-title}",
                 "family": "title",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -43,7 +29,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "offset": 32

--- a/engine/src/main/resources/assets/ui/menu/inputSettingsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/inputSettingsScreen.ui
@@ -5,30 +5,16 @@
         "type": "RelativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "family": "title",
                 "text": "${engine:menu#input-settings-title}",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -41,7 +27,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -5,30 +5,16 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
-                "id": "subtitle",
+                "id": "title",
                 "family": "title",
                 "text": "${engine:menu#join-server-title}",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -41,7 +27,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/newGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/newGameScreen.ui
@@ -5,30 +5,16 @@
     "type": "relativeLayout",
     "contents": [
       {
-        "type": "UIImage",
-        "image": "engine:terasology",
-        "id": "title",
-        "layoutInfo": {
-          "width": 512,
-          "height": 128,
-          "position-horizontal-center": {},
-          "position-top": {
-            "target": "TOP",
-            "offset": 48
-          }
-        }
-      },
-      {
         "type": "UILabel",
-        "id": "subtitle",
+        "id": "title",
         "family": "title",
         "text": "${engine:menu#new-game-title}",
         "layoutInfo": {
           "height": 48,
           "position-horizontal-center": {},
           "position-top": {
-            "target": "BOTTOM",
-            "widget": "title"
+            "target": "TOP",
+            "offset": 48
           }
         }
       },
@@ -42,7 +28,7 @@
           "position-horizontal-center": {},
           "position-top": {
             "target": "BOTTOM",
-            "widget": "subtitle"
+            "widget": "title"
           }
         }
       },
@@ -100,8 +86,10 @@
           "position-horizontal-center": {},
           "position-top": {
             "target": "BOTTOM",
-            "offset": 16,
             "widget": "gameTypeTitle"
+          },
+          "position-bottom": {
+            "target": "BOTTOM"
           }
         }
       },

--- a/engine/src/main/resources/assets/ui/menu/playerMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/playerMenuScreen.ui
@@ -5,30 +5,16 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "text": "${engine:menu#player-settings-title}",
                 "family": "title",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -169,7 +155,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/previewWorldScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/previewWorldScreen.ui
@@ -5,30 +5,16 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
-                "id": "subtitle",
+                "id": "title",
                 "family": "title",
                 "text": "${engine:menu#preview-world-title}",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -41,7 +27,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/settingsMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/settingsMenuScreen.ui
@@ -5,30 +5,16 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "text": "${engine:menu#settings-title}",
                 "family": "title",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -43,7 +29,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "offset": 32

--- a/engine/src/main/resources/assets/ui/menu/startPlayingScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/startPlayingScreen.ui
@@ -5,30 +5,16 @@
     "type": "relativeLayout",
     "contents": [
       {
-        "type": "UIImage",
-        "image": "engine:terasology",
-        "id": "title",
-        "layoutInfo": {
-          "width": 512,
-          "height": 128,
-          "position-horizontal-center": {},
-          "position-top": {
-            "target": "TOP",
-            "offset": 48
-          }
-        }
-      },
-      {
         "type": "UILabel",
-        "id": "subtitle",
+        "id": "title",
         "family": "title",
         "text": "${engine:menu#start-playing}",
         "layoutInfo": {
           "height": 48,
           "position-horizontal-center": {},
           "position-top": {
-            "target": "BOTTOM",
-            "widget": "title"
+            "target": "TOP",
+            "offset": 48
           }
         }
       },
@@ -41,7 +27,7 @@
           "position-top": {
             "target": "BOTTOM",
             "offset": 16,
-            "widget": "subtitle"
+            "widget": "title"
           },
           "position-bottom": {
             "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/universeSetupScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/universeSetupScreen.ui
@@ -5,30 +5,16 @@
     "type": "relativeLayout",
     "contents": [
       {
-        "type": "UIImage",
-        "image": "engine:terasology",
-        "id": "title",
-        "layoutInfo": {
-          "width": 512,
-          "height": 128,
-          "position-horizontal-center": {},
-          "position-top": {
-            "target": "TOP",
-            "offset": 48
-          }
-        }
-      },
-      {
         "type": "UILabel",
-        "id": "subtitle",
+        "id": "title",
         "family": "title",
         "text": "${engine:menu#universe-setup}",
         "layoutInfo": {
           "height": 48,
           "position-horizontal-center": {},
           "position-top": {
-            "target": "BOTTOM",
-            "widget": "title"
+            "target": "TOP",
+            "offset": 48
           }
         }
       },
@@ -140,8 +126,10 @@
           "position-horizontal-center": {},
           "position-top": {
             "target": "BOTTOM",
-            "offset": 64,
             "widget": "title"
+          },
+          "position-bottom": {
+            "target": "BOTTOM"
           }
         }
       },

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -5,30 +5,16 @@
         "type": "RelativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "family": "title",
                 "text": "${engine:menu#video-settings-title}",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -406,7 +392,7 @@
                     "position-top": {
                         "target": "BOTTOM",
                         "offset": 16,
-                        "widget": "subtitle"
+                        "widget": "title"
                     },
                     "position-bottom": {
                         "target": "TOP",

--- a/engine/src/main/resources/assets/ui/menu/worldPreGenerationScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/worldPreGenerationScreen.ui
@@ -5,30 +5,16 @@
     "type": "relativeLayout",
     "contents": [
       {
-        "type": "UIImage",
-        "image": "engine:terasology",
-        "id": "title",
-        "layoutInfo": {
-          "width": 512,
-          "height": 128,
-          "position-horizontal-center": {},
-          "position-top": {
-            "target": "TOP",
-            "offset": 48
-          }
-        }
-      },
-      {
         "type": "UILabel",
-        "id": "subtitle",
+        "id": "title",
         "family": "title",
         "text": "${engine:menu#world-pre-generation}",
         "layoutInfo": {
           "height": 48,
           "position-horizontal-center": {},
           "position-top": {
-            "target": "BOTTOM",
-            "widget": "title"
+            "target": "TOP",
+            "offset": 48
           }
         }
       },
@@ -41,7 +27,7 @@
           "position-top": {
             "target": "BOTTOM",
             "offset": 16,
-            "widget": "subtitle"
+            "widget": "title"
           },
           "position-bottom": {
             "target": "TOP",

--- a/engine/src/main/resources/assets/ui/telemetryScreen.ui
+++ b/engine/src/main/resources/assets/ui/telemetryScreen.ui
@@ -5,30 +5,16 @@
         "type": "RelativeLayout",
         "contents": [
             {
-                "type": "UIImage",
-                "image": "engine:terasology",
-                "id": "title",
-                "layoutInfo": {
-                    "width": 512,
-                    "height": 128,
-                    "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "TOP",
-                        "offset": 48
-                    }
-                }
-            },
-            {
                 "type": "UILabel",
                 "family": "title",
                 "text": "${engine:menu#telemetry-menu}",
-                "id": "subtitle",
+                "id": "title",
                 "layoutInfo": {
                     "height": 48,
                     "position-horizontal-center": {},
                     "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title"
+                        "target": "TOP",
+                        "offset": 48
                     }
                 }
             },
@@ -42,7 +28,7 @@
                     "position-horizontal-center": {},
                     "position-top": {
                         "target": "BOTTOM",
-                        "widget": "subtitle"
+                        "widget": "title"
                     }
                 }
             },

--- a/engine/src/main/resources/assets/ui/worldSetupScreen.ui
+++ b/engine/src/main/resources/assets/ui/worldSetupScreen.ui
@@ -5,20 +5,6 @@
     "type": "relativeLayout",
     "contents": [
       {
-        "type": "UIImage",
-        "image": "engine:terasology",
-        "id": "title",
-        "layoutInfo": {
-          "width": 512,
-          "height": 128,
-          "position-horizontal-center": {},
-          "position-top": {
-            "target": "TOP",
-            "offset": 48
-          }
-        }
-      },
-      {
         "type": "UILabel",
         "id": "subtitle",
         "family": "title",
@@ -27,8 +13,8 @@
           "height": 48,
           "position-horizontal-center": {},
           "position-top": {
-            "target": "BOTTOM",
-            "widget": "title"
+            "target": "TOP",
+            "offset": 48
           }
         }
       },


### PR DESCRIPTION
### Contains
Removes "Terasology" logo from various UI screens except from `mainMenuScreen` and `creditsScreen`, resolves #3509. 

### How to test
Go through each affected screen and check if "Terasology" logo is removed and the screen looks visually pleasing (UI elements are not out of view bounds). Alternatively `NUI Screen Editor` can be used to check each screen instead of navigating through the UI.