### PR TITLE
Added wildcard support to groovyw <item> get

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -355,15 +355,15 @@ class common {
      * @param regex the regex that the retrieved items should match
      */
     String[] retrieveAvailableItemsWithRegexMatch(String regex) {
-        ArrayList<String> selectedModules = new ArrayList<String>()
-        String[] moduleList = retrieveAvailableItems()
-        for (String module : moduleList) {
-            if (module.matches(regex)) {
-                selectedModules.add(module)
+        ArrayList<String> selectedItems = new ArrayList<String>()
+        String[] itemList = retrieveAvailableItems()
+        for (String item : itemList) {
+            if (item.matches(regex)) {
+                selectedItems.add(item)
             }
         }
 
-        return ((String[]) selectedModules.toArray());
+        return ((String[]) selectedItems.toArray());
     }
 
     /**

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -31,9 +31,11 @@ class common {
     /** The default name of a git remote we might want to work on or keep handy */
     String defaultRemote = "origin"
 
+    /** Should we cache the list of remote items */
     boolean itemListCached = false
 
-    String[] cachedItemList;
+    /** For keeping a list of remote items that can be retrieved */
+    String[] cachedItemList
 
     /**
      * Initialize defaults to match the target item type

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -31,6 +31,10 @@ class common {
     /** The default name of a git remote we might want to work on or keep handy */
     String defaultRemote = "origin"
 
+    boolean itemListCached = false
+
+    String[] cachedItemList;
+
     /**
      * Initialize defaults to match the target item type
      * @param type the type to be initialized
@@ -297,6 +301,9 @@ class common {
      * @return a String[] containing the names of items available for download.
      */
     String[] retrieveAvailableItems() {
+        if (itemListCached) {
+            return cachedItemList
+        }
 
         // TODO: We need better ways to display the result especially when it contains a lot of items
         // However, in some cases heavy filtering could still mean that very few items will actually display ...
@@ -323,7 +330,49 @@ class common {
             }
         }
 
-        return itemTypeScript.filterItemsFromApi(mappedPossibleItems)
+        String[] items = itemTypeScript.filterItemsFromApi(mappedPossibleItems)
+
+        return items;
+    }
+
+    /**
+     * Retrieves all the available items for the target type in the form of a list that match the specified regex.
+     *
+     * Forming the regex:
+     * "\Q" starts an explicit quote (which includes all reserved characters as well)
+     * "\E" ends an explicit quote
+     * "\w*" is equivalent to "*" - it selects anything that has the same characters
+     * (in the range of a-z, A-Z or 1-9) as before and after the asterisk
+     * "." is equivalent to "?" - it selects anything that has the rest of the pattern but any
+     * character in the "?" symbol's position
+     * So, "\Q<INPUT_PART1>\E\w*\Q\<INPUT_PART1>E", selects anything that starts with INPUT_PART1
+     * and ends with INPUT_PART2 - This regex expression is equivalent to the input argument
+     * "INPUT_PART1*INPUT_PART2"
+     *
+     * @return a String[] containing the names of items available for download.
+     * @param regex the regex that the retrieved items should match
+     */
+    String[] retrieveAvailableItemsWithRegexMatch(String regex) {
+        ArrayList<String> selectedModules = new ArrayList<String>()
+        String[] moduleList = retrieveAvailableItems()
+        for (String module : moduleList) {
+            if (module.matches(regex)) {
+                selectedModules.add(module)
+            }
+        }
+
+        return ((String[]) selectedModules.toArray());
+    }
+
+    /**
+     * Retrieves all the available items for the target type in the form of a list that match the specified regex.
+     *
+     * @param wildcardPattern the wildcard pattern that the retrieved items should match
+     * @return a String[] containing the names of items available for download.
+     */
+    String[] retrieveAvalibleItemsWithWildcardMatch(String wildcardPattern) {
+        String regex = ("\\Q" + wildcardPattern.replace("*", "\\E\\w*\\Q").replace("?", "\\E.\\Q") + "\\E")
+        return retrieveAvailableItemsWithRegexMatch(regex);
     }
 
     /**
@@ -352,5 +401,14 @@ class common {
             }
         }
         return localItems
+    }
+
+    void cacheItemList() {
+        cachedItemList = retrieveAvailableItems()
+        itemListCached = true
+    }
+
+    void unCacheItemList() {
+        itemListCached = false
     }
 }

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -54,19 +54,19 @@ switch(cleanerArgs[0]) {
         } else {
             // Note: processCustomRemote also drops one of the array elements from cleanerArgs
             cleanerArgs = common.processCustomRemote(cleanerArgs)
-            ArrayList<String> selectedModules = new ArrayList<String>()
+            ArrayList<String> selectedItems = new ArrayList<String>()
 
             common.cacheItemList()
             for (String arg : cleanerArgs) {
                 if (!arg.contains('*') && !arg.contains('?')) {
-                    selectedModules.add(arg)
+                    selectedItems.add(arg)
                 } else {
-                    selectedModules.addAll(common.retrieveAvalibleItemsWithWildcardMatch(arg));
+                    selectedItems.addAll(common.retrieveAvalibleItemsWithWildcardMatch(arg));
                 }
             }
             common.unCacheItemList()
 
-            common.retrieve(((String[])selectedModules.toArray()), recurse)
+            common.retrieve(((String[])selectedItems.toArray()), recurse)
         }
         break
 

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -54,6 +54,10 @@ switch(cleanerArgs[0]) {
         } else {
             // Note: processCustomRemote also drops one of the array elements from cleanerArgs
             cleanerArgs = common.processCustomRemote(cleanerArgs)
+            if (cleanerArgs[0] == "*") {
+                cleanerArgs = common.retrieveAvailableItems()
+            }
+
             common.retrieve cleanerArgs, recurse
         }
         break
@@ -214,6 +218,7 @@ def printUsage() {
     println "'-condensed-list-format' to group items by starting letter for the 'list' sub-command (default with many items)"
     println ""
     println "Example: 'groovyw module get Sample -remote jellysnake' - would retrieve Sample from jellysnake's Sample repo on GitHub."
+    println "Example: 'groovyw module get *' - would retrieve all the modules in the Terasology organisation on GitHub."
     println "Example: 'groovyw module recurse GooeysQuests Sample' - would retrieve those modules plus their dependencies as source"
     println "Example: 'groovyw lib list' - would list library projects compatible with being embedded in a Terasology workspace"
     println ""

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -227,10 +227,9 @@ def printUsage() {
     println ""
     println "Example: 'groovyw module get Sample -remote jellysnake' - would retrieve Sample from jellysnake's Sample repo on GitHub."
     println "Example: 'groovyw module get *' - would retrieve all the modules in the Terasology organisation on GitHub."
-    println "Example: 'groovyw module get *de*' - would retrieve all the modules in the Terasology organisation on GitHub" +
-            " that have the letter-pair \"de\" next somewhere within them."
-    println "Example: 'groovyw module get ?????Blocks' - would retrieve all the modules in the Terasology organisation on GitHub" +
-            " that start with any five characters and end with 'Blocks'."
+    println "Example: 'groovyw module get Sa??l*' - would retrieve all the modules in the Terasology organisation on GitHub" +
+            " that start with \"Sa\", have any two characters after that, then an \"l\" and then end with anything else." +
+            " This should retrieve the Sample repository from the Terasology organisation on GitHub."
     println ""
     println "*NOTE*: On UNIX platforms (MacOS and Linux), the arguments must be escaped with single quotes e.g. groovyw module get '*'."
     println ""

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -231,7 +231,7 @@ def printUsage() {
             " that start with \"Sa\", have any two characters after that, then an \"l\" and then end with anything else." +
             " This should retrieve the Sample repository from the Terasology organisation on GitHub."
     println ""
-    println "*NOTE*: On UNIX platforms (MacOS and Linux), the arguments must be escaped with single quotes e.g. groovyw module get '*'."
+    println "*NOTE*: On UNIX platforms (MacOS and Linux), the wildcard arguments must be escaped with single quotes e.g. groovyw module get '*'."
     println ""
     println "Example: 'groovyw module recurse GooeysQuests Sample' - would retrieve those modules plus their dependencies as source"
     println "Example: 'groovyw lib list' - would list library projects compatible with being embedded in a Terasology workspace"

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -55,7 +55,6 @@ switch(cleanerArgs[0]) {
             // Note: processCustomRemote also drops one of the array elements from cleanerArgs
             cleanerArgs = common.processCustomRemote(cleanerArgs)
             ArrayList<String> selectedModules = new ArrayList<String>()
-            String[] moduleList = common.retrieveAvailableItems()
 
             common.cacheItemList()
             for (String arg : cleanerArgs) {

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -66,15 +66,15 @@ switch(cleanerArgs[0]) {
                          * Forming the regex:
                          * "\Q" starts an explicit quote (which includes all reserved characters as well)
                          * "\E" ends an explicit quote
-                         * "\w*" is equivalent to "*" - it selects anything that has the same characters as before or
-                         * after the asterisk
-                         * "\w*" is equivalent to "?" - it selects anything that has the rest of the pattern but any
+                         * "\w*" is equivalent to "*" - it selects anything that has the same characters
+                         * (in the range of a-z, A-Z or 1-9) as before and after the asterisk
+                         * "." is equivalent to "?" - it selects anything that has the rest of the pattern but any
                          * character in the "?" symbol's position
                          * So, "\Q<INPUT_PART1>\E\w*\Q\<INPUT_PART1>E", selects anything that starts with INPUT_PART1
                          * and ends with INPUT_PART2 - This regex expression is equivalent to the input argument
                          * "INPUT_PART1*INPUT_PART2"
                          */
-                        String regex = ("\\Q" + arg.replace("*", "\\E\\w*\\Q").replace("?", "\\E\\w+\\Q") + "\\E")
+                        String regex = ("\\Q" + arg.replace("*", "\\E\\w*\\Q").replace("?", "\\E.\\Q") + "\\E")
                         if (module.matches(regex)) {
                             selectedModules.add(module)
                         }

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -57,30 +57,15 @@ switch(cleanerArgs[0]) {
             ArrayList<String> selectedModules = new ArrayList<String>()
             String[] moduleList = common.retrieveAvailableItems()
 
+            common.cacheItemList()
             for (String arg : cleanerArgs) {
                 if (!arg.contains('*') && !arg.contains('?')) {
                     selectedModules.add(arg)
                 } else {
-                    for (String module : moduleList) {
-                        /**
-                         * Forming the regex:
-                         * "\Q" starts an explicit quote (which includes all reserved characters as well)
-                         * "\E" ends an explicit quote
-                         * "\w*" is equivalent to "*" - it selects anything that has the same characters
-                         * (in the range of a-z, A-Z or 1-9) as before and after the asterisk
-                         * "." is equivalent to "?" - it selects anything that has the rest of the pattern but any
-                         * character in the "?" symbol's position
-                         * So, "\Q<INPUT_PART1>\E\w*\Q\<INPUT_PART1>E", selects anything that starts with INPUT_PART1
-                         * and ends with INPUT_PART2 - This regex expression is equivalent to the input argument
-                         * "INPUT_PART1*INPUT_PART2"
-                         */
-                        String regex = ("\\Q" + arg.replace("*", "\\E\\w*\\Q").replace("?", "\\E.\\Q") + "\\E")
-                        if (module.matches(regex)) {
-                            selectedModules.add(module)
-                        }
-                    }
+                    selectedModules.addAll(common.retrieveAvalibleItemsWithWildcardMatch(arg));
                 }
             }
+            common.unCacheItemList()
 
             common.retrieve(((String[])selectedModules.toArray()), recurse)
         }
@@ -245,6 +230,11 @@ def printUsage() {
     println "Example: 'groovyw module get *' - would retrieve all the modules in the Terasology organisation on GitHub."
     println "Example: 'groovyw module get *de*' - would retrieve all the modules in the Terasology organisation on GitHub" +
             " that have the letter-pair \"de\" next somewhere within them."
+    println "Example: 'groovyw module get ?????Blocks' - would retrieve all the modules in the Terasology organisation on GitHub" +
+            " that start with any five characters and end with 'Blocks'."
+    println ""
+    println "*NOTE*: On UNIX platforms (MacOS and Linux), the arguments must be escaped with single quotes e.g. groovyw module get '*'."
+    println ""
     println "Example: 'groovyw module recurse GooeysQuests Sample' - would retrieve those modules plus their dependencies as source"
     println "Example: 'groovyw lib list' - would list library projects compatible with being embedded in a Terasology workspace"
     println ""

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -61,7 +61,11 @@ if "x%~1" == "x" goto execute
 @REM set CMD_LINE_ARGS=%*
 :process_args
 IF "%1"=="" GOTO end
-IF "%1" == "*" (SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1") ELSE SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+echo "%1" | findstr /C:"\*" 1>nul && (
+    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1"
+) || (
+    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+)
 SHIFT
 GOTO process_args
 

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -61,10 +61,15 @@ if "x%~1" == "x" goto execute
 @REM set CMD_LINE_ARGS=%*
 :process_args
 IF "%1"=="" GOTO end
-echo "%1" | findstr /C:"\*" 1>nul && (
-    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1"
+SET ARG=%~1
+echo "%ARG%" | findstr /C:"\*" 1>nul && (
+    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%ARG%"
 ) || (
-    SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+    echo "%ARG%" | findstr /C:"\?" 1>nul && (
+        SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%ARG%"
+    ) || (
+        SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %ARG%
+    )
 )
 SHIFT
 GOTO process_args

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -58,7 +58,15 @@ set _SKIP=2
 :win9xME_args_slurp
 if "x%~1" == "x" goto execute
 
-set CMD_LINE_ARGS=%*
+@REM set CMD_LINE_ARGS=%*
+:process_args
+IF "%1"=="" GOTO end
+IF "%1" == "*" (SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%1") ELSE SET CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+SHIFT
+GOTO process_args
+
+:end
+SET CMD_LINE_ARGS=%CMD_LINE_ARGS:~1%
 
 :execute
 @rem Setup the command line

--- a/groovyw.bat
+++ b/groovyw.bat
@@ -58,10 +58,17 @@ set _SKIP=2
 :win9xME_args_slurp
 if "x%~1" == "x" goto execute
 
-@REM set CMD_LINE_ARGS=%*
+@REM Escapes all arguments containing either "*" or "?" before passing them to the groovy process
 :process_args
+@REM If we have no more arguments to process then exit the loop
 IF "%1"=="" GOTO end
 SET ARG=%~1
+@REM "echo "%ARG%" will simply output the argument as an escaped text string
+@REM for piping to other applications. This is needed to ensure that the arguments are not expanded.
+@REM findstr is a built-in Windows utility (it has been since Windows 2000)
+@REM that finds matches in strings based on regular expressions.
+@REM The "&&" operator is followed if the findstr program returns an exit code of 0
+@REM Otherwise, the "||" operator is followed instead.
 echo "%ARG%" | findstr /C:"\*" 1>nul && (
     SET CMD_LINE_ARGS=%CMD_LINE_ARGS% "%ARG%"
 ) || (
@@ -75,6 +82,8 @@ SHIFT
 GOTO process_args
 
 :end
+@REM For some reason, the escaped arguments always contain an extra space at the end, which confuses groovy.
+@REM This should remove it.
 SET CMD_LINE_ARGS=%CMD_LINE_ARGS:~1%
 
 :execute


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This PR adds wildcard support to the `groovyw <item> get <object>` e.g. `groovyw <item> get *`.

# Testing
Testing this PR could take some considerable time and effort to check all of the use-cases are correct, so these changes should only apply if wildcards (`*` or `?`) are detected in the input argument (see [Line 61 of util.groovy](https://github.com/BenjaminAmos/Terasology/blob/715d2450d077613a3fc3c6e5ee4ca26f3a9e9b7c/config/groovy/util.groovy#L61)). As such, I will list the series of tests that I have tried so far:
- Command: `groovyw module get *`
    - Expected result: All the available modules under the @Terasology organisation should be obtained.
- Command: `groovyw module get ?????Blocks`
    - Expected result: The [FunnyBlocks](https://github.com/Terasology/FunnyBlocks) module should be obtained.
- Command: `groovyw module get *StructureTemplates*`
    - Expected result: Both the [StructureTemplates](https://github.com/Terasology/StructureTemplates) and [AdditionalStructureTemplates](https://github.com/Terasology/AdditionalStructureTemplates) modules should be obtained.
- TODO: Add some more test examples - See [my other pull request](https://github.com/MovingBlocks/DestinationSol/pull/342) for another (although only functional with DestinationSol) set of examples.

# Outstanding Work
- [X] Such a large change needs significant testing. This change needs to be tested extensively to be proven useable, although I think that it should work most of the time. I still need to finish doing this, as I have not fully tested it yet.
    - Further tests to perform:
        - [X] Test that the regex characters (``[``, ``]``, ``(``, ``)``, ``*``, ``.``, ``\``) are not injected into the code
        - [X] Test if multiple wildcard selectors can be used to obtain completely different modules, e.g. using the command `groovyw module get *de* Fo*`, which should obtain all the modules that either have the letter pair "de" in them or that start with "Fo".

# Notes
This should not break any existing functionality, as the new wildcard handling code is only used when the `*` or `?` symbols are found.

The wildcard strings will have to be escaped using single quotes (e.g. ``./groovyw module get '*'`` rather than ``./groovyw module get *``) on POSIX platforms (Linux and MacOS), as otherwise the terminal appears to automatically expand them (replacing the arguments with the names all the files in the current directory matching that descriptor) before passing them to the program. I have modified the Windows script to automatically escape the arguments, although I am not sure if it is possible with POSIX platforms to do so.
<!--
### Pre Pull Request Checklist:
 When scanning the code with SonarLint, just don't introduce any new issues, and maybe even fix a few existing ones
- [ ] Code has been scanned with [SonarLint](http://www.sonarlint.org/intellij/)
- [ ] Methods have been annotated with @ Nullable and @ Nonnull ([Read more](https://github.com/MovingBlocks/DestinationSol/wiki/@Nullable-&-@Nonnull-Quickstart))
- [ ] There are no errors present in the project
- [ ] Code has been formatted and indented
- [ ] Methods have appropriate Javadoc ([How to write Javadoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html))
-->