### PR TITLE
Fixed OpenGL line width warning

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.logic.players;
 
+import java.util.List;
+
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.engine.SimpleUri;
@@ -78,8 +80,6 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.regions.BlockRegionComponent;
-
-import java.util.List;
 
 // TODO: This needs a really good cleanup
 // TODO: Move more input stuff to a specific input system?
@@ -162,26 +162,26 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
         Quat4f viewRotation;
         switch (characterMovementComponent.mode) {
-            case CROUCHING:
-            case WALKING:
-                if (!config.getRendering().isVrSupport()) {
-                    viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, 0, 0);
-                    playerCamera.setOrientation(viewRotation);
-                }
-                playerCamera.getOrientation().rotate(relMove, relMove);
-                break;
-            case CLIMBING:
-                // Rotation is applied in KinematicCharacterMover
-                relMove.y += relativeMovement.y;
-                break;
-            default:
-                if (!config.getRendering().isVrSupport()) {
-                    viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, TeraMath.DEG_TO_RAD * lookPitch, 0);
-                    playerCamera.setOrientation(viewRotation);
-                }
-                playerCamera.getOrientation().rotate(relMove, relMove);
-                relMove.y += relativeMovement.y;
-                break;
+        case CROUCHING:
+        case WALKING:
+            if (!config.getRendering().isVrSupport()) {
+                viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, 0, 0);
+                playerCamera.setOrientation(viewRotation);
+            }
+            playerCamera.getOrientation().rotate(relMove, relMove);
+            break;
+        case CLIMBING:
+            // Rotation is applied in KinematicCharacterMover
+            relMove.y += relativeMovement.y;
+            break;
+        default:
+            if (!config.getRendering().isVrSupport()) {
+                viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, TeraMath.DEG_TO_RAD * lookPitch, 0);
+                playerCamera.setOrientation(viewRotation);
+            }
+            playerCamera.getOrientation().rotate(relMove, relMove);
+            relMove.y += relativeMovement.y;
+            break;
         }
         // For some reason, Quat4f.rotate is returning NaN for valid inputs. This prevents those NaNs from causing trouble down the line.
         if (!Float.isNaN(relMove.getX()) && !Float.isNaN(relMove.getY()) && !Float.isNaN(relMove.getZ())) {
@@ -399,7 +399,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
         if (config.getRendering().isRenderPlacingBox()) {
             if (aabb != null) {
                 aabbRenderer.setAABB(aabb);
-                aabbRenderer.render(2f);
+                aabbRenderer.render(1f);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.logic.players;
 
-import java.util.List;
-
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.engine.SimpleUri;
@@ -80,6 +78,8 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.regions.BlockRegionComponent;
+
+import java.util.List;
 
 // TODO: This needs a really good cleanup
 // TODO: Move more input stuff to a specific input system?
@@ -162,26 +162,26 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
         Quat4f viewRotation;
         switch (characterMovementComponent.mode) {
-        case CROUCHING:
-        case WALKING:
-            if (!config.getRendering().isVrSupport()) {
-                viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, 0, 0);
-                playerCamera.setOrientation(viewRotation);
-            }
-            playerCamera.getOrientation().rotate(relMove, relMove);
-            break;
-        case CLIMBING:
-            // Rotation is applied in KinematicCharacterMover
-            relMove.y += relativeMovement.y;
-            break;
-        default:
-            if (!config.getRendering().isVrSupport()) {
-                viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, TeraMath.DEG_TO_RAD * lookPitch, 0);
-                playerCamera.setOrientation(viewRotation);
-            }
-            playerCamera.getOrientation().rotate(relMove, relMove);
-            relMove.y += relativeMovement.y;
-            break;
+            case CROUCHING:
+            case WALKING:
+                if (!config.getRendering().isVrSupport()) {
+                    viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, 0, 0);
+                    playerCamera.setOrientation(viewRotation);
+                }
+                playerCamera.getOrientation().rotate(relMove, relMove);
+                break;
+            case CLIMBING:
+                // Rotation is applied in KinematicCharacterMover
+                relMove.y += relativeMovement.y;
+                break;
+            default:
+                if (!config.getRendering().isVrSupport()) {
+                    viewRotation = new Quat4f(TeraMath.DEG_TO_RAD * lookYaw, TeraMath.DEG_TO_RAD * lookPitch, 0);
+                    playerCamera.setOrientation(viewRotation);
+                }
+                playerCamera.getOrientation().rotate(relMove, relMove);
+                relMove.y += relativeMovement.y;
+                break;
         }
         // For some reason, Quat4f.rotate is returning NaN for valid inputs. This prevents those NaNs from causing trouble down the line.
         if (!Float.isNaN(relMove.getX()) && !Float.isNaN(relMove.getY()) && !Float.isNaN(relMove.getZ())) {

--- a/engine/src/main/java/org/terasology/rendering/logic/RegionOutlineRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/RegionOutlineRenderer.java
@@ -15,17 +15,9 @@
  */
 package org.terasology.rendering.logic;
 
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glBegin;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glEnd;
-import static org.lwjgl.opengl.GL11.glLineWidth;
-import static org.lwjgl.opengl.GL11.glVertex3f;
-
-import java.nio.FloatBuffer;
-import java.util.Map;
-
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.terasology.assets.management.AssetManager;
@@ -47,9 +39,16 @@ import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.world.WorldRenderer;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
+import java.nio.FloatBuffer;
+import java.util.Map;
+
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glLineWidth;
+import static org.lwjgl.opengl.GL11.glVertex3f;
 
 /**
  * Renderes region outlines for all entities with  {@link RegionOutlineComponent}s.
@@ -80,13 +79,13 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
 
     @ReceiveEvent
     public void onRegionOutlineComponentActivation(OnActivatedComponent event, EntityRef entity,
-            RegionOutlineComponent component) {
+                                                   RegionOutlineComponent component) {
         entityToRegionOutlineMap.put(entity, component);
     }
 
     @ReceiveEvent
     public void onRegionOutlineComponentDeactivation(BeforeDeactivateComponent event, EntityRef entity,
-            RegionOutlineComponent component) {
+                                     RegionOutlineComponent component) {
         entityToRegionOutlineMap.remove(entity);
     }
 

--- a/engine/src/main/java/org/terasology/rendering/logic/RegionOutlineRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/RegionOutlineRenderer.java
@@ -15,9 +15,17 @@
  */
 package org.terasology.rendering.logic;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glLineWidth;
+import static org.lwjgl.opengl.GL11.glVertex3f;
+
+import java.nio.FloatBuffer;
+import java.util.Map;
+
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.terasology.assets.management.AssetManager;
@@ -39,16 +47,9 @@ import org.terasology.registry.In;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.world.WorldRenderer;
 
-import java.nio.FloatBuffer;
-import java.util.Map;
-
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glBegin;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glEnd;
-import static org.lwjgl.opengl.GL11.glLineWidth;
-import static org.lwjgl.opengl.GL11.glVertex3f;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 
 /**
  * Renderes region outlines for all entities with  {@link RegionOutlineComponent}s.
@@ -79,13 +80,13 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
 
     @ReceiveEvent
     public void onRegionOutlineComponentActivation(OnActivatedComponent event, EntityRef entity,
-                                                   RegionOutlineComponent component) {
+            RegionOutlineComponent component) {
         entityToRegionOutlineMap.put(entity, component);
     }
 
     @ReceiveEvent
     public void onRegionOutlineComponentDeactivation(BeforeDeactivateComponent event, EntityRef entity,
-                                     RegionOutlineComponent component) {
+            RegionOutlineComponent component) {
         entityToRegionOutlineMap.remove(entity);
     }
 
@@ -96,7 +97,7 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
             return; // skip everything if there is nothing to do to avoid possibly costly draw mode changes
         }
         glDisable(GL_DEPTH_TEST);
-        glLineWidth(2);
+        glLineWidth(1);
         Vector3f cameraPosition = worldRenderer.getActiveCamera().getPosition();
 
         FloatBuffer tempMatrixBuffer44 = BufferUtils.createFloatBuffer(16);

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -16,24 +16,14 @@
 
 package org.terasology.rendering.logic;
 
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glBegin;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glEnd;
-import static org.lwjgl.opengl.GL11.glLineWidth;
-import static org.lwjgl.opengl.GL11.glPopMatrix;
-import static org.lwjgl.opengl.GL11.glPushMatrix;
-import static org.lwjgl.opengl.GL11.glVertex3f;
-
-import java.nio.FloatBuffer;
-import java.util.List;
-import java.util.Random;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.utilities.Assets;
 import org.terasology.config.Config;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -60,10 +50,20 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.skeletalmesh.Bone;
 import org.terasology.rendering.opengl.OpenGLSkeletalMesh;
 import org.terasology.rendering.world.WorldRenderer;
-import org.terasology.utilities.Assets;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import java.nio.FloatBuffer;
+import java.util.List;
+import java.util.Random;
+
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glLineWidth;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glVertex3f;
 
 /**
  */

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -16,14 +16,24 @@
 
 package org.terasology.rendering.logic;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glLineWidth;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glVertex3f;
+
+import java.nio.FloatBuffer;
+import java.util.List;
+import java.util.Random;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.utilities.Assets;
 import org.terasology.config.Config;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -50,20 +60,10 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.skeletalmesh.Bone;
 import org.terasology.rendering.opengl.OpenGLSkeletalMesh;
 import org.terasology.rendering.world.WorldRenderer;
+import org.terasology.utilities.Assets;
 
-import java.nio.FloatBuffer;
-import java.util.List;
-import java.util.Random;
-
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glBegin;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glEnd;
-import static org.lwjgl.opengl.GL11.glLineWidth;
-import static org.lwjgl.opengl.GL11.glPopMatrix;
-import static org.lwjgl.opengl.GL11.glPushMatrix;
-import static org.lwjgl.opengl.GL11.glVertex3f;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 /**
  */
@@ -312,7 +312,7 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             material.setFloat("sunlight", 1.0f, true);
             material.setFloat("blockLight", 1.0f, true);
             material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
-            glLineWidth(2);
+            glLineWidth(1);
             Vector3f worldPos = new Vector3f();
 
 


### PR DESCRIPTION
This PR fixes #3665. It is a very simple fix, since there are only 3 places where a method call leads to a call to `glLineWidth`. All of these calls have been modified to have a line width of only 1. This should prevent any warnings from OpenGL.

Also, it seems like Eclipse automatically replaced all of the tabs with spaces (which shouldn't be an issue since most of the project uses spaces instead anyway), and reordered the imports. I don't think these should be major issues though.