### PR TITLE
Window size saved and debugEnabled set false before shutdown

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -177,6 +177,8 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         if (Display.isCreated() && !Display.isFullscreen() && Display.isVisible()) {
             config.setWindowPosX(Display.getX());
             config.setWindowPosY(Display.getY());
+            config.setWindowWidth(Display.getWidth());
+            config.setWindowHeight(Display.getHeight());
         }
     }
 

--- a/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
@@ -152,6 +152,11 @@ public class DebugControlSystem extends BaseComponentSystem {
         }
     }
 
+    @Override
+    public void preSave() {
+        config.getSystem().setDebugEnabled(false);
+    }
+
     @ReceiveEvent(components = CharacterComponent.class, priority = EventPriority.PRIORITY_HIGH)
     public void onMouseX(MouseAxisEvent event, EntityRef entity) {
         if (!mouseGrabbed) {


### PR DESCRIPTION
Issue #3625 
**Contains**
Fixes for resizing the game window to default after the game is restarted. Also I thought it would be nice that the debug info should be disabled right before the game is shutted down.
**How to test**
- Open the game, resize the window(should be in windowed display mode). Shut the game down, open again and we should get same position and size.
- For debug info just get in any world enable debug system, close the game, reopen and get in any world. We can see that debug is disabled.
