### PR TITLE
Font color tests

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class FontColorTest {
-	public static class IsValid {
+	public static class isValid {
 		
 		@Test
 		public void testResetColor() {
@@ -36,6 +36,6 @@ public class FontColorTest {
 		public void testInvalidColor() {
 			char invalidColor = 0xA10F;
 			assertFalse(FontColor.isValid(invalidColor));
-		}
+		}		
 	}
 }

--- a/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
@@ -1,0 +1,41 @@
+package org.terasology.rendering;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class FontColorTest {
+	public static class IsValid {
+		
+		@Test
+		public void testResetColor() {
+			char resetColor = 0xF000;
+			assertTrue(FontColor.isValid(resetColor));
+		}
+		
+		@Test
+		public void testFirstColor() {
+			char firstColor = 0xE000;
+			assertTrue(FontColor.isValid(firstColor));
+		}
+		
+		@Test
+		public void testLastColor() {
+			char lastColor = 0xEFFF;
+			assertTrue(FontColor.isValid(lastColor));
+		}
+		
+		@Test
+		public void testBetweenColor() {
+			char betweenColor = 0xEB8F;
+			assertTrue(FontColor.isValid(betweenColor));
+		}
+		
+		@Test
+		public void testInvalidColor() {
+			char invalidColor = 0xA10F;
+			assertFalse(FontColor.isValid(invalidColor));
+		}
+	}
+}

--- a/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
@@ -22,36 +22,34 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class FontColorTest {
-	public static class isValid {
 		
-		@Test
-		public void testResetColor() {
-			char resetColor = 0xF000;
-			assertTrue(FontColor.isValid(resetColor));
-		}
-		
-		@Test
-		public void testFirstColor() {
-			char firstColor = 0xE000;
-			assertTrue(FontColor.isValid(firstColor));
-		}
-		
-		@Test
-		public void testLastColor() {
-			char lastColor = 0xEFFF;
-			assertTrue(FontColor.isValid(lastColor));
-		}
-		
-		@Test
-		public void testBetweenColor() {
-			char betweenColor = 0xEB8F;
-			assertTrue(FontColor.isValid(betweenColor));
-		}
-		
-		@Test
-		public void testInvalidColor() {
-			char invalidColor = 0xA10F;
-			assertFalse(FontColor.isValid(invalidColor));
-		}		
-	}
+    @Test
+    public void testResetColor() {
+        char resetColor = 0xF000;
+        assertTrue(FontColor.isValid(resetColor));
+    }
+	
+    @Test
+	public void testFirstColor() {
+        char firstColor = 0xE000;
+        assertTrue(FontColor.isValid(firstColor));
+    }
+	
+	@Test
+	public void testLastColor() {
+        char lastColor = 0xEFFF;
+        assertTrue(FontColor.isValid(lastColor));
+    }
+	
+	@Test
+	public void testBetweenColor() {
+        char betweenColor = 0xEB8F;
+        assertTrue(FontColor.isValid(betweenColor));
+    }
+	
+	@Test
+	public void testInvalidColor() {
+        char invalidColor = 0xA10F;
+        assertFalse(FontColor.isValid(invalidColor));
+    }			
 }

--- a/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/FontColorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.terasology.rendering;
 
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

This pull request adds a new test suite under the engine-tests called FontColorTest. I mainly added tests for the isValid() method and the input it is required to take.

### How to test

Run my unit tests in the FontColorTest suite. (org.terasology.rendering)


