### PR TITLE
Added null checks when dependency is not found

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
@@ -228,7 +228,7 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
         installedVersion.bindText(new ReadOnlyBinding<String>() {
             @Override
             public String get() {
-                if (dependencyInfoBinding.get() != null) {
+                if (dependencyInfoBinding.get() != null && moduleManager.getRegistry().getLatestModuleVersion(dependencyInfoBinding.get().getId()) != null) {
                     return String.valueOf(moduleManager.getRegistry().getLatestModuleVersion(dependencyInfoBinding.get().getId()).getVersion());
                 }
                 return "";
@@ -316,7 +316,7 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
             public Boolean get() {
                 final String online = onlineVersion.getText();
                 final String installed = installedVersion.getText();
-                if (StringUtils.isNotBlank(online)) {
+                if (StringUtils.isNotBlank(online) && StringUtils.isNotBlank(installed)) {
                     return new Version(online).compareTo(new Version(installed)) > 0;
                 }
                 return false;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
@@ -288,6 +288,11 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
 
             @Override
             public void draw(DependencyInfo value, Canvas canvas) {
+                if (moduleManager.getRegistry().getLatestModuleVersion(value.getId()) == null) {
+                    canvas.setMode("invalid");
+                } else {
+                    canvas.setMode("available");
+                }
                 canvas.drawText(getString(value), canvas.getRegion());
             }
 


### PR DESCRIPTION
### Contains

Fixes #3464. Game no longer crashes when viewing Module details with missing dependencies.

### How to test

1. Repeat the steps given in #3464 to reproduce the issue
2. Go to a details page of the module with missing dependency. (eg. Gooey defense with Flexible pathfinding not installed)
