### PR TITLE
Gestalt 5.1.5

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -133,8 +133,8 @@ dependencies {
     compile 'com.jagrosh:DiscordIPC:0.4'
 
     // Our developed libs
-    compile group: 'org.terasology', name: 'gestalt-module', version: '5.1.4'
-    compile group: 'org.terasology', name: 'gestalt-asset-core', version: '5.1.4'
+    compile group: 'org.terasology', name: 'gestalt-module', version: '5.1.5'
+    compile group: 'org.terasology', name: 'gestalt-asset-core', version: '5.1.5'
     compile group: 'org.terasology', name: 'TeraMath', version: '1.4.0'
     compile group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.3.1'
     compile group: 'org.terasology', name: 'splash-screen', version: '1.0.2'

--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -155,8 +155,8 @@ public class InputSystem extends BaseComponentSystem {
                 || inputEntities.length != 2
                 || inputEntities[0] == null
                 || inputEntities[1] == null
-                || !inputEntities[0].equals(localPlayer.getClientEntity())
-                || !inputEntities[1].equals(localPlayer.getCharacterEntity())) {
+                || inputEntities[0] != localPlayer.getClientEntity()
+                || inputEntities[1] != localPlayer.getCharacterEntity()) {
             inputEntities = new EntityRef[]{localPlayer.getClientEntity(), localPlayer.getCharacterEntity()};
         }
     }


### PR DESCRIPTION
### Contains

Bump up gestalt version to 5.1.5
Merge after https://github.com/MovingBlocks/gestalt/pull/73
gestalt 5.1.5 contains extended logging for getProtectedDomain error.

Must help at least invistigate : https://github.com/MovingBlocks/Terasology/issues/3781

### How to test

* Make Invalid Component(With @Replicate) or Event with unprocessable type in type handlers e.g:
  1. make ```@Replicate``` annotation for field in Component with type ```com.google.common.collect.Multimap```(guava) or any collection not inherit from ```java.lang.Collection```
  2. make any field in Event with non-java type and with non-terasology type e.g. ```BigInteger```
* Start serve
* Start client
* Connect to server
* Make something for send network event made below
* in log u can see "Cannot determinate Module for type: <invalid type>"


