### PR TITLE
Close writer to prevent files from not being fully written

### DIFF
--- a/engine-tests/src/test/java/org/terasology/persistence/serializers/TypeSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/serializers/TypeSerializerTest.java
@@ -55,7 +55,7 @@ public class TypeSerializerTest {
         private final TypeSerializationLibrary typeSerializationLibrary = TypeSerializationLibrary.createDefaultLibrary(reflectFactory, new CopyStrategyLibrary(reflectFactory));
 
         @Test
-        public void testJsonSerialize() {
+        public void testJsonSerialize() throws IOException {
             GsonSerializer gsonSerializer = new GsonSerializer();
 
             TypeHandler<SomeClass<Integer>> typeHandler = typeSerializationLibrary.getTypeHandler(new TypeInfo<SomeClass<Integer>>() {}, TypeSerializerTest.class).get();

--- a/engine/src/main/java/org/terasology/persistence/serializers/GsonSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/GsonSerializer.java
@@ -45,7 +45,7 @@ public class GsonSerializer {
         this.gson = new Gson();
     }
 
-    public <T> String toJson(T object, TypeHandler<T> typeHandler) {
+    public <T> String toJson(T object, TypeHandler<T> typeHandler) throws IOException {
         StringWriter writer = new StringWriter();
 
         writeJson(object, typeHandler, writer);
@@ -53,14 +53,16 @@ public class GsonSerializer {
         return writer.toString();
     }
 
-    public <T> void writeJson(T object, TypeHandler<T> typeHandler, Writer writer) {
+    public <T> void writeJson(T object, TypeHandler<T> typeHandler, Writer writer) throws IOException {
         GsonPersistedData persistedData =
                 (GsonPersistedData) typeHandler.serialize(object, new GsonPersistedDataSerializer());
 
         gson.toJson(persistedData.getElement(), writer);
+
+        writer.close();
     }
 
-    public <T> void writeJson(T object, TypeHandler<T> typeHandler, OutputStream stream) {
+    public <T> void writeJson(T object, TypeHandler<T> typeHandler, OutputStream stream) throws IOException {
         writeJson(object, typeHandler, new BufferedWriter(new OutputStreamWriter(stream)));
     }
 


### PR DESCRIPTION
R&R is not running properly, because `FileWriter` has not been closed when saving the recording JSON. So the data in the buffer isn't written as the game ends without telling the writer to write the remaining content of its buffer. In other words, as the buffer isn't completely full and the writer isn't closed, it is holding the data assuming there will be more date to come.

### Contains

I called `writer.close()` right after `gson.toJson(persistedData.getElement(), writer)`.

### How to test

- Record a game and reply it.