### PR TITLE
Time out of sync for players in multiplayer

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/DebugControlSystem.java
@@ -31,12 +31,12 @@ import org.terasology.input.events.KeyEvent;
 import org.terasology.input.events.MouseAxisEvent;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.debug.DebugProperties;
+import org.terasology.logic.players.event.WorldtimeResetEvent;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.layers.ingame.metrics.DebugOverlay;
 import org.terasology.world.WorldProvider;
-
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class DebugControlSystem extends BaseComponentSystem {
@@ -86,20 +86,16 @@ public class DebugControlSystem extends BaseComponentSystem {
         if (debugEnabled && event.isDown()) {
             switch (event.getKey().getId()) {
                 case Keyboard.KeyId.UP:
-                    world.getTime().setDays(world.getTime().getDays() + 0.005f);
-                    event.consume();
+                    timeTravel(entity, event, 0.005f);
                     break;
                 case Keyboard.KeyId.DOWN:
-                    world.getTime().setDays(world.getTime().getDays() - 0.005f);
-                    event.consume();
+                    timeTravel(entity, event, -0.005f);
                     break;
                 case Keyboard.KeyId.RIGHT:
-                    world.getTime().setDays(world.getTime().getDays() + 0.02f);
-                    event.consume();
+                    timeTravel(entity, event, 0.02f);
                     break;
                 case Keyboard.KeyId.LEFT:
-                    world.getTime().setDays(world.getTime().getDays() - 0.02f);
-                    event.consume();
+                    timeTravel(entity, event, -0.02f);
                     break;
                 default:
                     break;
@@ -164,4 +160,9 @@ public class DebugControlSystem extends BaseComponentSystem {
         }
     }
 
+    private void timeTravel(EntityRef entity, KeyEvent event, float timeInDays) {
+        float days = world.getTime().getDays();
+        entity.send(new WorldtimeResetEvent(days + timeInDays));
+        event.consume();
+    }
 }

--- a/engine/src/main/java/org/terasology/logic/players/WorldtimeResyncSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/WorldtimeResyncSystem.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.time.WorldtimeResyncEvent;
+import org.terasology.network.ClientComponent;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class WorldtimeResyncSystem extends BaseComponentSystem {
+
+    @In
+    private WorldProvider world;
+
+    @ReceiveEvent(components = ClientComponent.class)
+    public void resyncWorldTime(WorldtimeResyncEvent event, EntityRef entity) {
+        ClientComponent client = entity.getComponent(ClientComponent.class);
+        if (client.local) {
+            world.getTime().setDays(event.days);
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/logic/players/event/FindClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/event/FindClientSystem.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players.event;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.time.WorldtimeResyncEvent;
+import org.terasology.network.ClientComponent;
+import org.terasology.registry.In;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class FindClientSystem extends BaseComponentSystem {
+
+    @In
+    EntityManager entityManager;
+
+    @ReceiveEvent
+    public void findClients(WorldtimeResetEvent event, EntityRef entity) {
+        if (entityManager.getCountOfEntitiesWith(ClientComponent.class) != 0) {
+            Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
+            for (EntityRef client : clients) {
+                client.send(new WorldtimeResyncEvent(event.days));
+            }
+        }
+    }
+}
+

--- a/engine/src/main/java/org/terasology/logic/players/event/WorldtimeResetEvent.java
+++ b/engine/src/main/java/org/terasology/logic/players/event/WorldtimeResetEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players.event;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.ServerEvent;
+
+@ServerEvent
+public class WorldtimeResetEvent implements Event {
+
+    public float days;
+
+    public WorldtimeResetEvent() {
+    }
+
+    public WorldtimeResetEvent(float days) {
+        this.days = days;
+    }
+}
+

--- a/engine/src/main/java/org/terasology/logic/time/TimeClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/time/TimeClientSystem.java
@@ -16,17 +16,35 @@
 package org.terasology.logic.time;
 
 import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.players.event.WorldtimeResetEvent;
 import org.terasology.registry.In;
+import org.terasology.world.WorldComponent;
+import org.terasology.world.WorldProvider;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class TimeClientSystem extends BaseComponentSystem {
     @In
     private Time time;
+
+    @In
+    private EntityManager entityManager;
+
+    @In
+    private WorldProvider world;
+
+    @Override
+    public void postBegin() {
+        for (EntityRef entity : entityManager.getEntitiesWith(WorldComponent.class)) {
+            entity.send(new WorldtimeResetEvent(world.getTime().getDays()));
+            return;
+        }
+    }
 
     @ReceiveEvent(netFilter = RegisterMode.REMOTE_CLIENT)
     public void resynchTime(TimeResynchEvent event, EntityRef entityRef) {

--- a/engine/src/main/java/org/terasology/logic/time/WorldtimeResyncEvent.java
+++ b/engine/src/main/java/org/terasology/logic/time/WorldtimeResyncEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.time;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.OwnerEvent;
+
+@OwnerEvent
+public class WorldtimeResyncEvent implements Event {
+    public float days;
+
+    public WorldtimeResyncEvent() {
+    }
+
+    public WorldtimeResyncEvent(float days) {
+        this.days = days;
+    }
+}


### PR DESCRIPTION
### Contains

Attempts to fix https://github.com/MovingBlocks/Terasology/issues/3670
The World time changed using debug mode by any client is now reflected in all clients.
This sketch board explains how i fixed it,by comparing it against the Ping System: https://sketchboard.me/fB4oPzAlhMkt#/.

### How to test

Start up a multiplayer game locally and change the World time using the debug mode,and you will see the time change being replicated in all clients.

### Outstanding before merging

The client that connects later lags the other clients by around 0.03 days. This is because the World time is updated on every frame, and the first frame is run some time after the new client's WorldProvider receives the host's World time. I tried fixing it by sending an event to reset time, right before the first frame of the new client(using the postBegin() method). But for some reason, the event handler is unable to catch this event. I am guessing that i am not sending the event using the right entity.