### PR TITLE
#3508 avoid zero and negative available size in ColumnLayout

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/ColumnLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/ColumnLayout.java
@@ -224,10 +224,10 @@ public class ColumnLayout extends CoreLayout<LayoutHint> {
         Vector2i availableSize = new Vector2i(areaHint);
         int numRows = TeraMath.ceilToInt((float) widgetList.size() / columns);
         if (numRows > 0) {
-            availableSize.y -= verticalSpacing * (numRows - 1);
+            availableSize.y = Math.max(1, availableSize.y - verticalSpacing * (numRows - 1));
         }
         if (columns > 0) {
-            availableSize.x -= horizontalSpacing * (columns - 1);
+            availableSize.x = Math.max(1, availableSize.x - horizontalSpacing * (columns - 1));
         }
 
         Iterator<List<UIWidget>> rows = getRowIterator();


### PR DESCRIPTION
### Contains

Fixes #3508.
It turned out when availableSize.y (org/terasology/rendering/nui/layouts/ColumnLayout.java:232) become negative or zero it causes incorrect row height calculation as Canvas size become (0, 0) and preferable Label height becomes significantly higher as it expects Label text to be split to as many lines as possible for 0 widths. 
Fix looks a bit hacky and I believe there is a better solution, but I hope this PR will at least help in a further investigation.

### How to test

See test case from #3508.