### PR TITLE
Update to BlockShape format: Replace BlockPart with String

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/block/shape/BlockShapeTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/shape/BlockShapeTest.java
@@ -80,16 +80,23 @@ public class BlockShapeTest extends TerasologyTestingEnvironment {
 
         ObjectArrayList<javax.vecmath.Vector3f> points = ((com.bulletphysics.collision.shapes.ConvexHullShape) bulletConvexHullShape.underlyingShape).getPoints();
         for (int x = 0; x < points.size(); x++) {
-            fuzzVectorTest(test[x], VecMath.from(points.get(x)));
-
+            fuzzVectorTest(test[x], points);
         }
 
     }
 
-    private void fuzzVectorTest(Vector3f test, Vector3f actual) {
-        assertEquals(test.x, actual.x, .1f);
-        assertEquals(test.y, actual.y, .1f);
-        assertEquals(test.z, actual.z, .1f);
+    private void fuzzVectorTest(Vector3f test, ObjectArrayList<javax.vecmath.Vector3f> actual) {
+        boolean match = false;
+        for (javax.vecmath.Vector3f actually : actual) {
+            if (Math.abs(actually.x - test.x) < 0.1) {
+                if (Math.abs(actually.y - test.y) < 0.1) {
+                    if (Math.abs(actually.z - test.z) < 0.1) {
+                        match = true;
+                    }
+                }
+            }
+        }
+        assertTrue(match);
     }
 
 

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.rendering.assets.mesh.Mesh;
 import org.terasology.world.ChunkView;
 import org.terasology.world.block.Block;
@@ -26,6 +27,8 @@ import org.terasology.world.block.BlockAppearance;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.shapes.BlockMeshPart;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
@@ -48,17 +51,17 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             Block blockToCheck = view.getBlock(x + offset.x, y + offset.y, z + offset.z);
             adjacentBlocks.put(side, blockToCheck);
         }
