### PR TITLE
Add in javadoc and minor refactoring for `org.terasology.world.propagation` package

### DIFF
--- a/engine/src/main/java/org/terasology/world/propagation/AbstractChunkView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/AbstractChunkView.java
@@ -20,6 +20,11 @@ import org.terasology.world.block.Block;
 import org.terasology.world.internal.ChunkViewCore;
 
 /**
+ * Intermediate abstract class for the propagater world view that handles common functionality.
+ * <p>
+ * Only provides a view for a single chunk
+ *
+ * @see AbstractFullWorldView
  */
 public abstract class AbstractChunkView implements PropagatorWorldView {
 
@@ -37,6 +42,13 @@ public abstract class AbstractChunkView implements PropagatorWorldView {
         return UNAVAILABLE;
     }
 
+    /**
+     * Equivalent to {@link #getValueAt(Vector3i)}
+     *
+     * @param view The chunk the position is within
+     * @param pos  The position of to get the value at
+     * @return The value of the propagating data at the given position
+     */
     protected abstract byte getValueAt(ChunkViewCore view, Vector3i pos);
 
     @Override
@@ -44,6 +56,13 @@ public abstract class AbstractChunkView implements PropagatorWorldView {
         setValueAt(chunkView, pos, value);
     }
 
+    /**
+     * Equivalent to {@link #setValueAt(Vector3i, byte)}
+     *
+     * @param view  The chunk the position is in
+     * @param pos   The position to set the value at
+     * @param value The value to set the position to
+     */
     protected abstract void setValueAt(ChunkViewCore view, Vector3i pos, byte value);
 
     @Override
@@ -54,6 +73,11 @@ public abstract class AbstractChunkView implements PropagatorWorldView {
         return null;
     }
 
+    /**
+     * Checks if the position is within the boundaries of the chunk represented by this class
+     *
+     * @param pos The position to check, in world coordinates
+     */
     public boolean isInBounds(Vector3i pos) {
         return chunkView.getWorldRegion().encompasses(pos);
     }

--- a/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
@@ -25,7 +25,6 @@ import org.terasology.world.chunks.LitChunk;
 
 /**
  * A base world view implementation sitting on ChunkProvider.
- *
  */
 public abstract class AbstractFullWorldView implements PropagatorWorldView {
 
@@ -35,6 +34,12 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
         this.chunkProvider = chunkProvider;
     }
 
+    /**
+     * Get's the chunk for a given position
+     *
+     * @param pos The position in the world
+     * @return The chunk for that position
+     */
     private Chunk getChunk(Vector3i pos) {
 
         return chunkProvider.getChunk(ChunkMath.calcChunkPos(pos));
@@ -52,7 +57,7 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
     /**
      * Obtains the relevant value from the given chunk
      *
-     * @param chunk
+     * @param chunk The chunk containing the position
      * @param pos   The internal position of the chunk to get the value from
      * @return The relevant value for this view
      */
@@ -72,7 +77,7 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
     /**
      * Sets the relevant value for the given chunk
      *
-     * @param chunk
+     * @param chunk The chunk containing the position
      * @param pos   The internal position of the chunk to set the value of
      * @param value The new value
      */

--- a/engine/src/main/java/org/terasology/world/propagation/BatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/BatchPropagator.java
@@ -21,17 +21,55 @@ import org.terasology.world.block.Block;
 import org.terasology.world.chunks.LitChunk;
 
 /**
+ * Handles propagating values through blocks on a block by block basis.
  */
 public interface BatchPropagator {
+
+    /**
+     * Handle one or more blocks being changed from one type to another
+     *
+     * @param changes The change being made
+     */
     void process(BlockChange... changes);
 
+    /**
+     * Equivalent to {@link #process(BlockChange...)}
+     *
+     * @param blockChanges The changes to handle
+     */
     void process(Iterable<BlockChange> blockChanges);
 
+    /**
+     * Propagate a value from one chunk to another
+     *
+     * @param chunk             The chunk the values are originating from
+     * @param adjChunk          The chunk the values are moving into
+     * @param side              The side the values are moving through
+     * @param propagateExternal TODO: Document
+     */
     void propagateBetween(LitChunk chunk, LitChunk adjChunk, Side side, boolean propagateExternal);
 
+    /**
+     * Propagates a value out of the block at the given position
+     *
+     * @param pos   The position of the block
+     * @param block The block type
+     */
     void propagateFrom(Vector3i pos, Block block);
 
+    /**
+     * Propagates a specific value out from a location
+     *
+     * @param pos   The position to propagate out of
+     * @param value The value to propagate out
+     */
     void propagateFrom(Vector3i pos, byte value);
 
+    /**
+     * TODO: Document
+     *
+     * @param pos   The position to regenerate at
+     * @param value The original value at this position
+     */
     void regenerate(Vector3i pos, byte value);
 }

--- a/engine/src/main/java/org/terasology/world/propagation/BiomeChange.java
+++ b/engine/src/main/java/org/terasology/world/propagation/BiomeChange.java
@@ -20,6 +20,8 @@ import org.terasology.world.biomes.Biome;
 
 /**
  * Used for notifying listeners that the biome at a spot in the world has changed.
+ * <p>
+ * A POJO hence no methods are documented.
  *
  */
 public class BiomeChange {

--- a/engine/src/main/java/org/terasology/world/propagation/BlockChange.java
+++ b/engine/src/main/java/org/terasology/world/propagation/BlockChange.java
@@ -19,6 +19,9 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 /**
+ * Represents a block change at a given position.
+ * <p>
+ * A POJO hence no methods are documented.
  */
 public class BlockChange {
     private Vector3i position;

--- a/engine/src/main/java/org/terasology/world/propagation/BlockChange.java
+++ b/engine/src/main/java/org/terasology/world/propagation/BlockChange.java
@@ -19,7 +19,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 /**
- * Represents a block change at a given position.
+ * Represents a block change at a given position. Used to update listeners that a block has been changed
  * <p>
  * A POJO hence no methods are documented.
  */

--- a/engine/src/main/java/org/terasology/world/propagation/LocalChunkView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/LocalChunkView.java
@@ -22,6 +22,7 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 
 /**
+ * Provides a simple view over some chunks using a propagation rule.
  */
 public class LocalChunkView implements PropagatorWorldView {
     private PropagationRules rules;
@@ -32,10 +33,16 @@ public class LocalChunkView implements PropagatorWorldView {
     public LocalChunkView(Chunk[] chunks, PropagationRules rules) {
         this.chunks = chunks;
         this.rules = rules;
+        //TODO fix this to not hardcode 13. This is a ugly smell
         topLeft.set(chunks[13].getPosition().x - 1, chunks[13].getPosition().y - 1, chunks[13].getPosition().z - 1);
-
     }
 
+    /**
+     * Gets the index of the chunk in {@link #chunks}
+     *
+     * @param blockPos The position of the block in world coordinates
+     * @return The index of the chunk in the array
+     */
     private int chunkIndexOf(Vector3i blockPos) {
         return ChunkMath.calcChunkPosX(blockPos.x, ChunkConstants.POWER_X) - topLeft.x
                 + 3 * (ChunkMath.calcChunkPosY(blockPos.y, ChunkConstants.POWER_Y) - topLeft.y

--- a/engine/src/main/java/org/terasology/world/propagation/PropagationComparison.java
+++ b/engine/src/main/java/org/terasology/world/propagation/PropagationComparison.java
@@ -17,18 +17,19 @@
 package org.terasology.world.propagation;
 
 /**
+ * An enum that describes how propagation rules have changes when blocks are replaced with others
  */
 public enum PropagationComparison {
     /**
-     * Lighting is restricted in some way it wasn't before
+     * Propagation is restricted in some way it wasn't before
      */
     MORE_RESTRICTED(true, false),
     /**
-     * Lighting is identical to before
+     * Propagation is identical to before
      */
     IDENTICAL(false, false),
     /**
-     * Lighting is strictly more permissive than before
+     * Propagation is strictly more permissive than before
      */
     MORE_PERMISSIVE(false, true);
 

--- a/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
@@ -44,7 +44,7 @@ public interface PropagationRules {
     PropagationComparison comparePropagation(Block newBlock, Block oldBlock, Side side);
 
     /**
-     * Get the new value after propgating in a specified manner
+     * Get the new value after propagating in a specified manner
      *
      * @param existingValue The value to propagate
      * @param side          The side the value is leaving by

--- a/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
@@ -26,9 +26,10 @@ import org.terasology.world.chunks.LitChunk;
 public interface PropagationRules {
 
     /**
-     * TODO: Document when this method is understood
-     * @param block
-     * @return The value of provided by the given block
+     * Gets the constant values for this block, that are unaffected by the light propagation rules
+     * @param block The block being checked
+     * @param pos The position of the block being checked
+     * @return The constant value of this block
      */
     byte getFixedValue(Block block, Vector3i pos);
 

--- a/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
@@ -22,66 +22,86 @@ import org.terasology.world.chunks.LitChunk;
 
 /**
  * Rules to drive value propagation.
- *
  */
 public interface PropagationRules {
 
     /**
+     * TODO: Document when this method is understood
      * @param block
      * @return The value of provided by the given block
      */
     byte getFixedValue(Block block, Vector3i pos);
 
     /**
-     * @param newBlock
-     * @param oldBlock
-     * @param side
-     * @return The change in propagation switching from oldBlock to newBlock, on the given side
+     * Compare the how the propagation changes if you replace the block with a different one, on a given side
+     *
+     * @param newBlock The new block
+     * @param oldBlock THe original block
+     * @param side     The side to check on
+     * @return How the propagation rules change
      */
     PropagationComparison comparePropagation(Block newBlock, Block oldBlock, Side side);
 
     /**
-     * @param existingValue
-     * @param side
-     * @param from          the block the value is leaving
-     * @return The value propagate in the given direction from an existing value
+     * Get the new value after propgating in a specified manner
+     *
+     * @param existingValue The value to propagate
+     * @param side          The side the value is leaving by
+     * @param from          The block the value is leaving
+     * @return The new value to set at the block position
      */
     byte propagateValue(byte existingValue, Side side, Block from);
 
     /**
-     * @return The maximum value
+     * @return The maximum value possible for this data
      */
     byte getMaxValue();
 
     /**
-     * @param block
-     * @param side
+     * Checks if the value can leave a given block, through a specific side
+     *
+     * @param block The block to leave
+     * @param side  The side to leave by
      * @return Whether the given block can propagated out through side
      */
     boolean canSpreadOutOf(Block block, Side side);
 
     /**
-     * @param block
-     * @param side
-     * @return Whether the given block can be propagated into through side
+     * Checks if the value can propagate into a given block, through a specific side
+     *
+     * @param block The block to propagate into
+     * @param side  The side to propagate via
+     * @return Whether the given block can be propagated
+     * into through side
      */
     boolean canSpreadInto(Block block, Side side);
 
     /**
-     * @param chunk
-     * @param pos
+     * Get the value of a given position
+     *
+     * @param chunk The chunk the position is in
+     * @param pos   The position to get from
      * @return The value of the given position of a chunk
      */
     byte getValue(LitChunk chunk, Vector3i pos);
 
+    /**
+     * See {@link #getValue(LitChunk, Vector3i)}
+     *
+     * @param chunk The chunk the position is in
+     * @param x     The x position
+     * @param y     The y position
+     * @param z     THe z position
+     * @return The value at the posiiton int he given chunk
+     */
     byte getValue(LitChunk chunk, int x, int y, int z);
 
     /**
      * Sets the value for a given chunk position
      *
-     * @param chunk
-     * @param pos
-     * @param value
+     * @param chunk The chunk the position is in
+     * @param pos   The position to set at
+     * @param value The value to set to
      */
     void setValue(LitChunk chunk, Vector3i pos, byte value);
 }

--- a/engine/src/main/java/org/terasology/world/propagation/PropagatorWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/PropagatorWorldView.java
@@ -19,27 +19,23 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 /**
- * A view providing access to the world for batch propagation
- *
+ * A view providing access to the world specifically for batch propagation
  */
 public interface PropagatorWorldView {
 
     byte UNAVAILABLE = -1;
 
     /**
-     * @param pos
-     * @return The value of interest at pos, or UNAVAILABLE if out of bounds
+     * @return The value of interest at pos, or {@link #UNAVAILABLE} if out of bounds
      */
     byte getValueAt(Vector3i pos);
 
     /**
-     * @param pos
      * @param value A new value at pos.
      */
     void setValueAt(Vector3i pos, byte value);
 
     /**
-     * @param pos
      * @return The block at pos, or null if out of bounds
      */
     Block getBlockAt(Vector3i pos);

--- a/engine/src/main/java/org/terasology/world/propagation/SingleChunkView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/SingleChunkView.java
@@ -21,6 +21,7 @@ import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.LitChunk;
 
 /**
+ * Provides a view over a single chunk using a given propagation rule.
  */
 public class SingleChunkView implements PropagatorWorldView {
 

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -175,22 +175,22 @@ public class StandardBatchPropagator implements BatchPropagator {
         }
     }
 
+    /**
+     * Process all increasing propagation requests
+     * This is done from the strongest through to the weakest.
+     */
     private void processIncrease() {
-        int depth = 0;
-        while (depth < rules.getMaxValue() - 1) {
+        for (int depth = 0; depth < rules.getMaxValue() - 1; depth++) {
             byte value = (byte) (rules.getMaxValue() - depth);
-            Set<Vector3i> toProcess = increaseQueues[depth];
-            if (!toProcess.isEmpty()) {
+
+            while (!increaseQueues[depth].isEmpty()) {
+                Set<Vector3i> toProcess = increaseQueues[depth];
                 increaseQueues[depth] = Sets.newLinkedHashSetWithExpectedSize(toProcess.size());
 
+                /* This step will add any new values to `increaseQueues` */
                 for (Vector3i pos : toProcess) {
                     push(pos, value);
                 }
-                if (increaseQueues[depth].isEmpty()) {
-                    depth++;
-                }
-            } else {
-                depth++;
             }
         }
     }

--- a/engine/src/main/java/org/terasology/world/propagation/light/CommonLightPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/CommonLightPropagationRules.java
@@ -21,9 +21,18 @@ import org.terasology.world.propagation.PropagationComparison;
 import org.terasology.world.propagation.PropagationRules;
 
 /**
+ * Defines a set of common rules for how light should propagate
+ * <p>
+ * {@inheritDoc}
  */
 public abstract class CommonLightPropagationRules implements PropagationRules {
 
+    /**
+     * Light is more permissive if the block is changed to be translucent or has an open side,
+     * otherwise is less permissive or identical.
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public PropagationComparison comparePropagation(Block newBlock, Block oldBlock, Side side) {
         if (newBlock.isTranslucent() && oldBlock.isTranslucent()) {
@@ -49,11 +58,26 @@ public abstract class CommonLightPropagationRules implements PropagationRules {
         return PropagationComparison.IDENTICAL;
     }
 
+    /**
+     * Light can spread out of a block if
+     * - it has luminance (ie, glows),
+     * - it is translucent
+     * - or the side isn't full
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public boolean canSpreadOutOf(Block block, Side side) {
         return block.getLuminance() > 0 || block.isTranslucent() || !block.isFullSide(side);
     }
 
+    /**
+     * Light can spread into a block if
+     * - it is translucent,
+     * - or the side isn't ful
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public boolean canSpreadInto(Block block, Side side) {
         return block.isTranslucent() || !block.isFullSide(side);

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightPropagationRules.java
@@ -21,22 +21,39 @@ import org.terasology.world.block.Block;
 import org.terasology.world.chunks.LitChunk;
 
 /**
+ * Rules for how standard light should propagate.
+ * Also provides implementation for setting and getting values
  */
 public class LightPropagationRules extends CommonLightPropagationRules {
 
+    /**
+     * Any luminance from the block is a constant
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte getFixedValue(Block block, Vector3i pos) {
         return block.getLuminance();
     }
 
+    /**
+     * When the light propagates it's light level reduces by one
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte propagateValue(byte existingValue, Side side, Block from) {
         return (byte) (existingValue - 1);
     }
 
+    /**
+     * The maximum light level is a full byte of 15
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte getMaxValue() {
-        return (byte) 15;
+        return 0xF; // 15
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightPropagationRules.java
@@ -18,6 +18,7 @@ package org.terasology.world.propagation.light;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
+import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.LitChunk;
 
 /**
@@ -53,7 +54,7 @@ public class LightPropagationRules extends CommonLightPropagationRules {
      */
     @Override
     public byte getMaxValue() {
-        return 0xF; // 15
+        return ChunkConstants.MAX_LIGHT; // 15
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightWorldView.java
@@ -21,6 +21,8 @@ import org.terasology.world.chunks.LitChunk;
 import org.terasology.world.propagation.AbstractFullWorldView;
 
 /**
+ * Basic world view that provides access to the standard lighting in the world.
+ * Simply delegates to getting the value from the provided chunk
  */
 public class LightWorldView extends AbstractFullWorldView {
 

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightPropagationRules.java
@@ -24,6 +24,7 @@ import org.terasology.world.propagation.PropagatorWorldView;
 import org.terasology.world.propagation.SingleChunkView;
 
 /**
+ * Rules that determine how the sunlight propagates
  */
 public class SunlightPropagationRules extends CommonLightPropagationRules {
 
@@ -37,17 +38,32 @@ public class SunlightPropagationRules extends CommonLightPropagationRules {
         this.regenWorldView = new SingleChunkView(new SunlightRegenPropagationRules(), chunk);
     }
 
+    /**
+     * If the light is above the sunlight regeneration threshold it is maintained, otherwise it is zero
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte getFixedValue(Block block, Vector3i pos) {
         byte lightVal = (byte) (regenWorldView.getValueAt(pos) - ChunkConstants.SUNLIGHT_REGEN_THRESHOLD);
         return (lightVal > 0) ? lightVal : 0;
     }
 
+    /**
+     * Sunlight reduces by one to a minimum of zero per propagation
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte propagateValue(byte existingValue, Side side, Block from) {
-        return (existingValue > 0) ? (byte) (existingValue - 1) : 0;
+        return (byte) Math.max(existingValue - 1, 0);
     }
 
+    /**
+     * The maximum sunlight is given by {@link ChunkConstants#MAX_SUNLIGHT}
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte getMaxValue() {
         return ChunkConstants.MAX_SUNLIGHT;

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
@@ -46,7 +46,7 @@ public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
     @Override
     public byte propagateValue(byte existingValue, Side side, Block from) {
         if (side == Side.BOTTOM) {
-            return (existingValue == ChunkConstants.MAX_SUNLIGHT_REGEN) ? existingValue : (byte) (existingValue + 1);
+            return (byte) Math.min(existingValue, ChunkConstants.MAX_SUNLIGHT_REGEN);
         }
         return 0;
     }

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
@@ -23,14 +23,26 @@ import org.terasology.world.chunks.LitChunk;
 import org.terasology.world.propagation.PropagationComparison;
 
 /**
+ * Defines and interfaces how sunlight values regenerate per block
  */
 public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
 
+    /**
+     * Sunlight has no fixed value per block
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte getFixedValue(Block block, Vector3i pos) {
         return 0;
     }
 
+    /**
+     * Sunlight goes to zero unless leaving via the bottom face.
+     * In that case it increases up until the maximum value in {@link ChunkConstants#MAX_SUNLIGHT_REGEN}
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte propagateValue(byte existingValue, Side side, Block from) {
         if (side == Side.BOTTOM) {
@@ -39,6 +51,11 @@ public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
         return 0;
     }
 
+    /**
+     * The maximum value of sunlight is given by {@link ChunkConstants#MAX_SUNLIGHT_REGEN}
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public byte getMaxValue() {
         return ChunkConstants.MAX_SUNLIGHT_REGEN;
@@ -59,6 +76,11 @@ public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
         chunk.setSunlightRegen(pos, value);
     }
 
+    /**
+     * In all non-vertical sides the propagation is unchanged
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public PropagationComparison comparePropagation(Block newBlock, Block oldBlock, Side side) {
         if (!side.isVertical()) {
@@ -67,11 +89,21 @@ public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
         return super.comparePropagation(newBlock, oldBlock, side);
     }
 
+    /**
+     * Sunlight can only spread out of the bottom of a non-liquid block
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public boolean canSpreadOutOf(Block block, Side side) {
         return side == Side.BOTTOM && !block.isLiquid() && (super.canSpreadOutOf(block, side));
     }
 
+    /**
+     * Sunlight can spread if the block is not a liquid
+     * <p>
+     * {@inheritDoc}
+     */
     @Override
     public boolean canSpreadInto(Block block, Side side) {
         return !block.isLiquid() && super.canSpreadInto(block, side);

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
@@ -46,7 +46,7 @@ public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
     @Override
     public byte propagateValue(byte existingValue, Side side, Block from) {
         if (side == Side.BOTTOM) {
-            return (byte) Math.min(existingValue, ChunkConstants.MAX_SUNLIGHT_REGEN);
+            return (existingValue == ChunkConstants.MAX_SUNLIGHT_REGEN) ? ChunkConstants.MAX_SUNLIGHT_REGEN  : (byte) (existingValue + 1);
         }
         return 0;
     }

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenWorldView.java
@@ -21,6 +21,9 @@ import org.terasology.world.chunks.LitChunk;
 import org.terasology.world.propagation.AbstractFullWorldView;
 
 /**
+ * Gets the sunlight regen values from the chunk.
+ * <p>
+ * Simply delegates to the provided chunk for values
  */
 public class SunlightRegenWorldView extends AbstractFullWorldView {
 

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightWorldView.java
@@ -21,6 +21,9 @@ import org.terasology.world.chunks.LitChunk;
 import org.terasology.world.propagation.AbstractFullWorldView;
 
 /**
+ * Gets the sunlight from the chunk.
+ * <p>
+ * Simply delegates to the provided chunk for values
  */
 public class SunlightWorldView extends AbstractFullWorldView {
 


### PR DESCRIPTION
This adds in javadoc for almost all the `org.terasology.world.propagation` package of the engine.  
It also contains some minor method refactors where they were extremely dense/confusing.

I may javadoc the last few methods/classes but they're stumping me for now so most likely they shall remain un-docced until I can figure out how/what they are doing. As such they aren't holding up merging this PR

## Testing
Simply ensure all tests pass and that no functionality is changed.