### PR TITLE
Multipayer Respawn Crash Bug Fix

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -33,6 +33,7 @@ import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.health.BeforeDestroyEvent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.players.event.BeforeRespawnEvent;
 import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.logic.players.event.RespawnRequestEvent;
@@ -210,7 +211,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         removeRelevanceEntity(entity);
     }
 
-    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL, components = {ClientComponent.class})
+    @ReceiveEvent(components = {ClientComponent.class})
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
         ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
         EntityRef character = clientComponent.character;
@@ -226,11 +227,11 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         loc.setWorldPosition(spawnPosition);
         loc.setLocalRotation(new Quat4f());  // reset rotation
         character.saveComponent(loc);
-    }
 
-    @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL, components = {ClientComponent.class})
-    public void onRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
-        Vector3f spawnPosition = entity.getComponent(LocationComponent.class).getWorldPosition();
+        BeforeRespawnEvent beforeRespawnEvent = entity.send(new BeforeRespawnEvent(entity));
+        // Implement a listener for BeforeRespawnEvent to modify the default spawn location in a module
+
+        spawnPosition = entity.getComponent(LocationComponent.class).getWorldPosition();
 
         if (worldProvider.isBlockRelevant(spawnPosition)) {
             respawnPlayer(entity);

--- a/engine/src/main/java/org/terasology/logic/players/event/BeforeRespawnEvent.java
+++ b/engine/src/main/java/org/terasology/logic/players/event/BeforeRespawnEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+
+
+/**
+ * This event is sent to an entity to allow modification of default spawn location.
+ */
+public class BeforeRespawnEvent implements Event {
+    private EntityRef entity;
+
+    public BeforeRespawnEvent(EntityRef entity) {
+        this.entity = entity;
+    }
+
+    public EntityRef getEntity() {
+        return entity;
+    }
+
+}


### PR DESCRIPTION
Contains

The game crashes when any player on the server tries to respawn when multiple players are present in the server.

How to test

1. Start a local server and two clients using run configurations .
2. Join the server from both the clients.
3. Die and respawn any player.(This causes the game to crash in the version before fix)

Other Modules Affected

The fix will cause AdventureAssets module's spawn location to not work (need to handle the spawn override using the new listener , A PR for that https://github.com/Terasology/AdventureAssets/pull/25 

What have I done 

The bug was due to a player being rendered before his spawn location was set (because making the player available  for rendering and setting his spawn location was being done asynchronously).
I have fixed the issue by making it synchronous and also made default spawnLocation modification  possible by making a BeforeRespawnEvent to handle it.
