### PR TITLE
UI Scaling

### DIFF
--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -611,8 +611,9 @@ public class RenderingConfig extends AbstractSubscribable {
     }
 
     public int getUiScale() {
-        if (uiScale == 0)
+        if (uiScale == 0) {
             return 100;
+        }
         return uiScale;
     }
 

--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -71,6 +71,7 @@ public class RenderingConfig extends AbstractSubscribable {
     public static final String V_SYNC = "VSync";
     public static final String FRAME_LIMIT = "FrameLimit";
     public static final String FBO_SCALE = "FboScale";
+    public static final String UI_SCALE = "UiScale";
     public static final String CLAMP_LIGHTING = "ClampLighting";
     public static final String SCREENSHOT_SIZE = "screenshotSize";
     public static final String SCREENSHOT_FORMAT = "ScreenshotFormat";
@@ -120,6 +121,7 @@ public class RenderingConfig extends AbstractSubscribable {
     private boolean vSync;
     private boolean clampLighting;
     private int fboScale;
+    private int uiScale = 100;
     private boolean dumpShaders;
     private boolean volumetricFog;
     private ScreenshotSize screenshotSize;
@@ -606,6 +608,18 @@ public class RenderingConfig extends AbstractSubscribable {
         int oldScale = this.fboScale;
         this.fboScale = fboScale;
         propertyChangeSupport.firePropertyChange(FBO_SCALE, oldScale, this.fboScale);
+    }
+
+    public int getUiScale() {
+        if (uiScale == 0)
+            return 100;
+        return uiScale;
+    }
+
+    public void setUiScale(int uiScale) {
+        int oldScale = this.uiScale;
+        this.uiScale = uiScale;
+        propertyChangeSupport.firePropertyChange(UI_SCALE, oldScale, this.uiScale);
     }
 
     public boolean isClampLighting() {

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglInput.java
@@ -68,7 +68,7 @@ public class LwjglInput extends BaseLwjglSubsystem {
             Mouse.create();
             InputSystem inputSystem = new InputSystem();
             context.put(InputSystem.class, inputSystem);
-            inputSystem.setMouseDevice(new LwjglMouseDevice());
+            inputSystem.setMouseDevice(new LwjglMouseDevice(context));
             inputSystem.setKeyboardDevice(new LwjglKeyboardDevice());
 
             ControllerConfig controllerConfig = context.get(Config.class).getInput().getControllers();

--- a/engine/src/main/java/org/terasology/engine/subsystem/openvr/OpenVRInput.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/openvr/OpenVRInput.java
@@ -76,7 +76,7 @@ public class OpenVRInput implements EngineSubsystem {
         InputSystem inputSystem = context.get(InputSystem.class);
         if (inputSystem == null) {
             inputSystem = new InputSystem();
-            inputSystem.setMouseDevice(new LwjglMouseDevice());
+            inputSystem.setMouseDevice(new LwjglMouseDevice(context));
             inputSystem.setKeyboardDevice(new LwjglKeyboardDevice());
             context.put(InputSystem.class, inputSystem);
         }

--- a/engine/src/main/java/org/terasology/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/input/lwjgl/LwjglMouseDevice.java
@@ -34,15 +34,15 @@ import java.util.Queue;
 /**
  */
 public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
+    private RenderingConfig renderingConfig;
+    private float uiScale;
+    private boolean mouseGrabbed;
+
     public LwjglMouseDevice(Context context) {
         this.renderingConfig = context.get(Config.class).getRendering();
         this.uiScale = this.renderingConfig.getUiScale() / 100f;
         this.renderingConfig.subscribe(RenderingConfig.UI_SCALE, this);
     }
-
-    private RenderingConfig renderingConfig;
-    private float uiScale;
-    private boolean mouseGrabbed;
 
     @Override
     public Vector2i getPosition() {

--- a/engine/src/main/java/org/terasology/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/input/lwjgl/LwjglMouseDevice.java
@@ -18,22 +18,35 @@ package org.terasology.input.lwjgl;
 import com.google.common.collect.Queues;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
+import org.terasology.context.Context;
 import org.terasology.input.ButtonState;
 import org.terasology.input.InputType;
 import org.terasology.input.device.MouseAction;
 import org.terasology.input.device.MouseDevice;
 import org.terasology.math.geom.Vector2i;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.Queue;
 
 /**
  */
-public class LwjglMouseDevice implements MouseDevice {
+public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
+    public LwjglMouseDevice(Context context) {
+        this.renderingConfig = context.get(Config.class).getRendering();
+        this.uiScale = this.renderingConfig.getUiScale() / 100f;
+        this.renderingConfig.subscribe(RenderingConfig.UI_SCALE, this);
+    }
+
+    private RenderingConfig renderingConfig;
+    private float uiScale;
     private boolean mouseGrabbed;
 
     @Override
     public Vector2i getPosition() {
-        return new Vector2i(Mouse.getX(), Display.getHeight() - Mouse.getY());
+        return new Vector2i(Mouse.getX() / this.uiScale, (Display.getHeight() - Mouse.getY()) / this.uiScale);
     }
 
     @Override
@@ -77,4 +90,10 @@ public class LwjglMouseDevice implements MouseDevice {
         return result;
     }
 
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals(RenderingConfig.UI_SCALE)) {
+            this.uiScale = this.renderingConfig.getUiScale() / 100f;
+        }
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.Time;
 import org.terasology.input.InputSystem;
@@ -62,6 +64,8 @@ import org.terasology.rendering.nui.widgets.UITooltip;
 import org.terasology.rendering.opengl.FrameBufferObject;
 import org.terasology.utilities.Assets;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
@@ -70,7 +74,7 @@ import java.util.Set;
 
 /**
  */
-public class CanvasImpl implements CanvasControl {
+public class CanvasImpl implements CanvasControl, PropertyChangeListener {
 
     private static final Logger logger = LoggerFactory.getLogger(CanvasImpl.class);
 
@@ -118,6 +122,8 @@ public class CanvasImpl implements CanvasControl {
     private Vector2i lastClickPosition = new Vector2i();
 
     private CanvasRenderer renderer;
+    private RenderingConfig renderingConfig;
+    private float uiScale = 1f;
 
     public CanvasImpl(NUIManager nuiManager, Context context, CanvasRenderer renderer) {
         this.renderer = renderer;
@@ -127,16 +133,25 @@ public class CanvasImpl implements CanvasControl {
         this.mouse = context.get(InputSystem.class).getMouseDevice();
         this.meshMat = Assets.getMaterial("engine:UILitMesh").get();
         this.whiteTexture = Assets.getTexture("engine:white").get();
+
+        this.renderingConfig = context.get(Config.class).getRendering();
+        this.uiScale = this.renderingConfig.getUiScale() / 100f;
+
+        this.renderingConfig.subscribe(RenderingConfig.UI_SCALE, this);
     }
 
     @Override
     public void preRender() {
         interactionRegions.clear();
         Vector2i size = renderer.getTargetSize();
+        size.x = (int)(size.x / uiScale);
+        size.y = (int)(size.y / uiScale);
+
         state = new CanvasState(null, Rect2i.createFromMinAndSize(0, 0, size.x, size.y));
         renderer.preRender();
         renderer.crop(state.cropRegion);
         focusDrawn = false;
+
     }
 
     @Override
@@ -737,6 +752,13 @@ public class CanvasImpl implements CanvasControl {
 
     private Rect2i relativeToAbsolute(Rect2i region) {
         return Line.relativeToAbsolute(region, state.drawRegion);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals(RenderingConfig.UI_SCALE)) {
+            this.uiScale = this.renderingConfig.getUiScale() / 100f;
+        }
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/CanvasImpl.java
@@ -144,8 +144,8 @@ public class CanvasImpl implements CanvasControl, PropertyChangeListener {
     public void preRender() {
         interactionRegions.clear();
         Vector2i size = renderer.getTargetSize();
-        size.x = (int)(size.x / uiScale);
-        size.y = (int)(size.y / uiScale);
+        size.x = (int) (size.x / uiScale);
+        size.y = (int) (size.y / uiScale);
 
         state = new CanvasState(null, Rect2i.createFromMinAndSize(0, 0, size.x, size.y));
         renderer.preRender();

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -199,8 +199,8 @@ public class LwjglCanvasRenderer implements CanvasRenderer, PropertyChangeListen
         Matrix4f centerTransform = new Matrix4f(BaseQuat4f.IDENTITY, centerOffset, 1.0f);
         Matrix4f userTransform = new Matrix4f(rotation, offset, -fitScale * scale);
         Matrix4f translateTransform = new Matrix4f(BaseQuat4f.IDENTITY,
-                new Vector3f(drawRegion.minX() + drawRegion.width() / 2,
-                        drawRegion.minY() + drawRegion.height() / 2, 0), 1);
+                new Vector3f((drawRegion.minX() + drawRegion.width() / 2) * uiScale,
+                    (drawRegion.minY() + drawRegion.height() / 2) * uiScale, 0), 1);
 
         userTransform.mul(centerTransform);
         translateTransform.mul(userTransform);
@@ -209,13 +209,20 @@ public class LwjglCanvasRenderer implements CanvasRenderer, PropertyChangeListen
         finalMat.mul(translateTransform);
         MatrixUtils.matrixToFloatBuffer(finalMat, matrixBuffer);
 
-        material.setFloat4(CROPPING_BOUNDARIES_PARAM, cropRegion.minX(), cropRegion.maxX(), cropRegion.minY(), cropRegion.maxY());
+        material.setFloat4(
+            CROPPING_BOUNDARIES_PARAM,
+            cropRegion.minX() * uiScale,
+            cropRegion.maxX() * uiScale,
+            cropRegion.minY() * uiScale,
+            cropRegion.maxY() * uiScale);
         material.setMatrix4("posMatrix", translateTransform);
         glEnable(GL11.GL_DEPTH_TEST);
         glClear(GL11.GL_DEPTH_BUFFER_BIT);
         glMatrixMode(GL11.GL_MODELVIEW);
         glPushMatrix();
         glLoadMatrix(matrixBuffer);
+
+        glScalef(this.uiScale, this.uiScale, this.uiScale);
         matrixBuffer.rewind();
 
         boolean matrixStackSupported = material.supportsFeature(ShaderProgramFeature.FEATURE_USE_MATRIX_STACK);

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -22,6 +22,8 @@ import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.math.AABB;
 import org.terasology.math.Border;
@@ -52,6 +54,8 @@ import org.terasology.rendering.opengl.FrameBufferObject;
 import org.terasology.rendering.opengl.LwjglFrameBufferObject;
 import org.terasology.utilities.Assets;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.nio.FloatBuffer;
 import java.util.Iterator;
 import java.util.List;
@@ -80,7 +84,7 @@ import static org.lwjgl.opengl.GL11.glTranslatef;
 
 /**
  */
-public class LwjglCanvasRenderer implements CanvasRenderer {
+public class LwjglCanvasRenderer implements CanvasRenderer, PropertyChangeListener {
 
     private static final String CROPPING_BOUNDARIES_PARAM = "croppingBoundaries";
     private static final Rect2f FULL_REGION = Rect2f.createFromMinAndSize(0, 0, 1, 1);
@@ -104,7 +108,8 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
     private Rect2i currentTextureCropRegion;
 
     private Map<ResourceUrn, LwjglFrameBufferObject> fboMap = Maps.newHashMap();
-
+    private RenderingConfig renderingConfig;
+    private float uiScale = 1f;
 
     public LwjglCanvasRenderer(Context context) {
         // TODO use context to get assets instead of static methods
@@ -112,6 +117,11 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
         this.billboard = Assets.getMesh("engine:UIBillboard").get();
         this.fontMeshBuilder = new FontMeshBuilder(context.get(AssetManager.class).getAsset("engine:UIUnderline", Material.class).get());
         // failure to load these can be due to failing shaders or missing resources
+
+        this.renderingConfig = context.get(Config.class).getRendering();
+        this.uiScale = this.renderingConfig.getUiScale() / 100f;
+
+        this.renderingConfig.subscribe(RenderingConfig.UI_SCALE, this);
     }
 
     @Override
@@ -134,6 +144,8 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
         MatrixUtils.matrixToFloatBuffer(modelView, matrixBuffer);
         glLoadMatrix(matrixBuffer);
         matrixBuffer.rewind();
+
+        glScalef(uiScale, uiScale, uiScale);
 
         requestedCropRegion = Rect2i.createFromMinAndSize(0, 0, Display.getWidth(), Display.getHeight());
         currentTextureCropRegion = requestedCropRegion;
@@ -506,6 +518,13 @@ public class LwjglCanvasRenderer implements CanvasRenderer {
 
                 addRectPoly(builder, vertLeft, vertTop, vertRight, vertBottom, texCoordLeft, texCoordTop, texCoordRight, texCoordBottom);
             }
+        }
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals(RenderingConfig.UI_SCALE)) {
+            this.uiScale = this.renderingConfig.getUiScale() / 100f;
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.assets.module.ModuleAwareAssetTypeManager;
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.module.ModuleManager;
@@ -43,6 +45,7 @@ import org.terasology.input.events.MouseAxisEvent;
 import org.terasology.input.events.MouseButtonEvent;
 import org.terasology.input.events.MouseWheelEvent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.geom.Vector2i;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.ClientComponent;
 import org.terasology.reflection.metadata.ClassLibrary;
@@ -60,6 +63,8 @@ import org.terasology.rendering.nui.layers.hud.HUDScreenLayer;
 import org.terasology.rendering.nui.layers.ingame.OnlinePlayersOverlay;
 import org.terasology.utilities.Assets;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -69,7 +74,7 @@ import java.util.Set;
 
 /**
  */
-public class NUIManagerInternal extends BaseComponentSystem implements NUIManager {
+public class NUIManagerInternal extends BaseComponentSystem implements NUIManager, PropertyChangeListener {
     private Logger logger = LoggerFactory.getLogger(NUIManagerInternal.class);
     private Deque<UIScreenLayer> screens = Queues.newArrayDeque();
     private HUDScreenLayer hudScreenLayer;
@@ -82,6 +87,8 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     private DisplayDevice display;
     private boolean forceReleaseMouse;
     private boolean updateFrozen;
+    private RenderingConfig renderingConfig;
+    private float uiScale = 1f;
 
     private Map<ResourceUrn, ControlWidget> overlays = Maps.newLinkedHashMap();
     private Context context;
@@ -94,6 +101,11 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
         this.canvas = new CanvasImpl(this, context, renderer);
         this.keyboard = context.get(InputSystem.class).getKeyboard();
         this.mouse = context.get(InputSystem.class).getMouseDevice();
+
+        this.renderingConfig = context.get(Config.class).getRendering();
+        this.uiScale = this.renderingConfig.getUiScale() / 100f;
+        this.renderingConfig.subscribe(RenderingConfig.UI_SCALE, this);
+
         this.display = context.get(DisplayDevice.class);
         this.assetManager = context.get(AssetManager.class);
         refreshWidgetsLibrary();
@@ -615,6 +627,9 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
                 return;
             }
         }
+
+
+
         if (canvas.processMouseWheel(event.getWheelTurns(), mouse.getPosition())) {
             event.consume();
         }
@@ -701,5 +716,12 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     @Override
     public CanvasControl getCanvas() {
         return canvas;
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName().equals(RenderingConfig.UI_SCALE)) {
+            this.uiScale = this.renderingConfig.getUiScale() / 100f;
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/NUIManagerInternal.java
@@ -45,7 +45,6 @@ import org.terasology.input.events.MouseAxisEvent;
 import org.terasology.input.events.MouseButtonEvent;
 import org.terasology.input.events.MouseWheelEvent;
 import org.terasology.logic.players.LocalPlayer;
-import org.terasology.math.geom.Vector2i;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.network.ClientComponent;
 import org.terasology.reflection.metadata.ClassLibrary;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -41,6 +41,7 @@ import org.terasology.rendering.nui.itemRendering.StringTextRenderer;
 import org.terasology.rendering.nui.itemRendering.ToStringTextRenderer;
 import org.terasology.rendering.nui.layers.mainMenu.WaitPopup;
 import org.terasology.rendering.nui.widgets.UIDropdown;
+import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UISlider;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 
@@ -238,25 +239,20 @@ public class VideoSettingsScreen extends CoreScreenLayer {
             });
         }
 
-        final UISlider uiScaleSlider = find("uiScale", UISlider.class);
-        if (uiScaleSlider != null) {
-            uiScaleSlider.setIncrement(5.0f);
-            uiScaleSlider.setPrecision(0);
-            uiScaleSlider.setMinimum(25);
-            uiScaleSlider.setRange(200);
-            uiScaleSlider.setLabelFunction(input -> String.valueOf(input.intValue()) + "%");
-            uiScaleSlider.bindValue(new Binding<Float>() {
-                @Override
-                public Float get() {
-                    return (float) config.getRendering().getUiScale();
-                }
+        final UILabel uiScaleLabel = find("uiScaleLabel", UILabel.class);
+        uiScaleLabel.setText(" " + config.getRendering().getUiScale() + "% ");
 
-                @Override
-                public void set(Float value) {
-                    config.getRendering().setUiScale(value.intValue());
-                }
-            });
-        }
+        WidgetUtil.trySubscribe(this, "uiScaleSmaller", button -> {
+            int newScale = Math.max(50, config.getRendering().getUiScale() - 25);
+            config.getRendering().setUiScale(newScale);
+            uiScaleLabel.setText(" " + config.getRendering().getUiScale() + "% ");
+        });
+
+        WidgetUtil.trySubscribe(this, "uiScaleLarger", button -> {
+            int newScale = Math.min(250, config.getRendering().getUiScale() + 25);
+            config.getRendering().setUiScale(newScale);
+            uiScaleLabel.setText(" " + config.getRendering().getUiScale() + "% ");
+        });
 
         UIDropdown<CameraSetting> cameraSetting = find("camera", UIDropdown.class);
         if (cameraSetting != null) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -238,6 +238,26 @@ public class VideoSettingsScreen extends CoreScreenLayer {
             });
         }
 
+        final UISlider uiScaleSlider = find("uiScale", UISlider.class);
+        if (uiScaleSlider != null) {
+            uiScaleSlider.setIncrement(5.0f);
+            uiScaleSlider.setPrecision(0);
+            uiScaleSlider.setMinimum(25);
+            uiScaleSlider.setRange(200);
+            uiScaleSlider.setLabelFunction(input -> String.valueOf(input.intValue()) + "%");
+            uiScaleSlider.bindValue(new Binding<Float>() {
+                @Override
+                public Float get() {
+                    return (float) config.getRendering().getUiScale();
+                }
+
+                @Override
+                public void set(Float value) {
+                    config.getRendering().setUiScale(value.intValue());
+                }
+            });
+        }
+
         UIDropdown<CameraSetting> cameraSetting = find("camera", UIDropdown.class);
         if (cameraSetting != null) {
             cameraSetting.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -287,6 +287,7 @@
     "reset-default": "reset-default",
     "reset-fov-amount": "reset-fov-amount",
     "resolution-scale": "resolution-scale",
+    "ui-scale": "ui-scale",
     "respawn": "respawn",
     "restore-defaults": "restore-defaults",
     "return-main-menu": "return-main-menu",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -293,6 +293,7 @@
     "re-roll": "Re-Roll",
     "reset-fov-amount": "Reset fov amount",
     "resolution-scale": "Resolution Scale",
+    "ui-scale": "UI Scale",
     "respawn": "Respawn",
     "restore-defaults": "Restore Defaults",
     "return-main-menu": "Exit to Main Menu",

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -240,6 +240,14 @@
                                 },
                                 {
                                     "type": "UILabel",
+                                    "text": "${engine:menu#ui-scale}: "
+                                },
+                                {
+                                    "type": "UISlider",
+                                    "id": "uiScale"
+                                },
+                                {
+                                    "type": "UILabel",
                                     "text": "${engine:menu#animate-grass}: "
                                 },
                                 {

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -242,9 +242,26 @@
                                     "type": "UILabel",
                                     "text": "${engine:menu#ui-scale}: "
                                 },
+
                                 {
-                                    "type": "UISlider",
-                                    "id": "uiScale"
+                                    "type": "RowLayout",
+                                    "contents": [
+                                        {
+                                            "type": "UIButton",
+                                            "text": "-",
+                                            "id": "uiScaleSmaller"
+                                        },
+                                        {
+                                            "type": "UILabel",
+                                            "id": "uiScaleLabel",
+                                            "text": " 100%"
+                                        },
+                                        {
+                                            "type": "UIButton",
+                                            "text": "+",
+                                            "id": "uiScaleLarger"
+                                        }
+                                    ]
                                 },
                                 {
                                     "type": "UILabel",


### PR DESCRIPTION
Implements rudimentary UI scaling (#1223). Feedback is welcome!

### Contains

- Adds `uiScaling` property to `RenderingConfig` and the video settings UI
- Modifies NUI to reduce the size of it's canvas, and the GL backend to use `glScalef()` to scale the canvas rendering up/down as necessary.
- Modifies the GL mouse input as appropriate

### How to test

Load it up, go to the Video Settings UI and modify the new "UI Scale" option. 

### Outstanding before merging

- [x] Render scaling 
- [x] Input scaling
- [x] Some inventory items render incorrectly (probably bypassing NUI)
- [x] Use buttons instead of slider, since the slider moves as the UI size changes
- [x] Cover non-GL implementations as needed
- [x] Checkstyle
- [ ] Translations
- [ ] Testing