### PR TITLE
added serilization compatibility for joml along with a basic test for…

### DIFF
--- a/engine-tests/src/main/java/org/terasology/testUtil/TeraAssert.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/TeraAssert.java
@@ -16,7 +16,11 @@
 package org.terasology.testUtil;
 
 import com.google.common.collect.Lists;
+import org.joml.Vector2fc;
+import org.joml.Vector3fc;
+import org.joml.Vector4fc;
 import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
 
@@ -61,6 +65,41 @@ public final class TeraAssert {
         }
     }
 
+    public static void assertEquals(Vector2f expected, Vector2f actual, float error) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertNotNull(actual);
+            Supplier<String> errorMessageSupplier = () -> "Expected " + expected + ", actual" + actual;
+            org.junit.jupiter.api.Assertions.assertEquals(expected.x, actual.x, error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.y, actual.y, error, errorMessageSupplier);
+        }
+    }
+
+    public static void assertEquals(Vector2fc expected, Vector2fc actual, float error) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertNotNull(actual);
+            Supplier<String> errorMessageSupplier = () -> "Expected " + expected + ", actual" + actual;
+            org.junit.jupiter.api.Assertions.assertEquals(expected.x(), actual.x(), error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.y(), actual.y(), error, errorMessageSupplier);
+        }
+    }
+
+
+    public static void assertEquals(Vector3fc expected, Vector3fc actual, float error) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertNotNull(actual);
+            Supplier<String> errorMessageSupplier = () -> "Expected " + expected + ", actual" + actual;
+            org.junit.jupiter.api.Assertions.assertEquals(expected.x(), actual.x(), error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.y(), actual.y(), error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.z(), actual.z(), error, errorMessageSupplier);
+        }
+    }
+
     public static void assertEquals(Vector4f expected, Vector4f actual, float error) {
         if (expected == null) {
             assertNull(actual);
@@ -71,6 +110,19 @@ public final class TeraAssert {
             org.junit.jupiter.api.Assertions.assertEquals(expected.y, actual.y, error, errorMessageSupplier);
             org.junit.jupiter.api.Assertions.assertEquals(expected.z, actual.z, error, errorMessageSupplier);
             org.junit.jupiter.api.Assertions.assertEquals(expected.w, actual.w, error, errorMessageSupplier);
+        }
+    }
+
+    public static void assertEquals(Vector4fc expected, Vector4fc actual, float error) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertNotNull(actual);
+            Supplier<String> errorMessageSupplier = () -> "Expected " + expected + ", actual" + actual;
+            org.junit.jupiter.api.Assertions.assertEquals(expected.x(), actual.x(), error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.y(), actual.y(), error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.z(), actual.z(), error, errorMessageSupplier);
+            org.junit.jupiter.api.Assertions.assertEquals(expected.w(), actual.w(), error, errorMessageSupplier);
         }
     }
 

