### PR TITLE
Use simpler german translation for "seed"

### DIFF
--- a/engine/src/main/resources/assets/i18n/menu_de.lang
+++ b/engine/src/main/resources/assets/i18n/menu_de.lang
@@ -248,5 +248,5 @@
     "widget-selection-prompt": "Bitte wähle ein Widget aus:",
     "widget-selection-title": "Widget-Auswahl",
     "world-config-preview": "Details ...",
-    "world-seed": "Unikale Weltensaat (Seed)"
+    "world-seed": "Seed"
 }


### PR DESCRIPTION
### Contains
Replaces the current german translation for "seed" which is "Unikale Weltensaat" with "Seed".
The reason is that the current translation sounds very niminy-piminy and most german people who ever came in touch with gaming or generators in the gaming context know what a "seed" is.

### How to test
Start the game with german language and go to advanced world generation. Check seed field description to say "Seed".