### PR TITLE
Use TypeInfo to store value type in Setting

### DIFF
--- a/engine-tests/src/test/java/org/terasology/config/flexible/internal/SettingImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/config/flexible/internal/SettingImplTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.terasology.config.flexible.Setting;
 import org.terasology.config.flexible.constraints.NumberRangeConstraint;
 import org.terasology.engine.SimpleUri;
+import org.terasology.reflection.TypeInfo;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
 
@@ -41,7 +42,7 @@ public class SettingImplTest {
         @Before
         public void setUp() {
             setting = new SettingImpl<>(SETTING_ID,
-                    50,
+                TypeInfo.of(Integer.class), 50,
                     new NumberRangeConstraint<>(0, 100, false, false),
                     "", "");
 
@@ -75,7 +76,7 @@ public class SettingImplTest {
         @Before
         public void setUp() {
             setting = new SettingImpl<>(SETTING_ID,
-                    50,
+                TypeInfo.of(Integer.class), 50,
                     new NumberRangeConstraint<>(0, 100, false, false),
                     "", "");
 

--- a/engine/src/main/java/org/terasology/config/flexible/Setting.java
+++ b/engine/src/main/java/org/terasology/config/flexible/Setting.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonElement;
 import org.terasology.config.flexible.constraints.SettingConstraint;
 import org.terasology.engine.SimpleUri;
 import org.terasology.module.sandbox.API;
+import org.terasology.reflection.TypeInfo;
 
 import java.beans.PropertyChangeListener;
 
@@ -36,10 +37,10 @@ public interface Setting<T> {
     SimpleUri getId();
 
     /**
-     * Returns a {@link Class} representing the type of values that can be stored in this
+     * Returns a {@link TypeInfo} representing the type of values that can be stored in this
      * {@link Setting}.
      */
-    Class<T> getValueClass();
+    TypeInfo<T> getValueType();
 
     /**
      * Returns the {@link SettingConstraint} used by this {@link Setting}, if present.

--- a/engine/src/main/java/org/terasology/config/flexible/internal/FlexibleConfigImpl.java
+++ b/engine/src/main/java/org/terasology/config/flexible/internal/FlexibleConfigImpl.java
@@ -27,6 +27,7 @@ import org.terasology.config.flexible.FlexibleConfig;
 import org.terasology.config.flexible.Setting;
 import org.terasology.config.flexible.constraints.SettingConstraint;
 import org.terasology.engine.SimpleUri;
+import org.terasology.reflection.TypeInfo;
 
 import java.io.Reader;
 import java.io.Writer;
@@ -56,7 +57,7 @@ class FlexibleConfigImpl implements FlexibleConfig {
      */
     @Override
     public <V> SettingEntry<V> newSetting(SimpleUri id, Class<V> valueType) {
-        return new SettingImplEntry<>(id);
+        return new SettingImplEntry<>(id, TypeInfo.of(valueType));
     }
 
     /**
@@ -90,7 +91,7 @@ class FlexibleConfigImpl implements FlexibleConfig {
             return null;
         }
 
-        Class settingValueClass = setting.getValueClass();
+        Class settingValueClass = setting.getValueType().getRawType();
 
         if (!settingValueClass.equals(valueType)) {
             throw new ClassCastException(
@@ -173,9 +174,11 @@ class FlexibleConfigImpl implements FlexibleConfig {
         private SettingConstraint<T> constraint;
         private String humanReadableName = "";
         private String description = "";
+        private TypeInfo<T> valueType;
 
-        private SettingImplEntry(SimpleUri id) {
+        private SettingImplEntry(SimpleUri id, TypeInfo<T> valueType) {
             this.id = id;
+            this.valueType = valueType;
         }
 
         @Override
@@ -209,7 +212,7 @@ class FlexibleConfigImpl implements FlexibleConfig {
         @Override
         public boolean addToConfig() {
             SettingImpl<T> setting = new SettingImpl<>(
-                    id, defaultValue, constraint, humanReadableName, description
+                    id, valueType, defaultValue, constraint, humanReadableName, description
             );
 
             if (id == null) {

--- a/engine/src/main/java/org/terasology/config/flexible/internal/SettingImpl.java
+++ b/engine/src/main/java/org/terasology/config/flexible/internal/SettingImpl.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.config.flexible.Setting;
 import org.terasology.config.flexible.constraints.SettingConstraint;
 import org.terasology.engine.SimpleUri;
+import org.terasology.reflection.TypeInfo;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -44,7 +45,7 @@ class SettingImpl<T> implements Setting<T> {
     private final String warningFormatString;
 
     private final T defaultValue;
-    private final Class<T> valueClass;
+    private final TypeInfo<T> valueType;
 
     private final String humanReadableName;
     private final String description;
@@ -56,17 +57,17 @@ class SettingImpl<T> implements Setting<T> {
 
     /**
      * Creates a new {@link SettingImpl} with the given id, default value and constraint.
-     *
-     * @param id                The id of the setting.
+     *  @param id                The id of the setting.
+     * @param valueType
      * @param defaultValue      The default value of the setting.
      * @param constraint        The constraint that the setting values must satisfy.
      * @param humanReadableName The human readable name of the setting.
      * @param description       A description of the setting.
      */
-    @SuppressWarnings("unchecked")
-    SettingImpl(SimpleUri id, T defaultValue, SettingConstraint<T> constraint,
+    SettingImpl(SimpleUri id, TypeInfo<T> valueType, T defaultValue, SettingConstraint<T> constraint,
                 String humanReadableName, String description) {
         this.id = id;
+        this.valueType = valueType;
         this.humanReadableName = humanReadableName;
         this.description = description;
 
@@ -83,7 +84,6 @@ class SettingImpl<T> implements Setting<T> {
 
         this.defaultValue = defaultValue;
         this.value = this.defaultValue;
-        this.valueClass = (Class<T>) defaultValue.getClass();
     }
 
     private String formatWarning(String s) {
@@ -157,8 +157,8 @@ class SettingImpl<T> implements Setting<T> {
     }
 
     @Override
-    public Class<T> getValueClass() {
-        return valueClass;
+    public TypeInfo<T> getValueType() {
+        return valueType;
     }
 
     /**
@@ -221,7 +221,7 @@ class SettingImpl<T> implements Setting<T> {
 
     @Override
     public void setValueFromJson(String json) {
-        value = GSON.fromJson(json, valueClass);
+        value = GSON.fromJson(json, valueType.getRawType());
     }
 
     @Override


### PR DESCRIPTION
The value type is stored as a `TypeInfo` which stores information like generic parameters. The `FlexibleConfig` API remains unchanged for now -- the `FlexibleConfig.newSetting` method still takes a `Class` parameter.