### PR TITLE
convered worldprovider to joml

### DIFF
--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -16,10 +16,11 @@
 package org.terasology;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
@@ -101,7 +102,7 @@ public class MapWorldProvider implements WorldProviderCore {
         Vector3i chunkPos = ChunkMath.calcChunkPos(pos);
         Chunk chunk = chunks.get(chunkPos);
         if (chunk == null && worldGenerator != null) {
-            chunk = new ChunkImpl(chunkPos, blockManager, extraDataManager);
+            chunk = new ChunkImpl(JomlUtil.from(chunkPos), blockManager, extraDataManager);
             worldGenerator.createChunk(chunk, entityBuffer);
             chunks.put(chunkPos, chunk);
         }
@@ -151,12 +152,12 @@ public class MapWorldProvider implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return 0;
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         return 0;
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return 0;

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -17,9 +17,9 @@
 package org.terasology.testUtil;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.internal.ChunkViewCore;
@@ -142,18 +142,18 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return 0;  //To change body of implemented methods use File | Settings | File Templates.
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         Integer prevValue = getExtraDataLayer(index).put(pos, value);
         return prevValue == null ? 0 : prevValue;
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return getExtraDataLayer(index).getOrDefault(new Vector3i(x, y, z), 0);
     }
-    
+
     private Map<Vector3i, Integer> getExtraDataLayer(int index) {
         while (extraData.size() <= index) {
             extraData.add(Maps.newHashMap());

--- a/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
@@ -17,6 +17,7 @@ package org.terasology.world;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
+import org.joml.Vector3i;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,6 @@ import org.terasology.entitySystem.stubs.IntegerComponent;
 import org.terasology.entitySystem.stubs.RetainedOnBlockChangeComponent;
 import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.network.NetworkComponent;
 import org.terasology.testUtil.WorldProviderCoreStub;
 import org.terasology.world.block.Block;
@@ -178,7 +178,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         testBlock.setKeepActive(true);
         // BlockFamily blockFamily = new SymmetricFamily(new BlockUri("test:keepActive"), testBlock);
         //blockManager.addBlockFamily(blockFamily, true);
-        worldStub.setBlock(Vector3i.zero(), testBlock);
+        worldStub.setBlock(new Vector3i(), testBlock);
 
         BlockEventChecker checker = new BlockEventChecker();
         entityManager.getEventSystem().registerEventHandler(checker);
@@ -196,8 +196,8 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
     public void testComponentsAddedAndActivatedWhenBlockChanged() {
         LifecycleEventChecker checker = new LifecycleEventChecker(entityManager.getEventSystem(), StringComponent.class);
 
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
-        EntityRef blockEntity = worldProvider.getBlockEntityAt(Vector3i.zero());
+        worldProvider.setBlock(new Vector3i(), blockWithString);
+        EntityRef blockEntity = worldProvider.getBlockEntityAt(new Vector3i());
         assertTrue(blockEntity.exists());
 
         assertEquals(Lists.newArrayList(new EventInfo(OnAddedComponent.newInstance(), blockEntity), new EventInfo(OnActivatedComponent.newInstance(), blockEntity)),
@@ -207,11 +207,11 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
     @Disabled("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testComponentsDeactivatedAndRemovedWhenBlockChanged() {
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
+        worldProvider.setBlock(new Vector3i(), blockWithString);
 
         LifecycleEventChecker checker = new LifecycleEventChecker(entityManager.getEventSystem(), StringComponent.class);
 
-        worldProvider.setBlock(Vector3i.zero(), airBlock);
+        worldProvider.setBlock(new Vector3i(), airBlock);
         EntityRef blockEntity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         assertTrue(blockEntity.exists());
 
@@ -222,11 +222,11 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
     @Disabled("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testComponentsUpdatedWhenBlockChanged() {
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
+        worldProvider.setBlock(new Vector3i(), blockWithString);
 
         LifecycleEventChecker checker = new LifecycleEventChecker(entityManager.getEventSystem(), StringComponent.class);
 
-        worldProvider.setBlock(Vector3i.zero(), blockWithDifferentString);
+        worldProvider.setBlock(new Vector3i(), blockWithDifferentString);
         EntityRef blockEntity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         assertTrue(blockEntity.exists());
 
@@ -235,9 +235,9 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testPrefabUpdatedWhenBlockChanged() {
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
+        worldProvider.setBlock(new Vector3i(), blockWithString);
         assertEquals(blockWithString.getPrefab().get().getName(), worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0)).getParentPrefab().getName());
-        worldProvider.setBlock(Vector3i.zero(), blockWithDifferentString);
+        worldProvider.setBlock(new Vector3i(), blockWithDifferentString);
         assertEquals(blockWithDifferentString.getPrefab().get().getName(), worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0)).getParentPrefab().getName());
     }
 
@@ -253,7 +253,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
     @Disabled("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testEntityCeasesToBeTemporaryIfBlockChangedToKeepActive() {
-        worldProvider.setBlock(Vector3i.zero(), keepActiveBlock);
+        worldProvider.setBlock(new Vector3i(), keepActiveBlock);
         worldProvider.update(1.0f);
         LifecycleEventChecker checker = new LifecycleEventChecker(entityManager.getEventSystem(), StringComponent.class);
         worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
@@ -262,9 +262,9 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testEntityBecomesTemporaryWhenChangedFromAKeepActiveBlock() {
-        worldProvider.setBlock(Vector3i.zero(), keepActiveBlock);
+        worldProvider.setBlock(new Vector3i(), keepActiveBlock);
         EntityRef blockEntity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
-        worldProvider.setBlock(Vector3i.zero(), airBlock);
+        worldProvider.setBlock(new Vector3i(), airBlock);
         worldProvider.update(1.0f);
         assertFalse(blockEntity.isActive());
     }
@@ -294,7 +294,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testEntityExtraComponentsRemovedBeforeCleanUpForBlocksWithPrefabs() {
-        worldStub.setBlock(Vector3i.zero(), blockWithString);
+        worldStub.setBlock(new Vector3i(), blockWithString);
         EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         entity.addComponent(new IntegerComponent(1));
 
@@ -307,7 +307,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testEntityMissingComponentsAddedBeforeCleanUp() {
-        worldStub.setBlock(Vector3i.zero(), blockWithString);
+        worldStub.setBlock(new Vector3i(), blockWithString);
         EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         entity.removeComponent(StringComponent.class);
 
@@ -320,7 +320,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testChangedComponentsRevertedBeforeCleanUp() {
-        worldStub.setBlock(Vector3i.zero(), blockWithString);
+        worldStub.setBlock(new Vector3i(), blockWithString);
         EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         StringComponent comp = entity.getComponent(StringComponent.class);
         comp.value = "Moo";
@@ -334,12 +334,12 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testAllComponentsNotMarkedAsRetainedRemovedOnBlockChange() {
-        worldStub.setBlock(Vector3i.zero(), blockWithString);
+        worldStub.setBlock(new Vector3i(), blockWithString);
         EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         entity.addComponent(new ForceBlockActiveComponent());
         entity.addComponent(new RetainedOnBlockChangeComponent(2));
 
-        worldProvider.setBlock(Vector3i.zero(), airBlock);
+        worldProvider.setBlock(new Vector3i(), airBlock);
 
         assertTrue(entity.hasComponent(RetainedOnBlockChangeComponent.class));
         assertFalse(entity.hasComponent(ForceBlockActiveComponent.class));
@@ -350,7 +350,7 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
         EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         entity.addComponent(new RetainedOnBlockChangeComponent(2));
 
-        worldProvider.setBlock(Vector3i.zero(), blockWithRetainedComponent);
+        worldProvider.setBlock(new Vector3i(), blockWithRetainedComponent);
 
         assertEquals(2, entity.getComponent(RetainedOnBlockChangeComponent.class).value);
     }
@@ -382,55 +382,55 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testComponentsNotAlteredIfBlockInSameFamily() {
-        worldProvider.setBlock(Vector3i.zero(), blockInFamilyOne);
-        EntityRef entity = worldProvider.getBlockEntityAt(Vector3i.zero());
+        worldProvider.setBlock(new Vector3i(), blockInFamilyOne);
+        EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i());
         entity.addComponent(new IntegerComponent());
-        worldProvider.setBlock(Vector3i.zero(), blockInFamilyTwo);
+        worldProvider.setBlock(new Vector3i(), blockInFamilyTwo);
         assertNotNull(entity.getComponent(IntegerComponent.class));
     }
 
     @Test
     public void testComponentsAlteredIfBlockInSameFamilyWhenForced() {
-        worldProvider.setBlock(Vector3i.zero(), blockInFamilyOne);
-        EntityRef entity = worldProvider.getBlockEntityAt(Vector3i.zero());
+        worldProvider.setBlock(new Vector3i(), blockInFamilyOne);
+        EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i());
         entity.addComponent(new IntegerComponent());
-        worldProvider.setBlockForceUpdateEntity(Vector3i.zero(), blockInFamilyTwo);
+        worldProvider.setBlockForceUpdateEntity(new Vector3i(), blockInFamilyTwo);
         assertNull(entity.getComponent(IntegerComponent.class));
     }
 
     @Test
     public void testComponentUntouchedIfRetainRequested() {
-        worldProvider.setBlock(Vector3i.zero(), blockInFamilyOne);
-        EntityRef entity = worldProvider.getBlockEntityAt(Vector3i.zero());
+        worldProvider.setBlock(new Vector3i(), blockInFamilyOne);
+        EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i());
         entity.addComponent(new IntegerComponent());
-        worldProvider.setBlockRetainComponent(Vector3i.zero(), blockWithString, IntegerComponent.class);
+        worldProvider.setBlockRetainComponent(new Vector3i(), blockWithString, IntegerComponent.class);
         assertNotNull(entity.getComponent(IntegerComponent.class));
     }
 
     @Disabled("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testBlockEntityPrefabCorrectlyAlteredOnChangeToDifferentPrefab() {
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
-        EntityRef entity = worldProvider.getBlockEntityAt(Vector3i.zero());
-        worldProvider.setBlock(Vector3i.zero(), blockWithDifferentString);
+        worldProvider.setBlock(new Vector3i(), blockWithString);
+        EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i());
+        worldProvider.setBlock(new Vector3i(), blockWithDifferentString);
         assertEquals(blockWithDifferentString.getPrefab().get().getUrn(), entity.getParentPrefab().getUrn());
     }
 
     @Disabled("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testBlockEntityPrefabCorrectlyRemovedOnChangeToBlockWithNoPrefab() {
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
-        EntityRef entity = worldProvider.getBlockEntityAt(Vector3i.zero());
-        worldProvider.setBlock(Vector3i.zero(), plainBlock);
+        worldProvider.setBlock(new Vector3i(), blockWithString);
+        EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i());
+        worldProvider.setBlock(new Vector3i(), plainBlock);
         assertEquals(null, entity.getParentPrefab());
     }
 
     @Disabled("Failing due to #2625. TODO: fix to match new behaviour")
     @Test
     public void testBlockEntityPrefabCorrectlyAddedOnChangeToBlockWithPrefab() {
-        worldProvider.setBlock(Vector3i.zero(), plainBlock);
-        EntityRef entity = worldProvider.getBlockEntityAt(Vector3i.zero());
-        worldProvider.setBlock(Vector3i.zero(), blockWithString);
+        worldProvider.setBlock(new Vector3i(), plainBlock);
+        EntityRef entity = worldProvider.getBlockEntityAt(new Vector3i());
+        worldProvider.setBlock(new Vector3i(), blockWithString);
         assertEquals(blockWithString.getPrefab().get().getUrn().toString(), entity.getParentPrefab().getUrn().toString());
     }
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayerSystem;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -217,7 +218,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
                 chunksInProximity.clear();
                 for (Vector3i chunkPosition : viewRegion) {
                     RenderableChunk c = chunkProvider.getChunk(chunkPosition);
-                    if (c != null && worldProvider.getLocalView(c.getPosition()) != null) {
+                    if (c != null && worldProvider.getLocalView(JomlUtil.from(c.getPosition())) != null) {
                         chunksInProximity.add(c);
                     } else {
                         chunksCurrentlyPending = true;
@@ -240,7 +241,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
                 // add
                 for (Vector3i chunkPosition : viewRegion) {
                     RenderableChunk c = chunkProvider.getChunk(chunkPosition);
-                    if (c != null && worldProvider.getLocalView(c.getPosition()) != null) {
+                    if (c != null && worldProvider.getLocalView(JomlUtil.from(c.getPosition())) != null) {
                         chunksInProximity.add(c);
                     } else {
                         chunksCurrentlyPending = true;

--- a/engine/src/main/java/org/terasology/input/cameraTarget/CameraTargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/CameraTargetSystem.java
@@ -21,6 +21,7 @@ import org.terasology.config.Config;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -82,7 +83,7 @@ public class CameraTargetSystem extends BaseComponentSystem {
 
     public void updateTarget() {
         if (!target.exists() && targetBlockPos != null && blockRegistry != null) {
-            target = blockRegistry.getEntityAt(targetBlockPos);
+            target = blockRegistry.getEntityAt(JomlUtil.from(targetBlockPos));
         }
     }
 

--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.CollisionGroup;
@@ -72,7 +73,7 @@ public class TargetSystem {
     public boolean updateTarget(Vector3f pos, Vector3f dir, float maxDist) {
 
         if (targetBlockPos != null && !target.exists()) {
-            target = blockRegistry.getEntityAt(targetBlockPos);
+            target = blockRegistry.getEntityAt(JomlUtil.from(targetBlockPos));
         }
 
         HitResult hitInfo = physics.rayTrace(pos, dir, maxDist, filter);

--- a/engine/src/main/java/org/terasology/logic/ai/HierarchicalAISystem.java
+++ b/engine/src/main/java/org/terasology/logic/ai/HierarchicalAISystem.java
@@ -28,6 +28,7 @@ import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.events.HorizontalCollisionEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.FastRandom;
@@ -69,7 +70,7 @@ public class HierarchicalAISystem extends BaseComponentSystem implements
             Vector3f worldPos = location.getWorldPosition();
 
             // Skip this AI if not in a loaded chunk
-            if (!worldProvider.isBlockRelevant(worldPos)) {
+            if (!worldProvider.isBlockRelevant(JomlUtil.from(worldPos))) {
                 continue;
             }
 

--- a/engine/src/main/java/org/terasology/logic/ai/SimpleAISystem.java
+++ b/engine/src/main/java/org/terasology/logic/ai/SimpleAISystem.java
@@ -28,6 +28,7 @@ import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.events.HorizontalCollisionEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.FastRandom;
@@ -56,7 +57,7 @@ public class SimpleAISystem extends BaseComponentSystem implements UpdateSubscri
             Vector3f worldPos = location.getWorldPosition();
 
             // Skip this AI if not in a loaded chunk
-            if (!worldProvider.isBlockRelevant(worldPos)) {
+            if (!worldProvider.isBlockRelevant(JomlUtil.from(worldPos))) {
                 continue;
             }
             SimpleAIComponent ai = entity.getComponent(SimpleAIComponent.class);

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterSoundSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterSoundSystem.java
@@ -34,6 +34,7 @@ import org.terasology.logic.characters.events.VerticalCollisionEvent;
 import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
@@ -71,7 +72,7 @@ public class CharacterSoundSystem extends BaseComponentSystem {
         // Check if the block the character is standing on has footstep sounds
         Vector3i blockPos = new Vector3i(locationComponent.getLocalPosition());
         blockPos.y--; // The block *below* the character's feet is interesting to us
-        Block block = worldProvider.getBlock(blockPos);
+        Block block = worldProvider.getBlock(JomlUtil.from(blockPos));
         if (block != null) {
             if (block.getSounds() == null) {
                 logger.error("Block '{}' has no sounds", block.getURI());

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -25,6 +25,7 @@ import org.terasology.logic.characters.events.OnEnterBlockEvent;
 import org.terasology.logic.characters.events.SwimStrokeEvent;
 import org.terasology.logic.characters.events.VerticalCollisionEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3fUtil;
 import org.terasology.math.geom.ImmutableVector3f;
@@ -99,7 +100,7 @@ public class KinematicCharacterMover implements CharacterMover {
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
         CharacterStateEvent result = new CharacterStateEvent(initial);
         result.setSequenceNumber(input.getSequenceNumber());
-        if (worldProvider.isBlockRelevant(initial.getPosition())) {
+        if (worldProvider.isBlockRelevant(JomlUtil.from(initial.getPosition()))) {
             updatePosition(characterMovementComponent, result, input, entity);
 
             if (input.isFirstRun()) {
@@ -137,7 +138,7 @@ public class KinematicCharacterMover implements CharacterMover {
             Block[] oldBlocks = new Block[(int) Math.ceil(characterHeight)];
             Vector3i currentPosition = new Vector3i(oldPosition);
             for (int currentHeight = 0; currentHeight < oldBlocks.length; currentHeight++) {
-                oldBlocks[currentHeight] = worldProvider.getBlock(currentPosition);
+                oldBlocks[currentHeight] = worldProvider.getBlock(JomlUtil.from(currentPosition));
                 currentPosition.add(0, 1, 0);
             }
 
@@ -145,7 +146,7 @@ public class KinematicCharacterMover implements CharacterMover {
             Block[] newBlocks = new Block[(int) Math.ceil(characterHeight)];
             currentPosition = new Vector3i(newPosition);
             for (int currentHeight = 0; currentHeight < characterHeight; currentHeight++) {
-                newBlocks[currentHeight] = worldProvider.getBlock(currentPosition);
+                newBlocks[currentHeight] = worldProvider.getBlock(JomlUtil.from(currentPosition));
                 currentPosition.add(0, 1, 0);
             }
 
@@ -177,8 +178,8 @@ public class KinematicCharacterMover implements CharacterMover {
         top.y += 0.5f * movementComp.height;
         bottom.y -= 0.5f * movementComp.height;
 
-        final boolean topUnderwater = worldProvider.getBlock(top).isLiquid();
-        final boolean bottomUnderwater = worldProvider.getBlock(bottom).isLiquid();
+        final boolean topUnderwater = worldProvider.getBlock(JomlUtil.from(top)).isLiquid();
+        final boolean bottomUnderwater = worldProvider.getBlock(JomlUtil.from(bottom)).isLiquid();
 
         final boolean newSwimming = !topUnderwater && bottomUnderwater;
         final boolean newDiving = topUnderwater && bottomUnderwater;
@@ -195,7 +196,7 @@ public class KinematicCharacterMover implements CharacterMover {
 
         updateMode(state, newSwimming, newDiving, newClimbing, isCrouching);
     }
-    
+
     /**
      * Updates a character's movement mode and changes his vertical velocity accordingly.
      * @param state The current state of the character.
@@ -247,7 +248,7 @@ public class KinematicCharacterMover implements CharacterMover {
         float distance = 100f;
 
         for (Vector3f side : sides) {
-            Block block = worldProvider.getBlock(side);
+            Block block = worldProvider.getBlock(JomlUtil.from(side));
             if (block.isClimbable()) {
                 //If any of our sides are near a climbable block, check if we are near to the side
                 Vector3i myPos = new Vector3i(worldPos, RoundingMode.HALF_UP);
@@ -734,7 +735,7 @@ public class KinematicCharacterMover implements CharacterMover {
                             break;
                         case DIVING:
                         case SWIMMING:
-                            entity.send(new SwimStrokeEvent(worldProvider.getBlock(state.getPosition())));
+                            entity.send(new SwimStrokeEvent(worldProvider.getBlock(JomlUtil.from(state.getPosition()))));
                             break;
                         case CLIMBING:
                         case FLYING:

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -380,7 +380,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
                 BlockRegionComponent blockRegion = target.getComponent(BlockRegionComponent.class);
                 if (blockComp != null || blockRegion != null) {
                     Vector3f blockPos = location.getWorldPosition();
-                    Block block = worldProvider.getBlock(blockPos);
+                    Block block = worldProvider.getBlock(JomlUtil.from(blockPos));
                     aabb = block.getBounds(blockPos);
                 } else {
                     MeshComponent mesh = target.getComponent(MeshComponent.class);

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -25,6 +25,7 @@ import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.AABB;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Quat4f;
@@ -152,8 +153,8 @@ public class PlayerFactory {
 
         // TODO: also start looking downwards if initial spawn pos is in the air
         for (int i = 1; i < 20; i++) {
-            if (worldProvider.isBlockRelevant(newSpawnPos)) {
-                if (worldProvider.getBlock(newSpawnPos).isPenetrable()) {
+            if (worldProvider.isBlockRelevant(JomlUtil.from(newSpawnPos))) {
+                if (worldProvider.getBlock(JomlUtil.from(newSpawnPos)).isPenetrable()) {
                     consecutiveAirBlocks++;
                 } else {
                     consecutiveAirBlocks = 0;

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -36,6 +36,7 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.logic.players.event.RespawnRequestEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -81,7 +82,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         Iterator<SpawningClientInfo> i = clientsPreparingToSpawn.iterator();
         while (i.hasNext()) {
             SpawningClientInfo spawning = i.next();
-            if (worldProvider.isBlockRelevant(spawning.position)) {
+            if (worldProvider.isBlockRelevant(JomlUtil.from(spawning.position))) {
                 PlayerStore playerStore = spawning.playerStore;
                 if (playerStore == null) {
                     spawnPlayer(spawning.clientEntity);
@@ -97,7 +98,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         i = clientsPreparingToRespawn.iterator();
         while (i.hasNext()) {
             SpawningClientInfo spawning = i.next();
-            if (worldProvider.isBlockRelevant(spawning.position)) {
+            if (worldProvider.isBlockRelevant(JomlUtil.from(spawning.position))) {
                 respawnPlayer(spawning.clientEntity);
                 i.remove();
             }
@@ -135,7 +136,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
             loc.setWorldPosition(storedLocation);
             entity.saveComponent(loc);
 
-            if (worldProvider.isBlockRelevant(storedLocation)) {
+            if (worldProvider.isBlockRelevant(JomlUtil.from(storedLocation))) {
                 // chunk for spawning location is ready, so spawn right now
                 playerStore.restoreEntities();
                 EntityRef character = playerStore.getCharacter();
@@ -153,7 +154,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
             entity.saveComponent(loc);
 
             addRelevanceEntity(entity, minViewDist, owner);
-            if (worldProvider.isBlockRelevant(spawnPosition)) {
+            if (worldProvider.isBlockRelevant(JomlUtil.from(spawnPosition))) {
                 spawnPlayer(entity);
             } else {
                 clientsPreparingToSpawn.add(new SpawningClientInfo(entity, spawnPosition));
@@ -232,7 +233,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
     public void onRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
         Vector3f spawnPosition = entity.getComponent(LocationComponent.class).getWorldPosition();
 
-        if (worldProvider.isBlockRelevant(spawnPosition)) {
+        if (worldProvider.isBlockRelevant(JomlUtil.from(spawnPosition))) {
             respawnPlayer(entity);
         } else {
             updateRelevanceEntity(entity, ViewDistance.LEGALLY_BLIND.getChunkDistance());

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -83,6 +83,10 @@ public final class ChunkMath {
         return calcChunkPos(pos.x, pos.y, pos.z);
     }
 
+    public static org.joml.Vector3i calcChunkPos(org.joml.Vector3i pos) {
+        return JomlUtil.from(calcChunkPos(pos.x, pos.y, pos.z));
+    }
+
     public static Vector3i calcChunkPos(int x, int y, int z) {
         return calcChunkPos(x, y, z, ChunkConstants.CHUNK_POWER);
     }
@@ -154,8 +158,13 @@ public final class ChunkMath {
         return calcBlockPosZ(blockZ, ChunkConstants.INNER_CHUNK_POS_FILTER.z);
     }
 
+    @Deprecated
     public static Vector3i calcBlockPos(Vector3i worldPos) {
         return calcBlockPos(worldPos.x, worldPos.y, worldPos.z, ChunkConstants.INNER_CHUNK_POS_FILTER);
+    }
+
+    public static org.joml.Vector3i calcBlockPos(org.joml.Vector3i worldPos) {
+        return JomlUtil.from(calcBlockPos(worldPos.x, worldPos.y, worldPos.z, ChunkConstants.INNER_CHUNK_POS_FILTER));
     }
 
     public static Vector3i calcBlockPos(int x, int y, int z) {

--- a/engine/src/main/java/org/terasology/math/JomlUtil.java
+++ b/engine/src/main/java/org/terasology/math/JomlUtil.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.math;
 
+import com.google.common.math.DoubleMath;
 import org.joml.Matrix3f;
 import org.joml.Matrix3fc;
 import org.joml.Matrix4f;
@@ -22,11 +23,14 @@ import org.joml.Matrix4fc;
 import org.joml.Quaternionf;
 import org.joml.Vector2f;
 import org.joml.Vector2fc;
+import org.joml.Vector2i;
 import org.joml.Vector2ic;
 import org.joml.Vector3fc;
+import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.joml.Vector4f;
 import org.joml.Vector4fc;
+import org.joml.Vector4i;
 import org.terasology.math.geom.BaseMatrix3f;
 import org.terasology.math.geom.BaseMatrix4f;
 import org.terasology.math.geom.BaseQuat4f;
@@ -35,6 +39,8 @@ import org.terasology.math.geom.BaseVector3f;
 import org.terasology.math.geom.BaseVector3i;
 import org.terasology.math.geom.BaseVector4f;
 import org.terasology.math.geom.Quat4f;
+
+import java.math.RoundingMode;
 
 public class JomlUtil {
 
@@ -108,5 +114,17 @@ public class JomlUtil {
 
     public static Quaternionf from(BaseQuat4f quat) {
         return new Quaternionf(quat.getX(), quat.getY(), quat.getZ(), quat.getW());
+    }
+
+    public static Vector3i round(Vector3fc vector, RoundingMode rm) {
+        return new Vector3i(DoubleMath.roundToInt(vector.x(), rm), DoubleMath.roundToInt(vector.y(), rm), DoubleMath.roundToInt(vector.z(), rm));
+    }
+
+    public static Vector2i round(Vector2fc vector, RoundingMode rm) {
+        return new Vector2i(DoubleMath.roundToInt(vector.x(), rm), DoubleMath.roundToInt(vector.y(), rm));
+    }
+
+    public static Vector4i round(Vector4fc vector, RoundingMode rm) {
+        return new Vector4i(DoubleMath.roundToInt(vector.x(), rm), DoubleMath.roundToInt(vector.y(), rm), DoubleMath.roundToInt(vector.z(), rm), DoubleMath.roundToInt(vector.w(), rm));
     }
 }

--- a/engine/src/main/java/org/terasology/math/Side.java
+++ b/engine/src/main/java/org/terasology/math/Side.java
@@ -294,9 +294,16 @@ public enum Side {
         }
     }
 
+    @Deprecated
     public Vector3i getAdjacentPos(Vector3i position) {
         Vector3i result = new Vector3i(position);
         result.add(vector3iDir);
+        return result;
+    }
+
+    public org.joml.Vector3i getAdjacentPos(org.joml.Vector3i position) {
+        org.joml.Vector3i result = new org.joml.Vector3i(position);
+        result.add(JomlUtil.from(vector3iDir));
         return result;
     }
 

--- a/engine/src/main/java/org/terasology/network/serialization/NetEntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/network/serialization/NetEntityRefTypeHandler.java
@@ -18,6 +18,7 @@ package org.terasology.network.serialization;
 
 import gnu.trove.list.TIntList;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.network.NetworkComponent;
 import org.terasology.network.internal.NetworkSystemImpl;
@@ -65,7 +66,7 @@ public class NetEntityRefTypeHandler extends TypeHandler<EntityRef> {
             if (array.isNumberArray() && array.size() == 3) {
                 TIntList items = data.getAsArray().getAsIntegerArray();
                 Vector3i pos = new Vector3i(items.get(0), items.get(1), items.get(2));
-                return Optional.ofNullable(blockEntityRegistry.getBlockEntityAt(pos));
+                return Optional.ofNullable(blockEntityRegistry.getBlockEntityAt(JomlUtil.from(pos)));
             }
         }
         if (data.isNumber()) {

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -57,6 +57,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.AABB;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.VecMath;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
@@ -242,7 +243,7 @@ public class BulletPhysics implements PhysicsEngine {
         discreteDynamicsWorld.rayTest(from, to, closest);
         if (closest.hasHit()) {
             if (closest.userData instanceof Vector3i) { //We hit a world block
-                final EntityRef entityAt = blockEntityRegistry.getEntityAt((Vector3i) closest.userData);
+                final EntityRef entityAt = blockEntityRegistry.getEntityAt(JomlUtil.from((Vector3i) closest.userData));
                 return new HitResult(entityAt,
                         VecMath.from(closest.hitPointWorld),
                         VecMath.from(closest.hitNormalWorld),

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
@@ -31,6 +31,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.location.LocationResynchEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.monitoring.PerformanceMonitor;
@@ -207,7 +208,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
                 while (true) {
                     HitResult hitInfo = physics.rayTrace(vLocation, vDirection, fDistanceThisFrame + 0.5f, DEFAULT_COLLISION_GROUP);
                     if (hitInfo.isHit()) {
-                        Block hitBlock = worldProvider.getBlock(hitInfo.getBlockPosition());
+                        Block hitBlock = worldProvider.getBlock(JomlUtil.from(hitInfo.getBlockPosition()));
                         if (hitBlock != null) {
                             Vector3f vTravelledDistance = vLocation.sub(hitInfo.getHitPoint());
                             float fTravelledDistance  = vTravelledDistance.length();

--- a/engine/src/main/java/org/terasology/rendering/cameras/SubmersibleCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/SubmersibleCamera.java
@@ -49,8 +49,8 @@ public abstract class SubmersibleCamera extends Camera {
             cameraPosition.y -= RenderHelper.evaluateOceanHeightAtPosition(cameraPosition, worldProvider.getTime().getDays());
         }
 
-        if (worldProvider.isBlockRelevant(cameraPosition)) {
-            return worldProvider.getBlock(cameraPosition).isLiquid();
+        if (worldProvider.isBlockRelevant(JomlUtil.from(cameraPosition))) {
+            return worldProvider.getBlock(JomlUtil.from(cameraPosition)).isLiquid();
         }
         return false;
     }

--- a/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
+++ b/engine/src/main/java/org/terasology/rendering/dag/nodes/InitialPostProcessingNode.java
@@ -134,7 +134,7 @@ public class InitialPostProcessingNode extends AbstractNode implements PropertyC
 
         // Shader Parameters
 
-        initialPostMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(JomlUtil.from(activeCamera.getPosition())).getTint(), true);
+        initialPostMaterial.setFloat3("inLiquidTint", worldProvider.getBlock(activeCamera.getPosition()).getTint(), true);
 
         if (bloomIsEnabled) {
             initialPostMaterial.setFloat("bloomFactor", bloomFactor, true);

--- a/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/FloatingTextRenderer.java
@@ -92,7 +92,7 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
             }
 
             Vector3f worldPos = location.getWorldPosition();
-            if (!worldProvider.isBlockRelevant(worldPos)) {
+            if (!worldProvider.isBlockRelevant(JomlUtil.from(worldPos))) {
                 continue;
             }
 

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -253,7 +253,7 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
      * @return true if the entity itself or the block at the given position are relevant, false otherwise.
      */
     private boolean isRelevant(EntityRef entity, Vector3f position) {
-        return worldProvider.isBlockRelevant(position) || entity.isAlwaysRelevant();
+        return worldProvider.isBlockRelevant(JomlUtil.from(position)) || entity.isAlwaysRelevant();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Queues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.chunk.ChunkMonitor;
@@ -167,7 +168,7 @@ public final class ChunkMeshUpdateManager {
         @Override
         public void run() {
             ChunkMesh newMesh;
-            ChunkView chunkView = worldProvider.getLocalView(c.getPosition());
+            ChunkView chunkView = worldProvider.getLocalView(JomlUtil.from(c.getPosition()));
             if (chunkView != null) {
                 /*
                  * Important set dirty flag first, so that a concurrent modification of the chunk in the mean time we

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -152,7 +152,7 @@ class RenderableWorldImpl implements RenderableWorld {
             if (chunk == null) {
                 pregenerationIsComplete = false;
             } else if (chunk.isDirty()) {
-                localView = worldProvider.getLocalView(chunkCoordinates);
+                localView = worldProvider.getLocalView(JomlUtil.from(chunkCoordinates));
                 if (localView == null) {
                     continue;
                 }
@@ -388,7 +388,7 @@ class RenderableWorldImpl implements RenderableWorld {
     }
 
     private boolean areSurroundingChunksLoaded(RenderableChunk chunk) {
-        return worldProvider.getWorldViewAround(chunk.getPosition()) != null;
+        return worldProvider.getWorldViewAround(JomlUtil.from(chunk.getPosition())) != null;
     }
 
     private boolean isChunkVisibleFromMainLight(RenderableChunk chunk) {

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -731,8 +731,8 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     @Override
     public float getRenderingLightIntensityAt(Vector3f pos) {
-        float rawLightValueSun = worldProvider.getSunlight(pos) / 15.0f;
-        float rawLightValueBlock = worldProvider.getLight(pos) / 15.0f;
+        float rawLightValueSun = worldProvider.getSunlight(JomlUtil.from(pos)) / 15.0f;
+        float rawLightValueBlock = worldProvider.getLight(JomlUtil.from(pos)) / 15.0f;
 
         float lightValueSun = (float) Math.pow(BLOCK_LIGHT_SUN_POW, (1.0f - rawLightValueSun) * 16.0) * rawLightValueSun;
         lightValueSun *= backdropProvider.getDaylight();
@@ -747,12 +747,12 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     @Override
     public float getMainLightIntensityAt(Vector3f position) {
-        return backdropProvider.getDaylight() * worldProvider.getSunlight(position) / 15.0f;
+        return backdropProvider.getDaylight() * worldProvider.getSunlight(JomlUtil.from(position)) / 15.0f;
     }
 
     @Override
     public float getBlockLightIntensityAt(Vector3f position) {
-        return worldProvider.getLight(position) / 15.0f;
+        return worldProvider.getLight(JomlUtil.from(position)) / 15.0f;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
+++ b/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
@@ -15,10 +15,10 @@
  */
 package org.terasology.world;
 
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 /**

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.world;
 
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.internal.WorldProviderCore;
 
@@ -87,7 +87,7 @@ public interface WorldProvider extends WorldProviderCore {
     byte getSunlight(Vector3i pos);
 
     byte getTotalLight(Vector3i pos);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -96,7 +96,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The (index)th extra-data value at the given position
      */
     int getExtraData(int index, Vector3i pos);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -108,7 +108,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The replaced value
      */
     int setExtraData(int index, int x, int y, int z, int value);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -119,7 +119,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The named extra-data value at the given position
      */
     int getExtraData(String fieldName, int x, int y, int z);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -128,7 +128,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The named extra-data value at the given position
      */
     int getExtraData(String fieldName, Vector3i pos);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -140,7 +140,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The replaced value
      */
     int setExtraData(String fieldName, int x, int y, int z, int value);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -35,6 +35,7 @@ import org.terasology.logic.inventory.events.GiveItemEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.network.ClientComponent;
 import org.terasology.physics.Physics;
 import org.terasology.registry.In;
@@ -210,7 +211,7 @@ public class BlockCommands extends BaseComponentSystem {
             if (def.isPresent()) {
                 BlockFamily blockFamily = blockManager.getBlockFamily(uri);
                 Block block = blockManager.getBlock(blockFamily.getURI());
-                world.setBlock(targetLocation.position, block);
+                world.setBlock(JomlUtil.from(targetLocation.position), block);
             } else if (matchingUris.size() > 1) {
                 StringBuilder builder = new StringBuilder();
                 builder.append("Non-unique shape name, possible matches: ");

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -29,6 +29,7 @@ import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.inventory.events.DropItemEvent;
 import org.terasology.logic.inventory.events.GiveItemEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.events.ImpulseEvent;
 import org.terasology.registry.In;
@@ -85,7 +86,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
     @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
     public void doDestroy(DoDestroyEvent event, EntityRef entity, BlockComponent blockComponent) {
         commonDestroyed(event, entity, blockComponent.block);
-        worldProvider.setBlock(blockComponent.position, blockManager.getBlock(BlockManager.AIR_ID));
+        worldProvider.setBlock(JomlUtil.from(blockComponent.position), blockManager.getBlock(BlockManager.AIR_ID));
     }
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
@@ -102,7 +103,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
                 if (blockComponent.dropBlocksInRegion) {
                     // loop through all the blocks in this region and drop them
                     for (Vector3i location : blockRegion.region) {
-                        Block blockInWorld = worldProvider.getBlock(location);
+                        Block blockInWorld = worldProvider.getBlock(JomlUtil.from(location));
                         commonDefaultDropsHandling(event, entity, location, blockInWorld.getBlockFamily().getArchetypeBlock());
                     }
                 } else {
@@ -135,7 +136,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
                 if (blockDamageModifierComponent != null) {
                     impulsePower = blockDamageModifierComponent.impulsePower;
                 }
-                
+
                 processDropping(item, location, impulsePower);
             }
         }

--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
@@ -111,14 +112,14 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
         for (Side side : Side.getAllSides()) {
             Vector3i neighborLocation = new Vector3i(blockLocation);
             neighborLocation.add(side.getVector3i());
-            if (worldProvider.isBlockRelevant(neighborLocation)) {
-                Block neighborBlock = worldProvider.getBlock(neighborLocation);
+            if (worldProvider.isBlockRelevant(JomlUtil.from(neighborLocation))) {
+                Block neighborBlock = worldProvider.getBlock(JomlUtil.from(neighborLocation));
                 final BlockFamily blockFamily = neighborBlock.getBlockFamily();
                 if (blockFamily instanceof UpdatesWithNeighboursFamily) {
                     UpdatesWithNeighboursFamily neighboursFamily = (UpdatesWithNeighboursFamily) blockFamily;
                     Block neighborBlockAfterUpdate = neighboursFamily.getBlockForNeighborUpdate(neighborLocation, neighborBlock);
                     if (neighborBlock != neighborBlockAfterUpdate) {
-                        worldProvider.setBlock(neighborLocation, neighborBlockAfterUpdate);
+                        worldProvider.setBlock(JomlUtil.from(neighborLocation), neighborBlockAfterUpdate);
                     }
                 }
             }

--- a/engine/src/main/java/org/terasology/world/block/entity/placement/PlaceBlocks.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/placement/PlaceBlocks.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.world.block.entity.placement;
 
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 import java.util.Collections;

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockPositionIterator.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockPositionIterator.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.internal;
 
 import gnu.trove.list.TIntList;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.BlockEntityRegistry;
 
@@ -53,7 +54,7 @@ public class BlockPositionIterator implements Iterator<Vector3i> {
             nextResult.x = positionList.get(i++);
             nextResult.y = positionList.get(i++);
             nextResult.z = positionList.get(i++);
-            if (!registry.hasPermanentBlockEntity(nextResult)) {
+            if (!registry.hasPermanentBlockEntity(JomlUtil.from(nextResult))) {
                 return;
             }
         }

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.items;
 
+import org.terasology.math.JomlUtil;
 import org.terasology.telemetry.GamePlayStatsComponent;
 import org.terasology.utilities.Assets;
 import org.terasology.audio.AudioManager;
@@ -95,10 +96,10 @@ public class BlockItemSystem extends BaseComponentSystem {
         if (canPlaceBlock(block, targetBlock, placementPos)) {
             // TODO: Fix this for changes.
             if (networkSystem.getMode().isAuthority()) {
-                PlaceBlocks placeBlocks = new PlaceBlocks(placementPos, block, event.getInstigator());
+                PlaceBlocks placeBlocks = new PlaceBlocks(JomlUtil.from(placementPos), block, event.getInstigator());
                 worldProvider.getWorldEntity().send(placeBlocks);
                 if (!placeBlocks.isConsumed()) {
-                    item.send(new OnBlockItemPlaced(placementPos, blockEntityRegistry.getBlockEntityAt(placementPos), event.getInstigator()));
+                    item.send(new OnBlockItemPlaced(placementPos, blockEntityRegistry.getBlockEntityAt(JomlUtil.from(placementPos)), event.getInstigator()));
                 } else {
                     event.consume();
                 }

--- a/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.health.DoDestroyEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
@@ -42,7 +43,7 @@ public class BlockRegionSystem extends BaseComponentSystem {
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
     public void onDestroyed(DoDestroyEvent event, EntityRef entity, BlockRegionComponent blockRegion) {
         for (Vector3i blockPosition : blockRegion.region) {
-            worldProvider.setBlock(blockPosition, blockManager.getBlock(BlockManager.AIR_ID));
+            worldProvider.setBlock(JomlUtil.from(blockPosition), blockManager.getBlock(BlockManager.AIR_ID));
         }
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/AttachSupportRequired.java
@@ -15,9 +15,10 @@
  */
 package org.terasology.world.block.structure;
 
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
@@ -90,7 +91,7 @@ public class AttachSupportRequired implements BlockStructuralSupport {
     }
 
     private boolean hasSupportFromBlockOnSide(Vector3i blockPosition, Side side, Map<Vector3i, Block> blockOverrides) {
-        final Vector3i sideBlockPosition = side.getAdjacentPos(blockPosition);
+        final Vector3i sideBlockPosition = JomlUtil.from(side.getAdjacentPos(JomlUtil.from(blockPosition)));
         if (!getWorldProvider().isBlockRelevant(sideBlockPosition)) {
             return true;
         }

--- a/engine/src/main/java/org/terasology/world/block/structure/BlockDefSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/BlockDefSupportRequired.java
@@ -15,8 +15,9 @@
  */
 package org.terasology.world.block.structure;
 
+import org.joml.Vector3i;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;

--- a/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupport.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupport.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.world.block.structure;
 
+import org.joml.Vector3i;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 import java.util.Map;

--- a/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupportSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/BlockStructuralSupportSystem.java
@@ -23,6 +23,7 @@ import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.health.DestroyEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.monitoring.PerformanceMonitor;
@@ -91,10 +92,10 @@ public class BlockStructuralSupportSystem extends BaseComponentSystem implements
 
     @ReceiveEvent
     public void preventInvalidPlacement(PlaceBlocks placeBlocks, EntityRef world) {
-        final Map<Vector3i, Block> blocksMap = placeBlocks.getBlocks();
+        final Map<org.joml.Vector3i, Block> blocksMap = placeBlocks.getBlocks();
         for (BlockStructuralSupport support : supports) {
-            for (Map.Entry<Vector3i, Block> blockEntry : blocksMap.entrySet()) {
-                final Vector3i position = blockEntry.getKey();
+            for (Map.Entry<org.joml.Vector3i, Block> blockEntry : blocksMap.entrySet()) {
+                final org.joml.Vector3i position = blockEntry.getKey();
                 if (!support.isSufficientlySupported(position, Collections.unmodifiableMap(blocksMap))) {
                     placeBlocks.consume();
                     return;
@@ -105,12 +106,12 @@ public class BlockStructuralSupportSystem extends BaseComponentSystem implements
 
     private void validateSupportForBlockOnSide(Vector3i replacedBlockPosition, Side side) {
         final Vector3i blockPosition = side.getAdjacentPos(replacedBlockPosition);
-        if (worldProvider.isBlockRelevant(blockPosition)) {
+        if (worldProvider.isBlockRelevant(JomlUtil.from(blockPosition))) {
             final Side sideReverse = side.reverse();
 
             for (BlockStructuralSupport support : supports) {
-                if (support.shouldBeRemovedDueToChange(blockPosition, sideReverse)) {
-                    blockEntityRegistry.getBlockEntityAt(blockPosition).send(new DestroyEvent(gatheringEntity,
+                if (support.shouldBeRemovedDueToChange(JomlUtil.from(blockPosition), sideReverse)) {
+                    blockEntityRegistry.getBlockEntityAt(JomlUtil.from(blockPosition)).send(new DestroyEvent(gatheringEntity,
                             EntityRef.NULL, prefabManager.getPrefab("engine:supportRemovedDamage")));
                     break;
                 }

--- a/engine/src/main/java/org/terasology/world/block/structure/SideBlockSupportRequired.java
+++ b/engine/src/main/java/org/terasology/world/block/structure/SideBlockSupportRequired.java
@@ -15,14 +15,15 @@
  */
 package org.terasology.world.block.structure;
 
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.logic.health.DestroyEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
@@ -63,7 +64,7 @@ public class SideBlockSupportRequired implements BlockStructuralSupport {
     @ReceiveEvent
     public void checkForSupport(DelayedActionTriggeredEvent event, EntityRef entity, BlockComponent block, SideBlockSupportRequiredComponent supportRequired) {
         if (event.getActionId().equals(SUPPORT_CHECK_ACTION_ID)) {
-            if (!isSufficientlySupported(block.position, null, Collections.<Vector3i, Block>emptyMap(), supportRequired)) {
+            if (!isSufficientlySupported(JomlUtil.from(block.position), null, Collections.<Vector3i, Block>emptyMap(), supportRequired)) {
                 PrefabManager prefabManager = CoreRegistry.get(PrefabManager.class);
                 entity.send(new DestroyEvent(entity, EntityRef.NULL, prefabManager.getPrefab("engine:supportRemovedDamage")));
             }

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -16,9 +16,9 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.time.WorldTime;
@@ -97,7 +97,7 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     }
 
     @Override
-    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
+    public Map<org.joml.Vector3i, Block> setBlocks(Map<org.joml.Vector3i, Block> blocks) {
         return base.setBlocks(blocks);
     }
 
@@ -120,12 +120,12 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return base.getTotalLight(x, y, z);
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return base.getExtraData(index, x, y, z);
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         return base.setExtraData(index, pos, value);

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -16,9 +16,10 @@
 package org.terasology.world.internal;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.time.WorldTime;
@@ -40,7 +41,7 @@ public interface WorldProviderCore {
 
     /**
      * Returns the title of this world.
-     *
+     *JomlUtil.round
      * @return the title of this world
      */
     String getTitle();
@@ -152,7 +153,7 @@ public interface WorldProviderCore {
     byte getSunlight(int x, int y, int z);
 
     byte getTotalLight(int x, int y, int z);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -163,7 +164,7 @@ public interface WorldProviderCore {
      * @return The (index)th extra-data value at the given position
      */
     int getExtraData(int index, int x, int y, int z);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -16,9 +16,10 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
@@ -46,7 +47,7 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
 
     @Override
     public boolean isBlockRelevant(Vector3f pos) {
-        return isBlockRelevant(new Vector3i(pos, RoundingMode.HALF_UP));
+        return isBlockRelevant(JomlUtil.round(pos, RoundingMode.HALF_UP));
     }
 
     @Override
@@ -56,7 +57,7 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
 
     @Override
     public Block getBlock(Vector3f pos) {
-        return getBlock(new Vector3i(pos, RoundingMode.HALF_UP));
+        return getBlock(JomlUtil.round(pos, RoundingMode.HALF_UP));
     }
 
     @Override
@@ -71,17 +72,17 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
 
     @Override
     public byte getLight(Vector3f pos) {
-        return getLight(new Vector3i(pos, RoundingMode.HALF_UP));
+        return getLight(JomlUtil.round(pos, RoundingMode.HALF_UP));
     }
 
     @Override
     public byte getSunlight(Vector3f pos) {
-        return getSunlight(new Vector3i(pos, RoundingMode.HALF_UP));
+        return getSunlight(JomlUtil.round(pos, RoundingMode.HALF_UP));
     }
 
     @Override
     public byte getTotalLight(Vector3f pos) {
-        return getTotalLight(new Vector3i(pos, RoundingMode.HALF_UP));
+        return getTotalLight(JomlUtil.round(pos, RoundingMode.HALF_UP));
     }
 
 
@@ -94,27 +95,27 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     public byte getTotalLight(Vector3i pos) {
         return core.getTotalLight(pos.x, pos.y, pos.z);
     }
-    
+
     public int getExtraData(int index, Vector3i pos) {
         return core.getExtraData(index, pos.x, pos.y, pos.z);
     }
-    
+
     public int setExtraData(int index, int x, int y, int z, int value) {
         return core.setExtraData(index, new Vector3i(x, y, z), value);
     }
-    
+
     public int getExtraData(String fieldName, int x, int y, int z) {
         return core.getExtraData(extraDataManager.getSlotNumber(fieldName), x, y, z);
     }
-    
+
     public int getExtraData(String fieldName, Vector3i pos) {
         return core.getExtraData(extraDataManager.getSlotNumber(fieldName), pos.x, pos.y, pos.z);
     }
-    
+
     public int setExtraData(String fieldName, int x, int y, int z, int value) {
         return core.setExtraData(extraDataManager.getSlotNumber(fieldName), new Vector3i(x, y, z), value);
     }
-    
+
     public int setExtraData(String fieldName, Vector3i pos, int value) {
         return core.setExtraData(extraDataManager.getSlotNumber(fieldName), pos, value);
     }

--- a/modules/Core/src/main/java/org/terasology/core/debug/BlockPlacementBenchmark.java
+++ b/modules/Core/src/main/java/org/terasology/core/debug/BlockPlacementBenchmark.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldProvider;
@@ -52,14 +53,14 @@ class BlockPlacementBenchmark extends AbstractBenchmarkInstance {
     @Override
     public void runStep() {
         if (useSetBlocksInsteadOfSetBlock) {
-            Map<Vector3i, Block> blocksToPlace = new HashMap<>();
+            Map<org.joml.Vector3i, Block> blocksToPlace = new HashMap<>();
             for (Vector3i v : region3i) {
-                blocksToPlace.put(v, blockToPlace);
+                blocksToPlace.put(JomlUtil.from(v), blockToPlace);
             }
             worldProvider.setBlocks(blocksToPlace);
         } else {
             for (Vector3i v : region3i) {
-                worldProvider.setBlock(v, blockToPlace);
+                worldProvider.setBlock(JomlUtil.from(v), blockToPlace);
             }
         }
         if (blockToPlace == stone) {

--- a/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/door/DoorSystem.java
@@ -31,6 +31,7 @@ import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
@@ -88,7 +89,7 @@ public class DoorSystem extends BaseComponentSystem {
 
         Vector3i primePos = new Vector3i(targetBlockComp.position);
         primePos.add(offsetDir.getVector3i());
-        Block primeBlock = worldProvider.getBlock(primePos);
+        Block primeBlock = worldProvider.getBlock(JomlUtil.from(primePos));
         if (!primeBlock.isReplacementAllowed()) {
             event.consume();
             return;
@@ -124,9 +125,9 @@ public class DoorSystem extends BaseComponentSystem {
         Block newBottomBlock = door.bottomBlockFamily.getBlockForPlacement(bottomBlockPos, closedSide, Side.TOP);
         Block newTopBlock = door.topBlockFamily.getBlockForPlacement(bottomBlockPos, closedSide, Side.TOP);
 
-        Map<Vector3i, Block> blockMap = new HashMap<>();
-        blockMap.put(bottomBlockPos, newBottomBlock);
-        blockMap.put(topBlockPos, newTopBlock);
+        Map<org.joml.Vector3i, Block> blockMap = new HashMap<>();
+        blockMap.put(JomlUtil.from(bottomBlockPos), newBottomBlock);
+        blockMap.put(JomlUtil.from(topBlockPos), newTopBlock);
         PlaceBlocks blockEvent = new PlaceBlocks(blockMap, event.getInstigator());
         worldProvider.getWorldEntity().send(blockEvent);
 
@@ -174,7 +175,7 @@ public class DoorSystem extends BaseComponentSystem {
     private boolean canAttachTo(Vector3i doorPos, Side side) {
         Vector3i adjacentBlockPos = new Vector3i(doorPos);
         adjacentBlockPos.add(side.getVector3i());
-        Block adjacentBlock = worldProvider.getBlock(adjacentBlockPos);
+        Block adjacentBlock = worldProvider.getBlock(JomlUtil.from(adjacentBlockPos));
         return adjacentBlock.isAttachmentAllowed();
     }
 
@@ -195,9 +196,9 @@ public class DoorSystem extends BaseComponentSystem {
         Side newSide = door.closedSide;
         BlockRegionComponent regionComp = entity.getComponent(BlockRegionComponent.class);
         Block bottomBlock = door.bottomBlockFamily.getBlockForPlacement(regionComp.region.min(), newSide, Side.TOP);
-        worldProvider.setBlock(regionComp.region.min(), bottomBlock);
+        worldProvider.setBlock(JomlUtil.from(regionComp.region.min()), bottomBlock);
         Block topBlock = door.topBlockFamily.getBlockForPlacement(regionComp.region.max(), newSide, Side.TOP);
-        worldProvider.setBlock(regionComp.region.max(), topBlock);
+        worldProvider.setBlock(JomlUtil.from(regionComp.region.max()), topBlock);
         if (door.closeSound != null) {
             entity.send(new PlaySoundEvent(door.closeSound, 1f));
         }
@@ -212,9 +213,9 @@ public class DoorSystem extends BaseComponentSystem {
         Side newSide = door.openSide;
         BlockRegionComponent regionComp = entity.getComponent(BlockRegionComponent.class);
         Block bottomBlock = door.bottomBlockFamily.getBlockForPlacement(regionComp.region.min(), newSide, Side.TOP);
-        worldProvider.setBlock(regionComp.region.min(), bottomBlock);
+        worldProvider.setBlock(JomlUtil.from(regionComp.region.min()), bottomBlock);
         Block topBlock = door.topBlockFamily.getBlockForPlacement(regionComp.region.max(), newSide, Side.TOP);
-        worldProvider.setBlock(regionComp.region.max(), topBlock);
+        worldProvider.setBlock(JomlUtil.from(regionComp.region.max()), topBlock);
         if (door.openSound != null) {
             entity.send(new PlaySoundEvent(door.openSound, 1f));
         }

--- a/modules/Core/src/main/java/org/terasology/core/logic/trunk/TrunkSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/trunk/TrunkSystem.java
@@ -31,6 +31,7 @@ import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
@@ -88,7 +89,7 @@ public class TrunkSystem extends BaseComponentSystem {
 
         Vector3i primePos = new Vector3i(targetBlockComp.position);
         primePos.add(offsetDir.getVector3i());
-        Block primeBlock = worldProvider.getBlock(primePos);
+        Block primeBlock = worldProvider.getBlock(JomlUtil.from(primePos));
         if (!primeBlock.isReplacementAllowed()) {
             event.consume();
             return;
@@ -131,9 +132,9 @@ public class TrunkSystem extends BaseComponentSystem {
             newBottomBlock = trunk.leftBlockFamily.getBlockForPlacement(leftBlockPos, Side.BOTTOM, facingDir.reverse());
             newTopBlock = trunk.rightBlockFamily.getBlockForPlacement(rightBlockPos, Side.BOTTOM, facingDir.reverse());
         }
-        Map<Vector3i, Block> blockMap = new HashMap<>();
-        blockMap.put(leftBlockPos, newBottomBlock);
-        blockMap.put(rightBlockPos, newTopBlock);
+        Map<org.joml.Vector3i, Block> blockMap = new HashMap<>();
+        blockMap.put(JomlUtil.from(leftBlockPos), newBottomBlock);
+        blockMap.put(JomlUtil.from(rightBlockPos), newTopBlock);
         PlaceBlocks blockEvent = new PlaceBlocks(blockMap, event.getInstigator());
         worldProvider.getWorldEntity().send(blockEvent);
 

--- a/modules/Core/src/main/java/org/terasology/logic/actions/ArrowAction.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/ArrowAction.java
@@ -26,6 +26,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.CollisionGroup;
@@ -78,7 +79,7 @@ public class ArrowAction extends BaseComponentSystem {
             HitResult result;
             result = physicsRenderer.rayTrace(position, dir, arrowActionComponent.maxDistance, filter);
 
-            Block currentBlock = worldProvider.getBlock(blockPos);
+            Block currentBlock = worldProvider.getBlock(JomlUtil.from(blockPos));
 
             if (currentBlock.isDestructible()) {
                 EntityBuilder builder = entityManager.newBuilder("CoreAssets:defaultBlockParticles");

--- a/modules/Core/src/main/java/org/terasology/logic/actions/ExplosionAuthoritySystem.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/ExplosionAuthoritySystem.java
@@ -31,6 +31,7 @@ import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
@@ -124,11 +125,11 @@ public class ExplosionAuthoritySystem extends BaseComponentSystem {
                 target.y += direction.y * j;
                 target.z += direction.z * j;
                 blockPos.set((int) target.x, (int) target.y, (int) target.z);
-                Block currentBlock = worldProvider.getBlock(blockPos);
+                Block currentBlock = worldProvider.getBlock(JomlUtil.from(blockPos));
 
                 /* PHYSICS */
                 if (currentBlock.isDestructible()) {
-                    EntityRef blockEntity = blockEntityRegistry.getEntityAt(blockPos);
+                    EntityRef blockEntity = blockEntityRegistry.getEntityAt(JomlUtil.from(blockPos));
                     // allow explosions to chain together,  but do not chain on the instigating block
                     if (!blockEntity.equals(instigatingBlockEntity) && blockEntity.hasComponent(ExplosionActionComponent.class)) {
                         doExplosion(blockEntity.getComponent(ExplosionActionComponent.class), blockPos.toVector3f(), blockEntity);
@@ -163,7 +164,7 @@ public class ExplosionAuthoritySystem extends BaseComponentSystem {
             if (entityRef.hasComponent(BlockComponent.class)) {
                 BlockComponent blockComponent = entityRef.getComponent(BlockComponent.class);
                 // always destroy the block that caused the explosion
-                worldProvider.setBlock(blockComponent.position, blockManager.getBlock(BlockManager.AIR_ID));
+                worldProvider.setBlock(JomlUtil.from(blockComponent.position), blockManager.getBlock(BlockManager.AIR_ID));
                 // create the explosion from the block's location
                 doExplosion(explosionActionComponent, blockComponent.position.toVector3f(), entityRef);
             } else if (entityRef.hasComponent(LocationComponent.class)) {

--- a/modules/Core/src/main/java/org/terasology/logic/actions/TunnelAction.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/TunnelAction.java
@@ -25,6 +25,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.Physics;
@@ -72,7 +73,7 @@ public class TunnelAction extends BaseComponentSystem {
         int blockCounter = tunnelActionComponent.maxDestroyedBlocks;
         for (int s = 0; s <= tunnelActionComponent.maxTunnelDepth; s++) {
             origin.add(dir);
-            if (!worldProvider.isBlockRelevant(origin)) {
+            if (!worldProvider.isBlockRelevant(JomlUtil.from(origin))) {
                 break;
             }
 
@@ -90,7 +91,7 @@ public class TunnelAction extends BaseComponentSystem {
 
                     blockPos.set((int) target.x, (int) target.y, (int) target.z);
 
-                    Block currentBlock = worldProvider.getBlock(blockPos);
+                    Block currentBlock = worldProvider.getBlock(JomlUtil.from(blockPos));
 
                     if (currentBlock.isDestructible()) {
                         if (particleEffects < tunnelActionComponent.maxParticalEffects) {
@@ -100,7 +101,7 @@ public class TunnelAction extends BaseComponentSystem {
                             particleEffects++;
                         }
                         if (random.nextFloat() < tunnelActionComponent.thoroughness) {
-                            EntityRef blockEntity = blockEntityRegistry.getEntityAt(blockPos);
+                            EntityRef blockEntity = blockEntityRegistry.getEntityAt(JomlUtil.from(blockPos));
                             blockEntity.send(new DoDamageEvent(tunnelActionComponent.damageAmount, tunnelActionComponent.damageType));
                         }
 


### PR DESCRIPTION
This is a continuation of #3811 and this PR mainly focused on world provider and ported over methods that use those methods. Some other classes had to be moved over because they use maps of block locations and blocks. I added a rounding method to JOMLUtility and we might want to look into adding a PR to JOML adding some kind of rounding constructor between Vector3f <--> Vector3i