### PR TITLE
World name similarity checks

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -274,14 +274,37 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     }
 
     /**
+     * returns true if 'name' matches (case-insensitive) with another world already present
+     * @param name The world name to be checked
+     */
+    public boolean worldNameMatchesAnother(String name){
+        boolean taken = false;
+
+        for(WorldSetupWrapper worldTaken: worlds){
+            if (worldTaken.getWorldName().toString().equalsIgnoreCase(name)){
+                taken = true;
+                break;
+            }
+        }
+
+        return taken;
+    }
+
+    /**
      * Called whenever the user decides to add a new world.
      * @param worldGeneratorInfo The {@link WorldGeneratorInfo} object for the new world.
      */
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
+        String selectedWorldName = worldGeneratorInfo.getDisplayName();
+
+        while(worldNameMatchesAnother(selectedWorldName + "-" + worldNumber)){
+            ++worldNumber;
+        }
+
         selectedWorld = worldGeneratorInfo.getDisplayName() + '-' + worldNumber;
         worlds.add(new WorldSetupWrapper(new Name(worldGeneratorInfo.getDisplayName() + '-' + worldNumber), worldGeneratorInfo));
         indexOfSelectedWorld = findIndex(worlds, selectedWorld);
-        worldNumber++;
+        ++worldNumber;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -277,11 +277,11 @@ public class UniverseSetupScreen extends CoreScreenLayer {
      * returns true if 'name' matches (case-insensitive) with another world already present
      * @param name The world name to be checked
      */
-    public boolean worldNameMatchesAnother(String name){
+    public boolean worldNameMatchesAnother(String name) {
         boolean taken = false;
 
-        for(WorldSetupWrapper worldTaken: worlds){
-            if (worldTaken.getWorldName().toString().equalsIgnoreCase(name)){
+        for (WorldSetupWrapper worldTaken: worlds) {
+            if (worldTaken.getWorldName().toString().equalsIgnoreCase(name)) {
                 taken = true;
                 break;
             }
@@ -297,7 +297,7 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     private void addNewWorld(WorldGeneratorInfo worldGeneratorInfo) {
         String selectedWorldName = worldGeneratorInfo.getDisplayName();
 
-        while(worldNameMatchesAnother(selectedWorldName + "-" + worldNumber)){
+        while (worldNameMatchesAnother(selectedWorldName + "-" + worldNumber)) {
             ++worldNumber;
         }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -91,23 +91,12 @@ public class WorldSetupScreen extends CoreScreenLayer {
             } else if (customWorldName.getText().equalsIgnoreCase(world.getWorldName().toString())) {
                 //same name as before: go back to universe setup
                 goBack = true;
+            } else if (universeSetupScreen.worldNameMatchesAnother(customWorldName.getText())) {
+                //if same name is already used, inform user with a  popup
+                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Name Already Used!", "Please use a different name for this world");
             } else {
-                boolean worldNameMatchesAnother = false;
-
-                //check for case insensitive equality of world names
-                for (String worldName : universeSetupScreen.worldNames()) {
-                    if (worldName.equalsIgnoreCase(customWorldName.getText())) {
-                        worldNameMatchesAnother = true;
-                        break;
-                    }
-                }
-
-                if (worldNameMatchesAnother) {
-                    getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Name Already Used!", "Please use a different name for this world");
-                } else {
-                    //no match found: go back to universe setup
-                    goBack = true;
-                }
+                //no match found: go back to universe setup
+                goBack = true;
             }
 
             if (goBack) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -81,13 +81,42 @@ public class WorldSetupScreen extends CoreScreenLayer {
             final UniverseSetupScreen universeSetupScreen = getManager().createScreen(UniverseSetupScreen.ASSET_URI, UniverseSetupScreen.class);
             final WorldPreGenerationScreen worldPreGenerationScreen = getManager().createScreen(WorldPreGenerationScreen.ASSET_URI, WorldPreGenerationScreen.class);
             UIText customWorldName = find("customisedWorldName", UIText.class);
-            if (!customWorldName.getText().isEmpty()) {
+
+            boolean goBack = false;
+
+            //sanity checks on world name
+            if (customWorldName.getText().isEmpty()) {
+                //name empty: display a popup, stay on the same screen
+                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Name Cannot Be Empty!", "Please add a name for the world");
+            } else if (customWorldName.getText().equalsIgnoreCase(world.getWorldName().toString())) {
+                //same name as before: go back to universe setup
+                goBack = true;
+            } else {
+                boolean worldNameMatchesAnother = false;
+
+                //check for case insensitive equality of world names
+                for (String worldName : universeSetupScreen.worldNames()) {
+                    if (worldName.equalsIgnoreCase(customWorldName.getText())) {
+                        worldNameMatchesAnother = true;
+                        break;
+                    }
+                }
+
+                if (worldNameMatchesAnother == true) {
+                    getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Name Already Used!", "Please use a different name for this world");
+                } else {
+                    //no match found: go back to universe setup
+                    goBack = true;
+                }
+            }
+
+            if (goBack == true) {
                 newWorldName = new Name(customWorldName.getText());
                 world.setWorldName(newWorldName);
                 universeSetupScreen.refreshWorldDropdown(worldsDropdown);
                 worldPreGenerationScreen.setName(newWorldName);
+                triggerBackAnimation();
             }
-            triggerBackAnimation();
         });
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -102,7 +102,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
                     }
                 }
 
-                if (worldNameMatchesAnother == true) {
+                if (worldNameMatchesAnother) {
                     getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Name Already Used!", "Please use a different name for this world");
                 } else {
                     //no match found: go back to universe setup
@@ -110,7 +110,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
                 }
             }
 
-            if (goBack == true) {
+            if (goBack) {
                 newWorldName = new Name(customWorldName.getText());
                 world.setWorldName(newWorldName);
                 universeSetupScreen.refreshWorldDropdown(worldsDropdown);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/WorldSetupScreen.java
@@ -122,6 +122,7 @@ public class WorldSetupScreen extends CoreScreenLayer {
 
     /**
      * This method sets the world name in title as well as in UITextBox
+     *
      * @param customWorldName
      */
     private void setCustomWorldName(UIText customWorldName) {
@@ -141,7 +142,8 @@ public class WorldSetupScreen extends CoreScreenLayer {
     /**
      * This method sets the world whose properties are to be changed. This function is called before the screen comes
      * to the forefront.
-     * @param subContext the new environment created in {@link UniverseSetupScreen}
+     *
+     * @param subContext    the new environment created in {@link UniverseSetupScreen}
      * @param worldSelected the world whose configurations are to be changed.
      * @throws UnresolvedWorldGeneratorException
      */


### PR DESCRIPTION
### Contains

Added checks for similar world names. If a similarly named world is found, a popup is shown.

### How to test

1. Create game -> Advanced Setup -> Universe Setup
2. Add a couple of worlds
3. Rename first to, say, "blocksEverywhere" (by selecting world and going into Configure menu)
4. Try to rename second world to the same name.

### Outstanding before merging

- [ ] Haven't checked for special characters.
- [ ] Didn't quite get that different seed thing mentioned in #3636 
