### PR TITLE
VisualCharacterSystemTest Fix and Whitelist PermissionManager

### DIFF
--- a/engine-tests/src/test/java/org/terasology/logic/characters/VisualCharacterSystemTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/characters/VisualCharacterSystemTest.java
@@ -113,6 +113,8 @@ public class VisualCharacterSystemTest {
         EntityRef otherCharacterEntity = mockEntityWithUniqueId();
         List<Event> otherCharacterEntityEvents = new ArrayList<>();
         recordEntityEventsToList(otherCharacterEntity, otherCharacterEntityEvents);
+        VisualCharacterComponent visualComponentOfOtherCharacter = new VisualCharacterComponent();
+        Mockito.when(otherCharacterEntity.getComponent(VisualCharacterComponent.class)).thenReturn(visualComponentOfOtherCharacter);
 
         clientEntityReturnedByLocalPlayer = EntityRef.NULL;
 
@@ -122,7 +124,7 @@ public class VisualCharacterSystemTest {
          * since the character is not properly linked yet nothing should happen
          */
         system.onActivatedVisualCharacter(OnActivatedComponent.newInstance(), otherCharacterEntity,
-                new VisualCharacterComponent());
+                visualComponentOfOtherCharacter);
         system.onActivatedVisualCharacter(OnActivatedComponent.newInstance(), ownCharacterEntity,
                 visualComponentOfOwnCharacter);
 
@@ -140,12 +142,14 @@ public class VisualCharacterSystemTest {
         EntityRef laterJoiningCharacterEntity = mockEntityWithUniqueId();
         List<Event> laterJoiningCharacterEntityEvents = new ArrayList<>();
         recordEntityEventsToList(laterJoiningCharacterEntity, laterJoiningCharacterEntityEvents);
+        VisualCharacterComponent visualComponentOfLaterJoiningCharacter = new VisualCharacterComponent();
+        Mockito.when(laterJoiningCharacterEntity.getComponent(VisualCharacterComponent.class)).thenReturn(visualComponentOfLaterJoiningCharacter);
 
         // Joined player is not properly linked but it should not matter:
         Mockito.when(laterJoiningCharacterEntity.getOwner()).thenReturn(EntityRef.NULL);
 
         system.onActivatedVisualCharacter(OnActivatedComponent.newInstance(), laterJoiningCharacterEntity,
-                new VisualCharacterComponent());
+                visualComponentOfLaterJoiningCharacter);
 
 
         /*

--- a/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/logic/permission/PermissionManager.java
@@ -17,7 +17,9 @@ package org.terasology.logic.permission;
 
 import com.google.common.base.Predicate;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.module.sandbox.API;
 
+@API
 public interface PermissionManager {
     /**
      * Allows the player to use chat commands.


### PR DESCRIPTION
### Contains

Fixes the currently failing `testSendingOfCreateVisualCharacterEvent` in `VisualCharacterSystemTest`.  
Also, whitelists the PermissionManager class for it to be used by modules.

### How to test

Run `testSendingOfCreateVisualCharacterEvent` in `VisualCharacterSystemTest`
