### PR TITLE
Add space after completing text in Console

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/ui/CyclingTabCompletionEngine.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/CyclingTabCompletionEngine.java
@@ -189,6 +189,9 @@ public class CyclingTabCompletionEngine implements TabCompletionEngine {
 
             result.append(" ");
             result.append(suggestion);
+
+            result.append(" ");
+
             return result.toString();
         }
     }

--- a/engine/src/main/java/org/terasology/logic/console/ui/CyclingTabCompletionEngine.java
+++ b/engine/src/main/java/org/terasology/logic/console/ui/CyclingTabCompletionEngine.java
@@ -177,7 +177,7 @@ public class CyclingTabCompletionEngine implements TabCompletionEngine {
     private String generateResult(String suggestion, Name commandName,
                                   List<String> commandParameters, int suggestedIndex) {
         if (suggestedIndex <= 0) {
-            return suggestion;
+            return suggestion + " ";
         } else {
             StringBuilder result = new StringBuilder();
             result.append(commandName.toString());


### PR DESCRIPTION
Emulates the autocomplete behaviour of `zsh` to further increase efficiency.

# Testing
Open the console and type `sScr` - should complete to `showScreen ` (note the space at the end), which allows you to type in the screen uri without having to manually enter a space.