### PR TITLE
Deprecated Perlin noise over Simplex

### DIFF
--- a/engine/src/main/java/org/terasology/utilities/procedural/PerlinNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/PerlinNoise.java
@@ -20,8 +20,10 @@ import org.terasology.utilities.random.FastRandom;
 
 /**
  * Improved Perlin noise based on the reference implementation by Ken Perlin.
+ * @deprecated Prefer using {@link SimplexNoise}, it is comparable to Perlin noise (fewer directional artifacts, lower computational overhead for higher dimensions).
  *
  */
+@Deprecated
 public class PerlinNoise extends AbstractNoise implements Noise2D, Noise3D {
 
     private final int[] noisePermutations;

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexBaseSurfaceProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexBaseSurfaceProvider.java
@@ -18,7 +18,7 @@ package org.terasology.core.world.generator.facetProviders;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.utilities.procedural.BrownianNoise;
-import org.terasology.utilities.procedural.PerlinNoise;
+import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.Facet;
@@ -33,14 +33,14 @@ import org.terasology.world.generation.facets.SurfaceHeightFacet;
  */
 @Produces(SurfaceHeightFacet.class)
 @Requires(@Facet(SeaLevelFacet.class))
-public class PerlinBaseSurfaceProvider implements FacetProvider {
+public class SimplexBaseSurfaceProvider implements FacetProvider {
     private static final int SAMPLE_RATE = 4;
 
     private SubSampledNoise surfaceNoise;
 
     @Override
     public void setSeed(long seed) {
-        BrownianNoise source = new BrownianNoise(new PerlinNoise(seed), 8);
+        BrownianNoise source = new BrownianNoise(new SimplexNoise(seed), 8);
         surfaceNoise = new SubSampledNoise(source, new Vector2f(0.004f, 0.004f), SAMPLE_RATE);
     }
 

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexHillsAndMountainsProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexHillsAndMountainsProvider.java
@@ -23,7 +23,7 @@ import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.utilities.procedural.BrownianNoise;
-import org.terasology.utilities.procedural.PerlinNoise;
+import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.ConfigurableFacetProvider;
 import org.terasology.world.generation.Facet;
@@ -39,17 +39,17 @@ import org.terasology.world.generation.facets.SurfaceTemperatureFacet;
  */
 @Requires({@Facet(SurfaceTemperatureFacet.class), @Facet(SurfaceHumidityFacet.class)})
 @Updates(@Facet(SurfaceHeightFacet.class))
-public class PerlinHillsAndMountainsProvider implements ConfigurableFacetProvider {
+public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvider {
 
     private SubSampledNoise mountainNoise;
     private SubSampledNoise hillNoise;
-    private PerlinHillsAndMountainsProviderConfiguration configuration = new PerlinHillsAndMountainsProviderConfiguration();
+    private SimplexHillsAndMountainsProviderConfiguration configuration = new SimplexHillsAndMountainsProviderConfiguration();
 
     @Override
     public void setSeed(long seed) {
         // TODO: reduce the number of octaves in BrownianNoise
-        mountainNoise = new SubSampledNoise(new BrownianNoise(new PerlinNoise(seed + 3)), new Vector2f(0.0002f, 0.0002f), 4);
-        hillNoise = new SubSampledNoise(new BrownianNoise(new PerlinNoise(seed + 4)), new Vector2f(0.0008f, 0.0008f), 4);
+        mountainNoise = new SubSampledNoise(new BrownianNoise(new SimplexNoise(seed + 3)), new Vector2f(0.0002f, 0.0002f), 4);
+        hillNoise = new SubSampledNoise(new BrownianNoise(new SimplexNoise(seed + 4)), new Vector2f(0.0008f, 0.0008f), 4);
     }
 
     @Override
@@ -88,10 +88,10 @@ public class PerlinHillsAndMountainsProvider implements ConfigurableFacetProvide
 
     @Override
     public void setConfiguration(Component configuration) {
-        this.configuration = (PerlinHillsAndMountainsProviderConfiguration) configuration;
+        this.configuration = (SimplexHillsAndMountainsProviderConfiguration) configuration;
     }
 
-    private static class PerlinHillsAndMountainsProviderConfiguration implements Component {
+    private static class SimplexHillsAndMountainsProviderConfiguration implements Component {
 
         @Range(min = 0, max = 3f, increment = 0.01f, precision = 2, description = "Mountain Amplitude")
         public float mountainAmplitude = 1f;

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexHumidityProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexHumidityProvider.java
@@ -20,7 +20,7 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.utilities.procedural.BrownianNoise;
-import org.terasology.utilities.procedural.PerlinNoise;
+import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.ConfigurableFacetProvider;
@@ -32,7 +32,7 @@ import org.terasology.world.generation.facets.SurfaceHumidityFacet;
  * Defines surface humidity in the range [0..1] based on random noise.
  */
 @Produces(SurfaceHumidityFacet.class)
-public class PerlinHumidityProvider implements ConfigurableFacetProvider {
+public class SimplexHumidityProvider implements ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 
     private SubSampledNoise humidityNoise;
@@ -41,14 +41,14 @@ public class PerlinHumidityProvider implements ConfigurableFacetProvider {
 
     private long seed;
 
-    public PerlinHumidityProvider() {
+    public SimplexHumidityProvider() {
         // use default values
     }
 
     /**
      * @param config the config to use
      */
-    public PerlinHumidityProvider(Configuration config) {
+    public SimplexHumidityProvider(Configuration config) {
         this.config = config;
     }
 
@@ -90,7 +90,7 @@ public class PerlinHumidityProvider implements ConfigurableFacetProvider {
     private void reload() {
         float realScale = config.scale * 0.01f;
         Vector2f scale = new Vector2f(realScale, realScale);
-        BrownianNoise brown = new BrownianNoise(new PerlinNoise(seed + 6), config.octaves);
+        BrownianNoise brown = new BrownianNoise(new SimplexNoise(seed + 6), config.octaves);
         humidityNoise = new SubSampledNoise(brown, scale, SAMPLE_RATE);
     }
 

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexOceanProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexOceanProvider.java
@@ -20,7 +20,7 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.utilities.procedural.BrownianNoise;
-import org.terasology.utilities.procedural.PerlinNoise;
+import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.ConfigurableFacetProvider;
 import org.terasology.world.generation.Facet;
@@ -32,15 +32,15 @@ import org.terasology.world.generation.facets.SurfaceHeightFacet;
  * Applies an amount of the max depth for regions that are oceans
  */
 @Updates(@Facet(SurfaceHeightFacet.class))
-public class PerlinOceanProvider implements ConfigurableFacetProvider {
+public class SimplexOceanProvider implements ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 
     private SubSampledNoise oceanNoise;
-    private PerlinOceanConfiguration configuration = new PerlinOceanConfiguration();
+    private SimplexOceanConfiguration configuration = new SimplexOceanConfiguration();
 
     @Override
     public void setSeed(long seed) {
-        oceanNoise = new SubSampledNoise(new BrownianNoise(new PerlinNoise(seed + 1), 8), new Vector2f(0.0009f, 0.0009f), SAMPLE_RATE);
+        oceanNoise = new SubSampledNoise(new BrownianNoise(new SimplexNoise(seed + 1), 8), new Vector2f(0.0009f, 0.0009f), SAMPLE_RATE);
     }
 
     @Override
@@ -66,10 +66,10 @@ public class PerlinOceanProvider implements ConfigurableFacetProvider {
 
     @Override
     public void setConfiguration(Component configuration) {
-        this.configuration = (PerlinOceanConfiguration) configuration;
+        this.configuration = (SimplexOceanConfiguration) configuration;
     }
 
-    private static class PerlinOceanConfiguration implements Component {
+    private static class SimplexOceanConfiguration implements Component {
         @Range(min = 0, max = 128f, increment = 1f, precision = 0, description = "Ocean Depth")
         public float maxDepth = 32;
     }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexRiverProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexRiverProvider.java
@@ -20,7 +20,7 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.utilities.procedural.BrownianNoise;
-import org.terasology.utilities.procedural.PerlinNoise;
+import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.ConfigurableFacetProvider;
 import org.terasology.world.generation.Facet;
@@ -33,15 +33,15 @@ import org.terasology.world.generation.facets.SurfaceHeightFacet;
  * Applies an amount of the max depth for regions that are rivers
  */
 @Updates(@Facet(SurfaceHeightFacet.class))
-public class PerlinRiverProvider implements FacetProvider, ConfigurableFacetProvider {
+public class SimplexRiverProvider implements FacetProvider, ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 
     private SubSampledNoise riverNoise;
-    private PerlinRiverProviderConfiguration configuration = new PerlinRiverProviderConfiguration();
+    private SimplexRiverProviderConfiguration configuration = new SimplexRiverProviderConfiguration();
 
     @Override
     public void setSeed(long seed) {
-        riverNoise = new SubSampledNoise(new BrownianNoise(new PerlinNoise(seed + 2), 8), new Vector2f(0.0008f, 0.0008f), SAMPLE_RATE);
+        riverNoise = new SubSampledNoise(new BrownianNoise(new SimplexNoise(seed + 2), 8), new Vector2f(0.0008f, 0.0008f), SAMPLE_RATE);
     }
 
     @Override
@@ -67,10 +67,10 @@ public class PerlinRiverProvider implements FacetProvider, ConfigurableFacetProv
 
     @Override
     public void setConfiguration(Component configuration) {
-        this.configuration = (PerlinRiverProviderConfiguration) configuration;
+        this.configuration = (SimplexRiverProviderConfiguration) configuration;
     }
 
-    private static class PerlinRiverProviderConfiguration implements Component {
+    private static class SimplexRiverProviderConfiguration implements Component {
         @Range(min = 0, max = 64f, increment = 1f, precision = 0, description = "River Depth")
         public float maxDepth = 16;
     }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexSurfaceTemperatureProvider.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/facetProviders/SimplexSurfaceTemperatureProvider.java
@@ -18,7 +18,7 @@ package org.terasology.core.world.generator.facetProviders;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.utilities.procedural.BrownianNoise;
-import org.terasology.utilities.procedural.PerlinNoise;
+import org.terasology.utilities.procedural.SimplexNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
@@ -28,14 +28,14 @@ import org.terasology.world.generation.facets.SurfaceTemperatureFacet;
 /**
  */
 @Produces(SurfaceTemperatureFacet.class)
-public class PerlinSurfaceTemperatureProvider implements FacetProvider {
+public class SimplexSurfaceTemperatureProvider implements FacetProvider {
     private static final int SAMPLE_RATE = 4;
 
     private SubSampledNoise temperatureNoise;
 
     @Override
     public void setSeed(long seed) {
-        temperatureNoise = new SubSampledNoise(new BrownianNoise(new PerlinNoise(seed + 5), 8), new Vector2f(0.0005f, 0.0005f), SAMPLE_RATE);
+        temperatureNoise = new SubSampledNoise(new BrownianNoise(new SimplexNoise(seed + 5), 8), new Vector2f(0.0005f, 0.0005f), SAMPLE_RATE);
     }
 
     @Override

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/FlatWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/FlatWorldGenerator.java
@@ -19,8 +19,8 @@ import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.FlatSurfaceHeightProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
@@ -49,8 +49,8 @@ public class FlatWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SeaLevelProvider(32))
                         // height of 40 so that it is far enough from sea level so that it doesnt just create beachfront
                 .addProvider(new FlatSurfaceHeightProvider(40))
-                .addProvider(new PerlinHumidityProvider())
-                .addProvider(new PerlinSurfaceTemperatureProvider())
+                .addProvider(new SimplexHumidityProvider())
+                .addProvider(new SimplexSurfaceTemperatureProvider())
                 .addProvider(new BiomeProvider())
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/HeightMapWorldGenerator.java
@@ -19,8 +19,8 @@ import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.HeightMapSurfaceHeightProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
@@ -51,8 +51,8 @@ public class HeightMapWorldGenerator extends BaseFacetedWorldGenerator {
                 .setSeaLevel(16)
                 .addProvider(new SeaLevelProvider(16))
                 .addProvider(new HeightMapSurfaceHeightProvider())
-                .addProvider(new PerlinHumidityProvider())
-                .addProvider(new PerlinSurfaceTemperatureProvider())
+                .addProvider(new SimplexHumidityProvider())
+                .addProvider(new SimplexSurfaceTemperatureProvider())
                 .addProvider(new BiomeProvider())
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/worldGenerators/SimplexFacetedWorldGenerator.java
@@ -19,12 +19,12 @@ import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
 import org.terasology.core.world.generator.facetProviders.PlateauProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinBaseSurfaceProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinHillsAndMountainsProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinOceanProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinRiverProvider;
-import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexBaseSurfaceProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexHillsAndMountainsProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexOceanProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexRiverProvider;
+import org.terasology.core.world.generator.facetProviders.SimplexSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
@@ -43,15 +43,15 @@ import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 /**
  */
-@RegisterWorldGenerator(id = "facetedperlin", displayName = "Perlin", description = "Faceted world generator")
-public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
+@RegisterWorldGenerator(id = "facetedsimplex", displayName = "Simplex", description = "Faceted world generator")
+public class SimplexFacetedWorldGenerator extends BaseFacetedWorldGenerator {
 
     private final FixedSpawner spawner = new FixedSpawner(0, 0);
 
     @In
     private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
 
-    public PerlinFacetedWorldGenerator(SimpleUri uri) {
+    public SimplexFacetedWorldGenerator(SimpleUri uri) {
         super(uri);
     }
 
@@ -68,12 +68,12 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
         return new WorldBuilder(worldGeneratorPluginLibrary)
                 .setSeaLevel(seaLevel)
                 .addProvider(new SeaLevelProvider(seaLevel))
-                .addProvider(new PerlinHumidityProvider())
-                .addProvider(new PerlinSurfaceTemperatureProvider())
-                .addProvider(new PerlinBaseSurfaceProvider())
-                .addProvider(new PerlinRiverProvider())
-                .addProvider(new PerlinOceanProvider())
-                .addProvider(new PerlinHillsAndMountainsProvider())
+                .addProvider(new SimplexHumidityProvider())
+                .addProvider(new SimplexSurfaceTemperatureProvider())
+                .addProvider(new SimplexBaseSurfaceProvider())
+                .addProvider(new SimplexRiverProvider())
+                .addProvider(new SimplexOceanProvider())
+                .addProvider(new SimplexHillsAndMountainsProvider())
                 .addProvider(new BiomeProvider())
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())

--- a/modules/CoreSampleGameplay/module.txt
+++ b/modules/CoreSampleGameplay/module.txt
@@ -7,5 +7,5 @@
         {"id": "Core", "minVersion": "2.0.0"}
     ],
     "isGameplay" : "true",
-    "defaultWorldGenerator" : "Core:FacetedPerlin"
+    "defaultWorldGenerator" : "Core:FacetedSimplex"
 }


### PR DESCRIPTION
Converted Core Perlin world generator to instead use Simplex noise. 

Deprecated Perlin noise in favor of Simplex noise, which is a newer algorithm from Ken Perlin with fewer directional artifacts, lower computational overhead for higher dimensions.