### PR TITLE
Implement movable selection feature

### DIFF
--- a/engine/src/main/java/org/terasology/logic/selection/LocalPlayerBlockSelectionByItemSystem.java
+++ b/engine/src/main/java/org/terasology/logic/selection/LocalPlayerBlockSelectionByItemSystem.java
@@ -21,9 +21,13 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.cameraTarget.CameraTargetChangedEvent;
+import org.terasology.input.events.LeftMouseDownButtonEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.Region3i;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.selection.BlockSelectionComponent;
 import org.terasology.world.selection.event.SetBlockSelectionEndingPointEvent;
@@ -77,11 +81,59 @@ public class LocalPlayerBlockSelectionByItemSystem extends BaseComponentSystem {
         }
 
         BlockSelectionComponent blockSelectionComponent = blockSelectionComponentEntity.getComponent(BlockSelectionComponent.class);
+
+        if (blockSelectionComponent == null) {
+            return;
+        }
+
+        EntityRef target = event.getNewTarget();
+        LocationComponent locationComponent = target.getComponent(LocationComponent.class);
+        Vector3f targetLocation = locationComponent.getWorldPosition();
+
+        if (blockSelectionComponent.isMovable) {
+            Region3i region = blockSelectionComponent.currentSelection;
+
+            blockSelectionComponent.currentSelection = Region3i.createFromCenterExtents(new Vector3i(targetLocation.x, targetLocation.y, targetLocation.z),
+                    new Vector3i(region.sizeX()/2, 0, region.sizeZ()/2));
+            blockSelectionComponentEntity.saveComponent(blockSelectionComponent);
+
+            return;
+        }
+
         if (blockSelectionComponent.startPosition == null) {
             return;
         }
-        EntityRef target = event.getNewTarget();
+
         target.send(new SetBlockSelectionEndingPointEvent(blockSelectionComponentEntity));
+    }
+
+    /**
+     * This event is sent after the size of a region is finalized and the location is to yet to be decided by the player.
+     * This event marks the start of the camera position binding with the region.
+     * @param event The event sent
+     * @param blockSelectionComponentEntity The entity sending the event. This entity must have the {@link BlockSelectionComponent}
+     */
+    @ReceiveEvent(components = {BlockSelectionComponent.class})
+    public void onMovableBlockSelectionStart(MovableSelectionStartEvent event, EntityRef blockSelectionComponentEntity) {
+        this.blockSelectionComponentEntity = blockSelectionComponentEntity;
+    }
+
+    /**
+     * This marks the end of the camera position binding with the region position.
+     * @param event LeftMouseButtonDownEvent
+     * @param entity Entity sending the event
+     */
+    @ReceiveEvent
+    public void onLeftMouseButtonDown(LeftMouseDownButtonEvent event, EntityRef entity) {
+        if (this.blockSelectionComponentEntity != EntityRef.NULL) {
+            BlockSelectionComponent blockSelectionComponent = blockSelectionComponentEntity.getComponent(BlockSelectionComponent.class);
+
+            if (blockSelectionComponent != null && blockSelectionComponent.isMovable) {
+                blockSelectionComponentEntity.send(new MovableSelectionEndEvent(blockSelectionComponent.currentSelection));
+
+                blockSelectionComponentEntity.destroy();
+            }
+        }
     }
 
 }

--- a/engine/src/main/java/org/terasology/logic/selection/MovableSelectionEndEvent.java
+++ b/engine/src/main/java/org/terasology/logic/selection/MovableSelectionEndEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.selection;
+
+import org.terasology.module.sandbox.API;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.Region3i;
+
+/**
+ * This event is sent when the player finalizes the position of a moving selection by clicking the left mouse button.
+ * This event marks the end of the binding of the camera position with the selected region and provides the final selected
+ * region.
+ */
+@API
+public class MovableSelectionEndEvent implements Event {
+    /**
+     * The final position of the selected region
+     */
+    private Region3i finalRegion;
+
+    public MovableSelectionEndEvent(Region3i selectedRegion) {
+        this.finalRegion = selectedRegion;
+    }
+
+    public Region3i getFinalRegion() {
+        return this.finalRegion;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/selection/MovableSelectionStartEvent.java
+++ b/engine/src/main/java/org/terasology/logic/selection/MovableSelectionStartEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.selection;
+
+import org.terasology.module.sandbox.API;
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * This event should be sent by a system after it receives a {@link ApplyBlockSelectionEvent} which marks the end of a
+ * region selection. This event marks the start of the binding of the camera position with the selected region.
+ * <br>
+ * The entity used to send this event must have the {@link org.terasology.world.selection.BlockSelectionComponent}
+ */
+@API
+public class MovableSelectionStartEvent implements Event {
+}

--- a/engine/src/main/java/org/terasology/world/selection/BlockSelectionComponent.java
+++ b/engine/src/main/java/org/terasology/world/selection/BlockSelectionComponent.java
@@ -54,4 +54,10 @@ public class BlockSelectionComponent implements Component {
      * Texture used to indicate the selected blocks when drawing block selection.  Defaults to "engine:selection" if not specified.
      */
     public Texture texture;
+
+    /**
+     * If this is the position of the selected region changes with the camera target. This must be set true for a component
+     * before sending the {@link org.terasology.logic.selection.MovableSelectionStartEvent} using the appropriate entity
+     */
+    public boolean isMovable = false;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Implementation for a new feature which enables the player to select a suitable position for a selected region after specifying its size.

There is no change in the block selection logic so any modules depending on old logic should work fine. In order to use the new feature, the `MovableSelectionStartEvent` must be sent which binds the camera position with the region and the player can select the final position of the region by clicking the left mouse button.

### How to test

Refer to the PR [MasterOfOreon#50](https://github.com/Terasology/MasterOfOreon/pull/50) for a working example and steps to test.
