### PR TITLE
Modified search to show if an asset is broken

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -267,11 +267,9 @@ public class CoreCommands extends BaseComponentSystem {
             }
             // If a prefab is broken , it will throw an exception
             catch(Exception e){
-                List<String> EmptyList=new ArrayList<String>();
                 console.addMessage("Note : Search may not return results if invalid assets are present");
                 console.addMessage("Error parsing : "+curUrn.toString());
                 console.addMessage(e.toString());
-                // return(EmptyList);
                 continue;
             }
         }

--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -84,7 +84,12 @@ import org.terasology.world.block.loader.BlockFamilyDefinition;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -250,15 +255,14 @@ public class CoreCommands extends BaseComponentSystem {
      */
     private List<String> findBlockMatches(String searchLowercase) {
         ResourceUrn curUrn;
-        List<String> l=new ArrayList<String>();
+        List<String> outputList=new ArrayList<String>();
         for (ResourceUrn urn : assetManager.getAvailableAssets(BlockFamilyDefinition.class)) {
             // Current urn for logging purposes to find the broken urn
             curUrn = urn;
             try{
                 Optional<BlockFamilyDefinition> def = assetManager.getAsset(urn, BlockFamilyDefinition.class);
                 if (def.isPresent() && def.get().isLoadable() && matchesSearch(searchLowercase, def.get())) {
-                    String s = new BlockUri(def.get().getUrn()).toString();
-                    l.add(s);
+                    outputList.add(new BlockUri(def.get().getUrn()).toString());
                 }
             }
             // If a prefab is broken , it will throw an exception
@@ -267,10 +271,11 @@ public class CoreCommands extends BaseComponentSystem {
                 console.addMessage("Note : Search may not return results if invalid assets are present");
                 console.addMessage("Error parsing : "+curUrn.toString());
                 console.addMessage(e.toString());
-                return(EmptyList);
+                // return(EmptyList);
+                continue;
             }
         }
-        return l;
+        return outputList;
 
     }
 
@@ -538,16 +543,17 @@ public class CoreCommands extends BaseComponentSystem {
         } else {
             dir.set(Direction.FORWARD.getVector3f());
         }
+        Quat4f rotation = Quat4f.shortestArcQuat(Direction.FORWARD.getVector3f(), dir);
 
-        return Assets.getPrefab(prefabName).map(prefab -> {
-            LocationComponent loc = prefab.getComponent(LocationComponent.class);
-            if (loc != null) {
-                entityManager.create(prefab, spawnPos);
-                return "Done";
-            } else {
-                return "Prefab cannot be spawned (no location component)";
-            }
-        }).orElse("Unknown prefab");
+        Optional<Prefab> prefab = Assets.getPrefab(prefabName);
+        if (prefab.isPresent() && prefab.get().getComponent(LocationComponent.class) != null) {
+            entityManager.create(prefab.get(), spawnPos, rotation);
+            return "Done";
+        } else if (!prefab.isPresent()) {
+            return "Unknown prefab";
+        } else {
+            return "Prefab cannot be spawned (no location component)";
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixed #3741 to harden the search for blocks. The console now shows which asset is broken when a search command is issued in the in game console . 

### How to test

Break an asset (eg : ladders) and write the command 'search stone' or search for any asset in the console. The search will return 0 results and return a message indicating that ladders is broken . Then fix it and run the same command and it should work.

### Outstanding before merging

If it works perfectly , can also be applied to prefabs and commands in the search
