### PR TITLE
Overhauled R&R serialization

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -110,7 +110,7 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
         assert !Files.isRegularFile(vfs.getPath("global.dat"));
 
         entityManager = context.get(EngineEntityManager.class);
-        moduleEnvironment = context.get(ModuleEnvironment.class);
+        moduleEnvironment = mock(ModuleEnvironment.class);
         blockManager = context.get(BlockManager.class);
         biomeManager = context.get(BiomeManager.class);
 

--- a/engine-tests/src/test/java/org/terasology/recording/EventSystemReplayImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/recording/EventSystemReplayImplTest.java
@@ -31,6 +31,7 @@ import org.terasology.entitySystem.prefab.internal.PojoPrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.input.binds.interaction.AttackButton;
 import org.terasology.input.events.InputEvent;
+import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -73,7 +74,9 @@ public class EventSystemReplayImplTest {
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
         CharacterStateEventPositionMap characterStateEventPositionMap = new CharacterStateEventPositionMap();
         DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
-        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, eventStore, recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList, null);
+        ModuleEnvironment moduleEnvironment = mock(ModuleEnvironment.class);
+        RecordAndReplaySerializer recordAndReplaySerializer = new RecordAndReplaySerializer(entityManager, eventStore,
+                recordAndReplayUtils, characterStateEventPositionMap, directionAndOriginPosRecorderList, moduleEnvironment);
         recordAndReplayCurrentStatus.setStatus(RecordAndReplayStatus.REPLAYING);
         entity = entityManager.create();
         Long id = entity.getId();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/CharacterTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/CharacterTypeHandler.java
