### PR TITLE
Fixes LGTM logger errors and warnings

### DIFF
--- a/engine/src/main/java/org/terasology/config/Config.java
+++ b/engine/src/main/java/org/terasology/config/Config.java
@@ -202,7 +202,7 @@ public final class Config {
                     return Optional.of(userConfig.getAsJsonObject());
                 }
             } catch (IOException e) {
-                logger.error("Failed to load config file {}, falling back on default config");
+                logger.error("Failed to load config file {}, falling back on default config", configPath);
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/logic/behavior/core/DecoratorNode.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/core/DecoratorNode.java
@@ -93,7 +93,7 @@ public class DecoratorNode extends ActionNode {
         try {
             modifiedState = action.modify(actor, lastState);
         } catch (Exception e) {
-            logger.info("Exception while running action {} from entity {}: ", action, actor.getEntity(), e.getStackTrace());
+            logger.info("Exception while running action {} from entity {}: {}", action, actor.getEntity(), e.getStackTrace());
             // TODO maybe returning UNDEFINED would be more canonical?
             return BehaviorState.FAILURE;
         }

--- a/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
+++ b/engine/src/main/java/org/terasology/logic/delay/DelayedActionSystem.java
@@ -92,9 +92,8 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
                     delayedEntity.send(new DelayedActionTriggeredEvent(actionId));
                 }
             } else {
-                logger.error("ERROR: This entity is missing a DelayedActionComponent. " +
-                        "So skipping delayed actions for this entity",
-                        delayedEntity);
+                logger.error("ERROR: This entity is missing a DelayedActionComponent: {}. " +
+                        "So skipping delayed actions for this entity.", delayedEntity);
             }
         });
     }
@@ -128,7 +127,7 @@ public class DelayedActionSystem extends BaseComponentSystem implements UpdateSu
                     periodicEntity.send(new PeriodicActionTriggeredEvent(actionId));
                 }
             } else {
-                logger.error("ERROR: This entity is missing a DelayedActionComponent. " +
+                logger.error("ERROR: This entity is missing a DelayedActionComponent: {}. " +
                         "So skipping delayed actions for this entity", periodicEntity);
             }
         });

--- a/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
+++ b/engine/src/main/java/org/terasology/network/internal/ServerImpl.java
@@ -381,7 +381,7 @@ public class ServerImpl implements Server {
                     }
                     blockManager.receiveFamilyRegistration(family, registrationMap);
                 } catch (BlockUriParseException e) {
-                    logger.error("Received invalid block uri", blockFamily.getBlockUri(0));
+                    logger.error("Received invalid block uri {}", blockFamily.getBlockUri(0));
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/editor/utils/NUIEditorMenuTreeBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/editor/utils/NUIEditorMenuTreeBuilder.java
@@ -272,7 +272,7 @@ public class NUIEditorMenuTreeBuilder {
                 }
             }
         } else {
-            logger.warn("Could not get class for node ", node.getValue().toString());
+            logger.warn("Could not get class for node {}", node.getValue().toString());
         }
     }
 

--- a/engine/src/main/java/org/terasology/telemetry/Metrics.java
+++ b/engine/src/main/java/org/terasology/telemetry/Metrics.java
@@ -89,10 +89,10 @@ public class Metrics {
                         metric = (Metric) constructor.newInstance(context);
                         classNameToMetric.put(metric.getClass().getName(), metric);
                     } else {
-                        logger.warn("Can't initialize the Metric, please initialize it and add it to Metrics:", constructor);
+                        logger.warn("Can't initialize the Metric, please initialize it and add it to Metrics: {}", constructor);
                     }
                 } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                    logger.error("Fail to initialize the metric instance", constructor);
+                    logger.error("Fail to initialize the metric instance: {}", constructor);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
@@ -197,7 +197,7 @@ public class BlockManagerImpl extends BlockManager {
             newState.blocksById.put(block.getId(), block);
             newState.idByUri.put(block.getURI(), block.getId());
         } else {
-            logger.info("Failed to register block {} - no id", block, block.getId());
+            logger.info("Failed to register block {} - no id", block);
         }
         newState.blocksByUri.put(block.getURI(), block);
     }


### PR DESCRIPTION
### Contains

Fixes the following LGTM errors and warnings from #3510:

- Missing format argument
- Unused format argument

Note that the logging statements previously would log less information than expected, since the unmatched argument would simply be omitted from the formatted log statement.

### How to test

Either reproducing the conditions that cause the logging to occur, or instead forcing the condition to occur by attaching a debugger and manually changing the state to force the logging code path.