### PR TITLE
Add hard references to tree blocks in initialize stage

### DIFF
--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/TreeRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/TreeRasterizer.java
@@ -43,6 +43,15 @@ public class TreeRasterizer implements WorldRasterizer {
     @Override
     public void initialize() {
         blockManager = CoreRegistry.get(BlockManager.class);
+        //TODO: Remove these lines when lazy block registration is fixed
+        //Currently they are required to ensure that the blocks are all registered before worldgen
+        blockManager.getBlock("CoreBlocks:OakTrunk");
+        blockManager.getBlock("CoreBlocks:PineTrunk");
+        blockManager.getBlock("CoreBlocks:BirchTrunk");
+        blockManager.getBlock("CoreBlocks:GreenLeaf");
+        blockManager.getBlock("CoreBlocks:DarkLeaf");
+        blockManager.getBlock("CoreBlocks:RedLeaf");
+        blockManager.getBlock("CoreBlocks:Cactus");
     }
 
     @Override


### PR DESCRIPTION
### Contains

Adds hard references to the blocks used by the Core tree rasterizer during the initialize stage, rather than waiting for lazy loading during generation. This fixes #3740 

### How to test

Open Josharias Survival and find trees. If they have leaves, it works.