### PR TITLE
feat(JOML): Migrate MeshRenderer/SkeletonRenderer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style
 // Check for Java 8
 if(JavaVersion.current() != JavaVersion.VERSION_1_8){
     def out = services.get(StyledTextOutputFactory).create("an-ouput")
-    out.withStyle(Style.FailureHeader).println("Terasology supports only Java 8 as of now, kindly set your JAVA_HOME env variable accordingly")
+    out.withStyle(Style.FailureHeader).println("WARNING: You're compiling with a JDK newer than Java 8, this may not be fully supported for Terasology, consider adjusting your JAVA_HOME accordingly")
 }
 
 // Declare "extra properties" (variables) for the project (and subs) - a Gradle thing that makes them special.

--- a/engine/src/main/java/org/terasology/math/MatrixUtils.java
+++ b/engine/src/main/java/org/terasology/math/MatrixUtils.java
@@ -48,10 +48,18 @@ public final class MatrixUtils {
         return buffer;
     }
 
+    /**
+     *
+     * Copies the given matrix into a newly allocated FloatBuffer
+     * the other of the elements in row-major.
+     * transformation operations happen on the inverse in the library
+     *
+     * @param m the matrix to copy
+     * @return a new Float buffer containing the matrix in row-major form
+     */
     public static FloatBuffer matrixToFloatBuffer(Matrix4fc m) {
         return m.getTransposed(BufferUtils.createFloatBuffer(16));
     }
-
 
     /**
      * Copies the given matrix into a newly allocated FloatBuffer.
@@ -75,7 +83,7 @@ public final class MatrixUtils {
      * Copies the given matrix into an existing FloatBuffer.
      * The order of the elements is column major (as used by OpenGL).
      *
-     * @param m  the matrix to copy
+     * @param m the matrix to copy
      * @param fb the float buffer to copy the matrix into
      * @return The provided float buffer.
      */
