### PR TITLE
Player can't create a game with special name from the player

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -154,16 +154,14 @@ public class NewGameScreen extends CoreScreenLayer {
         WidgetUtil.trySubscribe(this, "play", button -> {
             if (gameName.getText().isEmpty()) {
                 universeWrapper.setGameName(GameProvider.getNextGameName());
-                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Error", "Game name cannot be empty");
+            }
+            universeWrapper.setGameName(gameName.getText());
+            GameManifest gameManifest = GameManifestProvider.createGameManifest(universeWrapper, moduleManager, config);
+            if (gameManifest != null) {
+                gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
             } else {
-                universeWrapper.setGameName(gameName.getText());
-                GameManifest gameManifest = GameManifestProvider.createGameManifest(universeWrapper, moduleManager, config);
-                if (gameManifest != null) {
-                    gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
-                } else {
-                    MessagePopup errorPopup = getManager().createScreen(MessagePopup.ASSET_URI, MessagePopup.class);
-                    errorPopup.setMessage("Error", "Can't create new game!");
-                }
+                MessagePopup errorPopup = getManager().createScreen(MessagePopup.ASSET_URI, MessagePopup.class);
+                errorPopup.setMessage("Error", "Can't create new game!");
             }
         });
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -153,9 +153,10 @@ public class NewGameScreen extends CoreScreenLayer {
 
         WidgetUtil.trySubscribe(this, "play", button -> {
             if (gameName.getText().isEmpty()) {
+                universeWrapper.setGameName(GameProvider.getNextGameName());
                 getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Error", "Game name cannot be empty");
             } else {
-                universeWrapper.setGameName(GameProvider.getNextGameName());
+                universeWrapper.setGameName(gameName.getText());
                 GameManifest gameManifest = GameManifestProvider.createGameManifest(universeWrapper, moduleManager, config);
                 if (gameManifest != null) {
                     gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains
I found that when I create a game in the singleplayer. And put for example `Terasology World` in the game name textbox. Then the game should put that name But sadly the game generates a name for the game instead of using my given name. So, I made a small change to fix this issue.

### How to test
- Open the game
- Go to singleplayer
- Click on `Create` ( If you don't have any game it will show you the create screen )
- Fill any name from your mind
- Click on `Play`
- Click `Esc`
- Go back to the game menu. You will find the game with the given name that you wanted it to be.

### Outstanding before merging
- [ ] Does this will cause any issues in the future?
