### PR TITLE
Fix for game crashing when a player re-spawns in multiplayer

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -210,7 +210,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         removeRelevanceEntity(entity);
     }
 
-    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
+//    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
         ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
         EntityRef character = clientComponent.character;
@@ -228,8 +228,9 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         character.saveComponent(loc);
     }
 
-    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL, components = {ClientComponent.class})
+    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
     public void onRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
+        setSpawnLocationOnRespawnRequest(event,entity);
         Vector3f spawnPosition = entity.getComponent(LocationComponent.class).getWorldPosition();
 
         if (worldProvider.isBlockRelevant(spawnPosition)) {

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -210,7 +210,8 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         removeRelevanceEntity(entity);
     }
 
-//    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
+
+
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
         ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
         EntityRef character = clientComponent.character;


### PR DESCRIPTION
Contains

The game crashes when any player on the server tries to respawn when multiple players are present in the server.

How to test

1. Start a local server and two clients using run configurations .
2. Join the server from both the clients.
3. Die and respawn any player.(This causes the game to crash in the version before fix)

What have I done 

When a 'RespawnResquestEvent' is fired two listeners 'setSpawnLocationOnRespawnRequest' and 'onRespawnRequest' are triggered . Although the priority of 'setSpawnLocationOnRespawnRequest' was higher there is a chance that it finishes execution after 'onRespawnRequest' (they might run concurrently ) and in such an event the other player might try to render the respawned player before his spawn location is set which led to an error.

The code i have written runs RespawnResquestEvent after setSpawnLocationOnRespawnRequest thereby avoiding the error.
