### PR TITLE
Ability to Broadcast games on the Local Area Network

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/mode/StateHeadlessSetup.java
@@ -40,11 +40,13 @@ import org.terasology.logic.console.commands.CoreCommands;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.module.Module;
 import org.terasology.naming.Name;
+import org.terasology.network.BroadCastServer;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkMode;
 import org.terasology.recording.DirectionAndOriginPosRecorderList;
 import org.terasology.recording.RecordAndReplayCurrentStatus;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.internal.CanvasRenderer;
 import org.terasology.rendering.nui.internal.NUIManagerInternal;
@@ -65,6 +67,10 @@ public class StateHeadlessSetup implements GameState {
     private EventSystem eventSystem;
     private ComponentSystemManager componentSystemManager;
     private Context context;
+
+    @In
+    private BroadCastServer broadCastServer;
+
 
     public StateHeadlessSetup() {
     }
@@ -98,6 +104,9 @@ public class StateHeadlessSetup implements GameState {
         localPlayer.setClientEntity(localPlayerEntity);
 
         componentSystemManager.initialise();
+
+        //Lets get the server to broadcast
+        broadCastServer.startBroadcast();
 
         GameManifest gameManifest;
         List<GameInfo> savedGames = GameProvider.getSavedGames();

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -27,8 +27,8 @@ public class BroadCastServer {
 
     private static boolean turnOnBroadcast;
     private static final Logger logger = LoggerFactory.getLogger(BroadCastServer.class);
-    private static final String DISCOVERY_REQUEST = "DISCOVERY_REQUEST";
-    private static final String DISCOVERY_RESPONSE = "DISCOVERY_RESPONSE";
+    private  final String discoveryRequest = "DISCOVERY_REQUEST";
+    private  final String discoveryResponse = "DISCOVERY_RESPONSE";
     private  DatagramSocket receiveSocket;
     private  DatagramSocket sendSocket;
 
@@ -70,16 +70,16 @@ public class BroadCastServer {
     }
 
     private void listenToBroadCast() throws Exception {
-        byte[] buffer = DISCOVERY_REQUEST.getBytes(StandardCharsets.UTF_8);
+        byte[] buffer = discoveryRequest.getBytes(StandardCharsets.UTF_8);
         DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
         getReceiveSocket().receive(packet);
         logger.info("Discovery package received! -> " + packet.getAddress() + ":" + packet.getPort());
 
         //Validate the data sent.
         String data = new String(packet.getData()).trim();
-        if (data.equals(DISCOVERY_REQUEST)) { // validate command
+        if (data.equals(discoveryRequest)) { // validate command
             // Send response
-            byte[] response = new byte[DISCOVERY_RESPONSE.length()];
+            byte[] response = new byte[discoveryResponse.length()];
             DatagramPacket responsePacket = new DatagramPacket(response, response.length, packet.getAddress(), packet.getPort());
             getReceiveSocket().send(responsePacket);
             logger.info("Response sent to: " + packet.getAddress() + ":" + packet.getPort());
@@ -115,18 +115,18 @@ public class BroadCastServer {
 
     public void sendBroadCast() throws Exception {
         // Discovery request command
-        byte[] data = DISCOVERY_REQUEST.getBytes(StandardCharsets.UTF_8);
+        byte[] data = discoveryRequest.getBytes(StandardCharsets.UTF_8);
         DatagramPacket packet = new DatagramPacket(data, data.length, InetAddress.getByName("255.255.255.255"), 8002);
         getSendSocket().send(packet);
         logger.info("Discovery package sent!" + packet.getAddress() + ":" + packet.getPort());
 
         // Discovery response command
-        byte[] response = new byte[DISCOVERY_RESPONSE.length()];
+        byte[] response = new byte[discoveryResponse.length()];
         DatagramPacket responsePacket = new DatagramPacket(response, response.length);
         getSendSocket().receive(responsePacket);
         logger.info("Discovery response received!" + responsePacket.getAddress() + ":" + responsePacket.getPort());
         String responseData = new String(responsePacket.getData(), StandardCharsets.UTF_8);
-        if (responseData.equals(DISCOVERY_RESPONSE)) { // Check valid command
+        if (responseData.equals(discoveryResponse)) { // Check valid command
             logger.info("Found server!" + responsePacket.getAddress() + ":" + responsePacket.getPort());
         }
     }

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -38,10 +38,10 @@ public class BroadCastServer {
     private static DatagramSocket socket;
     private static boolean turnOnBroadcast;
     private static final Logger logger = LoggerFactory.getLogger(JoinGameScreen.class);
-    private NetworkSystem networkSystem;
+    private static ScheduledExecutorService service;
 
 
-    public boolean isTurnOnBroadcast() {
+    public boolean isBroadCastTurnedOn() {
         return turnOnBroadcast;
     }
 
@@ -50,6 +50,7 @@ public class BroadCastServer {
     }
 
     public void startBroadcast(String message) {
+        service = Executors.newSingleThreadScheduledExecutor();
         Runnable runnable = new Runnable() {
             public void run() {
                 try {
@@ -58,13 +59,17 @@ public class BroadCastServer {
                         broadcast(message, inadr);
                     }
                 } catch (Exception e) {
+                    logger.info("Broadcasting has been interrupted " + e.getMessage());
                     e.printStackTrace();
                 }
             }
         };
-        ScheduledExecutorService service = Executors
-            .newSingleThreadScheduledExecutor();
         service.scheduleAtFixedRate(runnable, 0, 300, TimeUnit.SECONDS);
+    }
+
+    public void stopBroadCast() {
+        logger.info("Shutting down BroadCasting");
+        service.shutdown();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -42,19 +42,20 @@ public class BroadCastServer {
         BroadCastServer.turnOnBroadcast = true;
         try {
             sendBroadCast();
-            service = Executors.newSingleThreadScheduledExecutor();
-            Runnable runnable = new Runnable() {
+            Executors.newSingleThreadExecutor().execute(new Runnable() {
+                @Override
                 public void run() {
-                    logger.info("Listening to broadcast");
-                    try {
-                        while(turnOnBroadcast) {
-                            listenToBroadCast();
+                    while (true) {
+                        try {
+                            while (turnOnBroadcast) {
+                                listenToBroadCast();
+                            }
+                        } catch (Exception e) {
+                            logger.error("Broadcasting has been interrupted" + e.getMessage());
                         }
-                    } catch (Exception e) {
-                        logger.error("Broadcasting has been interrupted" + e.getMessage());
                     }
                 }
-            };
+            });
         } catch (Exception e) {
         logger.info("Broadcasting has been interrupted " + e.getMessage());
         }

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -33,6 +33,8 @@ public class BroadCastServer {
     private static boolean turnOnBroadcast;
     private static final Logger logger = LoggerFactory.getLogger(JoinGameScreen.class);
     private static ScheduledExecutorService service;
+    private static String discoveryRequest = "__DISCOVERY_REQUEST__";
+    private static String discoveryResponse = "__DISCOVERY_RESPONSE__";
 
     public boolean isBroadCastTurnedOn() {
         return turnOnBroadcast;
@@ -69,16 +71,16 @@ public class BroadCastServer {
     }
 
     private void listenToBroadCast() throws Exception {
-        byte[] buffer = "__DISCOVERY_REQUEST__".getBytes();
+        byte[] buffer = discoveryRequest.getBytes();
         DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
         getReceiveSocket().receive(packet);
         logger.info("Discovery package received! -> " + packet.getAddress() + ":" + packet.getPort());
 
         //Validate the data sent.
         String data = new String(packet.getData()).trim();
-        if (data.equals("__DISCOVERY_REQUEST__")) { // validate command
+        if (data.equals(discoveryRequest)) { // validate command
             // Send response
-            byte[] response = new byte["__DISCOVERY_RESPONSE".length()];
+            byte[] response = new byte[discoveryResponse.length()];
             DatagramPacket responsePacket = new DatagramPacket(response, response.length, packet.getAddress(), packet.getPort());
             getReceiveSocket().send(responsePacket);
             logger.info("Response sent to: " + packet.getAddress() + ":" + packet.getPort());
@@ -114,18 +116,18 @@ public class BroadCastServer {
 
     public void sendBroadCast() throws Exception {
         // Discovery request command
-        byte[] data = "__DISCOVERY_REQUEST__".getBytes();
+        byte[] data = discoveryRequest.getBytes();
         DatagramPacket packet = new DatagramPacket(data, data.length, InetAddress.getByName("255.255.255.255"), 8002);
         getSendSocket().send(packet);
         logger.info("Discovery package sent!" + packet.getAddress() + ":" + packet.getPort());
 
         // Discovery response command
-        byte[] response = new byte["__DISCOVERY_RESPONSE__".length()];
+        byte[] response = new byte[discoveryResponse.length()];
         DatagramPacket responsePacket = new DatagramPacket(response, response.length);
         getSendSocket().receive(responsePacket);
         logger.info("Discovery response received!" + responsePacket.getAddress() + ":" + responsePacket.getPort());
         String responseData = new String(responsePacket.getData()).trim();
-        if (responseData.equals("__DISCOVERY_RESPONSE__")) { // Check valid command
+        if (responseData.equals(discoveryResponse)) { // Check valid command
             logger.info("Found server!" + responsePacket.getAddress() + ":" + responsePacket.getPort());
         }
     }

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -30,12 +30,17 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.config.Config;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.layers.mainMenu.JoinGameScreen;
 
 
 public class BroadCastServer {
 
     private static DatagramSocket socket;
+
+    @In
+    private Config config;
     private static boolean turnOnBroadcast;
     private static final Logger logger = LoggerFactory.getLogger(JoinGameScreen.class);
     private static ScheduledExecutorService service;
@@ -49,7 +54,8 @@ public class BroadCastServer {
         BroadCastServer.turnOnBroadcast = turnOnBroadcast;
     }
 
-    public void startBroadcast(String message) {
+    public void startBroadcast() {
+        String message = buildBroadCastMessage();
         service = Executors.newSingleThreadScheduledExecutor();
         Runnable runnable = new Runnable() {
             public void run() {
@@ -109,6 +115,13 @@ public class BroadCastServer {
                 .forEach(broadcastList::add);
         }
         return broadcastList;
+    }
+
+
+    private String buildBroadCastMessage() {
+        logger.info("Building Broadcast Message");
+        int serverPort = config.getNetwork().getServerPort();
+        return "Hello I am running on server" + config.getNetwork().getMasterServer() + "and Port:" + serverPort;
     }
 
 }

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -18,6 +18,7 @@ package org.terasology.network;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -71,7 +72,7 @@ public class BroadCastServer {
     }
 
     private void listenToBroadCast() throws Exception {
-        byte[] buffer = discoveryRequest.getBytes();
+        byte[] buffer = discoveryRequest.getBytes(StandardCharsets.UTF_8);
         DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
         getReceiveSocket().receive(packet);
         logger.info("Discovery package received! -> " + packet.getAddress() + ":" + packet.getPort());
@@ -116,7 +117,7 @@ public class BroadCastServer {
 
     public void sendBroadCast() throws Exception {
         // Discovery request command
-        byte[] data = discoveryRequest.getBytes();
+        byte[] data = discoveryRequest.getBytes(StandardCharsets.UTF_8);
         DatagramPacket packet = new DatagramPacket(data, data.length, InetAddress.getByName("255.255.255.255"), 8002);
         getSendSocket().send(packet);
         logger.info("Discovery package sent!" + packet.getAddress() + ":" + packet.getPort());

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.rendering.nui.layers.mainMenu;
+package org.terasology.network;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -28,11 +28,18 @@ import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.rendering.nui.layers.mainMenu.JoinGameScreen;
 
 
 public class BroadCastServer {
+
     private static DatagramSocket socket;
     private static boolean turnOnBroadcast;
+    private static final Logger logger = LoggerFactory.getLogger(JoinGameScreen.class);
+    private NetworkSystem networkSystem;
+
 
     public boolean isTurnOnBroadcast() {
         return turnOnBroadcast;
@@ -46,13 +53,13 @@ public class BroadCastServer {
         Runnable runnable = new Runnable() {
             public void run() {
                 try {
+                    logger.info("Broadcasting message" + message);
                     for (InetAddress inadr : listAllBroadcastAddresses()) {
                         broadcast(message, inadr);
                     }
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-                System.out.println("Hello !!");
             }
         };
         ScheduledExecutorService service = Executors
@@ -63,7 +70,6 @@ public class BroadCastServer {
     /**
      * @param broadcastMessage The broadcast Message
      * @param address address for which the message needs to be broadcasted
-     * @throws IOException
      */
     public void broadcast(
         String broadcastMessage, InetAddress address) throws IOException {
@@ -77,9 +83,9 @@ public class BroadCastServer {
         socket.send(packet);
         socket.close();
     }
+
     /**
      * @return List of InetAddresses for the network interface
-     * @throws SocketException
      */
     public static List<InetAddress> listAllBroadcastAddresses() throws SocketException {
         List<InetAddress> broadcastList = new ArrayList<>();
@@ -99,4 +105,5 @@ public class BroadCastServer {
         }
         return broadcastList;
     }
+
 }

--- a/engine/src/main/java/org/terasology/network/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/network/BroadCastServer.java
@@ -15,18 +15,11 @@
  */
 package org.terasology.network;
 
-import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -39,14 +32,9 @@ import org.terasology.rendering.nui.layers.mainMenu.JoinGameScreen;
 public class BroadCastServer {
 
     private static DatagramSocket socket;
-
-
     private static boolean turnOnBroadcast;
     private static final Logger logger = LoggerFactory.getLogger(JoinGameScreen.class);
     private static ScheduledExecutorService service;
-    private Config config;
-
-
 
     public boolean isBroadCastTurnedOn() {
         return turnOnBroadcast;
@@ -83,9 +71,8 @@ public class BroadCastServer {
         // Broadcast address for finding routers.
         final String ssdpIP = "239.255.255.250";
         int timeout = 5000;
-        InetAddress localhost = InetAddress.getLocalHost();
         // Send from localhost:1901
-        InetSocketAddress srcAddress = new InetSocketAddress(localhost, ssdpSearchPort);
+        InetSocketAddress srcAddress = new InetSocketAddress(ssdpSearchPort);
         // Send to 239.255.255.250:1900
         InetSocketAddress dstAddress = new InetSocketAddress(InetAddress.getByName(ssdpIP), ssdpPort);
         // ----------------------------------------- //
@@ -108,15 +95,14 @@ public class BroadCastServer {
         try {
             multicast = new MulticastSocket(null);
             multicast.bind(srcAddress);
-            multicast.setTimeToLive(4);
-            System.out.println("Send multicast request.");
+            multicast.setTimeToLive(timeout);
+            logger.info("Send multicast request.");
             // ----- Sending multi-cast packet ----- //
             multicast.send(discoveryPacket);
         } finally {
-            System.out.println("Multicast ends. Close connection.");
+            logger.info("Multicast ends. Close connection.");
             multicast.disconnect();
             multicast.close();
         }
     }
-
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/BroadCastServer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/BroadCastServer.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.nui.layers.mainMenu;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+public class BroadCastServer {
+    private static DatagramSocket socket;
+    private static boolean turnOnBroadcast;
+
+    public boolean isTurnOnBroadcast() {
+        return turnOnBroadcast;
+    }
+
+    public void setTurnOnBroadcast(boolean turnOnBroadcast) {
+        BroadCastServer.turnOnBroadcast = turnOnBroadcast;
+    }
+
+    public void startBroadcast(String message) {
+        Runnable runnable = new Runnable() {
+            public void run() {
+                try {
+                    for (InetAddress inadr : listAllBroadcastAddresses()) {
+                        broadcast(message, inadr);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                System.out.println("Hello !!");
+            }
+        };
+        ScheduledExecutorService service = Executors
+            .newSingleThreadScheduledExecutor();
+        service.scheduleAtFixedRate(runnable, 0, 300, TimeUnit.SECONDS);
+    }
+
+    /**
+     * @param broadcastMessage The broadcast Message
+     * @param address address for which the message needs to be broadcasted
+     * @throws IOException
+     */
+    public void broadcast(
+        String broadcastMessage, InetAddress address) throws IOException {
+        socket = new DatagramSocket();
+        socket.setBroadcast(true);
+
+        byte[] buffer = broadcastMessage.getBytes();
+
+        DatagramPacket packet
+            = new DatagramPacket(buffer, buffer.length, address, 4445);
+        socket.send(packet);
+        socket.close();
+    }
+    /**
+     * @return List of InetAddresses for the network interface
+     * @throws SocketException
+     */
+    public static List<InetAddress> listAllBroadcastAddresses() throws SocketException {
+        List<InetAddress> broadcastList = new ArrayList<>();
+        Enumeration<NetworkInterface> interfaces
+            = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+
+            if (networkInterface.isLoopback() || !networkInterface.isUp()) {
+                continue;
+            }
+
+            networkInterface.getInterfaceAddresses().stream()
+                .map(a -> a.getBroadcast())
+                .filter(Objects::nonNull)
+                .forEach(broadcastList::add);
+        }
+        return broadcastList;
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -19,15 +19,12 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import org.jboss.netty.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.config.ServerInfo;
-import org.terasology.context.Context;
 import org.terasology.engine.GameEngine;
 import org.terasology.engine.GameThread;
 import org.terasology.engine.modes.StateLoading;
@@ -41,7 +38,6 @@ import org.terasology.network.BroadCastServer;
 import org.terasology.network.JoinStatus;
 import org.terasology.network.NetworkSystem;
 import org.terasology.network.PingService;
-import org.terasology.network.Server;
 import org.terasology.network.ServerInfoMessage;
 import org.terasology.network.ServerInfoService;
 import org.terasology.registry.In;
@@ -373,8 +369,7 @@ public class JoinGameScreen extends CoreScreenLayer {
                 if (!broadCastServer.isBroadCastTurnedOn()) {
                     broadCastServer.setTurnOnBroadcast(true);
                     broadCastServerButton.setText(translationSystem.translate("${engine:menu#join-server-terminate-broadcast}"));
-                    String message = buildBroadCastMessage();
-                    broadCastServer.startBroadcast(message);
+                    broadCastServer.startBroadcast();
                 } else {
                     broadCastServerButton.setText(translationSystem.translate("${engine:menu#join-server-broadcast}"));
                     broadCastServer.setTurnOnBroadcast(false);
@@ -546,9 +541,4 @@ public class JoinGameScreen extends CoreScreenLayer {
         visibleList.setSelection(i);
     }
 
-    private String buildBroadCastMessage() {
-        logger.info("Building Broadcast Message");
-        int serverPort = config.getNetwork().getServerPort();
-        return "Hello I am running on server" + config.getNetwork().getMasterServer()+ "and Port:"+ serverPort;
-    }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -362,20 +362,24 @@ public class JoinGameScreen extends CoreScreenLayer {
         }
 
         UIButton broadCastServerButton = find("broadcast", UIButton.class);
-        broadCastServerButton.setText("Broadcast");
         if (broadCastServerButton != null) {
             broadCastServerButton.bindEnabled(new ReadOnlyBinding<Boolean>() {
                 @Override
                 public Boolean get() {
-                    return !broadCastServer.isTurnOnBroadcast();
+                    return true;
                 }
             });
             broadCastServerButton.subscribe(button -> {
+                if (!broadCastServer.isBroadCastTurnedOn()) {
                     broadCastServer.setTurnOnBroadcast(true);
-                    broadCastServerButton.setText("Stop BroadCast");
+                    broadCastServerButton.setText(translationSystem.translate("${engine:menu#join-server-terminate-broadcast}"));
                     String message = buildBroadCastMessage();
-                    System.out.println(message);
                     broadCastServer.startBroadcast(message);
+                } else {
+                    broadCastServerButton.setText(translationSystem.translate("${engine:menu#join-server-broadcast}"));
+                    broadCastServer.setTurnOnBroadcast(false);
+                    broadCastServer.stopBroadCast();
+                }
              });
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -363,7 +363,7 @@ public class JoinGameScreen extends CoreScreenLayer {
             broadCastServerButton.bindEnabled(new ReadOnlyBinding<Boolean>() {
                 @Override
                 public Boolean get() {
-                    return broadCastServer.isTurnOnBroadcast();
+                    return !broadCastServer.isTurnOnBroadcast();
                 }
             });
             broadCastServerButton.subscribe(button -> {

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -214,6 +214,8 @@
     "invert-z": "invert-z",
     "join-game-online": "join-game-online",
     "join-server-action": "join-server-action",
+    "join-server-broadcast": "join-server-broadcast",
+    "join-server-terminate-broadcast": "join-server-terminate-broadcast",
     "join-server-refresh": "join-server-refresh",
     "join-server-requested": "join-server-requested",
     "join-server-title": "join-server-title",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -218,6 +218,8 @@
     "join-game-online": "Join Game",
     "join-server-refresh": "Refresh",
     "join-server-action": "Join",
+    "join-server-broadcast": "Broadcast",
+    "join-server-terminate-broadcast": "Terminate Broadcast"
     "join-server-requested": "Requested",
     "join-server-title": "Join Server",
     "light-shafts": "Light Shafts",

--- a/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/joinGameScreen.ui
@@ -334,6 +334,18 @@
                                                 "target": "BOTTOM"
                                             }
                                         }
+                                    },
+                                    {
+                                        "type": "UIButton",
+                                        "id": "broadcast",
+                                        "text": "${engine:menu#join-server-broadcast}",
+                                        "family": "highlight",
+                                        "layoutInfo": {
+                                            "height": 40,
+                                            "position-bottom": {
+                                                "target": "BOTTOM"
+                                            }
+                                        }
                                     }
                                 ],
                                 "layoutInfo": {


### PR DESCRIPTION
Ability to Broadcast games on the Local Area Network

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

`JoinGameScreen.java` - Added the broadcast button to be enabled only when the server is not broadcasting, along with a custom message of all the modules, ports and IpAddresse's

`Broadcast.java` - Added the ability to broadcast the game on all local listening servers.
The message is broadcasted every 5 minutes.
"Fixes https://github.com/MovingBlocks/Terasology/issues/3760"

### How to test

The broadcast button is added to the User Interface and the respective broadcasted message can be read on the Join Game Server on a machine present on the LAN.

### Outstanding before merging

- :heavy_check_mark:  UI button for broadcasting
- :heavy_check_mark: Make sure Broadcasting is enabled for headless server.
-  [ ]  Need to add documentation for this.
