### PR TITLE
Make the order of overlapping widgets change

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
@@ -26,8 +26,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-/**
- */
 public abstract class AbstractWidget implements UIWidget {
 
     @LayoutConfig
@@ -47,6 +45,8 @@ public abstract class AbstractWidget implements UIWidget {
 
     @LayoutConfig
     private float tooltipDelay = 0.5f;
+
+    protected int depth = new DefaultBinding<Integer>(-99999).get();
 
     private boolean focused;
 

--- a/engine/src/main/java/org/terasology/rendering/nui/CoreScreenLayer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/CoreScreenLayer.java
@@ -52,8 +52,6 @@ public abstract class CoreScreenLayer extends AbstractWidget implements UIScreen
 
     private NUIManager manager;
 
-    private int index;
-
     private MenuAnimationSystem animationSystem = new MenuAnimationSystemStub();
 
     public CoreScreenLayer() {
@@ -137,16 +135,6 @@ public abstract class CoreScreenLayer extends AbstractWidget implements UIScreen
     public void onScreenOpened() {
         if (!SortOrder.isInSortOrder()) {
             addOrRemove(true);
-        }
-    }
-
-    public final int getIndex() {
-        return index;
-    }
-
-    public final void setIndex() {
-        if (SortOrder.isInitialized()) {
-            this.index = SortOrder.makeIndex();
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/FocusChangedEvent.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/FocusChangedEvent.java
@@ -1,0 +1,7 @@
+package org.terasology.rendering.nui;
+
+
+import org.terasology.entitySystem.event.Event;
+
+public class FocusChangedEvent implements Event {
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/NUIManager.java
@@ -19,7 +19,10 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.systems.ComponentSystem;
 import org.terasology.reflection.metadata.ClassLibrary;
 import org.terasology.rendering.nui.asset.UIElement;
+import org.terasology.rendering.nui.internal.CanvasControl;
 import org.terasology.rendering.nui.layers.hud.HUDScreenLayer;
+
+import java.util.Deque;
 
 /**
  */
@@ -107,6 +110,14 @@ public interface NUIManager extends ComponentSystem, FocusManager {
 
     void removeOverlay(ResourceUrn uri);
 
+    Deque<UIScreenLayer> getScreens();
+
+    void setScreens(Deque<UIScreenLayer> screens);
+
+    ResourceUrn getUri(UIScreenLayer screen);
+
+    //void setUpdateFrozen(boolean updateFrozen);
+
     void clear();
 
     void render();
@@ -128,5 +139,7 @@ public interface NUIManager extends ComponentSystem, FocusManager {
     void setForceReleasingMouse(boolean value);
 
     void invalidate();
+
+    CanvasControl getCanvas();
 
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
@@ -43,7 +43,6 @@ public class SortOrder extends BaseComponentSystem {
     private static int current;
     private static ArrayList<Integer[]> layersFilled; //arg1 of the Integer[] is the layer depth, arg2 is the number of things on that layer
     private static int index;
-    private static int uiIndex;
     private static boolean inSortOrder;
     private static ArrayList<CoreScreenLayer> enabledWidgets;
     private static boolean initialized = false;
@@ -104,7 +103,6 @@ public class SortOrder extends BaseComponentSystem {
         }
         current = 0;
         index = 0;
-        uiIndex = -1;
         layersFilled = new ArrayList<>();
         enabledWidgets = new ArrayList<>();
         used = new ArrayList<>();
@@ -230,10 +228,6 @@ public class SortOrder extends BaseComponentSystem {
     }
     public static ArrayList<CoreScreenLayer> getEnabledWidgets() {
         return enabledWidgets;
-    }
-    public static int makeIndex() {
-        uiIndex++;
-        return uiIndex;
     }
 
     public static boolean isInitialized() {

--- a/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.rendering.nui;
+
+import com.google.common.collect.Queues;
+import org.terasology.engine.SimpleUri;
+import org.terasology.engine.subsystem.config.BindsManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.input.BindButtonEvent;
+import org.terasology.input.BindButtonSubscriber;
+import org.terasology.input.BindableButton;
+import org.terasology.input.Keyboard;
+import org.terasology.input.internal.BindableButtonImpl;
+import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
+import org.terasology.registry.In;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Map;
+
+
+@RegisterSystem(RegisterMode.ALWAYS)
+public class SortOrder extends BaseComponentSystem {
+    private static int current;
+    private static ArrayList<Integer[]> layersFilled; //arg1 of the Integer[] is the layer depth, arg2 is the number of things on that layer
+    private static int index;
+    private static int uiIndex;
+    private static boolean inSortOrder;
+    private static ArrayList<CoreScreenLayer> enabledWidgets;
+    private static boolean initialized = false;
+    private static ArrayList<Integer> used;
+
+    @In
+    private BindsManager bindsManager;
+
+    /**
+     * Initializes sort order
+     * @param event
+     * @param player
+     */
+    @ReceiveEvent
+    public void onPlayerSpawnedEvent(OnPlayerSpawnedEvent event, EntityRef player) {
+        initialized = true;
+        Map<Integer, BindableButton> keys = bindsManager.getKeyBinds();
+        if (keys.containsKey(Keyboard.Key.SEMICOLON.getId())) {
+            keys.get(Keyboard.Key.SEMICOLON.getId()).subscribe(new BindButtonSubscriber() {
+                @Override
+                public boolean onPress(float delta, EntityRef target) {
+                    target.send(new FocusChangedEvent());
+                    return false;
+                }
+
+                @Override
+                public boolean onRepeat(float delta, EntityRef target) {
+                    target.send(new FocusChangedEvent());
+                    return false;
+                }
+
+                @Override
+                public boolean onRelease(float delta, EntityRef target) {
+                    return false;
+                }
+            });
+        } else {
+            BindButtonSubscriber bindButtonSubscriber = new BindButtonSubscriber() {
+                @Override
+                public boolean onPress(float delta, EntityRef target) {
+                    target.send(new FocusChangedEvent());
+                    return false;
+                }
+
+                @Override
+                public boolean onRepeat(float delta, EntityRef target) {
+                    target.send(new FocusChangedEvent());
+                    return false;
+                }
+
+                @Override
+                public boolean onRelease(float delta, EntityRef target) {
+                    return false;
+                }
+            };
+            keys.put(Keyboard.Key.SEMICOLON.getId(), new BindableButtonImpl(new SimpleUri("changeFocus"), "Change Focus", new BindButtonEvent()));
+            keys.get(Keyboard.Key.SEMICOLON.getId()).subscribe(bindButtonSubscriber);
+        }
+        current = 0;
+        index = 0;
+        uiIndex = -1;
+        layersFilled = new ArrayList<>();
+        enabledWidgets = new ArrayList<>();
+        used = new ArrayList<>();
+        inSortOrder = false;
+    }
+
+    @ReceiveEvent
+    public void changeFocus(FocusChangedEvent event, EntityRef ref) {
+        rotateOrder(true);
+    }
+    /**
+     * rotates through the elements
+     * @param increase where or not to increment index
+     */
+    public static void rotateOrder(boolean increase) {
+        if (layersFilled.size() > 0) {
+            Collections.sort(layersFilled, (a, b) -> Math.max(a[0], b[0]));
+            if (increase) {
+                index++;
+            }
+            int iterator;
+            if (index < layersFilled.size()) {
+                iterator = layersFilled.get(index)[0];
+            } else {
+                index = 0;
+                iterator = layersFilled.get(index)[0];
+            }
+            boolean loopThroughDone = false;
+
+
+            int tempIndex = index;
+            int timesLooping = 0;
+
+            ArrayList<CoreScreenLayer> widgetsCopy = new ArrayList<>(enabledWidgets);
+
+            while (!loopThroughDone) {
+                for (CoreScreenLayer widget : widgetsCopy) {
+                    inSortOrder = true;
+                    if (widget.getDepth() == iterator) {
+                        String widgId = widget.getId();
+                        widget.getManager().pushScreen(widgId);
+                        widget.getManager().render();
+                    }
+                    inSortOrder = false;
+                }
+                if (tempIndex < layersFilled.size()) {
+                    iterator = layersFilled.get(tempIndex)[0];
+                    tempIndex++;
+                } else {
+                    tempIndex = 0;
+                    iterator = layersFilled.get(tempIndex)[0];
+                    tempIndex++;
+                }
+                if (timesLooping > layersFilled.size()) {
+                    loopThroughDone = true;
+                }
+                timesLooping++;
+            }
+            for (CoreScreenLayer layer:enabledWidgets) {
+                Deque<UIScreenLayer> screens = layer.getManager().getScreens();
+                Deque<UIScreenLayer> toCreate = Queues.newArrayDeque();
+                for (UIScreenLayer screen: screens) {
+                    if (!toCreate.contains(screen)) {
+                        toCreate.add(screen);
+                    }
+                }
+                layer.getManager().setScreens(toCreate);
+            }
+
+            enabledWidgets = widgetsCopy;
+        }
+    }
+
+    /**
+     * increments current (for depth)
+     * @return the new value of current
+     */
+    public static int getCurrent() {
+        current++;
+        while (used.contains(current)) {
+            current++;
+        }
+        return current;
+    }
+
+    /**
+     * adds another occurrence of a certain depth to layers filled
+     * @param layer the depth
+     */
+    public static void addAnother(int layer) {
+        try {
+            layersFilled.get(layer)[1]++;
+        } catch (Exception e) {
+            Integer[] toAdd = new Integer[2];
+            toAdd[0] = layer;
+            toAdd[1] = 1;
+            layersFilled.add(toAdd);
+        }
+    }
+
+    /**
+     * removes an occurance of a certain depth to layers filled
+     * @param layer the depth
+     */
+    public static void removeOne(int layer) {
+        for (int i = 0; i < layersFilled.size(); i++) {
+            if (layersFilled.get(i)[0] == layer) {
+                layersFilled.get(i)[1]--;
+                return;
+            }
+        }
+    }
+
+    public static void setEnabledWidgets(ArrayList<CoreScreenLayer> widgetList) {
+        if (initialized) {
+            enabledWidgets = widgetList;
+        }
+    }
+    public static ArrayList<CoreScreenLayer> getEnabledWidgets() {
+        return enabledWidgets;
+    }
+    public static int makeIndex() {
+        uiIndex++;
+        return uiIndex;
+    }
+
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    public static boolean isInSortOrder() {
+        return inSortOrder;
+    }
+    public static ArrayList<Integer> getUsed() {
+        return used;
+    }
+    public static void setUsed(ArrayList<Integer> other) {
+        used = other;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
@@ -48,6 +48,7 @@ public class SortOrder extends BaseComponentSystem {
     private static ArrayList<CoreScreenLayer> enabledWidgets;
     private static boolean initialized = false;
     private static ArrayList<Integer> used;
+    private static int numAdded;
 
     @In
     private BindsManager bindsManager;
@@ -124,6 +125,8 @@ public class SortOrder extends BaseComponentSystem {
             Collections.sort(layersFilled, (a, b) -> Math.max(a[0], b[0]));
             if (increase) {
                 index++;
+                index += numAdded;
+                numAdded = 0;
             }
             int iterator;
             if (index < layersFilled.size()) {
@@ -203,6 +206,7 @@ public class SortOrder extends BaseComponentSystem {
             toAdd[1] = 1;
             layersFilled.add(toAdd);
         }
+        numAdded++;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/SortOrder.java
@@ -48,7 +48,6 @@ public class SortOrder extends BaseComponentSystem {
     private static ArrayList<CoreScreenLayer> enabledWidgets;
     private static boolean initialized = false;
     private static ArrayList<Integer> used;
-    private static int numAdded;
 
     @In
     private BindsManager bindsManager;
@@ -125,16 +124,15 @@ public class SortOrder extends BaseComponentSystem {
             Collections.sort(layersFilled, (a, b) -> Math.max(a[0], b[0]));
             if (increase) {
                 index++;
-                index += numAdded;
-                numAdded = 0;
             }
             int iterator;
-            if (index < layersFilled.size()) {
-                iterator = layersFilled.get(index)[0];
-            } else {
-                index = 0;
-                iterator = layersFilled.get(index)[0];
+
+            while(index>=layersFilled.size()) {
+                index -= layersFilled.size();
             }
+
+            iterator = layersFilled.get(index)[0];
+
             boolean loopThroughDone = false;
 
 
@@ -206,7 +204,7 @@ public class SortOrder extends BaseComponentSystem {
             toAdd[1] = 1;
             layersFilled.add(toAdd);
         }
-        numAdded++;
+        index = -1;
     }
 
     /**
@@ -217,6 +215,9 @@ public class SortOrder extends BaseComponentSystem {
         for (int i = 0; i < layersFilled.size(); i++) {
             if (layersFilled.get(i)[0] == layer) {
                 layersFilled.get(i)[1]--;
+                if (layersFilled.get(i)[1]==0) {
+                    layersFilled.remove(i);
+                }
                 return;
             }
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -79,6 +79,7 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     private MouseDevice mouse;
     private DisplayDevice display;
     private boolean forceReleaseMouse;
+    private boolean updateFrozen;
 
     private Map<ResourceUrn, ControlWidget> overlays = Maps.newLinkedHashMap();
     private Context context;
@@ -104,7 +105,14 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
         ModuleAwareAssetTypeManager maaTypeManager = context.get(ModuleAwareAssetTypeManager.class);
         maaTypeManager.getAssetType(UIElement.class).ifPresent(type -> type.disposeAll());
     }
-
+    @Override
+    public Deque<UIScreenLayer> getScreens() {
+        return screens;
+    }
+    @Override
+    public void setScreens(Deque<UIScreenLayer> toSet) {
+        screens = toSet;
+    }
     public void refreshWidgetsLibrary() {
         widgetsLibrary = new WidgetLibrary(context);
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
@@ -185,6 +193,11 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
         closeScreen(screenUri, sendEvents);
     }
 
+    @Override
+    public ResourceUrn getUri(UIScreenLayer screen) {
+        BiMap<ResourceUrn, UIScreenLayer> lookup =  HashBiMap.create(screenLookup);
+        return lookup.inverse().remove(screen);
+    }
     @Override
     public void closeScreen(UIScreenLayer screen) {
         if (screens.remove(screen)) {
@@ -678,5 +691,8 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
             setHUDVisible(true);
         }
     }
-
+    @Override
+    public CanvasControl getCanvas() {
+        return canvas;
+    }
 }


### PR DESCRIPTION
Allows the order of display (what renders in front of what) of overlapping windows to change when the semicolon key is pressed. 
This can be demonstrate by taking two overlapping UI screens - I used the core inventory screen and the crafting screen from the BasicCrafting module to test, although others should work - and press the semicolon key to see the front one move to the back and the back one to the front.