### PR TITLE
Improve performance of BlockMeshGeneratorSingleShape#generateChunkMesh

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -51,9 +51,12 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             adjacentBlocks.put(side, blockToCheck);
         }
 
+        Biome selfBiome = null;
         for (final Side side : Side.getAllSides()) {
             if (isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side)) {
-                final Biome selfBiome = view.getBiome(x, y, z);
+                if (selfBiome == null) {
+                    selfBiome = view.getBiome(x, y, z);
+                }
                 final ChunkMesh.RenderType renderType = getRenderType(selfBlock);
                 final BlockAppearance blockAppearance = selfBlock.getPrimaryAppearance();
                 final ChunkVertexFlag vertexFlag = getChunkVertexFlag(view, x, y, z, selfBlock);

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -43,20 +43,6 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
     public void generateChunkMesh(ChunkView view, ChunkMesh chunkMesh, int x, int y, int z) {
         final Block selfBlock = view.getBlock(x, y, z);
 
-        // TODO: Needs review - too much hardcoded special cases and corner cases resulting from this.
-        ChunkVertexFlag vertexFlag = ChunkVertexFlag.NORMAL;
-        if (selfBlock.isWater()) {
-            if (view.getBlock(x, y + 1, z).isWater()) {
-                vertexFlag = ChunkVertexFlag.WATER;
-            } else {
-                vertexFlag = ChunkVertexFlag.WATER_SURFACE;
-            }
-        } else if (selfBlock.isWaving() && selfBlock.isDoubleSided()) {
-            vertexFlag = ChunkVertexFlag.WAVING;
-        } else if (selfBlock.isWaving()) {
-            vertexFlag = ChunkVertexFlag.WAVING_BLOCK;
-        }
-
         // Gather adjacent blocks
         final Map<Side, Block> adjacentBlocks = Maps.newEnumMap(Side.class);
         for (Side side : Side.getAllSides()) {
@@ -70,6 +56,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                 final Biome selfBiome = view.getBiome(x, y, z);
                 final ChunkMesh.RenderType renderType = getRenderType(selfBlock);
                 final BlockAppearance blockAppearance = selfBlock.getPrimaryAppearance();
+                final ChunkVertexFlag vertexFlag = getChunkVertexFlag(view, x, y, z, selfBlock);
 
                 if (blockAppearance.getPart(BlockPart.CENTER) != null) {
                     final Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.CENTER, selfBiome);
@@ -108,6 +95,23 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                 }
             }
         }
+    }
+
+    private ChunkVertexFlag getChunkVertexFlag(ChunkView view, int x, int y, int z, Block selfBlock) {
+        // TODO: Needs review - too much hardcoded special cases and corner cases resulting from this.
+        ChunkVertexFlag vertexFlag = ChunkVertexFlag.NORMAL;
+        if (selfBlock.isWater()) {
+            if (view.getBlock(x, y + 1, z).isWater()) {
+                vertexFlag = ChunkVertexFlag.WATER;
+            } else {
+                vertexFlag = ChunkVertexFlag.WATER_SURFACE;
+            }
+        } else if (selfBlock.isWaving() && selfBlock.isDoubleSided()) {
+            vertexFlag = ChunkVertexFlag.WAVING;
+        } else if (selfBlock.isWaving()) {
+            vertexFlag = ChunkVertexFlag.WAVING_BLOCK;
+        }
+        return vertexFlag;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -66,27 +66,13 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             adjacentBlocks.put(side, blockToCheck);
         }
 
