### PR TITLE
Fixed the LGTM warnings "Useless comparison test"

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/ColorTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/ColorTest.java
@@ -15,48 +15,118 @@
  */
 package org.terasology.rendering.nui;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- */
 public class ColorTest {
+    private Color color;
 
-    @Test
-    public void testColorToHash() {
-        assertEquals("010A3CFF", new Color(1, 10, 60, 255).toHex());
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        color = new Color(1, 10, 60, 255);
     }
 
     @Test
-    public void testGetSetRed() {
-        Color color = new Color(1, 10, 60, 255);
+    public void testColorToHash() {
+        assertEquals("010A3CFF", color.toHex());
+    }
+
+    @Test
+    public void testGetRed() {
         assertEquals(1, color.r());
+    }
+
+    @Test
+    public void testAlterRed() {
         color = color.alterRed(72);
         assertEquals(72, color.r());
     }
 
     @Test
-    public void testGetSetGreen() {
-        Color color = new Color(1, 10, 60, 255);
+    public void testAlterRedThrowsWhenColorLessThanLowerBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterRed(-1);
+    }
+
+    @Test
+    public void testAlterRedThrowsWhenColorLargerThanUpperBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterRed(256);
+    }
+
+    @Test
+    public void testGetGreen() {
         assertEquals(10, color.g());
+    }
+
+    @Test
+    public void testAlterGreen() {
         color = color.alterGreen(72);
         assertEquals(72, color.g());
     }
 
     @Test
-    public void testGetSetBlue() {
-        Color color = new Color(1, 10, 60, 255);
+    public void testAlterGreenThrowsWhenColorLessThanLowerBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterGreen(-1);
+    }
+
+    @Test
+    public void testAlterGreenThrowsWhenColorLargerThanUpperBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterGreen(256);
+    }
+
+    @Test
+    public void testGetBlue() {
         assertEquals(60, color.b());
+    }
+
+    @Test
+    public void testAlterBlue() {
         color = color.alterBlue(72);
         assertEquals(72, color.b());
     }
 
     @Test
-    public void testGetSetAlpha() {
-        Color color = new Color(1, 10, 60, 255);
+    public void testAlterBlueThrowsWhenColorLessThanLowerBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterBlue(-1);
+    }
+
+    @Test
+    public void testAlterBlueThrowsWhenColorLargerThanUpperBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterBlue(256);
+    }
+
+    @Test
+    public void testGetAlpha() {
         assertEquals(255, color.a());
+    }
+
+    @Test
+    public void testAlterAlpha() {
         color = color.alterAlpha(72);
         assertEquals(72, color.a());
+    }
+
+    @Test
+    public void testAlterAlphaThrowsWhenColorLessThanLowerBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterAlpha(-1);
+    }
+
+    @Test
+    public void testAlterAlphaThrowsWhenColorLargerThanUpperBound() {
+        expectedException.expect(IllegalArgumentException.class);
+        color.alterAlpha(256);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameter.java
+++ b/engine/src/main/java/org/terasology/logic/console/commandSystem/CommandParameter.java
@@ -246,7 +246,7 @@ public final class CommandParameter<T> implements Parameter {
     }
 
     public boolean hasName() {
-        return name.length() >= 0;
+        return name.length() > 0;
     }
 
     public String getName() {

--- a/engine/src/main/java/org/terasology/rendering/nui/Color.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/Color.java
@@ -171,22 +171,22 @@ public class Color {
     }
 
     public Color alterRed(int value) {
-        Preconditions.checkArgument(value >= 0 || value <= MAX, "Color values must be in range 0-255");
+        Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value << RED_OFFSET | (representation & RED_FILTER));
     }
 
     public Color alterBlue(int value) {
-        Preconditions.checkArgument(value >= 0 || value <= MAX, "Color values must be in range 0-255");
+        Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value << BLUE_OFFSET | (representation & BLUE_FILTER));
     }
 
     public Color alterGreen(int value) {
-        Preconditions.checkArgument(value >= 0 || value <= MAX, "Color values must be in range 0-255");
+        Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value << GREEN_OFFSET | (representation & GREEN_FILTER));
     }
 
     public Color alterAlpha(int value) {
-        Preconditions.checkArgument(value >= 0 || value <= MAX, "Color values must be in range 0-255");
+        Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value | (representation & ALPHA_FILTER));
     }
 


### PR DESCRIPTION
### Contains

Fixes the "Useless comparison test" warnings from #3510.

### How to test

Run the unit test changed as part of this PR to verify that the Color changes work. The preconditions were not working due to using the boolean OR operator rather than boolean AND operator.

Note that the fix for CommandParameter is relevant since the precondition in the private constructor ensures that the `name` variable is never `null` or length `0`.