### PR TITLE
Fix crash when removing controllers

### DIFF
--- a/engine/src/main/java/org/terasology/input/lwjgl/JInputControllerDevice.java
+++ b/engine/src/main/java/org/terasology/input/lwjgl/JInputControllerDevice.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Retrieves information on connected controllers through JInput.
@@ -72,7 +73,8 @@ public class JInputControllerDevice implements ControllerDevice {
             .build();
 
     private ControllerConfig config;
-    private final List<Controller> controllers = new ArrayList<>();
+    /* MUST be a CopyOnWriteArrayList! Or else you just get crashes when unplugging controllers. */
+    private final List<Controller> controllers = new CopyOnWriteArrayList<>();
 
     public JInputControllerDevice(ControllerConfig config) {
         this.config = config;


### PR DESCRIPTION
Fixes #3556

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Brief description of what the PR does like "Fixes #12345"

### How to test

Brief description of how to test / confirm this PR before merging

Probably the best way to test this is with uinput on Linux. E.g. running this python program, with the `python-uinput` python package:

```python
import uinput

events = (
        uinput.BTN_JOYSTICK,
        uinput.ABS_X + (0, 255, 0, 0),
        uinput.ABS_Y + (0, 255, 0, 0),
        )

with uinput.Device(events) as device:
    while True:
        pass
```

and sending a keyboard interrupt to emulate unplugging the controller.

### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [ ] Need to consider use case x
- [ ] Still have to adjust the wiki doc
- [ ] Will need translation work
