### PR TITLE
Minor changes in dropdown menus

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
@@ -26,7 +26,6 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.InteractionListener;
 import org.terasology.rendering.nui.SubRegion;
-import org.terasology.rendering.nui.TabbingManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.events.NUIKeyEvent;
@@ -110,7 +109,8 @@ public class UIDropdown<T> extends ActivatableWidget {
             for (int i = 0; i < optionListeners.size(); ++i) {
                 if (optionListeners.get(i).isMouseOver()) {
                     canvas.setMode(HOVER_MODE);
-                } else if (i==highlighted && TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this)) {
+                    highlighted = i;
+                } else if (i==highlighted) {
                     canvas.setMode(HOVER_MODE);
                 } else {
                     canvas.setMode(DEFAULT_MODE);
@@ -137,7 +137,7 @@ public class UIDropdown<T> extends ActivatableWidget {
     public String getMode() {
         if (!isEnabled()) {
             return DISABLED_MODE;
-        } else if (opened || (TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this))) {
+        } else if (opened) {
             return ACTIVE_MODE;
         }
         return DEFAULT_MODE;
@@ -264,31 +264,31 @@ public class UIDropdown<T> extends ActivatableWidget {
 
     @Override
     public boolean onKeyEvent(NUIKeyEvent event) {
-        if (event.isDown() && TabbingManager.focusedWidget.equals(this)) {
-            if (opened) {
-                TabbingManager.setWidgetIsOpen(true);
-            } else {
-                TabbingManager.setWidgetIsOpen(false);
-            }
-
+        if (event.isDown()) {
             int keyId = event.getKey().getId();
-            if (keyId == Keyboard.KeyId.UP) {
-                this.changeHighlighted(false);
-                return true;
-            } else if (keyId == Keyboard.KeyId.DOWN) {
-                this.changeHighlighted(true);
-                return true;
-            }
-            if (keyId == Keyboard.KeyId.LEFT) {
-                if (opened) {
-                    setOpenedReverse(false);
-                }
-                return true;
-            } else if (keyId == Keyboard.KeyId.RIGHT) {
-                if (!opened) {
-                    setOpenedReverse(false);
-                }
-                return true;
+            switch (keyId){
+                case Keyboard.KeyId.UP:
+                    this.changeHighlighted(false);
+                    return false;
+                case Keyboard.KeyId.DOWN:
+                    this.changeHighlighted(true);
+                    return false;
+                case Keyboard.KeyId.LEFT:
+                    if (opened) {
+                        setOpenedReverse(false);
+                    }
+                    return true;
+                case Keyboard.KeyId.ENTER:
+                    if (opened) {
+                        setSelection(getOptions().get(highlighted));
+                        setOpenedReverse(false);
+                    }
+                    return true;
+                case Keyboard.KeyId.RIGHT:
+                    if (!opened) {
+                        setOpenedReverse(false);
+                    }
+                    return true;
             }
         }
         return super.onKeyEvent(event);

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdown.java
@@ -26,6 +26,7 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.InteractionListener;
 import org.terasology.rendering.nui.SubRegion;
+import org.terasology.rendering.nui.TabbingManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.events.NUIKeyEvent;
@@ -110,7 +111,7 @@ public class UIDropdown<T> extends ActivatableWidget {
                 if (optionListeners.get(i).isMouseOver()) {
                     canvas.setMode(HOVER_MODE);
                     highlighted = i;
-                } else if (i==highlighted) {
+                } else if (i == highlighted) {
                     canvas.setMode(HOVER_MODE);
                 } else {
                     canvas.setMode(DEFAULT_MODE);
@@ -137,7 +138,7 @@ public class UIDropdown<T> extends ActivatableWidget {
     public String getMode() {
         if (!isEnabled()) {
             return DISABLED_MODE;
-        } else if (opened) {
+        } else if (opened || this.equals(TabbingManager.focusedWidget)) {
             return ACTIVE_MODE;
         }
         return DEFAULT_MODE;
@@ -251,7 +252,7 @@ public class UIDropdown<T> extends ActivatableWidget {
         } else {
             highlighted--;
             if (highlighted < 0) {
-                highlighted = getOptions().size()-1;
+                highlighted = getOptions().size() - 1;
             }
         }
 
@@ -266,7 +267,7 @@ public class UIDropdown<T> extends ActivatableWidget {
     public boolean onKeyEvent(NUIKeyEvent event) {
         if (event.isDown()) {
             int keyId = event.getKey().getId();
-            switch (keyId){
+            switch (keyId) {
                 case Keyboard.KeyId.UP:
                     this.changeHighlighted(false);
                     return false;

--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIDropdownScrollable.java
@@ -24,7 +24,6 @@ import org.terasology.rendering.nui.BaseInteractionListener;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.InteractionListener;
 import org.terasology.rendering.nui.SubRegion;
-import org.terasology.rendering.nui.TabbingManager;
 import org.terasology.rendering.nui.databinding.Binding;
 import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
@@ -192,7 +191,8 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
     private void readItemMouseOver(Canvas canvas, int i) {
         if (optionListeners.get(i).isMouseOver()) {
             canvas.setMode(HOVER_MODE);
-        } else if (i == highlighted && TabbingManager.focusedWidget != null && TabbingManager.focusedWidget.equals(this)) {
+            highlighted = i;
+        } else if (i == highlighted) {
             canvas.setMode(HOVER_MODE);
         } else {
             canvas.setMode(DEFAULT_MODE);
@@ -309,44 +309,6 @@ public class UIDropdownScrollable<T> extends UIDropdown<T> {
             if (selectionSet) {
                 setSelection(getOptions().get(highlighted));
             }
-        }
-    }
-
-    public void changeHighlighted(boolean increase) {
-        if (!opened) {
-            highlighted = getOptions().indexOf(getSelection());
-        }
-
-        if (increase) {
-            highlighted++;
-            if (highlighted >= getOptions().size()) {
-                highlighted = 0;
-                if (opened) {
-                    verticalBar.setValue(verticalBar.getMinimum());
-                }
-            } else {
-                if (opened) {
-                    int scrollMultiplier = 0 - (verticalBar.getRange() * visibleOptionsNum) / (itemHeight * (optionListeners.size() / visibleOptionsNum));
-                    verticalBar.setValue(verticalBar.getValue() - scrollMultiplier);
-                }
-            }
-        } else {
-            highlighted--;
-            if (highlighted < 0) {
-                highlighted = getOptions().size() - 1;
-                if (opened) {
-                    verticalBar.setValue(verticalBar.getRange() - verticalBar.getMinimum());
-                }
-            } else {
-                if (opened) {
-                    int scrollMultiplier = 0 - (verticalBar.getRange() * visibleOptionsNum) / (itemHeight * (optionListeners.size() / visibleOptionsNum));
-                    verticalBar.setValue(verticalBar.getValue() + scrollMultiplier);
-                }
-            }
-        }
-
-        if (!opened) {
-            setSelection(getOptions().get(highlighted));
         }
     }
 


### PR DESCRIPTION
When I checked #3668 I saw that keys didn't work in dropdown menus at all. After that I found out, that TabbingManager.focusedWidget mention in UIDropdown and UIDropdownScrollable classes creates NullPointerException.

### Contains
PR fixes: 
-highlight of menu options with mouse or keyboard when widget is open
-change options with keyboard when widget is closed
-"enter" key event added (it chooses highlighted option)

### How to test
Open video settings or language settings and check out a dropdown widgets. "Up", "Down", "Left", "Right" and "Enter" keys should work. Options should be highlighted when cursor is over it AND when cursor is somewhere else.