### PR TITLE
feat: Make DebugMetrics available to modules

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.rendering.nui.layers.ingame.metrics;
 
-
 import com.google.common.base.Preconditions;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -24,11 +23,9 @@ import org.terasology.registry.Share;
 
 import java.util.ArrayList;
 
-
 /**
  * Manages an ordered set of MetricsMode instances.
- *
- *
+ * <p>
  * A number of default metrics modes is instantiated in the initialize() method and becomes immediately available by
  * iterating through the set repeatedly invoking the toggle() method. The getCurrentMode() method can also be used to
  * obtain the mode currently pointed at. Further modes can be added to the set via the register method, while registered
@@ -64,6 +61,7 @@ public class DebugMetricsSystem extends BaseComponentSystem {
     /**
      * Adds a MetricsMode instance to the set. Use the toggle() and getCurrentMode() methods to iterate over the set and
      * obtain the MetricsMode instances.
+     *
      * @param mode a MetricsMode instance
      */
     public boolean register(MetricsMode mode) {
@@ -78,6 +76,7 @@ public class DebugMetricsSystem extends BaseComponentSystem {
 
     /**
      * Returns current mode, initializes a default {@link NullMetricsMode}, if currentMode is null
+     *
      * @return the current MetricsMode instance
      */
     public MetricsMode getCurrentMode() {
@@ -87,6 +86,7 @@ public class DebugMetricsSystem extends BaseComponentSystem {
     /**
      * Iterates through the set of registered MetricsMode and returns the first instance whose method isAvailable()
      * returns true. Notice that this could be the MetricsMode that was current at the time this method was invoked.
+     *
      * @returns a MetricsMode instance
      */
     public MetricsMode toggle() {
@@ -101,7 +101,7 @@ public class DebugMetricsSystem extends BaseComponentSystem {
 
     /**
      * Removes from the set the MetricsMode instance provided as input.
-     *
+     * <p>
      * If the MetricsMode instance is the mode currently pointed at by the iterator, toggles the iterator forward. Unregistering
      * defaultMode is not allowed, therefore throws {@link IllegalArgumentException}.
      *

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
@@ -19,6 +19,7 @@ package org.terasology.rendering.nui.layers.ingame.metrics;
 import com.google.common.base.Preconditions;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.module.sandbox.API;
 import org.terasology.registry.Share;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
  */
 @RegisterSystem
 @Share(DebugMetricsSystem.class)
+@API
 public class DebugMetricsSystem extends BaseComponentSystem {
 
     private final MetricsMode defaultMode = new NullMetricsMode();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/DebugOverlay.java
@@ -36,7 +36,9 @@ import java.util.Locale;
 
 /**
  * Displays the content of the MetricsMode instances provided by the {@link DebugMetricsSystem}.
- *
+ * <p>
+ * Only a single {@link MetricsMode} is displayed on the screen.
+ * <p>
  * See the {@link #toggleMetricsMode()} method to iterate through the MetricsMode instances available for display.
  */
 public class DebugOverlay extends CoreScreenLayer {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/MetricsMode.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/MetricsMode.java
@@ -18,22 +18,51 @@ package org.terasology.rendering.nui.layers.ingame.metrics;
 import org.terasology.module.sandbox.API;
 
 /**
+ * A metrics mode is a named entry in the {@link DebugOverlay}.
+ *
+ * It is intended to show development information that is not intended for a player. It consists of a name and a metrics
+ * string to display. The metrics mode will be queried by the {@link DebugMetricsSystem} for the current metrics string
+ * (poll-based approach).
  */
 @API
 public abstract class MetricsMode {
 
     private String name;
 
+    /**
+     * Create a new metrics mode with the given name.
+     *
+     * @param name the name of this metrics mode
+     */
     public MetricsMode(String name) {
         this.name = name;
     }
 
+    /**
+     * The string to be displayed in the debug metrics overlay view.
+     *
+     * All formatting needs to be done by the metrics mode itself, as the debug overlay system will just print the
+     * string on screen. Use multi-line strings to spread the metrics over multiple lines.
+     *
+     * @return the full metrics string to be rendered in the debug overlay
+     */
     public abstract String getMetrics();
 
+    /**
+     * Whether the metric mode is currently available.
+     *
+     * This property may change over time. Using this flag a metrics mode can be registered with the debug overlay
+     * system without immediately showing it.
+     *
+     * @return whether the metrics mode is currently available (should be displayed)
+     */
     public abstract boolean isAvailable();
 
     public abstract boolean isPerformanceManagerMode();
 
+    /**
+     * A (human readable) name for the metrics mode.
+     */
     public String getName() {
         return name;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/MetricsMode.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/ingame/metrics/MetricsMode.java
@@ -15,8 +15,11 @@
  */
 package org.terasology.rendering.nui.layers.ingame.metrics;
 
+import org.terasology.module.sandbox.API;
+
 /**
  */
+@API
 public abstract class MetricsMode {
 
     private String name;


### PR DESCRIPTION
Simply make both DebugMetricsSystem and MetricsMode available as `@API`.
This allows to `@In` the debug system and register a new metrics mode.
