### PR TITLE
Fix APIScanner NPE when running MTE tests

### DIFF
--- a/engine/src/main/java/org/terasology/input/binds/inventory/UseItemButton.java
+++ b/engine/src/main/java/org/terasology/input/binds/inventory/UseItemButton.java
@@ -21,11 +21,13 @@ import org.terasology.input.DefaultBinding;
 import org.terasology.input.InputType;
 import org.terasology.input.RegisterBindButton;
 import org.terasology.input.ControllerId;
+import org.terasology.module.sandbox.API;
 
 /**
  */
 @RegisterBindButton(id = "useItem", description = "${engine:menu#binding-use-item}", repeating = true, category = "interaction")
 @DefaultBinding(type = InputType.MOUSE_BUTTON, id = 1)
 @DefaultBinding(type = InputType.CONTROLLER_BUTTON, id = ControllerId.THREE)
+@API
 public class UseItemButton extends BindButtonEvent {
 }

--- a/engine/src/main/java/org/terasology/input/binds/inventory/package-info.java
+++ b/engine/src/main/java/org/terasology/input/binds/inventory/package-info.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@API
 @InputCategory(id = "inventory",
         displayName = "${engine:menu#category-inventory}"
 ) package org.terasology.input.binds.inventory;


### PR DESCRIPTION
there are _two_ packages named `org.terasology.input.binds.inventory`: one in the engine, one in the Inventory module. The engine one is `@API`, but the Inventory one is not. When the APIScanner looks for API annotated types, Reflections _sometimes_ thinks it's returning the engine package but actually returns the Inventory package. APIScanner is unable to find the annotation on the Inventory package,  causing an NPE.

This is fixed by removing the API annotation from the package and moving it to the only class in the package, `UseItemButton`.

Resolves Terasology/ModuleTestingEnvironment#9.