### PR TITLE
Add try-catch to updateItem

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -6,6 +6,7 @@ import groovy.json.JsonSlurper
 @GrabResolver(name = 'jcenter', root = 'http://jcenter.bintray.com/')
 @Grab(group = 'org.ajoberstar', module = 'grgit', version = '1.9.3')
 import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.exception.GrgitException
 import org.ajoberstar.grgit.Remote
 
 class common {

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -199,11 +199,16 @@ class common {
         def clean = itemGit.status().clean
         println "Is \"$itemName\" clean? $clean"
         if (!clean) {
-            println "$itemType has uncommitted changes. Aborting."
+            println "$itemType has uncommitted changes. Skipping."
             return
         }
         println "Updating $itemType $itemName"
-        itemGit.pull remote: defaultRemote
+
+        try {
+            itemGit.pull remote: defaultRemote
+        } catch (GrgitException exception) {
+            println "Unable to update $itemName, Skipping: ${exception.getMessage()}"
+        }
     }
 
     /**


### PR DESCRIPTION
Adds a try catch to the update item call.
This allows the exception to be caught, and the item to be skipped.

# Testing
Break a module's git in some way so that `groovyw module update-all` doesn't work
Then verify that the module is skipped and the rest of the command works fine.