+
+        final ChunkMesh.RenderType renderType = getRenderType(selfBlock);
+        final BlockAppearance blockAppearance = selfBlock.getPrimaryAppearance();
+        final ChunkVertexFlag vertexFlag = getChunkVertexFlag(view, x, y, z, selfBlock);
+        final List<String> sectionsToRender = new ArrayList<>();
+
+        //Collect all sections that should be visible
         for (final Side side : Side.getAllSides()) {
             if (isSideVisibleForBlockTypes(adjacentBlocks.get(side), selfBlock, side)) {
-                final ChunkMesh.RenderType renderType = getRenderType(selfBlock);
-                final BlockAppearance blockAppearance = selfBlock.getPrimaryAppearance();
-                final ChunkVertexFlag vertexFlag = getChunkVertexFlag(view, x, y, z, selfBlock);
-
-                if (blockAppearance.getPart(BlockPart.CENTER) != null) {
-                    blockAppearance.getPart(BlockPart.CENTER).appendTo(chunkMesh, x, y, z, renderType, vertexFlag);
-                }
-
-                BlockMeshPart blockMeshPart = blockAppearance.getPart(BlockPart.fromSide(side));
+                List<String> blockMeshParts = blockAppearance.getParts(side);
+                List<BlockMeshPart> renderableParts = new ArrayList<>();
 
                 // If the selfBlock isn't lowered, some more faces may have to be drawn
                 if (selfBlock.isLiquid()) {
@@ -70,24 +73,46 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                         final Block adjacent = adjacentBlocks.get(side);
 
                         if (adjacent.isLiquid() && !adjacentAbove.isLiquid()) {
-                            blockMeshPart = selfBlock.getTopLiquidMesh(side);
+                            renderableParts.add(selfBlock.getTopLiquidMesh(side));
                         }
                     } else {
-                        if (blockMeshPart != null) {
-                            blockMeshPart = selfBlock.getLowLiquidMesh(side);
+                        if (blockMeshParts != null && !blockMeshParts.isEmpty()) {
+                            renderableParts.add(selfBlock.getLowLiquidMesh(side));
                         }
                     }
                 }
 
-                if (blockMeshPart != null) {
-                    // TODO: Needs review since the new per-vertex flags introduce a lot of special scenarios - probably a per-side setting?
-                    ChunkVertexFlag sideVertexFlag = vertexFlag;
-                    if (selfBlock.isGrass() && side != Side.TOP && side != Side.BOTTOM) {
-                        sideVertexFlag = ChunkVertexFlag.COLOR_MASK;
+                if (!renderableParts.isEmpty()) {
+                    for (BlockMeshPart part : renderableParts) {
+                        Vector4f colorOffset = selfBlock.getColorOffset("default");
+                        Vector4f colorSource = selfBlock.getColorSource("default").calcColor(null, x, y, z);
+                        Vector4f colorResult = new Vector4f(colorSource.x * colorOffset.x, colorSource.y * colorOffset.y, colorSource.z * colorOffset.z, colorSource.w * colorOffset.w);
+                        part.appendTo(chunkMesh, x, y, z, renderType, colorResult, vertexFlag);
                     }
-                    blockMeshPart.appendTo(chunkMesh, x, y, z, renderType, sideVertexFlag);
+                }
+
+                //Add the visible pieces to the list
+                if (blockMeshParts != null && !blockMeshParts.isEmpty()) {
+                    for (String name : blockMeshParts) {
+                        if (!sectionsToRender.contains(name)) {
+                            sectionsToRender.add(name);
+                        }
+                    }
                 }
             }
+        }
+
+        //Iterate through the list of visible sections we gathered per-side
+        for (String name : sectionsToRender) {
+            // TODO: Needs review since the new per-vertex flags introduce a lot of special scenarios - probably a per-side setting?
+            ChunkVertexFlag sideVertexFlag = vertexFlag;
+            if (selfBlock.isGrass() && !name.equals("top") && !name.equals("bottom")) {
+                sideVertexFlag = ChunkVertexFlag.COLOR_MASK;
+            }
+            Vector4f colorOffset = selfBlock.getColorOffset(name);
+            Vector4f colorSource = selfBlock.getColorSource(name).calcColor(null, x, y, z);
+            Vector4f colorResult = new Vector4f(colorSource.x * colorOffset.x, colorSource.y * colorOffset.y, colorSource.z * colorOffset.z, colorSource.w * colorOffset.w);
+            blockAppearance.getPart(name).appendTo(chunkMesh, x, y, z, renderType, colorResult, sideVertexFlag);
         }
     }
 
@@ -157,13 +182,16 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
     private void generateMesh() {
         Tessellator tessellator = new Tessellator();
-        for (BlockPart dir : BlockPart.values()) {
-            BlockMeshPart part = block.getPrimaryAppearance().getPart(dir);
-            if (part != null) {
-                if (block.isDoubleSided()) {
-                    tessellator.addMeshPartDoubleSided(part);
-                } else {
-                    tessellator.addMeshPart(part);
+        for (Side side : Side.getAllSides()) {
+            List<String> parts = block.getPrimaryAppearance().getParts(side);
+            for (String name : parts) {
+                BlockMeshPart part = block.getPrimaryAppearance().getPart(name);
+                if (part != null) {
+                    if (block.isDoubleSided()) {
+                        tessellator.addMeshPartDoubleSided(part);
+                    } else {
+                        tessellator.addMeshPart(part);
+                    }
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -24,7 +24,6 @@ import org.terasology.rendering.assets.mesh.Mesh;
 import org.terasology.world.ChunkView;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockAppearance;
-import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.shapes.BlockMeshPart;
 
 import java.util.ArrayList;
@@ -84,10 +83,12 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
                 if (!renderableParts.isEmpty()) {
                     for (BlockMeshPart part : renderableParts) {
-                        Vector4f colorOffset = selfBlock.getColorOffset("default");
-                        Vector4f colorSource = selfBlock.getColorSource("default").calcColor(null, x, y, z);
-                        Vector4f colorResult = new Vector4f(colorSource.x * colorOffset.x, colorSource.y * colorOffset.y, colorSource.z * colorOffset.z, colorSource.w * colorOffset.w);
-                        part.appendTo(chunkMesh, x, y, z, renderType, colorResult, vertexFlag);
+                        if (part != null) {
+                            Vector4f colorOffset = selfBlock.getColorOffset("default");
+                            Vector4f colorSource = selfBlock.getColorSource("default").calcColor(null, x, y, z);
+                            Vector4f colorResult = new Vector4f(colorSource.x * colorOffset.x, colorSource.y * colorOffset.y, colorSource.z * colorOffset.z, colorSource.w * colorOffset.w);
+                            part.appendTo(chunkMesh, x, y, z, renderType, colorResult, vertexFlag);
+                        }
                     }
                 }
 

--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -544,7 +544,10 @@ public final class Block {
     }
 
     public BlockColorSource getColorSource(String blockSection) {
-        return colorSource.computeIfAbsent(blockSection, (k) -> colorSource.get("default"));
+        if (colorSource.containsKey(blockSection) && colorSource.get(blockSection) != null) {
+            return colorSource.get(blockSection);
+        }
+        return colorSource.get("default");
     }
 
     public void setColorSource(BlockColorSource colorSource) {
@@ -556,7 +559,10 @@ public final class Block {
     }
 
     public Vector4f getColorOffset(String blockSection) {
-        return colorOffsets.computeIfAbsent(blockSection, (k) -> colorOffsets.get("default"));
+        if (colorOffsets.containsKey(blockSection) && colorOffsets.get(blockSection) != null) {
+            return colorOffsets.get(blockSection);
+        }
+        return colorOffsets.get("default");
     }
 
     public void setColorOffset(String blockSection, Vector4f color) {

--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -27,6 +27,7 @@ import org.terasology.math.Transform;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.Mesh;
@@ -42,6 +43,7 @@ import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.chunks.ChunkConstants;
 
 import java.math.RoundingMode;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -95,6 +97,8 @@ public final class Block {
     private boolean waving;
     private byte luminance;
     private Vector3f tint = new Vector3f(0, 0, 0);
+    private Map<String, BlockColorSource> colorSource = new HashMap<>();
+    private Map<String, Vector4f> colorOffsets = new HashMap<>();
 
     // Collision related
     private boolean penetrable;
@@ -125,6 +129,14 @@ public final class Block {
     private CollisionShape collisionShape;
     private Vector3f collisionOffset;
     private AABB bounds = AABB.createEmpty();
+
+    /**
+     * Init. a new block with default properties in place.
+     */
+    public Block() {
+        colorSource.put("default", DefaultColorSource.DEFAULT);
+        colorOffsets.put("default", new Vector4f(1.0f, 1.0f, 1.0f, 1.0f));
+    }
 
     public short getId() {
         return id;
@@ -527,10 +539,33 @@ public final class Block {
         return primaryAppearance;
     }
 
-    public void setPrimaryAppearance(BlockAppearance appearence) {
-        this.primaryAppearance = appearence;
+    public void setPrimaryAppearance(BlockAppearance appearance) {
+        this.primaryAppearance = appearance;
     }
 
+    public BlockColorSource getColorSource(String blockSection) {
+        return colorSource.computeIfAbsent(blockSection, (k) -> colorSource.get("default"));
+    }
+
+    public void setColorSource(BlockColorSource colorSource) {
+        this.colorSource.put("default", colorSource);
+    }
+
+    public void setColorSource(String blockSection, BlockColorSource value) {
+        this.colorSource.put(blockSection, value);
+    }
+
+    public Vector4f getColorOffset(String blockSection) {
+        return colorOffsets.computeIfAbsent(blockSection, (k) -> colorOffsets.get("default"));
+    }
+
+    public void setColorOffset(String blockSection, Vector4f color) {
+        colorOffsets.put(blockSection, color);
+    }
+
+    public void setColorOffsets(Vector4f color) {
+        colorOffsets.put("default", color);
+    }
 
     /**
      * @return Standalone mesh

--- a/engine/src/main/java/org/terasology/world/block/BlockAppearance.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockAppearance.java
@@ -18,10 +18,13 @@ package org.terasology.world.block;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 
+import org.terasology.math.Side;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.world.block.shapes.BlockMeshPart;
 
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,33 +33,32 @@ import java.util.Map;
  */
 public class BlockAppearance {
 
-    private Map<BlockPart, BlockMeshPart> blockParts;
-    private Map<BlockPart, Vector2f> textureAtlasPos = new EnumMap<>(BlockPart.class);
+    private Map<String, BlockMeshPart> blockParts = new HashMap<>();
+    private Map<String, Vector2f> textureAtlasPos = new HashMap<>();
+    private Map<Side, List<BlockMeshPart>> blockSides = Maps.newEnumMap(Side.class);
 
     public BlockAppearance() {
-        blockParts = Maps.newEnumMap(BlockPart.class);
-        textureAtlasPos = Maps.newEnumMap(BlockPart.class);
-        for (BlockPart part : BlockPart.values()) {
-            textureAtlasPos.put(part, new Vector2f());
-        }
     }
 
-    public BlockAppearance(Map<BlockPart, BlockMeshPart> blockParts, Map<BlockPart, Vector2f> textureAtlasPos) {
+    public BlockAppearance(Map<String, BlockMeshPart> blockParts, Map<Side, List<BlockMeshPart>> blockSide, Map<String, Vector2f> textureAtlasPos) {
         Preconditions.checkNotNull(blockParts);
+        Preconditions.checkNotNull(blockSide);
         Preconditions.checkNotNull(textureAtlasPos);
         this.blockParts = blockParts;
         this.textureAtlasPos.putAll(textureAtlasPos);
-        for (BlockPart part : BlockPart.values()) {
-            Preconditions.checkNotNull("Missing texture atlas position for part " + part, textureAtlasPos.get(part));
-        }
+        this.blockSides = blockSide;
     }
 
-    public BlockMeshPart getPart(BlockPart part) {
-        return blockParts.get(part);
+    public BlockMeshPart getPart(String name) {
+        return blockParts.get(name);
     }
 
-    public Vector2f getTextureAtlasPos(BlockPart part) {
-        return new Vector2f(textureAtlasPos.get(part));
+    public List<BlockMeshPart> getParts(Side side) {
+        return blockSides.get(side);
+    }
+
+    public Vector2f getTextureAtlasPos(String name) {
+        return new Vector2f(textureAtlasPos.get(name));
     }
 
 }

--- a/engine/src/main/java/org/terasology/world/block/BlockAppearance.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockAppearance.java
@@ -35,12 +35,12 @@ public class BlockAppearance {
 
     private Map<String, BlockMeshPart> blockParts = new HashMap<>();
     private Map<String, Vector2f> textureAtlasPos = new HashMap<>();
-    private Map<Side, List<BlockMeshPart>> blockSides = Maps.newEnumMap(Side.class);
+    private Map<Side, List<String>> blockSides = Maps.newEnumMap(Side.class);
 
     public BlockAppearance() {
     }
 
-    public BlockAppearance(Map<String, BlockMeshPart> blockParts, Map<Side, List<BlockMeshPart>> blockSide, Map<String, Vector2f> textureAtlasPos) {
+    public BlockAppearance(Map<String, BlockMeshPart> blockParts, Map<Side, List<String>> blockSide, Map<String, Vector2f> textureAtlasPos) {
         Preconditions.checkNotNull(blockParts);
         Preconditions.checkNotNull(blockSide);
         Preconditions.checkNotNull(textureAtlasPos);
@@ -53,7 +53,7 @@ public class BlockAppearance {
         return blockParts.get(name);
     }
 
-    public List<BlockMeshPart> getParts(Side side) {
+    public List<String> getParts(Side side) {
         return blockSides.get(side);
     }
 

--- a/engine/src/main/java/org/terasology/world/block/BlockColorSource.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockColorSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block;
+
+import org.terasology.math.geom.Vector4f;
+import org.terasology.world.generation.Region;
+
+/**
+ * Used to determine a multiplicative color for certain blocks based on the block's world conditions.
+ */
+@FunctionalInterface
+public interface BlockColorSource {
+
+    default Vector4f calcColor(Region worldData) {
+        return calcColor(worldData, 0, 0, 0);
+    };
+
+   default Vector4f calcColor(Region worldData, int x, int z) {
+       return calcColor(worldData, x, 0, z);
+   };
+
+    Vector4f calcColor(Region worldData, int x, int y, int z);
+
+}

--- a/engine/src/main/java/org/terasology/world/block/BlockPart.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockPart.java
@@ -24,7 +24,10 @@ import java.util.EnumMap;
 import java.util.List;
 
 /**
+ * The original method of determining when to render specific parts of a block shape.
+ * Deprecrated in favor of BlockSection.
  */
+@Deprecated
 public enum BlockPart {
     TOP(Side.TOP),
     LEFT(Side.LEFT),

--- a/engine/src/main/java/org/terasology/world/block/BlockSection.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockSection.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block;
+
+import org.terasology.math.Side;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * BlockSection is a replacement for BlockPart, which allows for the declaration
+ * of arbitrary components of shapes to be rendered whenever any valid side is visible.
+ */
+public class BlockSection {
+
+    /**
+     * getBit converts each valid facing into a specific bit within a byte.
+     * @param side A valid block side direction.
+     * @return The bitwise position within a byte that represents the side.
+     */
+    public static int getBit(Side side) {
+        switch (side) {
+            case FRONT: return 0;
+            case BACK: return 1;
+            case TOP: return 2;
+            case BOTTOM: return 3;
+            case LEFT: return 4;
+            case RIGHT: return 5;
+        }
+        return 0;
+    }
+
+    /**
+     * Determine whether the given face is enabled in the given byte.
+     * @param key The byte representing the section's face data.
+     * @param side The specific side to check.
+     * @return True if the section should render at that side.
+     */
+    public static boolean isSide(byte key, Side side) {
+        return ((byte)(key >> getBit(side)) & 1) == 1;
+    }
+
+    /**
+     * Creates a byte key representing the given sides.
+     * @param sides The sides to be enabled.
+     * @return The byte key.
+     */
+    public static byte key(Side... sides) {
+        byte result = 0;
+        for (Side side : sides) {
+            result |= 1 << getBit(side);
+        }
+        return result;
+    }
+
+    /**
+     * Creates a byte key representing the sides which match the provided string.
+     * @param string A directional word, such as "left", "right", or "sides".
+     * @return The byte key for the proper faces to be enabled.
+     */
+    public static byte key(String string) {
+        return key(fromWord(string));
+    }
+
+    /**
+     * Creates a list of all valid sides represented by the given key.
+     * It is generally recommended to instead use isSide(key, side)
+     * @param key The byte key representing a section.
+     * @return A List containing all sides that are enabled.
+     */
+    public static List<Side> fromKey(byte key) {
+        List<Side> result = new ArrayList<Side>();
+        for (Side side : Side.values()) {
+            if (isSide(key, side)) result.add(side);
+        }
+        return result;
+    }
+
+    /**
+     * Returns an array of sides represented by a given string.
+     * @param name A directional phrase, such as "up", "left", or "sides".
+     * @return The array of all sides represented by the phrase.
+     */
+    public static Side[] fromWord(String name) {
+        name = name.toLowerCase();
+        switch(name) {
+            case "left": return new Side[]{Side.LEFT};
+            case "right": return new Side[]{Side.RIGHT};
+            case "up":
+            case "top": return new Side[]{Side.TOP};
+            case "down":
+            case "bottom": return new Side[]{Side.BOTTOM};
+            case "forward":
+            case "forwards":
+            case "front": return new Side[]{Side.FRONT};
+            case "backward":
+            case "backwards":
+            case "back": return new Side[]{Side.BACK};
+            case "all":
+            case "center":
+            case "any": return Side.values();
+            case "sides": return new Side[]{Side.FRONT, Side.BACK, Side.LEFT, Side.RIGHT};
+        }
+        return new Side[0];
+    }
+}

--- a/engine/src/main/java/org/terasology/world/block/DefaultColorSource.java
+++ b/engine/src/main/java/org/terasology/world/block/DefaultColorSource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.math.geom.Vector4f;
+import org.terasology.world.generation.Region;
+import org.terasology.world.generation.facets.SurfaceHumidityFacet;
+import org.terasology.world.generation.facets.SurfaceTemperatureFacet;
+
+import javax.imageio.ImageIO;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Different color sources for blocks.
+ */
+public enum DefaultColorSource implements BlockColorSource {
+
+    DEFAULT {
+        @Override
+        public Vector4f calcColor(Region worldData, int x, int y, int z) {
+            return new Vector4f(1, 1, 1, 1);
+        }
+    },
+    COLOR_LUT {
+        @Override
+        public Vector4f calcColor(Region worldData, int x, int y, int z) {
+            float humidity = worldData.getFacet(SurfaceHumidityFacet.class).get(x, z);
+            float temperature = worldData.getFacet(SurfaceTemperatureFacet.class).get(x, z);
+            float prod = temperature * humidity;
+            int rgbValue = colorLut.getRGB((int) ((1.0 - temperature) * 255.0), (int) ((1.0 - prod) * 255.0));
+
+            Color c = new Color(rgbValue);
+            return new Vector4f(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, 1.0f);
+        }
+    },
+    FOLIAGE_LUT {
+        @Override
+        public Vector4f calcColor(Region worldData, int x, int y, int z) {
+            float humidity = worldData.getFacet(SurfaceHumidityFacet.class).get(x, z);
+            float temperature = worldData.getFacet(SurfaceTemperatureFacet.class).get(x, z);
+            float prod = humidity * temperature;
+            int rgbValue = foliageLut.getRGB((int) ((1.0 - temperature) * 255.0), (int) ((1.0 - prod) * 255.0));
+
+            Color c = new Color(rgbValue);
+            return new Vector4f(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, 1.0f);
+        }
+    };
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultColorSource.class);
+
+    /* LUTs */
+    private static BufferedImage colorLut;
+
+    private static BufferedImage foliageLut;
+
+    static {
+        try {
+            // TODO: Read these from asset manager
+            colorLut = ImageIO.read(DefaultColorSource.class.getResource("/assets/textures/grasscolor.png"));
+            foliageLut = ImageIO.read(DefaultColorSource.class.getResource("/assets/textures/foliagecolor.png"));
+        } catch (IOException e) {
+            logger.error("Failed to load LUTs", e);
+        }
+    }
+
+}

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
@@ -185,7 +185,7 @@ public class BlockBuilder implements BlockBuilderHelper {
 
     private BlockAppearance createAppearance(BlockShape shape, Map<String, BlockTile> tiles, Rotation rot) {
         Map<String, BlockMeshPart> meshParts = new HashMap<>();
-        Map<Side, List<BlockMeshPart>> sideListMap = Maps.newEnumMap(Side.class);
+        Map<Side, List<String>> sideListMap = Maps.newEnumMap(Side.class);
         Map<String, Vector2f> textureAtlasPositions = new HashMap<>();
         for (String blockPart : shape.getMeshMap().keySet()) {
             // TODO: Need to be more sensible with the texture atlas. Because things like block particles read from a part that may not exist, we're being fairly lenient

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
@@ -123,9 +123,11 @@ public class BlockBuilder implements BlockBuilderHelper {
         setBlockFullSides(block, shape, rotation);
         block.setCollision(shape.getCollisionOffset(rotation), shape.getCollisionShape(rotation));
 
-        for (String part : shape.getMeshMap().keySet()) {
-            block.setColorSource(part, section.getColorSources().get(part));
-            block.setColorOffset(part, section.getColorOffsets().get(part));
+        for (String key : section.getColorSources().keySet()) {
+            block.setColorSource(key, section.getColorSources().get(key));
+        }
+        for (String key : section.getColorOffsets().keySet()) {
+            block.setColorOffset(key, section.getColorOffsets().get(key));
         }
 
         block.setUri(uri);
@@ -191,7 +193,12 @@ public class BlockBuilder implements BlockBuilderHelper {
             // TODO: Need to be more sensible with the texture atlas. Because things like block particles read from a part that may not exist, we're being fairly lenient
             Vector2f atlasPos;
             int frameCount;
-            BlockTile tile = tiles.get(blockPart);
+            BlockTile tile;
+            if (tiles.containsKey(blockPart)) {
+                tile = tiles.get(blockPart);
+            } else {
+                tile = tiles.get("default");
+            }
             if (tile == null) {
                 atlasPos = new Vector2f();
                 frameCount = 1;

--- a/engine/src/main/java/org/terasology/world/block/loader/AutoBlockProvider.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/AutoBlockProvider.java
@@ -70,9 +70,7 @@ public class AutoBlockProvider implements AssetDataProducer<BlockFamilyDefinitio
         Optional<BlockTile> blockTile = assetManager.getAsset(urn, BlockTile.class);
         if (blockTile.isPresent() && blockTile.get().isAutoBlock()) {
             BlockFamilyDefinitionData data = new BlockFamilyDefinitionData();
-            for (BlockPart part : BlockPart.values()) {
-                data.getBaseSection().getBlockTiles().put(part, blockTile.get());
-            }
+            data.getBaseSection().getBlockTiles().put("default", blockTile.get());
             data.getBaseSection().setSounds(assetManager.getAsset("engine:default", BlockSounds.class).get());
             data.setBlockFamily(FreeformFamily.class);
             return Optional.of(data);

--- a/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
@@ -28,6 +28,7 @@ import org.terasology.world.block.tiles.BlockTile;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  */
@@ -256,7 +257,7 @@ public class SectionDefinitionData {
         this.tint = tint;
     }
 
-    public HashMap<String, BlockTile> getBlockTiles() {
+    public Map<String, BlockTile> getBlockTiles() {
         return blockTiles;
     }
 
@@ -264,7 +265,7 @@ public class SectionDefinitionData {
         blockTiles.put("default", tile);
     }
 
-    public HashMap<String, DefaultColorSource> getColorSources() {
+    public Map<String, DefaultColorSource> getColorSources() {
         return colorSources;
     }
 
@@ -272,7 +273,7 @@ public class SectionDefinitionData {
         colorSources.put("default", source);
     }
 
-    public HashMap<String, Vector4f> getColorOffsets() {
+    public Map<String, Vector4f> getColorOffsets() {
         return colorOffsets;
     }
 

--- a/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
@@ -16,14 +16,18 @@
 package org.terasology.world.block.loader;
 
 import com.google.common.collect.Maps;
+import org.terasology.math.geom.BaseVector4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.module.sandbox.API;
 import org.terasology.world.block.BlockPart;
+import org.terasology.world.block.DefaultColorSource;
 import org.terasology.world.block.shapes.BlockShape;
 import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.block.tiles.BlockTile;
 
 import java.util.EnumMap;
+import java.util.HashMap;
 
 /**
  */
@@ -52,7 +56,9 @@ public class SectionDefinitionData {
 
     private Vector3f tint = new Vector3f();
 
-    private EnumMap<BlockPart, BlockTile> blockTiles = Maps.newEnumMap(BlockPart.class);
+    private HashMap<String, BlockTile> blockTiles = new HashMap<>();
+    private HashMap<String, DefaultColorSource> colorSources = new HashMap<>();
+    private HashMap<String, Vector4f> colorOffsets = new HashMap<>();
 
     private float mass = 10f;
     private boolean debrisOnDestroy = true;
@@ -68,6 +74,8 @@ public class SectionDefinitionData {
     private boolean ice;
 
     public SectionDefinitionData() {
+        colorSources.put("default", DefaultColorSource.DEFAULT);
+        colorOffsets.put("default", new Vector4f(1, 1, 1, 1));
     }
 
     public SectionDefinitionData(SectionDefinitionData other) {
@@ -93,7 +101,9 @@ public class SectionDefinitionData {
         this.luminance = other.luminance;
         this.tint = new Vector3f(other.tint);
 
-        this.blockTiles = new EnumMap<>(other.blockTiles);
+        this.blockTiles = new HashMap<>(other.blockTiles);
+        this.colorSources = new HashMap<>(other.colorSources);
+        this.colorOffsets = new HashMap<>(other.colorOffsets);
 
         this.mass = other.mass;
         this.debrisOnDestroy = other.debrisOnDestroy;
@@ -246,14 +256,28 @@ public class SectionDefinitionData {
         this.tint = tint;
     }
 
-    public EnumMap<BlockPart, BlockTile> getBlockTiles() {
+    public HashMap<String, BlockTile> getBlockTiles() {
         return blockTiles;
     }
 
     public void setAllTiles(BlockTile tile) {
-        for (BlockPart part : BlockPart.values()) {
-            blockTiles.put(part, tile);
-        }
+        blockTiles.put("default", tile);
+    }
+
+    public HashMap<String, DefaultColorSource> getColorSources() {
+        return colorSources;
+    }
+
+    public void setAllColorSources(DefaultColorSource source) {
+        colorSources.put("default", source);
+    }
+
+    public HashMap<String, Vector4f> getColorOffsets() {
+        return colorOffsets;
+    }
+
+    public void setAllColorOffsets(BaseVector4f offset) {
+        colorOffsets.put("default", new Vector4f(offset));
     }
 
     public float getMass() {

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockMeshPart.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockMeshPart.java
@@ -18,6 +18,7 @@ package org.terasology.world.block.shapes;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.rendering.primitives.ChunkMesh;
 import org.terasology.rendering.primitives.ChunkVertexFlag;
 
@@ -30,6 +31,7 @@ import java.util.Arrays;
  */
 public class BlockMeshPart {
     private static final float BORDER = 1f / 128f;
+    private static final Vector4f plainColor = new Vector4f(1, 1, 1, 1);
 
     private Vector3f[] vertices;
     private Vector3f[] normals;
@@ -87,7 +89,7 @@ public class BlockMeshPart {
         return new BlockMeshPart(vertices, normals, newTexCoords, indices, frames);
     }
 
-    public void appendTo(ChunkMesh chunk, int offsetX, int offsetY, int offsetZ, ChunkMesh.RenderType renderType, ChunkVertexFlag flags) {
+    public void appendTo(ChunkMesh chunk, int offsetX, int offsetY, int offsetZ, ChunkMesh.RenderType renderType, Vector4f colorResult, ChunkVertexFlag flags) {
         ChunkMesh.VertexElements elements = chunk.getVertexElements(renderType);
         for (Vector2f texCoord : texCoords) {
             elements.tex.add(texCoord.x);
@@ -96,10 +98,10 @@ public class BlockMeshPart {
 
         int nextIndex = elements.vertexCount;
         for (int vIdx = 0; vIdx < vertices.length; ++vIdx) {
-            elements.color.add(1);
-            elements.color.add(1);
-            elements.color.add(1);
-            elements.color.add(1);
+            elements.color.add(colorResult.x);
+            elements.color.add(colorResult.y);
+            elements.color.add(colorResult.z);
+            elements.color.add(colorResult.w);
             elements.vertices.add(vertices[vIdx].x + offsetX);
             elements.vertices.add(vertices[vIdx].y + offsetY);
             elements.vertices.add(vertices[vIdx].z + offsetZ);
@@ -114,6 +116,10 @@ public class BlockMeshPart {
         for (int index : indices) {
             elements.indices.add(index + nextIndex);
         }
+    }
+
+    public void appendTo(ChunkMesh chunk, int offsetX, int offsetY, int offsetZ, ChunkMesh.RenderType renderType, ChunkVertexFlag flags) {
+        this.appendTo(chunk, offsetX, offsetY, offsetZ, renderType, plainColor, flags);
     }
 
     public BlockMeshPart rotate(Quat4f rotation) {

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
@@ -24,7 +24,9 @@ import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.world.block.BlockPart;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Describes a shape that a block can take. The shape may also be rotated if not symmetrical.
@@ -42,15 +44,14 @@ public abstract class BlockShape extends Asset<BlockShapeData> {
     public abstract String getDisplayName();
 
     /**
-     * @return All mesh parts contained by the block
-     */
-    public abstract List<BlockMeshPart> getMeshParts();
-
-    /**
      * @param side
      * @return The mesh parts for the given side of the block, or null if it has none
      */
     public abstract List<BlockMeshPart> getMeshParts(Side side);
+
+    public abstract Map<String, BlockMeshPart> getMeshMap();
+
+    public abstract BlockMeshPart getMeshPart(String name);
 
     /**
      * @param side

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
@@ -47,7 +47,7 @@ public abstract class BlockShape extends Asset<BlockShapeData> {
      * @param side
      * @return The mesh parts for the given side of the block, or null if it has none
      */
-    public abstract List<BlockMeshPart> getMeshParts(Side side);
+    public abstract List<String> getMeshParts(Side side);
 
     public abstract Map<String, BlockMeshPart> getMeshMap();
 

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
@@ -24,6 +24,8 @@ import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.world.block.BlockPart;
 
+import java.util.List;
+
 /**
  * Describes a shape that a block can take. The shape may also be rotated if not symmetrical.
  *
@@ -40,10 +42,15 @@ public abstract class BlockShape extends Asset<BlockShapeData> {
     public abstract String getDisplayName();
 
     /**
-     * @param part
-     * @return The mesh part for the given part of the block, or null if it has none
+     * @return All mesh parts contained by the block
      */
-    public abstract BlockMeshPart getMeshPart(BlockPart part);
+    public abstract List<BlockMeshPart> getMeshParts();
+
+    /**
+     * @param side
+     * @return The mesh parts for the given side of the block, or null if it has none
+     */
+    public abstract List<BlockMeshPart> getMeshParts(Side side);
 
     /**
      * @param side

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class BlockShapeData implements AssetData {
     private String displayName = "";
     public HashMap<String, BlockMeshPart> meshParts = new HashMap<>();
-    private EnumMap<Side, List<BlockMeshPart>> meshBySide = new EnumMap<>(Side.class);
+    private EnumMap<Side, List<String>> meshBySide = new EnumMap<>(Side.class);
     private EnumBooleanMap<Side> fullSide = new EnumBooleanMap<>(Side.class);
     private CollisionShape collisionShape;
     private Vector3f collisionOffset = new Vector3f();
@@ -53,7 +53,7 @@ public class BlockShapeData implements AssetData {
         this.displayName = displayName;
     }
 
-    public List<BlockMeshPart> getMeshParts(Side side) {
+    public List<String> getMeshParts(Side side) {
         return meshBySide.get(side);
     }
 
@@ -65,7 +65,7 @@ public class BlockShapeData implements AssetData {
     public void setMeshPart(BlockMeshPart mesh, String name, byte key) {
         List<Side> sides = BlockSection.fromKey(key);
         for (Side side : sides) {
-            meshBySide.computeIfAbsent(side, (v) -> new ArrayList<>()).add(mesh);
+            meshBySide.computeIfAbsent(side, (v) -> new ArrayList<>()).add(name);
         }
         meshParts.put(name, mesh);
     }

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
@@ -26,13 +26,14 @@ import org.terasology.world.block.BlockSection;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 
 /**
  */
 public class BlockShapeData implements AssetData {
     private String displayName = "";
-    private List<BlockMeshPart> meshParts = new ArrayList<>();
+    public HashMap<String, BlockMeshPart> meshParts = new HashMap<>();
     private EnumMap<Side, List<BlockMeshPart>> meshBySide = new EnumMap<>(Side.class);
     private EnumBooleanMap<Side> fullSide = new EnumBooleanMap<>(Side.class);
     private CollisionShape collisionShape;
@@ -52,10 +53,6 @@ public class BlockShapeData implements AssetData {
         this.displayName = displayName;
     }
 
-    public List<BlockMeshPart> getMeshParts() {
-        return meshParts;
-    }
-
     public List<BlockMeshPart> getMeshParts(Side side) {
         return meshBySide.get(side);
     }
@@ -65,12 +62,12 @@ public class BlockShapeData implements AssetData {
      *
      * @param mesh
      */
-    public void setMeshPart(BlockMeshPart mesh, byte key) {
+    public void setMeshPart(BlockMeshPart mesh, String name, byte key) {
         List<Side> sides = BlockSection.fromKey(key);
         for (Side side : sides) {
             meshBySide.computeIfAbsent(side, (v) -> new ArrayList<>()).add(mesh);
         }
-        meshParts.add(mesh);
+        meshParts.put(name, mesh);
     }
 
     public boolean isBlockingSide(Side side) {

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
@@ -22,14 +22,18 @@ import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.utilities.collection.EnumBooleanMap;
 import org.terasology.world.block.BlockPart;
+import org.terasology.world.block.BlockSection;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.List;
 
 /**
  */
 public class BlockShapeData implements AssetData {
     private String displayName = "";
-    private EnumMap<BlockPart, BlockMeshPart> meshParts = Maps.newEnumMap(BlockPart.class);
+    private List<BlockMeshPart> meshParts = new ArrayList<>();
+    private EnumMap<Side, List<BlockMeshPart>> meshBySide = new EnumMap<>(Side.class);
     private EnumBooleanMap<Side> fullSide = new EnumBooleanMap<>(Side.class);
     private CollisionShape collisionShape;
     private Vector3f collisionOffset = new Vector3f();
@@ -48,18 +52,25 @@ public class BlockShapeData implements AssetData {
         this.displayName = displayName;
     }
 
-    public BlockMeshPart getMeshPart(BlockPart part) {
-        return meshParts.get(part);
+    public List<BlockMeshPart> getMeshParts() {
+        return meshParts;
+    }
+
+    public List<BlockMeshPart> getMeshParts(Side side) {
+        return meshBySide.get(side);
     }
 
     /**
-     * Sets the mesh to use for the given block part
+     * Adds the given mesh to the lists of faces to render at the proper sides
      *
-     * @param part
      * @param mesh
      */
-    public void setMeshPart(BlockPart part, BlockMeshPart mesh) {
-        meshParts.put(part, mesh);
+    public void setMeshPart(BlockMeshPart mesh, byte key) {
+        List<Side> sides = BlockSection.fromKey(key);
+        for (Side side : sides) {
+            meshBySide.computeIfAbsent(side, (v) -> new ArrayList<>()).add(mesh);
+        }
+        meshParts.add(mesh);
     }
 
     public boolean isBlockingSide(Side side) {

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
@@ -41,7 +41,7 @@ public class BlockShapeImpl extends BlockShape {
 
     private String displayName;
     public Map<String, BlockMeshPart> meshParts = new HashMap<>();
-    private EnumMap<Side, List<BlockMeshPart>> meshBySide = new EnumMap<>(Side.class);
+    private EnumMap<Side, List<String>> meshBySide = new EnumMap<>(Side.class);
     private EnumBooleanMap<Side> fullSide = new EnumBooleanMap<>(Side.class);
     private CollisionShape baseCollisionShape;
     private Vector3f baseCollisionOffset = new Vector3f();
@@ -72,7 +72,7 @@ public class BlockShapeImpl extends BlockShape {
     }
 
     @Override
-    public List<BlockMeshPart> getMeshParts(Side side) {
+    public List<String> getMeshParts(Side side) {
         return meshBySide.get(side);
     }
 

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
@@ -26,10 +26,12 @@ import org.terasology.math.Side;
 import org.terasology.math.Yaw;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.utilities.collection.EnumBooleanMap;
+import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockPart;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +40,7 @@ import java.util.Map;
 public class BlockShapeImpl extends BlockShape {
 
     private String displayName;
-    private List<BlockMeshPart> meshParts = new ArrayList<>();
+    public Map<String, BlockMeshPart> meshParts = new HashMap<>();
     private EnumMap<Side, List<BlockMeshPart>> meshBySide = new EnumMap<>(Side.class);
     private EnumBooleanMap<Side> fullSide = new EnumBooleanMap<>(Side.class);
     private CollisionShape baseCollisionShape;
@@ -59,12 +61,14 @@ public class BlockShapeImpl extends BlockShape {
         return displayName;
     }
 
-    /**
-     * @return All mesh parts contained by the block
-     */
     @Override
-    public List<BlockMeshPart> getMeshParts() {
+    public Map<String, BlockMeshPart> getMeshMap() {
         return meshParts;
+    }
+
+    @Override
+    public BlockMeshPart getMeshPart(String name) {
+        return meshParts.get(name);
     }
 
     @Override
@@ -81,7 +85,7 @@ public class BlockShapeImpl extends BlockShape {
     protected void doReload(BlockShapeData data) {
         collisionShape.clear();
         displayName = data.getDisplayName();
-        this.meshParts.addAll(data.getMeshParts());
+        this.meshParts.putAll(data.meshParts);
 
         for (Side side : Side.getAllSides()) {
             this.fullSide.put(side, data.isBlockingSide(side));

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
@@ -28,7 +28,9 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.utilities.collection.EnumBooleanMap;
 import org.terasology.world.block.BlockPart;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,7 +38,8 @@ import java.util.Map;
 public class BlockShapeImpl extends BlockShape {
 
     private String displayName;
-    private EnumMap<BlockPart, BlockMeshPart> meshParts = Maps.newEnumMap(BlockPart.class);
+    private List<BlockMeshPart> meshParts = new ArrayList<>();
+    private EnumMap<Side, List<BlockMeshPart>> meshBySide = new EnumMap<>(Side.class);
     private EnumBooleanMap<Side> fullSide = new EnumBooleanMap<>(Side.class);
     private CollisionShape baseCollisionShape;
     private Vector3f baseCollisionOffset = new Vector3f();
@@ -56,9 +59,17 @@ public class BlockShapeImpl extends BlockShape {
         return displayName;
     }
 
+    /**
+     * @return All mesh parts contained by the block
+     */
     @Override
-    public BlockMeshPart getMeshPart(BlockPart part) {
-        return meshParts.get(part);
+    public List<BlockMeshPart> getMeshParts() {
+        return meshParts;
+    }
+
+    @Override
+    public List<BlockMeshPart> getMeshParts(Side side) {
+        return meshBySide.get(side);
     }
 
     @Override
@@ -70,11 +81,11 @@ public class BlockShapeImpl extends BlockShape {
     protected void doReload(BlockShapeData data) {
         collisionShape.clear();
         displayName = data.getDisplayName();
-        for (BlockPart part : BlockPart.values()) {
-            this.meshParts.put(part, data.getMeshPart(part));
-        }
+        this.meshParts.addAll(data.getMeshParts());
+
         for (Side side : Side.getAllSides()) {
             this.fullSide.put(side, data.isBlockingSide(side));
+            this.meshBySide.put(side, data.getMeshParts(side));
         }
         this.baseCollisionShape = data.getCollisionShape();
         this.baseCollisionOffset.set(data.getCollisionOffset());

--- a/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
@@ -146,7 +146,7 @@ public class JsonBlockShapeLoader extends AbstractAssetFileFormat<BlockShapeData
                             //If there is no "sides" parameter, the part's name is used, as with legacy .shape files.
                             sides = BlockSection.key(entry.getKey());
                         }
-                        shape.setMeshPart((BlockMeshPart) context.deserialize(meshObj, BlockMeshPart.class), sides);
+                        shape.setMeshPart(context.deserialize(meshObj, BlockMeshPart.class), entry.getKey(), sides);
                     }
                 }
             }
@@ -209,7 +209,7 @@ public class JsonBlockShapeLoader extends AbstractAssetFileFormat<BlockShapeData
 
         private List<Vector3f> buildVertList(BlockShapeData shape) {
             List<Vector3f> result = new ArrayList<>();
-            for (BlockMeshPart meshPart : shape.getMeshParts()) {
+            for (BlockMeshPart meshPart : shape.meshParts.values()) {
                 if (meshPart != null) {
                     for (int i = 0; i < meshPart.size(); ++i) {
                         result.add(meshPart.getVertex(i));

--- a/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
@@ -26,6 +26,7 @@ import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.shapes.BlockMeshPart;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class AttachSupportRequired implements BlockStructuralSupport {
@@ -47,8 +48,8 @@ public class AttachSupportRequired implements BlockStructuralSupport {
     }
 
     private boolean hasRequiredSupportOnSideForBlock(Vector3i location, Side sideChanged, Block block) {
-        final BlockMeshPart part = block.getPrimaryAppearance().getPart(BlockPart.fromSide(sideChanged));
-        if (part != null) {
+        final List<BlockMeshPart> parts = block.getPrimaryAppearance().getParts(sideChanged);
+        if (!parts.isEmpty()) {
             // This block has mesh on this side, therefore it requires a support on that side
             if (!hasSupportFromBlockOnSide(location, sideChanged, Collections.<Vector3i, Block>emptyMap())) {
                 return false;

--- a/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
@@ -48,7 +48,7 @@ public class AttachSupportRequired implements BlockStructuralSupport {
     }
 
     private boolean hasRequiredSupportOnSideForBlock(Vector3i location, Side sideChanged, Block block) {
-        final List<BlockMeshPart> parts = block.getPrimaryAppearance().getParts(sideChanged);
+        final List<String> parts = block.getPrimaryAppearance().getParts(sideChanged);
         if (!parts.isEmpty()) {
             // This block has mesh on this side, therefore it requires a support on that side
             if (!hasSupportFromBlockOnSide(location, sideChanged, Collections.<Vector3i, Block>emptyMap())) {

--- a/engine/src/main/resources/assets/shaders/chunk_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/chunk_frag.glsl
@@ -179,7 +179,22 @@ void main() {
         discard;
     }
 #endif
+    /* APPLY OVERALL BIOME COLOR OFFSET */
+    if (!checkFlag(BLOCK_HINT_GRASS, blockHint)) {
+        if (gl_Color.r < 0.99 && gl_Color.g < 0.99 && gl_Color.b < 0.99) {
+            if (color.g > 0.5) {
+                color.rgb = vec3(color.g) * gl_Color.rgb;
+            } else {
+                color.rgb *= gl_Color.rgb;
+            }
+        }
+    /* MASK GRASS AND APPLY BIOME COLOR */
+    } else {
+        vec4 maskColor = texture2D(textureEffects, vec2(10.0 * TEXTURE_OFFSET_EFFECTS + mod(texCoord.x, TEXTURE_OFFSET_EFFECTS), mod(texCoord.y, TEXTURE_OFFSET_EFFECTS)));
 
+        // Only use one channel so the color won't be altered
+        if (maskColor.a != 0.0) color.rgb = vec3(color.g) * gl_Color.rgb;
+    }
 #endif
 
     // Calculate daylight lighting value


### PR DESCRIPTION
This PR updates the block shape system to rely on String-based maps as opposed to Enum-based maps. There are some minor performance benefits; particularly, values can be mapped to the "default" key instead of being copied to every side. But the primary benefit is that block shapes are no longer limited to the seven faces of top, bottom, left, right, front, back, and center; this allows for significantly more advanced block design and texture mapping.

All existing shapes should remain functional; this update should not change the behavior of any existing shape files or the appearance of any blocks.

A number of modules will require minor updates to gain compatibility with this PR.