### PR TITLE
Vignette node draft

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -98,6 +98,7 @@ public class ShaderManagerLwjgl implements ShaderManager {
         addShaderProgram("prePostComposite");
         addShaderProgram("highPass");
         addShaderProgram("blur");
+        addShaderProgram("vignette");
         addShaderProgram("downSampler");
         addShaderProgram("toneMapping");
         addShaderProgram("sky");

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -36,7 +36,6 @@ import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FBOConfig;
-import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.utilities.random.FastRandom;
@@ -54,12 +53,12 @@ import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
 
 /**
  * An instance of this class adds depth of field blur, motion blur and film grain to the rendering
- * of the scene obtained so far. Furthermore, depending if a screenshot has been requested,
- * it instructs the ScreenGrabber to save it to a file.
+ * of the scene obtained so far.
  * <p>
  * If RenderingDebugConfig.isEnabled() returns true, this node is instead responsible for displaying
  * the content of a number of technical buffers rather than the final, post-processed rendering
  * of the scene.
+ * Stores the result into the FinalPostProcessingnode.POST_FBO_URI, to be used at a later stage.
  */
 public class FinalPostProcessingNode extends AbstractNode implements PropertyChangeListener {
     public static final SimpleUri POST_FBO_URI = new SimpleUri("engine:fbo.post");
@@ -67,7 +66,6 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
 
     private WorldRenderer worldRenderer;
     private RenderingConfig renderingConfig;
-    private ScreenGrabber screenGrabber;
 
     private Material postMaterial;
 
@@ -95,7 +93,6 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
 
         worldRenderer = context.get(WorldRenderer.class);
         activeCamera = worldRenderer.getActiveCamera();
-        screenGrabber = context.get(ScreenGrabber.class);
         cameraTargetSystem = context.get(CameraTargetSystem.class);
 
         postMaterial = getMaterial(POST_MATERIAL_URN);
@@ -158,10 +155,6 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
         }
 
         renderFullscreenQuad();
-
-        if (screenGrabber.isTakingScreenshot()) {
-            screenGrabber.saveScreenshot();
-        }
 
         PerformanceMonitor.endActivity();
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -19,6 +19,7 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
+import org.terasology.engine.SimpleUri;
 import org.terasology.input.cameraTarget.CameraTargetSystem;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
@@ -34,6 +35,7 @@ import org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FBOConfig;
 import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
@@ -48,6 +50,7 @@ import static org.terasology.rendering.dag.nodes.ToneMappingNode.TONE_MAPPING_FB
 import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.ColorTexture;
 import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.DepthStencilTexture;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
+import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
 import static org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs.FINAL_BUFFER;
 
 /**
@@ -60,6 +63,7 @@ import static org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBO
  * of the scene.
  */
 public class FinalPostProcessingNode extends AbstractNode implements PropertyChangeListener {
+    public static final SimpleUri POST_FBO_URI = new SimpleUri("engine:fbo.post");
     private static final ResourceUrn POST_MATERIAL_URN = new ResourceUrn("engine:prog.post");
 
     private WorldRenderer worldRenderer;
@@ -100,9 +104,9 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
         addDesiredStateChange(new EnableMaterial(POST_MATERIAL_URN));
 
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
-        FBO finalBuffer = displayResolutionDependentFBOs.get(FINAL_BUFFER);
-        addDesiredStateChange(new BindFbo(finalBuffer));
-        addDesiredStateChange(new SetViewportToSizeOf(finalBuffer));
+        FBO postFbo = requiresFBO(new FBOConfig(POST_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT), displayResolutionDependentFBOs);
+        addDesiredStateChange(new BindFbo(postFbo));
+        addDesiredStateChange(new SetViewportToSizeOf(postFbo));
 
         renderingConfig = context.get(Config.class).getRendering();
         isFilmGrainEnabled = renderingConfig.isFilmGrain();

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -51,13 +51,12 @@ import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.F
 import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.DepthStencilTexture;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
-import static org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs.FINAL_BUFFER;
 
 /**
  * An instance of this class adds depth of field blur, motion blur and film grain to the rendering
  * of the scene obtained so far. Furthermore, depending if a screenshot has been requested,
  * it instructs the ScreenGrabber to save it to a file.
- *
+ * <p>
  * If RenderingDebugConfig.isEnabled() returns true, this node is instead responsible for displaying
  * the content of a number of technical buffers rather than the final, post-processed rendering
  * of the scene.
@@ -136,7 +135,7 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
 
     /**
      * Execute the final post processing on the rendering of the scene obtained so far.
-     *
+     * <p>
      * It uses the data stored in multiple FBOs as input and the FINAL FBO to store its output, rendering everything to a quad.
      */
     @Override

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -101,12 +101,12 @@ public class FinalPostProcessingNode extends AbstractNode implements PropertyCha
 
         postMaterial = getMaterial(POST_MATERIAL_URN);
 
-        addDesiredStateChange(new EnableMaterial(POST_MATERIAL_URN));
-
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
         FBO postFbo = requiresFBO(new FBOConfig(POST_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT), displayResolutionDependentFBOs);
         addDesiredStateChange(new BindFbo(postFbo));
         addDesiredStateChange(new SetViewportToSizeOf(postFbo));
+
+        addDesiredStateChange(new EnableMaterial(POST_MATERIAL_URN));
 
         renderingConfig = context.get(Config.class).getRendering();
         isFilmGrainEnabled = renderingConfig.isFilmGrain();

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
@@ -27,7 +27,6 @@ import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.stateChanges.BindFbo;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
-import org.terasology.rendering.dag.stateChanges.SetInputTexture2D;
 import org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.nui.properties.Range;
@@ -108,13 +107,16 @@ public class InitialPostProcessingNode extends AbstractNode implements PropertyC
         FBO one8thBloomFbo = requiresFBO(one8thScaleBloomConfig, displayResolutionDependentFBOs);
 
         int textureSlot = 0;
-        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texScene"));
+        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(),
+                ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texScene"));
         // TODO::deprecate vignette here
 //        if(initPostVignetteEnabled) {
 //            addDesiredStateChange(new SetInputTexture2D(textureSlot++, "engine:vignette", INITIAL_POST_MATERIAL_URN, "texVignette"));
 //        }
-        setBloomInputTexture = new SetInputTextureFromFbo(textureSlot++, one8thBloomFbo, ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texBloom");
-        setLightShaftsInputTexture = new SetInputTextureFromFbo(textureSlot, LIGHT_SHAFTS_FBO_URI, ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texLightShafts");
+        setBloomInputTexture = new SetInputTextureFromFbo(textureSlot++, one8thBloomFbo, ColorTexture, displayResolutionDependentFBOs,
+                INITIAL_POST_MATERIAL_URN, "texBloom");
+        setLightShaftsInputTexture = new SetInputTextureFromFbo(textureSlot, LIGHT_SHAFTS_FBO_URI, ColorTexture, displayResolutionDependentFBOs,
+                INITIAL_POST_MATERIAL_URN, "texLightShafts");
 
         if (bloomIsEnabled) {
             addDesiredStateChange(setBloomInputTexture);

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
@@ -64,6 +64,7 @@ public class InitialPostProcessingNode extends AbstractNode implements PropertyC
 
     private boolean bloomIsEnabled;
     private boolean lightShaftsAreEnabled;
+//    private boolean initPostVignetteIsEnabled = false;
 
     private StateChange setBloomInputTexture;
     private StateChange setLightShaftsInputTexture;
@@ -108,7 +109,10 @@ public class InitialPostProcessingNode extends AbstractNode implements PropertyC
 
         int textureSlot = 0;
         addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texScene"));
-        addDesiredStateChange(new SetInputTexture2D(textureSlot++, "engine:vignette", INITIAL_POST_MATERIAL_URN, "texVignette"));
+        // TODO::deprecate vignette here
+//        if(initPostVignetteEnabled) {
+//            addDesiredStateChange(new SetInputTexture2D(textureSlot++, "engine:vignette", INITIAL_POST_MATERIAL_URN, "texVignette"));
+//        }
         setBloomInputTexture = new SetInputTextureFromFbo(textureSlot++, one8thBloomFbo, ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texBloom");
         setLightShaftsInputTexture = new SetInputTextureFromFbo(textureSlot, LIGHT_SHAFTS_FBO_URI, ColorTexture, displayResolutionDependentFBOs, INITIAL_POST_MATERIAL_URN, "texLightShafts");
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
@@ -133,11 +133,11 @@ public class InitialPostProcessingNode extends AbstractNode implements PropertyC
 
         // Common Shader Parameters
 
-        initialPostMaterial.setFloat("swimming", activeCamera.isUnderWater() ? 1.0f : 0.0f, true);
+        //initialPostMaterial.setFloat("swimming", activeCamera.isUnderWater() ? 1.0f : 0.0f, true);
 
         // Shader Parameters
 
-        initialPostMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(activeCamera.getPosition()).getTint(), true);
+        //initialPostMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(activeCamera.getPosition()).getTint(), true);
 
         if (bloomIsEnabled) {
             initialPostMaterial.setFloat("bloomFactor", bloomFactor, true);

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OutputToHMDNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OutputToHMDNode.java
@@ -26,6 +26,7 @@ import org.terasology.rendering.dag.ConditionDependentNode;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FBOConfig;
+import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.openvrprovider.OpenVRProvider;
 import org.terasology.rendering.world.WorldRenderer.RenderingStage;
@@ -51,12 +52,16 @@ public class OutputToHMDNode extends ConditionDependentNode {
     private FBO rightEyeFbo;
     private FBO finalFbo;
 
+    private ScreenGrabber screenGrabber;
+
     /**
      * Constructs an instance of this node. Specifically, initialize the vrProvider and pass the frame buffer
      * information for the vrProvider to use.
      */
     public OutputToHMDNode(String nodeUri, Context context) {
         super(nodeUri, context);
+
+        screenGrabber = context.get(ScreenGrabber.class);
 
         vrProvider = context.get(OpenVRProvider.class);
         requiresCondition(() -> (context.get(Config.class).getRendering().isVrSupport() && vrProvider.isInitialized()));
@@ -90,6 +95,9 @@ public class OutputToHMDNode extends ConditionDependentNode {
         PerformanceMonitor.startActivity("rendering/" + getUri());
         finalFbo.bindTexture();
         renderFinalStereoImage(worldRenderer.getCurrentRenderStage());
+        if (screenGrabber.isTakingScreenshot()) {
+            screenGrabber.saveScreenshot();
+        }
         PerformanceMonitor.endActivity();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/OutputToScreenNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/OutputToScreenNode.java
@@ -25,6 +25,7 @@ import org.terasology.rendering.dag.StateChange;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo;
 import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.SwappableFBO;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 
@@ -45,9 +46,11 @@ public class OutputToScreenNode extends ConditionDependentNode {
 
     private StateChange bindFbo;
 
+    private ScreenGrabber screenGrabber;
+
     public OutputToScreenNode(String nodeUri, Context context) {
         super(nodeUri, context);
-
+        screenGrabber = context.get(ScreenGrabber.class);
         displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
 
         requiresCondition(() -> worldRenderer.getCurrentRenderStage() == MONO || worldRenderer.getCurrentRenderStage() == LEFT_EYE);
@@ -70,6 +73,9 @@ public class OutputToScreenNode extends ConditionDependentNode {
         // and not that of some FBO. Hence, we are manually setting the viewport via glViewport over here.
         glViewport(0, 0, Display.getWidth(), Display.getHeight());
         renderFullscreenQuad();
+        if (screenGrabber.isTakingScreenshot()) {
+            screenGrabber.saveScreenshot();
+        }
         PerformanceMonitor.endActivity();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -31,6 +31,7 @@ import org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.SetInputTexture2D;
 import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -47,8 +48,9 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 /**
  * An instance of this node adds vignette onto the rendering achieved so far, stored in the gbuffer.
  * It should provide ability to use various vignette textures and tinting.
- * 1 Channeled transparency texture is used atm.
- * Stores the result into the VignetteNode.VIGNETTE_FBO_URI, to be used at a later stage.
+ * 1 Channeled transparency texture is used atm. Furthermore, depending if a screenshot has been requested,
+ * it instructs the ScreenGrabber to save it to a file.
+ * Stores the result into the displayResolutionDependentFBOs.FINAL_BUFFER, to be displayed on the screen.
  * Requirements: https://github.com/MovingBlocks/Terasology/issues/3040
  */
 public class VignetteNode extends AbstractNode implements PropertyChangeListener {
@@ -58,6 +60,8 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
     private WorldProvider worldProvider;
     private WorldRenderer worldRenderer;
     private SubmersibleCamera activeCamera;
+
+    private ScreenGrabber screenGrabber;
 
     private Material vignetteMaterial;
 
@@ -75,6 +79,7 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
         worldRenderer = context.get(WorldRenderer.class);
         activeCamera = worldRenderer.getActiveCamera();
+        screenGrabber = context.get(ScreenGrabber.class);
 
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
         // TODO: see if we could write this straight into a GBUFFER
@@ -122,6 +127,10 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
         // Actual Node Processing
 
         renderFullscreenQuad();
+
+        if (screenGrabber.isTakingScreenshot()) {
+            screenGrabber.saveScreenshot();
+        }
 
         PerformanceMonitor.endActivity();
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -19,7 +19,6 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
-import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
@@ -53,7 +52,6 @@ import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
  * Requirements: https://github.com/MovingBlocks/Terasology/issues/3040
  */
 public class VignetteNode extends AbstractNode implements PropertyChangeListener {
-    public static final SimpleUri VIGNETTE_FBO_URI = new SimpleUri("engine:fbo.vignette");
     private static final ResourceUrn VIGNETTE_MATERIAL_URN = new ResourceUrn("engine:prog.vignette");
 
     private RenderingConfig renderingConfig;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -26,10 +26,12 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.SubmersibleCamera;
 import org.terasology.rendering.dag.AbstractNode;
 import org.terasology.rendering.dag.StateChange;
-import org.terasology.rendering.dag.stateChanges.*;
-import org.terasology.rendering.nui.properties.Range;
+import org.terasology.rendering.dag.stateChanges.BindFbo;
+import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
+import org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo;
+import org.terasology.rendering.dag.stateChanges.EnableMaterial;
+import org.terasology.rendering.dag.stateChanges.SetInputTexture2D;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.FBOConfig;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -42,8 +44,6 @@ import static org.terasology.rendering.dag.nodes.FinalPostProcessingNode.POST_FB
 
 import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.ColorTexture;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
-import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
-import static org.terasology.rendering.opengl.ScalingFactors.ONE_8TH_SCALE;
 
 /**
  * An instance of this node adds vignette onto the rendering achieved so far, stored in the gbuffer.
@@ -65,7 +65,7 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
     private boolean vignetteIsEnabled;
     // TODO: figure where from to set this variable
-    private Vector3f tint = new Vector3f(.0f,.0f,.0f);
+    private Vector3f tint = new Vector3f(.0f, .0f, .0f);
 //    private Vector3f tint = new Vector3f(0.937f,0.126f,0.016f);
 
     private StateChange setVignetteInputTexture;
@@ -80,7 +80,7 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
         // TODO: see if we could write this straight into a GBUFFER
-       // FBO vignetteFbo = requiresFBO(new FBOConfig(VIGNETTE_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT), displayResolutionDependentFBOs);
+        // FBO vignetteFbo = requiresFBO(new FBOConfig(VIGNETTE_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT), displayResolutionDependentFBOs);
         FBO finalBuffer = displayResolutionDependentFBOs.get(FINAL_BUFFER);
         addDesiredStateChange(new BindFbo(finalBuffer));
         addDesiredStateChange(new SetViewportToSizeOf(finalBuffer));
@@ -94,12 +94,13 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
         renderingConfig.subscribe(RenderingConfig.VIGNETTE, this);
 
         int textureSlot = 0;
-        //addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
-        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, POST_FBO_URI , ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
+//        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture,
+//                displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
+        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, POST_FBO_URI, ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
 
         setVignetteInputTexture = new SetInputTexture2D(textureSlot++, "engine:vignette", VIGNETTE_MATERIAL_URN, "texVignette");
 
-        if(vignetteIsEnabled) {
+        if (vignetteIsEnabled) {
             addDesiredStateChange(setVignetteInputTexture);
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -63,9 +63,9 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
     private Material vignetteMaterial;
 
     private boolean vignetteIsEnabled;
+
     // TODO: figure where from to set this variable
     private Vector3f tint = new Vector3f(.0f, .0f, .0f);
-//    private Vector3f tint = new Vector3f(0.937f,0.126f,0.016f);
 
     private StateChange setVignetteInputTexture;
 
@@ -78,8 +78,7 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
         activeCamera = worldRenderer.getActiveCamera();
 
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
-        // TODO: see if we could write this straight into a GBUFFER
-        // FBO vignetteFbo = requiresFBO(new FBOConfig(VIGNETTE_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT), displayResolutionDependentFBOs);
+
         FBO finalBuffer = displayResolutionDependentFBOs.get(FINAL_BUFFER);
         addDesiredStateChange(new BindFbo(finalBuffer));
         addDesiredStateChange(new SetViewportToSizeOf(finalBuffer));
@@ -93,8 +92,6 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
         renderingConfig.subscribe(RenderingConfig.VIGNETTE, this);
 
         int textureSlot = 0;
-//        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture,
-//                displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
         addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, POST_FBO_URI, ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
 
         setVignetteInputTexture = new SetInputTexture2D(textureSlot++, "engine:vignette", VIGNETTE_MATERIAL_URN, "texVignette");

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.dag.nodes;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.config.Config;
+import org.terasology.config.RenderingConfig;
+import org.terasology.context.Context;
+import org.terasology.engine.SimpleUri;
+import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.rendering.assets.material.Material;
+import org.terasology.rendering.cameras.SubmersibleCamera;
+import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.StateChange;
+import org.terasology.rendering.dag.stateChanges.*;
+import org.terasology.rendering.nui.properties.Range;
+import org.terasology.rendering.opengl.FBO;
+import org.terasology.rendering.opengl.FBOConfig;
+import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
+import org.terasology.rendering.world.WorldRenderer;
+import org.terasology.world.WorldProvider;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import static org.terasology.rendering.dag.nodes.LightShaftsNode.LIGHT_SHAFTS_FBO_URI;
+import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.ColorTexture;
+import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
+import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
+import static org.terasology.rendering.opengl.ScalingFactors.ONE_8TH_SCALE;
+
+/**
+ * An instance of this node adds vignette onto the rendering achieved so far, stored in the gbuffer.
+ * It should provide ability to use various vignette textures and tinting.
+ * 1 Channeled transparency texture is used atm.
+ * Stores the result into the InitialPostProcessingNode.VIGNETTE_FBO_URI, to be used at a later stage.
+ * Requirements: https://github.com/MovingBlocks/Terasology/issues/3040
+ */
+public class VignetteNode extends AbstractNode implements PropertyChangeListener {
+    static final SimpleUri VIGNETTE_FBO_URI = new SimpleUri("engine:fbo.vignette");
+    private static final ResourceUrn VIGNETTE_MATERIAL_URN = new ResourceUrn("engine:prog.vignette");
+
+    private RenderingConfig renderingConfig;
+    private WorldProvider worldProvider;
+    private WorldRenderer worldRenderer;
+    private SubmersibleCamera activeCamera;
+
+    private Material vignetteMaterial;
+
+    private boolean vignetteIsEnabled;
+
+    private StateChange setVignetteInputTexture;
+
+    public VignetteNode(String nodeUri, Context context) {
+        super(nodeUri, context);
+
+        worldProvider = context.get(WorldProvider.class);
+
+        worldRenderer = context.get(WorldRenderer.class);
+        activeCamera = worldRenderer.getActiveCamera();
+
+        DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
+        // TODO: see if we could write this straight into a GBUFFER
+        FBO vignetteFbo = requiresFBO(new FBOConfig(VIGNETTE_FBO_URI, FULL_SCALE, FBO.Type.HDR), displayResolutionDependentFBOs);
+        addDesiredStateChange(new BindFbo(vignetteFbo));
+        addDesiredStateChange(new SetViewportToSizeOf(vignetteFbo));
+
+        addDesiredStateChange(new EnableMaterial(VIGNETTE_MATERIAL_URN));
+
+        vignetteMaterial = getMaterial(VIGNETTE_MATERIAL_URN);
+
+        renderingConfig = context.get(Config.class).getRendering();
+//        bloomIsEnabled = renderingConfig.isBloom();
+//        renderingConfig.subscribe(RenderingConfig.BLOOM, this);
+//        lightShaftsAreEnabled = renderingConfig.isLightShafts();
+//        renderingConfig.subscribe(RenderingConfig.LIGHT_SHAFTS, this);
+        vignetteIsEnabled = renderingConfig.isVignette();
+        renderingConfig.subscribe(RenderingConfig.VIGNETTE, this);
+
+        // TODO: Temporary hack for now.
+//        FBOConfig one8thScaleBloomConfig = new FBOConfig(BloomBlurNode.ONE_8TH_SCALE_FBO_URI, ONE_8TH_SCALE, FBO.Type.DEFAULT);
+//        FBO one8thBloomFbo = requiresFBO(one8thScaleBloomConfig, displayResolutionDependentFBOs);
+
+        int textureSlot = 0;
+        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
+        addDesiredStateChange(new SetInputTexture2D(textureSlot++, "engine:vignette", VIGNETTE_MATERIAL_URN, "texVignette"));
+//        setBloomInputTexture = new SetInputTextureFromFbo(textureSlot++, one8thBloomFbo, ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texBloom");
+//        setLightShaftsInputTexture = new SetInputTextureFromFbo(textureSlot, LIGHT_SHAFTS_FBO_URI, ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texLightShafts");
+
+//        if (bloomIsEnabled) {
+//            addDesiredStateChange(setBloomInputTexture);
+//        }
+//        if (lightShaftsAreEnabled) {
+//            addDesiredStateChange(setLightShaftsInputTexture);
+//        }
+    }
+
+    /**
+     * Renders a quad, in turn filling the InitialPostProcessingNode.VIGNETTE_FBO_URI.
+     */
+    @Override
+    public void process() {
+        PerformanceMonitor.startActivity("rendering/" + getUri());
+
+        // Common Shader Parameters
+
+        vignetteMaterial.setFloat("swimming", activeCamera.isUnderWater() ? 1.0f : 0.0f, true);
+
+        // Shader Parameters
+
+        vignetteMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(activeCamera.getPosition()).getTint(), true);
+
+        // Actual Node Processing
+
+        renderFullscreenQuad();
+
+        PerformanceMonitor.endActivity();
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent event) {
+        String propertyName = event.getPropertyName();
+
+        switch (propertyName) {
+            case RenderingConfig.VIGNETTE:
+                vignetteIsEnabled = renderingConfig.isBloom();
+                if (vignetteIsEnabled) {
+                    addDesiredStateChange(setVignetteInputTexture);
+                } else {
+                    removeDesiredStateChange(setVignetteInputTexture);
+                }
+                break;
+
+            // default: no other cases are possible - see subscribe operations in initialize().
+        }
+
+        worldRenderer.requestTaskListRefresh();
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -20,6 +20,7 @@ import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
+import org.terasology.math.geom.Vector3f;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.SubmersibleCamera;
@@ -36,7 +37,9 @@ import org.terasology.world.WorldProvider;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-import static org.terasology.rendering.dag.nodes.LightShaftsNode.LIGHT_SHAFTS_FBO_URI;
+import static org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs.FINAL_BUFFER;
+import static org.terasology.rendering.dag.nodes.FinalPostProcessingNode.POST_FBO_URI;
+
 import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.ColorTexture;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
 import static org.terasology.rendering.opengl.ScalingFactors.FULL_SCALE;
@@ -46,11 +49,11 @@ import static org.terasology.rendering.opengl.ScalingFactors.ONE_8TH_SCALE;
  * An instance of this node adds vignette onto the rendering achieved so far, stored in the gbuffer.
  * It should provide ability to use various vignette textures and tinting.
  * 1 Channeled transparency texture is used atm.
- * Stores the result into the InitialPostProcessingNode.VIGNETTE_FBO_URI, to be used at a later stage.
+ * Stores the result into the VignetteNode.VIGNETTE_FBO_URI, to be used at a later stage.
  * Requirements: https://github.com/MovingBlocks/Terasology/issues/3040
  */
 public class VignetteNode extends AbstractNode implements PropertyChangeListener {
-    static final SimpleUri VIGNETTE_FBO_URI = new SimpleUri("engine:fbo.vignette");
+    public static final SimpleUri VIGNETTE_FBO_URI = new SimpleUri("engine:fbo.vignette");
     private static final ResourceUrn VIGNETTE_MATERIAL_URN = new ResourceUrn("engine:prog.vignette");
 
     private RenderingConfig renderingConfig;
@@ -61,6 +64,9 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
     private Material vignetteMaterial;
 
     private boolean vignetteIsEnabled;
+    // TODO: figure where from to set this variable
+    //private Vector3f tint = new Vector3f(1.0f,1.0f,1.0f);
+    private Vector3f tint = new Vector3f(0.937f,0.126f,0.016f);
 
     private StateChange setVignetteInputTexture;
 
@@ -74,38 +80,28 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
         // TODO: see if we could write this straight into a GBUFFER
-        FBO vignetteFbo = requiresFBO(new FBOConfig(VIGNETTE_FBO_URI, FULL_SCALE, FBO.Type.HDR), displayResolutionDependentFBOs);
-        addDesiredStateChange(new BindFbo(vignetteFbo));
-        addDesiredStateChange(new SetViewportToSizeOf(vignetteFbo));
+       // FBO vignetteFbo = requiresFBO(new FBOConfig(VIGNETTE_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT), displayResolutionDependentFBOs);
+        FBO finalBuffer = displayResolutionDependentFBOs.get(FINAL_BUFFER);
+        addDesiredStateChange(new BindFbo(finalBuffer));
+        addDesiredStateChange(new SetViewportToSizeOf(finalBuffer));
 
         addDesiredStateChange(new EnableMaterial(VIGNETTE_MATERIAL_URN));
 
         vignetteMaterial = getMaterial(VIGNETTE_MATERIAL_URN);
 
         renderingConfig = context.get(Config.class).getRendering();
-//        bloomIsEnabled = renderingConfig.isBloom();
-//        renderingConfig.subscribe(RenderingConfig.BLOOM, this);
-//        lightShaftsAreEnabled = renderingConfig.isLightShafts();
-//        renderingConfig.subscribe(RenderingConfig.LIGHT_SHAFTS, this);
         vignetteIsEnabled = renderingConfig.isVignette();
         renderingConfig.subscribe(RenderingConfig.VIGNETTE, this);
 
-        // TODO: Temporary hack for now.
-//        FBOConfig one8thScaleBloomConfig = new FBOConfig(BloomBlurNode.ONE_8TH_SCALE_FBO_URI, ONE_8TH_SCALE, FBO.Type.DEFAULT);
-//        FBO one8thBloomFbo = requiresFBO(one8thScaleBloomConfig, displayResolutionDependentFBOs);
-
         int textureSlot = 0;
-        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
-        addDesiredStateChange(new SetInputTexture2D(textureSlot++, "engine:vignette", VIGNETTE_MATERIAL_URN, "texVignette"));
-//        setBloomInputTexture = new SetInputTextureFromFbo(textureSlot++, one8thBloomFbo, ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texBloom");
-//        setLightShaftsInputTexture = new SetInputTextureFromFbo(textureSlot, LIGHT_SHAFTS_FBO_URI, ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texLightShafts");
+        //addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
+        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot++, POST_FBO_URI , ColorTexture, displayResolutionDependentFBOs, VIGNETTE_MATERIAL_URN, "texScene"));
 
-//        if (bloomIsEnabled) {
-//            addDesiredStateChange(setBloomInputTexture);
-//        }
-//        if (lightShaftsAreEnabled) {
-//            addDesiredStateChange(setLightShaftsInputTexture);
-//        }
+        setVignetteInputTexture = new SetInputTexture2D(textureSlot++, "engine:vignette", VIGNETTE_MATERIAL_URN, "texVignette");
+
+        if(vignetteIsEnabled) {
+            addDesiredStateChange(setVignetteInputTexture);
+        }
     }
 
     /**
@@ -122,6 +118,7 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
         // Shader Parameters
 
         vignetteMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(activeCamera.getPosition()).getTint(), true);
+        vignetteMaterial.setFloat3("tint", tint);
 
         // Actual Node Processing
 
@@ -136,7 +133,7 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
         switch (propertyName) {
             case RenderingConfig.VIGNETTE:
-                vignetteIsEnabled = renderingConfig.isBloom();
+                vignetteIsEnabled = renderingConfig.isVignette();
                 if (vignetteIsEnabled) {
                     addDesiredStateChange(setVignetteInputTexture);
                 } else {

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -65,8 +65,8 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
     private boolean vignetteIsEnabled;
     // TODO: figure where from to set this variable
-    //private Vector3f tint = new Vector3f(1.0f,1.0f,1.0f);
-    private Vector3f tint = new Vector3f(0.937f,0.126f,0.016f);
+    private Vector3f tint = new Vector3f(.0f,.0f,.0f);
+//    private Vector3f tint = new Vector3f(0.937f,0.126f,0.016f);
 
     private StateChange setVignetteInputTexture;
 

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/VignetteNode.java
@@ -31,7 +31,6 @@ import org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo;
 import org.terasology.rendering.dag.stateChanges.EnableMaterial;
 import org.terasology.rendering.dag.stateChanges.SetInputTexture2D;
 import org.terasology.rendering.opengl.FBO;
-import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
 import org.terasology.world.WorldProvider;
@@ -61,8 +60,6 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
     private WorldRenderer worldRenderer;
     private SubmersibleCamera activeCamera;
 
-    private ScreenGrabber screenGrabber;
-
     private Material vignetteMaterial;
 
     private boolean vignetteIsEnabled;
@@ -79,7 +76,6 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
 
         worldRenderer = context.get(WorldRenderer.class);
         activeCamera = worldRenderer.getActiveCamera();
-        screenGrabber = context.get(ScreenGrabber.class);
 
         DisplayResolutionDependentFBOs displayResolutionDependentFBOs = context.get(DisplayResolutionDependentFBOs.class);
         // TODO: see if we could write this straight into a GBUFFER
@@ -127,10 +123,6 @@ public class VignetteNode extends AbstractNode implements PropertyChangeListener
         // Actual Node Processing
 
         renderFullscreenQuad();
-
-        if (screenGrabber.isTakingScreenshot()) {
-            screenGrabber.saveScreenshot();
-        }
 
         PerformanceMonitor.endActivity();
     }

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -261,6 +261,8 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         addFinalPostProcessingNodes(renderGraph);
 
+        addVignetteNode(renderGraph);
+
         addOutputNodes(renderGraph);
 
         renderTaskListGenerator = new RenderTaskListGenerator();
@@ -537,22 +539,27 @@ public final class WorldRendererImpl implements WorldRenderer {
         Node finalPostProcessingNode = new FinalPostProcessingNode("finalPostProcessingNode", context);
         renderGraph.addNode(finalPostProcessingNode);
 
+        renderGraph.connect(toneMappingNode, firstLateBlurNode ,secondLateBlurNode, finalPostProcessingNode);
+    }
+
+    private void addVignetteNode(RenderGraph renderGraph){
+        Node finalPostProcessingNode = renderGraph.findNode("engine:finalPostProcessingNode");
+
         VignetteNode vignetteNode = new VignetteNode("vignetteNode",context);
         renderGraph.addNode(vignetteNode);
-
-        renderGraph.connect(toneMappingNode, firstLateBlurNode, secondLateBlurNode, vignetteNode, finalPostProcessingNode);
+        renderGraph.connect(finalPostProcessingNode, vignetteNode);
     }
 
     private void addOutputNodes(RenderGraph renderGraph) {
-        Node finalPostProcessingNode = renderGraph.findNode("engine:finalPostProcessingNode");
+        Node vignetteNode = renderGraph.findNode("engine:finalPostProcessingNode");
 
         Node outputToVRFrameBufferNode = new OutputToHMDNode("outputToVRFrameBufferNode", context);
         renderGraph.addNode(outputToVRFrameBufferNode);
-        renderGraph.connect(finalPostProcessingNode, outputToVRFrameBufferNode);
+        renderGraph.connect(vignetteNode, outputToVRFrameBufferNode);
 
         Node outputToScreenNode = new OutputToScreenNode("outputToScreenNode", context);
         renderGraph.addNode(outputToScreenNode);
-        renderGraph.connect(finalPostProcessingNode, outputToScreenNode);
+        renderGraph.connect(vignetteNode, outputToScreenNode);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -825,10 +825,10 @@ public final class WorldRendererImpl implements WorldRenderer {
      * concerned Nodes, which in turn take care of executing them.
      * <p>
      * Usage:
-     * dagCommandNode <nodeUri> <command> <parameters>
+     *      dagCommandNode <nodeUri> <command> <parameters>
      * <p>
      * Example:
-     * dagNodeCommand engine:outputToScreenNode setFbo engine:fbo.ssao
+     *      dagNodeCommand engine:outputToScreenNode setFbo engine:fbo.ssao
      */
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void dagNodeCommand(

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -16,6 +16,7 @@
 package org.terasology.rendering.world;
 
 import java.util.List;
+
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
@@ -87,6 +88,7 @@ import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.utilities.Assets;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
+
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
@@ -190,9 +192,9 @@ public final class WorldRendererImpl implements WorldRenderer {
             if (vrProvider.init()) {
                 playerCamera = new OpenVRStereoCamera(vrProvider, worldProvider, renderingConfig);
                 /*
-                * The origin of OpenVR's coordinate system lies on the ground of the user. We have to move this origin
-                * such that the ground plane of the rendering system and the ground plane of the room the VR user is
-                * in match.
+                 * The origin of OpenVR's coordinate system lies on the ground of the user. We have to move this origin
+                 * such that the ground plane of the rendering system and the ground plane of the room the VR user is
+                 * in match.
                  */
                 vrProvider.getState().setGroundPlaneYOffset(
                         GROUND_PLANE_HEIGHT_DISPARITY - context.get(Config.class).getPlayer().getEyeHeight());
@@ -272,10 +274,12 @@ public final class WorldRendererImpl implements WorldRenderer {
     private void addGBufferClearingNodes(RenderGraph renderGraph) {
         SwappableFBO gBufferPair = displayResolutionDependentFBOs.getGBufferPair();
 
-        BufferClearingNode lastUpdatedGBufferClearingNode = new BufferClearingNode("lastUpdatedGBufferClearingNode", context, gBufferPair.getLastUpdatedFbo(), GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+        BufferClearingNode lastUpdatedGBufferClearingNode = new BufferClearingNode("lastUpdatedGBufferClearingNode", context,
+                gBufferPair.getLastUpdatedFbo(), GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
         renderGraph.addNode(lastUpdatedGBufferClearingNode);
 
-        BufferClearingNode staleGBufferClearingNode = new BufferClearingNode("staleGBufferClearingNode", context, gBufferPair.getStaleFbo(), GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+        BufferClearingNode staleGBufferClearingNode = new BufferClearingNode("staleGBufferClearingNode", context,
+                gBufferPair.getStaleFbo(), GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
         renderGraph.addNode(staleGBufferClearingNode);
     }
 
@@ -286,7 +290,8 @@ public final class WorldRendererImpl implements WorldRenderer {
         FBOConfig intermediateHazeConfig = new FBOConfig(HazeNode.INTERMEDIATE_HAZE_FBO_URI, ONE_16TH_SCALE, FBO.Type.DEFAULT);
         FBO intermediateHazeFbo = displayResolutionDependentFBOs.request(intermediateHazeConfig);
 
-        HazeNode intermediateHazeNode = new HazeNode("intermediateHazeNode", context, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), intermediateHazeFbo);
+        HazeNode intermediateHazeNode = new HazeNode("intermediateHazeNode", context,
+                displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), intermediateHazeFbo);
         renderGraph.addNode(intermediateHazeNode);
 
         FBOConfig finalHazeConfig = new FBOConfig(HazeNode.FINAL_HAZE_FBO_URI, ONE_32TH_SCALE, FBO.Type.DEFAULT);
@@ -336,7 +341,8 @@ public final class WorldRendererImpl implements WorldRenderer {
         Node staleGBufferClearingNode = renderGraph.findNode("engine:staleGBufferClearingNode");
 
         FBOConfig shadowMapConfig = new FBOConfig(ShadowMapNode.SHADOW_MAP_FBO_URI, FBO.Type.NO_COLOR).useDepthBuffer();
-        BufferClearingNode shadowMapClearingNode = new BufferClearingNode("shadowMapClearingNode", context, shadowMapConfig, shadowMapResolutionDependentFBOs, GL_DEPTH_BUFFER_BIT);
+        BufferClearingNode shadowMapClearingNode = new BufferClearingNode("shadowMapClearingNode", context,
+                shadowMapConfig, shadowMapResolutionDependentFBOs, GL_DEPTH_BUFFER_BIT);
         renderGraph.addNode(shadowMapClearingNode);
 
         shadowMapNode = new ShadowMapNode("shadowMapNode", context);
@@ -392,7 +398,8 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     private void addReflectionAndRefractionNodes(RenderGraph renderGraph) {
         FBOConfig reflectedBufferConfig = new FBOConfig(BackdropReflectionNode.REFLECTED_FBO_URI, HALF_SCALE, FBO.Type.DEFAULT).useDepthBuffer();
-        BufferClearingNode reflectedBufferClearingNode = new BufferClearingNode("reflectedBufferClearingNode", context, reflectedBufferConfig, displayResolutionDependentFBOs, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        BufferClearingNode reflectedBufferClearingNode = new BufferClearingNode("reflectedBufferClearingNode", context,
+                reflectedBufferConfig, displayResolutionDependentFBOs, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         renderGraph.addNode(reflectedBufferClearingNode);
 
         Node reflectedBackdropNode = new BackdropReflectionNode("reflectedBackdropNode", context);
@@ -404,7 +411,8 @@ public final class WorldRendererImpl implements WorldRenderer {
         renderGraph.connect(reflectedBufferClearingNode, reflectedBackdropNode, worldReflectionNode);
 
         FBOConfig reflectedRefractedBufferConfig = new FBOConfig(RefractiveReflectiveBlocksNode.REFRACTIVE_REFLECTIVE_FBO_URI, FULL_SCALE, FBO.Type.HDR).useNormalBuffer();
-        BufferClearingNode reflectedRefractedBufferClearingNode = new BufferClearingNode("reflectedRefractedBufferClearingNode", context, reflectedRefractedBufferConfig, displayResolutionDependentFBOs, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        BufferClearingNode reflectedRefractedBufferClearingNode = new BufferClearingNode("reflectedRefractedBufferClearingNode", context,
+                reflectedRefractedBufferConfig, displayResolutionDependentFBOs, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         renderGraph.addNode(reflectedRefractedBufferClearingNode);
 
         Node chunksRefractiveReflectiveNode = new RefractiveReflectiveBlocksNode("chunksRefractiveReflectiveNode", context);
@@ -452,41 +460,49 @@ public final class WorldRendererImpl implements WorldRenderer {
         FBOConfig halfScaleBloomConfig = new FBOConfig(BloomBlurNode.HALF_SCALE_FBO_URI, HALF_SCALE, FBO.Type.DEFAULT);
         FBO halfScaleBloomFbo = displayResolutionDependentFBOs.request(halfScaleBloomConfig);
 
-        BloomBlurNode halfScaleBlurredBloomNode = new BloomBlurNode("halfScaleBlurredBloomNode", context, displayResolutionDependentFBOs.get(HighPassNode.HIGH_PASS_FBO_URI), halfScaleBloomFbo);
+        BloomBlurNode halfScaleBlurredBloomNode = new BloomBlurNode("halfScaleBlurredBloomNode", context,
+                displayResolutionDependentFBOs.get(HighPassNode.HIGH_PASS_FBO_URI), halfScaleBloomFbo);
         renderGraph.addNode(halfScaleBlurredBloomNode);
 
         FBOConfig quarterScaleBloomConfig = new FBOConfig(BloomBlurNode.QUARTER_SCALE_FBO_URI, QUARTER_SCALE, FBO.Type.DEFAULT);
         FBO quarterScaleBloomFbo = displayResolutionDependentFBOs.request(quarterScaleBloomConfig);
 
-        BloomBlurNode quarterScaleBlurredBloomNode = new BloomBlurNode("quarterScaleBlurredBloomNode", context, halfScaleBloomFbo, quarterScaleBloomFbo);
+        BloomBlurNode quarterScaleBlurredBloomNode = new BloomBlurNode("quarterScaleBlurredBloomNode", context,
+                halfScaleBloomFbo, quarterScaleBloomFbo);
         renderGraph.addNode(quarterScaleBlurredBloomNode);
 
         FBOConfig one8thScaleBloomConfig = new FBOConfig(BloomBlurNode.ONE_8TH_SCALE_FBO_URI, ONE_8TH_SCALE, FBO.Type.DEFAULT);
         FBO one8thScaleBloomFbo = displayResolutionDependentFBOs.request(one8thScaleBloomConfig);
 
-        BloomBlurNode one8thScaleBlurredBloomNode = new BloomBlurNode("one8thScaleBlurredBloomNode", context, quarterScaleBloomFbo, one8thScaleBloomFbo);
+        BloomBlurNode one8thScaleBlurredBloomNode = new BloomBlurNode("one8thScaleBlurredBloomNode", context,
+                quarterScaleBloomFbo, one8thScaleBloomFbo);
         renderGraph.addNode(one8thScaleBlurredBloomNode);
 
         Node simpleBlendMaterialsNode = renderGraph.findNode("engine:simpleBlendMaterialsNode");
         renderGraph.connect(simpleBlendMaterialsNode, highPassNode, halfScaleBlurredBloomNode,
-                                        quarterScaleBlurredBloomNode, one8thScaleBlurredBloomNode);
+                quarterScaleBlurredBloomNode, one8thScaleBlurredBloomNode);
     }
 
     private void addExposureNodes(RenderGraph renderGraph) {
         FBOConfig gBuffer2Config = displayResolutionDependentFBOs.getFboConfig(new SimpleUri("engine:fbo.gBuffer2")); // TODO: Remove the hard coded value here
-        DownSamplerForExposureNode exposureDownSamplerTo16pixels = new DownSamplerForExposureNode("exposureDownSamplerTo16pixels", context, gBuffer2Config, displayResolutionDependentFBOs, FBO_16X16_CONFIG, immutableFBOs);
+        DownSamplerForExposureNode exposureDownSamplerTo16pixels = new DownSamplerForExposureNode("exposureDownSamplerTo16pixels",
+                context, gBuffer2Config, displayResolutionDependentFBOs, FBO_16X16_CONFIG, immutableFBOs);
         renderGraph.addNode(exposureDownSamplerTo16pixels);
 
-        DownSamplerForExposureNode exposureDownSamplerTo8pixels = new DownSamplerForExposureNode("exposureDownSamplerTo8pixels", context, FBO_16X16_CONFIG, immutableFBOs, FBO_8X8_CONFIG, immutableFBOs);
+        DownSamplerForExposureNode exposureDownSamplerTo8pixels = new DownSamplerForExposureNode("exposureDownSamplerTo8pixels",
+                context, FBO_16X16_CONFIG, immutableFBOs, FBO_8X8_CONFIG, immutableFBOs);
         renderGraph.addNode(exposureDownSamplerTo8pixels);
 
-        DownSamplerForExposureNode exposureDownSamplerTo4pixels = new DownSamplerForExposureNode("exposureDownSamplerTo4pixels", context, FBO_8X8_CONFIG, immutableFBOs, FBO_4X4_CONFIG, immutableFBOs);
+        DownSamplerForExposureNode exposureDownSamplerTo4pixels = new DownSamplerForExposureNode("exposureDownSamplerTo4pixels",
+                context, FBO_8X8_CONFIG, immutableFBOs, FBO_4X4_CONFIG, immutableFBOs);
         renderGraph.addNode(exposureDownSamplerTo4pixels);
 
-        DownSamplerForExposureNode exposureDownSamplerTo2pixels = new DownSamplerForExposureNode("exposureDownSamplerTo2pixels", context, FBO_4X4_CONFIG, immutableFBOs, FBO_2X2_CONFIG, immutableFBOs);
+        DownSamplerForExposureNode exposureDownSamplerTo2pixels = new DownSamplerForExposureNode("exposureDownSamplerTo2pixels",
+                context, FBO_4X4_CONFIG, immutableFBOs, FBO_2X2_CONFIG, immutableFBOs);
         renderGraph.addNode(exposureDownSamplerTo2pixels);
 
-        DownSamplerForExposureNode exposureDownSamplerTo1pixel = new DownSamplerForExposureNode("exposureDownSamplerTo1pixel", context, FBO_2X2_CONFIG, immutableFBOs, FBO_1X1_CONFIG, immutableFBOs);
+        DownSamplerForExposureNode exposureDownSamplerTo1pixel = new DownSamplerForExposureNode("exposureDownSamplerTo1pixel",
+                context, FBO_2X2_CONFIG, immutableFBOs, FBO_1X1_CONFIG, immutableFBOs);
         renderGraph.addNode(exposureDownSamplerTo1pixel);
 
         Node updateExposureNode = new UpdateExposureNode("updateExposureNode", context);
@@ -494,8 +510,8 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         Node simpleBlendMaterialsNode = renderGraph.findNode("engine:simpleBlendMaterialsNode");
         renderGraph.connect(simpleBlendMaterialsNode, exposureDownSamplerTo16pixels, exposureDownSamplerTo8pixels,
-                            exposureDownSamplerTo4pixels, exposureDownSamplerTo2pixels, exposureDownSamplerTo1pixel,
-                            updateExposureNode);
+                exposureDownSamplerTo4pixels, exposureDownSamplerTo2pixels, exposureDownSamplerTo1pixel,
+                updateExposureNode);
     }
 
     private void addInitialPostProcessingNodes(RenderGraph renderGraph) {
@@ -527,25 +543,27 @@ public final class WorldRendererImpl implements WorldRenderer {
         FBOConfig firstLateBlurConfig = new FBOConfig(FIRST_LATE_BLUR_FBO_URI, HALF_SCALE, FBO.Type.DEFAULT);
         FBO firstLateBlurFbo = displayResolutionDependentFBOs.request(firstLateBlurConfig);
 
-        LateBlurNode firstLateBlurNode = new LateBlurNode("firstLateBlurNode", context, displayResolutionDependentFBOs.get(ToneMappingNode.TONE_MAPPING_FBO_URI), firstLateBlurFbo);
+        LateBlurNode firstLateBlurNode = new LateBlurNode("firstLateBlurNode", context,
+                displayResolutionDependentFBOs.get(ToneMappingNode.TONE_MAPPING_FBO_URI), firstLateBlurFbo);
         renderGraph.addNode(firstLateBlurNode);
 
         FBOConfig secondLateBlurConfig = new FBOConfig(SECOND_LATE_BLUR_FBO_URI, HALF_SCALE, FBO.Type.DEFAULT);
         FBO secondLateBlurFbo = displayResolutionDependentFBOs.request(secondLateBlurConfig);
 
-        LateBlurNode secondLateBlurNode = new LateBlurNode("secondLateBlurNode", context, firstLateBlurFbo, secondLateBlurFbo);
+        LateBlurNode secondLateBlurNode = new LateBlurNode("secondLateBlurNode", context,
+                firstLateBlurFbo, secondLateBlurFbo);
         renderGraph.addNode(secondLateBlurNode);
 
         Node finalPostProcessingNode = new FinalPostProcessingNode("finalPostProcessingNode", context);
         renderGraph.addNode(finalPostProcessingNode);
 
-        renderGraph.connect(toneMappingNode, firstLateBlurNode ,secondLateBlurNode, finalPostProcessingNode);
+        renderGraph.connect(toneMappingNode, firstLateBlurNode, secondLateBlurNode, finalPostProcessingNode);
     }
 
-    private void addVignetteNode(RenderGraph renderGraph){
+    private void addVignetteNode(RenderGraph renderGraph) {
         Node finalPostProcessingNode = renderGraph.findNode("engine:finalPostProcessingNode");
 
-        VignetteNode vignetteNode = new VignetteNode("vignetteNode",context);
+        VignetteNode vignetteNode = new VignetteNode("vignetteNode", context);
         renderGraph.addNode(vignetteNode);
         renderGraph.connect(finalPostProcessingNode, vignetteNode);
     }
@@ -732,7 +750,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         lightValueSun *= 0.9f;
         lightValueSun += 0.05f;
 
-        float lightValueBlock = (float) Math.pow(BLOCK_LIGHT_POW, (1.0f - (double)rawLightValueBlock) * 16.0f) * rawLightValueBlock * BLOCK_INTENSITY_FACTOR;
+        float lightValueBlock = (float) Math.pow(BLOCK_LIGHT_POW, (1.0f - (double) rawLightValueBlock) * 16.0f) * rawLightValueBlock * BLOCK_INTENSITY_FACTOR;
 
         return Math.max(lightValueBlock, lightValueSun);
     }
@@ -792,7 +810,7 @@ public final class WorldRendererImpl implements WorldRenderer {
     /**
      * Forces a recompilation of all shaders. This command, backed by Gestalt's monitoring feature,
      * allows developers to hot-swap shaders for easy development.
-     *
+     * <p>
      * To run the command simply type "recompileShaders" and then press Enter in the console.
      */
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
@@ -805,15 +823,18 @@ public final class WorldRendererImpl implements WorldRenderer {
     /**
      * Acts as an interface between the console and the Nodes. All parameters passed to command are redirected to the
      * concerned Nodes, which in turn take care of executing them.
-     *
+     * <p>
      * Usage:
-     *      dagCommandNode <nodeUri> <command> <parameters>
-     *
+     * dagCommandNode <nodeUri> <command> <parameters>
+     * <p>
      * Example:
-     *      dagNodeCommand engine:outputToScreenNode setFbo engine:fbo.ssao
+     * dagNodeCommand engine:outputToScreenNode setFbo engine:fbo.ssao
      */
     @Command(shortDescription = "Debugging command for DAG.", requiredPermission = PermissionManager.NO_PERMISSION)
-    public void dagNodeCommand(@CommandParam("nodeUri") final String nodeUri, @CommandParam("command") final String command, @CommandParam(value= "arguments") final String... arguments) {
+    public void dagNodeCommand(
+            @CommandParam("nodeUri") final String nodeUri,
+            @CommandParam("command") final String command,
+            @CommandParam(value = "arguments") final String... arguments) {
         Node node = renderGraph.findNode(nodeUri);
         if (node == null) {
             throw new RuntimeException(("No node is associated with URI '" + nodeUri + "'"));

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -72,6 +72,7 @@ import org.terasology.rendering.dag.nodes.ShadowMapNode;
 import org.terasology.rendering.dag.nodes.SimpleBlendMaterialsNode;
 import org.terasology.rendering.dag.nodes.ToneMappingNode;
 import org.terasology.rendering.dag.nodes.UpdateExposureNode;
+import org.terasology.rendering.dag.nodes.VignetteNode;
 import org.terasology.rendering.dag.nodes.WorldReflectionNode;
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.opengl.FBO;
@@ -536,7 +537,10 @@ public final class WorldRendererImpl implements WorldRenderer {
         Node finalPostProcessingNode = new FinalPostProcessingNode("finalPostProcessingNode", context);
         renderGraph.addNode(finalPostProcessingNode);
 
-        renderGraph.connect(toneMappingNode, firstLateBlurNode, secondLateBlurNode, finalPostProcessingNode);
+        VignetteNode vignetteNode = new VignetteNode("vignetteNode",context);
+        renderGraph.addNode(vignetteNode);
+
+        renderGraph.connect(toneMappingNode, firstLateBlurNode, secondLateBlurNode, vignetteNode, finalPostProcessingNode);
     }
 
     private void addOutputNodes(RenderGraph renderGraph) {

--- a/engine/src/main/resources/assets/shaders/initialPost_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/initialPost_frag.glsl
@@ -29,7 +29,7 @@ uniform vec2 aberrationOffset = vec2(0.0, 0.0);
 
 uniform sampler2D texScene;
 
-#ifdef VIGNETTE
+#ifdef INIT_POST_VIGNETTE
 uniform sampler2D texVignette;
 uniform vec3 inLiquidTint;
 #endif
@@ -60,7 +60,7 @@ void main() {
     color += colorBloom * bloomFactor;
 #endif
 
-#ifdef VIGNETTE
+#ifdef INIT_POST_VIGNETTE
     float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
 
     if (!swimming) {

--- a/engine/src/main/resources/assets/shaders/initialPost_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/initialPost_frag.glsl
@@ -29,11 +29,6 @@ uniform vec2 aberrationOffset = vec2(0.0, 0.0);
 
 uniform sampler2D texScene;
 
-#ifdef INIT_POST_VIGNETTE
-uniform sampler2D texVignette;
-uniform vec3 inLiquidTint;
-#endif
-
 #ifdef LIGHT_SHAFTS
 uniform sampler2D texLightShafts;
 #endif
@@ -58,17 +53,6 @@ void main() {
 #ifdef BLOOM
     vec4 colorBloom = texture2D(texBloom, gl_TexCoord[0].xy);
     color += colorBloom * bloomFactor;
-#endif
-
-#ifdef INIT_POST_VIGNETTE
-    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
-
-    if (!swimming) {
-        color.rgb *= vig;
-    } else {
-        color.rgb *= vig * vig * vig;
-        color.rgb *= inLiquidTint;
-    }
 #endif
 
     gl_FragData[0].rgba = color.rgba;

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -1,10 +1,11 @@
-#ifdef VIGNETTE
+uniform sampler2D texScene;
+
 uniform sampler2D texVignette;
 uniform vec3 inLiquidTint;
-#endif
 
 void main(){
-	#ifdef VIGNETTE
+	vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
+
 	    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
 
 	    if (!swimming) {
@@ -13,7 +14,6 @@ void main(){
 	        color.rgb *= vig * vig * vig;
 	        color.rgb *= inLiquidTint;
 	    }
-	#endif
+	    gl_FragData[0].rgba = color.rgba;
 
-	gl_FragData[0].rgba = color.rgba;
 }

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -1,0 +1,19 @@
+#ifdef VIGNETTE
+uniform sampler2D texVignette;
+uniform vec3 inLiquidTint;
+#endif
+
+void main(){
+	#ifdef VIGNETTE
+	    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
+
+	    if (!swimming) {
+	        color.rgb *= vig;
+	    } else {
+	        color.rgb *= vig * vig * vig;
+	        color.rgb *= inLiquidTint;
+	    }
+	#endif
+
+	gl_FragData[0].rgba = color.rgba;
+}

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -3,19 +3,14 @@ uniform sampler2D texScene;
 
 uniform sampler2D texVignette;
 uniform vec3 inLiquidTint;
-uniform vec3 tint = vec3(0.937,0.126,0.016);
-uniform bool isTint = true;
+uniform vec3 tint = vec3(1.0,1.0,1.0);
 
 void main(){
 	vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
     float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;    
     if (!swimming) {
-		if(isTint){
-			color.rgb *=  vec3(vig)+vec3(1-vig)*tint.rgb;      
-        }
-        else{
-        	color.rgb *= vig;
-    	}
+			color.rgb *= vec3(vig)+(1-vig)*tint.rgb;      
+        	//color.rgb *= vig;
     } else {
         color.rgb *= vig * vig * vig;
         color.rgb *= inLiquidTint;

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -1,12 +1,15 @@
-#ifdef VIGNETTE
 uniform sampler2D texScene;
 
+#ifdef VIGNETTE
 uniform sampler2D texVignette;
 uniform vec3 inLiquidTint;
 uniform vec3 tint = vec3(1.0,1.0,1.0);
+#endif
 
 void main(){
 	vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
+
+#ifdef VIGNETTE
     float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;    
     if (!swimming) {
 			color.rgb *= vec3(vig)+(1-vig)*tint.rgb;      
@@ -15,6 +18,6 @@ void main(){
         color.rgb *= vig * vig * vig;
         color.rgb *= inLiquidTint;
     }
+#endif    
     gl_FragData[0].rgba = color.rgba;
 }
-#endif

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -1,19 +1,25 @@
+#ifdef VIGNETTE
 uniform sampler2D texScene;
 
 uniform sampler2D texVignette;
 uniform vec3 inLiquidTint;
+uniform vec3 tint = vec3(0.937,0.126,0.016);
+uniform bool isTint = true;
 
 void main(){
 	vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
-
-	    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
-
-	    if (!swimming) {
-	        color.rgb *= vig;
-	    } else {
-	        color.rgb *= vig * vig * vig;
-	        color.rgb *= inLiquidTint;
-	    }
-	    gl_FragData[0].rgba = color.rgba;
-
+    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;    
+    if (!swimming) {
+		if(isTint){
+			color.rgb *=  vec3(vig)+vec3(1-vig)*tint.rgb;      
+        }
+        else{
+        	color.rgb *= vig;
+    	}
+    } else {
+        color.rgb *= vig * vig * vig;
+        color.rgb *= inLiquidTint;
+    }
+    gl_FragData[0].rgba = color.rgba;
 }
+#endif

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -7,17 +7,16 @@ uniform vec3 tint = vec3(1.0,1.0,1.0);
 #endif
 
 void main(){
-	vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
+    vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
 
 #ifdef VIGNETTE
-    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;    
+    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
     if (!swimming) {
-			color.rgb *= vec3(vig)+(1-vig)*tint.rgb;      
-        	//color.rgb *= vig;
+            color.rgb *= vec3(vig)+(1-vig)*tint.rgb;
     } else {
         color.rgb *= vig * vig * vig;
         color.rgb *= inLiquidTint;
     }
-#endif    
+#endif
     gl_FragData[0].rgba = color.rgba;
 }

--- a/engine/src/main/resources/assets/shaders/vignette_vert.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_vert.glsl
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void main()
+{
+	gl_Position = ftransform();
+    gl_TexCoord[0] = gl_MultiTexCoord0;
+    gl_FrontColor = gl_Color;
+}

--- a/engine/src/main/resources/assets/shaders/vignette_vert.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_vert.glsl
@@ -16,7 +16,7 @@
 
 void main()
 {
-	gl_Position = ftransform();
+    gl_Position = ftransform();
     gl_TexCoord[0] = gl_MultiTexCoord0;
     gl_FrontColor = gl_Color;
 }


### PR DESCRIPTION
### Contains

**This PR proposes a solution for issue #3578 by placing vignette at the end of the shader pipeline**, as opposed to the present state where the vignette is a part of initial post-processing node/shader. This solution comes to mind as the blur effects responsible for this issue are currently the very last.
**Whether this approach is correct is a subject for further discussion. It is debatable, whether such change is for the better.**

This PR also attacks Stage 1 of issue #3040 by creating a separate node for Vignette. I would like to ask @vampcat to check if my approach is headed the right way and, if need be, to tag other contributors responsible for such changes to review.

The changes should be rather light-weight, but this is the first time I played with the engine's dag, so keep that in mind :).

### How to test
Enable Vignette, Blur,...various graphical effects combinations to check if the graphics behave correctly. 


## Notes
Suggestion of directly tinting vignette by general composition and tint nodes (currently non-existent) is irrelevant at this stage as vignette node creation is a common step.

### Outstanding before merging

- [ ] Needs to be updated to work with #3732 
- [x] Need to discuss whether the solution to #3578 is wanted. It is debatable whether such change is for the better. @Cervator said whichever looked better to us
- [ ] finish at least stage 1 of #3040  -  enable setting tint from outside somehow
- [ ] verify graphical correctness (correct buffers are passed - hdr, default, no effects are left behind)
**If fix for #3578 is accepted like this:**
- [ ] ~~Move debugging into vignette node? - just to not forget about it until the overhaul is ready~~
- [x]  Move screenshotting from finalPostProcessNode/vignetteNode to OutputNodes

suggested [DAG here](https://sketchboard.me/TBrKdjFknbZv#/)

**VR output node is named OutputToHMDNode, not outputToVRFrameBufferNode**
DAG before:
![image](https://user-images.githubusercontent.com/5579661/52526466-52215980-2cb9-11e9-9018-c96690a48419.png)

DAG after:
![image](https://user-images.githubusercontent.com/5579661/54921504-36d77a00-4f06-11e9-8288-9ed7654db580.png)




please suggest further needs or dismiss this PR as not-important atm.

**Blurred vignette**
![vignette-blurred](https://user-images.githubusercontent.com/5579661/52167150-11549e00-2717-11e9-85e5-d7f1e369bdb7.gif)

**Not blurred vignette**
![vignette-notblurred](https://user-images.githubusercontent.com/5579661/52167145-01d55500-2717-11e9-8553-22d5de42d9b0.gif)
