### PR TITLE
Minor Gradle dependency tweak

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -69,11 +69,13 @@ configurations.all {
 dependencies {
     // White list packages {@see ExternalApiWhiteList class}
     apiElements group: 'com.google.guava', name: 'guava', version: '23.0'
+    apiElements group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     apiElements group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
     apiElements group: 'org.lwjgl.lwjgl', name: 'lwjgl', version: LwjglVersion
     apiElements(group: 'com.snowplowanalytics', name: 'snowplow-java-tracker', version: '0.8.0') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
+    apiElements group: 'org.joml', name: 'joml', version: '1.9.19'
     apiElements group: 'java3d', name: 'vecmath', version: '1.3.1'
     // Light and Shadow use it
     apiElements group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
@@ -99,7 +101,7 @@ dependencies {
     implementation group: 'org.lwjgl.lwjgl', name: 'lwjgl', version: LwjglVersion
     implementation group: 'org.lwjgl.lwjgl', name: 'lwjgl_util', version: LwjglVersion
     implementation group: 'java3d', name: 'vecmath', version: '1.3.1'
-    compile group: 'org.joml', name: 'joml', version: '1.9.19'
+    implementation group: 'org.joml', name: 'joml', version: '1.9.19'
     implementation group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.3'
     implementation group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
     implementation group: 'de.matthiasmann.twl', name: 'PNGDecoder', version: '1111'


### PR DESCRIPTION
I'm still trying to understand the `apiElements` and other fancy more modern Gradle stuff introduced with #3835, but I believe this tweak might be going in the right direction.

GSON not being in the `apiElements` list is why I believe the build of the Kallisti module (which admittedly won't function at runtime without security off) failed in Jenkins - it used to build OK then fail expectedly at runtime unless you ran with security disabled.

Likewise I had added JOML to the legacy `compile` configuration as it was added during the Gradle 6 upgrade finished in #3835, but now believe I understand it better, with it needing to be both `implementation` and `apiElements` - or maybe something else so we can declare it fully in just one statement. It isn't actually used at all in modulespace yet but it will be and has already been whitelisted.

My belief is that being in `apiElements` doesn't whitelist anything on its own, just declares an intent, then we secondarily whitelist using our normal methods.

I'm also wondering if GSON _should_ be on the whitelist? Pros/cons? Could be one less obstacle to making Kallisti work within the sandbox. Note that it builds in two different ways, this PR only relates to how it can build as a Terasology module (with our standard module build file), there's no impact to its [standalone build](http://jenkins.terasology.org/view/All/job/KallistiStandalone/) which should still just work

PR just for doc & discussion, merging right away to continue testing in Jenkins. But happy to have my understanding updated and for us to improve this segment of Gradle better yet!

Maybe of interest to @DarkWeird @skaldarnar @immortius @asiekierka @engiValk (security angle). Maybe slightly related to #3725