### PR TITLE
Fix crash on certain environments

### DIFF
--- a/engine/src/main/java/org/terasology/reflection/TypeRegistry.java
+++ b/engine/src/main/java/org/terasology/reflection/TypeRegistry.java
@@ -110,7 +110,6 @@ public class TypeRegistry {
                         .toArray(ClassLoader[]::new)
                 ))
                 .filterInputsBy(TypeRegistry::filterWhitelistedTypes)
-                .useParallelExecutor()
         );
 
     }


### PR DESCRIPTION
Fix #3745 
Removing this line fixes a crash for certain users with no obvious repercussions.
From my very limited research, I think that all the line did was tell reflections to run on multiple threads which, although nice, is not worth causing crashes for some users. It also might not at all be what it's doing so I'll create an issue to investigate this.