### PR TITLE
Log warning when module specified in override.cfg not found

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.engine.subsystem.headless.mode;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
 import org.terasology.config.WorldGenerationConfig;
 import org.terasology.context.Context;
@@ -60,6 +62,8 @@ import java.util.List;
  *
  */
 public class StateHeadlessSetup implements GameState {
+
+    private static final Logger logger = LoggerFactory.getLogger(StateHeadlessSetup.class);
 
     private EngineEntityManager entityManager;
     private EventSystem eventSystem;
@@ -125,6 +129,8 @@ public class StateHeadlessSetup implements GameState {
             Module module = moduleManager.getRegistry().getLatestModuleVersion(moduleName);
             if (module != null) {
                 gameManifest.addModule(module.getId(), module.getVersion());
+            } else {
+                logger.warn("ModuleRegistry has no latest version for module {}", moduleName);
             }
         }
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #3673
Logs warning in `StateHeadlessServer` when module is not found in module registry.

### How to test

Add a non-existing module (e.g. TestMissingModule) to the `override.cfg` file and then start the headless server (make sure you have no saved games otherwise it will load the config from the first one). In the logs you should see the message "ModuleRegistry has no latest version for module <module>".

Note: I noticed that the modules from `override.cfg` are loaded first, and then `config.cfg`. This tripped me up while testing. First you'll have to delete any entry in `config.cfg` for this
```
"defaultModSelection": {
    "modules": []
```
otherwise what you specify in `override.cfg` will be completely ignored.