### PR TITLE
LightShafts calculated from the Moon during night time and with half exposure.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/LightShaftsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/LightShaftsNode.java
@@ -107,7 +107,8 @@ public class LightShaftsNode extends ConditionDependentNode {
         lightShaftsMaterial = getMaterial(LIGHT_SHAFTS_MATERIAL_URN);
 
         int textureSlot = 0;
-        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(), ColorTexture, displayResolutionDependentFBOs, LIGHT_SHAFTS_MATERIAL_URN, "texScene"));
+        addDesiredStateChange(new SetInputTextureFromFbo(textureSlot, displayResolutionDependentFBOs.getGBufferPair().getLastUpdatedFbo(),
+                                    ColorTexture, displayResolutionDependentFBOs, LIGHT_SHAFTS_MATERIAL_URN, "texScene"));
     }
 
     /**
@@ -119,13 +120,15 @@ public class LightShaftsNode extends ConditionDependentNode {
     public void process() {
         PerformanceMonitor.startActivity("rendering/" + getUri());
 
-        // Get time of day from midnight to midnight <0, 1>, 0.5 being noon;
+        // Get time of day from midnight to midnight <0, 1>, 0.5 being noon.
+
         float days = worldProvider.getTime().getDays();
         days = days - (int) days;
 
         // If sun is down and moon is up, do lightshafts from moon.
         // This is a temporary solution to sun causing light shafts even at night.
-        if(days < 0.25f || days > 0.75f) {
+
+        if (days < 0.25f || days > 0.75f) {
             sunDirection = backdropProvider.getSunDirection(true);
             exposure = exposureNight;
         } else {

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/LightShaftsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/LightShaftsNode.java
@@ -71,7 +71,7 @@ public class LightShaftsNode extends ConditionDependentNode {
     private float exposureDay = 0.0075f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.01f)
-    private float exposureNight = exposure/2.f;
+    private float exposureNight = 0.00375f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 10.0f)
     private float weight = 8.0f;

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/LightShaftsNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/LightShaftsNode.java
@@ -36,6 +36,7 @@ import org.terasology.rendering.opengl.FBO;
 import org.terasology.rendering.opengl.FBOConfig;
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFBOs;
 import org.terasology.rendering.world.WorldRenderer;
+import org.terasology.world.WorldProvider;
 
 import static org.terasology.rendering.dag.stateChanges.SetInputTextureFromFbo.FboTexturesTypes.ColorTexture;
 import static org.terasology.rendering.opengl.OpenGLUtils.renderFullscreenQuad;
@@ -58,15 +59,19 @@ public class LightShaftsNode extends ConditionDependentNode {
 
     private BackdropProvider backdropProvider;
     private SubmersibleCamera activeCamera;
-
+    private WorldProvider worldProvider;
     private Material lightShaftsMaterial;
+    private float exposure;
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 10.0f)
     private float density = 1.0f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 0.01f)
-    private float exposure = 0.0075f;
+    private float exposureDay = 0.0075f;
+    @SuppressWarnings("FieldCanBeLocal")
+    @Range(min = 0.0f, max = 0.01f)
+    private float exposureNight = exposure/2.f;
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 10.0f)
     private float weight = 8.0f;
@@ -84,6 +89,7 @@ public class LightShaftsNode extends ConditionDependentNode {
     public LightShaftsNode(String nodeUri, Context context) {
         super(nodeUri, context);
 
+        worldProvider = context.get(WorldProvider.class);
         backdropProvider = context.get(BackdropProvider.class);
         activeCamera = context.get(WorldRenderer.class).getActiveCamera();
 
@@ -113,6 +119,20 @@ public class LightShaftsNode extends ConditionDependentNode {
     public void process() {
         PerformanceMonitor.startActivity("rendering/" + getUri());
 
+        // Get time of day from midnight to midnight <0, 1>, 0.5 being noon;
+        float days = worldProvider.getTime().getDays();
+        days = days - (int) days;
+
+        // If sun is down and moon is up, do lightshafts from moon.
+        // This is a temporary solution to sun causing light shafts even at night.
+        if(days < 0.25f || days > 0.75f) {
+            sunDirection = backdropProvider.getSunDirection(true);
+            exposure = exposureNight;
+        } else {
+            sunDirection = backdropProvider.getSunDirection(false);
+            exposure = exposureDay;
+        }
+
         // Shader Parameters
 
         lightShaftsMaterial.setFloat("density", density, true);
@@ -120,7 +140,6 @@ public class LightShaftsNode extends ConditionDependentNode {
         lightShaftsMaterial.setFloat("weight", weight, true);
         lightShaftsMaterial.setFloat("decay", decay, true);
 
-        sunDirection = backdropProvider.getSunDirection(false);
         sunPositionWorldSpace4.set(sunDirection.x * 10000.0f, sunDirection.y * 10000.0f, sunDirection.z * 10000.0f, 1.0f);
         sunPositionScreenSpace.set(sunPositionWorldSpace4);
         activeCamera.getViewProjectionMatrix().transform(sunPositionScreenSpace);
@@ -141,4 +160,6 @@ public class LightShaftsNode extends ConditionDependentNode {
 
         PerformanceMonitor.endActivity();
     }
+
+
 }


### PR DESCRIPTION
### Contains
Quick tweak for sun shafts being present during night, which looks really bad.
This PR presents a quick solution remapping light shafts' source position to the moon with lowered exposure during night. An overlap instead of a switch would be nicer, or perhaps to just shorten the interval for moonshafts, start with sun a little bit more under the horizon.

### Tackles #3064 

### How to test
- Turn on light shafts in the video settings
- Open console '~', write setWorldTime [time], where time is any float in *days*. 
                    0,1,2 -> midnights;  0.5,1.5,2.5 - noons;   
- Verify that with the beginning of night the shafts start to appear from the moon and stop appearing from the sun under the horizon. And vice-versa

### Outstanding before merging
[ ] - Nothing yet