### PR TITLE
Optimize give command, reduce noise spam

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -338,9 +338,10 @@ public class BlockCommands extends BaseComponentSystem {
         }
 
         EntityRef playerEntity = client.getComponent(ClientComponent.class).character;
+        int stackLimit = blockFamily.getArchetypeBlock().isStackable() ? 99 : 1;
 
-        for (int quantityLeft = quantity; quantityLeft > 0; quantityLeft--) {
-            EntityRef item = blockItemFactory.newInstance(blockFamily, 1);
+        for (int quantityLeft = quantity; quantityLeft > 0; quantityLeft = quantityLeft - stackLimit) {
+            EntityRef item = blockItemFactory.newInstance(blockFamily, Math.min(quantity, stackLimit));
             if (!item.exists()) {
                 throw new IllegalArgumentException("Unknown block or item");
             }


### PR DESCRIPTION
The current implementation of the `give` command loops creates an item entity for every individual block or item, and sends an individual event for each item. This is a largely unnecessary loop, as the Inventory module is fully capable of handling arbitrarily large stacks. 

It also has the unwanted side effect of triggering the pickup-item sound many times consecutively, resulting in an absurdly loud and jarring noise whenever receiving the default 16 blocks.

This quick fix allows the give command to send as many blocks in one entity as is logical for that block; it is still only 1 item per event if the block s not stackable, but if it is stackable, it will group up to 99 together in each event, significantly reducing unnecessary overhead.

The remaining potential noise problem for unstackable objects or > 99 stackable objects should be handled separately as a change to the audio system.