### PR TITLE
new button by the name of "EXTRAS'' has been added in InGame Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ blacklist.json
 
 # Profiling related
 terasology.jfr
+local.properties

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/ExtraMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/ExtraMenuScreen.java
@@ -18,7 +18,6 @@ package org.terasology.rendering.nui.layers.ingame;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.LoggingContext;
 import org.terasology.engine.Time;
-import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
@@ -38,22 +37,10 @@ public class ExtraMenuScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "devTools", widget -> getManager().pushScreen("devToolsMenuScreen"));
         WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("There is no error."), LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER));
-        WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "close", widget -> getManager().closeScreen(ExtraMenuScreen.this));
-    }
-
-    @Override
-    public void onScreenOpened() {
-        getManager().removeOverlay("engine:onlinePlayersOverlay");
-    }
-
-    @Override
-    public void onClosed() {
-        if (networkSystem.getMode() == NetworkMode.NONE) {
-            time.setPaused(false);
-        }
     }
 }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/ExtraMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/ExtraMenuScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,20 @@
  */
 package org.terasology.rendering.nui.layers.ingame;
 
-import org.terasology.engine.GameEngine;
+import org.terasology.crashreporter.CrashReporter;
+import org.terasology.engine.LoggingContext;
 import org.terasology.engine.Time;
-import org.terasology.engine.modes.StateMainMenu;
 import org.terasology.network.NetworkMode;
 import org.terasology.network.NetworkSystem;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.telemetry.TelemetryScreen;
 
 /**
+ * Handles the "Extras" button from the game's pause menu screen.
  */
-public class PauseMenu extends CoreScreenLayer {
+public class ExtraMenuScreen extends CoreScreenLayer {
 
     @In
     private Time time;
@@ -37,12 +38,10 @@ public class PauseMenu extends CoreScreenLayer {
 
     @Override
     public void initialise() {
-        WidgetUtil.trySubscribe(this, "close", widget -> getManager().closeScreen(PauseMenu.this));
-        WidgetUtil.trySubscribe(this, "extra", widget -> getManager().pushScreen("extraMenuScreen"));
-        WidgetUtil.trySubscribe(this, "settings", widget -> getManager().pushScreen("settingsMenuScreen"));
-        WidgetUtil.trySubscribe(this, "mainMenu", widget -> CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu()));
-        WidgetUtil.trySubscribe(this, "exit", widget -> CoreRegistry.get(GameEngine.class).shutdown());
-
+        WidgetUtil.trySubscribe(this, "devTools", widget -> getManager().pushScreen("devToolsMenuScreen"));
+        WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("There is no error."), LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER));
+        WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
+        WidgetUtil.trySubscribe(this, "close", widget -> getManager().closeScreen(ExtraMenuScreen.this));
     }
 
     @Override

--- a/engine/src/main/resources/assets/ui/ingame/extraMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/ingame/extraMenuScreen.ui
@@ -1,0 +1,83 @@
+{
+    "type": "engine:extraMenuScreen",
+    "skin": "engine:mainmenu",
+    "contents": {
+        "type": "relativeLayout",
+        "contents": [
+            {
+                "type": "UIImage",
+                "image": "engine:terasology",
+                "id": "title",
+                "layoutInfo": {
+                    "width": 512,
+                    "height": 128,
+                    "position-horizontal-center": {},
+                    "position-top": {
+                        "target": "TOP",
+                        "offset": 48
+                    }
+                }
+            },
+            {
+                "type": "UILabel",
+                "text": "${engine:menu#extras-label}",
+                "family": "title",
+                "id": "subtitle",
+                "layoutInfo": {
+                    "height": 48,
+                    "position-horizontal-center": {},
+                    "position-top": {
+                        "target": "BOTTOM",
+                        "widget": "title"
+                    }
+                }
+            },
+            {
+                "type": "engine:columnLayout",
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-top": {
+                        "target": "BOTTOM",
+                        "offset": 16,
+                        "widget": "subtitle"
+                    },
+                    "position-bottom": {
+                        "offset": 32
+                    }
+                },
+                "columns": 1,
+                "verticalSpacing": 8,
+                "family": "menu-options",
+                "contents": [
+                    {
+                        "type": "UIButton",
+                        "text": "${engine:menu#telemetry-button}",
+                        "id": "telemetry"
+                    },
+                    {
+                        "type": "UIButton",
+                        "id": "devTools",
+                        "text": "${engine:menu#dev-tools-title}"
+                    },
+                    {
+                        "type": "UIButton",
+                        "text": "${engine:menu#crash-reporter}",
+                        "id": "crashReporter"
+                    },
+                    {
+                        "type": "UISpace",
+                        "size": [1, 64]
+                    },
+                    {
+                        "type": "UIButton",
+                        "id": "close",
+                        "text": "${engine:menu#back}"
+                    }
+                ]
+            }
+        ]
+    }
+}
+

--- a/engine/src/main/resources/assets/ui/ingame/pauseMenu.ui
+++ b/engine/src/main/resources/assets/ui/ingame/pauseMenu.ui
@@ -32,6 +32,11 @@
                         ]
                     },
                     {
+                       "type": "UIButton",
+                       "id": "extra",
+                       "text": "${engine:menu#extras-label}"
+                    },
+                    {
                         "type": "UIButton",
                         "id": "settings",
                         "text": "${engine:menu#game-settings}"
@@ -54,53 +59,6 @@
                     "position-vertical-center": {}
                 }
             },
-            {
-                "type": "UIButton",
-                "id": "devTools",
-                "text": "${engine:menu#dev-tools-title}",
-                "layoutInfo": {
-                    "use-content-width": true,
-                    "use-content-height": true,
-                    "position-bottom": {
-                        "offset": 8
-                    },
-                    "position-right": {
-                        "offset": 8
-                    }
-                }
-            },
-            {
-                "type": "UIButton",
-                "id": "crashReporter",
-                "text": "${engine:menu#crash-reporter}",
-                "layoutInfo": {
-                    "use-content-width": true,
-                    "use-content-height": true,
-                    "position-bottom": {
-                        "offset": 8
-                    },
-                    "position-right": {
-                        "offset": 8,
-                        "target": "LEFT",
-                        "widget": "devTools"
-                    }
-                }
-            },
-            {
-                "type": "UIButton",
-                "text": "${engine:menu#telemetry-button}",
-                "id": "telemetry",
-                "layoutInfo": {
-                    "use-content-width": true,
-                    "use-content-height": true,
-                    "position-bottom": {
-                        "offset": 8
-                    },
-                    "position-left": {
-                        "offset": 8
-                    }
-                }
-            }
         ]
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

As stated in Issue #3608 I have added an **Extras** button  in **InGame Menu** which includes following buttons in it **"Metrics Menu "**, **"Issue Reporter"**, **"Developer Tools"** along with **"Back"** Button 

![52813413-bd0ad000-30bf-11e9-86ed-e50dbf046f00](https://user-images.githubusercontent.com/22188087/52835856-5365e280-310e-11e9-8383-b7a7362e24d0.png)

to solve above issue I created **2** new files
1-**ExtraMenuScreen.java**
2-**extraMenuScreen.ui**

### How to test

Create a new game or load any previous games and then press **esc** .
**InGame Menu** screen will appear then click on button by the name of **EXTRAS**.
then after clicking a new screen will appear which will includes **"Metrics Menu "**, **"Issue Reporter"**, **"Developer Tools"** and  **"Back"** Button.
