### PR TITLE
 Issue 3553 solved. Can't go back after enabling Animated Menus option

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -69,7 +69,7 @@ public class MenuControlSystem extends BaseComponentSystem {
             event.consume();
         }
         if (networkSystem.getMode() == NetworkMode.NONE) {
-            if (nuiManager.isOpen("engine:pauseMenu")) {
+            if (!nuiManager.isOpen("engine:pauseMenu")) {
                 time.setPaused(true);
             } else {
                 time.setPaused(false);


### PR DESCRIPTION
Fixes #3553 
First of all I was thinking it's an issue from the implementation of animation. I spent a lot of time there and everything was fine, then I thought somewhere the screen who gotta be pushed it's null or some of his properties are not how they should be and again I spent a lot of time through PauseMenu, MainMenuScreen, SettingsScreen etc trying to print with logger in console those properties and compare so I can see something unusual, but again everything was fine. Finally I got in MenuControlSystem where I observed the DeathScreen so I set that screen to be animated too and everything worked perfect. I get back to PauseMenu and the only source of this issue could came from method onTogglePause(...). First of all I checked if toggleScreen was doing his job and of course it was ok , so I checked how networkSystem works, but nothing wrong here and finally I get to this if(...) and of course it should be the opposite of what it was. I wanted to explain what I did cause it wasn't that easy to go through all this code and check everything was fine even if the solution it was just a "!"