### PR TITLE
Fixed tabbing between widgets after Escape is pressed

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/AbstractWidget.java
@@ -300,6 +300,12 @@ public abstract class AbstractWidget implements UIWidget {
                 if (!TabbingManager.isInitialized()) {
                     TabbingManager.init();
                 }
+                if (TabbingManager.getOpenScreen().getManager().getFocus() == null) {
+                    if (TabbingManager.getWidgetsList().size() > 0) {
+                        TabbingManager.resetCurrentNum();
+                        TabbingManager.focusedWidget = TabbingManager.getWidgetsList().get(0);
+                    }
+                }
                 TabbingManager.focusSetThrough = true;
                 TabbingManager.changeCurrentNum(!shiftPressed);
 

--- a/engine/src/main/java/org/terasology/rendering/nui/CoreScreenLayer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/CoreScreenLayer.java
@@ -215,6 +215,21 @@ public abstract class CoreScreenLayer extends AbstractWidget implements UIScreen
     @Override
     public void update(float delta) {
         if (contents != null) {
+            if (!TabbingManager.isInitialized()) {
+                TabbingManager.init();
+                TabbingManager.setOpenScreen(this);
+
+                Iterator<UIWidget> widgets = contents.iterator();
+                iterateThrough(widgets);
+            }
+
+            if (TabbingManager.getOpenScreen() == null) {
+                TabbingManager.setOpenScreen(this);
+
+                Iterator<UIWidget> widgets = contents.iterator();
+                iterateThrough(widgets);
+
+            }
             contents.update(delta);
             animationSystem.update(delta);
             if (depth == SortOrderSystem.DEFAULT_DEPTH) {
@@ -222,13 +237,6 @@ public abstract class CoreScreenLayer extends AbstractWidget implements UIScreen
             }
             if (activateBindEvent) {
                 onBindEvent(new TabbingUIButton());
-            }
-
-            if (!TabbingManager.isInitialized()) {
-                TabbingManager.init();
-
-                Iterator<UIWidget> widgets = contents.iterator();
-                iterateThrough(widgets);
             }
         }
     }


### PR DESCRIPTION
### Contains

Fixes widget tabbing so that it can be used after `Esc` has been pressed (the second problem mentioned in #3577)

### How to test

Press `Esc` on the main menu or other screens, then `Tab` in order to tab through the widgets.
