### PR TITLE
Added gradle FlightRecorder profiling task

### DIFF
--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -101,6 +101,28 @@ task game(type:JavaExec) {
     classpath project(':engine').configurations.runtime
 }
 
+task profile(type:JavaExec) {
+    description = "Run 'Terasology' to play the game as a standard PC application (with Java FlightRecorder profiling)"
+
+    // Dependencies: natives + all modules & the PC facade itself (which will trigger the engine)
+    dependsOn rootProject.extractNatives
+    dependsOn rootProject.moduleClasses
+    dependsOn classes
+
+    // Run arguments
+    jvmArgs = ["-Xms256m", "-Xmx1536m", "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:StartFlightRecording=filename=terasology.jfr,dumponexit=true"]
+    main = mainClassName
+    workingDir = rootDir
+    String[] runArgs = ["-homedir"]
+    args runArgs
+
+    // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
+    classpath sourceSets.main.output.classesDir
+    classpath sourceSets.main.output.resourcesDir
+    classpath project(':engine').sourceSets.main.output.classesDir
+    classpath project(':engine').configurations.runtime
+}
+
 task debug(type:JavaExec) {
     description = "Run 'Terasology' to play the game as a standard PC application (in debug mode)"
 


### PR DESCRIPTION
This PR adds a gradle task for FlightRecorder profiling.

### Contains

This PR adds a `profile` task to gradle. It is equivalent to the IntelliJ IDEA configuration added by #3475. Running it generates a `terasology.jfr` file in the root project directory which can be opened with Java Mission Control and reviewed for performance enhancement. This is mainly for people who don't use IntelliJ (like me).

### How to test

Run `gradlew jar profile` to start the game with the profiler. Once the game is finished, the `terasology.jfr` file will be created in the root project directory and can be opened with Mission Control to make sure everything is working properly.
