### PR TITLE
Fixed world saving error when running with ServerFacade

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -106,6 +106,13 @@ public class StateHeadlessSetup implements GameState {
         } else {
             gameManifest = createGameManifest();
         }
+
+        Config config = context.get(Config.class);
+        WorldInfo worldInfo = gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD);
+        config.getUniverseConfig().addWorldManager(worldInfo);
+        config.getUniverseConfig().setSpawnWorldTitle(worldInfo.getTitle());
+        config.getUniverseConfig().setUniverseSeed(gameManifest.getSeed());
+
         gameEngine.changeState(new StateLoading(gameManifest, NetworkMode.LISTEN_SERVER));
     }
 


### PR DESCRIPTION
### Contains

Fixes a bug where the FacadeServer fails to save the `worlds` object in `manifest.json`, which causes this error on start.

The Headless client doesn't have this error though, so it might be something else, but this is just a quick fix.

There are still errors in FacadeServer when you connect to it which go away if you disable world saving.

```
21:21:09.124 [main] ERROR o.terasology.engine.TerasologyEngine - Uncaught exception, attempting clean game shutdown
java.lang.NullPointerException: null
at org.terasology.engine.modes.loadProcesses.InitialiseWorld.step(InitialiseWorld.java:100)
at org.terasology.engine.modes.StateLoading.update(StateLoading.java:243)
at org.terasology.engine.TerasologyEngine.tick(TerasologyEngine.java:458)
at org.terasology.engine.TerasologyEngine.mainLoop(TerasologyEngine.java:421)
at org.terasology.engine.TerasologyEngine.run(TerasologyEngine.java:397)
at org.terasology.web.EngineRunner.runEngine(EngineRunner.java:66)
at org.terasology.web.ServerMain.main(ServerMain.java:124)
```

### How to test

Install FacadeServer and run it. It should start up without any problems

### Outstanding before merging

- [ ] Fix outstanding errors