### PR TITLE
Upgrade Artifactory plugin to fix compatibility issue with latest Gradle version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 
     dependencies {
         // Artifactory plugin
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.0.0')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.10.0')
 
         // Git plugin for Gradle
         classpath 'org.ajoberstar:gradle-git:0.6.3'


### PR DESCRIPTION
The engine Jenkins build started failing after #3743, the minor Gradle upgrade. At least that's my theory based on logging in Jenkins. With this version bump to the associated Artifactory plugin for Gradle it publishes normally again, at least locally. PR test won't show it (no publish step) so this PR is for doc purposes and will be merged immediately to test the fix in Jenkins.