### PR TITLE
BeforeChunkUnload sending now in multiplayer on invalidate. Fix Respawn in multiplayer

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -212,17 +212,20 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
-        EntityRef clientInfo = entity.getComponent(ClientComponent.class).clientInfo;
+        ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
+        EntityRef character = clientComponent.character;
+        EntityRef clientInfo = clientComponent.clientInfo;
+
         Vector3f spawnPosition;
         if (clientInfo.hasComponent(StaticSpawnLocationComponent.class)) {
             spawnPosition = clientInfo.getComponent(StaticSpawnLocationComponent.class).position;
         } else {
             spawnPosition = worldGenerator.getSpawnPosition(entity);
         }
-        LocationComponent loc = entity.getComponent(LocationComponent.class);
+        LocationComponent loc = character.getComponent(LocationComponent.class);
         loc.setWorldPosition(spawnPosition);
         loc.setLocalRotation(new Quat4f());  // reset rotation
-        entity.saveComponent(loc);
+        character.saveComponent(loc);
     }
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL, components = {ClientComponent.class})
@@ -242,15 +245,12 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
 
         ClientComponent client = clientEntity.getComponent(ClientComponent.class);
         EntityRef playerCharacter = client.character;
-        LocationComponent location = clientEntity.getComponent(LocationComponent.class);
+        LocationComponent location = playerCharacter.getComponent(LocationComponent.class);
         PlayerFactory playerFactory = new PlayerFactory(entityManager, worldProvider);
         Vector3f spawnPosition = playerFactory.findSpawnPositionFromLocationComponent(location);
 
         playerCharacter.addComponent(new AliveCharacterComponent());
         playerCharacter.send(new CharacterTeleportEvent(spawnPosition));
-
-        location.setWorldPosition(spawnPosition);
-        clientEntity.saveComponent(location);
 
         logger.debug("Re-spawing player at: {}", spawnPosition);
 

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -245,11 +245,12 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         LocationComponent location = clientEntity.getComponent(LocationComponent.class);
         PlayerFactory playerFactory = new PlayerFactory(entityManager, worldProvider);
         Vector3f spawnPosition = playerFactory.findSpawnPositionFromLocationComponent(location);
-        location.setWorldPosition(spawnPosition);
-        clientEntity.saveComponent(location);
 
         playerCharacter.addComponent(new AliveCharacterComponent());
         playerCharacter.send(new CharacterTeleportEvent(spawnPosition));
