### PR TITLE
Make world generation random again

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameManifestProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameManifestProvider.java
@@ -78,7 +78,7 @@ public class GameManifestProvider {
         String seed;
         if (universeWrapper.getTargetWorld() != null) {
             uri = universeWrapper.getTargetWorld().getWorldGenerator().getUri();
-            seed = universeWrapper.getTargetWorld().getWorldName().toString() + 0;
+            seed = universeWrapper.getTargetWorld().getWorldGenerator().getWorldSeed();
             gameManifest.setSeed(seed);
         } else {
             uri = config.getWorldGeneration().getDefaultGenerator();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -267,7 +267,8 @@ public class WorldPreGenerationScreen extends CoreScreenLayer implements UISlide
      * @return The seed as a string.
      */
     private String createSeed(String world) {
-        return world + seedNumber++;
+        String seed = context.get(UniverseWrapper.class).getSeed();
+        return seed + world + seedNumber++;
     }
 
     private void setWorldGenerators() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #3610, making the worlds generate randomly again.

### How to test

1) Use the reproduction steps from the issue to verify the bug exists for your workspace.
2) Use this branch and repeat the steps given in the issue. The generation should now be random. 

Create a world with the same world-generator twice and compare the result. (It should be a different world).