### PR TITLE
Add/Repair UI animations for in-game menus

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/DevToolsMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/DevToolsMenuScreen.java
@@ -19,6 +19,7 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.rendering.nui.editor.systems.NUIEditorSystem;
 import org.terasology.rendering.nui.editor.systems.NUISkinEditorSystem;
 
@@ -36,10 +37,12 @@ public class DevToolsMenuScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
+
         WidgetUtil.trySubscribe(this, "nuiEditor", button -> nuiEditorSystem.toggleEditor());
         WidgetUtil.trySubscribe(this, "nuiSkinEditor", button -> nuiSkinEditorSystem.toggleEditor());
         WidgetUtil.trySubscribe(this, "btEditor", button -> getManager().toggleScreen("engine:behaviorEditorScreen"));
-        WidgetUtil.trySubscribe(this, "close", button -> getManager().closeScreen(ASSET_URI));
+        WidgetUtil.trySubscribe(this, "close", button -> triggerBackAnimation());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/ExtraMenuScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/ExtraMenuScreen.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.rendering.nui.layers.ingame;
 
+import org.terasology.assets.ResourceUrn;
 import org.terasology.crashreporter.CrashReporter;
 import org.terasology.engine.LoggingContext;
 import org.terasology.engine.Time;
@@ -22,12 +23,15 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
 import org.terasology.telemetry.TelemetryScreen;
 
 /**
  * Handles the "Extras" button from the game's pause menu screen.
  */
 public class ExtraMenuScreen extends CoreScreenLayer {
+
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:extraMenuScreen");
 
     @In
     private Time time;
@@ -37,10 +41,17 @@ public class ExtraMenuScreen extends CoreScreenLayer {
 
     @Override
     public void initialise() {
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
+
         WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
-        WidgetUtil.trySubscribe(this, "devTools", widget -> getManager().pushScreen("devToolsMenuScreen"));
+        WidgetUtil.trySubscribe(this, "devTools", widget -> triggerForwardAnimation(DevToolsMenuScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("There is no error."),
                 LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER));
-        WidgetUtil.trySubscribe(this, "close", widget -> getManager().closeScreen(ExtraMenuScreen.this));
+        WidgetUtil.trySubscribe(this, "close", widget -> triggerBackAnimation());
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/PauseMenu.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.rendering.nui.layers.ingame;
 
+import org.terasology.assets.ResourceUrn;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.Time;
 import org.terasology.engine.modes.StateMainMenu;
@@ -24,6 +25,8 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.animation.MenuAnimationSystems;
+import org.terasology.rendering.nui.layers.mainMenu.settings.SettingsMenuScreen;
 
 /**
  * In-game menu that appears when the player presses `ESC` (by default) to open the menu system.
@@ -31,6 +34,8 @@ import org.terasology.rendering.nui.WidgetUtil;
  * In single player mode this also pauses the game time.
  */
 public class PauseMenu extends CoreScreenLayer {
+
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:pauseMenu");
 
     @In
     private Time time;
@@ -40,9 +45,11 @@ public class PauseMenu extends CoreScreenLayer {
 
     @Override
     public void initialise() {
-        WidgetUtil.trySubscribe(this, "close", widget -> getManager().closeScreen(PauseMenu.this));
-        WidgetUtil.trySubscribe(this, "extra", widget -> getManager().pushScreen("extraMenuScreen"));
-        WidgetUtil.trySubscribe(this, "settings", widget -> getManager().pushScreen("settingsMenuScreen"));
+        setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
+
+        WidgetUtil.trySubscribe(this, "close", widget -> triggerBackAnimation());
+        WidgetUtil.trySubscribe(this, "extra", widget -> triggerForwardAnimation(ExtraMenuScreen.ASSET_URI));
+        WidgetUtil.trySubscribe(this, "settings", widget -> triggerForwardAnimation(SettingsMenuScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "mainMenu", widget -> CoreRegistry.get(GameEngine.class).changeState(new StateMainMenu()));
         WidgetUtil.trySubscribe(this, "exit", widget -> CoreRegistry.get(GameEngine.class).shutdown());
 


### PR DESCRIPTION
### Contains
Adds animations and extends fixes from #3615 to the in-game menus.

### How to Test
- Animated menus should now work for all in-game menus (with the exception of developer tool buttons).