### PR TITLE
Small Improvement for handling Paths on Windows for module classloading

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 
 public class ModuleManagerImpl implements ModuleManager {
     private static final Logger logger = LoggerFactory.getLogger(ModuleManagerImpl.class);
@@ -160,17 +159,24 @@ public class ModuleManagerImpl implements ModuleManager {
                     if (null == id || displayName.equalsIgnoreCase("")) {
                         logger.warn("Found a module-like JAR on the class path with no id or display name. Skipping");
                         logger.warn("{}", url);
+                        continue;
                     }
 
                     logger.info("Loading module {} from class path at {}", displayName, url.getFile());
 
                     // the url contains a protocol, and points to the module.txt
                     // we need to trim both of those away to get the module's path
-                    Path path = Paths.get(url.getFile()
+                    String targetFile = url.getFile()
                             .replace("file:", "")
                             .replace("!/" + TerasologyConstants.MODULE_INFO_FILENAME, "")
-                            .replace("/" + TerasologyConstants.MODULE_INFO_FILENAME, "")
-                    );
+                            .replace("/" + TerasologyConstants.MODULE_INFO_FILENAME, "");
+
+                    // Windows specific check - Path doesn't like /C:/... style Strings indicating files
+                    if (targetFile.matches("/[a-zA-Z]:.*")) {
+                        targetFile = targetFile.substring(1);
+                    }
+
+                    Path path = Paths.get(targetFile);
 
                     Module module = loader.load(path);
                     registry.add(module);


### PR DESCRIPTION
### Contains

A possible tiny improvement to how classpath entries are processed for modules specifically on Windows. While chasing mysteries for https://github.com/Terasology/DynamicCities/pull/40 I discovered that in a brand new mini-workspace with _just_ DynamicCities added I got a weird error about loading jar files instead of the original issue I posted to that DC PR.

The problem was specific to Strings referring to jar files starting with something like `/C:/...` which did not gracefully turn into `Path` objects. Chances are that I haven't hit that in my mega-workspace as I have _every_ relevant module in source form so I never end up loading modules from jars, let alone specifically while running MTE tests - and it may be specific to MTE tests somehow? Unsure.

After applying this fix I could run the tests in DC's `RegionEntitiesTest` successfully in the mini-workspace. However, it still failed with the original error in my mega-workspace even with this PR in place. I kept adding pieces to the mini-workspace and finally reproduced the error again with a much larger module load. So there's still another piece to the puzzle, probably still related to classpath stuff (sandbox denial of a class from another module? Huh), but not necessarily directly related to this fix.

Alternative fixes are possible - you could feed the "bad" String to `new File` and it would figure it out easily enough, tested that and just passed in a `toString` from the `File`. Actually kinda disappointed that `Path` isn't doing that automatically, unless I'm missing some obvious way to normalize. To avoid bringing in `File` I just regexed a little pattern to find this case and take off the leading slash. Incidentally https://regex101.com is handy

I also noticed an odd bit of error handling talking about skipping an entry, then never actually skipping it. So I added a `continue;` there - probably it just never happened or got noticed before.

### How to test

Without this PR first add https://github.com/Terasology/DynamicCities to a tiny workspace *on Windows* and attempt to run the tests from `RegionEntitiesTest` - with a little luck they'll fail, but over a failure to work with jar files. If you hit `Denied access to class (not allowed with this module's permissions): org.terasology.cities.BlockType` you hit the second layer error instead.

Pull this PR, retry, see if the tests now pass. The error before the fix should look something like the following:

```
:12:34.833 [main] ERROR o.terasology.engine.TerasologyEngine - Failed to initialise Terasology
java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Users/cerva/.gradle/caches/modules-2/files-2.1/org.terasology.modules/Inventory/1.0.0-SNAPSHOT/6ca35c4d9f0300c5a5cba9d5cc4d263c23bd38bd/Inventory-1.0.0-SNAPSHOT.jar
	at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
	at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
	at java.nio.file.Paths.get(Paths.java:84)
	at org.terasology.engine.module.ModuleManagerImpl.loadModulesFromClassPath(ModuleManagerImpl.java:169)
...
```

Worth noting: Inventory is a dependency of Core, which gets skipped when recursively fetching modules in source form. So my mini workspace after the `groovyw recurse` command listed below still lacks Inventory as source. I'm not sure if that plays a bigger role in all this - Core was dependency-less until fairly recently and treated as a special case, now it has several.

### Outstanding before merging

* Is this the most ideal fix?
* Might there be more we can do to also fix https://github.com/Terasology/DynamicCities/pull/40/files in a _large_ workspace of whatever configuration triggers that issue? It almost certainly is a more fundamental issue with the MTE (or engine) rather than an issue with that test.
  * Simply adding Cities as a dependency in the MTE setup didn't help
  * I noticed that both Cities and StaticCities have a copy of `BlockType` and a bunch of others - SC got cloned a bit more than I had expected. 
    * Deleting and redirecting that copy to Cities didn't fix the issue. 
    * Nor did adding both Cities + StaticCities to the mini workspace _cause_ the issue, although I'm not entirely sure how thoroughly I did that. 
    * It took `groovyw module recurse LightAndShadow joshariassurvival gooeysquests neotta polyworld metalrenegades gookeeper gooeydefence medievalcities ` to provoke it for sure - could likely reduce that list to narrow it down further.

Going to ping @kaen separately (haven't got in the review box) along with @eviltak as a highlight as we finally may have a good reproducible use case that shows a quirk with the MTE :-)