### PR TITLE
Create LocationChangedEvent for moving entities

### DIFF
--- a/engine/src/main/java/org/terasology/logic/location/LocationChangedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationChangedEvent.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.location;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.BaseVector3f;
+import org.terasology.math.geom.ImmutableQuat4f;
+import org.terasology.math.geom.ImmutableVector3f;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
+
+public class LocationChangedEvent implements Event {
+    public final LocationComponent component;
+    public final ImmutableVector3f oldPosition;
+    public final ImmutableQuat4f oldRotation;
+    public final ImmutableVector3f newPosition;
+    public final ImmutableQuat4f newRotation;
+
+    public LocationChangedEvent(LocationComponent newLocation) {
+        this(newLocation, null, null, newLocation.position, newLocation.rotation);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition) {
+        this(newLocation, oPosition, null, newLocation.position, null);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition, Vector3f nPosition) {
+        this(newLocation, oPosition, null, nPosition, newLocation.rotation);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Quat4f oRotation) {
+        this(newLocation, null, oRotation, newLocation.position, newLocation.rotation);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Quat4f oRotation, Quat4f nRotation) {
+        this(newLocation, null, oRotation, newLocation.position, nRotation);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition, Quat4f oRotation) {
+        this(newLocation, oPosition, oRotation, newLocation.position, newLocation.rotation);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition, Quat4f oRotation, Vector3f nPosition) {
+        this(newLocation, oPosition, oRotation, nPosition, newLocation.rotation);
+    }
+
+    public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition, Quat4f oRotation, Quat4f nRotation)
+    {
+        this(newLocation, oPosition, oRotation, newLocation.position, nRotation);
+    }
+
+    public LocationChangedEvent(LocationComponent nComponent, Vector3f oPosition, Quat4f oRotation, Vector3f nPosition, Quat4f nRotation)
+    {
+        oldPosition = ImmutableVector3f.createOrUse(oPosition);
+        oldRotation = new ImmutableQuat4f(oRotation.x, oRotation.y, oRotation.z, oRotation.w);
+        newPosition = ImmutableVector3f.createOrUse(nPosition);
+        newRotation = new ImmutableQuat4f(nRotation.x, nRotation.y, nRotation.z, nRotation.w);;
+        component = nComponent;
+    }
+
+    public BaseVector3f vectorMoved()
+    {
+        return oldPosition != null ? newPosition.sub(oldPosition) : Vector3f.zero();
+    }
+
+    public float distanceMoved()
+    {
+        return oldPosition != null ? newPosition.distance(oldPosition) : 0.0F;
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/location/LocationChangedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationChangedEvent.java
@@ -30,23 +30,23 @@ public class LocationChangedEvent implements Event {
     public final ImmutableQuat4f newRotation;
 
     public LocationChangedEvent(LocationComponent newLocation) {
-        this(newLocation, null, null, newLocation.position, newLocation.rotation);
+        this(newLocation, newLocation.position, newLocation.rotation, newLocation.position, newLocation.rotation);
     }
 
     public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition) {
-        this(newLocation, oPosition, null, newLocation.position, null);
+        this(newLocation, oPosition, newLocation.rotation, newLocation.position, newLocation.rotation);
     }
 
     public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition, Vector3f nPosition) {
-        this(newLocation, oPosition, null, nPosition, newLocation.rotation);
+        this(newLocation, oPosition, newLocation.rotation, nPosition, newLocation.rotation);
     }
 
     public LocationChangedEvent(LocationComponent newLocation, Quat4f oRotation) {
-        this(newLocation, null, oRotation, newLocation.position, newLocation.rotation);
+        this(newLocation, newLocation.position, oRotation, newLocation.position, newLocation.rotation);
     }
 
     public LocationChangedEvent(LocationComponent newLocation, Quat4f oRotation, Quat4f nRotation) {
-        this(newLocation, null, oRotation, newLocation.position, nRotation);
+        this(newLocation, newLocation.position, oRotation, newLocation.position, nRotation);
     }
 
     public LocationChangedEvent(LocationComponent newLocation, Vector3f oPosition, Quat4f oRotation) {

--- a/engine/src/main/java/org/terasology/logic/location/LocationChangedSystem.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationChangedSystem.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.location;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class LocationChangedSystem extends BaseComponentSystem {
+    @ReceiveEvent(components = {LocationComponent.class})
+    public void onItemUpdate(OnChangedComponent event, EntityRef entity)
+    {
+        LocationComponent lc = entity.getComponent(LocationComponent.class);
+        if (!lc.lastPosition.equals(lc.position) || !lc.lastRotation.equals(lc.rotation))
+        {
+            entity.send(new LocationChangedEvent(lc, lc.lastPosition, lc.lastRotation));
+            lc.lastPosition.set(lc.position);
+            lc.lastRotation.set(lc.rotation);
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -53,12 +53,16 @@ public final class LocationComponent implements Component, ReplicationCheck {
     Quat4f rotation = new Quat4f(0, 0, 0, 1);
     @Replicate
     float scale = 1.0f;
+    @Replicate
+    Vector3f lastPosition = new Vector3f();
+    @Replicate
+    Quat4f lastRotation = new Quat4f(0,0,0,1);
 
     public LocationComponent() {
     }
 
     public LocationComponent(Vector3f position) {
-        this.position.set(position);
+        setLocalPosition(position);
     }
 
     /**
@@ -69,6 +73,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     public void setLocalPosition(Vector3f newPos) {
+        lastPosition.set(position);
         position.set(newPos);
     }
 
@@ -83,6 +88,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     public void setLocalRotation(Quat4f newQuat) {
+        lastRotation.set(rotation);
         rotation.set(newQuat);
     }
 
@@ -144,7 +150,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     public void setWorldPosition(Vector3f value) {
-        this.position.set(value);
+        setLocalPosition(value);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (parentLoc != null) {
             this.position.sub(parentLoc.getWorldPosition());
@@ -156,7 +162,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     public void setWorldRotation(Quat4f value) {
-        this.rotation.set(value);
+        setLocalRotation(value);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (parentLoc != null) {
             Quat4f worldRot = parentLoc.getWorldRotation();


### PR DESCRIPTION
### Contains
This PR adds two classes, LocationChangedEvent and LocationChangedSystem, as well as adds two variables to LocationComponent -- lastPosition and lastRotation.

This allows other systems to listen for a LocationChangedEvent to handle moving entities such as players, items, or creatures, without having to constantly check their own cache of previous locations.

### How to test
Create a class that implements BaseComponentSystem and subscribes for a LocationChangedEvent. It should trigger whenever a valid entity (such as the player or their camera) moves position or rotates.