### PR TITLE
Properly implement OnChangedBlock event for setBlocks() calls

### DIFF
--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -125,6 +125,21 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     }
 
     @Override
+    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
+        if (GameThread.isCurrentThread()) {
+            Map<Vector3i, Block> oldBlocks = super.setBlocks(blocks);
+            for (Vector3i vec : oldBlocks.keySet()) {
+                if (oldBlocks.get(vec) != null) {
+                    EntityRef blockEntity = getBlockEntityAt(vec);
+                    updateBlockEntity(blockEntity, vec, oldBlocks.get(vec), blocks.get(vec), false, Collections.<Class<? extends Component>>emptySet());
+                }
+            }
+            return oldBlocks;
+        }
+        return null;
+    }
+
+    @Override
     @SafeVarargs
     public final Block setBlockRetainComponent(Vector3i pos, Block type, Class<? extends Component>... components) {
         if (GameThread.isCurrentThread()) {

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -124,6 +124,10 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
         return null;
     }
 
+    //SetBlocks, not SetBlock, is currently triggered by the engine whenever a player places a block.
+    //This allows for several useful features, such as quickly synchronizing placement across networks.
+    //However, this means that even if only one block is placed, this is the method being called.
+    //It must be overridden here to allow an OnChangedBlock event to be properly sent for placed blocks.
     @Override
     public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
         if (GameThread.isCurrentThread()) {

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -267,7 +267,6 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 listener.onBlockChanged(pos, type, oldType);
             }
         }
-        type.getEntity().send(new OnChangedBlock(pos, type, oldType));
     }
     
     private void notifyExtraDataChanged(int index, Vector3i pos, int newData, int oldData) {


### PR DESCRIPTION
Previously, #3757 attempted to fix the lack of the OnChangedBlock event being called when a block was placed by the player.

For the specific use case being tested, where the listener did not care about a LocationComponent, it was sufficient. But upon further review, it was still not being properly issued. Instead of the event being sent to the *specific* world-block entity that was being updated, it was being sent to the block *type* entity.

This time, the event should be sent to the proper location, and is being sent from the proper world provider.