### PR TITLE
Update Core build.gradle artifactory plugin for new gradle

### DIFF
--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
     dependencies {
         // Artifactory plugin
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.0.0')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.10.0')
 
         // Git plugin for Gradle
         classpath 'org.ajoberstar:gradle-git:0.6.3'


### PR DESCRIPTION
Upgrades the artifactory plugin from 4.0.0 to 4.10.0 to fix Jenkins builds for the recent Gradle upgrade, as with #3764 