### PR TITLE
Adjustments to Block Updates

### DIFF
--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -148,11 +148,13 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
         if (forceEntityUpdate || !(Objects.equal(oldType.getBlockFamily(), type.getBlockFamily()) && Objects.equal(oldType.getPrefab(), type.getPrefab()))) {
             updateBlockEntityComponents(blockEntity, oldType, type, retainComponents);
         }
+
+        OnChangedBlock changedEvent = new OnChangedBlock(pos, type, oldType);
         EntityRef regionEntity = blockRegionLookup.get(pos);
         if (regionEntity != null) {
-            regionEntity.send(new OnChangedBlock(pos, type, oldType));
+            regionEntity.send(changedEvent);
         }
-        blockEntity.send(new OnChangedBlock(new Vector3i(pos), type, oldType));
+        blockEntity.send(changedEvent);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -28,6 +28,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.world.OnChangedBlock;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.block.Block;
@@ -266,6 +267,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 listener.onBlockChanged(pos, type, oldType);
             }
         }
+        type.getEntity().send(new OnChangedBlock(pos, type, oldType));
     }
     
     private void notifyExtraDataChanged(int index, Vector3i pos, int newData, int oldData) {


### PR DESCRIPTION
Previously, the OnChangedBlock event was not being created when blocks were placed by the player.

Additionally, the event sent to the block *region* was separate from the event sent to the *block.*

This PR corrects those two problems with minimal changes to the codebase. It should solve Terasology/SimpleLiquids#4

Wider-reaching changes, such as fully replacing usage of the BlockChange class with the OnChangedBlock event, should remain within the scope of a separate PR.