### PR TITLE
Restore pre-BiomeAPI foliage shading

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGenerator.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGenerator.java
@@ -18,6 +18,7 @@ package org.terasology.rendering.primitives;
 import org.terasology.module.sandbox.API;
 import org.terasology.rendering.assets.mesh.Mesh;
 import org.terasology.world.ChunkView;
+import org.terasology.world.generation.Region;
 
 /**
  * This is used to generate Mesh data from a block in a chunk to a ChunkMesh output.
@@ -34,7 +35,7 @@ public interface BlockMeshGenerator {
      * @param y     Input position Y.
      * @param z     Input position Z.
      */
-    void generateChunkMesh(ChunkView view, ChunkMesh mesh, int x, int y, int z);
+    void generateChunkMesh(ChunkView view, ChunkMesh mesh, Region worldData, int x, int y, int z);
 
     /**
      * @return A standalone mesh used for items, inventory, etc...

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
@@ -27,6 +27,7 @@ import org.terasology.rendering.RenderMath;
 import org.terasology.world.ChunkView;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.ChunkConstants;
+import org.terasology.world.generation.Region;
 
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +45,7 @@ public final class ChunkTessellator {
         this.bufferPool = bufferPool;
     }
 
-    public ChunkMesh generateMesh(ChunkView chunkView, int meshHeight, int verticalOffset) {
+    public ChunkMesh generateMesh(ChunkView chunkView, Region worldData, int meshHeight, int verticalOffset) {
         PerformanceMonitor.startActivity("GenerateMesh");
         ChunkMesh mesh = new ChunkMesh(bufferPool);
 
@@ -55,7 +56,7 @@ public final class ChunkTessellator {
                 for (int y = verticalOffset; y < verticalOffset + meshHeight; y++) {
                     Block block = chunkView.getBlock(x, y, z);
                     if (block != null && block.getMeshGenerator() != null) {
-                        block.getMeshGenerator().generateChunkMesh(chunkView, mesh, x, y, z);
+                        block.getMeshGenerator().generateChunkMesh(chunkView, mesh, worldData, x, y, z);
                     }
                 }
             }

--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -23,6 +23,7 @@ import org.terasology.math.ChunkMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.chunk.ChunkMonitor;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.primitives.ChunkTessellator;
 import org.terasology.utilities.concurrency.TaskMaster;
@@ -32,6 +33,8 @@ import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.RenderableChunk;
 import org.terasology.world.chunks.pipeline.ChunkTask;
 import org.terasology.world.chunks.pipeline.ShutdownChunkTask;
+import org.terasology.world.generation.World;
+import org.terasology.world.generator.WorldGenerator;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -135,6 +138,7 @@ public final class ChunkMeshUpdateManager {
         private RenderableChunk c;
         private ChunkTessellator tessellator;
         private WorldProvider worldProvider;
+        private World world;
         private ChunkMeshUpdateManager chunkMeshUpdateManager;
 
         ChunkUpdateTask(RenderableChunk chunk, ChunkTessellator tessellator, WorldProvider worldProvider, ChunkMeshUpdateManager chunkMeshUpdateManager) {
@@ -142,6 +146,7 @@ public final class ChunkMeshUpdateManager {
             this.c = chunk;
             this.tessellator = tessellator;
             this.worldProvider = worldProvider;
+            this.world = CoreRegistry.get(WorldGenerator.class).getWorld();
         }
 
         @Override
@@ -170,7 +175,7 @@ public final class ChunkMeshUpdateManager {
                  */
                 c.setDirty(false);
                 if (chunkView.isValidView()) {
-                    newMesh = tessellator.generateMesh(chunkView, ChunkConstants.SIZE_Y, 0);
+                    newMesh = tessellator.generateMesh(chunkView, world.getWorldData(chunkView.getWorldRegion()), ChunkConstants.SIZE_Y, 0);
 
                     c.setPendingMesh(newMesh);
                     ChunkMonitor.fireChunkTessellated(c.getPosition(), newMesh);

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -38,6 +38,9 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
 import org.terasology.world.chunks.RenderableChunk;
+import org.terasology.world.generation.Region;
+import org.terasology.world.generation.World;
+import org.terasology.world.generator.WorldGenerator;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -138,9 +141,11 @@ class RenderableWorldImpl implements RenderableWorld {
         chunkProvider.completeUpdate();
         chunkProvider.beginUpdate();
 
+        World world = CoreRegistry.get(WorldGenerator.class).getWorld();
         RenderableChunk chunk;
         ChunkMesh newMesh;
         ChunkView localView;
+        Region worldData;
         for (Vector3i chunkCoordinates : calculateRenderableRegion(renderingConfig.getViewDistance())) {
             chunk = chunkProvider.getChunk(chunkCoordinates);
             if (chunk == null) {
@@ -152,7 +157,8 @@ class RenderableWorldImpl implements RenderableWorld {
                 }
                 chunk.setDirty(false);
 
-                newMesh = chunkTessellator.generateMesh(localView, ChunkConstants.SIZE_Y, 0);
+                worldData = world.getWorldData(localView.getWorldRegion());
+                newMesh = chunkTessellator.generateMesh(localView, worldData, ChunkConstants.SIZE_Y, 0);
                 newMesh.generateVBOs();
 
                 if (chunk.hasMesh()) {

--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -27,6 +27,7 @@ import org.terasology.math.Transform;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.Mesh;
@@ -95,6 +96,8 @@ public final class Block {
     private boolean waving;
     private byte luminance;
     private Vector3f tint = new Vector3f(0, 0, 0);
+    private Map<BlockPart, BlockColorSource> colorSource = Maps.newEnumMap(BlockPart.class);
+    private Map<BlockPart, Vector4f> colorOffsets = Maps.newEnumMap(BlockPart.class);
 
     // Collision related
     private boolean penetrable;
@@ -125,6 +128,16 @@ public final class Block {
     private CollisionShape collisionShape;
     private Vector3f collisionOffset;
     private AABB bounds = AABB.createEmpty();
+
+    /**
+     * Init. a new block with default properties in place.
+     */
+    public Block() {
+        for (BlockPart part : BlockPart.values()) {
+            colorSource.put(part, DefaultColorSource.DEFAULT);
+            colorOffsets.put(part, new Vector4f(1.0f, 1.0f, 1.0f, 1.0f));
+        }
+    }
 
     public short getId() {
         return id;
@@ -531,6 +544,33 @@ public final class Block {
         this.primaryAppearance = appearence;
     }
 
+    public BlockColorSource getColorSource(BlockPart part) {
+        return colorSource.get(part);
+    }
+
+    public void setColorSource(BlockColorSource colorSource) {
+        for (BlockPart part : BlockPart.values()) {
+            this.colorSource.put(part, colorSource);
+        }
+    }
+
+    public void setColorSource(BlockPart part, BlockColorSource value) {
+        this.colorSource.put(part, value);
+    }
+
+    public Vector4f getColorOffset(BlockPart part) {
+        return colorOffsets.get(part);
+    }
+
+    public void setColorOffset(BlockPart part, Vector4f color) {
+        colorOffsets.put(part, color);
+    }
+
+    public void setColorOffsets(Vector4f color) {
+        for (BlockPart part : BlockPart.values()) {
+            colorOffsets.put(part, color);
+        }
+    }
 
     /**
      * @return Standalone mesh

--- a/engine/src/main/java/org/terasology/world/block/BlockColorSource.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockColorSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block;
+
+import org.terasology.math.geom.Vector4f;
+import org.terasology.world.generation.Region;
+
+/**
+ * Used to determine a multiplicative color for certain blocks based on the block's world conditions.
+ */
+@FunctionalInterface
+public interface BlockColorSource {
+
+    default Vector4f calcColor(Region worldData) {
+        return calcColor(worldData, 0, 0, 0);
+    };
+
+   default Vector4f calcColor(Region worldData, int x, int z) {
+       return calcColor(worldData, x, 0, z);
+   };
+
+    Vector4f calcColor(Region worldData, int x, int y, int z);
+
+}

--- a/engine/src/main/java/org/terasology/world/block/DefaultColorSource.java
+++ b/engine/src/main/java/org/terasology/world/block/DefaultColorSource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.math.geom.Vector4f;
+import org.terasology.world.generation.Region;
+import org.terasology.world.generation.facets.SurfaceHumidityFacet;
+import org.terasology.world.generation.facets.SurfaceTemperatureFacet;
+
+import javax.imageio.ImageIO;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Different color sources for blocks.
+ */
+public enum DefaultColorSource implements BlockColorSource {
+
+    DEFAULT {
+        @Override
+        public Vector4f calcColor(Region worldData, int x, int y, int z) {
+            return new Vector4f(1, 1, 1, 1);
+        }
+    },
+    COLOR_LUT {
+        @Override
+        public Vector4f calcColor(Region worldData, int x, int y, int z) {
+            float humidity = worldData.getFacet(SurfaceHumidityFacet.class).get(x, z);
+            float temperature = worldData.getFacet(SurfaceTemperatureFacet.class).get(x, z);
+            float prod = temperature * humidity;
+            int rgbValue = colorLut.getRGB((int) ((1.0 - temperature) * 255.0), (int) ((1.0 - prod) * 255.0));
+
+            Color c = new Color(rgbValue);
+            return new Vector4f(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, 1.0f);
+        }
+    },
+    FOLIAGE_LUT {
+        @Override
+        public Vector4f calcColor(Region worldData, int x, int y, int z) {
+            float humidity = worldData.getFacet(SurfaceHumidityFacet.class).get(x, z);
+            float temperature = worldData.getFacet(SurfaceTemperatureFacet.class).get(x, z);
+            float prod = humidity * temperature;
+            int rgbValue = foliageLut.getRGB((int) ((1.0 - temperature) * 255.0), (int) ((1.0 - prod) * 255.0));
+
+            Color c = new Color(rgbValue);
+            return new Vector4f(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, 1.0f);
+        }
+    };
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultColorSource.class);
+
+    /* LUTs */
+    private static BufferedImage colorLut;
+
+    private static BufferedImage foliageLut;
+
+    static {
+        try {
+            // TODO: Read these from asset manager
+            colorLut = ImageIO.read(DefaultColorSource.class.getResource("/assets/textures/grasscolor.png"));
+            foliageLut = ImageIO.read(DefaultColorSource.class.getResource("/assets/textures/foliagecolor.png"));
+        } catch (IOException e) {
+            logger.error("Failed to load LUTs", e);
+        }
+    }
+
+}

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
@@ -120,6 +120,11 @@ public class BlockBuilder implements BlockBuilderHelper {
         setBlockFullSides(block, shape, rotation);
         block.setCollision(shape.getCollisionOffset(rotation), shape.getCollisionShape(rotation));
 
+        for (BlockPart part : BlockPart.values()) {
+            block.setColorSource(part, section.getColorSources().get(part));
+            block.setColorOffset(part, section.getColorOffsets().get(part));
+        }
+
         block.setUri(uri);
         block.setBlockFamily(blockFamily);
 

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
@@ -43,6 +43,7 @@ import org.terasology.utilities.gson.CaseInsensitiveEnumTypeAdapterFactory;
 import org.terasology.utilities.gson.Vector3fTypeAdapter;
 import org.terasology.utilities.gson.Vector4fTypeAdapter;
 import org.terasology.world.block.BlockPart;
+import org.terasology.world.block.DefaultColorSource;
 import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.family.BlockFamilyLibrary;
 import org.terasology.world.block.family.FreeformFamily;
@@ -196,6 +197,8 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
             setObject(data::setTint, jsonObject, "tint", Vector3f.class, context);
 
             readBlockPartMap(jsonObject, "tile", "tiles", data::getBlockTiles, BlockTile.class, context);
+            readBlockPartMap(jsonObject, "colorSource", "colorSources", data::getColorSources, DefaultColorSource.class, context);
+            readBlockPartMap(jsonObject, "colorOffset", "colorOffsets", data::getColorOffsets, Vector4f.class, context);
 
             setFloat(data::setMass, jsonObject, "mass");
             setBoolean(data::setDebrisOnDestroy, jsonObject, "debrisOnDestroy");

--- a/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
@@ -16,9 +16,12 @@
 package org.terasology.world.block.loader;
 
 import com.google.common.collect.Maps;
+import org.terasology.math.geom.BaseVector4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.module.sandbox.API;
 import org.terasology.world.block.BlockPart;
+import org.terasology.world.block.DefaultColorSource;
 import org.terasology.world.block.shapes.BlockShape;
 import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.block.tiles.BlockTile;
@@ -53,6 +56,8 @@ public class SectionDefinitionData {
     private Vector3f tint = new Vector3f();
 
     private EnumMap<BlockPart, BlockTile> blockTiles = Maps.newEnumMap(BlockPart.class);
+    private EnumMap<BlockPart, DefaultColorSource> colorSources;
+    private EnumMap<BlockPart, Vector4f> colorOffsets;
 
     private float mass = 10f;
     private boolean debrisOnDestroy = true;
@@ -68,6 +73,12 @@ public class SectionDefinitionData {
     private boolean ice;
 
     public SectionDefinitionData() {
+        colorSources = Maps.newEnumMap(BlockPart.class);
+        colorOffsets = Maps.newEnumMap(BlockPart.class);
+        for (BlockPart part : BlockPart.values()) {
+            colorSources.put(part, DefaultColorSource.DEFAULT);
+            colorOffsets.put(part, new Vector4f(1, 1, 1, 1));
+        }
     }
 
     public SectionDefinitionData(SectionDefinitionData other) {
@@ -94,6 +105,8 @@ public class SectionDefinitionData {
         this.tint = new Vector3f(other.tint);
 
         this.blockTiles = new EnumMap<>(other.blockTiles);
+        this.colorSources = new EnumMap<>(other.colorSources);
+        this.colorOffsets = new EnumMap<>(other.colorOffsets);
 
         this.mass = other.mass;
         this.debrisOnDestroy = other.debrisOnDestroy;
@@ -253,6 +266,26 @@ public class SectionDefinitionData {
     public void setAllTiles(BlockTile tile) {
         for (BlockPart part : BlockPart.values()) {
             blockTiles.put(part, tile);
+        }
+    }
+
+    public EnumMap<BlockPart, DefaultColorSource> getColorSources() {
+        return colorSources;
+    }
+
+    public void setAllColorSources(DefaultColorSource source) {
+        for (BlockPart part : BlockPart.values()) {
+            colorSources.put(part, source);
+        }
+    }
+
+    public EnumMap<BlockPart, Vector4f> getColorOffsets() {
+        return colorOffsets;
+    }
+
+    public void setAllColorOffsets(BaseVector4f offset) {
+        for (BlockPart part : BlockPart.values()) {
+            colorOffsets.put(part, new Vector4f(offset));
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockMeshPart.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockMeshPart.java
@@ -18,6 +18,7 @@ package org.terasology.world.block.shapes;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.primitives.ChunkVertexFlag;
 
@@ -87,7 +88,7 @@ public class BlockMeshPart {
         return new BlockMeshPart(vertices, normals, newTexCoords, indices, frames);
     }
 
-    public void appendTo(ChunkMesh chunk, int offsetX, int offsetY, int offsetZ, ChunkMesh.RenderType renderType, ChunkVertexFlag flags) {
+    public void appendTo(ChunkMesh chunk, int offsetX, int offsetY, int offsetZ, ChunkMesh.RenderType renderType, Vector4f colorOffset, ChunkVertexFlag flags) {
         ChunkMesh.VertexElements elements = chunk.getVertexElements(renderType);
         for (Vector2f texCoord : texCoords) {
             elements.tex.add(texCoord.x);
@@ -96,10 +97,10 @@ public class BlockMeshPart {
 
         int nextIndex = elements.vertexCount;
         for (int vIdx = 0; vIdx < vertices.length; ++vIdx) {
-            elements.color.add(1);
-            elements.color.add(1);
-            elements.color.add(1);
-            elements.color.add(1);
+            elements.color.add(colorOffset.x);
+            elements.color.add(colorOffset.y);
+            elements.color.add(colorOffset.z);
+            elements.color.add(colorOffset.w);
             elements.vertices.add(vertices[vIdx].x + offsetX);
             elements.vertices.add(vertices[vIdx].y + offsetY);
             elements.vertices.add(vertices[vIdx].z + offsetZ);

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -179,7 +179,22 @@ void main() {
         discard;
     }
 #endif
+    /* APPLY OVERALL BIOME COLOR OFFSET */
+    if (!checkFlag(BLOCK_HINT_GRASS, blockHint)) {
+        if (gl_Color.r < 0.99 && gl_Color.g < 0.99 && gl_Color.b < 0.99) {
+            if (color.g > 0.5) {
+                color.rgb = vec3(color.g) * gl_Color.rgb;
+            } else {
+                color.rgb *= gl_Color.rgb;
+            }
+        }
+    /* MASK GRASS AND APPLY BIOME COLOR */
+    } else {
+        vec4 maskColor = texture2D(textureEffects, vec2(10.0 * TEXTURE_OFFSET_EFFECTS + mod(texCoord.x, TEXTURE_OFFSET_EFFECTS), mod(texCoord.y, TEXTURE_OFFSET_EFFECTS)));
 
+        // Only use one channel so the color won't be altered
+        if (maskColor.a != 0.0) color.rgb = vec3(color.g) * gl_Color.rgb;
+    }
 #endif
 
     // Calculate daylight lighting value


### PR DESCRIPTION
During the extraction of biomes from the engine, block color sources and offsets were removed due to their integration with biomes. This resulted in rather dead-looking grass and leaves, as well as consequences with other color-shifted blocks not being color-shifted.

This PR re-implements the system as close to the original as possible without making reference to biomes, and instead referring to the world's humidity and temperature facets directly.

![image](https://user-images.githubusercontent.com/2421117/70829971-12397000-1dbd-11ea-8d02-0a0702af8b5b.png)
