### PR TITLE
Fixes the display mode dropdown

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
@@ -110,7 +110,7 @@ public class UIDropdown<T> extends ActivatableWidget {
             for (int i = 0; i < optionListeners.size(); ++i) {
                 if (optionListeners.get(i).isMouseOver()) {
                     canvas.setMode(HOVER_MODE);
-                } else if (i==highlighted) {
+                } else if (i==highlighted && TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this)) {
                     canvas.setMode(HOVER_MODE);
                     setSelection(getOptions().get(highlighted));
                 } else {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
@@ -24,6 +24,7 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.InteractionListener;
 import org.terasology.rendering.nui.SubRegion;
+import org.terasology.rendering.nui.TabbingManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
@@ -191,7 +192,7 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
     private void readItemMouseOver(Canvas canvas, int i) {
         if (optionListeners.get(i).isMouseOver()) {
             canvas.setMode(HOVER_MODE);
-        } else if (i == highlighted) {
+        } else if (i == highlighted && TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this)) {
             canvas.setMode(HOVER_MODE);
             setSelection(getOptions().get(highlighted));
         } else {


### PR DESCRIPTION
### Contains

Fixes #3587.

### How to test

Go to the display mode dropdown (inside the video settings menu) and click it with the mouse. The dropdown will now function as expected.