@@ -134,7 +142,7 @@ public final class MatrixUtils {
      *
      * @param m  the matrix to copy
      * @param fb the float buffer to copy the matrix into
-     * @return The provided float buffer.
+     * @return the provided float buffer with matrix elements in column major order.
      */
     public static FloatBuffer matrixToFloatBuffer(Matrix4fc m, FloatBuffer fb) {
         return m.getTransposed(fb);
@@ -255,10 +263,6 @@ public final class MatrixUtils {
         Matrix4f result = new Matrix4f();
         result.mul(m, vm);
         return result;
-    }
-
-    public static org.joml.Matrix4f calcModelViewMatrix(Matrix4fc m, Matrix4fc vm) {
-        return new org.joml.Matrix4f(vm).mul(m);
     }
 
     public static Matrix3f calcNormalMatrix(Matrix4f mv) {

--- a/engine/src/main/java/org/terasology/math/MatrixUtils.java
+++ b/engine/src/main/java/org/terasology/math/MatrixUtils.java
@@ -18,6 +18,7 @@ package org.terasology.math;
 
 import org.joml.Matrix3fc;
 import org.joml.Matrix4fc;
+import org.joml.Vector3ic;
 import org.lwjgl.BufferUtils;
 import org.terasology.math.geom.Matrix3f;
 import org.terasology.math.geom.Matrix4f;
@@ -40,8 +41,10 @@ public final class MatrixUtils {
      *
      * @param m the matrix to copy
      * @return A new FloatBuffer containing the matrix in column-major form.
-     * @deprecated used JOML method that uses Matrix4fc
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #matrixToFloatBuffer(Matrix4fc)}.
      */
+    @Deprecated
     public static FloatBuffer matrixToFloatBuffer(Matrix4f m) {
         FloatBuffer buffer = BufferUtils.createFloatBuffer(16);
         matrixToFloatBuffer(m, buffer);
@@ -67,7 +70,8 @@ public final class MatrixUtils {
      *
      * @param m the matrix to copy
      * @return A new FloatBuffer containing the matrix in column-major form.
-     * @deprecated used JOML method that uses Matrix3fc
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #matrixToFloatBuffer(Matrix3fc)}.
      */
     public static FloatBuffer matrixToFloatBuffer(Matrix3f m) {
         FloatBuffer buffer = BufferUtils.createFloatBuffer(9);
@@ -75,6 +79,13 @@ public final class MatrixUtils {
         return buffer;
     }
 
+    /**
+     * Copies the given matrix into a newly allocated FloatBuffer.
+     * The order of the elements is column major (as used by OpenGL).
+     *
+     * @param m the matrix to copy
+     * @return A new FloatBuffer containing the matrix in column-major form.
+     */
     public static FloatBuffer matrixToFloatBuffer(Matrix3fc m) {
         return m.getTransposed(BufferUtils.createFloatBuffer(9));
     }
@@ -86,7 +97,10 @@ public final class MatrixUtils {
      * @param m the matrix to copy
      * @param fb the float buffer to copy the matrix into
      * @return The provided float buffer.
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #matrixToFloatBuffer(Matrix3fc, FloatBuffer)}.
      */
+    @Deprecated
     public static FloatBuffer matrixToFloatBuffer(Matrix3f m, FloatBuffer fb) {
         fb.put(m.m00);
         fb.put(m.m10);
@@ -102,6 +116,14 @@ public final class MatrixUtils {
         return fb;
     }
 
+    /**
+     * Copies the given matrix into an existing buffer.
+     * The order of the elements is column major (as used by OpenGL).
+     *
+     * @param m  the matrix to copy
+     * @param fb the float buffer to copy the matrix into
+     * @return The provided float buffer.
+     */
     public static FloatBuffer matrixToFloatBuffer(Matrix3fc m, FloatBuffer fb) {
         return m.getTransposed(fb);
     }
@@ -113,7 +135,10 @@ public final class MatrixUtils {
      * @param m  the matrix to copy
      * @param fb the float buffer to copy the matrix into
      * @return The provided float buffer.
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #matrixToFloatBuffer(Matrix4fc, FloatBuffer)}.
      */
+    @Deprecated
     public static FloatBuffer matrixToFloatBuffer(Matrix4f m, FloatBuffer fb) {
         fb.put(m.m00);
         fb.put(m.m10);
@@ -282,6 +307,11 @@ public final class MatrixUtils {
         return result;
     }
 
+    /**
+     * Calculated normal view matrix from a modelViewMatrix
+     * @param mv ModelViewMatrix
+     * @return 3x3 normal matrix
+     */
     public static org.joml.Matrix3f calcNormalMatrix(Matrix4fc mv) {
         return mv.get3x3(new org.joml.Matrix3f()).invert().transpose();
     }

--- a/engine/src/main/java/org/terasology/math/MatrixUtils.java
+++ b/engine/src/main/java/org/terasology/math/MatrixUtils.java
@@ -94,6 +94,10 @@ public final class MatrixUtils {
         return fb;
     }
 
+    public static FloatBuffer matrixToFloatBuffer(Matrix3fc m, FloatBuffer fb) {
+        return m.getTransposed(fb);
+    }
+
     /**
      * Copies the given matrix into an existing FloatBuffer.
      * The order of the elements is column major (as used by OpenGL).
@@ -122,6 +126,18 @@ public final class MatrixUtils {
 
         fb.flip();
         return fb;
+    }
+
+    /**
+     * Copies the given matrix into an existing FloatBuffer.
+     * The order of the elements is column major (as used by OpenGL).
+     *
+     * @param m  the matrix to copy
+     * @param fb the float buffer to copy the matrix into
+     * @return The provided float buffer.
+     */
+    public static FloatBuffer matrixToFloatBuffer(Matrix4fc m, FloatBuffer fb) {
+        return m.getTransposed(fb);
     }
 
     public static org.joml.Matrix4f createViewMatrix(float eyeX, float eyeY, float eyeZ, float centerX, float centerY, float centerZ, float upX, float upY, float upZ) {
@@ -241,6 +257,10 @@ public final class MatrixUtils {
         return result;
     }
 
+    public static org.joml.Matrix4f calcModelViewMatrix(Matrix4fc m, Matrix4fc vm) {
+        return new org.joml.Matrix4f(m).mul(vm);
+    }
+
     public static Matrix3f calcNormalMatrix(Matrix4f mv) {
         Matrix3f result = new Matrix3f();
         result.m00 = mv.m00;
@@ -252,6 +272,23 @@ public final class MatrixUtils {
         result.m02 = mv.m02;
         result.m12 = mv.m12;
         result.m22 = mv.m22;
+
+        result.invert();
+        result.transpose();
+        return result;
+    }
+
+    public static org.joml.Matrix3f calcNormalMatrix(Matrix4fc mv) {
+        org.joml.Matrix3f result = new org.joml.Matrix3f();
+        result.m00 = mv.m00();
+        result.m10 = mv.m10();
+        result.m20 = mv.m20();
+        result.m01 = mv.m01();
+        result.m11 = mv.m11();
+        result.m21 = mv.m21();
+        result.m02 = mv.m02();
+        result.m12 = mv.m12();
+        result.m22 = mv.m22();
 
         result.invert();
         result.transpose();

--- a/engine/src/main/java/org/terasology/math/MatrixUtils.java
+++ b/engine/src/main/java/org/terasology/math/MatrixUtils.java
@@ -258,7 +258,7 @@ public final class MatrixUtils {
     }
 
     public static org.joml.Matrix4f calcModelViewMatrix(Matrix4fc m, Matrix4fc vm) {
-        return new org.joml.Matrix4f(m).mul(vm);
+        return new org.joml.Matrix4f(vm).mul(m);
     }
 
     public static Matrix3f calcNormalMatrix(Matrix4f mv) {
@@ -279,19 +279,6 @@ public final class MatrixUtils {
     }
 
     public static org.joml.Matrix3f calcNormalMatrix(Matrix4fc mv) {
-        org.joml.Matrix3f result = new org.joml.Matrix3f();
-        result.m00 = mv.m00();
-        result.m10 = mv.m10();
-        result.m20 = mv.m20();
-        result.m01 = mv.m01();
-        result.m11 = mv.m11();
-        result.m21 = mv.m21();
-        result.m02 = mv.m02();
-        result.m12 = mv.m12();
-        result.m22 = mv.m22();
-
-        result.invert();
-        result.transpose();
-        return result;
+        return mv.get3x3(new org.joml.Matrix3f()).invert().transpose();
     }
 }

--- a/engine/src/main/java/org/terasology/math/MatrixUtils.java
+++ b/engine/src/main/java/org/terasology/math/MatrixUtils.java
@@ -97,8 +97,7 @@ public final class MatrixUtils {
      * @param m the matrix to copy
      * @param fb the float buffer to copy the matrix into
      * @return The provided float buffer.
-     * @deprecated This is scheduled for removal in an upcoming version
-     *             method will be replaced with JOML implementation {@link #matrixToFloatBuffer(Matrix3fc, FloatBuffer)}.
+     * @deprecated This is scheduled for removal. Use JOML matrices.
      */
     @Deprecated
     public static FloatBuffer matrixToFloatBuffer(Matrix3f m, FloatBuffer fb) {
@@ -117,26 +116,13 @@ public final class MatrixUtils {
     }
 
     /**
-     * Copies the given matrix into an existing buffer.
-     * The order of the elements is column major (as used by OpenGL).
-     *
-     * @param m  the matrix to copy
-     * @param fb the float buffer to copy the matrix into
-     * @return The provided float buffer.
-     */
-    public static FloatBuffer matrixToFloatBuffer(Matrix3fc m, FloatBuffer fb) {
-        return m.getTransposed(fb);
-    }
-
-    /**
      * Copies the given matrix into an existing FloatBuffer.
      * The order of the elements is column major (as used by OpenGL).
      *
      * @param m  the matrix to copy
      * @param fb the float buffer to copy the matrix into
      * @return The provided float buffer.
-     * @deprecated This is scheduled for removal in an upcoming version
-     *             method will be replaced with JOML implementation {@link #matrixToFloatBuffer(Matrix4fc, FloatBuffer)}.
+     * @deprecated This is scheduled for removal. Use JOML matrices.
      */
     @Deprecated
     public static FloatBuffer matrixToFloatBuffer(Matrix4f m, FloatBuffer fb) {
@@ -159,18 +145,6 @@ public final class MatrixUtils {
 
         fb.flip();
         return fb;
-    }
-
-    /**
-     * Copies the given matrix into an existing FloatBuffer.
-     * The order of the elements is column major (as used by OpenGL).
-     *
-     * @param m  the matrix to copy
-     * @param fb the float buffer to copy the matrix into
-     * @return the provided float buffer with matrix elements in column major order.
-     */
-    public static FloatBuffer matrixToFloatBuffer(Matrix4fc m, FloatBuffer fb) {
-        return m.getTransposed(fb);
     }
 
     public static org.joml.Matrix4f createViewMatrix(float eyeX, float eyeY, float eyeZ, float centerX, float centerY, float centerZ, float upX, float upY, float upZ) {

--- a/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimationFrame.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/animation/MeshAnimationFrame.java
@@ -18,8 +18,8 @@ package org.terasology.rendering.assets.animation;
 
 import com.google.common.collect.Lists;
 
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 
 import java.util.Collection;
 import java.util.List;
@@ -28,9 +28,9 @@ import java.util.List;
  */
 public class MeshAnimationFrame {
     private List<Vector3f> bonePositions;
-    private List<Quat4f> boneRotations;
+    private List<Quaternionf> boneRotations;
 
-    public MeshAnimationFrame(Collection<Vector3f> bonePositions, Collection<Quat4f> boneRotations) {
+    public MeshAnimationFrame(Collection<Vector3f> bonePositions, Collection<Quaternionf> boneRotations) {
         this.bonePositions = Lists.newArrayList(bonePositions);
         this.boneRotations = Lists.newArrayList(boneRotations);
     }
@@ -39,7 +39,7 @@ public class MeshAnimationFrame {
         return bonePositions.get(boneId);
     }
 
-    public Quat4f getRotation(int boneId) {
+    public Quaternionf getRotation(int boneId) {
         return boneRotations.get(boneId);
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/Bone.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/Bone.java
@@ -64,7 +64,6 @@ public class Bone {
             pos.sub(parent.getObjectPosition());
             Quaternionf inverseParentRot = new Quaternionf();
             parent.getObjectRotation().invert(inverseParentRot);
-//            inverseParentRot.inverse(parent.getObjectRotation());
             inverseParentRot.transform(pos, pos);
         }
         return pos;
@@ -83,9 +82,7 @@ public class Bone {
         if (parent != null) {
             Quaternionf inverseParentRot = new Quaternionf();
             parent.getObjectRotation().invert(inverseParentRot);
-//            inverseParentRot.inverse(parent.getObjectRotation());
             rot.premul(inverseParentRot);
-//            inverseParentRot.mul(rot,rot);
         }
         return rot;
     }

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/Bone.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/Bone.java
@@ -17,9 +17,9 @@
 package org.terasology.rendering.assets.skeletalmesh;
 
 import com.google.common.collect.Lists;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,12 +30,12 @@ public class Bone {
     private String name;
     private int index;
     private Vector3f objectSpacePos = new Vector3f();
-    private Quat4f rotation = new Quat4f(0, 0, 0, 1);
+    private Quaternionf rotation = new Quaternionf(0, 0, 0, 1);
 
     private Bone parent;
     private List<Bone> children = Lists.newArrayList();
 
-    public Bone(int index, String name, Vector3f position, Quat4f rotation) {
+    public Bone(int index, String name, Vector3f position, Quaternionf rotation) {
         this.index = index;
         this.name = name;
         this.objectSpacePos.set(position);
@@ -62,27 +62,30 @@ public class Bone {
         Vector3f pos = new Vector3f(objectSpacePos);
         if (parent != null) {
             pos.sub(parent.getObjectPosition());
-            Quat4f inverseParentRot = new Quat4f();
-            inverseParentRot.inverse(parent.getObjectRotation());
-            inverseParentRot.rotate(pos, pos);
+            Quaternionf inverseParentRot = new Quaternionf();
+            parent.getObjectRotation().invert(inverseParentRot);
+//            inverseParentRot.inverse(parent.getObjectRotation());
+            inverseParentRot.transform(pos, pos);
         }
         return pos;
     }
 
-    public Quat4f getObjectRotation() {
+    public Quaternionf getObjectRotation() {
         return rotation;
     }
 
-    public void setObjectRotation(Quat4f newRotation) {
+    public void setObjectRotation(Quaternionf newRotation) {
         this.rotation = newRotation;
     }
 
-    public Quat4f getLocalRotation() {
-        Quat4f rot = new Quat4f(rotation);
+    public Quaternionf getLocalRotation() {
+        Quaternionf rot = new Quaternionf(rotation);
         if (parent != null) {
-            Quat4f inverseParentRot = new Quat4f();
-            inverseParentRot.inverse(parent.getObjectRotation());
-            rot.mul(inverseParentRot, rot);
+            Quaternionf inverseParentRot = new Quaternionf();
+            parent.getObjectRotation().invert(inverseParentRot);
+//            inverseParentRot.inverse(parent.getObjectRotation());
+            rot.premul(inverseParentRot);
+//            inverseParentRot.mul(rot,rot);
         }
         return rot;
     }

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/BoneWeight.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/BoneWeight.java
@@ -16,7 +16,7 @@
 
 package org.terasology.rendering.assets.skeletalmesh;
 
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 
 /**
  */

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshData.java
@@ -160,8 +160,8 @@ public class SkeletalMeshData implements AssetData {
         Vector3f norm = new Vector3f();
         for (int i = 0; i < indices.size() / 3; ++i) {
             Vector3f baseVert = vertices.get(indices.get(i * 3));
-            v1.sub(vertices.get(indices.get(i * 3 + 1)), baseVert);
-            v2.sub(vertices.get(indices.get(i * 3 + 2)), baseVert);
+            vertices.get(indices.get(i * 3 + 1)).sub(baseVert, v1);
+            vertices.get(indices.get(i * 3 + 2)).sub(baseVert, v2);
             v1.normalize();
             v2.normalize();
             norm.cross(v1, v2);

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshData.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshData.java
@@ -20,11 +20,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
+import org.joml.Quaternionf;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
 import org.terasology.assets.AssetData;
 import org.terasology.math.AABB;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
 
 import java.util.Collection;
 import java.util.List;
@@ -75,7 +75,7 @@ public class SkeletalMeshData implements AssetData {
 
     public List<Vector3f> getBindPoseVertexPositions() {
         List<Vector3f> positions = Lists.newArrayListWithCapacity(bones.size());
-        List<Quat4f> rotations = Lists.newArrayListWithCapacity(getBones().size());
+        List<Quaternionf> rotations = Lists.newArrayListWithCapacity(getBones().size());
         for (Bone bone : bones) {
             positions.add(bone.getObjectPosition());
             rotations.add(bone.getObjectRotation());
@@ -85,7 +85,7 @@ public class SkeletalMeshData implements AssetData {
 
     public List<Vector3f> getBindPoseVertexNormals() {
         List<Vector3f> positions = Lists.newArrayListWithCapacity(bones.size());
-        List<Quat4f> rotations = Lists.newArrayListWithCapacity(getBones().size());
+        List<Quaternionf> rotations = Lists.newArrayListWithCapacity(getBones().size());
         for (Bone bone : bones) {
             positions.add(bone.getObjectPosition());
             rotations.add(bone.getObjectRotation());
@@ -93,7 +93,7 @@ public class SkeletalMeshData implements AssetData {
         return getVertexNormals(positions, rotations);
     }
 
-    public List<Vector3f> getVertexPositions(List<Vector3f> bonePositions, List<Quat4f> boneRotations) {
+    public List<Vector3f> getVertexPositions(List<Vector3f> bonePositions, List<Quaternionf> boneRotations) {
         List<Vector3f> results = Lists.newArrayListWithCapacity(getVertexCount());
         for (int i = 0; i < vertexStartWeights.size(); ++i) {
             Vector3f vertexPos = new Vector3f();
@@ -101,9 +101,9 @@ public class SkeletalMeshData implements AssetData {
                 int weightIndex = vertexStartWeights.get(i) + weightIndexOffset;
                 BoneWeight weight = weights.get(weightIndex);
 
-                Vector3f current = boneRotations.get(weight.getBoneIndex()).rotate(weight.getPosition(), new Vector3f());
+                Vector3f current = boneRotations.get(weight.getBoneIndex()).transform(weight.getPosition(), new Vector3f());
                 current.add(bonePositions.get(weight.getBoneIndex()));
-                current.scale(weight.getBias());
+                current.mul(weight.getBias());
                 vertexPos.add(current);
             }
             results.add(vertexPos);
@@ -111,7 +111,7 @@ public class SkeletalMeshData implements AssetData {
         return results;
     }
 
-    public List<Vector3f> getVertexNormals(List<Vector3f> bonePositions, List<Quat4f> boneRotations) {
+    public List<Vector3f> getVertexNormals(List<Vector3f> bonePositions, List<Quaternionf> boneRotations) {
         List<Vector3f> results = Lists.newArrayListWithCapacity(getVertexCount());
         for (int i = 0; i < vertexStartWeights.size(); ++i) {
             Vector3f vertexNorm = new Vector3f();
@@ -119,8 +119,8 @@ public class SkeletalMeshData implements AssetData {
                 int weightIndex = vertexStartWeights.get(i) + weightIndexOffset;
                 BoneWeight weight = weights.get(weightIndex);
 
-                Vector3f current = boneRotations.get(weight.getBoneIndex()).rotate(weight.getNormal(), new Vector3f());
-                current.scale(weight.getBias());
+                Vector3f current = boneRotations.get(weight.getBoneIndex()).transform(weight.getNormal(), new Vector3f());
+                current.mul(weight.getBias());
                 vertexNorm.add(current);
             }
             results.add(vertexNorm);
@@ -172,13 +172,14 @@ public class SkeletalMeshData implements AssetData {
 
         normals.forEach(Vector3f::normalize);
 
-        Quat4f inverseRot = new Quat4f();
+        Quaternionf inverseRot = new Quaternionf();
         for (int vertIndex = 0; vertIndex < vertices.size(); ++vertIndex) {
             Vector3f normal = normals.get(vertIndex);
             for (int weightIndex = 0; weightIndex < vertexWeightCounts.get(vertIndex); ++weightIndex) {
                 BoneWeight weight = weights.get(weightIndex + vertexStartWeights.get(vertIndex));
-                inverseRot.inverse(bones.get(weight.getBoneIndex()).getObjectRotation());
-                inverseRot.rotate(normal, norm);
+                bones.get(weight.getBoneIndex()).getObjectRotation().invert(inverseRot);
+//                inverseRot.inverse(bones.get(weight.getBoneIndex()).getObjectRotation());
+                inverseRot.transform(normal, norm);
                 weight.setNormal(norm);
             }
         }
@@ -201,7 +202,7 @@ public class SkeletalMeshData implements AssetData {
             sb.append(bone.getObjectPosition().x).append(" ");
             sb.append(bone.getObjectPosition().y).append(" ");
             sb.append(bone.getObjectPosition().z).append(" ) ( ");
-            Quat4f rot = new Quat4f(bone.getObjectRotation());
+            Quaternionf rot = new Quaternionf(bone.getObjectRotation());
             rot.normalize();
             if (rot.w > 0) {
                 rot.x = -rot.x;

--- a/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshDataBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/skeletalmesh/SkeletalMeshDataBuilder.java
@@ -19,9 +19,10 @@ import com.google.common.collect.Lists;
 import gnu.trove.list.TFloatList;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
 import org.terasology.math.AABB;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.math.JomlUtil;
 import org.terasology.rendering.assets.mesh.MeshBuilder;
 import org.terasology.rendering.assets.mesh.MeshData;
 
@@ -75,7 +76,7 @@ public class SkeletalMeshDataBuilder {
     public SkeletalMeshDataBuilder addBox(Bone bone, Vector3f offset, Vector3f size, float u, float v) {
         MeshBuilder meshBuilder = new MeshBuilder();
         meshBuilder.setTextureMapper(textureMapper);
-        meshBuilder.addBox(offset, size, u, v);
+        meshBuilder.addBox(JomlUtil.from(offset), JomlUtil.from(size), u, v);
         return addMesh(bone, meshBuilder);
     }
 
@@ -141,7 +142,7 @@ public class SkeletalMeshDataBuilder {
         }
         AABB staticAabb;
         if (minOfAABB != null && maxOfAABB != null) {
-            staticAabb = AABB.createMinMax(minOfAABB, maxOfAABB);
+            staticAabb = AABB.createMinMax(JomlUtil.from(minOfAABB), JomlUtil.from(maxOfAABB));
         } else {
             staticAabb = AABB.createEmpty();
         }

--- a/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/collada/ColladaLoader.java
@@ -27,6 +27,7 @@ import org.eaxy.NonMatchingPathException;
 import org.eaxy.Xml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Matrix4f;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
@@ -345,7 +346,7 @@ public class ColladaLoader {
                 throw new ColladaParseException("no joint orientation for joint with element id " + joint.element.id());
             }
             // index argument is not used for anything currently, so we'll just set it to -1
-            joint.bone = new Bone(-1, joint.name, joint.position, joint.orientation);
+            joint.bone = new Bone(-1, joint.name, JomlUtil.from(joint.position), JomlUtil.from(joint.orientation));
         }
 
         for (MD5Joint joint : md5JointList) {

--- a/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/MeshRenderer.java
@@ -223,7 +223,7 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
 
                         modelViewMatrix.set(worldRenderer.getActiveCamera().getViewMatrix()).transpose().mul(matrixCameraSpace);
                         modelViewMatrix.get(tempMatrixBuffer44);
-                        modelViewMatrix.get3x3(normalMatrix).invert().get(tempMatrixBuffer33);
+                        modelViewMatrix.get3x3(normalMatrix).invert().getTransposed(tempMatrixBuffer33);
 
                         material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix(), true);
                         material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -18,6 +18,7 @@ package org.terasology.rendering.logic;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import jdk.nashorn.internal.scripts.JO;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -95,8 +96,8 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                 EntityRef parent = (bone.getParent() != null) ? skeleton.boneEntities.get(bone.getParent().getName()) : entity;
                 EntityRef boneEntity = entityManager.create(loc);
                 Location.attachChild(parent, boneEntity);
-                loc.setLocalPosition(bone.getLocalPosition());
-                loc.setLocalRotation(bone.getLocalRotation());
+                loc.setLocalPosition(JomlUtil.from(bone.getLocalPosition()));
+                loc.setLocalRotation(JomlUtil.from(bone.getLocalRotation()));
 
                 if (bone.getParent() == null) {
                     skeleton.rootBone = boneEntity;
@@ -266,8 +267,8 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             skeletalMesh.material.setFloat("sunlight", worldRenderer.getMainLightIntensityAt(JomlUtil.from(worldPos)), true);
             skeletalMesh.material.setFloat("blockLight", worldRenderer.getBlockLightIntensityAt(JomlUtil.from(worldPos)), true);
 
-            List<org.terasology.math.geom.Vector3f> bonePositions = Lists.newArrayListWithCapacity(skeletalMesh.mesh.getVertexCount());
-            List<Quat4f> boneRotations = Lists.newArrayListWithCapacity(skeletalMesh.mesh.getVertexCount());
+            List<Vector3f> bonePositions = Lists.newArrayListWithCapacity(skeletalMesh.mesh.getVertexCount());
+            List<Quaternionf> boneRotations = Lists.newArrayListWithCapacity(skeletalMesh.mesh.getVertexCount());
             for (Bone bone : skeletalMesh.mesh.getBones()) {
                 EntityRef boneEntity = skeletalMesh.boneEntities.get(bone.getName());
                 if (boneEntity == null) {
@@ -278,17 +279,17 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                     Vector3f pos = JomlUtil.from(boneLocation.getWorldPosition());
                     pos.sub(worldPos);
                     inverseWorldRot.transform(pos, pos);
-                    bonePositions.add(JomlUtil.from(pos));
+                    bonePositions.add(pos);
                     Quaternionf rot = new Quaternionf(inverseWorldRot);
                     rot.mul(JomlUtil.from(boneLocation.getWorldRotation()));
-                    boneRotations.add(JomlUtil.from(rot));
+                    boneRotations.add(rot);
                 } else {
                     logger.warn("Unable to resolve bone \"{}\"", bone.getName());
-                    bonePositions.add(JomlUtil.from(new Vector3f()));
-                    boneRotations.add(new Quat4f());
+                    bonePositions.add(new Vector3f());
+                    boneRotations.add(new Quaternionf());
                 }
             }
-            ((OpenGLSkeletalMesh) skeletalMesh.mesh).setScaleTranslate(skeletalMesh.scale, skeletalMesh.translate);
+            ((OpenGLSkeletalMesh) skeletalMesh.mesh).setScaleTranslate(JomlUtil.from(skeletalMesh.scale), JomlUtil.from(skeletalMesh.translate));
             ((OpenGLSkeletalMesh) skeletalMesh.mesh).render(bonePositions, boneRotations);
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -252,12 +252,10 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             Vector3f worldPositionCameraSpace = worldPos.sub(cameraPosition,new Vector3f());
 
             worldPos.y -= skeletalMesh.heightOffset;
+            Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,new Quaternionf(), worldScale).transpose();
 
-            Matrix4f matrixCameraSpace = new Matrix4f()
-                .translate(worldPositionCameraSpace)
-                .scale(worldScale);
 
-            Matrix4f modelViewMatrix = MatrixUtils.calcModelViewMatrix(worldRenderer.getActiveCamera().getViewMatrix(), matrixCameraSpace);
+            Matrix4f modelViewMatrix = new Matrix4f(matrixCameraSpace).mul(worldRenderer.getActiveCamera().getViewMatrix());
             MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
 
             skeletalMesh.material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
@@ -322,11 +320,9 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                 Vector3f worldPositionCameraSpace =  worldPos.sub(cameraPosition,new Vector3f());
 
                 float worldScale = location.getWorldScale();
-                Matrix4f matrixCameraSpace = new Matrix4f()
-                    .translate(worldPositionCameraSpace)
-                    .scale(worldScale);
+                Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,new Quaternionf(), worldScale).transpose();
 
-                Matrix4f modelViewMatrix = MatrixUtils.calcModelViewMatrix(worldRenderer.getActiveCamera().getViewMatrix(), matrixCameraSpace);
+                Matrix4f modelViewMatrix = new Matrix4f(matrixCameraSpace).mul(worldRenderer.getActiveCamera().getViewMatrix());
                 MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
 
                 material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -18,7 +18,6 @@ package org.terasology.rendering.logic;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import jdk.nashorn.internal.scripts.JO;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -41,7 +40,6 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.AABB;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.MatrixUtils;
-import org.terasology.math.geom.Quat4f;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.animation.MeshAnimation;
 import org.terasology.rendering.assets.animation.MeshAnimationFrame;

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -197,9 +197,9 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             }
             LocationComponent boneLoc = boneEntity.getComponent(LocationComponent.class);
             if (boneLoc != null) {
-                Vector3f newPos = new Vector3f(JomlUtil.from(frameA.getPosition(i))).lerp(JomlUtil.from(frameB.getPosition(i)), interpolationVal);
+                Vector3f newPos = new Vector3f(frameA.getPosition(i)).lerp(frameB.getPosition(i), interpolationVal);
                 boneLoc.setLocalPosition(JomlUtil.from(newPos));
-                Quaternionf newRot = new Quaternionf(JomlUtil.from(frameA.getRotation(i))).nlerp(JomlUtil.from(frameB.getRotation(i)),interpolationVal);
+                Quaternionf newRot = new Quaternionf(frameA.getRotation(i)).nlerp(frameB.getRotation(i),interpolationVal);
                 newRot.normalize();
                 boneLoc.setLocalRotation(JomlUtil.from(newRot));
                 boneEntity.saveComponent(boneLoc);

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -198,7 +198,6 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                 Vector3f newPos = new Vector3f(frameA.getPosition(i)).lerp(frameB.getPosition(i), interpolationVal);
                 boneLoc.setLocalPosition(JomlUtil.from(newPos));
                 Quaternionf newRot = new Quaternionf(frameA.getRotation(i)).nlerp(frameB.getRotation(i),interpolationVal);
-                newRot.normalize();
                 boneLoc.setLocalRotation(JomlUtil.from(newRot));
                 boneEntity.saveComponent(boneLoc);
             }

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -252,7 +252,7 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             Vector3f worldPositionCameraSpace = worldPos.sub(cameraPosition,new Vector3f());
 
             worldPos.y -= skeletalMesh.heightOffset;
-            Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,new Quaternionf(), worldScale).transpose();
+            Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,worldRot, worldScale).transpose();
 
 
             Matrix4f modelViewMatrix = new Matrix4f(matrixCameraSpace).mul(worldRenderer.getActiveCamera().getViewMatrix());

--- a/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/SkeletonRenderer.java
@@ -18,6 +18,7 @@ package org.terasology.rendering.logic;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -250,15 +251,15 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             Vector3f worldPositionCameraSpace = worldPos.sub(cameraPosition,new Vector3f());
 
             worldPos.y -= skeletalMesh.heightOffset;
-            Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,worldRot, worldScale).transpose();
+            Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,worldRot, worldScale);
 
 
             Matrix4f modelViewMatrix = new Matrix4f(matrixCameraSpace).mul(worldRenderer.getActiveCamera().getViewMatrix());
-            MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
+            modelViewMatrix.get(tempMatrixBuffer44);
 
             skeletalMesh.material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
 
-            MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
+            modelViewMatrix.get3x3(new Matrix3f()).invert().getTransposed(tempMatrixBuffer33);
             skeletalMesh.material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
 
             skeletalMesh.material.setFloat("sunlight", worldRenderer.getMainLightIntensityAt(JomlUtil.from(worldPos)), true);
@@ -318,14 +319,14 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
                 Vector3f worldPositionCameraSpace =  worldPos.sub(cameraPosition,new Vector3f());
 
                 float worldScale = location.getWorldScale();
-                Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,new Quaternionf(), worldScale).transpose();
+                Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace,new Quaternionf(), worldScale);
 
                 Matrix4f modelViewMatrix = new Matrix4f(matrixCameraSpace).mul(worldRenderer.getActiveCamera().getViewMatrix());
-                MatrixUtils.matrixToFloatBuffer(modelViewMatrix, tempMatrixBuffer44);
+                modelViewMatrix.get(tempMatrixBuffer44);
 
                 material.setMatrix4("worldViewMatrix", tempMatrixBuffer44, true);
 
-                MatrixUtils.matrixToFloatBuffer(MatrixUtils.calcNormalMatrix(modelViewMatrix), tempMatrixBuffer33);
+                modelViewMatrix.get3x3(new Matrix3f()).invert().getTransposed(tempMatrixBuffer33);
                 material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
 
                 SkeletalMeshComponent skeletalMesh = entity.getComponent(SkeletalMeshComponent.class);

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
@@ -20,13 +20,14 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.math.AABB;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.math.JomlUtil;
 import org.terasology.rendering.assets.animation.MeshAnimationData;
 import org.terasology.rendering.assets.animation.MeshAnimationFrame;
 
@@ -117,7 +118,7 @@ public class MD5AnimationLoader extends AbstractAssetFileFormat<MeshAnimationDat
                 }
             }
 
-            List<Quat4f> rotations = rawRotations.stream().map(rot ->
+            List<Quaternionf> rotations = rawRotations.stream().map(rot ->
                     MD5ParserCommon.completeQuat4f(rot.x, rot.y, rot.z)).collect(Collectors.toCollection(ArrayList::new));
 
             // Rotate just the root bone to correct for coordinate system differences
@@ -224,7 +225,7 @@ public class MD5AnimationLoader extends AbstractAssetFileFormat<MeshAnimationDat
             max.x = Math.max(a.x, b.x);
             max.y = Math.max(a.y, b.y);
             max.z = Math.max(a.z, b.z);
-            md5.bounds[i] = AABB.createMinMax(min, max);
+            md5.bounds[i] = AABB.createMinMax(JomlUtil.from(min), JomlUtil.from(max));
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5AnimationLoader.java
@@ -217,14 +217,8 @@ public class MD5AnimationLoader extends AbstractAssetFileFormat<MeshAnimationDat
             }
             Vector3f a = MD5ParserCommon.readVector3fAndCorrect(matcher.group(1), matcher.group(2), matcher.group(3));
             Vector3f b = MD5ParserCommon.readVector3fAndCorrect(matcher.group(4), matcher.group(5), matcher.group(6));
-            Vector3f min = new Vector3f();
-            min.x = Math.min(a.x, b.x);
-            min.y = Math.min(a.y, b.y);
-            min.z = Math.min(a.z, b.z);
-            Vector3f max = new Vector3f();
-            max.x = Math.max(a.x, b.x);
-            max.y = Math.max(a.y, b.y);
-            max.z = Math.max(a.z, b.z);
+            Vector3f min = new Vector3f(a).min(b);
+            Vector3f max = new Vector3f(a).max(b);
             md5.bounds[i] = AABB.createMinMax(JomlUtil.from(min), JomlUtil.from(max));
         }
     }

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5ParserCommon.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5ParserCommon.java
@@ -38,7 +38,6 @@ public final class MD5ParserCommon {
         CORRECTION_MATRIX = new Matrix3f(-1, 0, 0, 0, 0, 1, 0, 1, 0);
         CORRECTION_QUATERNION = new Quaternionf(0, 0, 0, 1);
         CORRECTION_QUATERNION.setFromNormalized(CORRECTION_MATRIX);
-//        CORRECTION_QUATERNION.set(CORRECTION_MATRIX);
     }
 
     public static Vector2f readUV(String u, String v) throws NumberFormatException {

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5ParserCommon.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5ParserCommon.java
@@ -16,10 +16,10 @@
 
 package org.terasology.rendering.md5;
 
-import org.terasology.math.geom.Matrix3f;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
+import org.joml.Matrix3f;
+import org.joml.Quaternionf;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,15 +29,16 @@ import java.io.IOException;
 public final class MD5ParserCommon {
 
     public static final Matrix3f CORRECTION_MATRIX;
-    public static final Quat4f CORRECTION_QUATERNION;
+    public static final Quaternionf CORRECTION_QUATERNION;
 
     private MD5ParserCommon() {
     }
 
     static {
         CORRECTION_MATRIX = new Matrix3f(-1, 0, 0, 0, 0, 1, 0, 1, 0);
-        CORRECTION_QUATERNION = new Quat4f(0, 0, 0, 1);
-        CORRECTION_QUATERNION.set(CORRECTION_MATRIX);
+        CORRECTION_QUATERNION = new Quaternionf(0, 0, 0, 1);
+        CORRECTION_QUATERNION.setFromNormalized(CORRECTION_MATRIX);
+//        CORRECTION_QUATERNION.set(CORRECTION_MATRIX);
     }
 
     public static Vector2f readUV(String u, String v) throws NumberFormatException {
@@ -54,32 +55,32 @@ public final class MD5ParserCommon {
         return result;
     }
 
-    public static Quat4f readQuat4f(String xValue, String yValue, String zValue) throws NumberFormatException {
+    public static Quaternionf readQuat4f(String xValue, String yValue, String zValue) throws NumberFormatException {
         float x = Float.parseFloat(xValue);
         float y = Float.parseFloat(yValue);
         float z = Float.parseFloat(zValue);
         return correctQuat4f(completeQuat4f(x, y, z));
     }
 
-    public static Quat4f completeQuat4f(float x, float y, float z) {
+    public static Quaternionf completeQuat4f(float x, float y, float z) {
         float t = 1.0f - (x * x) - (y * y) - (z * z);
         float w = 0;
         if (t > 0.0f) {
             w = (float) -Math.sqrt(t);
         }
-        Quat4f result = new Quat4f(x, y, z, w);
+        Quaternionf result = new Quaternionf(x, y, z, w);
         result.normalize();
         return result;
     }
 
-    public static Quat4f correctQuat4f(Quat4f rot) {
-        Quat4f result = new Quat4f(CORRECTION_QUATERNION);
+    public static Quaternionf correctQuat4f(Quaternionf rot) {
+        Quaternionf result = new Quaternionf(CORRECTION_QUATERNION);
         result.mul(rot);
         return result;
     }
 
     public static Vector3f correctOffset(Vector3f offset) {
-        return CORRECTION_QUATERNION.rotate(offset, new Vector3f());
+        return CORRECTION_QUATERNION.transform(offset, new Vector3f());
     }
 
 

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5SkeletonLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5SkeletonLoader.java
@@ -26,6 +26,7 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
@@ -47,16 +48,16 @@ public class MD5SkeletonLoader extends AbstractAssetFileFormat<SkeletalMeshData>
 
     private static final Logger logger = LoggerFactory.getLogger(MD5SkeletonLoader.class);
 
-    private Pattern jointPattern = Pattern.compile("\"(.*)\"\\s+" + MD5Patterns.INTEGER_PATTERN + 
+    private Pattern jointPattern = Pattern.compile("\"(.*)\"\\s+" + MD5Patterns.INTEGER_PATTERN +
             "\\s*" + MD5Patterns.VECTOR3_PATTERN + "\\s*" + MD5Patterns.VECTOR3_PATTERN);
-    private Pattern vertPatten = Pattern.compile("vert\\s+" + MD5Patterns.INTEGER_PATTERN + 
-            "\\s+" + MD5Patterns.VECTOR2_PATTERN + "\\s+" + MD5Patterns.INTEGER_PATTERN + 
+    private Pattern vertPatten = Pattern.compile("vert\\s+" + MD5Patterns.INTEGER_PATTERN +
+            "\\s+" + MD5Patterns.VECTOR2_PATTERN + "\\s+" + MD5Patterns.INTEGER_PATTERN +
             "\\s+" + MD5Patterns.INTEGER_PATTERN);
-    private Pattern triPattern = Pattern.compile("tri\\s+" + MD5Patterns.INTEGER_PATTERN + 
-            "\\s+" + MD5Patterns.INTEGER_PATTERN + "\\s+" + MD5Patterns.INTEGER_PATTERN + 
+    private Pattern triPattern = Pattern.compile("tri\\s+" + MD5Patterns.INTEGER_PATTERN +
+            "\\s+" + MD5Patterns.INTEGER_PATTERN + "\\s+" + MD5Patterns.INTEGER_PATTERN +
             "\\s+" + MD5Patterns.INTEGER_PATTERN);
-    private Pattern weightPattern = Pattern.compile("weight\\s+" + MD5Patterns.INTEGER_PATTERN + 
-            "\\s+" + MD5Patterns.INTEGER_PATTERN + "\\s+" + MD5Patterns.FLOAT_PATTERN + 
+    private Pattern weightPattern = Pattern.compile("weight\\s+" + MD5Patterns.INTEGER_PATTERN +
+            "\\s+" + MD5Patterns.INTEGER_PATTERN + "\\s+" + MD5Patterns.FLOAT_PATTERN +
             "\\s+" + MD5Patterns.VECTOR3_PATTERN);
 
     public MD5SkeletonLoader() {
@@ -71,7 +72,7 @@ public class MD5SkeletonLoader extends AbstractAssetFileFormat<SkeletalMeshData>
             List<Bone> bones = Lists.newArrayListWithCapacity(md5.numJoints);
             for (int i = 0; i < md5.numJoints; ++i) {
                 MD5Joint joint = md5.joints[i];
-                Bone bone = new Bone(i, joint.name, joint.position, joint.orientation);
+                Bone bone = new Bone(i, joint.name, JomlUtil.from(joint.position), JomlUtil.from(joint.orientation));
                 bones.add(bone);
                 if (joint.parent != -1) {
                     bones.get(joint.parent).addChild(bone);
@@ -82,14 +83,14 @@ public class MD5SkeletonLoader extends AbstractAssetFileFormat<SkeletalMeshData>
                 // TODO: Support multiple mesh somehow?
                 MD5Mesh mesh = md5.meshes[0];
                 for (MD5Weight weight : mesh.weightList) {
-                    skeletonBuilder.addWeight(new BoneWeight(weight.position, weight.bias, weight.jointIndex));
+                    skeletonBuilder.addWeight(new BoneWeight(JomlUtil.from(weight.position), weight.bias, weight.jointIndex));
                 }
 
-                List<Vector2f> uvs = Lists.newArrayList();
+                List<org.joml.Vector2f> uvs = Lists.newArrayList();
                 TIntList vertexStartWeight = new TIntArrayList(mesh.numVertices);
                 TIntList vertexWeightCount = new TIntArrayList(mesh.numVertices);
                 for (MD5Vertex vert : mesh.vertexList) {
-                    uvs.add(vert.uv);
+                    uvs.add(JomlUtil.from(vert.uv));
                     vertexStartWeight.add(vert.startWeight);
                     vertexWeightCount.add(vert.countWeight);
                 }

--- a/engine/src/main/java/org/terasology/rendering/md5/MD5SkeletonLoader.java
+++ b/engine/src/main/java/org/terasology/rendering/md5/MD5SkeletonLoader.java
@@ -20,6 +20,9 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
+import org.joml.Quaternionf;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
@@ -27,9 +30,6 @@ import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.assets.skeletalmesh.Bone;
 import org.terasology.rendering.assets.skeletalmesh.BoneWeight;
 import org.terasology.rendering.assets.skeletalmesh.SkeletalMeshData;
@@ -72,7 +72,7 @@ public class MD5SkeletonLoader extends AbstractAssetFileFormat<SkeletalMeshData>
             List<Bone> bones = Lists.newArrayListWithCapacity(md5.numJoints);
             for (int i = 0; i < md5.numJoints; ++i) {
                 MD5Joint joint = md5.joints[i];
-                Bone bone = new Bone(i, joint.name, JomlUtil.from(joint.position), JomlUtil.from(joint.orientation));
+                Bone bone = new Bone(i, joint.name, joint.position, joint.orientation);
                 bones.add(bone);
                 if (joint.parent != -1) {
                     bones.get(joint.parent).addChild(bone);
@@ -83,14 +83,14 @@ public class MD5SkeletonLoader extends AbstractAssetFileFormat<SkeletalMeshData>
                 // TODO: Support multiple mesh somehow?
                 MD5Mesh mesh = md5.meshes[0];
                 for (MD5Weight weight : mesh.weightList) {
-                    skeletonBuilder.addWeight(new BoneWeight(JomlUtil.from(weight.position), weight.bias, weight.jointIndex));
+                    skeletonBuilder.addWeight(new BoneWeight(weight.position, weight.bias, weight.jointIndex));
                 }
 
-                List<org.joml.Vector2f> uvs = Lists.newArrayList();
+                List<Vector2f> uvs = Lists.newArrayList();
                 TIntList vertexStartWeight = new TIntArrayList(mesh.numVertices);
                 TIntList vertexWeightCount = new TIntArrayList(mesh.numVertices);
                 for (MD5Vertex vert : mesh.vertexList) {
-                    uvs.add(JomlUtil.from(vert.uv));
+                    uvs.add(vert.uv);
                     vertexStartWeight.add(vert.startWeight);
                     vertexWeightCount.add(vert.countWeight);
                 }
@@ -225,7 +225,7 @@ public class MD5SkeletonLoader extends AbstractAssetFileFormat<SkeletalMeshData>
         String name;
         int parent;
         Vector3f position;
-        Quat4f orientation;
+        Quaternionf orientation;
     }
 
     private static class MD5Mesh {

--- a/engine/src/main/java/org/terasology/rendering/opengl/OpenGLSkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/rendering/opengl/OpenGLSkeletalMesh.java
@@ -15,6 +15,9 @@
  */
 package org.terasology.rendering.opengl;
 
+import org.joml.Quaternionf;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
@@ -26,9 +29,6 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.engine.GameThread;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.math.AABB;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.VertexBufferObjectUtil;
 import org.terasology.rendering.assets.skeletalmesh.Bone;
 import org.terasology.rendering.assets.skeletalmesh.SkeletalMesh;
@@ -166,7 +166,7 @@ public class OpenGLSkeletalMesh extends SkeletalMesh {
         postRender();
     }
 
-    public void render(List<Vector3f> bonePositions, List<Quat4f> boneRotations) {
+    public void render(List<Vector3f> bonePositions, List<Quaternionf> boneRotations) {
         preRender();
         doRender(data.getVertexPositions(bonePositions, boneRotations), data.getVertexNormals(bonePositions, boneRotations));
         postRender();


### PR DESCRIPTION
I went in a bit of a different direction and I'll probably work outwards in. so this is just a conversion of the SkeletonRenderer since it does not have a lot of dependencies and building up those utility methods will help with porting the rest of everything. 

This can be tested with WildAnimals and spawning a deer in. any block entities should use the MeshRenderer. Player hand and anything held is also handled by the MeshRenderer. If everything works correctly then the player hand should work default with held items, explosions, the walk cycle on deers in Wildanimals should walk correctly.

```
./groovyw module recurse WildAnimals
./spawnprefab deer
```
I noticed a rotation problem but this seems to also be a problem with the base develop branch. 