### PR TITLE
add java 8 check to gradlew

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,16 @@ import java.nio.file.StandardCopyOption
 // Test for right version of Java in use for running this script
 assert org.gradle.api.JavaVersion.current().isJava8Compatible()
 
+import org.gradle.internal.logging.text.StyledTextOutput 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+// Check for Java 8
+if(JavaVersion.current() != JavaVersion.VERSION_1_8){
+    def out = services.get(StyledTextOutputFactory).create("an-ouput")
+    out.withStyle(Style.FailureHeader).println("Terasology supports only Java 8 as of now, kindly set your JAVA_HOME env variable accordingly")
+}
+
 // Declare "extra properties" (variables) for the project (and subs) - a Gradle thing that makes them special.
 ext {
     dirNatives = 'natives'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Adds a check for Java 8 to gradlew

### How to test

Set your JAVA_HOME env var to point to some other Java version and watch gradlew complain about it

