### PR TITLE
More Gradle: now with makeshift release management! Ready for v3.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node ("default-java") {
         }
     }
     stage('Analytics') {
-        sh "./gradlew --console=plain check"
+        sh "./gradlew --console=plain check javadoc"
     }
     stage('Record') {
         junit testResults: '**/build/test-results/test/*.xml',  allowEmptyResults: true

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ import java.nio.file.StandardCopyOption
 // Test for right version of Java in use for running this script
 assert org.gradle.api.JavaVersion.current().isJava8Compatible()
 
-import org.gradle.internal.logging.text.StyledTextOutput 
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 

--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -17,15 +17,29 @@ publishing {
                 maven {
                     name = 'TerasologyOrg'
 
-                    def repoViaEnv = System.getenv()["PUBLISH_REPO"]
+                    String repoViaEnv = System.getenv()["PUBLISH_REPO"]
+                    String gitBranch = System.getenv()["BRANCH_NAME"]
                     if (rootProject.hasProperty("publishRepo")) {
+                        // This first option is good for local testing, you can set an explicit target repo in gradle.properties
                         url = "http://artifactory.terasology.org/artifactory/$publishRepo"
                         println "Changing PUBLISH repoKey set via property to $publishRepo"
                     } else if (repoViaEnv != null && repoViaEnv != "") {
+                        // Support varying publish target based on branch name
+                        if (gitBranch != null && gitBranch != "" && gitBranch.equals("master")) {
+                            println "We're working on a 'master' branch so replacing 'snapshot' with 'release' in the Artifactory repo"
+                            repoViaEnv = repoViaEnv.replace("snapshot", "release")
+                        }
+                        // Second one is aimed at Jenkins, where env vars can be set based on jobs/folders.
                         url = "http://artifactory.terasology.org/artifactory/$repoViaEnv"
                         println "Changing PUBLISH repoKey set via env var to $repoViaEnv"
                     } else {
-                        url = 'http://artifactory.terasology.org/artifactory/terasology-snapshot-local'
+                        // Finally this handles defaults while still supporting varying the publish target based on branch name
+                        if (gitBranch != null && gitBranch != "" && gitBranch.equals("master")) {
+                            println "We're working on a 'master' branch so using'release' in the Artifactory repo"
+                            url = 'http://artifactory.terasology.org/artifactory/terasology-release-local'
+                        } else {
+                            url = 'http://artifactory.terasology.org/artifactory/terasology-snapshot-local'
+                        }
                         println "PUBLISH repoKey is terasology-snapshot-local (default value)"
                     }
 

--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -17,30 +17,45 @@ publishing {
                 maven {
                     name = 'TerasologyOrg'
 
-                    String repoViaEnv = System.getenv()["PUBLISH_REPO"]
-                    String gitBranch = System.getenv()["BRANCH_NAME"]
                     if (rootProject.hasProperty("publishRepo")) {
-                        // This first option is good for local testing, you can set an explicit target repo in gradle.properties
+                        // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
                         url = "http://artifactory.terasology.org/artifactory/$publishRepo"
-                        println "Changing PUBLISH repoKey set via property to $publishRepo"
-                    } else if (repoViaEnv != null && repoViaEnv != "") {
-                        // Support varying publish target based on branch name
-                        if (gitBranch != null && gitBranch != "" && gitBranch.equals("master")) {
-                            println "We're working on a 'master' branch so replacing 'snapshot' with 'release' in the Artifactory repo"
-                            repoViaEnv = repoViaEnv.replace("snapshot", "release")
-                        }
-                        // Second one is aimed at Jenkins, where env vars can be set based on jobs/folders.
-                        url = "http://artifactory.terasology.org/artifactory/$repoViaEnv"
-                        println "Changing PUBLISH repoKey set via env var to $repoViaEnv"
+                        println "Changing PUBLISH repoKey set via Gradle property to $publishRepo"
                     } else {
-                        // Finally this handles defaults while still supporting varying the publish target based on branch name
-                        if (gitBranch != null && gitBranch != "" && gitBranch.equals("master")) {
-                            println "We're working on a 'master' branch so using'release' in the Artifactory repo"
-                            url = 'http://artifactory.terasology.org/artifactory/terasology-release-local'
-                        } else {
-                            url = 'http://artifactory.terasology.org/artifactory/terasology-snapshot-local'
+                        // In this case we are going to fletch the publish repo together from a few things
+                        // First if we have an override from the environment to use a different target publish org
+                        String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
+                        if (deducedPublishRepo == null || deducedPublishRepo == "") {
+                            // If not then default
+                            deducedPublishRepo = "terasology"
                         }
-                        println "PUBLISH repoKey is terasology-snapshot-local (default value)"
+                        String releaseRepoFragment = "-release-local"
+                        String snapshotRepoFragment = "-snapshot-local"
+
+                        // Secondly we're going to find out if we're doing a release or a snapshot - this gets a little more complicated
+                        String gitBranch = System.getenv()["BRANCH_NAME"]
+                        if (gitBranch != null && gitBranch != "" && gitBranch.equals("master")) {
+                            // Okay we're in an environment where a branch name is set to 'master' so we might be doing a release
+                            // This is the funny part. Modules aren't ready globally to accept master branch == release, so check a prop that defaults to bypass
+                            if (project.hasProperty("bypassModuleReleaseManagement")) {
+                                if (bypassModuleReleaseManagement == "true") {
+                                    println "Release management not enabled for " + project.name + ", using snapshot repo despite building 'master' branch"
+                                    deducedPublishRepo += snapshotRepoFragment
+                                } else {
+                                    println "Release management *is* enabled for " + project.name + ", using release repo since building 'master' branch"
+                                    deducedPublishRepo += releaseRepoFragment
+                                }
+                            } else {
+                                println "We're working on a 'master' branch with defaults so using the release publish repo"
+                                deducedPublishRepo += releaseRepoFragment
+                            }
+                        } else {
+                            // No master branch so we for sure are just doing snapshots
+                            println "We're not working with a branch name set that's 'master' so assuming we're publishing snapshots"
+                            deducedPublishRepo += "-snapshot-local"
+                        }
+                        println "The final deduced publish repo is $deducedPublishRepo"
+                        url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
                     }
 
                     if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {

--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -22,38 +22,21 @@ publishing {
                         url = "http://artifactory.terasology.org/artifactory/$publishRepo"
                         println "Changing PUBLISH repoKey set via Gradle property to $publishRepo"
                     } else {
-                        // In this case we are going to fletch the publish repo together from a few things
-                        // First if we have an override from the environment to use a different target publish org
+                        // Support override from the environment to use a different target publish org
                         String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
                         if (deducedPublishRepo == null || deducedPublishRepo == "") {
                             // If not then default
                             deducedPublishRepo = "terasology"
                         }
-                        String releaseRepoFragment = "-release-local"
-                        String snapshotRepoFragment = "-snapshot-local"
 
-                        // Secondly we're going to find out if we're doing a release or a snapshot - this gets a little more complicated
+                        // Check the active Git branch and some module logic to see whether we're doing a release or snapshot
                         String gitBranch = System.getenv()["BRANCH_NAME"]
-                        if (gitBranch != null && gitBranch != "" && gitBranch.equals("master")) {
-                            // Okay we're in an environment where a branch name is set to 'master' so we might be doing a release
-                            // This is the funny part. Modules aren't ready globally to accept master branch == release, so check a prop that defaults to bypass
-                            if (project.hasProperty("bypassModuleReleaseManagement")) {
-                                if (bypassModuleReleaseManagement == "true") {
-                                    println "Release management not enabled for " + project.name + ", using snapshot repo despite building 'master' branch"
-                                    deducedPublishRepo += snapshotRepoFragment
-                                } else {
-                                    println "Release management *is* enabled for " + project.name + ", using release repo since building 'master' branch"
-                                    deducedPublishRepo += releaseRepoFragment
-                                }
-                            } else {
-                                println "We're working on a 'master' branch with defaults so using the release publish repo"
-                                deducedPublishRepo += releaseRepoFragment
-                            }
+                        if (isMaster(gitBranch) && !shouldBypassModuleRelease()) {
+                            deducedPublishRepo += "-release-local"
                         } else {
-                            // No master branch so we for sure are just doing snapshots
-                            println "We're not working with a branch name set that's 'master' so assuming we're publishing snapshots"
                             deducedPublishRepo += "-snapshot-local"
                         }
+
                         println "The final deduced publish repo is $deducedPublishRepo"
                         url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
                     }
@@ -73,3 +56,11 @@ publishing {
     }
 }
 
+def isMaster(gitBranch) {
+    return gitBranch != null && gitBranch != "" && gitBranch.equals("master");
+}
+
+// Mildly awkward: Modules aren't ready globally to accept master branch == release, so make it opt-in by checking a prop that defaults to bypass
+def shouldBypassModuleRelease() {
+    return project.hasProperty("bypassModuleReleaseManagement") && bypassModuleReleaseManagement == "true";
+}

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -5,6 +5,11 @@ apply from: "$rootDir/config/gradle/publish.gradle"
 
 import groovy.json.JsonSlurper
 
+ext {
+    // Read environment variables, including variables passed by jenkins continuous integration server
+    env = System.getenv()
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Java Section                                                                                                      //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -23,6 +28,11 @@ def moduleConfig = slurper.parseText(moduleFile.text)
 
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set differently)
 version = moduleConfig.version
+
+// The only case in which we make non-snapshots is when BRANCH_NAME exists and contains "master" - otherwise snapshots
+if (env.BRANCH_NAME == null || !env.BRANCH_NAME.equals("master")) {
+    version += "-SNAPSHOT"
+}
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.engine'

--- a/engine-tests/src/main/resources/module.txt
+++ b/engine-tests/src/main/resources/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "unittest",
-    "version" : "3.0.0-SNAPSHOT",
+    "version" : "3.0.0",
     "displayName" : "Terasology Engine Test",
     "description" : "Engine unit test content"
 }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -235,6 +235,11 @@ def moduleConfig = slurper.parseText(moduleFile.text)
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set differently)
 version = moduleConfig.version
 
+// The only case in which we make non-snapshots is when BRANCH_NAME exists and contains "master" - otherwise snapshots
+if (env.BRANCH_NAME == null || !env.BRANCH_NAME.equals("master")) {
+    version += "-SNAPSHOT"
+}
+
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.engine'
 

--- a/engine/src/main/resources/engine-module.txt
+++ b/engine/src/main/resources/engine-module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "engine",
-    "version" : "3.0.0-SNAPSHOT",
+    "version" : "3.0.0",
     "displayName" : "Terasology Engine",
     "description" : "Core engine content"
 }

--- a/facades/subprojects.gradle
+++ b/facades/subprojects.gradle
@@ -1,9 +1,13 @@
 // This magically allows subdirs in this subproject to themselves become sub-subprojects in a proper tree structure
 new File(rootDir, 'facades').eachDir { possibleSubprojectDir ->
-    def subprojectName = 'facades:' + possibleSubprojectDir.name
-    println "Processing facade $subprojectName, including it as a sub-project"
-    include subprojectName
-    def subprojectPath = ':' + subprojectName
-    def subproject = project(subprojectPath)
-    subproject.projectDir = possibleSubprojectDir
+    if (!possibleSubprojectDir.name.startsWith(".")) {
+        def subprojectName = 'facades:' + possibleSubprojectDir.name
+        println "Processing facade $subprojectName, including it as a sub-project"
+        include subprojectName
+        def subprojectPath = ':' + subprojectName
+        def subproject = project(subprojectPath)
+        subproject.projectDir = possibleSubprojectDir
+    } else {
+        println "Ignoring entry $possibleSubprojectDir as it starts with ."
+    }
 }

--- a/metas/subprojects.gradle
+++ b/metas/subprojects.gradle
@@ -1,9 +1,13 @@
 // This magically allows subdirs in this subproject to themselves become sub-subprojects in a proper tree structure
 new File(rootDir, 'metas').eachDir { possibleSubprojectDir ->
-    def subprojectName = 'metas:' + possibleSubprojectDir.name
-    println "Processing meta module $subprojectName, including it as a sub-project"
-    include subprojectName
-    def subprojectPath = ':' + subprojectName
-    def subproject = project(subprojectPath)
-    subproject.projectDir = possibleSubprojectDir
+    if (!possibleSubprojectDir.name.startsWith(".")) {
+        def subprojectName = 'metas:' + possibleSubprojectDir.name
+        println "Processing meta module $subprojectName, including it as a sub-project"
+        include subprojectName
+        def subprojectPath = ':' + subprojectName
+        def subproject = project(subprojectPath)
+        subproject.projectDir = possibleSubprojectDir
+    } else {
+        println "Ignoring entry $possibleSubprojectDir as it starts with ."
+    }
 }

--- a/modules/BiomesAPI/build.gradle
+++ b/modules/BiomesAPI/build.gradle
@@ -70,22 +70,23 @@ version = moduleConfig.version
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
+// Check for an outright -SNAPSHOT in the loaded version - for ease of use we want to get rid of that everywhere, so warn about it and remove for the variable
+def undesiredSnapshotTag = version.endsWith("-SNAPSHOT")
+println "BiomesAPI version before the snapshot check: " + version
+if (undesiredSnapshotTag) {
+    println "Taking off undesired -SNAPSHOT"
+    version -= "-SNAPSHOT"
+    def out = services.get(StyledTextOutputFactory).create("an-ouput")
+    out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+}
+
 // The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
 if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
     // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
     ext.bypassModuleReleaseManagement = false
-    if (version.contains("-SNAPSHOT")) {
-        version -= "-SNAPSHOT"
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
 } else {
-    if (!version.contains("-SNAPSHOT")) {
-        version += "-SNAPSHOT"
-    } else {
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
+    // In the case where we actually are building a snapshot we load -SNAPSHOT into the version variable, even if it wasn't there in module.txt
+    version += "-SNAPSHOT"
 }
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor

--- a/modules/BiomesAPI/build.gradle
+++ b/modules/BiomesAPI/build.gradle
@@ -1,15 +1,5 @@
 // Simple build file for modules - the one under the Core module is the template, will be copied as needed to modules
 
-// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
-apply from: "$rootDir/config/gradle/publish.gradle"
-
-import groovy.json.JsonSlurper
-import org.reflections.Reflections
-import org.reflections.util.FilterBuilder
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.util.ConfigurationBuilder
-
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
@@ -35,17 +25,25 @@ buildscript {
     }
 }
 
-// Handle some logic related to where what is
-sourceSets {
-    main.java.outputDir = new File("$buildDir/classes")
-    test.java.outputDir = new File("$buildDir/testClasses")
-}
-JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
-SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
+import groovy.json.JsonSlurper
+import org.reflections.Reflections
+import org.reflections.util.FilterBuilder
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.reflections.util.ConfigurationBuilder
 
 ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
     env = System.getenv()
+
+    // This is a fun one ... when versions switched to dynamic -SNAPSHOT or not based on branch existing modules using `master` would suddenly try publishing releases
+    // This won't work without additionally doing constant version bumps (perhaps via Git tags) - but too much work to switch around all modules at once
+    // Complicating things more the use of publish.gradle to centralize logic means modules and engine bits are treated the same, yet we need to vary modules
+    // Temporary workaround: default modules to bypass release management: master branch builds will still make snapshot builds for the snapshot repo
+    // If a module actually wants release management simply include `"isReleaseManaged" : true` in module.txt - this is needed for the engine repo embedded modules
+    // One option would be to slowly convert modulespace to default to a `develop` + `master` setup living in harmony with associated automation/github tweaks
+    // Alternatively one more round of refactoring could switch to Git tags, a single `master` branch, and possible other things to help match snaps/PR builds somehow?
+    bypassModuleReleaseManagement = "true"
 }
 
 def moduleDepends = [];
@@ -69,10 +67,43 @@ for (dependency in moduleConfig.dependencies) {
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set somewhere else I guess)
 version = moduleConfig.version
 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+// The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
+if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
+    // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
+    ext.bypassModuleReleaseManagement = false
+    if (version.contains("-SNAPSHOT")) {
+        version -= "-SNAPSHOT"
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+} else {
+    if (!version.contains("-SNAPSHOT")) {
+        version += "-SNAPSHOT"
+    } else {
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+}
+
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.modules'
 
 println "Version for $project.name loaded as $version for group $group"
+
+// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
+// Note that this statement is down a ways because it is affected by the stuff higher in this file like setting versioning
+apply from: "$rootDir/config/gradle/publish.gradle"
+
+// Handle some logic related to where what is
+sourceSets {
+    main.java.outputDir = new File("$buildDir/classes")
+    test.java.outputDir = new File("$buildDir/testClasses")
+}
+JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
+SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
 
 // TODO: Remove when we don't need to rely on snapshots. Needed here for solo builds in Jenkins
 configurations.all {

--- a/modules/BiomesAPI/module.txt
+++ b/modules/BiomesAPI/module.txt
@@ -6,5 +6,6 @@
     "description" : "Provides API for working with biomes - thematical sections of world. Previously part of engine.",
     "dependencies" : [],
     "serverSideOnly" : false,
-    "isLibrary": true
+    "isLibrary" : true,
+    "isReleaseManaged" : true
 }

--- a/modules/BiomesAPI/module.txt
+++ b/modules/BiomesAPI/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "BiomesAPI",
-    "version" : "3.0.0-SNAPSHOT",
+    "version" : "3.0.0",
     "author" : "",
     "displayName" : "BiomesAPI",
     "description" : "Provides API for working with biomes - thematical sections of world. Previously part of engine.",

--- a/modules/BuilderSampleGameplay/build.gradle
+++ b/modules/BuilderSampleGameplay/build.gradle
@@ -70,22 +70,23 @@ version = moduleConfig.version
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
+// Check for an outright -SNAPSHOT in the loaded version - for ease of use we want to get rid of that everywhere, so warn about it and remove for the variable
+def undesiredSnapshotTag = version.endsWith("-SNAPSHOT")
+println "BiomesAPI version before the snapshot check: " + version
+if (undesiredSnapshotTag) {
+    println "Taking off undesired -SNAPSHOT"
+    version -= "-SNAPSHOT"
+    def out = services.get(StyledTextOutputFactory).create("an-ouput")
+    out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+}
+
 // The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
 if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
     // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
     ext.bypassModuleReleaseManagement = false
-    if (version.contains("-SNAPSHOT")) {
-        version -= "-SNAPSHOT"
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
 } else {
-    if (!version.contains("-SNAPSHOT")) {
-        version += "-SNAPSHOT"
-    } else {
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
+    // In the case where we actually are building a snapshot we load -SNAPSHOT into the version variable, even if it wasn't there in module.txt
+    version += "-SNAPSHOT"
 }
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor

--- a/modules/BuilderSampleGameplay/build.gradle
+++ b/modules/BuilderSampleGameplay/build.gradle
@@ -1,15 +1,5 @@
 // Simple build file for modules - the one under the Core module is the template, will be copied as needed to modules
 
-// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
-apply from: "$rootDir/config/gradle/publish.gradle"
-
-import groovy.json.JsonSlurper
-import org.reflections.Reflections
-import org.reflections.util.FilterBuilder
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.util.ConfigurationBuilder
-
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
@@ -35,17 +25,25 @@ buildscript {
     }
 }
 
-// Handle some logic related to where what is
-sourceSets {
-    main.java.outputDir = new File("$buildDir/classes")
-    test.java.outputDir = new File("$buildDir/testClasses")
-}
-JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
-SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
+import groovy.json.JsonSlurper
+import org.reflections.Reflections
+import org.reflections.util.FilterBuilder
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.reflections.util.ConfigurationBuilder
 
 ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
     env = System.getenv()
+
+    // This is a fun one ... when versions switched to dynamic -SNAPSHOT or not based on branch existing modules using `master` would suddenly try publishing releases
+    // This won't work without additionally doing constant version bumps (perhaps via Git tags) - but too much work to switch around all modules at once
+    // Complicating things more the use of publish.gradle to centralize logic means modules and engine bits are treated the same, yet we need to vary modules
+    // Temporary workaround: default modules to bypass release management: master branch builds will still make snapshot builds for the snapshot repo
+    // If a module actually wants release management simply include `"isReleaseManaged" : true` in module.txt - this is needed for the engine repo embedded modules
+    // One option would be to slowly convert modulespace to default to a `develop` + `master` setup living in harmony with associated automation/github tweaks
+    // Alternatively one more round of refactoring could switch to Git tags, a single `master` branch, and possible other things to help match snaps/PR builds somehow?
+    bypassModuleReleaseManagement = "true"
 }
 
 def moduleDepends = [];
@@ -69,10 +67,43 @@ for (dependency in moduleConfig.dependencies) {
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set somewhere else I guess)
 version = moduleConfig.version
 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+// The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
+if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
+    // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
+    ext.bypassModuleReleaseManagement = false
+    if (version.contains("-SNAPSHOT")) {
+        version -= "-SNAPSHOT"
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+} else {
+    if (!version.contains("-SNAPSHOT")) {
+        version += "-SNAPSHOT"
+    } else {
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+}
+
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.modules'
 
 println "Version for $project.name loaded as $version for group $group"
+
+// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
+// Note that this statement is down a ways because it is affected by the stuff higher in this file like setting versioning
+apply from: "$rootDir/config/gradle/publish.gradle"
+
+// Handle some logic related to where what is
+sourceSets {
+    main.java.outputDir = new File("$buildDir/classes")
+    test.java.outputDir = new File("$buildDir/testClasses")
+}
+JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
+SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
 
 // TODO: Remove when we don't need to rely on snapshots. Needed here for solo builds in Jenkins
 configurations.all {

--- a/modules/BuilderSampleGameplay/module.txt
+++ b/modules/BuilderSampleGameplay/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "BuilderSampleGameplay",
-    "version" : "3.0.0-SNAPSHOT",
+    "version" : "3.0.0",
     "author" : "Community",
     "displayName" : "Builder Sample Gameplay",
     "description" : "The last block you pick up is what you place. Extreme minimalistic gameplay setting to showcase engine running nearly solo (no inventory, health, etc). More for testing than playing",

--- a/modules/BuilderSampleGameplay/module.txt
+++ b/modules/BuilderSampleGameplay/module.txt
@@ -7,5 +7,6 @@
     "dependencies" : [],
     "serverSideOnly" : false,
     "isGameplay" : "true",
-    "defaultWorldGenerator" : "BuilderSampleGameplay:BuilderSampleWorld"
+    "defaultWorldGenerator" : "BuilderSampleGameplay:BuilderSampleWorld",
+    "isReleaseManaged" : true
 }

--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -70,22 +70,23 @@ version = moduleConfig.version
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
+// Check for an outright -SNAPSHOT in the loaded version - for ease of use we want to get rid of that everywhere, so warn about it and remove for the variable
+def undesiredSnapshotTag = version.endsWith("-SNAPSHOT")
+println "BiomesAPI version before the snapshot check: " + version
+if (undesiredSnapshotTag) {
+    println "Taking off undesired -SNAPSHOT"
+    version -= "-SNAPSHOT"
+    def out = services.get(StyledTextOutputFactory).create("an-ouput")
+    out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+}
+
 // The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
 if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
     // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
     ext.bypassModuleReleaseManagement = false
-    if (version.contains("-SNAPSHOT")) {
-        version -= "-SNAPSHOT"
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
 } else {
-    if (!version.contains("-SNAPSHOT")) {
-        version += "-SNAPSHOT"
-    } else {
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
+    // In the case where we actually are building a snapshot we load -SNAPSHOT into the version variable, even if it wasn't there in module.txt
+    version += "-SNAPSHOT"
 }
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor

--- a/modules/Core/build.gradle
+++ b/modules/Core/build.gradle
@@ -1,15 +1,5 @@
 // Simple build file for modules - the one under the Core module is the template, will be copied as needed to modules
 
-// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
-apply from: "$rootDir/config/gradle/publish.gradle"
-
-import groovy.json.JsonSlurper
-import org.reflections.Reflections
-import org.reflections.util.FilterBuilder
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.util.ConfigurationBuilder
-
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
@@ -35,17 +25,25 @@ buildscript {
     }
 }
 
-// Handle some logic related to where what is
-sourceSets {
-    main.java.outputDir = new File("$buildDir/classes")
-    test.java.outputDir = new File("$buildDir/testClasses")
-}
-JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
-SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
+import groovy.json.JsonSlurper
+import org.reflections.Reflections
+import org.reflections.util.FilterBuilder
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.reflections.util.ConfigurationBuilder
 
 ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
     env = System.getenv()
+
+    // This is a fun one ... when versions switched to dynamic -SNAPSHOT or not based on branch existing modules using `master` would suddenly try publishing releases
+    // This won't work without additionally doing constant version bumps (perhaps via Git tags) - but too much work to switch around all modules at once
+    // Complicating things more the use of publish.gradle to centralize logic means modules and engine bits are treated the same, yet we need to vary modules
+    // Temporary workaround: default modules to bypass release management: master branch builds will still make snapshot builds for the snapshot repo
+    // If a module actually wants release management simply include `"isReleaseManaged" : true` in module.txt - this is needed for the engine repo embedded modules
+    // One option would be to slowly convert modulespace to default to a `develop` + `master` setup living in harmony with associated automation/github tweaks
+    // Alternatively one more round of refactoring could switch to Git tags, a single `master` branch, and possible other things to help match snaps/PR builds somehow?
+    bypassModuleReleaseManagement = "true"
 }
 
 def moduleDepends = [];
@@ -69,10 +67,43 @@ for (dependency in moduleConfig.dependencies) {
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set somewhere else I guess)
 version = moduleConfig.version
 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+// The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
+if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
+    // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
+    ext.bypassModuleReleaseManagement = false
+    if (version.contains("-SNAPSHOT")) {
+        version -= "-SNAPSHOT"
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+} else {
+    if (!version.contains("-SNAPSHOT")) {
+        version += "-SNAPSHOT"
+    } else {
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+}
+
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.modules'
 
 println "Version for $project.name loaded as $version for group $group"
+
+// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
+// Note that this statement is down a ways because it is affected by the stuff higher in this file like setting versioning
+apply from: "$rootDir/config/gradle/publish.gradle"
+
+// Handle some logic related to where what is
+sourceSets {
+    main.java.outputDir = new File("$buildDir/classes")
+    test.java.outputDir = new File("$buildDir/testClasses")
+}
+JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
+SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
 
 // TODO: Remove when we don't need to rely on snapshots. Needed here for solo builds in Jenkins
 configurations.all {

--- a/modules/Core/module.txt
+++ b/modules/Core/module.txt
@@ -24,5 +24,6 @@
         "id" : "CoreBlocks",
         "minVersion" : "1.0.0"
       }
-    ]
+    ],
+    "isReleaseManaged" : true
 }

--- a/modules/Core/module.txt
+++ b/modules/Core/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "Core",
-    "version" : "3.0.0-SNAPSHOT",
+    "version" : "3.0.0",
     "displayName" : "Core Content",
     "description" : "This module adds a set of base content for Terasology",
     "dependencies" : [

--- a/modules/CoreSampleGameplay/build.gradle
+++ b/modules/CoreSampleGameplay/build.gradle
@@ -70,22 +70,23 @@ version = moduleConfig.version
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
+// Check for an outright -SNAPSHOT in the loaded version - for ease of use we want to get rid of that everywhere, so warn about it and remove for the variable
+def undesiredSnapshotTag = version.endsWith("-SNAPSHOT")
+println "BiomesAPI version before the snapshot check: " + version
+if (undesiredSnapshotTag) {
+    println "Taking off undesired -SNAPSHOT"
+    version -= "-SNAPSHOT"
+    def out = services.get(StyledTextOutputFactory).create("an-ouput")
+    out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+}
+
 // The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
 if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
     // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
     ext.bypassModuleReleaseManagement = false
-    if (version.contains("-SNAPSHOT")) {
-        version -= "-SNAPSHOT"
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
 } else {
-    if (!version.contains("-SNAPSHOT")) {
-        version += "-SNAPSHOT"
-    } else {
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
+    // In the case where we actually are building a snapshot we load -SNAPSHOT into the version variable, even if it wasn't there in module.txt
+    version += "-SNAPSHOT"
 }
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor

--- a/modules/CoreSampleGameplay/build.gradle
+++ b/modules/CoreSampleGameplay/build.gradle
@@ -1,15 +1,5 @@
 // Simple build file for modules - the one under the Core module is the template, will be copied as needed to modules
 
-// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
-apply from: "$rootDir/config/gradle/publish.gradle"
-
-import groovy.json.JsonSlurper
-import org.reflections.Reflections
-import org.reflections.util.FilterBuilder
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.util.ConfigurationBuilder
-
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
@@ -35,17 +25,25 @@ buildscript {
     }
 }
 
-// Handle some logic related to where what is
-sourceSets {
-    main.java.outputDir = new File("$buildDir/classes")
-    test.java.outputDir = new File("$buildDir/testClasses")
-}
-JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
-SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
+import groovy.json.JsonSlurper
+import org.reflections.Reflections
+import org.reflections.util.FilterBuilder
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.reflections.util.ConfigurationBuilder
 
 ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
     env = System.getenv()
+
+    // This is a fun one ... when versions switched to dynamic -SNAPSHOT or not based on branch existing modules using `master` would suddenly try publishing releases
+    // This won't work without additionally doing constant version bumps (perhaps via Git tags) - but too much work to switch around all modules at once
+    // Complicating things more the use of publish.gradle to centralize logic means modules and engine bits are treated the same, yet we need to vary modules
+    // Temporary workaround: default modules to bypass release management: master branch builds will still make snapshot builds for the snapshot repo
+    // If a module actually wants release management simply include `"isReleaseManaged" : true` in module.txt - this is needed for the engine repo embedded modules
+    // One option would be to slowly convert modulespace to default to a `develop` + `master` setup living in harmony with associated automation/github tweaks
+    // Alternatively one more round of refactoring could switch to Git tags, a single `master` branch, and possible other things to help match snaps/PR builds somehow?
+    bypassModuleReleaseManagement = "true"
 }
 
 def moduleDepends = [];
@@ -69,10 +67,43 @@ for (dependency in moduleConfig.dependencies) {
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set somewhere else I guess)
 version = moduleConfig.version
 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+// The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
+if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
+    // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
+    ext.bypassModuleReleaseManagement = false
+    if (version.contains("-SNAPSHOT")) {
+        version -= "-SNAPSHOT"
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+} else {
+    if (!version.contains("-SNAPSHOT")) {
+        version += "-SNAPSHOT"
+    } else {
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+}
+
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.modules'
 
 println "Version for $project.name loaded as $version for group $group"
+
+// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
+// Note that this statement is down a ways because it is affected by the stuff higher in this file like setting versioning
+apply from: "$rootDir/config/gradle/publish.gradle"
+
+// Handle some logic related to where what is
+sourceSets {
+    main.java.outputDir = new File("$buildDir/classes")
+    test.java.outputDir = new File("$buildDir/testClasses")
+}
+JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
+SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
 
 // TODO: Remove when we don't need to rely on snapshots. Needed here for solo builds in Jenkins
 configurations.all {

--- a/modules/CoreSampleGameplay/module.txt
+++ b/modules/CoreSampleGameplay/module.txt
@@ -7,5 +7,6 @@
         {"id": "Core", "minVersion": "3.0.0"}
     ],
     "isGameplay" : "true",
-    "defaultWorldGenerator" : "Core:FacetedPerlin"
+    "defaultWorldGenerator" : "Core:FacetedPerlin",
+    "isReleaseManaged" : true
 }

--- a/modules/CoreSampleGameplay/module.txt
+++ b/modules/CoreSampleGameplay/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "CoreSampleGameplay",
-    "version" : "3.0.0-SNAPSHOT",
+    "version" : "3.0.0",
     "displayName" : "Core Gameplay",
     "description" : "Minimal gameplay template. Little content but a few starting items.",
     "dependencies" : [

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -70,22 +70,23 @@ version = moduleConfig.version
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
+// Check for an outright -SNAPSHOT in the loaded version - for ease of use we want to get rid of that everywhere, so warn about it and remove for the variable
+def undesiredSnapshotTag = version.endsWith("-SNAPSHOT")
+println "BiomesAPI version before the snapshot check: " + version
+if (undesiredSnapshotTag) {
+    println "Taking off undesired -SNAPSHOT"
+    version -= "-SNAPSHOT"
+    def out = services.get(StyledTextOutputFactory).create("an-ouput")
+    out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+}
+
 // The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
 if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
     // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
     ext.bypassModuleReleaseManagement = false
-    if (version.contains("-SNAPSHOT")) {
-        version -= "-SNAPSHOT"
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
 } else {
-    if (!version.contains("-SNAPSHOT")) {
-        version += "-SNAPSHOT"
-    } else {
-        def out = services.get(StyledTextOutputFactory).create("an-ouput")
-        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
-    }
+    // In the case where we actually are building a snapshot we load -SNAPSHOT into the version variable, even if it wasn't there in module.txt
+    version += "-SNAPSHOT"
 }
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -1,15 +1,5 @@
 // Simple build file for modules - the one under the Core module is the template, will be copied as needed to modules
 
-// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
-apply from: "$rootDir/config/gradle/publish.gradle"
-
-import groovy.json.JsonSlurper
-import org.reflections.Reflections
-import org.reflections.util.FilterBuilder
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.util.ConfigurationBuilder
-
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
@@ -35,17 +25,25 @@ buildscript {
     }
 }
 
-// Handle some logic related to where what is
-sourceSets {
-    main.java.outputDir = new File("$buildDir/classes")
-    test.java.outputDir = new File("$buildDir/testClasses")
-}
-JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
-SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
+import groovy.json.JsonSlurper
+import org.reflections.Reflections
+import org.reflections.util.FilterBuilder
+import org.reflections.scanners.SubTypesScanner
+import org.reflections.scanners.TypeAnnotationsScanner
+import org.reflections.util.ConfigurationBuilder
 
 ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
     env = System.getenv()
+
+    // This is a fun one ... when versions switched to dynamic -SNAPSHOT or not based on branch existing modules using `master` would suddenly try publishing releases
+    // This won't work without additionally doing constant version bumps (perhaps via Git tags) - but too much work to switch around all modules at once
+    // Complicating things more the use of publish.gradle to centralize logic means modules and engine bits are treated the same, yet we need to vary modules
+    // Temporary workaround: default modules to bypass release management: master branch builds will still make snapshot builds for the snapshot repo
+    // If a module actually wants release management simply include `"isReleaseManaged" : true` in module.txt - this is needed for the engine repo embedded modules
+    // One option would be to slowly convert modulespace to default to a `develop` + `master` setup living in harmony with associated automation/github tweaks
+    // Alternatively one more round of refactoring could switch to Git tags, a single `master` branch, and possible other things to help match snaps/PR builds somehow?
+    bypassModuleReleaseManagement = "true"
 }
 
 def moduleDepends = [];
