### PR TITLE
Issue #3553 solved. Can't go back after enabling Animated Menus

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -69,7 +69,7 @@ public class MenuControlSystem extends BaseComponentSystem {
             event.consume();
         }
         if (networkSystem.getMode() == NetworkMode.NONE) {
-            if (nuiManager.isOpen("engine:pauseMenu")) {
+            if (!nuiManager.isOpen("engine:pauseMenu")) {
                 time.setPaused(true);
             } else {
                 time.setPaused(false);

--- a/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/MenuControlSystem.java
@@ -69,7 +69,7 @@ public class MenuControlSystem extends BaseComponentSystem {
             event.consume();
         }
         if (networkSystem.getMode() == NetworkMode.NONE) {
-            if (!nuiManager.isOpen("engine:pauseMenu")) {
+            if (nuiManager.isOpen("engine:pauseMenu")) {
                 time.setPaused(true);
             } else {
                 time.setPaused(false);

--- a/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
@@ -177,9 +177,9 @@ public class SwipeMenuAnimationSystem implements MenuAnimationSystem {
     public void update(float delta) {
         float animDelta = delta;
 
-        if (animDelta > 0.1f) {
+        if (animDelta > 0.1f || animDelta == 0.0f) {
             // avoid skipping over fast animations on heavy load
-            animDelta = 0.1f;
+            animDelta = 0.035f;
         }
 
         flyIn.update(animDelta);

--- a/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
@@ -56,6 +56,8 @@ public class SwipeMenuAnimationSystem implements MenuAnimationSystem {
 
     private float scale;
 
+    private static float PAUSED_ANIMATION_FRAME_TICK_TIME = 0.035f;
+
     /**
      * Creates default animations
      * @param duration the duration of the animation in seconds
@@ -181,14 +183,15 @@ public class SwipeMenuAnimationSystem implements MenuAnimationSystem {
             // avoid skipping over fast animations on heavy load
             animDelta = 0.1f;
         }
-        if(animDelta == 0.0f) {
-            // in case time is paused
-            animDelta = 0.035f;
+        if (animDelta < 0.0001f) {
+            // when we are inGameState and get to pauseMenu the time is paused
+            // so we need to fake the time is still running at a set rate
+            animDelta = PAUSED_ANIMATION_FRAME_TICK_TIME;
         }
 
         flyIn.update(animDelta);
         flyOut.update(animDelta);
-    }   
+    }
 
     @Override
     public Rect2i animateRegion(Rect2i rc) {

--- a/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
@@ -188,7 +188,7 @@ public class SwipeMenuAnimationSystem implements MenuAnimationSystem {
 
         flyIn.update(animDelta);
         flyOut.update(animDelta);
-    }
+    }   
 
     @Override
     public Rect2i animateRegion(Rect2i rc) {

--- a/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/animation/SwipeMenuAnimationSystem.java
@@ -177,8 +177,12 @@ public class SwipeMenuAnimationSystem implements MenuAnimationSystem {
     public void update(float delta) {
         float animDelta = delta;
 
-        if (animDelta > 0.1f || animDelta == 0.0f) {
+        if (animDelta > 0.1f) {
             // avoid skipping over fast animations on heavy load
+            animDelta = 0.1f;
+        }
+        if(animDelta == 0.0f) {
+            // in case time is paused
             animDelta = 0.035f;
         }
 


### PR DESCRIPTION
#3553 
### The problem
In MenuControlSystem if networkMode is off the time is paused, so any animation cannot happen over time.
### Solution 
 Even if the time is paused we let the menu system pass in an estimated delta time(in SwipeAnimationSystem in case animDelta is 0 it is set it to 0.035f).