### PR TITLE
Feature: Read shaders from source folder on recompile by Loonride

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessShader.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessShader.java
@@ -33,6 +33,11 @@ public class HeadlessShader extends Shader {
     }
 
     @Override
+    public void nonInitialRecompile() {
+        // do nothing
+    }
+
+    @Override
     public void recompile() {
         // do nothing
     }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessShader.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/assets/HeadlessShader.java
@@ -33,11 +33,6 @@ public class HeadlessShader extends Shader {
     }
 
     @Override
-    public void nonInitialRecompile() {
-        // do nothing
-    }
-
-    @Override
     public void recompile() {
         // do nothing
     }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/ShaderManagerHeadless.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/ShaderManagerHeadless.java
@@ -43,7 +43,7 @@ public class ShaderManagerHeadless implements ShaderManager {
     }
 
     @Override
-    public void recompileAllShaders() {
+    public void recompileAllShaders(boolean development) {
         // Do nothing
     }
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/ShaderManagerHeadless.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/ShaderManagerHeadless.java
@@ -43,7 +43,7 @@ public class ShaderManagerHeadless implements ShaderManager {
     }
 
     @Override
-    public void recompileAllShaders(boolean development) {
+    public void recompileAllShaders(boolean fromSource) {
         // Do nothing
     }
 

--- a/engine/src/main/java/org/terasology/rendering/ShaderManager.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManager.java
@@ -28,7 +28,16 @@ public interface ShaderManager {
 
     Material getActiveMaterial();
 
-    void recompileAllShaders();
+    default void recompileAllShaders() {
+        recompileAllShaders(false);
+    }
+
+    /**
+     * Shader recompilation that considers if the recompilation is for development
+     * purposes or not, allowing to change what the source of the shaders is
+     * @param development whether this recompile is for development purposes
+     */
+    void recompileAllShaders(boolean development);
 
     /**
      * Enables the default shader program.

--- a/engine/src/main/java/org/terasology/rendering/ShaderManager.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManager.java
@@ -35,9 +35,9 @@ public interface ShaderManager {
     /**
      * Shader recompilation that considers if the recompilation is for development
      * purposes or not, allowing to change what the source of the shaders is
-     * @param development whether this recompile is for development purposes
+     * @param fromSource whether this recompile reads files from source folder. True - from source. False - from build.
      */
-    void recompileAllShaders(boolean development);
+    void recompileAllShaders(boolean fromSource);
 
     /**
      * Enables the default shader program.

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -139,8 +139,7 @@ public class ShaderManagerLwjgl implements ShaderManager {
         AssetManager assetManager = CoreRegistry.get(AssetManager.class);
         if (development) {
             assetManager.getLoadedAssets(Shader.class).forEach(Shader::developmentRecompile);
-        }
-        else {
+        } else {
             assetManager.getLoadedAssets(Shader.class).forEach(Shader::recompile);
         }
 

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -135,11 +135,14 @@ public class ShaderManagerLwjgl implements ShaderManager {
     }
 
     @Override
-    public void recompileAllShaders() {
+    public void recompileAllShaders(boolean development) {
         AssetManager assetManager = CoreRegistry.get(AssetManager.class);
-        // call nonInitialRecompile since recompileAllShaders method should only be called
-        // after initial load/compile of all the shaders
-        assetManager.getLoadedAssets(Shader.class).forEach(Shader::nonInitialRecompile);
+        if (development) {
+            assetManager.getLoadedAssets(Shader.class).forEach(Shader::developmentRecompile);
+        }
+        else {
+            assetManager.getLoadedAssets(Shader.class).forEach(Shader::recompile);
+        }
 
         assetManager.getLoadedAssets(Material.class).forEach(Material::recompile);
 

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -135,10 +135,10 @@ public class ShaderManagerLwjgl implements ShaderManager {
     }
 
     @Override
-    public void recompileAllShaders(boolean development) {
+    public void recompileAllShaders(boolean fromSource) {
         AssetManager assetManager = CoreRegistry.get(AssetManager.class);
-        if (development) {
-            assetManager.getLoadedAssets(Shader.class).forEach(Shader::developmentRecompile);
+        if (fromSource) {
+            assetManager.getLoadedAssets(Shader.class).forEach(Shader::recompileFromSource);
         } else {
             assetManager.getLoadedAssets(Shader.class).forEach(Shader::recompile);
         }

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -137,7 +137,9 @@ public class ShaderManagerLwjgl implements ShaderManager {
     @Override
     public void recompileAllShaders() {
         AssetManager assetManager = CoreRegistry.get(AssetManager.class);
-        assetManager.getLoadedAssets(Shader.class).forEach(Shader::recompile);
+        // call nonInitialRecompile since recompileAllShaders method should only be called
+        // after initial load/compile of all the shaders
+        assetManager.getLoadedAssets(Shader.class).forEach(Shader::nonInitialRecompile);
 
         assetManager.getLoadedAssets(Material.class).forEach(Material::recompile);
 

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/GLSLShaderFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/GLSLShaderFormat.java
@@ -31,9 +31,7 @@ import org.terasology.assets.format.AssetFileFormat;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.naming.Name;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.file.PathMatcher;
 import java.util.List;
@@ -75,18 +73,23 @@ public class GLSLShaderFormat implements AssetFileFormat<ShaderData> {
         String vertProgram = null;
         String fragProgram = null;
         ShaderMetadata metadata = new ShaderMetadata();
+        AssetDataFile vertFile = null;
+        AssetDataFile fragFile = null;
 
         for (AssetDataFile input : inputs) {
             if (input.getFilename().endsWith(VERTEX_SUFFIX)) {
                 vertProgram = readInput(input);
+                vertFile = input;
+
             } else if (input.getFilename().endsWith(FRAGMENT_SUFFIX)) {
                 fragProgram = readInput(input);
+                fragFile = input;
             } else {
                 metadata = readMetadata(input);
             }
         }
         if (vertProgram != null && fragProgram != null) {
-            return new ShaderData(vertProgram, fragProgram, metadata.getParameters());
+            return new ShaderData(vertProgram, fragProgram, metadata.getParameters(), vertFile, fragFile);
         }
         throw new IOException("Failed to load shader '" + urn + "' - missing vertex or fragment program");
     }

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/GLSLShaderFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/GLSLShaderFormat.java
@@ -31,7 +31,9 @@ import org.terasology.assets.format.AssetFileFormat;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.naming.Name;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.Type;
 import java.nio.file.PathMatcher;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/Shader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/Shader.java
@@ -29,16 +29,16 @@ public abstract class Shader extends Asset<ShaderData> {
     }
 
     /**
-     * Recompiles the shader for development purposes. This allows for behavior to change when
+     * Recompiles the shader from source asset folder. This allows for behavior to change when
      * the recompileShaders command is used in the game, ie. recompiling shaders from the
      * source folder rather than the build folder
      */
-    public void developmentRecompile() {
+    public void recompileFromSource() {
         recompile();
     }
 
     /**
-     * Recompiles the shader
+     * Recompiles the shader from build asset folder.
      */
     public abstract void recompile();
 

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/Shader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/Shader.java
@@ -29,12 +29,13 @@ public abstract class Shader extends Asset<ShaderData> {
     }
 
     /**
-     * Recompiles the shader, but only to be used after the initial load and compilation
-     * of a shader. This allows for behavior to change on subsequent recompiles of a shader,
-     * specifically so that the shader can come from the build folder on the first compile,
-     * but will be loaded from source folder on subsequent recompiles
+     * Recompiles the shader for development purposes. This allows for behavior to change when
+     * the recompileShaders command is used in the game, ie. recompiling shaders from the
+     * source folder rather than the build folder
      */
-    public abstract void nonInitialRecompile();
+    public void developmentRecompile() {
+        recompile();
+    }
 
     /**
      * Recompiles the shader

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/Shader.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/Shader.java
@@ -29,6 +29,14 @@ public abstract class Shader extends Asset<ShaderData> {
     }
 
     /**
+     * Recompiles the shader, but only to be used after the initial load and compilation
+     * of a shader. This allows for behavior to change on subsequent recompiles of a shader,
+     * specifically so that the shader can come from the build folder on the first compile,
+     * but will be loaded from source folder on subsequent recompiles
+     */
+    public abstract void nonInitialRecompile();
+
+    /**
      * Recompiles the shader
      */
     public abstract void recompile();

--- a/engine/src/main/java/org/terasology/rendering/assets/shader/ShaderData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/shader/ShaderData.java
@@ -15,9 +15,15 @@
  */
 package org.terasology.rendering.assets.shader;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
 import org.terasology.assets.AssetData;
+import org.terasology.assets.format.AssetDataFile;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 
 /**
@@ -27,11 +33,15 @@ public class ShaderData implements AssetData {
     private String vertexProgram;
     private String fragmentProgram;
     private List<ShaderParameterMetadata> parameterMetadata;
+    private AssetDataFile vertexFile;
+    private AssetDataFile fragmentFile;
 
-    public ShaderData(String vertexProgram, String fragmentProgram, List<ShaderParameterMetadata> parameterMetadata) {
+    public ShaderData(String vertexProgram, String fragmentProgram, List<ShaderParameterMetadata> parameterMetadata, AssetDataFile vertexFile, AssetDataFile fragmentFile) {
         this.vertexProgram = vertexProgram;
         this.fragmentProgram = fragmentProgram;
         this.parameterMetadata = ImmutableList.copyOf(parameterMetadata);
+        this.vertexFile = vertexFile;
+        this.fragmentFile = fragmentFile;
     }
 
     public String getVertexProgram() {
@@ -44,5 +54,49 @@ public class ShaderData implements AssetData {
 
     public List<ShaderParameterMetadata> getParameterMetadata() {
         return parameterMetadata;
+    }
+
+    /**
+     * Reload the shader data from the source development folder, circumventing the Gestalt
+     * filesystem in order to make it easier to develop shaders
+     * @throws IOException
+     */
+    public void reloadFromSource() throws IOException {
+        vertexProgram = readSourceFile(vertexFile);
+        fragmentProgram = readSourceFile(fragmentFile);
+        // metadata was not included here because it is small element and does not
+        // give much benefit for reloading from source
+    }
+
+    /**
+     * Reads shader from the source folder, rather than the shader in the build folder,
+     * allowing developers to do hot reloading of shaders during shader development in the source folder,
+     * rather than the temporary build folder.
+     * A somewhat hacky approach which does not use the Gestalt filesystem to load the asset
+     * @param input Gestalt asset data file, used to get filename and path
+     * @return shader program string
+     * @throws IOException if thrown, this probably means the file was deleted, or there is no src folder
+     */
+    private String readSourceFile(AssetDataFile input) throws IOException {
+        // TODO: consider overwriting existing build file with source file read here
+
+        List<String> inputPath = input.getPath();
+        inputPath.remove(0);
+        String pathToShaderSource = "engine/src/main/resources/" + String.join("/", inputPath) + "/";
+        String fullPath = pathToShaderSource + input.getFilename();
+
+        return readFile(fullPath);
+    }
+
+    /**
+     * Read file given path
+     * @param path path string
+     * @return contents of file
+     * @throws IOException
+     */
+    private String readFile(String path) throws IOException {
+        try (InputStreamReader reader = new InputStreamReader(new FileInputStream(path), Charsets.UTF_8)) {
+            return CharStreams.toString(reader);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -125,6 +125,19 @@ public class GLSLShader extends Shader {
     }
 
     @Override
+    public void nonInitialRecompile() {
+        // try to load the shaders from the source folder, not the build folder,
+        // on recompiles caused by the recompileShaders command
+        try {
+            shaderProgramBase.reloadFromSource();
+        }
+        catch (IOException e) {
+            logger.warn("Shader source files not found for {}", getUrn());
+        }
+        recompile();
+    }
+
+    @Override
     public void recompile() {
         registerAllShaderPermutations();
         // TODO: reload materials

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -130,8 +130,7 @@ public class GLSLShader extends Shader {
         // on recompiles caused by the recompileShaders command
         try {
             shaderProgramBase.reloadFromSource();
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             logger.warn("Shader source files not found for {}", getUrn());
         }
         recompile();

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -125,7 +125,7 @@ public class GLSLShader extends Shader {
     }
 
     @Override
-    public void nonInitialRecompile() {
+    public void developmentRecompile() {
         // try to load the shaders from the source folder, not the build folder,
         // on recompiles caused by the recompileShaders command
         try {

--- a/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/GLSLShader.java
@@ -125,7 +125,7 @@ public class GLSLShader extends Shader {
     }
 
     @Override
-    public void developmentRecompile() {
+    public void recompileFromSource() {
         // try to load the shaders from the source folder, not the build folder,
         // on recompiles caused by the recompileShaders command
         try {

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -787,7 +787,10 @@ public final class WorldRendererImpl implements WorldRenderer {
     @Command(shortDescription = "Forces a recompilation of shaders.", requiredPermission = PermissionManager.NO_PERMISSION)
     public void recompileShaders() {
         console.addMessage("Recompiling shaders... ", false);
-        shaderManager.recompileAllShaders();
+        // if this command is used in game, it means the user is developing shaders
+        // so we should try to load and compile then from the source directory this time,
+        // which is what happens when development is set to true for recompileAllShaders
+        shaderManager.recompileAllShaders(true);
         console.addMessage("done!");
     }
 


### PR DESCRIPTION
Continuation of Loonride's #3658.

@eviltak mentioned there was 

> a couple of questions about how the `development` flag is being handled in the PR.

This PR suggests following changes :
Rename boolean 'development' to 'fromSource' for ShaderManager(headless/-/impl)'s recompileAllShaders(bool fromSource) and rename Shader.developmentRecompile() to [GLSL/-]Shader.recompileFromSource()

_I think it's preferable to name methods based on what they do rather than what they are used for. Especially since the latter is not self-explanatory (hence the variable rename, to be aligned with the method name and more self-explanatory)._ 

Legacy #3658 PR's description:
> Contains
> When the recompileShaders command was run in the game in the past, it would use the shader files in the build folder, not the source folder. This made it harder to develop and test shaders. This PR introduces a somewhat hacky method to force loading of shader files from the source folder upon recompile. It will not do this on initial compilation, since most users and players will not be using this feature, or possibly will not have the local src folder. If the recompileShaders command is run without the proper src folder, or with a file missing, loading from the source folder for that particular file will simply not happen.
> 
> How to test
> Start the game
> Change something in the shader source folder
> run recompileShaders command and see the shader change
> Outstanding before merging
> I did not implement this for metadata, because it is such a small feature, unlikely to be useful when recompiling
> I considered making the loaded file info from the source folder overwrite the build folder files, but decided against it in case someone accidentally starts making changes in the build folder and realizes their mistake (functionally there is no difference between it being overwritten or not overwritten)
> The source file loading happens in the ShaderData class. The class was not designed for loading the data, but I think it is the best intermediary between the GLSLShader and the GLSLShaderFormat, which is usually responsible for the loading but I don't believe is reachable in any way to be used for this use case.