### PR TITLE
fix: Use 16 bit TeraArray in ChunkImpl 

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockManagerImpl.java
@@ -135,6 +135,13 @@ public class BlockManagerImpl extends BlockManager {
         return (short) nextId.getAndIncrement();
     }
 
+    /**
+     * Get cached instance of the air block.
+     *
+     * We do this for performance reasons because a lookup by BlockURI happens the first time a block is set when
+     * getting the previous block. This causes performance problems eventually down the line when it then uses the
+     * ResourceUrn's hashcode to do a lookup into the block map.
+     */
     private Block getAirBlock() {
         if (airBlock == null) {
             airBlock = getBlock(AIR_ID);
@@ -256,7 +263,7 @@ public class BlockManagerImpl extends BlockManager {
                 } catch (Exception ex) {
                     // A family can fail to register if the block is missing uri or list of categories,
                     // but can fail to register if the family throws an error for any reason
-                    logger.error("Failed to register block familiy '{}'", newFamily, ex);
+                    logger.error("Failed to register block family '{}'", newFamily, ex);
                 } finally {
                     lock.unlock();
                 }

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -124,8 +124,8 @@ public class ChunkImpl implements Chunk {
     @Override
     public int getEstimatedMemoryConsumptionInBytes() {
         int extraDataSize = 0;
-        for (int i = 0; i < extraData.length; i++) {
-            extraDataSize += extraData[i].getEstimatedMemoryConsumptionInBytes();
+        for (TeraArray extraDatum : extraData) {
+            extraDataSize += extraDatum.getEstimatedMemoryConsumptionInBytes();
         }
         return blockData.getEstimatedMemoryConsumptionInBytes()
                 + sunlightData.getEstimatedMemoryConsumptionInBytes()
@@ -230,12 +230,12 @@ public class ChunkImpl implements Chunk {
     public int getExtraData(int index, int x, int y, int z) {
         return extraData[index].get(x, y, z);
     }
-    
+
     @Override
     public int getExtraData(int index, BaseVector3i pos) {
         return getExtraData(index, pos.x(), pos.y(), pos.z());
     }
-    
+
     @Override
     public void setExtraData(int index, int x, int y, int z, int value) {
         if (extraDataSnapshots != null && extraData[index] == extraDataSnapshots[index]) {
@@ -243,7 +243,7 @@ public class ChunkImpl implements Chunk {
         }
         extraData[index].set(x, y, z, value);
     }
-    
+
     @Override
     public void setExtraData(int index, BaseVector3i pos, int value) {
         setExtraData(index, pos.x(), pos.y(), pos.z(), value);
@@ -315,8 +315,8 @@ public class ChunkImpl implements Chunk {
             int sunlightRegenSize = sunlightRegenData.getEstimatedMemoryConsumptionInBytes();
             int lightSize = lightData.getEstimatedMemoryConsumptionInBytes();
             int extraSize = 0;
-            for (int i = 0; i < extraData.length; i++) {
-                extraSize += extraData[i].getEstimatedMemoryConsumptionInBytes();
+            for (TeraArray extraDatum : extraData) {
+                extraSize += extraDatum.getEstimatedMemoryConsumptionInBytes();
             }
             int totalSize = blocksSize + sunlightRegenSize + sunlightSize + lightSize + extraSize;
 
@@ -329,8 +329,8 @@ public class ChunkImpl implements Chunk {
             int blocksReduced = blockData.getEstimatedMemoryConsumptionInBytes();
             int lightReduced = lightData.getEstimatedMemoryConsumptionInBytes();
             int extraReduced = 0;
-            for (int i = 0; i < extraData.length; i++) {
-                extraReduced += extraData[i].getEstimatedMemoryConsumptionInBytes();
+            for (TeraArray extraDatum : extraData) {
+                extraReduced += extraDatum.getEstimatedMemoryConsumptionInBytes();
             }
             int totalReduced = blocksReduced + sunlightRegenSize + sunlightSize + lightReduced + extraReduced;
 
@@ -391,8 +391,8 @@ public class ChunkImpl implements Chunk {
                             "bytes, size-after: {} " +
                             "bytes, total-deflated-by: {}%, " +
                             "sunlight-deflated-by={}%, " +
-                            "sunlight-regen-deflated-by={}%, " +
-                            chunkPos,
+                            "sunlight-regen-deflated-by={}%",
+                    chunkPos,
                     SIZE_FORMAT.format(totalSize),
                     SIZE_FORMAT.format(totalReduced),
                     PERCENT_FORMAT.format(totalPercent),

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -34,6 +34,7 @@ import org.terasology.world.chunks.ChunkBlockIterator;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.blockdata.TeraArray;
+import org.terasology.world.chunks.blockdata.TeraDenseArray16Bit;
 import org.terasology.world.chunks.blockdata.TeraDenseArray8Bit;
 import org.terasology.world.chunks.deflate.TeraDeflator;
 import org.terasology.world.chunks.deflate.TeraStandardDeflator;
@@ -86,7 +87,7 @@ public class ChunkImpl implements Chunk {
 
     public ChunkImpl(Vector3i chunkPos, BlockManager blockManager, ExtraBlockDataManager extraDataManager) {
         this(chunkPos,
-                new TeraDenseArray8Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
+                new TeraDenseArray16Bit(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
                 extraDataManager.makeDataArrays(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z),
                 blockManager);
     }


### PR DESCRIPTION
As we are using shorts for block ids for some time now having only an
8-bit array in the chunk implementation will lead to blocks not being
rendered when exceeding block id 128.

Probably related to #3882 and #2516

---

Find a way to register more than 128 blocks (e.g., by getting a bunch of stairs, slopes, slopecorners, ...) and place them in the world. All blocks, including the ones with ids greater 128 should be visible.