### PR TITLE
Extend tabbing to UISlider

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButton.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIButton.java
@@ -88,9 +88,6 @@ public class UIButton extends ActivatableWidget {
         public void onMouseRelease(NUIMouseReleaseEvent event) {
             if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
                 if (isMouseOver()) {
-                    if (getClickSound() != null) {
-                        getClickSound().play(getClickVolume());
-                    }
                     activateWidget();
                 }
                 down = false;
@@ -193,6 +190,14 @@ public class UIButton extends ActivatableWidget {
             return HOVER_MODE;
         }
         return DEFAULT_MODE;
+    }
+
+    @Override
+    protected void activateWidget() {
+        if (getClickSound() != null) {
+            getClickSound().play(getClickVolume());
+        }
+        super.activateWidget();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UISlider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UISlider.java
@@ -22,7 +22,13 @@ import org.terasology.input.events.MouseWheelEvent;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2i;
-import org.terasology.rendering.nui.*;
+import org.terasology.rendering.nui.ActivatableWidget;
+import org.terasology.rendering.nui.BaseInteractionListener;
+import org.terasology.rendering.nui.Canvas;
+import org.terasology.rendering.nui.InteractionListener;
+import org.terasology.rendering.nui.LayoutConfig;
+import org.terasology.rendering.nui.SubRegion;
+import org.terasology.rendering.nui.TabbingManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.events.NUIKeyEvent;
@@ -171,7 +177,7 @@ public class UISlider extends ActivatableWidget {
             return DISABLED_MODE;
         }
 
-        if (active || (TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this))) {
+        if (active || this.equals(TabbingManager.focusedWidget)) {
             return ACTIVE_MODE;
         } else if (tickerListener.isMouseOver()) {
             return HOVER_MODE;
@@ -180,13 +186,13 @@ public class UISlider extends ActivatableWidget {
     }
 
     private void changeValue(float delta) {
-        float newValue = TeraMath.clamp(getValue() + delta, 0, getRange() + getMinimum());
+        float newValue = TeraMath.clamp(getValue() + delta, getMinimum(), getRange() + getMinimum());
         setValue(newValue);
     }
 
     @Override
     public boolean onKeyEvent(NUIKeyEvent event) {
-        if (event.isDown() && TabbingManager.focusedWidget.equals(this)) {
+        if (event.isDown() && this.equals(TabbingManager.focusedWidget)) {
             int keyId = event.getKey().getId();
             if (keyId == Keyboard.KeyId.RIGHT || keyId == Keyboard.KeyId.UP) {
                 this.changeValue(getIncrement());

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UISlider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UISlider.java
@@ -16,18 +16,16 @@
 package org.terasology.rendering.nui.widgets;
 
 import com.google.common.base.Function;
+import org.terasology.input.Keyboard;
 import org.terasology.input.MouseInput;
+import org.terasology.input.events.MouseWheelEvent;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2i;
-import org.terasology.rendering.nui.BaseInteractionListener;
-import org.terasology.rendering.nui.Canvas;
-import org.terasology.rendering.nui.CoreWidget;
-import org.terasology.rendering.nui.InteractionListener;
-import org.terasology.rendering.nui.LayoutConfig;
-import org.terasology.rendering.nui.SubRegion;
+import org.terasology.rendering.nui.*;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
+import org.terasology.rendering.nui.events.NUIKeyEvent;
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
 import org.terasology.rendering.nui.events.NUIMouseDragEvent;
 import org.terasology.rendering.nui.events.NUIMouseReleaseEvent;
@@ -35,7 +33,7 @@ import org.terasology.rendering.nui.events.NUIMouseReleaseEvent;
 /**
  * A simple value slider bar with one handle
  */
-public class UISlider extends CoreWidget {
+public class UISlider extends ActivatableWidget {
     public static final String SLIDER = "slider";
     public static final String TICKER = "ticker";
 
@@ -173,12 +171,37 @@ public class UISlider extends CoreWidget {
             return DISABLED_MODE;
         }
 
-        if (active) {
+        if (active || (TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this))) {
             return ACTIVE_MODE;
         } else if (tickerListener.isMouseOver()) {
             return HOVER_MODE;
         }
         return DEFAULT_MODE;
+    }
+
+    private void changeValue(float delta) {
+        float newValue = TeraMath.clamp(getValue() + delta, 0, getRange() + getMinimum());
+        setValue(newValue);
+    }
+
+    @Override
+    public boolean onKeyEvent(NUIKeyEvent event) {
+        if (event.isDown() && TabbingManager.focusedWidget.equals(this)) {
+            int keyId = event.getKey().getId();
+            if (keyId == Keyboard.KeyId.RIGHT || keyId == Keyboard.KeyId.UP) {
+                this.changeValue(getIncrement());
+                return true;
+            } else if (keyId == Keyboard.KeyId.LEFT || keyId == Keyboard.KeyId.DOWN) {
+                this.changeValue(-1 * getIncrement());
+                return true;
+            }
+        }
+        return super.onKeyEvent(event);
+    }
+
+    @Override
+    public void onMouseWheelEvent(MouseWheelEvent event) {
+        event.consume();
     }
 
     public void bindMinimum(Binding<Float> binding) {


### PR DESCRIPTION
Fixes the first problem mentioned in #3577 
Sliders can now be activated with Tab and used with the arrow keys.
This also fixes the activation persistence problem of sliders, i.e, holding down a slider and scrolling prevented the slider from deactivating.

### How to test
- Go to a menu with sliders (eg. Audio Settings)
- Navigate to a slider using Tab or Shift+Tab
- Increase its value using RIGHT/UP key, or decrease using LEFT/DOWN key