-        /*
-         * Determine the render process.
-         */
-        ChunkMesh.RenderType renderType = ChunkMesh.RenderType.TRANSLUCENT;
-
-        if (!selfBlock.isTranslucent()) {
-            renderType = ChunkMesh.RenderType.OPAQUE;
-        }
-        // TODO: Review special case, or alternatively compare uris.
-        if (selfBlock.isWater() || selfBlock.isIce()) {
-            renderType = ChunkMesh.RenderType.WATER_AND_ICE;
-        }
-        if (selfBlock.isDoubleSided()) {
-            renderType = ChunkMesh.RenderType.BILLBOARD;
-        }
-
         BlockMeshPart[] drawParts = new BlockMeshPart[6];
 
         for (final Side side : Side.getAllSides()) {
             if (isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side)) {
                 BlockAppearance blockAppearance = selfBlock.getAppearance(adjacentBlocks);
+                final ChunkMesh.RenderType renderType = getRenderType(selfBlock);
+
                 if (blockAppearance.getPart(BlockPart.CENTER) != null) {
                     Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.CENTER, selfBiome);
                     blockAppearance.getPart(BlockPart.CENTER).appendTo(chunkMesh, x, y, z, colorOffset, renderType, vertexFlag);
@@ -125,6 +111,27 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             }
         }
     }
