### PR TITLE
world name appear when quick start game

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -285,7 +285,12 @@ public class GameDetailsScreen extends CoreScreenLayer {
         gameWorlds.setItemRenderer(new AbstractItemRenderer<WorldInfo>() {
             @Override
             public void draw(WorldInfo value, Canvas canvas) {
-                canvas.drawText(value.getCustomTitle());
+                if(value.getCustomTitle().isEmpty()==true) {
+                    canvas.drawText(value.getTitle());
+                }
+                else {
+                    canvas.drawText(value.getCustomTitle());
+                }
             }
 
             @Override
@@ -297,7 +302,14 @@ public class GameDetailsScreen extends CoreScreenLayer {
     }
 
     private String getWorldDescription(final WorldInfo worldInfo) {
-        return translationSystem.translate("${engine:menu#game-details-game-title} ") + worldInfo.getCustomTitle() + '\n' + '\n' +
+        String game_title;
+        if(worldInfo.getCustomTitle().isEmpty()==true) {
+            game_title=worldInfo.getTitle();
+        }
+        else {
+            game_title=worldInfo.getCustomTitle();
+        }
+        return translationSystem.translate("${engine:menu#game-details-game-title} ") + game_title + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-game-seed} ") + worldInfo.getSeed() + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-world-generator}: ") + worldInfo.getWorldGenerator().toString() + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-game-duration} ") + DateTimeHelper.getDeltaBetweenTimestamps(new Date(0).getTime(), worldInfo.getTime());

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -285,7 +285,7 @@ public class GameDetailsScreen extends CoreScreenLayer {
         gameWorlds.setItemRenderer(new AbstractItemRenderer<WorldInfo>() {
             @Override
             public void draw(WorldInfo value, Canvas canvas) {
-                if(value.getCustomTitle().isEmpty()==true) {
+                if(value.getCustomTitle().isEmpty()) {
                     canvas.drawText(value.getTitle());
                 }
                 else {
@@ -303,7 +303,7 @@ public class GameDetailsScreen extends CoreScreenLayer {
 
     private String getWorldDescription(final WorldInfo worldInfo) {
         String game_title;
-        if(worldInfo.getCustomTitle().isEmpty()==true) {
+        if(worldInfo.getCustomTitle().isEmpty()) {
             game_title=worldInfo.getTitle();
         }
         else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #3583 by showing the world name in worlds&biomes and in description box of world when game is quick start 
![image](https://user-images.githubusercontent.com/22188087/53496638-74dcac00-3ac8-11e9-8598-68bcea982daf.png)


### How to test

- Click on Single Player and quick start a game

- Start Playing a game and exit to main menu

- Again Click on Single player and then Click on your last Played game

- Click on details then Click on World&Biomes you will be able to see the name of world

- Click on the name of world you will be able to see the name in Module description

### Outstanding before merging

- [ ] * Still could allow for custom names (where the player can name the world what they would like instead of "main" or "Perlin-1").
