### PR TITLE
added serilization check

### DIFF
--- a/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/logic/console/commands/CoreCommands.java
@@ -496,18 +496,18 @@ public class CoreCommands extends BaseComponentSystem {
         PrefabSerializer prefabSerializer = new PrefabSerializer(engineEntityManager.getComponentLibrary(), engineEntityManager.getTypeSerializerLibrary());
         WorldDumper worldDumper = new WorldDumper(engineEntityManager, prefabSerializer);
         if (componentNames.length == 0) {
-            savedEntityCount = worldDumper .save(PathManager.getInstance().getHomePath().resolve("entityDump.txt"));
+            savedEntityCount = worldDumper.save(PathManager.getInstance().getHomePath().resolve("entityDump.txt"));
         } else {
             List<Class<? extends Component>> filterComponents = Arrays.stream(componentNames)
-                    .map(String::trim) //Trim off whitespace
-                    .filter(o -> !o.isEmpty()) //Remove empty strings
-                    .map(o -> o.toLowerCase().endsWith("component") ? o : o + "component") //All component class names finish with "component"
-                    .map(o -> Streams.stream(moduleManager.getEnvironment().getSubtypesOf(Component.class))
-                            .filter(e -> e.getSimpleName().equalsIgnoreCase(o))
-                            .findFirst())
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .collect(Collectors.toList());
+                .map(String::trim) //Trim off whitespace
+                .filter(o -> !o.isEmpty()) //Remove empty strings
+                .map(o -> o.toLowerCase().endsWith("component") ? o : o + "component") //All component class names finish with "component"
+                .map(o -> Streams.stream(moduleManager.getEnvironment().getSubtypesOf(Component.class))
+                    .filter(e -> e.getSimpleName().equalsIgnoreCase(o))
+                    .findFirst())
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
             if (!filterComponents.isEmpty()) {
                 savedEntityCount = worldDumper.save(PathManager.getInstance().getHomePath().resolve("entityDump.txt"), filterComponents);
             } else {

--- a/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
+++ b/engine/src/main/java/org/terasology/persistence/serializers/WorldSerializerImpl.java
@@ -73,7 +73,11 @@ public class WorldSerializerImpl implements WorldSerializer {
         }
 
         for (Prefab prefab : prefabManager.listPrefabs()) {
-            world.addPrefab(prefabSerializer.serialize(prefab));
+            try {
+                world.addPrefab(prefabSerializer.serialize(prefab));
+            } catch (Throwable ex) {
+                logger.error("failed to serialize prefab: {}", prefab.getName(), ex);
+            }
         }
 
         for (EntityRef entity : entityManager.getAllEntities()) {
@@ -102,7 +106,11 @@ public class WorldSerializerImpl implements WorldSerializer {
 
         for (Prefab prefab : prefabManager.listPrefabs()) {
             if (prefab.hasAnyComponents(filterComponents)) {
-                world.addPrefab(prefabSerializer.serialize(prefab));
+                try {
+                    world.addPrefab(prefabSerializer.serialize(prefab));
+                } catch (Throwable ex) {
+                    logger.error("failed to serialize prefab: {}", prefab.getName(), ex);
+                }
             }
         }
 


### PR DESCRIPTION
I added some try and catch logic for `WorldSerializerImpl` for when prefabs are saved. this is for #3877. The main cause of this is narrowed down in #3879. not sure if we still want this check for serialization when using dumpEntities.

here is the dump from that issue
```
16:24:38.837 [Thread-3] DEBUG c.j.d.entities.pipe.UnixPipe - Received packet: Pkt:FRAME{"evt":null,"data":{"assets":{"large_image":"515746954660151306"},"timestamps":{"start":1586129069000},"name":"Terasology","details":"Name: Player70857","state":"Solo | Game 7","secrets":{},"application_id":"515274721080639504"},"cmd":"SET_ACTIVITY","nonce":"a36f0a9b-30f7-45b2-beb8-baba4202110c"}
16:24:42.043 [main] ERROR o.t.p.s.WorldSerializerImpl - failed to serialize prefab: engine:camera {}
java.lang.StackOverflowError: null
	at org.terasology.utilities.ReflectionUtil.lambda$cascadeTypeVariableDeclarationToSupertypes$4(ReflectionUtil.java:444)
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:269)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)
	at java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:731)
	at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:295)
	at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:207)
	at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:162)
	at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:301)
	at java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:731)
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.stream.Streams$StreamBuilderImpl.tryAdvance(Streams.java:405)
	at java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:728)
	at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:295)
	at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:207)
	at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:162)
	at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:301)
	at java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:731)
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.stream.Streams$StreamBuilderImpl.tryAdvance(Streams.java:405)
	at java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:728)
	at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:295)
	at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:207)
	at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:162)
	at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:301)
	at java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:731)
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.findAny(ReferencePipeline.java:536)
	at org.terasology.utilities.ReflectionUtil.resolveTypeVariable(ReflectionUtil.java:402)
	at org.terasology.utilities.ReflectionUtil.resolveType(ReflectionUtil.java:306)
	at org.terasology.utilities.ReflectionUtil.resolveTypes(ReflectionUtil.java:387)
	at org.terasology.utilities.ReflectionUtil.resolveType(ReflectionUtil.java:331)
	at org.terasology.utilities.ReflectionUtil.parameterizeandResolveRawType(ReflectionUtil.java:510)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.getRuntimeTypeIfMoreSpecific(RuntimeDelegatingTypeHandler.java:170)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.serializeNonNull(RuntimeDelegatingTypeHandler.java:76)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler.serializeNonNull(ObjectFieldMapTypeHandler.java:71)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.serializeNonNull(RuntimeDelegatingTypeHandler.java:131)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler.serializeNonNull(ObjectFieldMapTypeHandler.java:71)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.serializeNonNull(RuntimeDelegatingTypeHandler.java:131)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler.serializeNonNull(ObjectFieldMapTypeHandler.java:71)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.serializeNonNull(RuntimeDelegatingTypeHandler.java:131)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler.serializeNonNull(ObjectFieldMapTypeHandler.java:71)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.serializeNonNull(RuntimeDelegatingTypeHandler.java:131)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler.serializeNonNull(ObjectFieldMapTypeHandler.java:71)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
	at org.terasology.persistence.typeHandling.coreTypes.RuntimeDelegatingTypeHandler.serializeNonNull(RuntimeDelegatingTypeHandler.java:131)
	at org.terasology.persistence.typeHandling.TypeHandler.serialize(TypeHandler.java:49)
...
```