### PR TITLE
Graceful spawn fail on chunk load timeout: git cleaned up

### DIFF
--- a/engine/src/main/java/org/terasology/config/SystemConfig.java
+++ b/engine/src/main/java/org/terasology/config/SystemConfig.java
@@ -30,6 +30,7 @@ public class SystemConfig {
     private boolean debugEnabled;
     private boolean monitoringEnabled;
     private boolean writeSaveGamesEnabled;
+    private long chunkGenerationFailTimeoutInMs;
     private String locale;
 
     public long getDayNightLengthInMs() {
@@ -90,6 +91,14 @@ public class SystemConfig {
 
     public void setWriteSaveGamesEnabled(boolean writeSaveGamesEnabled) {
         this.writeSaveGamesEnabled = writeSaveGamesEnabled;
+    }
+
+    public long getChunkGenerationFailTimeoutInMs() {
+        return chunkGenerationFailTimeoutInMs;
+    }
+
+    public void setChunkGenerationFailTimeoutInMs(long chunkGenerationFailTimeoutInMs) {
+        this.chunkGenerationFailTimeoutInMs = chunkGenerationFailTimeoutInMs;
     }
 
     public Locale getLocale() {

--- a/engine/src/main/java/org/terasology/engine/modes/GameState.java
+++ b/engine/src/main/java/org/terasology/engine/modes/GameState.java
@@ -18,6 +18,8 @@ package org.terasology.engine.modes;
 
 import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.world.chunks.event.OnChunkLoaded;
 
 /**
  * @version 0.1
@@ -55,4 +57,8 @@ public interface GameState {
     String getLoggingPhase();
 
     Context getContext();
+
+    default void onChunkLoaded(OnChunkLoaded chunkAvailable, EntityRef worldEntity) {
+        
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/modes/StateLoading.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.engine.EngineTime;
 import org.terasology.engine.GameEngine;
@@ -87,10 +88,11 @@ public class StateLoading implements GameState {
 
     private LoadingScreen loadingScreen;
 
+    private Config config;
+
     private int progress;
     private int maxProgress;
 
-    private static final long chunkGenerationTimeout = 20000;
     private boolean chunkGenerationStarted;
     private long timeLastChunkGenerated;
 
@@ -117,6 +119,8 @@ public class StateLoading implements GameState {
     public void init(GameEngine engine) {
         this.context = engine.createChildContext();
         CoreRegistry.setContext(context);
+
+        config = context.get(Config.class);
 
         this.nuiManager = new NUIManagerInternal(context.get(CanvasRenderer.class), context);
         context.put(NUIManager.class, nuiManager);
@@ -270,8 +274,10 @@ public class StateLoading implements GameState {
 
             if (chunkGenerationStarted) {
                 long timeSinceLastChunk = time.getRealTimeInMs() - timeLastChunkGenerated;
+                long chunkGenerationTimeout = config.getSystem().getChunkGenerationFailTimeoutInMs();
                 if (timeSinceLastChunk > chunkGenerationTimeout) {
-                    gameEngine.changeState(new StateMainMenu("World generation timed out"));
+                    String errorMessage = "World generation timed out, check the log for more info";
+                    gameEngine.changeState(new StateMainMenu(errorMessage));
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadingChunkEventSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadingChunkEventSystem.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.engine.modes.loadProcesses;
+
+import org.terasology.context.Context;
+import org.terasology.engine.GameEngine;
+import org.terasology.engine.modes.GameState;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+import org.terasology.world.WorldComponent;
+import org.terasology.world.chunks.event.OnChunkLoaded;
+
+@RegisterSystem
+public class LoadingChunkEventSystem extends BaseComponentSystem {
+
+    @In
+    private Context context;
+
+    @ReceiveEvent(components = {WorldComponent.class})
+    public void onNewChunk(OnChunkLoaded chunkAvailable, EntityRef worldEntity) {
+        GameEngine gameEngine = context.get(GameEngine.class);
+
+        GameState gameState = gameEngine.getState();
+        gameState.onChunkLoaded(chunkAvailable, worldEntity);
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadingChunkEventSystem.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/LoadingChunkEventSystem.java
@@ -26,12 +26,22 @@ import org.terasology.registry.In;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.chunks.event.OnChunkLoaded;
 
+/**
+ * A system to send new chunk events to the current game state, which can be
+ * useful to identify when chunk generation fails on initial load
+ */
 @RegisterSystem
 public class LoadingChunkEventSystem extends BaseComponentSystem {
 
     @In
     private Context context;
 
+    /**
+     * Event handler which waits for new chunk events, then sends those
+     * events to the current game state
+     * @param chunkAvailable an event which includes the position of the new chunk
+     * @param worldEntity the world entity that this event was sent to
+     */
     @ReceiveEvent(components = {WorldComponent.class})
     public void onNewChunk(OnChunkLoaded chunkAvailable, EntityRef worldEntity) {
         GameEngine gameEngine = context.get(GameEngine.class);

--- a/engine/src/main/resources/default.cfg
+++ b/engine/src/main/resources/default.cfg
@@ -6,7 +6,8 @@
     "maxUnloadedChunksPercentageTillSave": 40,
     "debugEnabled": false,
     "monitoringEnabled": false,
-    "writeSaveGamesEnabled": true
+    "writeSaveGamesEnabled": true,
+    "chunkGenerationFailTimeoutInMs": 20000
   },
   "input": {
     "mouseSensitivity": 0.075,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

@Cervator Cleaned up git a bit as requested. Follow-up of previous PR which I will close: https://github.com/MovingBlocks/Terasology/pull/3642, solving https://github.com/MovingBlocks/Terasology/issues/2753.

I have added Javadoc to the new LoadingChunkEventSystem, and have moved the timeout time to system config. I told the user to check the log for more info if the failure occurs.

### How to test

As stated before:
Player should spawn without issues when everything goes as expected. If an error is introduced in the chunk generation process, the player will fail to spawn, and the game will time out back to the main menu.

To introduce an error in the chunk generation process:
Add `int num = 4 / (4 - 4);` at the start of the `generateChunk` method in BuilderWorldRasterizer: https://github.com/MovingBlocks/Terasology/blob/dbfe54ea07bcecabe90a1fae5bdd67e1e0380b38/modules/BuilderSampleGameplay/src/main/java/org/terasology/BuilderSampleGameplay/world/BuilderWorldRasterizer.java

### Outstanding before merging

2 Things I can still potentially add, if you would like:

- As the time since last chunk load increases (eg. every 5 seconds) the message changes with likelihood that something went wrong, indicating to the user that the game has not gone unresponsive. Also maybe a more detailed error message once user is sent back to home screen.
- Setting to change how long the timeout is (I am not sure which category in the settings this would fit under)