### PR TITLE
Fixes Game Details screen by restoring Worlds & Biomes page

### DIFF
--- a/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/gameDetailsScreen.ui
@@ -227,6 +227,55 @@
                                     },
                                     {
                                         "type":"RelativeLayout",
+                                        "id": "page2",
+                                        "layoutInfo": {
+                                            "use-content-height": true,
+                                            "position-horizontal-center": {},
+                                            "position-top": {
+                                                "target": "TOP"
+                                            }
+                                        },
+                                        "contents": [
+                                            {
+                                                "type": "ScrollableArea",
+                                                "skin": "mainmenu",
+                                                "family": "biome-list",
+                                                "content": {
+                                                    "type": "ColumnLayout",
+                                                    "columns": 1,
+                                                    "layoutInfo": {
+                                                    },
+                                                    "contents": [
+                                                        {
+                                                            "type": "UILabel",
+                                                            "family": "subheading",
+                                                            "text": "${engine:menu#game-details-worlds}"
+                                                        },
+                                                        {
+                                                            "type": "UIList",
+                                                            "id": "worlds"
+                                                        },
+                                                        {
+                                                            "type": "UILabel",
+                                                            "family": "subheading",
+                                                            "text": "${engine:menu#game-details-biomes}"
+                                                        },
+                                                        {
+                                                            "type": "UIList",
+                                                            "id": "biomes"
+                                                        }
+                                                    ]
+                                                },
+                                                "layoutInfo": {
+                                                    "position-top": {
+                                                        "target": "TOP"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type":"RelativeLayout",
                                         "id": "page3",
                                         "layoutInfo": {
                                             "use-content-height": true,


### PR DESCRIPTION
Partially reverts ff190cf3e59f8e1a59b6d59ddec2a63dd71071ee which removed page2 from the UI, breaking the screen entirely. 

The Biomes section of the UI will remain non-functional until a new implementation is made using BiomesAPI, but it is now merely an empty label, rather than erroring the entire screen.

To test, create any singleplayer world, return to main menu, and then click the "Details" button on that world. It should show the modules and blocks used in that world without creating an error popup.