### PR TITLE
Various animation/UI system fixes

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
@@ -51,6 +51,7 @@ public class PauseMenu extends CoreScreenLayer {
 
     @Override
     public void onScreenOpened() {
+        super.onScreenOpened();
         getManager().removeOverlay("engine:onlinePlayersOverlay");
     }
 
@@ -59,5 +60,10 @@ public class PauseMenu extends CoreScreenLayer {
         if (networkSystem.getMode() == NetworkMode.NONE) {
             time.setPaused(false);
         }
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NameRecordingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NameRecordingScreen.java
@@ -76,6 +76,7 @@ public class NameRecordingScreen extends CoreScreenLayer {
 
     @Override
     public void onScreenOpened() {
+        super.onScreenOpened();
         // resets the description from any earlier error messages, in case the user re-opens the screen.
         description.setText(translationSystem.translate("${engine:menu#name-recording-description}"));
     }
@@ -197,5 +198,10 @@ public class NameRecordingScreen extends CoreScreenLayer {
 
     public void setGameInfo(GameInfo gameInfo) {
         this.gameInfo = gameInfo;
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -244,6 +244,8 @@ public class NewGameScreen extends CoreScreenLayer {
 
     @Override
     public void onOpened() {
+        super.onOpened();
+
         final UIText gameName = find("gameName", UIText.class);
         setGameName(gameName);
 
@@ -299,6 +301,11 @@ public class NewGameScreen extends CoreScreenLayer {
             }
         }
         return super.onKeyEvent(event);
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
     }
 }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/RecordScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/RecordScreen.java
@@ -84,6 +84,8 @@ public class RecordScreen extends SelectionScreen {
 
     @Override
     public void onOpened() {
+        super.onOpened();
+
         if (isValidScreen()) {
             refreshGameInfoList(GameProvider.getSavedGames());
         } else {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ReplayScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/ReplayScreen.java
@@ -28,6 +28,7 @@ import org.terasology.recording.RecordAndReplayStatus;
 import org.terasology.recording.RecordAndReplayUtils;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
 import org.terasology.rendering.nui.widgets.UIButton;
@@ -57,6 +58,8 @@ public class ReplayScreen extends SelectionScreen {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
+
         initWidgets();
 
         if (isValidScreen()) {
@@ -95,6 +98,7 @@ public class ReplayScreen extends SelectionScreen {
 
     @Override
     public void onOpened() {
+        super.onOpened();
 
         if (isValidScreen()) {
             refreshGameInfoList(GameProvider.getSavedRecordings());
@@ -149,4 +153,8 @@ public class ReplayScreen extends SelectionScreen {
         return true;
     }
 
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -24,6 +24,7 @@ import org.terasology.engine.paths.PathManager;
 import org.terasology.game.GameManifest;
 import org.terasology.network.NetworkMode;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 import org.terasology.rendering.nui.layers.mainMenu.gameDetailsScreen.GameDetailsScreen;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
@@ -54,6 +55,7 @@ public class SelectGameScreen extends SelectionScreen {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
 
         initWidgets();
 
@@ -102,7 +104,7 @@ public class SelectGameScreen extends SelectionScreen {
             final NewGameScreen newGameScreen = getManager().createScreen(NewGameScreen.ASSET_URI, NewGameScreen.class);
             create.subscribe(e -> {
                 newGameScreen.setUniverseWrapper(universeWrapper);
-                getManager().pushScreen(newGameScreen);
+                triggerForwardAnimation(newGameScreen);
             });
 
             close.subscribe(e -> triggerBackAnimation());
@@ -132,7 +134,7 @@ public class SelectGameScreen extends SelectionScreen {
             if (GameProvider.isSavesFolderEmpty()) {
                 final NewGameScreen newGameScreen = getManager().createScreen(NewGameScreen.ASSET_URI, NewGameScreen.class);
                 newGameScreen.setUniverseWrapper(universeWrapper);
-                getManager().pushScreen(newGameScreen);
+                triggerForwardAnimation(newGameScreen);
             }
 
             if (isLoadingAsServer() && !super.config.getPlayer().hasEnteredUsername()) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/StartPlayingScreen.java
@@ -31,6 +31,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.world.WorldSetupWrapper;
@@ -62,6 +63,7 @@ public class StartPlayingScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
 
         WidgetUtil.trySubscribe(this, "close", button ->
                 triggerBackAnimation()
@@ -103,6 +105,8 @@ public class StartPlayingScreen extends CoreScreenLayer {
 
     @Override
     public void onOpened() {
+        super.onOpened();
+
         UIImage previewImage = find("preview", UIImage.class);
         previewImage.setImage(texture);
 
@@ -121,5 +125,10 @@ public class StartPlayingScreen extends CoreScreenLayer {
         worldSetupWrappers = worldSetupWrapperList;
         universeWrapper = context.get(UniverseWrapper.class);
         targetWorld = spawnWorld;
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -47,6 +47,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.asset.UIData;
 import org.terasology.rendering.nui.asset.UIElement;
 import org.terasology.rendering.nui.databinding.Binding;
@@ -105,6 +106,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
 
         final UIDropdownScrollable<WorldGeneratorInfo> worldGenerator = find("worldGenerators", UIDropdownScrollable.class);
         if (worldGenerator != null) {
@@ -235,6 +237,8 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
     @Override
     public void onOpened() {
+        super.onOpened();
+
         worlds.clear();
         worldNumber = 0;
         final UIDropdownScrollable worldsDropdown = find("worlds", UIDropdownScrollable.class);
@@ -375,5 +379,9 @@ public class UniverseSetupScreen extends CoreScreenLayer {
         return selectedWorld;
     }
 
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
 }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldPreGenerationScreen.java
@@ -30,6 +30,7 @@ import org.terasology.rendering.assets.texture.TextureData;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.layers.mainMenu.preview.FacetLayerPreview;
 import org.terasology.rendering.nui.layers.mainMenu.preview.PreviewGenerator;
@@ -114,6 +115,7 @@ public class WorldPreGenerationScreen extends CoreScreenLayer implements UISlide
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
 
         zoomSlider = find("zoomSlider", UISlider.class);
         if (zoomSlider != null) {
@@ -186,6 +188,8 @@ public class WorldPreGenerationScreen extends CoreScreenLayer implements UISlide
 
     @Override
     public void onOpened() {
+        super.onOpened();
+
         try {
             if (findWorldByName(selectedWorld).getWorldGenerator() == null) {
                 worldGenerator = WorldGeneratorManager.createWorldGenerator(findWorldByName(selectedWorld).getWorldGeneratorInfo().getUri(), context, environment);
@@ -288,4 +292,8 @@ public class WorldPreGenerationScreen extends CoreScreenLayer implements UISlide
         updatePreview();
     }
 
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -27,6 +27,7 @@ import org.terasology.reflection.metadata.FieldMetadata;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.layouts.PropertyLayout;
 import org.terasology.rendering.nui.properties.Property;
@@ -69,6 +70,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
 
         WidgetUtil.trySubscribe(this, "close", button -> {
             triggerBackAnimation();
@@ -77,6 +79,8 @@ public class WorldSetupScreen extends CoreScreenLayer {
 
     @Override
     public void onOpened() {
+        super.onOpened();
+
         UILabel subitle = find("subtitle", UILabel.class);
         subitle.setText(translationSystem.translate("${engine:menu#world-setup}") + " for " + world.getWorldName().toString());
     }
@@ -230,5 +234,10 @@ public class WorldSetupScreen extends CoreScreenLayer {
                 ((Binding<Float>) binding).set(value);
             }
         }
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -578,4 +578,9 @@ public class GameDetailsScreen extends CoreScreenLayer {
         }
         return true;
     }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ChangeBindingPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/ChangeBindingPopup.java
@@ -90,6 +90,7 @@ public class ChangeBindingPopup extends CoreScreenLayer {
 
     @Override
     public void onClosed() {
+        super.onClosed();
         bindsManager.registerBinds();
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/InputSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/inputSettings/InputSettingsScreen.java
@@ -302,6 +302,7 @@ public class InputSettingsScreen extends CoreScreenLayer {
 
     @Override
     public void onClosed() {
+        super.onClosed();
         bindsManager.registerBinds();
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
@@ -473,4 +473,9 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
         }
         return true;
     }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
 }

--- a/engine/src/main/java/org/terasology/telemetry/TelemetryScreen.java
+++ b/engine/src/main/java/org/terasology/telemetry/TelemetryScreen.java
@@ -438,4 +438,9 @@ public class TelemetryScreen extends CoreScreenLayer {
         list.sort(Comparator.comparing(Map.Entry::getKey));
         return list;
     }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
 }


### PR DESCRIPTION
### Contains

Fixes three problems relating to animated menus in the main menu. Related to #3553 and #3614.

Three main issues are resolved:
- Animations in the advanced game setup menus have been added.
- Fixed incomplete animations between selection screens, advanced game setup, and various other locations (by adding `isLowerLayerVisible()` statements where they were needed).
- Fixed clipping animations between some menus (by adding `super.onOpened()/onClosed()` where they were needed).

### How to test

- All main menu animations should now run without error or need to use the escape key.