### PR TITLE
Fix for Z-fighting on back faces of transparent blocks

### DIFF
--- a/engine/src/main/resources/assets/shaders/chunk_vert.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_vert.glsl
@@ -178,4 +178,11 @@ void main()
 
     vertexProjPos = gl_ProjectionMatrix * vertexViewPos;
     gl_Position = vertexProjPos;
+
+#if defined (FEATURE_ALPHA_REJECT)
+    //TODO: find the right methods to determine which vertices have normals facing away from the viewpoint, and only alter those
+    //if (normal.x * vertexViewPos.x < 0 || normal.y * vertexViewPos.y < 0 || normal.z * vertexViewPos.z < 0) {
+        gl_Position.z -= 0.001;
+    //}
+#endif
 }


### PR DESCRIPTION
This prevents the interior faces of partially transparent blocks from being merged into the exterior faces of the blocks behind them.

It would be wise to only adjust interior faces, and not exterior faces, but as of yet I have been unable to determine the proper way to accomplish this. This means that currently, it will not fix z-fighting between two blocks that are both partially transparent.

To test this, create or use a block marked "translucent" with the full cube shape, and a texture that is partially transparent so that you can see inside the block. When placed adjacent to a solid block, the interior face of the transparent block should be fully visible and overlaying the face of the block behind it.
