### PR TITLE
Deprecating methods in Biome API

### DIFF
--- a/engine/src/main/java/org/terasology/world/biomes/Biome.java
+++ b/engine/src/main/java/org/terasology/world/biomes/Biome.java
@@ -17,6 +17,11 @@ package org.terasology.world.biomes;
 
 import org.terasology.module.sandbox.API;
 
+/**
+ * Biomes can be assigned to different blocks during worldgen as well as on runtime, to provide additional metadata
+ * about player's surroundings usable to enhance player experience.
+ * @see BiomeChangeEvent
+ */
 @API
 public interface Biome {
 

--- a/engine/src/main/java/org/terasology/world/biomes/Biome.java
+++ b/engine/src/main/java/org/terasology/world/biomes/Biome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,10 +31,19 @@ public interface Biome {
      */
     String getName();
 
-    float getFog();
+    @Deprecated
+    default float getFog() {
+        return 0.5f;
+    }
 
-    float getHumidity();
+    @Deprecated
+    default float getHumidity() {
+        return 0.5f;
+    }
 
-    float getTemperature();
+    @Deprecated
+    default float getTemperature() {
+        return 0.5f;
+    }
 
 }

--- a/engine/src/main/java/org/terasology/world/biomes/BiomeChangeEvent.java
+++ b/engine/src/main/java/org/terasology/world/biomes/BiomeChangeEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.biomes;
+
+import org.terasology.entitySystem.event.Event;
+
+public class BiomeChangeEvent implements Event {
+    private Biome oldBiome;
+    private Biome newBiome;
+
+    public BiomeChangeEvent(Biome oldBiome, Biome newBiome) {
+        this.oldBiome = oldBiome;
+        this.newBiome = newBiome;
+    }
+
+    public Biome getOldBiome() {
+        return oldBiome;
+    }
+
+    public Biome getNewBiome() {
+        return newBiome;
+    }
+}

--- a/engine/src/main/java/org/terasology/world/biomes/BiomeChangeEvent.java
+++ b/engine/src/main/java/org/terasology/world/biomes/BiomeChangeEvent.java
@@ -17,6 +17,10 @@ package org.terasology.world.biomes;
 
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * This event is thrown to entities with {@link org.terasology.logic.players.PlayerCharacterComponent} whenever they
+ * change the biome they are in.
+ */
 public class BiomeChangeEvent implements Event {
     private Biome oldBiome;
     private Biome newBiome;
@@ -26,10 +30,16 @@ public class BiomeChangeEvent implements Event {
         this.newBiome = newBiome;
     }
 
+    /**
+     * @return Biome the entity just left
+     */
     public Biome getOldBiome() {
         return oldBiome;
     }
 
+    /**
+     * @return Biome the entity just entered
+     */
     public Biome getNewBiome() {
         return newBiome;
     }

--- a/engine/src/main/java/org/terasology/world/biomes/PlayerBiomeChangeTrackerSystem.java
+++ b/engine/src/main/java/org/terasology/world/biomes/PlayerBiomeChangeTrackerSystem.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.world.biomes;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -29,11 +27,13 @@ import org.terasology.physics.events.MovedEvent;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 
+/**
+ * This system is responsible for sending {@link BiomeChangeEvent} whenever applicable.
+ */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class PlayerBiomeChangeTrackerSystem extends BaseComponentSystem {
     @In
     private WorldProvider world;
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerBiomeChangeTrackerSystem.class);
 
     @ReceiveEvent(components = {PlayerCharacterComponent.class})
     public void checkForBiomeChange(MovedEvent event, EntityRef entity) {
@@ -46,7 +46,6 @@ public class PlayerBiomeChangeTrackerSystem extends BaseComponentSystem {
         final Biome newBiome = world.getBiome(newPos);
         if (!oldBiome.equals(newBiome)) {
             entity.send(new BiomeChangeEvent(oldBiome, newBiome));
-            LOGGER.info("Biome changed: " + newBiome.getName());
         }
     }
 }

--- a/engine/src/main/java/org/terasology/world/biomes/PlayerBiomeChangeTrackerSystem.java
+++ b/engine/src/main/java/org/terasology/world/biomes/PlayerBiomeChangeTrackerSystem.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.biomes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.players.PlayerCharacterComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.physics.events.MovedEvent;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class PlayerBiomeChangeTrackerSystem extends BaseComponentSystem {
+    @In
+    private WorldProvider world;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerBiomeChangeTrackerSystem.class);
+
+    @ReceiveEvent(components = {PlayerCharacterComponent.class})
+    public void checkForBiomeChange(MovedEvent event, EntityRef entity) {
+        final Vector3i newPos = new Vector3i(event.getPosition());
+        final Vector3i oldPos = new Vector3i(new Vector3f(event.getPosition()).sub(event.getDelta()));
+        if (newPos.equals(oldPos)) {
+            return;
+        }
+        final Biome oldBiome = world.getBiome(oldPos);
+        final Biome newBiome = world.getBiome(newPos);
+        if (!oldBiome.equals(newBiome)) {
+            entity.send(new BiomeChangeEvent(oldBiome, newBiome));
+            LOGGER.info("Biome changed: " + newBiome.getName());
+        }
+    }
+}


### PR DESCRIPTION
### Contains

`Biome` interface currently contains methods not actually useful for lots of use cases. This PR aims to deprecate them.

### How to test

Just check nothing breaks

### TODO
- [ ] javadoc on new event