### PR TITLE
Fix Columnlayout and MultiRowLayout spacing issues by fixing integer casts

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/ColumnLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/ColumnLayout.java
@@ -206,7 +206,7 @@ public class ColumnLayout extends CoreLayout<LayoutHint> {
             UIWidget widget = row.get(i);
             Vector2i cellSize = new Vector2i(availableWidth, areaHint.y);
             if (!autoSizeColumns) {
-                cellSize.x *= (int) columnWidths[i];
+                cellSize.x = (int) (cellSize.x * columnWidths[i]);
             }
             if (widget != null) {
                 Vector2i contentSize = canvas.calculateRestrictedSize(widget, cellSize);

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/MultiRowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/MultiRowLayout.java
@@ -186,7 +186,7 @@ public class MultiRowLayout extends CoreLayout<LayoutHint> {
             UIWidget widget = column.get(i);
             Vector2i cellSize = new Vector2i(areaHint.x, availableHeight);
             if (!autoSizeRows) {
-                cellSize.y *= (int) rowHeights[i];
+                cellSize.y = (int) (cellSize.y * rowHeights[i]);
             }
             if (widget != null) {
                 Vector2i contentSize = canvas.calculateRestrictedSize(widget, cellSize);


### PR DESCRIPTION
### Contains

Fixes integer casts of normalized float multiplication in `ColumnLayout.java` and `MultiRowLayout.java`.

This solves spacing errors that were present in the settings menus (video settings, audio settings etc.), fixing item four in #3577.

MultiRowLayout is not currently used in the game, but I change the cast to fit with the columnlayout cast.

### How to test

- Open the three settings menus (video, audio, input) and confirm that the spacing between the various elements is normal.