+
+        location.setWorldPosition(spawnPosition);
+        clientEntity.saveComponent(location);
 
         logger.debug("Re-spawing player at: {}", spawnPosition);
 

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -132,10 +132,7 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
         invalidateChunks.drainTo(positions, UNLOAD_PER_FRAME);
         for (Vector3i pos : positions) {
             Chunk removed = chunkCache.remove(pos);
-            if (removed != null) {
-                if (!removed.isReady()) {
-                    sortedReadyChunks.remove(removed);
-                }
+            if (removed != null && !removed.isReady() && !sortedReadyChunks.remove(removed)) {
                 worldEntity.send(new BeforeChunkUnload(pos));
                 removed.dispose();
             }

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -35,6 +35,7 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.ChunkRegionListener;
+import org.terasology.world.chunks.event.BeforeChunkUnload;
 import org.terasology.world.chunks.event.OnChunkLoaded;
 import org.terasology.world.chunks.internal.GeneratingChunkProvider;
 import org.terasology.world.chunks.pipeline.AbstractChunkTask;
@@ -54,13 +55,16 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
 /**
+ *
  */
 public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvider {
 
-    private static final int LOAD_PER_FRAME = 1;
+    private static final int UNLOAD_PER_FRAME = 64;
+
     private static final Logger logger = LoggerFactory.getLogger(RemoteChunkProvider.class);
     private Map<Vector3i, Chunk> chunkCache = Maps.newHashMap();
     private final BlockingQueue<Chunk> readyChunks = Queues.newLinkedBlockingQueue();
+    private final BlockingQueue<Vector3i> invalidateChunks = Queues.newLinkedBlockingQueue();
     private List<Chunk> sortedReadyChunks = Lists.newArrayList();
     private ChunkReadyListener listener;
     private EntityRef worldEntity = EntityRef.NULL;
@@ -101,39 +105,64 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
     }
 
     public void invalidateChunks(Vector3i pos) {
-        Chunk removed = chunkCache.remove(pos);
-        if (removed != null && !removed.isReady()) {
-            sortedReadyChunks.remove(removed);
-        }
+        invalidateChunks.offer(pos);
+    }
 
+
+    @Override
+    public void completeUpdate() {
+        Chunk chunk = lightMerger.completeMerge();
+        if (chunk != null) {
+            chunk.markReady();
+            listener.onChunkReady(chunk.getPosition());
+            worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
+        }
     }
 
     @Override
     public void beginUpdate() {
         if (listener != null) {
-            List<Chunk> newReadyChunks = Lists.newArrayList();
-            readyChunks.drainTo(newReadyChunks);
-            if (!newReadyChunks.isEmpty()) {
-                sortedReadyChunks.addAll(newReadyChunks);
-                Collections.sort(sortedReadyChunks, new ReadyChunkRelevanceComparator());
-                for (Chunk chunk : newReadyChunks) {
-                    Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
-                    if (oldChunk != null) {
-                        oldChunk.dispose();
-                    }
+            checkForUnload();
+            makeChunksAvailable();
+        }
+    }
+
+    private void checkForUnload() {
+        List<Vector3i> positions = Lists.newArrayListWithCapacity(UNLOAD_PER_FRAME);
+        invalidateChunks.drainTo(positions, UNLOAD_PER_FRAME);
+        for (Vector3i pos : positions) {
+            Chunk removed = chunkCache.remove(pos);
+            if (removed != null && !removed.isReady()) {
+                sortedReadyChunks.remove(removed);
+            }
+            worldEntity.send(new BeforeChunkUnload(pos));
+            removed.dispose();
+        }
+    }
+
+    private void makeChunksAvailable() {
+        List<Chunk> newReadyChunks = Lists.newArrayList();
+        readyChunks.drainTo(newReadyChunks);
+        if (!newReadyChunks.isEmpty()) {
+            sortedReadyChunks.addAll(newReadyChunks);
+            Collections.sort(sortedReadyChunks, new ReadyChunkRelevanceComparator());
+            for (Chunk chunk : newReadyChunks) {
+                Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
+                if (oldChunk != null) {
+                    oldChunk.dispose();
                 }
             }
-            if (!sortedReadyChunks.isEmpty()) {
-                int loaded = 0;
-                for (int i = sortedReadyChunks.size() - 1; i >= 0 && loaded < LOAD_PER_FRAME; i--) {
-                    Chunk chunkInfo = sortedReadyChunks.get(i);
-                    PerformanceMonitor.startActivity("Make Chunk Available");
-                    if (makeChunkAvailable(chunkInfo)) {
-                        sortedReadyChunks.remove(i);
-                        loaded++;
-                    }
-                    PerformanceMonitor.endActivity();
+        }
+        if (!sortedReadyChunks.isEmpty()) {
+            boolean loaded = false;
+            for (int i = sortedReadyChunks.size() - 1; i >= 0 && !loaded; i--) {
+                Chunk chunkInfo = sortedReadyChunks.get(i);
+                PerformanceMonitor.startActivity("Make Chunk Available");
+                if (makeChunkAvailable(chunkInfo)) {
+                    sortedReadyChunks.remove(i);
+                    loaded = true;
                 }
+                PerformanceMonitor.endActivity();
             }
         }
     }
@@ -246,28 +275,22 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
 
     @Override
     public void addRelevanceEntity(EntityRef entity, Vector3i distance) {
+        // RemoteChunkProvider not track Entities(players) by region now
     }
 
     @Override
     public void addRelevanceEntity(EntityRef entity, Vector3i distance, ChunkRegionListener chunkRegionListener) {
+        // RemoteChunkProvider not track Entities(players) by region now
     }
 
     @Override
     public void updateRelevanceEntity(EntityRef entity, Vector3i distance) {
+        // RemoteChunkProvider not track Entities(players) by region now
     }
 
     @Override
     public void removeRelevanceEntity(EntityRef entity) {
-    }
-
-    @Override
-    public void completeUpdate() {
-        Chunk chunk = lightMerger.completeMerge();
-        if (chunk != null) {
-            chunk.markReady();
-            listener.onChunkReady(chunk.getPosition());
-            worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
-        }
+        // RemoteChunkProvider not track Entities(players) by region now
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -132,11 +132,13 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
         invalidateChunks.drainTo(positions, UNLOAD_PER_FRAME);
         for (Vector3i pos : positions) {
             Chunk removed = chunkCache.remove(pos);
-            if (removed != null && !removed.isReady()) {
-                sortedReadyChunks.remove(removed);
+            if (removed != null) {
+                if (!removed.isReady()) {
+                    sortedReadyChunks.remove(removed);
+                }
+                worldEntity.send(new BeforeChunkUnload(pos));
+                removed.dispose();
             }
-            worldEntity.send(new BeforeChunkUnload(pos));
-            removed.dispose();
         }
     }
 


### PR DESCRIPTION
### Contains

Added missing event source:  BeforeChunkUnload.Client's
Systems will be notified of unloaded chunks now.

Fixes https://github.com/MovingBlocks/Terasology/issues/3006
Possible fix https://github.com/MovingBlocks/Terasology/issues/2477

### How to test
---
1. Multiplayer:
  * Start server
   * Start client
   * Connect to server
   * Go far from the spawn area (minimum distance to draw)
   * Open Console
   * Type 'kill'
   * Press 'Enter'
   * You on spawn area
   * World load, chunks visible

---
2.  Singleplayer
   * Start client
   * Create game
   * Go far from the spawn area (minimum distance to draw)
   * Open Console
   * Type 'kill'
   * Press 'Enter'
   * You on spawn area
   * World load, chunks visible

 