### PR TITLE
Implemented parameterized version of dumpEntities() command (Enhance …

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/ComponentContainer.java
+++ b/engine/src/main/java/org/terasology/entitySystem/ComponentContainer.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.entitySystem;
 
+import java.util.List;
+
 /**
  */
 public interface ComponentContainer {
@@ -24,6 +26,13 @@ public interface ComponentContainer {
      * @return If this has a component of the given type
      */
     boolean hasComponent(Class<? extends Component> component);
+
+    /**
+     * @param filterComponents
+     * @return If this has at least one component from the list of components
+     */
+    boolean hasComponents(List<Class<? extends Component>> filterComponents);
+
 
     /**
      * @param componentClass

--- a/engine/src/main/java/org/terasology/entitySystem/ComponentContainer.java
+++ b/engine/src/main/java/org/terasology/entitySystem/ComponentContainer.java
@@ -22,17 +22,25 @@ import java.util.List;
 public interface ComponentContainer {
 
     /**
-     * @param component
+     * Check existence of component in container
+     * @param component component class to check
      * @return If this has a component of the given type
      */
     boolean hasComponent(Class<? extends Component> component);
 
     /**
-     * @param filterComponents
+     * Check existence of any of provided components in container
+     * @param filterComponents list of Component classes to check
      * @return If this has at least one component from the list of components
      */
-    boolean hasComponents(List<Class<? extends Component>> filterComponents);
+    boolean hasAnyComponents(List<Class<? extends Component>> filterComponents);
 
+    /**
+     * Check existence of all provided components in container
+     * @param filterComponents list of Component classes to check
+     * @return If this has all components from the list of components
+     */
+    boolean hasAllComponents(List<Class<? extends Component>> filterComponents);
 
     /**
      * @param componentClass

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
@@ -141,8 +141,13 @@ public class EntityBuilder implements MutableComponentContainer {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
         return !Collections.disjoint(components.keySet(), filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        return components.keySet().containsAll(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
@@ -29,6 +29,7 @@ import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
 import org.terasology.entitySystem.prefab.Prefab;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -137,6 +138,11 @@ public class EntityBuilder implements MutableComponentContainer {
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
         return components.keySet().contains(component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        return !Collections.disjoint(components.keySet(), filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityStore.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityStore.java
@@ -21,6 +21,8 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.MutableComponentContainer;
 import org.terasology.entitySystem.prefab.Prefab;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,6 +47,11 @@ public class EntityStore implements MutableComponentContainer {
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
         return components.keySet().contains(component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        return !Collections.disjoint(components.keySet(), filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityStore.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityStore.java
@@ -50,8 +50,13 @@ public class EntityStore implements MutableComponentContainer {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
         return !Collections.disjoint(components.keySet(), filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        return components.keySet().containsAll(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -30,6 +30,7 @@ import org.terasology.persistence.serializers.EntitySerializer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
+import java.util.List;
 
 import static org.terasology.entitySystem.entity.internal.EntityScope.CHUNK;
 import static org.terasology.entitySystem.entity.internal.EntityScope.GLOBAL;
@@ -209,6 +210,15 @@ public abstract class BaseEntityRef extends EntityRef {
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
         return exists() && entityManager.hasComponent(getId(), component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        boolean hasComponents = false;
+        for (Class<? extends Component> component : filterComponents) {
+            hasComponents |= entityManager.hasComponent(getId(), component);
+        }
+        return exists() && hasComponents;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/BaseEntityRef.java
@@ -213,12 +213,21 @@ public abstract class BaseEntityRef extends EntityRef {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
         boolean hasComponents = false;
         for (Class<? extends Component> component : filterComponents) {
             hasComponents |= entityManager.hasComponent(getId(), component);
         }
         return exists() && hasComponents;
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        int numPosessedComponents = 0;
+        for (Class<? extends Component> component : filterComponents) {
+            numPosessedComponents += entityManager.hasComponent(getId(), component) ? 1 : 0;
+        }
+        return exists() && (numPosessedComponents == filterComponents.size());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
@@ -58,7 +58,12 @@ public final class NullEntityRef extends EntityRef {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
+        return false;
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
         return false;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/NullEntityRef.java
@@ -21,6 +21,7 @@ import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Null entity implementation - acts the same as an empty entity, except you cannot add anything to it.
@@ -53,6 +54,11 @@ public final class NullEntityRef extends EntityRef {
 
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
+        return false;
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
         return false;
     }
 

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/PrefabData.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/PrefabData.java
@@ -20,6 +20,8 @@ import org.terasology.assets.AssetData;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.MutableComponentContainer;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -61,6 +63,11 @@ public class PrefabData implements MutableComponentContainer, AssetData {
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
         return components.containsKey(component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        return !Collections.disjoint(components.keySet(), filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/PrefabData.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/PrefabData.java
@@ -66,8 +66,13 @@ public class PrefabData implements MutableComponentContainer, AssetData {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
         return !Collections.disjoint(components.keySet(), filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        return components.keySet().containsAll(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefab.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefab.java
@@ -74,8 +74,13 @@ public class PojoPrefab extends Prefab {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
         return !Collections.disjoint(componentMap.keySet(), filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        return componentMap.keySet().containsAll(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefab.java
+++ b/engine/src/main/java/org/terasology/entitySystem/prefab/internal/PojoPrefab.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabData;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -70,6 +71,11 @@ public class PojoPrefab extends Prefab {
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
         return componentMap.containsKey(component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        return !Collections.disjoint(componentMap.keySet(), filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -151,7 +151,14 @@ public class InputSystem extends BaseComponentSystem {
      * Updates the client and input entities of the local player, to be used in input events against the local player.
      */
     private void updateInputEntities() {
-        inputEntities = new EntityRef[] {localPlayer.getClientEntity(), localPlayer.getCharacterEntity()};
+        if (inputEntities == null
+                || inputEntities.length != 2
+                || inputEntities[0] == null
+                || inputEntities[1] == null
+                || !inputEntities[0].equals(localPlayer.getClientEntity())
+                || !inputEntities[1].equals(localPlayer.getCharacterEntity())) {
+            inputEntities = new EntityRef[]{localPlayer.getClientEntity(), localPlayer.getCharacterEntity()};
+        }
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -16,7 +16,6 @@
 package org.terasology.logic.console.commands;
 
 import com.google.common.collect.Ordering;
-import org.apache.http.util.EntityUtils;
 import org.reflections.Reflections;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
@@ -33,12 +32,10 @@ import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.EntityStore;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
-import org.terasology.entitySystem.systems.ComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.i18n.TranslationProject;
 import org.terasology.i18n.TranslationSystem;
@@ -65,10 +62,7 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.network.PingService;
 import org.terasology.network.Server;
 import org.terasology.persistence.WorldDumper;
-import org.terasology.persistence.serializers.EntityDataJSONFormat;
-import org.terasology.persistence.serializers.EntitySerializer;
 import org.terasology.persistence.serializers.PrefabSerializer;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.In;
 import org.terasology.rendering.FontColor;
 import org.terasology.rendering.nui.NUIManager;
@@ -478,7 +472,7 @@ public class CoreCommands extends BaseComponentSystem {
         } else {
             Reflections reflections = new Reflections("org.terasology");
             List<Class<? extends Component>> filterComponents = new LinkedList<>();
-            List<String> componentNamesList = Arrays.asList(componentNames.split(" "));
+            List<String> componentNamesList = new LinkedList<>(Arrays.asList(componentNames.split(" ")));
             for (String componentName : componentNamesList) {
                 if (componentName.trim().length() > 0) {
                     Optional<Class<? extends Component>> component = reflections.getSubTypesOf(Component.class).stream().filter(e -> e.getSimpleName().equals(componentName)).findFirst();

--- a/engine/src/main/java/org/terasology/persistence/WorldDumper.java
+++ b/engine/src/main/java/org/terasology/persistence/WorldDumper.java
@@ -42,7 +42,13 @@ public class WorldDumper {
         this.persisterHelper = new WorldSerializerImpl(entityManager, prefabSerializer);
     }
 
-    public void save(Path file) throws IOException {
+    /**
+     * Save all world entities to file
+     * @param file  path to file in which entities will be saved
+     * @return number of saved entities and prefabs
+     * @throws IOException thrown when error occurs while saving world to file
+     */
+    public int save(Path file) throws IOException {
         final EntityData.GlobalStore world = persisterHelper.serializeWorld(true);
 
         Path parentFile = file.toAbsolutePath().getParent();
@@ -53,15 +59,17 @@ public class WorldDumper {
         try (BufferedWriter writer = Files.newBufferedWriter(file, TerasologyConstants.CHARSET)) {
             EntityDataJSONFormat.write(world, writer);
         }
+        return world.getEntityCount() + world.getPrefabCount();
     }
 
     /***
      * Save World entities, which only contain some of Components
-     * @param file
-     * @param filterComponents
-     * @throws IOException
+     * @param file  path to file in which entities will be saved
+     * @param filterComponents list of component classes to filter by World entities
+     * @return number of saved entities and prefabs
+     * @throws IOException thrown when error occurs while saving world to file
      */
-    public void save(Path file, List<Class<? extends Component>> filterComponents) throws IOException {
+    public int save(Path file, List<Class<? extends Component>> filterComponents) throws IOException {
         final EntityData.GlobalStore world = persisterHelper.serializeWorld(true, filterComponents);
 
         Path parentFile = file.toAbsolutePath().getParent();
@@ -72,5 +80,6 @@ public class WorldDumper {
         try (BufferedWriter writer = Files.newBufferedWriter(file, TerasologyConstants.CHARSET)) {
             EntityDataJSONFormat.write(world, writer);
         }
+        return world.getEntityCount() + world.getPrefabCount();
     }
 }

--- a/engine/src/main/java/org/terasology/persistence/WorldDumper.java
+++ b/engine/src/main/java/org/terasology/persistence/WorldDumper.java
@@ -16,6 +16,7 @@
 package org.terasology.persistence;
 
 import org.terasology.engine.TerasologyConstants;
+import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.persistence.serializers.EntityDataJSONFormat;
 import org.terasology.persistence.serializers.PrefabSerializer;
@@ -27,6 +28,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Used to create a dump of the current state of the world (specifically, entities)
@@ -42,6 +44,25 @@ public class WorldDumper {
 
     public void save(Path file) throws IOException {
         final EntityData.GlobalStore world = persisterHelper.serializeWorld(true);
+
+        Path parentFile = file.toAbsolutePath().getParent();
+        if (!Files.isDirectory(parentFile)) {
+            Files.createDirectories(parentFile);
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(file, TerasologyConstants.CHARSET)) {
+            EntityDataJSONFormat.write(world, writer);
+        }
+    }
+
+    /***
+     * Save World entities, which only contain some of Components
+     * @param file
+     * @param filterComponents
+     * @throws IOException
+     */
+    public void save(Path file, List<Class<? extends Component>> filterComponents) throws IOException {
+        final EntityData.GlobalStore world = persisterHelper.serializeWorld(true, filterComponents);
 
         Path parentFile = file.toAbsolutePath().getParent();
         if (!Files.isDirectory(parentFile)) {

--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
@@ -139,8 +139,13 @@ public class DelayedEntityRef extends EntityRef {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
-        return getEntityRef().hasComponents(filterComponents);
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
+        return getEntityRef().hasAnyComponents(filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        return getEntityRef().hasAllComponents(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
+++ b/engine/src/main/java/org/terasology/persistence/internal/DelayedEntityRef.java
@@ -21,6 +21,8 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 
+import java.util.List;
+
 /**
  * The class represents a future entity ref that has yet to be bound to an entity manager.
  * <p>
@@ -134,6 +136,11 @@ public class DelayedEntityRef extends EntityRef {
     @Override
     public boolean hasComponent(Class<? extends Component> component) {
         return getEntityRef().hasComponent(component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        return getEntityRef().hasComponents(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializer.java
@@ -27,11 +27,16 @@ import java.util.List;
 public interface WorldSerializer {
 
     /**
+     * Serialize current EntityManager's and PrefabManager's data
+     * @param verbose verbosity level of serialization
      * @return The serialized form of the current EntityManager's and PrefabManager's data
      */
     EntityData.GlobalStore serializeWorld(boolean verbose);
 
     /**
+     * Serialize current EntityManager's and PrefabManager's data filtered by list of Components
+     * @param verbose verbosity level of serialization
+     * @param filterComponent list of component classes to filter world entities and prefabs
      * @return The serialized form of the current EntityManager's and PrefabManager's data filtered by list of Components
      */
     EntityData.GlobalStore serializeWorld(boolean verbose, List<Class<? extends Component>> filterComponent);

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializer.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializer.java
@@ -15,7 +15,10 @@
  */
 package org.terasology.persistence.serializers;
 
+import org.terasology.entitySystem.Component;
 import org.terasology.protobuf.EntityData;
+
+import java.util.List;
 
 /**
  * Serializes an entity system, with all prefabs and entities.
@@ -27,6 +30,12 @@ public interface WorldSerializer {
      * @return The serialized form of the current EntityManager's and PrefabManager's data
      */
     EntityData.GlobalStore serializeWorld(boolean verbose);
+
+    /**
+     * @return The serialized form of the current EntityManager's and PrefabManager's data filtered by list of Components
+     */
+    EntityData.GlobalStore serializeWorld(boolean verbose, List<Class<? extends Component>> filterComponent);
+
 
     /**
      * Deserializes a world message, applying it to the current EntityManager

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
@@ -101,13 +101,13 @@ public class WorldSerializerImpl implements WorldSerializer {
         }
 
         for (Prefab prefab : prefabManager.listPrefabs()) {
-            if (prefab.hasComponents(filterComponents)) {
+            if (prefab.hasAnyComponents(filterComponents)) {
                 world.addPrefab(prefabSerializer.serialize(prefab));
             }
         }
 
         for (EntityRef entity : entityManager.getAllEntities()) {
-            if ((verbose || entity.isPersistent()) && entity.hasComponents(filterComponents)) {
+            if ((verbose || entity.isPersistent()) && entity.hasAnyComponents(filterComponents)) {
                 world.addEntity(entitySerializer.serialize(entity));
             }
         }

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
@@ -38,6 +38,7 @@ import org.terasology.registry.CoreRegistry;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -88,6 +89,35 @@ public class WorldSerializerImpl implements WorldSerializer {
         return world.build();
     }
 
+    @Override
+    public EntityData.GlobalStore serializeWorld(boolean verbose, List<Class<? extends Component>> filterComponents) {
+        if (filterComponents == null) {
+            return serializeWorld(true);
+        }
+        final EntityData.GlobalStore.Builder world = EntityData.GlobalStore.newBuilder();
+
+        if (!verbose) {
+            writeComponentTypeTable(world);
+        }
+
+        for (Prefab prefab : prefabManager.listPrefabs()) {
+            if (prefab.hasComponents(filterComponents)) {
+                world.addPrefab(prefabSerializer.serialize(prefab));
+            }
+        }
+
+        for (EntityRef entity : entityManager.getAllEntities()) {
+            if ((verbose || entity.isPersistent()) && entity.hasComponents(filterComponents)) {
+                world.addEntity(entitySerializer.serialize(entity));
+            }
+        }
+
+        writeIdInfo(world);
+
+        entitySerializer.removeComponentIdMapping();
+        prefabSerializer.removeComponentIdMapping();
+        return world.build();
+    }
 
     @Override
     public void deserializeWorld(EntityData.GlobalStore world) {

--- a/engine/src/main/java/org/terasology/recording/RecordedEntityRef.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEntityRef.java
@@ -22,7 +22,6 @@ import org.terasology.entitySystem.entity.internal.NullEntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -150,9 +149,15 @@ public class RecordedEntityRef extends EntityRef {
     }
 
     @Override
-    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
         updateRealEntityRef();
-        return this.realEntityRef.hasComponents(filterComponents);
+        return this.realEntityRef.hasAnyComponents(filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        updateRealEntityRef();
+        return this.realEntityRef.hasAllComponents(filterComponents);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/recording/RecordedEntityRef.java
+++ b/engine/src/main/java/org/terasology/recording/RecordedEntityRef.java
@@ -22,6 +22,9 @@ import org.terasology.entitySystem.entity.internal.NullEntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.prefab.Prefab;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Class used instead of other EntityRef types during RecordedEvent deserialization. This class is necessary because
  * during RecordedEvent deserialization, it is not possible to correctly deserialize EntityRef fields because they do
@@ -144,6 +147,12 @@ public class RecordedEntityRef extends EntityRef {
     public boolean hasComponent(Class<? extends Component> component) {
         updateRealEntityRef();
         return this.realEntityRef.hasComponent(component);
+    }
+
+    @Override
+    public boolean hasComponents(List<Class<? extends Component>> filterComponents) {
+        updateRealEntityRef();
+        return this.realEntityRef.hasComponents(filterComponents);
     }
 
     @Override


### PR DESCRIPTION
…the `dumpEntities` command #3683).

It is now possible to provide list of Components for save only entities and prefabs that contains any of provided components.

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Implements #3683 

### How to test

run in console window

dumpEntities - to save all entites
dumpEntities BlockComponent - to save all entities that contains BlockComponent
dumpEntities "BlockComponent EntityInfoComponent" - to save all entities that contains either BlockComponent or EntityInfoComponent
dumpEntities someword  - nothing will be saved

### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [x ] Still have to adjust the wiki doc
