### PR TITLE
Fix InputSystem#inputEntities sync with localPlayer's entities.

### DIFF
--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -155,8 +155,8 @@ public class InputSystem extends BaseComponentSystem {
                 || inputEntities.length != 2
                 || inputEntities[0] == null
                 || inputEntities[1] == null
-                || !inputEntities[0].equals(localPlayer.getClientEntity())
-                || !inputEntities[1].equals(localPlayer.getCharacterEntity())) {
+                || inputEntities[0] != localPlayer.getClientEntity()
+                || inputEntities[1] != localPlayer.getCharacterEntity()) {
             inputEntities = new EntityRef[]{localPlayer.getClientEntity(), localPlayer.getCharacterEntity()};
         }
     }


### PR DESCRIPTION
### Contains

Fixes #3768

### How to test

* Create and save a game and exit Terasology (e.g. LaS)
* Enforce a dependency issue for some module used in the game (e.g. adapt dependency version of LaS dependency)
* Try to load the game (should result in an error dialog popping up)
* Try to click the "Ok" button 