@@ -22,14 +22,17 @@ import org.terasology.persistence.typeHandling.TypeHandler;
 import java.util.Optional;
 
 public class CharacterTypeHandler extends TypeHandler<Character> {
+
     @Override
     protected PersistedData serializeNonNull(Character value, PersistedDataSerializer serializer) {
+        // converts value to string since char is not a JSON primitive type
         return serializer.serialize(Character.toString(value));
     }
 
     @Override
     public Optional<Character> deserialize(PersistedData data) {
         if (data.isString()) {
+            // returns the character that was serialized as string
             return Optional.of(data.getAsString().charAt(0));
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordAndReplaySerializer.java
@@ -47,7 +47,6 @@ public final class RecordAndReplaySerializer {
     private static final String STATE_EVENT_POSITION = "/state_event_position" + JSON;
     private static final String DIRECTION_ORIGIN_LIST = "/direction_origin_list" + JSON;
 
-    private EntityManager entityManager;
     private RecordedEventStore recordedEventStore;
     private RecordAndReplayUtils recordAndReplayUtils;
     private CharacterStateEventPositionMap characterStateEventPositionMap;
@@ -57,12 +56,11 @@ public final class RecordAndReplaySerializer {
     public RecordAndReplaySerializer(EntityManager manager, RecordedEventStore store,
                                      RecordAndReplayUtils recordAndReplayUtils, CharacterStateEventPositionMap characterStateEventPositionMap,
                                      DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList, ModuleEnvironment moduleEnvironment) {
-        this.entityManager = manager;
         this.recordedEventStore = store;
         this.recordAndReplayUtils = recordAndReplayUtils;
         this.characterStateEventPositionMap = characterStateEventPositionMap;
         this.directionAndOriginPosRecorderList = directionAndOriginPosRecorderList;
-        this.recordedEventSerializer = new RecordedEventSerializer(entityManager, moduleEnvironment);
+        this.recordedEventSerializer = new RecordedEventSerializer(manager, moduleEnvironment);
     }
 
     /**
@@ -73,7 +71,7 @@ public final class RecordAndReplaySerializer {
         serializeRecordedEvents(recordingPath);
         Gson gson = new GsonBuilder().create();
         serializeFileAmount(gson, recordingPath);
-        serializeCharacterStateEventPositonMap(gson, recordingPath);
+        serializeCharacterStateEventPositionMap(gson, recordingPath);
         serializeAttackEventExtraRecorder(gson, recordingPath);
     }
 
@@ -97,7 +95,7 @@ public final class RecordAndReplaySerializer {
         deserializeRecordedEvents(recordingPath);
         Gson gson = new GsonBuilder().create();
         deserializeFileAmount(gson, recordingPath);
-        deserializeCharacterStateEventPositonMap(gson, recordingPath);
+        deserializeCharacterStateEventPositionMap(gson, recordingPath);
         deserializeAttackEventExtraRecorder(gson, recordingPath);
     }
 
@@ -135,7 +133,7 @@ public final class RecordAndReplaySerializer {
         }
     }
 
-    private void serializeCharacterStateEventPositonMap(Gson gson, String recordingPath) {
+    private void serializeCharacterStateEventPositionMap(Gson gson, String recordingPath) {
         try {
             JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + STATE_EVENT_POSITION));
             gson.toJson(characterStateEventPositionMap.getIdToData(), HashMap.class, writer);
@@ -147,7 +145,7 @@ public final class RecordAndReplaySerializer {
         }
     }
 
-    private void deserializeCharacterStateEventPositonMap(Gson gson, String recordingPath) {
+    private void deserializeCharacterStateEventPositionMap(Gson gson, String recordingPath) {
         try {
             JsonParser parser = new JsonParser();
             JsonElement jsonElement = parser.parse(new FileReader(recordingPath + STATE_EVENT_POSITION));

--- a/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
@@ -39,6 +39,7 @@ import org.terasology.persistence.typeHandling.gson.GsonPersistedDataSerializer;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
+import org.terasology.utilities.ReflectionUtil;
 
 import java.io.Reader;
 import java.io.FileReader;
@@ -70,7 +71,10 @@ class RecordedEventSerializer {
         typeSerializationLibrary.addTypeHandler(MouseInput.class, new EnumTypeHandler<>(MouseInput.class));
         typeSerializationLibrary.addTypeHandler(MovementMode.class, new EnumTypeHandler<>(MovementMode.class));
 
-        this.recordedEventListTypeHandler = typeSerializationLibrary.getTypeHandler(new TypeInfo<List<RecordedEvent>>() {}).get();
+        ClassLoader[] classLoaders = ReflectionUtil.getComprehensiveEngineClassLoaders(moduleEnvironment);
+
+        this.recordedEventListTypeHandler = typeSerializationLibrary.getTypeHandler(
+                new TypeInfo<List<RecordedEvent>>() {}, classLoaders).get();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
@@ -110,6 +110,10 @@ class RecordedEventSerializer {
 
             Optional<List<RecordedEvent>> recordedEvents = recordedEventListTypeHandler.deserialize(persistedData);
             recordedEvents.ifPresent(events::addAll);
+
+            if (!recordedEvents.isPresent()) {
+                logger.error("Some problem occurred during deserialization, no recorded events was found");
+            }
         } catch (IOException e) {
             logger.error("Error while serializing recorded events", e);
         }

--- a/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
@@ -17,6 +17,7 @@ package org.terasology.recording;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
@@ -80,11 +81,11 @@ class RecordedEventSerializer {
      */
     public void serializeRecordedEvents(List<RecordedEvent> events, String filePath) {
         GsonPersistedDataSerializer serializationContext = new GsonPersistedDataSerializer();
-        PersistedData data = recordedEventListTypeHandler.serialize(events, serializationContext);
+        GsonPersistedData data = (GsonPersistedData) recordedEventListTypeHandler.serialize(events, serializationContext);
 
         try (Writer writer = new FileWriter(filePath)) {
             Gson gson = new GsonBuilder().create();
-            gson.toJson(data, writer);
+            gson.toJson(data.getElement(), writer);
         } catch (IOException e) {
             logger.error("Error while serializing recorded events", e);
         }
@@ -100,8 +101,10 @@ class RecordedEventSerializer {
 
         try (Reader reader = new FileReader(filePath)) {
             Gson gson = new GsonBuilder().create();
-            PersistedData record = gson.fromJson(reader, GsonPersistedData.class);
-            Optional<List<RecordedEvent>> recordedEvents = recordedEventListTypeHandler.deserialize(record);
+            JsonElement jsonElement = gson.fromJson(reader, JsonElement.class);
+            PersistedData persistedData = new GsonPersistedData(jsonElement);
+
+            Optional<List<RecordedEvent>> recordedEvents = recordedEventListTypeHandler.deserialize(persistedData);
             recordedEvents.ifPresent(events::addAll);
         } catch (IOException e) {
             logger.error("Error while serializing recorded events", e);

--- a/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEventSerializer.java
@@ -17,46 +17,17 @@ package org.terasology.recording;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.stream.JsonWriter;
-import gnu.trove.list.TFloatList;
-import gnu.trove.list.array.TFloatArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.audio.StaticSound;
-import org.terasology.audio.events.PlaySoundEvent;
-import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.LowLevelEntityManager;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
-import org.terasology.entitySystem.event.Event;
-import org.terasology.input.BindAxisEvent;
-import org.terasology.input.BindButtonEvent;
 import org.terasology.input.ButtonState;
 import org.terasology.input.Keyboard;
 import org.terasology.input.MouseInput;
-import org.terasology.input.cameraTarget.CameraTargetChangedEvent;
-import org.terasology.input.events.InputEvent;
-import org.terasology.input.events.KeyDownEvent;
-import org.terasology.input.events.KeyEvent;
-import org.terasology.input.events.KeyRepeatEvent;
-import org.terasology.input.events.KeyUpEvent;
 import org.terasology.input.events.MouseAxisEvent;
-import org.terasology.input.events.MouseButtonEvent;
-import org.terasology.input.events.MouseWheelEvent;
-import org.terasology.logic.characters.CharacterMoveInputEvent;
-import org.terasology.logic.characters.GetMaxSpeedEvent;
 import org.terasology.logic.characters.MovementMode;
-import org.terasology.logic.characters.events.AttackEvent;
-import org.terasology.math.geom.Vector2i;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.module.ModuleEnvironment;
-import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
@@ -64,16 +35,18 @@ import org.terasology.persistence.typeHandling.coreTypes.EnumTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.EntityRefTypeHandler;
 import org.terasology.persistence.typeHandling.gson.GsonPersistedData;
 import org.terasology.persistence.typeHandling.gson.GsonPersistedDataSerializer;
+import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
 
+import java.io.Reader;
 import java.io.FileReader;
+import java.io.Writer;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 /**
  * Serializes and deserializes RecordedEvents.
@@ -81,445 +54,59 @@ import java.util.Map;
 class RecordedEventSerializer {
 
     private static final Logger logger = LoggerFactory.getLogger(RecordedEventSerializer.class);
-    private static final double DEFAULT_DOUBLE_VALUE = 0.0;
-    private TypeSerializationLibrary typeSerializationLibrary;
-    private EntityManager entityManager;
-    private ModuleEnvironment moduleEnvironment;
-    private Map<String, Class<? extends InputEvent>> inputEventClassMap;
 
+    private TypeHandler<List<RecordedEvent>> recordedEventListTypeHandler;
 
-    RecordedEventSerializer(EntityManager entityManager, ModuleEnvironment moduleEnvironment) {
+    public RecordedEventSerializer(EntityManager entityManager, ModuleEnvironment moduleEnvironment) {
         ReflectionReflectFactory reflectFactory = new ReflectionReflectFactory();
         CopyStrategyLibrary copyStrategyLibrary = new CopyStrategyLibrary(reflectFactory);
-        this.typeSerializationLibrary = TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
+
+        TypeSerializationLibrary typeSerializationLibrary = TypeSerializationLibrary.createDefaultLibrary(reflectFactory, copyStrategyLibrary);
         typeSerializationLibrary.addTypeHandler(EntityRef.class, new EntityRefTypeHandler((EngineEntityManager) entityManager));
         typeSerializationLibrary.addTypeHandler(MouseAxisEvent.MouseAxis.class, new EnumTypeHandler<>(MouseAxisEvent.MouseAxis.class));
         typeSerializationLibrary.addTypeHandler(ButtonState.class, new EnumTypeHandler<>(ButtonState.class));
         typeSerializationLibrary.addTypeHandler(Keyboard.Key.class, new EnumTypeHandler<>(Keyboard.Key.class));
         typeSerializationLibrary.addTypeHandler(MouseInput.class, new EnumTypeHandler<>(MouseInput.class));
         typeSerializationLibrary.addTypeHandler(MovementMode.class, new EnumTypeHandler<>(MovementMode.class));
-        this.entityManager = entityManager;
-        this.moduleEnvironment = moduleEnvironment;
+
+        this.recordedEventListTypeHandler = typeSerializationLibrary.getTypeHandler(new TypeInfo<List<RecordedEvent>>() {}).get();
     }
 
-    void serializeRecordedEvents(List<RecordedEvent> events, String filePath) {
-        try {
-            JsonWriter writer = new JsonWriter(new FileWriter(filePath));
-            writer.beginObject();
-            writer.name("events");
-            writer.beginArray();
-            for (RecordedEvent event : events) {
-                writer.beginObject();
-                writer.name("entityRef_ID").value(event.getEntityId());
-                writer.name("timestamp").value(event.getTimestamp());
-                writer.name("index").value(event.getIndex());
-                writer.name("event_class").value(event.getEvent().getClass().getName());
-                writer.name("event_data");
-                writer.beginObject();
-                writeSpecificEventData(writer, event.getEvent());
-                writer.endObject();
-                writer.endObject();
-            }
-            writer.endArray();
-            writer.endObject();
-            writer.close();
-        } catch (Exception e) {
-            logger.error("Error while serializing events:", e);
-        }
+    /**
+     * Serializes RecordedEvent's list.
+     *
+     * @param events RecordedEvent's list.
+     * @param filePath path where the data should be saved.
+     */
+    public void serializeRecordedEvents(List<RecordedEvent> events, String filePath) {
+        GsonPersistedDataSerializer serializationContext = new GsonPersistedDataSerializer();
+        PersistedData data = recordedEventListTypeHandler.serialize(events, serializationContext);
 
-
-    }
-
-    private void writeSpecificEventData(JsonWriter writer, Event event) {
-        try {
-            GsonPersistedDataSerializer serializationContext = new GsonPersistedDataSerializer();
+        try (Writer writer = new FileWriter(filePath)) {
             Gson gson = new GsonBuilder().create();
-            if (event instanceof InputEvent) {
-                InputEvent e = (InputEvent) event;
-                writer.name("delta").value(e.getDelta());
-                writer.name("consumed").value(e.isConsumed());
-                writer.name("target").value(e.getTarget().getId());
-
-                writeVector3fData(writer, serializationContext, e);
-                writeInputEventInstanceData(writer, event, serializationContext);
-
-
-            } else if (event instanceof CameraTargetChangedEvent) {
-                CameraTargetChangedEvent e = (CameraTargetChangedEvent) event;
-                writer.name("OldTarget").value(e.getOldTarget().getId());
-                writer.name("NewTarget").value(e.getNewTarget().getId());
-            } else if (event instanceof PlaySoundEvent) {
-                PlaySoundEvent e = (PlaySoundEvent) event;
-                writer.name("volume").value(e.getVolume());
-                TypeHandler handler = typeSerializationLibrary.getTypeHandler(StaticSound.class, getClass().getClassLoader()).get();
-                PersistedData data = handler.serialize(e.getSound(), serializationContext);
-                writer.name("sound").value(data.getAsString());
-
-            } else if (event instanceof CharacterMoveInputEvent) {
-                CharacterMoveInputEvent e = (CharacterMoveInputEvent) event;
-                writer.name("delta").value(e.getDeltaMs());
-                writer.name("pitch").value(e.getPitch());
-                writer.name("yaw").value(e.getYaw());
-                writer.name("running").value(e.isRunning());
-                writer.name("crouching").value(e.isCrouching());
-                writer.name("jumpRequested").value(e.isJumpRequested());
-                writer.name("sequeceNumber").value(e.getSequenceNumber());
-                writer.name("firstRun").value(e.isFirstRun());
-                TypeHandler handler = typeSerializationLibrary.getTypeHandler(Vector3f.class, getClass().getClassLoader()).get();
-                GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getMovementDirection(), serializationContext);
-                writer.name("movementDirection");
-                writer.beginObject();
-                JsonArray array = data.getElement().getAsJsonArray();
-                writer.name("x").value(array.get(0).getAsFloat());
-                writer.name("y").value(array.get(1).getAsFloat());
-                writer.name("z").value(array.get(2).getAsFloat());
-                writer.endObject();
-
-            } else if (event instanceof GetMaxSpeedEvent) {
-                GetMaxSpeedEvent e = (GetMaxSpeedEvent) event;
-                writer.name("baseValue").value(e.getBaseValue());
-                TypeHandler handler = typeSerializationLibrary.getTypeHandler(MovementMode.class, getClass().getClassLoader()).get();
-                GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getMovementMode(), serializationContext);
-                writer.name("movementMode").value(data.getAsString());
-                writer.name("modifiers");
-                gson.toJson(e.getModifiers(), TFloatArrayList.class, writer);
-                writer.name("multipliers");
-                gson.toJson(e.getMultipliers(), TFloatArrayList.class, writer);
-                writer.name("postModifiers");
-                gson.toJson(e.getPostModifiers(), TFloatArrayList.class, writer);
-            } else if (event instanceof AttackEvent) {
-                AttackEvent e = (AttackEvent) event;
-                writer.name("instigator").value(e.getInstigator().getId());
-                writer.name("directCause").value(e.getDirectCause().getId());
-            } else {
-                logger.error("ERROR: EVENT NOT SUPPORTED FOR SERIALIZATION");
-            }
-        } catch (Exception e) {
-            logger.error("Could not serialize this event: " + event.toString(), e);
+            gson.toJson(data, writer);
+        } catch (IOException e) {
+            logger.error("Error while serializing recorded events", e);
         }
     }
 
-    private void writeVector3fData(JsonWriter writer, GsonPersistedDataSerializer serializationContext, InputEvent e) throws IOException {
-        if (e.getHitNormal() == null) {
-            writeDefaultVector3fData(writer);
-        } else {
-            writeRealVector3fData(writer, serializationContext, e);
-        }
-    }
-
-    private void writeRealVector3fData(JsonWriter writer, GsonPersistedDataSerializer serializationContext, InputEvent e) throws IOException {
-        TypeHandler handler = typeSerializationLibrary.getTypeHandler(Vector3f.class, getClass().getClassLoader()).get();
-        GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getHitNormal(), serializationContext);
-        writer.name("hitNormal");
-        writer.beginObject();
-        JsonArray array = data.getElement().getAsJsonArray();
-        writer.name("x").value(array.get(0).getAsFloat());
-        writer.name("y").value(array.get(1).getAsFloat());
-        writer.name("z").value(array.get(2).getAsFloat());
-        writer.endObject();
-
-        data = (GsonPersistedData) handler.serialize(e.getHitPosition(), serializationContext);
-        writer.name("hitPosition");
-        writer.beginObject();
-        array = data.getElement().getAsJsonArray();
-        writer.name("x").value(array.get(0).getAsFloat());
-        writer.name("y").value(array.get(1).getAsFloat());
-        writer.name("z").value(array.get(2).getAsFloat());
-        writer.endObject();
-
-        handler = typeSerializationLibrary.getTypeHandler(Vector3i.class, getClass().getClassLoader()).get();
-        data = (GsonPersistedData) handler.serialize(e.getTargetBlockPosition(), serializationContext);
-        writer.name("targetBlockPosition");
-        writer.beginObject();
-        array = data.getElement().getAsJsonArray();
-        writer.name("x").value(array.get(0).getAsInt());
-        writer.name("y").value(array.get(1).getAsInt());
-        writer.name("z").value(array.get(2).getAsInt());
-        writer.endObject();
-    }
-
-    private void writeDefaultVector3fData(JsonWriter writer) throws IOException {
-        writer.name("hitNormal");
-        writer.beginObject();
-        writer.name("x").value(DEFAULT_DOUBLE_VALUE);
-        writer.name("y").value(DEFAULT_DOUBLE_VALUE);
-        writer.name("z").value(DEFAULT_DOUBLE_VALUE);
-        writer.endObject();
-
-        writer.name("hitPosition");
-        writer.beginObject();
-        writer.name("x").value(DEFAULT_DOUBLE_VALUE);
-        writer.name("y").value(DEFAULT_DOUBLE_VALUE);
-        writer.name("z").value(DEFAULT_DOUBLE_VALUE);
-        writer.endObject();
-
-        writer.name("targetBlockPosition");
-        writer.beginObject();
-        writer.name("x").value(DEFAULT_DOUBLE_VALUE);
-        writer.name("y").value(DEFAULT_DOUBLE_VALUE);
-        writer.name("z").value(DEFAULT_DOUBLE_VALUE);
-        writer.endObject();
-    }
-
-    private void writeInputEventInstanceData(JsonWriter writer, Event event, GsonPersistedDataSerializer serializationContext) throws Exception {
-        if (event instanceof MouseWheelEvent) {
-            MouseWheelEvent e = (MouseWheelEvent) event;
-            writer.name("wheelTurns").value(e.getWheelTurns());
-            TypeHandler handler = typeSerializationLibrary.getTypeHandler(Vector2i.class, getClass().getClassLoader()).get();
-            GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getMousePosition(), serializationContext);
-            writer.name("mousePosition");
-            writer.beginObject();
-            JsonArray array = data.getElement().getAsJsonArray();
-            writer.name("x").value(array.get(0).getAsInt());
-            writer.name("y").value(array.get(1).getAsInt());
-            writer.endObject();
-        } else if (event instanceof MouseAxisEvent) {
-            MouseAxisEvent e = (MouseAxisEvent) event;
-            writer.name("value").value(e.getValue());
-            TypeHandler handler = typeSerializationLibrary.getTypeHandler(MouseAxisEvent.MouseAxis.class, getClass().getClassLoader()).get();
-            GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getMouseAxis(), serializationContext);
-            writer.name("mouseAxis").value(data.getAsString());
-        } else if (event instanceof BindAxisEvent) {
-            BindAxisEvent e = (BindAxisEvent) event;
-            writer.name("id").value(e.getId());
-            writer.name("value").value(e.getValue());
-        } else if (event instanceof BindButtonEvent) {
-            BindButtonEvent e = (BindButtonEvent) event;
-            TypeHandler handler = typeSerializationLibrary.getTypeHandler(ButtonState.class, getClass().getClassLoader()).get();
-            GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getState(), serializationContext);
-            writer.name("state").value(data.getAsString());
-            writer.name("id");
-            writer.beginObject();
-            handler = typeSerializationLibrary.getTypeHandler(Name.class, getClass().getClassLoader()).get();
-            data = (GsonPersistedData) handler.serialize(e.getId().getModuleName(), serializationContext);
-            writer.name("moduleName").value(data.getAsString());
-            data = (GsonPersistedData) handler.serialize(e.getId().getObjectName(), serializationContext);
-            writer.name("objectName").value(data.getAsString());
-            writer.endObject();
-        } else if (event instanceof KeyEvent) {
-            KeyEvent e = (KeyEvent) event;
-            writer.name("keychar").value(e.getKeyCharacter());
-            TypeHandler handler = typeSerializationLibrary.getTypeHandler(ButtonState.class, getClass().getClassLoader()).get();
-            GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getState(), serializationContext);
-            writer.name("state").value(data.getAsString());
-            handler = typeSerializationLibrary.getTypeHandler(Keyboard.Key.class, getClass().getClassLoader()).get(); // might need to add some things to key
-            data = (GsonPersistedData) handler.serialize(e.getKey(), serializationContext);
-            writer.name("input").value(data.getAsString());
-        } else if (event instanceof MouseButtonEvent) {
-            MouseButtonEvent e = (MouseButtonEvent) event;
-            TypeHandler handler = typeSerializationLibrary.getTypeHandler(ButtonState.class, getClass().getClassLoader()).get();
-            GsonPersistedData data = (GsonPersistedData) handler.serialize(e.getState(), serializationContext);
-            writer.name("state").value(data.getAsString());
-            handler = typeSerializationLibrary.getTypeHandler(MouseInput.class, getClass().getClassLoader()).get();
-            data = (GsonPersistedData) handler.serialize(e.getButton(), serializationContext);
-            writer.name("button").value(data.getAsString());
-            handler = typeSerializationLibrary.getTypeHandler(Vector2i.class, getClass().getClassLoader()).get();
-            data = (GsonPersistedData) handler.serialize(e.getMousePosition(), serializationContext);
-            writer.name("mousePosition");
-            writer.beginObject();
-            JsonArray array = data.getElement().getAsJsonArray();
-            writer.name("x").value(array.get(0).getAsInt());
-            writer.name("y").value(array.get(1).getAsInt());
-            writer.endObject();
-        } else {
-            logger.error("ERROR, EVENT NOT COMPATIBLE");
-        }
-    }
-
-    List<RecordedEvent> deserializeRecordedEvents(String path) {
+    /**
+     * Deserializes RecordedEvent's list.
+     *
+     * @param filePath path where the data should be saved.
+     */
+    public List<RecordedEvent> deserializeRecordedEvents(String filePath) {
         List<RecordedEvent> events = new ArrayList<>();
-        createInputEventClassMap();
-        JsonObject jsonObject;
-        try {
-            JsonParser parser = new JsonParser();
-            JsonElement jsonElement = parser.parse(new FileReader(path));
-            jsonObject = jsonElement.getAsJsonObject();
-            JsonArray jsonEvents = jsonObject.getAsJsonArray("events");
-            for (JsonElement element : jsonEvents) {
-                jsonObject = element.getAsJsonObject();
-                String className = jsonObject.get("event_class").getAsString();
-                long refId = jsonObject.get("entityRef_ID").getAsLong();
-                long index = jsonObject.get("index").getAsLong();
-                long timestamp = jsonObject.get("timestamp").getAsLong();
-                Event event = deserializeSpecificEventData(jsonObject.get("event_data").getAsJsonObject(), className);
-                RecordedEvent re = new RecordedEvent(refId, event, timestamp, index);
-                events.add(re);
-            }
-        } catch (Exception e) {
-            logger.error("Error while deserializing event:", e);
+
+        try (Reader reader = new FileReader(filePath)) {
+            Gson gson = new GsonBuilder().create();
+            PersistedData record = gson.fromJson(reader, GsonPersistedData.class);
+            Optional<List<RecordedEvent>> recordedEvents = recordedEventListTypeHandler.deserialize(record);
+            recordedEvents.ifPresent(events::addAll);
+        } catch (IOException e) {
+            logger.error("Error while serializing recorded events", e);
         }
 
         return events;
-    }
-
-    private void createInputEventClassMap() {
-        this.inputEventClassMap = new HashMap<>();
-        Iterable<Class<? extends InputEvent>> classes = moduleEnvironment.getSubtypesOf(InputEvent.class);
-        for (Class<? extends InputEvent> c : classes) {
-            this.inputEventClassMap.put(c.getName(), c);
-        }
-    }
-
-    private Event deserializeSpecificEventData(JsonObject jsonObject, String className) {
-        Event result = null;
-        Gson gson = new GsonBuilder().create();
-        if (className.equals(CameraTargetChangedEvent.class.getName())) {
-            EntityRef oldTarget = new RecordedEntityRef(jsonObject.get("OldTarget").getAsLong(), (LowLevelEntityManager) this.entityManager);
-            EntityRef newTarget =  new RecordedEntityRef(jsonObject.get("NewTarget").getAsLong(), (LowLevelEntityManager) this.entityManager);
-            result = new CameraTargetChangedEvent(oldTarget, newTarget);
-        } else if (className.equals(PlaySoundEvent.class.getName())) {
-            float volume = jsonObject.get("volume").getAsFloat();
-            GsonPersistedData data = new GsonPersistedData(jsonObject.get("sound"));
-            TypeHandler<StaticSound> handler = typeSerializationLibrary.getTypeHandler(StaticSound.class, getClass().getClassLoader()).get();
-            StaticSound sound = handler.deserializeOrThrow(data);
-            result = new PlaySoundEvent(sound, volume);
-        } else if (className.equals(CharacterMoveInputEvent.class.getName())) {
-            long delta = jsonObject.get("delta").getAsLong();
-            float pitch = jsonObject.get("pitch").getAsFloat();
-            float yaw = jsonObject.get("yaw").getAsFloat();
-            boolean running = jsonObject.get("running").getAsBoolean();
-            boolean crouching = jsonObject.get("crouching").getAsBoolean();
-            boolean jumpRequested = jsonObject.get("jumpRequested").getAsBoolean();
-            int sequenceNumber = jsonObject.get("sequeceNumber").getAsInt();
-            boolean firstRun = jsonObject.get("firstRun").getAsBoolean();
-            JsonObject objMoveDirection = jsonObject.get("movementDirection").getAsJsonObject();
-            Vector3f movementDirection = new Vector3f(objMoveDirection.get("x").getAsFloat(),
-                    objMoveDirection.get("y").getAsFloat(),
-                    objMoveDirection.get("z").getAsFloat());
-            result = new CharacterMoveInputEvent(sequenceNumber, pitch, yaw, movementDirection, running, crouching, jumpRequested, delta);
-        } else if (className.equals(GetMaxSpeedEvent.class.getName())) {
-            float baseValue = jsonObject.get("baseValue").getAsFloat();
-            TypeHandler<MovementMode> handler = typeSerializationLibrary.getTypeHandler(MovementMode.class, getClass().getClassLoader()).get();
-            GsonPersistedData data = new GsonPersistedData(jsonObject.get("movementMode"));
-            MovementMode movementMode = handler.deserializeOrThrow(data);
-            TFloatList modifiers = gson.fromJson(jsonObject.get("modifiers"), TFloatArrayList.class);
-            TFloatList multipliers = gson.fromJson(jsonObject.get("multipliers"), TFloatArrayList.class);
-            TFloatList postModifiers = gson.fromJson(jsonObject.get("postModifiers"), TFloatArrayList.class);
-            GetMaxSpeedEvent event = new GetMaxSpeedEvent(baseValue, movementMode);
-            event.setPostModifiers(postModifiers);
-            event.setMultipliers(multipliers);
-            event.setModifiers(modifiers);
-            result = event;
-        } else if (className.equals(AttackEvent.class.getName())) {
-            EntityRef instigator = new RecordedEntityRef(jsonObject.get("instigator").getAsLong(), (LowLevelEntityManager) this.entityManager);
-            EntityRef directCause = new RecordedEntityRef(jsonObject.get("directCause").getAsLong(), (LowLevelEntityManager) this.entityManager);
-            result = new AttackEvent(instigator, directCause);
-        } else if (getInputEventSpecificType(jsonObject, className) != null) { //input events
-            result = getInputEventSpecificType(jsonObject, className);
-        }
-
-        return result;
-    }
-
-    private InputEvent getInputEventSpecificType(JsonObject jsonObject, String className) {
-        InputEvent newEvent = null;
-        try {
-            Class clazz = this.inputEventClassMap.get(className);
-            if (BindButtonEvent.class.isAssignableFrom(clazz) || BindAxisEvent.class.isAssignableFrom(clazz)) {
-                newEvent = (InputEvent) clazz.getConstructor().newInstance();
-            } else if (clazz.equals(KeyDownEvent.class) || clazz.equals(KeyRepeatEvent.class) || clazz.equals(KeyUpEvent.class)) { //KeyEvent
-                GsonPersistedData data = new GsonPersistedData(jsonObject.get("input"));
-                TypeHandler<Keyboard.Key> keyTypeHandler = typeSerializationLibrary.getTypeHandler(Keyboard.Key.class, getClass().getClassLoader()).get();
-                Keyboard.Key input = keyTypeHandler.deserializeOrThrow(data);
-                data = new GsonPersistedData(jsonObject.get("state"));
-                TypeHandler<ButtonState> buttonStateTypeHandler =
-                        typeSerializationLibrary.getTypeHandler(ButtonState.class, getClass().getClassLoader()).get();
-                ButtonState state = buttonStateTypeHandler.deserializeOrThrow(data);
-                char keychar = jsonObject.get("keychar").getAsCharacter();
-                float delta = jsonObject.get("delta").getAsFloat();
-                KeyEvent aux;
-                if (clazz.equals(KeyDownEvent.class)) {
-                    aux = KeyDownEvent.create(input, keychar, delta); // The instance created here is static
-                    aux = KeyDownEvent.createCopy((KeyDownEvent) aux); // This copies the static value so each KeyEvent does not have the same value
-                } else if (clazz.equals(KeyRepeatEvent.class)) {
-                    aux = KeyRepeatEvent.create(input, keychar, delta);
-                    aux = KeyRepeatEvent.createCopy((KeyRepeatEvent) aux);
-                } else {
-                    aux = KeyUpEvent.create(input, keychar, delta);
-                    aux = KeyUpEvent.createCopy((KeyUpEvent) aux);
-                }
-                newEvent = aux;
-            } else if (clazz.equals(MouseButtonEvent.class)) {
-                GsonPersistedData data = new GsonPersistedData(jsonObject.get("button"));
-                TypeHandler<MouseInput> mouseInputTypeHandler =
-                        typeSerializationLibrary.getTypeHandler(MouseInput.class, getClass().getClassLoader()).get();
-                MouseInput button = mouseInputTypeHandler.deserializeOrThrow(data);
-                data = new GsonPersistedData(jsonObject.get("state"));
-                TypeHandler<ButtonState> buttonStateTypeHandler =
-                        typeSerializationLibrary.getTypeHandler(ButtonState.class, getClass().getClassLoader()).get();
-                ButtonState state = buttonStateTypeHandler.deserializeOrThrow(data);
-                JsonObject aux = jsonObject.get("mousePosition").getAsJsonObject();
-                Vector2i mousePosition = new Vector2i(aux.get("x").getAsInt(), aux.get("y").getAsInt());
-                float delta = jsonObject.get("delta").getAsFloat();
-                MouseButtonEvent event = new MouseButtonEvent(button, state, delta);
-                event.setMousePosition(mousePosition);
-                newEvent = event;
-            } else if (clazz.equals(MouseAxisEvent.class)) {
-                GsonPersistedData data = new GsonPersistedData(jsonObject.get("mouseAxis"));
-                TypeHandler<MouseAxisEvent.MouseAxis> typeHandler =
-                        typeSerializationLibrary.getTypeHandler(MouseAxisEvent.MouseAxis.class, getClass().getClassLoader()).get();
-                MouseAxisEvent.MouseAxis mouseAxis = typeHandler.deserializeOrThrow(data);
-                float value = jsonObject.get("value").getAsFloat();
-                float delta = jsonObject.get("delta").getAsFloat();
-                MouseAxisEvent aux = MouseAxisEvent.create(mouseAxis, value, delta);
-                newEvent = MouseAxisEvent.createCopy(aux);
-            } else if (clazz.equals(MouseWheelEvent.class)) {
-                JsonObject aux = jsonObject.get("mousePosition").getAsJsonObject();
-                Vector2i mousePosition = new Vector2i(aux.get("x").getAsInt(), aux.get("y").getAsInt());
-                int wheelTurns = jsonObject.get("wheelTurns").getAsInt();
-                float delta = jsonObject.get("delta").getAsFloat();
-                newEvent = new MouseWheelEvent(mousePosition, wheelTurns, delta);
-            } else {
-                logger.error("Not an Input Event");
-                return null;
-            }
-
-            if (newEvent instanceof BindButtonEvent) {
-                bindButtonEventSetup((BindButtonEvent) newEvent, jsonObject);
-            } else if (newEvent instanceof BindAxisEvent) {
-                bindAxisEvent((BindAxisEvent) newEvent, jsonObject);
-            }
-
-            inputEventSetup(newEvent, jsonObject);
-        } catch (Exception e) {
-            logger.error("Error while deserializing event. Could not find class " + className, e);
-        }
-        return newEvent;
-    }
-
-    private void bindButtonEventSetup(BindButtonEvent event, JsonObject jsonObject) {
-        GsonPersistedData data = new GsonPersistedData(jsonObject.get("state"));
-        TypeHandler<ButtonState> buttonStateTypeHandler =
-                typeSerializationLibrary.getTypeHandler(ButtonState.class, getClass().getClassLoader()).get();
-        ButtonState state = buttonStateTypeHandler.deserializeOrThrow(data);
-        float delta = jsonObject.get("delta").getAsFloat();
-        TypeHandler<Name> nameTypeHandler = typeSerializationLibrary.getTypeHandler(Name.class, getClass().getClassLoader()).get();
-        JsonObject aux = jsonObject.get("id").getAsJsonObject();
-        data = new GsonPersistedData(aux.get("moduleName"));
-        Name moduleName = nameTypeHandler.deserializeOrThrow(data);
-        data = new GsonPersistedData(aux.get("objectName"));
-        Name objectName = nameTypeHandler.deserializeOrThrow(data);
-        SimpleUri id = new SimpleUri(moduleName, objectName);
-        event.prepare(id, state, delta);
-    }
-
-    private void bindAxisEvent(BindAxisEvent event, JsonObject jsonObject) {
-        String id = jsonObject.get("id").getAsString();
-        float value = jsonObject.get("value").getAsFloat();
-        float delta = jsonObject.get("delta").getAsFloat();
-        event.prepare(id, value, delta);
-    }
-
-    private void inputEventSetup(InputEvent event, JsonObject jsonObject) {
-        float delta = jsonObject.get("delta").getAsFloat();
-        boolean consumed = jsonObject.get("consumed").getAsBoolean();
-        EntityRef target =  new RecordedEntityRef(jsonObject.get("target").getAsLong(), (LowLevelEntityManager) this.entityManager);
-        JsonObject aux = jsonObject.get("hitNormal").getAsJsonObject();
-        Vector3f hitNormal = new Vector3f(aux.get("x").getAsFloat(), aux.get("y").getAsFloat(), aux.get("z").getAsFloat());
-        aux = jsonObject.get("hitPosition").getAsJsonObject();
-        Vector3f hitPosition = new Vector3f(aux.get("x").getAsFloat(), aux.get("y").getAsFloat(), aux.get("z").getAsFloat());
-        aux = jsonObject.get("targetBlockPosition").getAsJsonObject();
-        Vector3i targetBlockPosition = new Vector3i(aux.get("x").getAsInt(), aux.get("y").getAsInt(), aux.get("z").getAsInt());
-        event.setTargetInfo(target, targetBlockPosition, hitPosition, hitNormal);
     }
 }


### PR DESCRIPTION
### Contains

With `CollectionTypeHandler`, the way `RecordedEvents` are serialized are now greatly improved, making the whole serialization more general, without having to write code for each and every type of event supported by R&R. By the way, before in `RecordedEventSerializer` we had **523** lines and now only **112** including javadocs. :smile: 

### How to test

- Create a record.
- Replay the record.

Closes #3466.