### PR TITLE
Fix NPEs related to movable selections

### DIFF
--- a/engine/src/main/java/org/terasology/logic/selection/LocalPlayerBlockSelectionByItemSystem.java
+++ b/engine/src/main/java/org/terasology/logic/selection/LocalPlayerBlockSelectionByItemSystem.java
@@ -88,6 +88,11 @@ public class LocalPlayerBlockSelectionByItemSystem extends BaseComponentSystem {
 
         EntityRef target = event.getNewTarget();
         LocationComponent locationComponent = target.getComponent(LocationComponent.class);
+
+        if (locationComponent == null) {
+            return;
+        }
+
         Vector3f targetLocation = locationComponent.getWorldPosition();
 
         if (blockSelectionComponent.isMovable) {
@@ -125,9 +130,8 @@ public class LocalPlayerBlockSelectionByItemSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onLeftMouseButtonDown(LeftMouseDownButtonEvent event, EntityRef entity) {
-        if (this.blockSelectionComponentEntity != EntityRef.NULL) {
+        if (this.blockSelectionComponentEntity != null && this.blockSelectionComponentEntity != EntityRef.NULL) {
             BlockSelectionComponent blockSelectionComponent = blockSelectionComponentEntity.getComponent(BlockSelectionComponent.class);
-
             if (blockSelectionComponent != null && blockSelectionComponent.isMovable) {
                 blockSelectionComponentEntity.send(new MovableSelectionEndEvent(blockSelectionComponent.currentSelection));
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fix for two NPEs thrown by the `LocalPlayerBlockSelectionByItemSystem`:
- When the cam target had no `LocationComponent`, for eg: when the player is looking up at the sky
- When `onLeftMouseButtonDown` event was not triggered after a selection had been made, in which case the `blockSelectionComponentEntity` would be null

