### PR TITLE
New asset: Group

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -133,8 +133,8 @@ dependencies {
     compile 'com.jagrosh:DiscordIPC:0.4'
 
     // Our developed libs
-    compile group: 'org.terasology', name: 'gestalt-module', version: '5.1.3'
-    compile group: 'org.terasology', name: 'gestalt-asset-core', version: '5.1.3'
+    compile group: 'org.terasology', name: 'gestalt-module', version: '5.1.4'
+    compile group: 'org.terasology', name: 'gestalt-asset-core', version: '5.1.4'
     compile group: 'org.terasology', name: 'TeraMath', version: '1.4.0'
     compile group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.3.1'
     compile group: 'org.terasology', name: 'splash-screen', version: '1.0.2'

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/Group.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/Group.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.behavior.asset;
+
+import org.terasology.assets.Asset;
+import org.terasology.assets.AssetType;
+import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.module.annotations.RegisterAssetType;
+import org.terasology.module.sandbox.API;
+
+@RegisterAssetType(folderName = "groups", factoryClass = GroupFactory.class)
+@API
+public class Group extends Asset<GroupData> {
+
+    private GroupData groupData;
+
+    public Group(ResourceUrn urn, GroupData data, AssetType<?, GroupData> type) {
+        super(urn, type);
+        reload(data);
+    }
+
+    @Override
+    protected void doReload(GroupData data) {
+        this.groupData = data;
+    }
+
+    public GroupData getGroupData() {
+        return groupData;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/Group.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/Group.java
@@ -21,8 +21,16 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.module.annotations.RegisterAssetType;
 import org.terasology.module.sandbox.API;
 
+/**
+ * The main Group asset class. This is the reference type
+ * used by the asset manager to find all groups loaded
+ * from .group files. The annotation below indicates that
+ * all .group files will be under the assets/groups folder.
+ * A factory class is used to assist the asset creation.
+ * Using the Group asset is illustrated in the
+ * WildAnimalsMadness module.
+ */
 @RegisterAssetType(folderName = "groups", factoryClass = GroupFactory.class)
-@API
 public class Group extends Asset<GroupData> {
 
     private GroupData groupData;

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupBuilder.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.behavior.asset;
+
+import com.google.gson.Gson;
+import org.terasology.module.sandbox.API;
+import org.terasology.registry.In;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+@API
+public class GroupBuilder {
+
+    private GroupData groupData;
+
+    @In
+    private Gson gson;
+
+    public GroupData loadFromJson(InputStream json) {
+
+        GroupData groupFromFile = new GroupData();
+        try {
+            gson = new Gson();
+            groupFromFile = gson.fromJson(new InputStreamReader(json), GroupData.class);
+        } catch (Exception e) {
+            groupFromFile.setGroupLabel("ERROR");
+            e.printStackTrace();
+        }
+        return groupFromFile;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupBuilder.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupBuilder.java
@@ -16,12 +16,21 @@
 package org.terasology.logic.behavior.asset;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
 import org.terasology.module.sandbox.API;
 import org.terasology.registry.In;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+/**
+ * This class is responsible for implementing the
+ * serialization functionality required by the Group
+ * asset class to load group information from .group
+ * asset files.
+ * @see Group
+ */
 @API
 public class GroupBuilder {
 
@@ -36,8 +45,11 @@ public class GroupBuilder {
         try {
             gson = new Gson();
             groupFromFile = gson.fromJson(new InputStreamReader(json), GroupData.class);
-        } catch (Exception e) {
-            groupFromFile.setGroupLabel("ERROR");
+        } catch (JsonSyntaxException e) {
+            groupFromFile.setGroupLabel("ERROR - Syntax");
+            e.printStackTrace();
+        } catch (JsonIOException e) {
+            groupFromFile.setGroupLabel("ERROR - IO");
             e.printStackTrace();
         }
         return groupFromFile;

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupData.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupData.java
@@ -20,12 +20,30 @@ import org.terasology.assets.AssetData;
 import java.util.List;
 
 /**
- * Every group is described by a GroupData asset.
+ * Every Group asset is described by a GroupData class.
+ * @see Group
  */
 public class GroupData implements AssetData {
 
+    /**
+     * The unique group identifier
+     */
     public String groupLabel;
+
+    /**
+     * Flags the need for a hivemind
+     * structure (when group members
+     * need to behave in unison)
+     */
     public Boolean needsHive;
+
+    /**
+     * The name of the behavior tree
+     * used by the group (trees
+     * from other modules can be used as
+     * long as they are listed as
+     * dependencies)
+     */
     public String behavior;
 
     public GroupData() {

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupData.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupData.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.behavior.asset;
+
+import org.terasology.assets.AssetData;
+
+import java.util.List;
+
+/**
+ * Every group is described by a GroupData asset.
+ */
+public class GroupData implements AssetData {
+
+    public String groupLabel;
+    public Boolean needsHive;
+    public String behavior;
+
+    public GroupData() {
+    }
+
+    public GroupData(String groupLabel, Boolean needsHive, String behavior) {
+        this.groupLabel = groupLabel;
+        this.needsHive = needsHive;
+        this.behavior = behavior;
+    }
+
+    public String getGroupLabel() {
+        return groupLabel;
+    }
+
+    public void setGroupLabel(String groupLabel) {
+        this.groupLabel = groupLabel;
+    }
+
+    public Boolean getNeedsHive() {
+        return needsHive;
+    }
+
+    public void setNeedsHive(Boolean needsHive) {
+        this.needsHive = needsHive;
+    }
+
+    public String getBehavior() {
+        return behavior;
+    }
+
+    public void setBehavior(String behavior) {
+        this.behavior = behavior;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFactory.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.behavior.asset;
+
+import org.terasology.assets.AssetFactory;
+import org.terasology.assets.AssetType;
+import org.terasology.assets.ResourceUrn;
+
+public class GroupFactory implements AssetFactory<Group, GroupData> {
+
+    @Override
+    public Group build(ResourceUrn urn, AssetType<Group, GroupData> type, GroupData data) {
+        return new Group(urn, data, type);
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFactory.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFactory.java
@@ -19,6 +19,11 @@ import org.terasology.assets.AssetFactory;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 
+/**
+ * Factory class used to assist the creation
+ * of new Group assets.
+ * @see Group
+ */
 public class GroupFactory implements AssetFactory<Group, GroupData> {
 
     @Override

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFormat.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFormat.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.behavior.asset;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.format.AbstractAssetFileFormat;
+import org.terasology.assets.format.AssetDataFile;
+import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
+import org.terasology.registry.CoreRegistry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@RegisterAssetFileFormat
+public class GroupFormat extends AbstractAssetFileFormat<GroupData> {
+
+    public GroupFormat() {
+        super("group");
+    }
+
+    @Override
+    public GroupData load(ResourceUrn resourceUrn, List<AssetDataFile> list) throws IOException {
+        GroupBuilder builder = CoreRegistry.get(GroupBuilder.class);
+        if (builder == null) {
+            builder = new GroupBuilder();
+            CoreRegistry.put(GroupBuilder.class, builder);
+        }
+        try (InputStream stream = list.get(0).openStream()) {
+            return builder.loadFromJson(stream);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new GroupData("ERROR",false,"none");
+        }
+
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFormat.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/asset/GroupFormat.java
@@ -25,6 +25,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+/**
+ * This class is responsible for
+ * associating the correct file extensions
+ * (.group) with the Group asset class.
+ * It is also the actual responsible
+ * for invoking the serialization method
+ * from the builder class.
+ * @see Group
+ * @see GroupBuilder
+ */
 @RegisterAssetFileFormat
 public class GroupFormat extends AbstractAssetFileFormat<GroupData> {
 
@@ -39,12 +49,7 @@ public class GroupFormat extends AbstractAssetFileFormat<GroupData> {
             builder = new GroupBuilder();
             CoreRegistry.put(GroupBuilder.class, builder);
         }
-        try (InputStream stream = list.get(0).openStream()) {
-            return builder.loadFromJson(stream);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return new GroupData("ERROR",false,"none");
-        }
 
+        return builder.loadFromJson(list.get(0).openStream());
     }
 }


### PR DESCRIPTION
### Contains
- New asset: Group
- Updates the build with gestalt version 5.1.4 (required by asset structure)

### Objective
- The new Group asset allows group configurations to be loaded from JSON files (assets/groups/.group). 
- Gestalt 5.1.4 contains a fix to a bug that would sometimes prevent an asset file to be loaded. This error appears as an `java.security.AccessControlException` exception ("access denied"), with the stack trace leading to `org.terasology.assets.format.AssetDataFile.openStream(AssetDataFile.java:99)` .

### Changes

- New asset structure: `Group`, `GroupBuilder`, GroupData`, GroupFactory`, and `GroupFormat`. The new implementation is hermetic and shouldn't affect any of the existing classes.
- Updates both `gestalt-module` and `gestalt-asset-core`  to version 5.1.4 in `build.gradle`

### Usage

- Make sure to thoroughly rebuild the project to avoid broken references using `gradlew clean cleanIdea idea jar` (so that the new gestalt version can be properly used)
- The new asset structure is demonstrated in the [WildAnimalsMadness](https://github.com/casals/WildAnimalsMadness) module