### PR TITLE
Handle unexpected (old or weird) OSes that may not support our directory detection.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/paths/PathManager.java
@@ -151,7 +151,7 @@ public final class PathManager {
      * @param rootPath Path to use as the home path.
      * @throws IOException Thrown when required directories cannot be accessed.
      */
-    public void useOverrideHomePath(Path rootPath) throws IOException {
+    public void useOverrideHomePath(Path rootPath) throws Exception {
         this.homePath = rootPath;
         updateDirs();
     }
@@ -160,7 +160,7 @@ public final class PathManager {
      * Uses a platform-specific default home path for this execution.
      * @throws IOException Thrown when required directories cannot be accessed.
      */
-    public void useDefaultHomePath() throws IOException {
+    public void useDefaultHomePath() throws Exception {
         switch (LWJGLUtil.getPlatform()) {
             case LWJGLUtil.PLATFORM_LINUX:
                 homePath = Paths.get(System.getProperty("user.home")).resolve(LINUX_HOME_SUBPATH);
@@ -185,6 +185,11 @@ public final class PathManager {
                 homePath = Paths.get(System.getProperty("user.home")).resolve(LINUX_HOME_SUBPATH);
                 break;
         }
+        updateDirs();
+    }
+
+    public void chooseHomePathManually(Path manualPath) throws Exception {
+        this.homePath = manualPath;
         updateDirs();
     }
 
@@ -280,7 +285,7 @@ public final class PathManager {
      * Updates all of the path manager's file/directory references to match the path settings. Creates directories if they don't already exist.
      * @throws IOException Thrown when required directories cannot be accessed.
      */
-    private void updateDirs() throws IOException {
+    private void updateDirs() throws Exception {
         Files.createDirectories(homePath);
         savesPath = homePath.resolve(SAVED_GAMES_DIR);
         Files.createDirectories(savesPath);

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,9 +17,6 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import java.io.File;
-import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileSystemView;
 import org.terasology.config.Config;
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
@@ -116,6 +113,7 @@ public final class Terasology {
     private static boolean soundEnabled = true;
     private static boolean splashEnabled = true;
     private static boolean loadLastGame;
+
 
     private Terasology() {
     }
@@ -364,21 +362,13 @@ public final class Terasology {
                 PathManager.getInstance().useDefaultHomePath();
             }
 
-        } catch (Exception e) {
+        } catch (IOException e) {
             reportException(e);
-
-            // This would allow the user to choose the file path manually.
-            JFileChooser jfc = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory());
-            int returnValue = jfc.showOpenDialog(null);
-            if (returnValue == JFileChooser.APPROVE_OPTION) {
-                File selectedFile = jfc.getSelectedFile();
-                homePath = Paths.get(selectedFile.getAbsolutePath());
-                try {
-                    PathManager.getInstance().chooseHomePathManually(homePath);
-                } catch (Exception ex) {
-                    reportException(ex);
-                    System.exit(0);
-                }
+            try {
+                PathManager.getInstance().chooseHomePathManually();
+            } catch (IOException ex) {
+                reportException(e);
+                System.exit(0);
             }
             System.exit(0);
         }

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -367,10 +367,9 @@ public final class Terasology {
             try {
                 PathManager.getInstance().chooseHomePathManually();
             } catch (IOException ex) {
-                reportException(e);
+                reportException(ex);
                 System.exit(0);
             }
-            System.exit(0);
         }
     }
 

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,6 +17,9 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileSystemView;
 import org.terasology.config.Config;
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
@@ -361,8 +364,22 @@ public final class Terasology {
                 PathManager.getInstance().useDefaultHomePath();
             }
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             reportException(e);
+
+            // This would allow the user to choose the file path manually.
+            JFileChooser jfc = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory());
+            int returnValue = jfc.showOpenDialog(null);
+            if (returnValue == JFileChooser.APPROVE_OPTION) {
+                File selectedFile = jfc.getSelectedFile();
+                homePath = Paths.get(selectedFile.getAbsolutePath());
+                try {
+                    PathManager.getInstance().chooseHomePathManually(homePath);
+                } catch (Exception ex) {
+                    reportException(ex);
+                    System.exit(0);
+                }
+            }
             System.exit(0);
         }
     }

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -17,6 +17,8 @@ package org.terasology.engine;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
 import org.terasology.config.SystemConfig;
 import org.terasology.crashreporter.CrashReporter;
@@ -41,6 +43,7 @@ import org.terasology.engine.subsystem.lwjgl.LwjglTimer;
 import org.terasology.engine.subsystem.openvr.OpenVRInput;
 import org.terasology.engine.subsystem.rpc.DiscordRPCSubSystem;
 import org.terasology.game.GameManifest;
+import org.terasology.logic.characters.CharacterSystem;
 import org.terasology.network.NetworkMode;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
@@ -107,6 +110,8 @@ public final class Terasology {
     private static final String NO_SPLASH = "-noSplash";
     private static final String SERVER_PORT = "-serverPort=";
     private static final String OVERRIDE_DEFAULT_CONFIG = "-overrideDefaultConfig=";
+    private static final Logger logger = LoggerFactory.getLogger(Terasology.class);
+
 
     private static boolean isHeadless;
     private static boolean crashReportEnabled = true;
@@ -363,7 +368,7 @@ public final class Terasology {
             }
 
         } catch (IOException e) {
-            reportException(e);
+            logger.warn("The game cannot detect default home directory");
             try {
                 PathManager.getInstance().chooseHomePathManually();
             } catch (IOException ex) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

This PR deals with errors thrown during directory detection, specifically giving a chance to run the game again if the default directory detection fails.
In case of headless servers we have defaulted to choosing the home path as the current directory.
Fixes https://github.com/MovingBlocks/Terasology/issues/3566

### How to test

Run the game on Windows XP. If you can find something with XP on it or a wierd OS that throws our directory detection out of the window.

### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [ x ] Still have to adjust the wiki doc 
The doc has to be updated if in case we hit any such OSes in the future.
