### PR TITLE
Added Refresh on changing from listed to custom in join game

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/JoinGameScreen.java
@@ -131,6 +131,7 @@ public class JoinGameScreen extends CoreScreenLayer {
             find("customButton", UIButton.class).setFamily("highlight");
             find("onlineButton", UIButton.class).setFamily("default");
             visibleList = customServerList;
+            refresh();
         };
 
         WidgetUtil.trySubscribe(this, "customButton", activateCustom);
@@ -140,6 +141,7 @@ public class JoinGameScreen extends CoreScreenLayer {
             find("customButton", UIButton.class).setFamily("default");
             find("onlineButton", UIButton.class).setFamily("highlight");
             visibleList = onlineServerList;
+            refresh();
         };
         WidgetUtil.trySubscribe(this, "onlineButton", activateOnline);
 


### PR DESCRIPTION

Contains

The server info field "ping" remains unchanged when switching from Listed servers to Custom servers, ideally it should get refreshed according to the server whose information is being displayed at the moment.This PR fixes it.

How to test

1. Go to the join game screen 
2. Select a server in both listed and custom section  
3. Now changing the tab from listed to custom and vice-versa updates the ping field according to the server being displayed (it was not so earlier).
