### PR TITLE
Fixes invalid values for 'port' in AddServerPopup

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/AddServerPopup.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/AddServerPopup.java
@@ -60,7 +60,7 @@ public class AddServerPopup extends CoreScreenLayer {
             String name = nameText.getText();
             String owner = ownerText.getText();
             String address = addressText.getText();
-            Integer portBoxed = Ints.tryParse(portText.getText());
+            Integer portBoxed = Ints.tryParse(portText.getText().trim());
             int port = (portBoxed != null) ? portBoxed : TerasologyConstants.DEFAULT_PORT;
 
             if (serverInfo == null) {
@@ -87,7 +87,7 @@ public class AddServerPopup extends CoreScreenLayer {
             public Boolean get() {
                 return !nameText.getText().isEmpty()
                         && !addressText.getText().isEmpty()
-                        && Ints.tryParse(portText.getText()) != null;
+                        && Ints.tryParse(portText.getText().trim()) != null;
             }
         });
 


### PR DESCRIPTION
This fix applies `.trim()` to the text to ignore trailing whitespaces.

The 'port' value in the `AddServerPopup` can end up invalid due to
whitespaces, such as newline characters (`\n`). This will disable the _OK_ button and the user cannot add a new server.