--- a/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/entitySystem/PojoPrefabManagerTest.java
@@ -34,8 +34,8 @@ import org.terasology.entitySystem.stubs.StringComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
-import org.terasology.persistence.typeHandling.mathTypes.Quat4fTypeHandler;
-import org.terasology.persistence.typeHandling.mathTypes.Vector3fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyQuat4fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector3fTypeHandler;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 import org.terasology.utilities.Assets;
@@ -62,8 +62,8 @@ public class PojoPrefabManagerTest {
         Reflections reflections = new Reflections(getClass().getClassLoader());
         TypeHandlerLibrary lib = new TypeHandlerLibrary(reflections);
 
-        lib.addTypeHandler(Vector3f.class, new Vector3fTypeHandler());
-        lib.addTypeHandler(Quat4f.class, new Quat4fTypeHandler());
+        lib.addTypeHandler(Vector3f.class, new LegacyVector3fTypeHandler());
+        lib.addTypeHandler(Quat4f.class, new LegacyQuat4fTypeHandler());
 
         entitySystemLibrary = new EntitySystemLibrary(context, lib);
         componentLibrary = entitySystemLibrary.getComponentLibrary();

--- a/engine-tests/src/test/java/org/terasology/persistence/ComponentSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/ComponentSerializerTest.java
@@ -36,8 +36,8 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.network.NetworkSystem;
 import org.terasology.persistence.serializers.ComponentSerializer;
 import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
-import org.terasology.persistence.typeHandling.mathTypes.Quat4fTypeHandler;
-import org.terasology.persistence.typeHandling.mathTypes.Vector3fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyQuat4fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector3fTypeHandler;
 import org.terasology.protobuf.EntityData;
 import org.terasology.recording.RecordAndReplayCurrentStatus;
 import org.terasology.registry.CoreRegistry;
@@ -70,8 +70,8 @@ public class ComponentSerializerTest {
         Reflections reflections = new Reflections(getClass().getClassLoader());
         TypeHandlerLibrary serializationLibrary = new TypeHandlerLibrary(reflections);
 
-        serializationLibrary.addTypeHandler(Vector3f.class, new Vector3fTypeHandler());
-        serializationLibrary.addTypeHandler(Quat4f.class, new Quat4fTypeHandler());
+        serializationLibrary.addTypeHandler(Vector3f.class, new LegacyVector3fTypeHandler());
+        serializationLibrary.addTypeHandler(Quat4f.class, new LegacyQuat4fTypeHandler());
 
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         context.put(NetworkSystem.class, networkSystem);

--- a/engine-tests/src/test/java/org/terasology/persistence/serializers/TypeSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/serializers/TypeSerializerTest.java
@@ -36,12 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TypeSerializerTest extends ModuleEnvironmentTest {
     private static final SomeClass<Integer> INSTANCE = new SomeClass<>(0xdeadbeef);
-    private static final String INSTANCE_JSON = "{\"generic-t\":-559038737,\"list\":[50,51,-52,-53],\"animals\":[{\"class\":\"org.terasology.persistence.serializers.TypeSerializerTest$Dog\",\"tailPosition\":[3.15,54.51,-0.001],\"data\":{\"class\":\"java.lang.Integer\",\"content\":1}},{\"class\":\"org.terasology.persistence.serializers.TypeSerializerTest$Cheetah\",\"spotColor\":[255,0,255,255],\"data\":{\"class\":\"java.lang.Integer\",\"content\":2}}]}";
+    private static final String INSTANCE_JSON = "{\"generic-t\":-559038737,\"list\":[50,51,-52,-53],\"animals\":[{\"class\":\"org.terasology.persistence.serializers.TypeSerializerTest$Dog\",\"tailPosition\":[3.15,54.51,-0.001],\"headPosition\":[10.0,30.0,-0.001],\"data\":{\"class\":\"java.lang.Integer\",\"content\":1}},{\"class\":\"org.terasology.persistence.serializers.TypeSerializerTest$Cheetah\",\"spotColor\":[255,0,255,255],\"data\":{\"class\":\"java.lang.Integer\",\"content\":2}}]}";
 
     static {
         INSTANCE.list.addAll(Lists.newArrayList(50, 51, -52, -53));
 
-        INSTANCE.animals.add(new Dog<>(1, new Vector3f(3.15f, 54.51f, -0.001f)));
+        INSTANCE.animals.add(new Dog<>(1, new Vector3f(3.15f, 54.51f, -0.001f), new org.joml.Vector3f(10.0f,30.0f,-0.001f)));
 
         INSTANCE.animals.add(new Cheetah<>(2, Color.MAGENTA));
     }
@@ -154,10 +154,12 @@ public class TypeSerializerTest extends ModuleEnvironmentTest {
 
     private static class Dog<T> extends Animal<T> {
         private final Vector3f tailPosition;
+        private final org.joml.Vector3f headPosition;
 
-        private Dog(T data, Vector3f tailPosition) {
+        private Dog(T data, Vector3f tailPosition,org.joml.Vector3f headPosition) {
             super(data);
             this.tailPosition = tailPosition;
+            this.headPosition = headPosition;
         }
 
         @Override
@@ -172,20 +174,21 @@ public class TypeSerializerTest extends ModuleEnvironmentTest {
                 return false;
             }
             Dog dog = (Dog) o;
-            return Objects.equals(tailPosition, dog.tailPosition);
+            return Objects.equals(tailPosition, dog.tailPosition) &&  Objects.equals(headPosition, dog.headPosition);
         }
 
         @Override
         public String toString() {
             return "Dog{" +
-                    "name='" + data + '\'' +
-                    ", tailPosition=" + tailPosition +
-                    '}';
+                "name='" + data + '\'' +
+                ", tailPosition=" + tailPosition +
+                ", headPosition=" + headPosition +
+                '}';
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), tailPosition);
+            return Objects.hash(super.hashCode(), tailPosition, headPosition);
         }
     }
 

--- a/engine-tests/src/test/java/org/terasology/persistence/serializers/VectorTypeSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/serializers/VectorTypeSerializerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.serializers;
+
+import org.junit.jupiter.api.Test;
+import org.terasology.ModuleEnvironmentTest;
+import org.terasology.math.geom.Vector2f;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector4f;
+import org.terasology.naming.Name;
+import org.terasology.persistence.ModuleContext;
+import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
+import org.terasology.reflection.TypeInfo;
+import org.terasology.testUtil.TeraAssert;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
+
+    static class TestObject{
+        public Vector3f v1;
+        public Vector2f v2;
+        public Vector4f v3;
+        public org.joml.Vector3f v11;
+        public org.joml.Vector2f v22;
+        public org.joml.Vector4f v33;
+    }
+    static class TestObject1 {
+        public org.joml.Vector3f v1;
+        public org.joml.Vector2f v2;
+        public org.joml.Vector4f v3;
+    }
+
+    private TypeHandlerLibrary typeHandlerLibrary;
+    private ProtobufSerializer protobufSerializer;
+    private GsonSerializer gsonSerializer;
+
+    @Override
+    public void setup() {
+        ModuleContext.setContext(moduleManager.getEnvironment().get(new Name("unittest")));
+
+        typeHandlerLibrary = TypeHandlerLibrary.forModuleEnvironment(moduleManager, typeRegistry);
+
+        protobufSerializer = new ProtobufSerializer(typeHandlerLibrary);
+        gsonSerializer = new GsonSerializer(typeHandlerLibrary);
+    }
+
+    @Test
+    public void testJsonSerializeRemapped() throws IOException {
+        TestObject a = new TestObject();
+        a.v1 = new Vector3f(11.5f, 13.15f, 3);
+        a.v2 = new Vector2f(12, 13f);
+        a.v3 = new Vector4f(12, 12.2f, 3f, 15.5f);
+        a.v11 = new org.joml.Vector3f(11.5f, 13.15f, 3);
+        a.v22 = new org.joml.Vector2f(12, 13f);
+        a.v33 = new org.joml.Vector4f(12, 12.2f, 3f, 15.5f);
+
+        String data = gsonSerializer.toJson(a, new TypeInfo<TestObject>() {
+        });
+
+        TestObject1 o = gsonSerializer.fromJson(data, new TypeInfo<TestObject1>() {
+        });
+
+        TeraAssert.assertEquals(o.v1, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        TeraAssert.assertEquals(o.v2, new org.joml.Vector2f(12f, 13f), .00001f);
+        TeraAssert.assertEquals(o.v3, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+
+    }
+
+    @Test
+    public void testProtobufSerializeRemapped() throws IOException {
+        TestObject a = new TestObject();
+        a.v1 = new Vector3f(11.5f, 13.15f, 3);
+        a.v2 = new Vector2f(12, 13f);
+        a.v3 = new Vector4f(12, 12.2f, 3f, 15.5f);
+        a.v11 = new org.joml.Vector3f(11.5f, 13.15f, 3);
+        a.v22 = new org.joml.Vector2f(12, 13f);
+        a.v33 = new org.joml.Vector4f(12, 12.2f, 3f, 15.5f);
+
+        byte[] data = protobufSerializer.toBytes(a, new TypeInfo<TestObject>() {
+        });
+
+        TestObject1 o = protobufSerializer.fromBytes(data, new TypeInfo<TestObject1>() {
+        });
+
+        TeraAssert.assertEquals(o.v1, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        TeraAssert.assertEquals(o.v2, new org.joml.Vector2f(12f, 13f), .00001f);
+        TeraAssert.assertEquals(o.v3, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+
+    }
+
+    @Test
+    public void testJsonSerialize() throws IOException {
+        TestObject a = new TestObject();
+        a.v1 = new Vector3f(11.5f, 13.15f, 3);
+        a.v2 = new Vector2f(12, 13f);
+        a.v3 = new Vector4f(12, 12.2f, 3f, 15.5f);
+        a.v11 = new org.joml.Vector3f(11.5f, 13.15f, 3);
+        a.v22 = new org.joml.Vector2f(12, 13f);
+        a.v33 = new org.joml.Vector4f(12, 12.2f, 3f, 15.5f);
+
+        String data = gsonSerializer.toJson(a, new TypeInfo<TestObject>() {
+        });
+
+        TestObject o = gsonSerializer.fromJson(data, new TypeInfo<TestObject>() {
+        });
+
+        TeraAssert.assertEquals(o.v1, new Vector3f(11.5f, 13.15f, 3), .00001f);
+        TeraAssert.assertEquals(o.v2, new Vector2f(12f, 13f), .00001f);
+        TeraAssert.assertEquals(o.v3, new Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+
+        TeraAssert.assertEquals(o.v11, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        TeraAssert.assertEquals(o.v22, new org.joml.Vector2f(12f, 13f), .00001f);
+        TeraAssert.assertEquals(o.v33, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+    }
+
+    @Test
+    public void testProtobufSerialize() throws IOException {
+        TestObject a = new TestObject();
+        a.v1 = new Vector3f(11.5f, 13.15f, 3);
+        a.v2 = new Vector2f(12, 13f);
+        a.v3 = new Vector4f(12, 12.2f, 3f, 15.5f);
+        a.v11 = new org.joml.Vector3f(11.5f, 13.15f, 3);
+        a.v22 = new org.joml.Vector2f(12, 13f);
+        a.v33 = new org.joml.Vector4f(12, 12.2f, 3f, 15.5f);
+
+        byte[] bytes = protobufSerializer.toBytes(a, new TypeInfo<TestObject>() {
+        });
+
+        TestObject o = protobufSerializer.fromBytes(bytes, new TypeInfo<TestObject>() {
+        });
+
+        TeraAssert.assertEquals(o.v1, new Vector3f(11.5f, 13.15f, 3), .00001f);
+        TeraAssert.assertEquals(o.v2, new Vector2f(12f, 13f), .00001f);
+        TeraAssert.assertEquals(o.v3, new Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+
+        TeraAssert.assertEquals(o.v11, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        TeraAssert.assertEquals(o.v22, new org.joml.Vector2f(12f, 13f), .00001f);
+        TeraAssert.assertEquals(o.v33, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
@@ -18,6 +18,7 @@ package org.terasology.persistence.typeHandling;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.joml.Quaternionf;
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,12 +55,18 @@ import org.terasology.persistence.typeHandling.extensionTypes.TextureRegionTypeH
 import org.terasology.persistence.typeHandling.extensionTypes.factories.AssetTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.extensionTypes.factories.TextureRegionAssetTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.mathTypes.IntegerRangeHandler;
-import org.terasology.persistence.typeHandling.mathTypes.Quat4fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.QuaternionfTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector2fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector2iTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector3fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector3iTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector4fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyQuat4fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector2fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector2iTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector3fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector3iTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector4fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.factories.Rect2fTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.mathTypes.factories.Rect2iTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.reflection.ModuleEnvironmentSandbox;
@@ -181,7 +188,8 @@ public class TypeHandlerLibrary {
 
     private static void populateWithDefaultHandlers(TypeHandlerLibrary serializationLibrary) {
         serializationLibrary.addTypeHandler(Color.class, new ColorTypeHandler());
-        serializationLibrary.addTypeHandler(Quat4f.class, new Quat4fTypeHandler());
+        serializationLibrary.addTypeHandler(Quat4f.class, new LegacyQuat4fTypeHandler());
+        serializationLibrary.addTypeHandler(Quaternionf.class, new QuaternionfTypeHandler());
 
         serializationLibrary.addTypeHandlerFactory(new AssetTypeHandlerFactory());
 
@@ -190,11 +198,19 @@ public class TypeHandlerLibrary {
 
         serializationLibrary.addTypeHandlerFactory(new TextureRegionAssetTypeHandlerFactory());
 
-        serializationLibrary.addTypeHandler(Vector4f.class, new Vector4fTypeHandler());
-        serializationLibrary.addTypeHandler(Vector3f.class, new Vector3fTypeHandler());
-        serializationLibrary.addTypeHandler(Vector2f.class, new Vector2fTypeHandler());
-        serializationLibrary.addTypeHandler(Vector3i.class, new Vector3iTypeHandler());
-        serializationLibrary.addTypeHandler(Vector2i.class, new Vector2iTypeHandler());
+        serializationLibrary.addTypeHandler(Vector4f.class, new LegacyVector4fTypeHandler());
+        serializationLibrary.addTypeHandler(Vector3f.class, new LegacyVector3fTypeHandler());
+        serializationLibrary.addTypeHandler(Vector2f.class, new LegacyVector2fTypeHandler());
+        serializationLibrary.addTypeHandler(Vector3i.class, new LegacyVector3iTypeHandler());
+        serializationLibrary.addTypeHandler(Vector2i.class, new LegacyVector2iTypeHandler());
+
+        serializationLibrary.addTypeHandler(org.joml.Vector4f.class, new Vector4fTypeHandler());
+        serializationLibrary.addTypeHandler(org.joml.Vector3f.class, new Vector3fTypeHandler());
+        serializationLibrary.addTypeHandler(org.joml.Vector2f.class, new Vector2fTypeHandler());
+        serializationLibrary.addTypeHandler(org.joml.Vector3i.class, new Vector3iTypeHandler());
+        serializationLibrary.addTypeHandler(org.joml.Vector2i.class, new Vector2iTypeHandler());
+
+
         serializationLibrary.addTypeHandlerFactory(new Rect2iTypeHandlerFactory());
         serializationLibrary.addTypeHandlerFactory(new Rect2fTypeHandlerFactory());
         serializationLibrary.addTypeHandler(Prefab.class, new PrefabTypeHandler());

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/QuaternionfTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/QuaternionfTypeHandler.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.persistence.typeHandling.mathTypes;
 
-import gnu.trove.list.TIntList;
-import org.joml.Vector3i;
+import gnu.trove.list.TFloatList;
+import org.joml.Quaternionf;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 /**
  */
-public class Vector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
+public class QuaternionfTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Quaternionf> {
 
     @Override
-    public PersistedData serializeNonNull(Vector3i value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.x, value.y, value.z);
+    public PersistedData serializeNonNull(Quaternionf value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.x, value.y, value.z, value.w);
     }
 
     @Override
-    public Optional<Vector3i> deserialize(PersistedData data) {
+    public Optional<Quaternionf> deserialize(PersistedData data) {
         if (data.isArray()) {
             PersistedDataArray dataArray = data.getAsArray();
-            if (dataArray.isNumberArray() && dataArray.size() > 2) {
-                TIntList ints = dataArray.getAsIntegerArray();
-                return Optional.of(new Vector3i(ints.get(0), ints.get(1), ints.get(2)));
+            if (dataArray.isNumberArray() && dataArray.size() > 3) {
+                TFloatList floats = dataArray.getAsFloatArray();
+                return Optional.of(new Quaternionf(floats.get(0), floats.get(1), floats.get(2), floats.get(3)));
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2fTypeHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,7 @@ package org.terasology.persistence.typeHandling.mathTypes;
 
 
 import gnu.trove.list.TFloatList;
-import org.terasology.math.geom.Vector2f;
+import org.joml.Vector2f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector2iTypeHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
 package org.terasology.persistence.typeHandling.mathTypes;
 
 import gnu.trove.list.TIntList;
-import org.terasology.math.geom.Vector2i;
+import org.joml.Vector2i;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector3fTypeHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
 package org.terasology.persistence.typeHandling.mathTypes;
 
 import gnu.trove.list.TFloatList;
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector4fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/Vector4fTypeHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,7 @@ package org.terasology.persistence.typeHandling.mathTypes;
 
 
 import gnu.trove.list.TFloatList;
-import org.terasology.math.geom.Vector4f;
+import org.joml.Vector4f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyQuat4fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyQuat4fTypeHandler.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.persistence.typeHandling.mathTypes;
+package org.terasology.persistence.typeHandling.mathTypes.legacy;
 
-import gnu.trove.list.TIntList;
-import org.joml.Vector3i;
+import gnu.trove.list.TFloatList;
+import org.terasology.math.geom.Quat4f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 /**
  */
-public class Vector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
+public class LegacyQuat4fTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Quat4f> {
 
     @Override
-    public PersistedData serializeNonNull(Vector3i value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.x, value.y, value.z);
+    public PersistedData serializeNonNull(Quat4f value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.x, value.y, value.z, value.w);
     }
 
     @Override
-    public Optional<Vector3i> deserialize(PersistedData data) {
+    public Optional<Quat4f> deserialize(PersistedData data) {
         if (data.isArray()) {
             PersistedDataArray dataArray = data.getAsArray();
-            if (dataArray.isNumberArray() && dataArray.size() > 2) {
-                TIntList ints = dataArray.getAsIntegerArray();
-                return Optional.of(new Vector3i(ints.get(0), ints.get(1), ints.get(2)));
+            if (dataArray.isNumberArray() && dataArray.size() > 3) {
+                TFloatList floats = dataArray.getAsFloatArray();
+                return Optional.of(new Quat4f(floats.get(0), floats.get(1), floats.get(2), floats.get(3)));
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector2fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector2fTypeHandler.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.persistence.typeHandling.mathTypes;
+package org.terasology.persistence.typeHandling.mathTypes.legacy;
 
-import gnu.trove.list.TIntList;
-import org.joml.Vector3i;
+
+import gnu.trove.list.TFloatList;
+import org.terasology.math.geom.Vector2f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,20 +26,20 @@ import java.util.Optional;
 
 /**
  */
-public class Vector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
+public class LegacyVector2fTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector2f> {
 
     @Override
-    public PersistedData serializeNonNull(Vector3i value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.x, value.y, value.z);
+    public PersistedData serializeNonNull(Vector2f value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.x, value.y);
     }
 
     @Override
-    public Optional<Vector3i> deserialize(PersistedData data) {
+    public Optional<Vector2f> deserialize(PersistedData data) {
         if (data.isArray()) {
             PersistedDataArray dataArray = data.getAsArray();
-            if (dataArray.isNumberArray() && dataArray.size() > 2) {
-                TIntList ints = dataArray.getAsIntegerArray();
-                return Optional.of(new Vector3i(ints.get(0), ints.get(1), ints.get(2)));
+            if (dataArray.isNumberArray() && dataArray.size() > 1) {
+                TFloatList floats = dataArray.getAsFloatArray();
+                return Optional.of(new Vector2f(floats.get(0), floats.get(1)));
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector2iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector2iTypeHandler.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.persistence.typeHandling.mathTypes;
+package org.terasology.persistence.typeHandling.mathTypes.legacy;
 
 import gnu.trove.list.TIntList;
-import org.joml.Vector3i;
+import org.terasology.math.geom.Vector2i;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 /**
  */
-public class Vector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
+public class LegacyVector2iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector2i> {
 
     @Override
-    public PersistedData serializeNonNull(Vector3i value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.x, value.y, value.z);
+    public PersistedData serializeNonNull(Vector2i value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.x, value.y);
     }
 
     @Override
-    public Optional<Vector3i> deserialize(PersistedData data) {
+    public Optional<Vector2i> deserialize(PersistedData data) {
         if (data.isArray()) {
             PersistedDataArray dataArray = data.getAsArray();
-            if (dataArray.isNumberArray() && dataArray.size() > 2) {
+            if (dataArray.isNumberArray() && dataArray.size() > 1) {
                 TIntList ints = dataArray.getAsIntegerArray();
-                return Optional.of(new Vector3i(ints.get(0), ints.get(1), ints.get(2)));
+                return Optional.of(new Vector2i(ints.get(0), ints.get(1)));
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector3fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector3fTypeHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.persistence.typeHandling.mathTypes;
+package org.terasology.persistence.typeHandling.mathTypes.legacy;
 
 import gnu.trove.list.TFloatList;
-import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,20 +25,20 @@ import java.util.Optional;
 
 /**
  */
-public class Quat4fTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Quat4f> {
+public class LegacyVector3fTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3f> {
 
     @Override
-    public PersistedData serializeNonNull(Quat4f value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.x, value.y, value.z, value.w);
+    public PersistedData serializeNonNull(Vector3f value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.x, value.y, value.z);
     }
 
     @Override
-    public Optional<Quat4f> deserialize(PersistedData data) {
+    public Optional<Vector3f> deserialize(PersistedData data) {
         if (data.isArray()) {
             PersistedDataArray dataArray = data.getAsArray();
-            if (dataArray.isNumberArray() && dataArray.size() > 3) {
+            if (dataArray.isNumberArray() && dataArray.size() > 2) {
                 TFloatList floats = dataArray.getAsFloatArray();
-                return Optional.of(new Quat4f(floats.get(0), floats.get(1), floats.get(2), floats.get(3)));
+                return Optional.of(new Vector3f(floats.get(0), floats.get(1), floats.get(2)));
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector3iTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector3iTypeHandler.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.persistence.typeHandling.mathTypes;
+package org.terasology.persistence.typeHandling.mathTypes.legacy;
 
 import gnu.trove.list.TIntList;
-import org.joml.Vector3i;
+import org.terasology.math.geom.Vector3i;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 /**
  */
-public class Vector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
+public class LegacyVector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
 
     @Override
     public PersistedData serializeNonNull(Vector3i value, PersistedDataSerializer serializer) {

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector4fTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/legacy/LegacyVector4fTypeHandler.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.persistence.typeHandling.mathTypes;
+package org.terasology.persistence.typeHandling.mathTypes.legacy;
 
-import gnu.trove.list.TIntList;
-import org.joml.Vector3i;
+
+import gnu.trove.list.TFloatList;
+import org.terasology.math.geom.Vector4f;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataArray;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -25,20 +26,20 @@ import java.util.Optional;
 
 /**
  */
-public class Vector3iTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector3i> {
+public class LegacyVector4fTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<Vector4f> {
 
     @Override
-    public PersistedData serializeNonNull(Vector3i value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.x, value.y, value.z);
+    public PersistedData serializeNonNull(Vector4f value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.x, value.y, value.z, value.w);
     }
 
     @Override
-    public Optional<Vector3i> deserialize(PersistedData data) {
+    public Optional<Vector4f> deserialize(PersistedData data) {
         if (data.isArray()) {
             PersistedDataArray dataArray = data.getAsArray();
-            if (dataArray.isNumberArray() && dataArray.size() > 2) {
-                TIntList ints = dataArray.getAsIntegerArray();
-                return Optional.of(new Vector3i(ints.get(0), ints.get(1), ints.get(2)));
+            if (dataArray.isNumberArray() && dataArray.size() > 3) {
+                TFloatList floats = dataArray.getAsFloatArray();
+                return Optional.of(new Vector4f(floats.get(0), floats.get(1), floats.get(2), floats.get(3)));
             }
         }
         return Optional.empty();

--- a/engine/src/main/java/org/terasology/rendering/assets/atlas/AtlasFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/atlas/AtlasFormat.java
@@ -33,7 +33,7 @@ import org.terasology.math.geom.Vector2i;
 import org.terasology.naming.Name;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.subtexture.SubtextureData;
-import org.terasology.utilities.gson.Vector2iTypeAdapter;
+import org.terasology.utilities.gson.legacy.LegacyVector2iTypeAdapter;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -55,7 +55,7 @@ public class AtlasFormat extends AbstractAssetFileFormat<AtlasData> {
     public AtlasFormat(AssetManager assetManager) {
         super("atlas");
         this.assetManager = assetManager;
-        gson = new GsonBuilder().registerTypeAdapter(Vector2i.class, new Vector2iTypeAdapter()).create();
+        gson = new GsonBuilder().registerTypeAdapter(Vector2i.class, new LegacyVector2iTypeAdapter()).create();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/utilities/gson/QuaternionfTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/QuaternionfTypeAdapter.java
@@ -21,16 +21,22 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import org.joml.Vector2f;
+import org.joml.Quaternionf;
 
 import java.lang.reflect.Type;
 
 /**
  */
-public class Vector2fTypeAdapter implements JsonDeserializer<Vector2f> {
+public class QuaternionfTypeAdapter implements JsonDeserializer<Quaternionf> {
+
     @Override
-    public Vector2f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        JsonArray jsonArray = json.getAsJsonArray();
-        return new Vector2f(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat());
+    public Quaternionf deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (json.isJsonArray()) {
+            JsonArray array = json.getAsJsonArray();
+            if (array.size() == 4) {
+                return new Quaternionf(array.get(0).getAsFloat(), array.get(1).getAsFloat(), array.get(2).getAsFloat(), array.get(3).getAsFloat());
+            }
+        }
+        return null;
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/gson/Vector2iTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/Vector2iTypeAdapter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-
-import org.terasology.math.geom.Vector2i;
+import org.joml.Vector2i;
 
 import java.lang.reflect.Type;
 

--- a/engine/src/main/java/org/terasology/utilities/gson/Vector3fTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/Vector3fTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 
 import java.lang.reflect.Type;
 

--- a/engine/src/main/java/org/terasology/utilities/gson/Vector4fTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/Vector4fTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-
-import org.terasology.math.geom.Vector4f;
+import org.joml.Vector4f;
 
 import java.lang.reflect.Type;
 

--- a/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyQuat4fTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyQuat4fTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.terasology.utilities.gson;
+package org.terasology.utilities.gson.legacy;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
@@ -28,7 +28,7 @@ import java.lang.reflect.Type;
 
 /**
  */
-public class Quat4fTypeAdapter implements JsonDeserializer<Quat4f> {
+public class LegacyQuat4fTypeAdapter implements JsonDeserializer<Quat4f> {
 
     @Override
     public Quat4f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {

--- a/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector2fTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector2fTypeAdapter.java
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package org.terasology.utilities.gson;
+package org.terasology.utilities.gson.legacy;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import org.joml.Vector2f;
+
+import org.terasology.math.geom.Vector2f;
 
 import java.lang.reflect.Type;
 
 /**
  */
-public class Vector2fTypeAdapter implements JsonDeserializer<Vector2f> {
+public class LegacyVector2fTypeAdapter implements JsonDeserializer<Vector2f> {
     @Override
     public Vector2f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonArray jsonArray = json.getAsJsonArray();

--- a/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector2iTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector2iTypeAdapter.java
@@ -14,23 +14,24 @@
  * limitations under the License.
  */
 
-package org.terasology.utilities.gson;
+package org.terasology.utilities.gson.legacy;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import org.joml.Vector2f;
+
+import org.terasology.math.geom.Vector2i;
 
 import java.lang.reflect.Type;
 
 /**
  */
-public class Vector2fTypeAdapter implements JsonDeserializer<Vector2f> {
+public class LegacyVector2iTypeAdapter implements JsonDeserializer<Vector2i> {
     @Override
-    public Vector2f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    public Vector2i deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonArray jsonArray = json.getAsJsonArray();
-        return new Vector2f(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat());
+        return new Vector2i(jsonArray.get(0).getAsInt(), jsonArray.get(1).getAsInt());
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector3fTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector3fTypeAdapter.java
@@ -14,23 +14,24 @@
  * limitations under the License.
  */
 
-package org.terasology.utilities.gson;
+package org.terasology.utilities.gson.legacy;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import org.joml.Vector2f;
+
+import org.terasology.math.geom.Vector3f;
 
 import java.lang.reflect.Type;
 
 /**
  */
-public class Vector2fTypeAdapter implements JsonDeserializer<Vector2f> {
+public class LegacyVector3fTypeAdapter implements JsonDeserializer<Vector3f> {
     @Override
-    public Vector2f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    public Vector3f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonArray jsonArray = json.getAsJsonArray();
-        return new Vector2f(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat());
+        return new Vector3f(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat(), jsonArray.get(2).getAsFloat());
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector4fTypeAdapter.java
+++ b/engine/src/main/java/org/terasology/utilities/gson/legacy/LegacyVector4fTypeAdapter.java
@@ -14,23 +14,32 @@
  * limitations under the License.
  */
 
-package org.terasology.utilities.gson;
+package org.terasology.utilities.gson.legacy;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import org.joml.Vector2f;
+
+import org.terasology.math.geom.Vector4f;
 
 import java.lang.reflect.Type;
 
 /**
  */
-public class Vector2fTypeAdapter implements JsonDeserializer<Vector2f> {
+public class LegacyVector4fTypeAdapter implements JsonDeserializer<Vector4f> {
+
     @Override
-    public Vector2f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        JsonArray jsonArray = json.getAsJsonArray();
-        return new Vector2f(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat());
+    public Vector4f deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (json.isJsonArray()) {
+            JsonArray array = json.getAsJsonArray();
+            if (array.size() == 4) {
+                return new Vector4f(array.get(0).getAsFloat(), array.get(1).getAsFloat(), array.get(2).getAsFloat(), array.get(3).getAsFloat());
+            } else if (array.size() == 3) {
+                return new Vector4f(array.get(0).getAsFloat(), array.get(1).getAsFloat(), array.get(2).getAsFloat(), 1);
+            }
+        }
+        return null;
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
@@ -40,8 +40,9 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.gson.CaseInsensitiveEnumTypeAdapterFactory;
+import org.terasology.utilities.gson.legacy.LegacyVector3fTypeAdapter;
 import org.terasology.utilities.gson.Vector3fTypeAdapter;
-import org.terasology.utilities.gson.Vector4fTypeAdapter;
+import org.terasology.utilities.gson.legacy.LegacyVector4fTypeAdapter;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.family.BlockFamilyLibrary;
@@ -81,8 +82,8 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
                 .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
                 .registerTypeAdapterFactory(new AssetTypeAdapterFactory(assetManager))
                 .registerTypeAdapter(BlockFamilyDefinitionData.class, new BlockFamilyDefinitionDataHandler())
-                .registerTypeAdapter(Vector3f.class, new Vector3fTypeAdapter())
-                .registerTypeAdapter(Vector4f.class, new Vector4fTypeAdapter())
+                .registerTypeAdapter(Vector3f.class, new LegacyVector3fTypeAdapter())
+                .registerTypeAdapter(Vector4f.class, new LegacyVector4fTypeAdapter())
                 .registerTypeAdapter(Class.class, new BlockFamilyHandler())
                 .create();
     }

--- a/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
@@ -39,8 +39,8 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.physics.shapes.CompoundShape;
 import org.terasology.physics.shapes.ConvexHullShape;
-import org.terasology.utilities.gson.Vector2fTypeAdapter;
-import org.terasology.utilities.gson.Vector3fTypeAdapter;
+import org.terasology.utilities.gson.legacy.LegacyVector2fTypeAdapter;
+import org.terasology.utilities.gson.legacy.LegacyVector3fTypeAdapter;
 import org.terasology.world.block.BlockPart;
 
 import java.io.IOException;
@@ -64,8 +64,8 @@ public class JsonBlockShapeLoader extends AbstractAssetFileFormat<BlockShapeData
                 .setPrettyPrinting()
                 .registerTypeAdapter(BlockShapeData.class, new BlockShapeHandler())
                 .registerTypeAdapter(BlockMeshPart.class, new BlockMeshPartHandler())
-                .registerTypeAdapter(Vector3f.class, new Vector3fTypeAdapter())
-                .registerTypeAdapter(Vector2f.class, new Vector2fTypeAdapter())
+                .registerTypeAdapter(Vector3f.class, new LegacyVector3fTypeAdapter())
+                .registerTypeAdapter(Vector2f.class, new LegacyVector2fTypeAdapter())
                 .create();
     }
 


### PR DESCRIPTION
I added joml and moved termath to a legacy namespace along with a basic test to show that joml and termath vectors will serialize both for a given component. There are also some stub object I setup for gson that will start to play a role when I start porting in stuff like blocks and block families. I think it would be wise to introduce some more TypeSerializerTest to show that object will serialize back and forth correctly. At some point I think will remove the legacy termath stuff from TypeSerializer. 