### PR TITLE
Increase chunkloading speed

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -86,7 +86,7 @@ public class LocalChunkProviderTest {
     public void testCompleteUpdateMarksChunkReady() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
 
         chunkProvider.completeUpdate();
 
@@ -97,7 +97,7 @@ public class LocalChunkProviderTest {
     public void testCompleteUpdateHandlesFinalizedChunkIfReady() throws Exception {
         final Chunk chunk = mockChunkAt(0, 0, 0);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
 
         chunkProvider.completeUpdate();
 
@@ -113,7 +113,7 @@ public class LocalChunkProviderTest {
         final EntityStore entityStore = createEntityStoreWithComponents(testComponent);
         final List<EntityStore> entityStores = Collections.singletonList(entityStore);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), entityStores);
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
         final EntityRef mockEntity = mock(EntityRef.class);
         when(entityManager.create()).thenReturn(mockEntity);
 
@@ -130,7 +130,7 @@ public class LocalChunkProviderTest {
         final EntityStore entityStore = createEntityStoreWithPrefabAndComponents(prefab, testComponent);
         final List<EntityStore> entityStores = Collections.singletonList(entityStore);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForNewChunk(chunk, new TShortObjectHashMap<>(), entityStores);
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
         final EntityRef mockEntity = mock(EntityRef.class);
         when(entityManager.create(any(Prefab.class))).thenReturn(mockEntity);
 
@@ -145,7 +145,7 @@ public class LocalChunkProviderTest {
         final Chunk chunk = mockChunkAt(0, 0, 0);
         final ChunkStore chunkStore = mock(ChunkStore.class);
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, new TShortObjectHashMap<>(), chunkStore, Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
 
         chunkProvider.completeUpdate();
 
@@ -161,7 +161,7 @@ public class LocalChunkProviderTest {
         final TShortObjectHashMap<TIntList> blockPositionMappings = new TShortObjectHashMap<>();
         blockPositionMappings.put(blockId, withPositions(new Vector3i(1, 2, 3)));
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMappings, mock(ChunkStore.class), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
 
         chunkProvider.completeUpdate();
 
@@ -182,7 +182,7 @@ public class LocalChunkProviderTest {
         registerBlockWithIdAndEntity(blockId, blockEntity, blockManager);
         blockPositionMappings.put(blockId, withPositions(new Vector3i(1, 2, 3)));
         final ReadyChunkInfo readyChunkInfo = ReadyChunkInfo.createForRestoredChunk(chunk, blockPositionMappings, mock(ChunkStore.class), Collections.emptyList());
-        when(chunkFinalizer.completeFinalization()).thenReturn(readyChunkInfo);
+        when(chunkFinalizer.completeFinalization()).thenReturn(Collections.singletonList(readyChunkInfo));
 
         chunkProvider.completeUpdate();
 

--- a/engine/src/main/java/org/terasology/network/ServerInfoService.java
+++ b/engine/src/main/java/org/terasology/network/ServerInfoService.java
@@ -64,5 +64,6 @@ public class ServerInfoService implements AutoCloseable {
     @Override
     public void close() {
         factory.releaseExternalResources();
+        pool.shutdown();
     }
 }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkFinalizer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/ChunkFinalizer.java
@@ -19,6 +19,8 @@ import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.internal.GeneratingChunkProvider;
 import org.terasology.world.chunks.internal.ReadyChunkInfo;
 
+import java.util.List;
+
 /**
  * Post-processor for loaded or generated chunks.
  * Can be used to add extra runtime-metadata like light merging to a chunk before the chunk is stored in memory.
@@ -27,7 +29,7 @@ public interface ChunkFinalizer {
 
     void initialize(GeneratingChunkProvider generatingChunkProvider);
 
-    ReadyChunkInfo completeFinalization();
+    List<ReadyChunkInfo> completeFinalization();
 
     void beginFinalization(Chunk chunk, ReadyChunkInfo readyChunkInfo);
 

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LightMergingChunkFinalizer.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LightMergingChunkFinalizer.java
@@ -20,6 +20,8 @@ import org.terasology.world.chunks.internal.GeneratingChunkProvider;
 import org.terasology.world.chunks.internal.ReadyChunkInfo;
 import org.terasology.world.propagation.light.LightMerger;
 
+import java.util.List;
+
 class LightMergingChunkFinalizer implements ChunkFinalizer {
 
     private LightMerger<ReadyChunkInfo> lightMerger;
@@ -30,7 +32,7 @@ class LightMergingChunkFinalizer implements ChunkFinalizer {
     }
 
     @Override
-    public ReadyChunkInfo completeFinalization() {
+    public List<ReadyChunkInfo> completeFinalization() {
         return lightMerger.completeMerge();
     }
 

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -262,10 +262,8 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
 
     @Override
     public void completeUpdate() {
-        ReadyChunkInfo readyChunkInfo = chunkFinalizer.completeFinalization();
-        if (readyChunkInfo != null) {
-            processReadyChunk(readyChunkInfo);
-        }
+        List<ReadyChunkInfo> readyChunkInfos = chunkFinalizer.completeFinalization();
+        readyChunkInfos.forEach(this::processReadyChunk);
     }
 
     private void processReadyChunk(final ReadyChunkInfo readyChunkInfo) {
@@ -364,13 +362,11 @@ public class LocalChunkProvider implements GeneratingChunkProvider {
             Collections.sort(sortedReadyChunks, new ReadyChunkRelevanceComparator());
         }
         if (!sortedReadyChunks.isEmpty()) {
-            boolean loaded = false;
-            for (int i = sortedReadyChunks.size() - 1; i >= 0 && !loaded; i--) {
+            for (int i = sortedReadyChunks.size() - 1; i >= 0; i--) {
                 ReadyChunkInfo chunkInfo = sortedReadyChunks.get(i);
                 PerformanceMonitor.startActivity("Make Chunk Available");
                 if (makeChunkAvailable(chunkInfo)) {
                     sortedReadyChunks.remove(i);
-                    loaded = true;
                 }
                 PerformanceMonitor.endActivity();
             }


### PR DESCRIPTION
### Contains

Increase chunk loading speed for client and server (not world generation).
Maximum effect should be visible on SSDs. Or in multiplayer with 6+ players who are far apart

+ Seems, fix zombie thread, that prevent close client. (maybe #3738)

### How to test

Chunks:
1. Open Terasology
2. Load  world, which chunks generated with max view distance
3. try compare chunkloading speed before and after (load world before using PR and after)


Thread:
1. Open Terasology
2. Open Mutliplayer
3. Close Terasology( you can exit  from JoinServerScreen)
4. You haven't Terasology process in Task Manager/top/htop/etc