### PR TITLE
Bump Gradle to latest 4.x

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jan 27 18:22:28 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
Seems to work OK in my mega-workspace. Should resolve an issue where you might fail to compile the game with a Java too new for our prior version of Gradle 4.x. Gradle 5.x on the other hand is bound to bring in a lot more change.

Also tested it with a sample `groovyw get` module check. Anybody else want to see if they can come up with something Gradle-related that'll break with this?

Will see if Jenkins builds this OK as well. Probably can merge pretty soon. Pinging @pollend for review, maybe anybody else with a mega-workspace and interest, like @jellysnake @eviltak @Qwertygiy  or somebody :-)