@@ -69,10 +67,43 @@ for (dependency in moduleConfig.dependencies) {
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set somewhere else I guess)
 version = moduleConfig.version
 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+// The only case in which we make module non-snapshots is if release management is enabled and BRANCH_NAME is "master"
+if (moduleConfig.isReleaseManaged && env.BRANCH_NAME == "master") {
+    // This is mildly awkward since we need to bypass by default, yet if release management is on (true) then we set the bypass to false ..
+    ext.bypassModuleReleaseManagement = false
+    if (version.contains("-SNAPSHOT")) {
+        version -= "-SNAPSHOT"
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+} else {
+    if (!version.contains("-SNAPSHOT")) {
+        version += "-SNAPSHOT"
+    } else {
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.withStyle(Style.FailureHeader).println("WARNING: Module " + project.name + " is explicitly versioned as a snapshot in module.txt, please remove '-SNAPSHOT'")
+    }
+}
+
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.modules'
 
 println "Version for $project.name loaded as $version for group $group"
+
+// Grab all the common stuff like plugins to use, artifact repositories, code analysis config, Artifactory settings, Git magic
+// Note that this statement is down a ways because it is affected by the stuff higher in this file like setting versioning
+apply from: "$rootDir/config/gradle/publish.gradle"
+
+// Handle some logic related to where what is
+sourceSets {
+    main.java.outputDir = new File("$buildDir/classes")
+    test.java.outputDir = new File("$buildDir/testClasses")
+}
+JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
+SourceSet mainSourceSet = convention.getSourceSets().getByName("main");
 
 // TODO: Remove when we don't need to rely on snapshots. Needed here for solo builds in Jenkins
 configurations.all {


### PR DESCRIPTION
This ate my entire weekend, although just the spare time between GSOC proposal review, baby maintenance, and so on. Up way too late so will be brief :tm: - had imagined I might merge this straight to develop then PR to master for the v3.0.0 release, but too late and now too big.

Realized I needed to be able to vary how artifacts get published, either as releases or snapshots to Artifactory. This used to be done by having two separate jobs in the legacy Jenkins, one tied to `master` that made releases, one tied to `develop` that made snapshots. The actual version numbers were modified *by hand* as part of doing a release (take off `-SNAPSHOT`, push to `master`, bump version and reattach `-SNAPSHOT` ...)

New Jenkins has a multi-branch pipeline job. Shiny. But it was publishing _everything_ as snapshots, even pull requests getting built, meaning at any point in time a _module_ build could run against some engine artifact that came out of an unmerged PR. Not great.

Okay not too bad. Quick conditional to vary publishing by branch just for now. Oh, and really then I might as well just leave the version numbers without `-SNAPSHOT` and attach that dynamically if we're in `develop` ! Awesome bonus. Wait, but then what about modules. They use the same shared `publish.gradle` to keep things standard. That means they'll publish releases when building from `master` branches 🤔 

Alright, too much work to make `develop` branches for everything, default them, have devs do both branches as a standard... besides we might be able to do better like with Git tags (ohai @skaldarnar) instead of branches, and hey now checks are in place in code to where we could probably just look at tags instead of branches. But this needs to work right now.

Awkward release management to the rescue! We'll _default_ modules to not have release management enabled, meaning even while building `master` branches unless `"isReleaseManaged" : true` is added to `module.txt` the new stuff won't trigger and we'll still just make snapshots. And the embedded modules with the engine will get that set, but nobody else yet. It isn't super pretty, but ... it works.

For any reviewers: The actual change in `build.gradle` for modules is minimal, I just had to move some things around. This has been tested with the Nanoware job line in Jenkins and repo line in Artifactory (which also took some extra effort to get right)

Bonus: The code will now gently (or angrily, if red text is angry) warn about modules that still use `-SNAPSHOT` in their own version in `module.txt`, so we can eventually clean that out (or just move the version out of code into tags). Thanks @sin3point14 for that!

### Outstanding

- [ ] Goes with https://github.com/MovingBlocks/ModuleJteConfig/pull/3
- [ ] Javadoc fails on modules that have none, leading to failed build (huh, did this not trigger earlier?)
- [ ] Analytics run _after_ publishing - that's a sinful allowance since there are no quality gates in recording the analytics yet so no way to fail the build anyway and this way it gets to the interesting parts sooner
- [ ] Think about next steps sooner or later, this isn't perfect but gets us closer ...
- [ ] Modules in theory can now run release builds, if enabled. However these will still use the "build harness" from the `develop` build of the engine. More work to do and scenarios to satisfy - but we'll get there. Shout out to @PS-Soundwave 