### PR TITLE
Graceful spawn fail when chunk loading times out

### DIFF
--- a/engine/src/main/java/org/terasology/engine/modes/GameState.java
+++ b/engine/src/main/java/org/terasology/engine/modes/GameState.java
@@ -18,6 +18,8 @@ package org.terasology.engine.modes;
 
 import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.world.chunks.event.OnChunkLoaded;
 
 /**
  * @version 0.1
@@ -55,4 +57,8 @@ public interface GameState {
     String getLoggingPhase();
 
     Context getContext();
+
+    default void onChunkLoaded(OnChunkLoaded chunkAvailable, EntityRef worldEntity) {
+        
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -58,6 +58,7 @@ import org.terasology.engine.modes.loadProcesses.RegisterSystems;
 import org.terasology.engine.modes.loadProcesses.SetupLocalPlayer;
 import org.terasology.engine.modes.loadProcesses.SetupRemotePlayer;
 import org.terasology.engine.modes.loadProcesses.StartServer;
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.game.Game;
 import org.terasology.game.GameManifest;
 import org.terasology.network.JoinStatus;
@@ -67,6 +68,7 @@ import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
 import org.terasology.rendering.nui.layers.mainMenu.loadingScreen.LoadingScreen;
+import org.terasology.world.chunks.event.OnChunkLoaded;
 
 import java.util.Queue;
 
@@ -87,6 +89,10 @@ public class StateLoading implements GameState {
 
     private int progress;
     private int maxProgress;
+
+    private static final long chunkGenerationTimeout = 20000;
+    private boolean chunkGenerationStarted;
+    private long timeLastChunkGenerated;
 
     /**
      * Constructor for server or single player games
@@ -138,6 +144,8 @@ public class StateLoading implements GameState {
         popStep();
         loadingScreen = nuiManager.pushScreen("engine:loadingScreen", LoadingScreen.class);
         loadingScreen.updateStatus(current.getMessage(), current.getProgress());
+
+        chunkGenerationStarted = false;
     }
 
     private void initClient() {
@@ -252,6 +260,19 @@ public class StateLoading implements GameState {
             float progressValue = (progress + current.getExpectedCost() * current.getProgress()) / maxProgress;
             loadingScreen.updateStatus(current.getMessage(), progressValue);
             nuiManager.update(delta);
+
+            if (current instanceof AwaitCharacterSpawn && !chunkGenerationStarted) {
+                chunkGenerationStarted = true;
+                // in case no chunks generate, this should be set for a basis
+                timeLastChunkGenerated = time.getRealTimeInMs();
+            }
+
+            if (chunkGenerationStarted) {
+                long timeSinceLastChunk = time.getRealTimeInMs() - timeLastChunkGenerated;
+                if (timeSinceLastChunk > chunkGenerationTimeout) {
+                    gameEngine.changeState(new StateMainMenu("World generation timed out"));
+                }
+            }
         }
     }
 
@@ -273,5 +294,11 @@ public class StateLoading implements GameState {
     @Override
     public Context getContext() {
         return context;
+    }
+
+    @Override
+    public void onChunkLoaded(OnChunkLoaded chunkAvailable, EntityRef worldEntity) {
+        EngineTime time = (EngineTime) context.get(Time.class);
+        timeLastChunkGenerated = time.getRealTimeInMs();
     }
 }

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -261,6 +261,7 @@ public class StateLoading implements GameState {
             loadingScreen.updateStatus(current.getMessage(), progressValue);
             nuiManager.update(delta);
 
+            // chunk generation begins at the AwaitCharacterSpawn step
             if (current instanceof AwaitCharacterSpawn && !chunkGenerationStarted) {
                 chunkGenerationStarted = true;
                 // in case no chunks generate, this should be set for a basis

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadingChunkEventSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadingChunkEventSystem.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.modes.loadProcesses;
+
+import org.terasology.context.Context;
+import org.terasology.engine.GameEngine;
+import org.terasology.engine.modes.GameState;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+import org.terasology.world.WorldComponent;
+import org.terasology.world.chunks.event.OnChunkLoaded;
+
+@RegisterSystem
+public class LoadingChunkEventSystem extends BaseComponentSystem {
+
+    @In
+    private Context context;
+
+    @ReceiveEvent(components = {WorldComponent.class})
+    public void onNewChunk(OnChunkLoaded chunkAvailable, EntityRef worldEntity) {
+        GameEngine gameEngine = context.get(GameEngine.class);
+
+        GameState gameState = gameEngine.getState();
+        gameState.onChunkLoaded(chunkAvailable, worldEntity);
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,9 @@ import java.util.Set;
  * for a particular game template.
  */
 public class UniverseSetupScreen extends CoreScreenLayer {
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:universeSetupScreen");
 
     private static final Logger logger = LoggerFactory.getLogger(UniverseSetupScreen.class);
-
-    public static final ResourceUrn ASSET_URI = new ResourceUrn("engine:universeSetupScreen");
 
     @In
     private WorldGeneratorManager worldGeneratorManager;
@@ -103,8 +102,8 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     private Context context;
     private int worldNumber;
     private String selectedWorld = "";
-    public int indexOfSelectedWorld;
-    public WorldSetupWrapper copyOfSelectedWorld;
+    private int indexOfSelectedWorld;
+    private WorldSetupWrapper copyOfSelectedWorld;
 
     @Override
     public void initialise() {
@@ -200,7 +199,8 @@ public class UniverseSetupScreen extends CoreScreenLayer {
 
         WidgetUtil.trySubscribe(this, "addGenerator", button -> {
             if (worldGenerator.getSelection().getUri().toString().equals("Core:heightMap")) {
-                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("HeightMap not supported", "HeightMap is not supported for advanced setup right now, a game template will be introduced soon.");
+                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage(
+                        "HeightMap not supported", "HeightMap is not supported for advanced setup right now, a game template will be introduced soon.");
             } else {
                 addNewWorld(worldGenerator.getSelection());
                 worldsDropdown.setOptions(worldNames());
@@ -228,7 +228,8 @@ public class UniverseSetupScreen extends CoreScreenLayer {
                     return true;
                 }, true);
             } else {
-                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Worlds List Empty!", "Please select a world generator and add words to the dropdown!");
+                getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage(
+                        "Worlds List Empty!", "Please select a world generator and add words to the dropdown!");
             }
         });
 
@@ -284,9 +285,8 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     }
 
     /**
-     * This method refreshes the worlds drop-down menu
-     * when world name is changed and updates variable selectedWorld.
-     * @param worldsDropdown
+     * This method refreshes the worlds drop-down menu when world name is changed and updates variable selectedWorld.
+     * @param worldsDropdown the drop-down to work on
      */
     public void refreshWorldDropdown(UIDropdownScrollable worldsDropdown) {
         worldsDropdown.setOptions(worldNames());
@@ -331,13 +331,12 @@ public class UniverseSetupScreen extends CoreScreenLayer {
     }
 
     /**
-     * This method finds index of selected world from array list.
-     * and return -1 if unable to find it.
-     * @param worldsList
-     * @param worldName
-     * @return
+     * Looks for the index of a selected world from the given list.
+     * @param worldsList the list to search
+     * @param worldName the name of the world to find
+     * @return the found index value or -1 if not found
      */
-    public int findIndex(List<WorldSetupWrapper> worldsList, String worldName) {
+    private int findIndex(List<WorldSetupWrapper> worldsList, String worldName) {
         for (int i = 0; i < worldsList.size(); i++) {
             WorldSetupWrapper currentWorldFromList = worldsList.get(i);
             Name customName = currentWorldFromList.getWorldName();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

I decided to take a go at this issue for my first PR: https://github.com/MovingBlocks/Terasology/issues/2753

I added a method in GameState to listen for new chunks, specifically so that StateLoading can keep track of when new chunks load and time out back to the main menu if a chunk does not load for a long period (Once chunks are actually supposed to start loading).

### How to test

Player should spawn without issues when everything goes as expected. If an error is introduced in the chunk generation process, the player will fail to spawn, and the game will time out back to the main menu.

To introduce an error in the chunk generation process:
Add `int num = 4 / (4 - 4);` at the start of the `generateChunk` method in BuilderWorldRasterizer: https://github.com/MovingBlocks/Terasology/blob/dbfe54ea07bcecabe90a1fae5bdd67e1e0380b38/modules/BuilderSampleGameplay/src/main/java/org/terasology/BuilderSampleGameplay/world/BuilderWorldRasterizer.java

### Outstanding before merging

Nothing must be done before merging, but it should be considered if 20000 is a good timeout time. The `onChunkLoaded` method I added in StateLoading could be used in the future to add more movement to the progress bar, if we can find a way to predict how many chunks will be loaded during initial load.
