### PR TITLE
Revert #3595, re-fix #3584, thereby fixing main title cropping

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectionScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectionScreen.java
@@ -30,6 +30,7 @@ import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
+import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UIImageSlideshow;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
@@ -126,7 +127,10 @@ public abstract class SelectionScreen extends CoreScreenLayer {
         }
 
         previewSlideshow.clean();
-        textures.forEach(previewSlideshow::addImage);
+        textures.forEach(tex -> {
+            UIImage image = new UIImage(null, tex, true);
+            previewSlideshow.addImage(image);
+        });
     }
 
     protected void remove(final UIList<GameInfo> gameList, Path world, String removeString) {

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImage.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIImage.java
@@ -65,12 +65,12 @@ public class UIImage extends CoreWidget {
     public void onDraw(Canvas canvas) {
         if (image.get() != null) {
             if (ignoreAspectRatio) {
-                canvas.drawTexture(image.get(), tint.get());
-            } else {
                 ScaleMode scaleMode = canvas.getCurrentStyle().getTextureScaleMode();
-                canvas.getCurrentStyle().setTextureScaleMode(ScaleMode.SCALE_FILL);
+                canvas.getCurrentStyle().setTextureScaleMode(ScaleMode.STRETCH);
                 canvas.drawTexture(image.get(), tint.get());
                 canvas.getCurrentStyle().setTextureScaleMode(scaleMode);
+            } else {
+                canvas.drawTexture(image.get(), tint.get());
             }
         }
     }


### PR DESCRIPTION
### Contains

The previous fix to #3584 changes the scaling mode for every UIImage, with potentially unpredictable results. The most prominent of these results is that the main title is cropped instead of scaled to size.

This PR replaces #3595 with a backwards-compatible fix instead, avoiding this issue and presumably others.

### How to test

- Ensure title is not cropped
- Ensure previews fill their UI box on the game select, replay select, and record screens
