### PR TITLE
Improve logging in module update script

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -10,6 +10,8 @@ import org.ajoberstar.grgit.exception.GrgitException
 import org.ajoberstar.grgit.Remote
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 
+import static Ansi.*
+
 class common {
 
     /** For preparing an instance of the target item type utility class we want to work with */
@@ -185,10 +187,9 @@ class common {
      * @param itemName the name of the item to update
      */
     def updateItem(String itemName) {
-        println "Attempting to update $itemType $itemName"
         File targetDir = new File(targetDirectory, itemName)
         if (!targetDir.exists()) {
-            println "$itemType \"$itemName\" not found"
+            println color("$itemType \"$itemName\" not found", Ansi.RED)
             return
         }
         try {
@@ -200,26 +201,28 @@ class common {
                 it.name == defaultRemote
             }?.url
             if (targetUrl == null || !isUrlValid(targetUrl)) {
-                println "While updating $itemName found its '$defaultRemote' remote invalid or its URL unresponsive: $targetUrl"
+                println color("While updating $itemName found its '$defaultRemote' remote invalid or its URL unresponsive: $targetUrl", Ansi.RED)
                 return
             }
 
             // At this point we should have a valid remote to pull from. If local repo is clean then pull!
             def clean = itemGit.status().clean
-            println "Is \"$itemName\" clean? $clean"
-            if (!clean) {
-                println "$itemType has uncommitted changes. Skipping."
-                return
-            }
-            println "Updating $itemType $itemName"
+            def branchName = itemGit.branch.getCurrent().fullName
 
-            try {
-                itemGit.pull remote: defaultRemote
-            } catch (GrgitException exception) {
-                println "Unable to update $itemName, Skipping: ${exception.getMessage()}"
+            print "$itemType '$itemName' [$branchName]: "
+
+            if (!clean) {
+                println color("uncommitted changes. Skipping.", Ansi.YELLOW)
+            } else {
+                println color("updating $itemType $itemName", Ansi.GREEN)
+                try {
+                    itemGit.pull remote: defaultRemote
+                } catch (GrgitException exception) {
+                    println color("Unable to update $itemName, Skipping: ${exception.getMessage()}", Ansi.RED)
+                }
             }
         } catch(RepositoryNotFoundException exception) {
-            println "Skipping update for $itemName: no repository found (probably engine module)"
+            println color("Skipping update for $itemName: no repository found (probably engine module)", Ansi.LIGHT_YELLOW)
         }
     }
 
@@ -436,4 +439,45 @@ class common {
     void unCacheItemList() {
         itemListCached = false
     }
+}
+
+/**
+ * Small ANSI coloring utility.
+ * @see https://gist.github.com/tvinke/db4d21dfdbdae49e6f92dcf1ca6120de
+ * @see http://www.bluesock.org/~willg/dev/ansi.html
+ * @see https://gist.github.com/dainkaplan/4651352
+ */
+class Ansi {
+
+    static final String NORMAL          = "\u001B[0m"
+
+    static final String	BOLD            = "\u001B[1m"
+    static final String	ITALIC	        = "\u001B[3m"
+    static final String	UNDERLINE       = "\u001B[4m"
+    static final String	BLINK           = "\u001B[5m"
+    static final String	RAPID_BLINK	    = "\u001B[6m"
+    static final String	REVERSE_VIDEO   = "\u001B[7m"
+    static final String	INVISIBLE_TEXT  = "\u001B[8m"
+
+    static final String	BLACK           = "\u001B[30m"
+    static final String	RED             = "\u001B[31m"
+    static final String	GREEN           = "\u001B[32m"
+    static final String	YELLOW          = "\u001B[33m"
+    static final String	BLUE            = "\u001B[34m"
+    static final String	MAGENTA         = "\u001B[35m"
+    static final String	CYAN            = "\u001B[36m"
+    static final String	WHITE           = "\u001B[37m"
+
+    static final String	DARK_GRAY       = "\u001B[1;30m"
+    static final String	LIGHT_RED       = "\u001B[1;31m"
+    static final String	LIGHT_GREEN     = "\u001B[1;32m"
+    static final String LIGHT_YELLOW    = "\u001B[1;33m"
+    static final String	LIGHT_BLUE      = "\u001B[1;34m"
+    static final String	LIGHT_PURPLE    = "\u001B[1;35m"
+    static final String	LIGHT_CYAN      = "\u001B[1;36m"
+
+    static String color(String text, String ansiValue) {
+        ansiValue + text + NORMAL
+    }
+
 }


### PR DESCRIPTION
### Contains

Adds colored logging to `groovyw module update-all` and restructures the
logging output a bit. Overall, the noise is reduced, and the logged
messages now contain info about the branch that is currently checked
out.

![image](https://user-images.githubusercontent.com/1448874/67891567-1c781580-fb53-11e9-8da6-454ab70a2a30.png)

### How to test

Just run `./groovyw module update-all` in your workspace. Preferably, with modules in different states (clean, dirty), non-git modules, etc.

### Outstanding before merging

Nothing.
