### PR TITLE
Fixed UI bug at Advanced Game Setup window, Issue #3818

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -124,7 +124,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
             info.setExplicitSelection(config.getDefaultModSelection().hasModule(info.getMetadata().getId()));
         }
 
-        refreshSelection();
+        //refreshSelection();
         filterModules();
     }
 
@@ -694,6 +694,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
         allSortedModules.addAll(sortedModules);
 
         filterModules();
+        refreshSelection();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -124,7 +124,6 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
             info.setExplicitSelection(config.getDefaultModSelection().hasModule(info.getMetadata().getId()));
         }
 
-        //refreshSelection();
         filterModules();
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

## Summary

### Result

Double-clicking on a module that has not been downloaded, doesn't break the Advanced Game Setup selection anymore.

### Original Issue 

* UI falsely indicated that (not-downloaded) module as active after double click
* Activate-Deactivate button of an activated module remained "Deactivate" no matter how many times clicked
* Activated modules no longer were in green color

Closes #3818 

## Contents

### Changes

* Moved the `refreshSelection();` from `onOpened()` to `updateModuleInformation()`

## How to test

* Go to the Advanced settings option while creating a new world in Terasology
* Double click on a module that has not been downloaded yet

Note: The issue occurred only during **the first double click**. Meaning, if you double click an already downloaded module, and afterward double click one that is not, the issue does not occur even without the changes.

## Outstanding before merging

I was unsure if the `refreshSelection();` at `onOpened()` influences other sections irrelevant to the issue I was working on, thus I left it as a comment instead of deleting it completely. The issue does not occur either way. Should be deleted if not retrieved.