+
+    /**
+     * Determine the render process of the block.
+     * @return The render process for the block
+     */
+    private ChunkMesh.RenderType getRenderType(final Block selfBlock) {
+        ChunkMesh.RenderType renderType = ChunkMesh.RenderType.TRANSLUCENT;
+
+        if (!selfBlock.isTranslucent()) {
+            renderType = ChunkMesh.RenderType.OPAQUE;
+        }
+        // TODO: Review special case, or alternatively compare uris.
+        if (selfBlock.isWater() || selfBlock.isIce()) {
+            renderType = ChunkMesh.RenderType.WATER_AND_ICE;
+        }
+        if (selfBlock.isDoubleSided()) {
+            renderType = ChunkMesh.RenderType.BILLBOARD;
+        }
+        return renderType;
+    }
+
 
     /**
      * Returns true if the side should be rendered adjacent to the second side provided.

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -65,8 +65,6 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             adjacentBlocks.put(side, blockToCheck);
         }
 
-        BlockMeshPart[] drawParts = new BlockMeshPart[6];
-
         for (final Side side : Side.getAllSides()) {
             if (isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side)) {
                 final Biome selfBiome = view.getBiome(x, y, z);
@@ -78,7 +76,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                     blockAppearance.getPart(BlockPart.CENTER).appendTo(chunkMesh, x, y, z, colorOffset, renderType, vertexFlag);
                 }
 
-                drawParts[side.ordinal()] = blockAppearance.getPart(BlockPart.fromSide(side));
+                BlockMeshPart blockMeshPart = blockAppearance.getPart(BlockPart.fromSide(side));
 
                 // If the selfBlock isn't lowered, some more faces may have to be drawn
                 if (selfBlock.isLiquid()) {
@@ -90,23 +88,23 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                         final Block adjacent = adjacentBlocks.get(side);
 
                         if (adjacent.isLiquid() && !adjacentAbove.isLiquid()) {
-                            drawParts[side.ordinal()] = selfBlock.getTopLiquidMesh(side);
+                            blockMeshPart = selfBlock.getTopLiquidMesh(side);
                         }
                     } else {
-                        if (drawParts[side.ordinal()] != null) {
-                            drawParts[side.ordinal()] = selfBlock.getLowLiquidMesh(side);
+                        if (blockMeshPart != null) {
+                            blockMeshPart = selfBlock.getLowLiquidMesh(side);
                         }
                     }
                 }
 
-                if (drawParts[side.ordinal()] != null) {
+                if (blockMeshPart != null) {
                     final Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(side), selfBiome);
                     // TODO: Needs review since the new per-vertex flags introduce a lot of special scenarios - probably a per-side setting?
                     ChunkVertexFlag sideVertexFlag = vertexFlag;
                     if (selfBlock.isGrass() && side != Side.TOP && side != Side.BOTTOM) {
                         sideVertexFlag = ChunkVertexFlag.COLOR_MASK;
                     }
-                    drawParts[side.ordinal()].appendTo(chunkMesh, x, y, z, colorOffset, renderType, sideVertexFlag);
+                    blockMeshPart.appendTo(chunkMesh, x, y, z, colorOffset, renderType, sideVertexFlag);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -41,8 +41,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
     @Override
     public void generateChunkMesh(ChunkView view, ChunkMesh chunkMesh, int x, int y, int z) {
-        Biome selfBiome = view.getBiome(x, y, z);
-        Block selfBlock = view.getBlock(x, y, z);
+        final Block selfBlock = view.getBlock(x, y, z);
 
         // TODO: Needs review - too much hardcoded special cases and corner cases resulting from this.
         ChunkVertexFlag vertexFlag = ChunkVertexFlag.NORMAL;
@@ -59,7 +58,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
         }
 
         // Gather adjacent blocks
-        Map<Side, Block> adjacentBlocks = Maps.newEnumMap(Side.class);
+        final Map<Side, Block> adjacentBlocks = Maps.newEnumMap(Side.class);
         for (Side side : Side.getAllSides()) {
             Vector3i offset = side.getVector3i();
             Block blockToCheck = view.getBlock(x + offset.x, y + offset.y, z + offset.z);
@@ -70,11 +69,12 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
         for (final Side side : Side.getAllSides()) {
             if (isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side)) {
-                BlockAppearance blockAppearance = selfBlock.getAppearance(adjacentBlocks);
+                final Biome selfBiome = view.getBiome(x, y, z);
                 final ChunkMesh.RenderType renderType = getRenderType(selfBlock);
+                final BlockAppearance blockAppearance = selfBlock.getPrimaryAppearance();
 
                 if (blockAppearance.getPart(BlockPart.CENTER) != null) {
-                    Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.CENTER, selfBiome);
+                    final Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.CENTER, selfBiome);
                     blockAppearance.getPart(BlockPart.CENTER).appendTo(chunkMesh, x, y, z, colorOffset, renderType, vertexFlag);
                 }
 
@@ -82,12 +82,12 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
                 // If the selfBlock isn't lowered, some more faces may have to be drawn
                 if (selfBlock.isLiquid()) {
-                    Block topBlock = adjacentBlocks.get(Side.TOP);
+                    final Block topBlock = adjacentBlocks.get(Side.TOP);
                     // Draw horizontal sides if visible from below
                     if (topBlock.isLiquid() && Side.horizontalSides().contains(side)) {
-                        Vector3i offset = side.getVector3i();
-                        Block adjacentAbove = view.getBlock(x + offset.x, y + 1, z + offset.z);
-                        Block adjacent = adjacentBlocks.get(side);
+                        final Vector3i offset = side.getVector3i();
+                        final Block adjacentAbove = view.getBlock(x + offset.x, y + 1, z + offset.z);
+                        final Block adjacent = adjacentBlocks.get(side);
 
                         if (adjacent.isLiquid() && !adjacentAbove.isLiquid()) {
                             drawParts[side.ordinal()] = selfBlock.getTopLiquidMesh(side);
@@ -100,7 +100,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                 }
 
                 if (drawParts[side.ordinal()] != null) {
-                    Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(side), selfBiome);
+                    final Vector4f colorOffset = selfBlock.calcColorOffsetFor(BlockPart.fromSide(side), selfBiome);
                     // TODO: Needs review since the new per-vertex flags introduce a lot of special scenarios - probably a per-side setting?
                     ChunkVertexFlag sideVertexFlag = vertexFlag;
                     if (selfBlock.isGrass() && side != Side.TOP && side != Side.BOTTOM) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Improved performance by the following changes:
- Reduced looping over all block sides from 3 to 1 loop
- Only load values when they will be used later

On my Surface Pro 3 with an i5 and high rendering settings the FPS increased at world loading from ~10 to ~13. Also the world loading feels faster.

### How to test

Run the game.

### Outstanding before merging

Nothing from my side.