### PR TITLE
Fix for Incorrect VisualCharacter entity

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/VisualCharacterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/VisualCharacterSystem.java
@@ -115,7 +115,7 @@ public class VisualCharacterSystem extends BaseComponentSystem {
     public void onAwaitedLocalCharacterSpawnEvent(AwaitedLocalCharacterSpawnEvent event, EntityRef entity) {
         awaitedLocalCharacterSpawn = true;
         for (EntityRef character: entityManager.getEntitiesWith(VisualCharacterComponent.class)) {
-            createVisualCharacterIfNotOwnCharacter(character, entity.getComponent(VisualCharacterComponent.class));
+            createVisualCharacterIfNotOwnCharacter(character, character.getComponent(VisualCharacterComponent.class));
         }
     }
 
@@ -127,7 +127,6 @@ public class VisualCharacterSystem extends BaseComponentSystem {
         entityBuilder.addPrefab(prefab);
         event.consume();
     }
-
 
     /**
      * For tests only


### PR DESCRIPTION
### Contains
Fixes #3685

### How to test
Add this command to `VisualCharacterSystem.java`:
```java
@Command(shortDescription = "print all characters and visual entities present currently")
public String printVisualEntities() {
    StringBuilder message = new StringBuilder();
    for (EntityRef character: entityManager.getEntitiesWith(PlayerCharacterComponent.class)) {
        if (character.hasComponent(VisualCharacterComponent.class)) {
            EntityRef visualCharacter = character.getComponent(VisualCharacterComponent.class).visualCharacter;
            message.append(character.toFullDescription());
            message.append("\n");
            message.append(visualCharacter.toFullDescription());
            message.append("\n");
        }
    }
    return message.toString();
}
```
Now, start 3-4 instances of game, host a Core Gameplay mode game on one of them, and join using others. Once, everyone has joined and game has loaded on each of them, use this command to check if the character entities and their visual entities are printed correctly. For the local player character in each of the instances, visual character should by EntityRef.NULL, i.e., it should just print `{ }`.