### PR TITLE
feat(JOML): migrate bullet system

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/block/shape/BlockShapeTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/shape/BlockShapeTest.java
@@ -80,13 +80,13 @@ public class BlockShapeTest extends TerasologyTestingEnvironment {
 
         ObjectArrayList<javax.vecmath.Vector3f> points = ((com.bulletphysics.collision.shapes.ConvexHullShape) bulletConvexHullShape.underlyingShape).getPoints();
         for (int x = 0; x < points.size(); x++) {
-            fuzzVectorTest(test[x], VecMath.from(points.get(x)));
+            fuzzVectorTest(test[x], points.get(x));
 
         }
 
     }
 
-    private void fuzzVectorTest(Vector3f test, Vector3f actual) {
+    private void fuzzVectorTest(Vector3f test, javax.vecmath.Vector3f actual) {
         assertEquals(test.x, actual.x, .1f);
         assertEquals(test.y, actual.y, .1f);
         assertEquals(test.z, actual.z, .1f);

--- a/engine/src/main/java/org/terasology/input/cameraTarget/CameraTargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/CameraTargetSystem.java
@@ -21,6 +21,7 @@ import org.terasology.config.Config;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -111,18 +112,18 @@ public class CameraTargetSystem extends BaseComponentSystem {
         }
 
 
-        HitResult hitInfo = physics.rayTrace(new Vector3f(localPlayer.getViewPosition()),
-                new Vector3f(localPlayer.getViewDirection()), targetDistance, filter);
+        HitResult hitInfo = physics.rayTrace(JomlUtil.from(new Vector3f(localPlayer.getViewPosition())),
+            JomlUtil.from(new Vector3f(localPlayer.getViewDirection())), targetDistance, filter);
         updateFocalDistance(hitInfo, delta);
         Vector3i newBlockPos = null;
 
         EntityRef newTarget = EntityRef.NULL;
         if (hitInfo.isHit()) {
             newTarget = hitInfo.getEntity();
-            hitPosition = hitInfo.getHitPoint();
-            hitNormal = hitInfo.getHitNormal();
+            hitPosition = JomlUtil.from(hitInfo.getHitPoint());
+            hitNormal = JomlUtil.from(hitInfo.getHitNormal());
             if (hitInfo.isWorldHit()) {
-                newBlockPos = new Vector3i(hitInfo.getBlockPosition());
+                newBlockPos = new Vector3i(JomlUtil.from(hitInfo.getBlockPosition()));
             }
         }
         if (!Objects.equal(target, newTarget) || lostTarget) {
@@ -143,7 +144,7 @@ public class CameraTargetSystem extends BaseComponentSystem {
         if (hitInfo.isHit()) {
             Vector3f playerToTargetRay = new Vector3f();
             //calculate the distance from the player to the hit point
-            playerToTargetRay.sub(hitInfo.getHitPoint(), localPlayer.getViewPosition());
+            playerToTargetRay.sub(JomlUtil.from(hitInfo.getHitPoint()), localPlayer.getViewPosition());
             //gradually adjust focalDistance from it's current value to the hit point distance
             focalDistance = TeraMath.lerp(focalDistance, playerToTargetRay.length(), delta * focusRate);
             //if nothing was hit, gradually adjust the focusDistance to the maximum length of the update function trace

--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.CollisionGroup;
@@ -75,7 +76,7 @@ public class TargetSystem {
             target = blockRegistry.getEntityAt(targetBlockPos);
         }
 
-        HitResult hitInfo = physics.rayTrace(pos, dir, maxDist, filter);
+        HitResult hitInfo = physics.rayTrace(JomlUtil.from(pos), JomlUtil.from(dir), maxDist, filter);
         EntityRef newTarget = hitInfo.getEntity();
 
         if (hitInfo.isWorldHit()) {
@@ -84,7 +85,7 @@ public class TargetSystem {
                     return false;
                 }
             }
-            targetBlockPos = hitInfo.getBlockPosition();
+            targetBlockPos = JomlUtil.from(hitInfo.getBlockPosition());
         } else {
             if (target.equals(newTarget)) {
                 return false;

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterMovementSystemUtility.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterMovementSystemUtility.java
@@ -17,6 +17,7 @@ package org.terasology.logic.characters;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.BaseQuat4f;
 import org.terasology.math.geom.BaseVector3f;
@@ -138,6 +139,6 @@ public final class CharacterMovementSystemUtility {
      */
     private void setPhysicsLocation(EntityRef entity, Vector3f newPos) {
         CharacterCollider collider = physics.getCharacterCollider(entity);
-        collider.setLocation(newPos);
+        collider.setLocation(JomlUtil.from(newPos));
     }
 }

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterSystem.java
@@ -47,6 +47,7 @@ import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.PlayerCharacterComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.NetworkSystem;
@@ -226,7 +227,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
                 originPos = data[1];
             }
 
-            HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
+            HitResult result = physics.rayTrace(JomlUtil.from(originPos), JomlUtil.from(direction), characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
 
             if (result.isHit()) {
                 result.getEntity().send(new AttackEvent(character, event.getItem()));
@@ -361,7 +362,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
                 return false; // can happen if target existed on client
             }
 
-            HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
+            HitResult result = physics.rayTrace(JomlUtil.from(originPos), JomlUtil.from(direction), characterComponent.interactionRange, Sets.newHashSet(character), DEFAULTPHYSICSFILTER);
             if (!result.isHit()) {
                 String msg = "Denied activation attempt by {} since at the authority there was nothing to activate at that place";
                 logger.info(msg, getPlayerNameFromCharacter(character));
@@ -379,7 +380,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
                 return false;
             }
 
-            if (!(vectorsAreAboutEqual(event.getHitPosition(), result.getHitPoint()))) {
+            if (!(vectorsAreAboutEqual(event.getHitPosition(), JomlUtil.from(result.getHitPoint())))) {
                 String msg = "Denied activation attempt by {} since at the authority the object got hit at a differnt position";
                 logger.info(msg, getPlayerNameFromCharacter(character));
                 return false;

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -25,6 +25,7 @@ import org.terasology.logic.characters.events.OnEnterBlockEvent;
 import org.terasology.logic.characters.events.SwimStrokeEvent;
 import org.terasology.logic.characters.events.VerticalCollisionEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Vector3fUtil;
 import org.terasology.math.geom.ImmutableVector3f;
@@ -195,7 +196,7 @@ public class KinematicCharacterMover implements CharacterMover {
 
         updateMode(state, newSwimming, newDiving, newClimbing, isCrouching);
     }
-    
+
     /**
      * Updates a character's movement mode and changes his vertical velocity accordingly.
      * @param state The current state of the character.
@@ -382,7 +383,7 @@ public class KinematicCharacterMover implements CharacterMover {
         boolean hit = false;
         int iteration = 0;
         while (remainingDist > physics.getEpsilon() && iteration++ < 10) {
-            SweepCallback callback = collider.sweep(position, targetPos, VERTICAL_PENETRATION, -1.0f);
+            SweepCallback callback = collider.sweep(JomlUtil.from(position), JomlUtil.from(targetPos), VERTICAL_PENETRATION, -1.0f);
             float actualDist = Math.max(0,
                     (remainingDist + VERTICAL_PENETRATION_LEEWAY) * callback.getClosestHitFraction() - VERTICAL_PENETRATION_LEEWAY);
             Vector3f expectedMove = new Vector3f(targetPos);
@@ -465,7 +466,7 @@ public class KinematicCharacterMover implements CharacterMover {
         int iteration = 0;
         Vector3f lastHitNormal = new Vector3f(0, 1, 0);
         while (remainingFraction >= 0.01f && iteration++ < 10) {
-            SweepCallback callback = collider.sweep(position, targetPos, HORIZONTAL_PENETRATION, slopeFactor);
+            SweepCallback callback = collider.sweep(JomlUtil.from(position), JomlUtil.from(targetPos), HORIZONTAL_PENETRATION, slopeFactor);
 
             /* Note: this isn't quite correct (after the first iteration the closestHitFraction is only for part of the moment)
              but probably close enough */
@@ -538,7 +539,7 @@ public class KinematicCharacterMover implements CharacterMover {
     private float moveUp(float riseAmount, CharacterCollider collider, Vector3f position) {
         Vector3f to = new Vector3f(position.x, position.y + riseAmount + VERTICAL_PENETRATION_LEEWAY, position.z);
         if (collider != null) {
-            SweepCallback callback = collider.sweep(position, to, VERTICAL_PENETRATION_LEEWAY, -1f);
+            SweepCallback callback = collider.sweep(JomlUtil.from(position), JomlUtil.from(to), VERTICAL_PENETRATION_LEEWAY, -1f);
             if (callback.hasHit()) {
                 float actualDist = Math.max(0,
                         ((riseAmount + VERTICAL_PENETRATION_LEEWAY) * callback.getClosestHitFraction()) - VERTICAL_PENETRATION_LEEWAY);

--- a/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/ItemPickupAuthoritySystem.java
@@ -30,6 +30,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.inventory.events.DropItemEvent;
 import org.terasology.logic.inventory.events.GiveItemEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.physics.components.RigidBodyComponent;
 import org.terasology.physics.components.shapes.BoxShapeComponent;
@@ -101,11 +102,11 @@ public class ItemPickupAuthoritySystem extends BaseComponentSystem {
 
         if (blockFamily.getArchetypeBlock().getCollisionShape() instanceof BoxShape) {
             BoxShape collisionShape = (BoxShape) blockFamily.getArchetypeBlock().getCollisionShape();
-            Vector3f extents = collisionShape.getExtents();
+            Vector3f extents = JomlUtil.from(collisionShape.getExtents());
             extents.x = Math.max(extents.x, 0.5f);
             extents.y = Math.max(extents.y, 0.5f);
             extents.z = Math.max(extents.z, 0.5f);
-            boxShapeComponent.extents.set(extents);
+            boxShapeComponent.extents.set(JomlUtil.from(extents));
             itemEntity.saveComponent(boxShapeComponent);
         }
     }

--- a/engine/src/main/java/org/terasology/logic/location/Location.java
+++ b/engine/src/main/java/org/terasology/logic/location/Location.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 
@@ -123,8 +124,8 @@ public class Location extends BaseComponentSystem {
 
     @ReceiveEvent(netFilter = RegisterMode.REMOTE_CLIENT)
     public void onResyncLocation(LocationResynchEvent event, EntityRef entityRef, LocationComponent locationComponent) {
-        locationComponent.setWorldPosition(event.getPosition());
-        locationComponent.setWorldRotation(event.getRotation());
+        locationComponent.setWorldPosition(JomlUtil.from(event.getPosition()));
+        locationComponent.setWorldRotation(JomlUtil.from(event.getRotation()));
         entityRef.saveComponent(locationComponent);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/location/LocationResynchEvent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationResynchEvent.java
@@ -15,20 +15,20 @@
  */
 package org.terasology.logic.location;
 
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.BroadcastEvent;
 
 @BroadcastEvent
 public class LocationResynchEvent implements Event {
     public Vector3f position;
-    public Quat4f rotation;
+    public Quaternionf rotation;
 
     public LocationResynchEvent() {
     }
 
-    public LocationResynchEvent(Vector3f position, Quat4f rotation) {
+    public LocationResynchEvent(Vector3f position, Quaternionf rotation) {
         this.position = position;
         this.rotation = rotation;
     }
@@ -37,7 +37,7 @@ public class LocationResynchEvent implements Event {
         return position;
     }
 
-    public Quat4f getRotation() {
+    public Quaternionf getRotation() {
         return rotation;
     }
 }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -24,6 +24,7 @@ import org.terasology.logic.characters.events.ActivationPredicted;
 import org.terasology.logic.characters.events.ActivationRequest;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.Direction;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
@@ -216,14 +217,14 @@ public class LocalPlayer {
         boolean ownedEntityUsage = usedOwnedEntity.exists();
         int activationId = nextActivationId++;
         Physics physics = CoreRegistry.get(Physics.class);
-        HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character), CharacterSystem.DEFAULTPHYSICSFILTER);
+        HitResult result = physics.rayTrace(JomlUtil.from(originPos), JomlUtil.from(direction), characterComponent.interactionRange, Sets.newHashSet(character), CharacterSystem.DEFAULTPHYSICSFILTER);
         boolean eventWithTarget = result.isHit();
         if (eventWithTarget) {
             EntityRef activatedObject = usedOwnedEntity.exists() ? usedOwnedEntity : result.getEntity();
             activatedObject.send(new ActivationPredicted(character, result.getEntity(), originPos, direction,
-                    result.getHitPoint(), result.getHitNormal(), activationId));
+                JomlUtil.from(result.getHitPoint()), JomlUtil.from(result.getHitNormal()), activationId));
             character.send(new ActivationRequest(character, ownedEntityUsage, usedOwnedEntity, eventWithTarget, result.getEntity(),
-                    originPos, direction, result.getHitPoint(), result.getHitNormal(), activationId));
+                    originPos, direction, JomlUtil.from(result.getHitPoint()), JomlUtil.from(result.getHitNormal()), activationId));
             return true;
         } else if (ownedEntityUsage) {
             usedOwnedEntity.send(new ActivationPredicted(character, EntityRef.NULL, originPos, direction,

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -96,7 +96,7 @@ public class PlayerFactory {
     private float getHeightOf(ComponentContainer prefab) {
         BoxShapeComponent box = prefab.getComponent(BoxShapeComponent.class);
         if (box != null) {
-            return box.extents.getY();
+            return box.extents.y();
         }
 
         CylinderShapeComponent cylinder = prefab.getComponent(CylinderShapeComponent.class);

--- a/engine/src/main/java/org/terasology/math/VecMath.java
+++ b/engine/src/main/java/org/terasology/math/VecMath.java
@@ -16,8 +16,9 @@
 
 package org.terasology.math;
 
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
 
 /**
  * Some utilities for compatibility with VecMath.
@@ -32,15 +33,20 @@ public final class VecMath {
         return new Vector3f(v.x, v.y, v.z);
     }
 
-    public static javax.vecmath.Vector3f to(Vector3f v) {
-        return new javax.vecmath.Vector3f(v.x, v.y, v.z);
+//    public static javax.vecmath.Vector3f to(Vector3f v) {
+//        return new javax.vecmath.Vector3f(v.x, v.y, v.z);
+//    }
+
+    public static javax.vecmath.Vector3f to(Vector3fc v) {
+        return new javax.vecmath.Vector3f(v.x(), v.y(), v.z());
     }
 
-    public static Quat4f from(javax.vecmath.Quat4f v) {
-        return new Quat4f(v.x, v.y, v.z, v.w);
+
+    public static Quaternionf from(javax.vecmath.Quat4f v) {
+        return new Quaternionf(v.x, v.y, v.z, v.w);
     }
 
-    public static javax.vecmath.Quat4f to(Quat4f v) {
+    public static javax.vecmath.Quat4f to(Quaternionf v) {
         return new javax.vecmath.Quat4f(v.x, v.y, v.z, v.w);
     }
 

--- a/engine/src/main/java/org/terasology/particles/updating/ParticleUpdaterImpl.java
+++ b/engine/src/main/java/org/terasology/particles/updating/ParticleUpdaterImpl.java
@@ -20,6 +20,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableList;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.particles.ParticleDataMask;
@@ -139,7 +140,7 @@ class ParticleUpdaterImpl implements ParticleUpdater {
             float dist = (vel.length() + 0.5f) * movingAvgDelta * PHYSICS_SKIP_NR * 1.5f;
             vel.normalize();
 
-            HitResult hitResult = physics.rayTrace(curr, vel, dist, StandardCollisionGroup.WORLD);
+            HitResult hitResult = physics.rayTrace(JomlUtil.from(curr), JomlUtil.from(vel), dist, StandardCollisionGroup.WORLD);
             if (hitResult.isHit()) {
                 pool.energy[i] = 0;
             }

--- a/engine/src/main/java/org/terasology/physics/HitResult.java
+++ b/engine/src/main/java/org/terasology/physics/HitResult.java
@@ -16,11 +16,11 @@
 
 package org.terasology.physics;
 
+import org.joml.RoundingMode;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 
-import java.math.RoundingMode;
 
 /**
  * A HitResult holds the result of a ray-trace.

--- a/engine/src/main/java/org/terasology/physics/Physics.java
+++ b/engine/src/main/java/org/terasology/physics/Physics.java
@@ -15,10 +15,9 @@
  */
 package org.terasology.physics;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.AABB;
-import org.terasology.math.geom.Vector3f;
-
 import java.util.List;
 import java.util.Set;
 

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletSweepCallback.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletSweepCallback.java
@@ -35,7 +35,7 @@ public class BulletSweepCallback extends CollisionWorld.ClosestConvexResultCallb
     protected final Vector3f up;
     protected float minSlopeDot;
 
-    public BulletSweepCallback(CollisionObject me, org.terasology.math.geom.Vector3f up, float minSlopeDot) {
+    public BulletSweepCallback(CollisionObject me, org.joml.Vector3f up, float minSlopeDot) {
         super(new Vector3f(), new Vector3f());
         this.me = me;
         this.up = new Vector3f(up.x, up.y, up.z);

--- a/engine/src/main/java/org/terasology/physics/bullet/EntityMotionState.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/EntityMotionState.java
@@ -20,6 +20,7 @@ import com.bulletphysics.linearmath.MotionState;
 import com.bulletphysics.linearmath.Transform;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.VecMath;
 
 /**
@@ -46,7 +47,7 @@ public class EntityMotionState extends MotionState {
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         if (loc != null&& !Float.isNaN(loc.getWorldPosition().x)) {
             // NOTE: JBullet ignores scale anyway
-            transform.set(new javax.vecmath.Matrix4f(VecMath.to(loc.getWorldRotation()), VecMath.to(loc.getWorldPosition()), 1));
+            transform.set(new javax.vecmath.Matrix4f(VecMath.to(JomlUtil.from(loc.getWorldRotation())), VecMath.to(JomlUtil.from(loc.getWorldPosition())), 1));
         }
         return transform;
     }
@@ -55,8 +56,8 @@ public class EntityMotionState extends MotionState {
     public void setWorldTransform(Transform transform) {
         LocationComponent loc = entity.getComponent(LocationComponent.class);
         if (loc != null&& !Float.isNaN(loc.getWorldPosition().x)) {
-            loc.setWorldPosition(VecMath.from(transform.origin));
-            loc.setWorldRotation(VecMath.from(transform.getRotation(new javax.vecmath.Quat4f())));
+            loc.setWorldPosition(JomlUtil.from(VecMath.from(transform.origin)));
+            loc.setWorldRotation(JomlUtil.from(VecMath.from(transform.getRotation(new javax.vecmath.Quat4f()))));
         }
     }
 

--- a/engine/src/main/java/org/terasology/physics/bullet/PhysicsLiquidWrapper.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/PhysicsLiquidWrapper.java
@@ -15,13 +15,14 @@
  */
 package org.terasology.physics.bullet;
 
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.terasology.math.JomlUtil;
 import org.terasology.physics.bullet.shapes.BulletCollisionShape;
 import org.terasology.physics.shapes.CollisionShape;
 import com.bulletphysics.collision.shapes.voxel.VoxelInfo;
 import com.bulletphysics.collision.shapes.voxel.VoxelPhysicsWorld;
 import org.terasology.math.VecMath;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 
@@ -54,7 +55,7 @@ public class PhysicsLiquidWrapper implements VoxelPhysicsWorld {
 
          LiquidVoxelInfo(Block block, Vector3i position) {
             this.shape = block.getCollisionShape();
-            this.offset = block.getCollisionOffset();
+            this.offset = JomlUtil.from(block.getCollisionOffset());
             this.colliding = block.isLiquid();
             this.blocking = false;
             this.position = position;

--- a/engine/src/main/java/org/terasology/physics/bullet/PhysicsWorldWrapper.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/PhysicsWorldWrapper.java
@@ -16,13 +16,14 @@
 
 package org.terasology.physics.bullet;
 
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.terasology.math.JomlUtil;
 import org.terasology.physics.bullet.shapes.BulletCollisionShape;
 import org.terasology.physics.shapes.CollisionShape;
 import com.bulletphysics.collision.shapes.voxel.VoxelInfo;
 import com.bulletphysics.collision.shapes.voxel.VoxelPhysicsWorld;
 import org.terasology.math.VecMath;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 
@@ -60,7 +61,7 @@ public class PhysicsWorldWrapper implements VoxelPhysicsWorld {
 
          TeraVoxelInfo(Block block, boolean colliding, boolean blocking, Vector3i position) {
             this.shape = block.getCollisionShape();
-            this.offset = block.getCollisionOffset();
+            this.offset = JomlUtil.from(block.getCollisionOffset());
             this.colliding = shape != null && colliding;
             this.blocking = shape != null && blocking;
             this.position = position;

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletBoxShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletBoxShape.java
@@ -16,15 +16,16 @@
 package org.terasology.physics.bullet.shapes;
 
 import com.bulletphysics.collision.shapes.BoxShape;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
 import org.terasology.math.VecMath;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.physics.shapes.CollisionShape;
 
 public class BulletBoxShape extends BulletCollisionShape implements org.terasology.physics.shapes.BoxShape {
     private final BoxShape boxShape;
 
-    public BulletBoxShape(Vector3f halfExtents) {
+    public BulletBoxShape(Vector3fc halfExtents) {
         this(VecMath.to(halfExtents));
     }
 
@@ -34,7 +35,7 @@ public class BulletBoxShape extends BulletCollisionShape implements org.terasolo
     }
 
     @Override
-    public CollisionShape rotate(Quat4f rot) {
+    public CollisionShape rotate(Quaternionf rot) {
         javax.vecmath.Vector3f halfExtentsWithMargin =
                 boxShape.getHalfExtentsWithMargin(new javax.vecmath.Vector3f());
         com.bulletphysics.linearmath.QuaternionUtil.quatRotate(VecMath.to(rot), halfExtentsWithMargin, halfExtentsWithMargin);
@@ -45,6 +46,6 @@ public class BulletBoxShape extends BulletCollisionShape implements org.terasolo
     @Override
     public Vector3f getExtents() {
         javax.vecmath.Vector3f out = new javax.vecmath.Vector3f();
-        return VecMath.from(boxShape.getHalfExtentsWithoutMargin(out)).scale(2);
+        return VecMath.from(boxShape.getHalfExtentsWithoutMargin(out)).mul(2);
     }
 }

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletCollisionShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletCollisionShape.java
@@ -19,6 +19,7 @@ package org.terasology.physics.bullet.shapes;
 import com.bulletphysics.collision.shapes.CollisionShape;
 import com.bulletphysics.linearmath.Transform;
 import org.terasology.math.AABB;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.VecMath;
 
 public abstract class BulletCollisionShape implements org.terasology.physics.shapes.CollisionShape {
@@ -32,13 +33,13 @@ public abstract class BulletCollisionShape implements org.terasology.physics.sha
         javax.vecmath.Vector3f max = new javax.vecmath.Vector3f();
         underlyingShape.getAabb(t, min, max);
 
-        return AABB.createMinMax(VecMath.from(min), VecMath.from(max));
+        return AABB.createMinMax(JomlUtil.from(VecMath.from(min)), JomlUtil.from(VecMath.from(max)));
     }
 
     protected static Transform toBulletTransform(org.terasology.math.Transform transform) {
         return new Transform(
-                new javax.vecmath.Matrix4f(VecMath.to(transform.rotation),
-                        VecMath.to(transform.origin), transform.scale)
+                new javax.vecmath.Matrix4f(VecMath.to(JomlUtil.from(transform.rotation)),
+                        VecMath.to(JomlUtil.from(transform.origin)), transform.scale)
         );
     }
 }

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletCollisionShapeFactory.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletCollisionShapeFactory.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.physics.bullet.shapes;
 
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 import org.terasology.physics.shapes.BoxShape;
 import org.terasology.physics.shapes.CollisionShapeFactory;
 import org.terasology.physics.shapes.CompoundShape;

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletCompoundShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletCompoundShape.java
@@ -19,9 +19,10 @@ package org.terasology.physics.bullet.shapes;
 import com.bulletphysics.collision.shapes.CompoundShape;
 import com.bulletphysics.collision.shapes.CompoundShapeChild;
 import com.bulletphysics.linearmath.Transform;
+import org.joml.Quaternionf;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.VecMath;
-import org.terasology.math.geom.Quat4f;
 import org.terasology.physics.shapes.CollisionShape;
 
 import java.util.ArrayList;
@@ -55,12 +56,12 @@ public class BulletCompoundShape extends BulletCollisionShape implements org.ter
     // TODO: Add removeChildShape if needed
 
     @Override
-    public CollisionShape rotate(Quat4f rot) {
+    public CollisionShape rotate(Quaternionf rot) {
         CompoundShape newShape = new CompoundShape();
         for (BulletCompoundShapeChild child : childList) {
             CollisionShape rotatedChild = child.childShape.rotate(rot);
             javax.vecmath.Vector3f offset = com.bulletphysics.linearmath.QuaternionUtil.quatRotate(VecMath.to(rot), child.transform.origin, new javax.vecmath.Vector3f());
-            newShape.addChildShape(new Transform(new javax.vecmath.Matrix4f(VecMath.to(Rotation.none().getQuat4f()), offset, 1.0f)), ((BulletCollisionShape) rotatedChild).underlyingShape);
+            newShape.addChildShape(new Transform(new javax.vecmath.Matrix4f(VecMath.to(JomlUtil.from(Rotation.none().getQuat4f())), offset, 1.0f)), ((BulletCollisionShape) rotatedChild).underlyingShape);
         }
         return new BulletCompoundShape(newShape);
     }

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletConvexHullShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletConvexHullShape.java
@@ -17,11 +17,9 @@ package org.terasology.physics.bullet.shapes;
 
 import com.bulletphysics.collision.shapes.ConvexHullShape;
 import com.bulletphysics.util.ObjectArrayList;
-import org.terasology.math.AABB;
-import org.terasology.math.Transform;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.terasology.math.VecMath;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.physics.shapes.CollisionShape;
 
 import java.util.List;
@@ -46,7 +44,7 @@ public class BulletConvexHullShape extends BulletCollisionShape implements org.t
     }
 
     @Override
-    public CollisionShape rotate(Quat4f rot) {
+    public CollisionShape rotate(Quaternionf rot) {
         ObjectArrayList<javax.vecmath.Vector3f> transformedVerts = new ObjectArrayList<>();
         for (javax.vecmath.Vector3f vert : convexHullShape.getPoints()) {
             transformedVerts.add(com.bulletphysics.linearmath.QuaternionUtil.quatRotate(VecMath.to(rot), vert, new javax.vecmath.Vector3f()));

--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletSphereShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletSphereShape.java
@@ -16,7 +16,7 @@
 package org.terasology.physics.bullet.shapes;
 
 import com.bulletphysics.collision.shapes.SphereShape;
-import org.terasology.math.geom.Quat4f;
+import org.joml.Quaternionf;
 import org.terasology.physics.shapes.CollisionShape;
 
 public class BulletSphereShape extends BulletCollisionShape implements org.terasology.physics.shapes.SphereShape {
@@ -28,7 +28,7 @@ public class BulletSphereShape extends BulletCollisionShape implements org.teras
     }
 
     @Override
-    public CollisionShape rotate(Quat4f rot) {
+    public CollisionShape rotate(Quaternionf rot) {
         return this;
     }
 

--- a/engine/src/main/java/org/terasology/physics/components/RigidBodyComponent.java
+++ b/engine/src/main/java/org/terasology/physics/components/RigidBodyComponent.java
@@ -18,8 +18,8 @@ package org.terasology.physics.components;
 
 import com.google.common.collect.Lists;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.Replicate;
 import org.terasology.physics.CollisionGroup;
 import org.terasology.physics.StandardCollisionGroup;

--- a/engine/src/main/java/org/terasology/physics/components/shapes/BoxShapeComponent.java
+++ b/engine/src/main/java/org/terasology/physics/components/shapes/BoxShapeComponent.java
@@ -16,8 +16,8 @@
 
 package org.terasology.physics.components.shapes;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.Replicate;
 
 /**

--- a/engine/src/main/java/org/terasology/physics/engine/CharacterCollider.java
+++ b/engine/src/main/java/org/terasology/physics/engine/CharacterCollider.java
@@ -16,7 +16,8 @@
 
 package org.terasology.physics.engine;
 
-import org.terasology.math.geom.Vector3f;
+
+import org.joml.Vector3f;
 
 /**
  * A character collider is a non-blocking collider for use calculating character movement.

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsEngine.java
@@ -16,11 +16,10 @@
 
 package org.terasology.physics.engine;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.physics.CollisionGroup;
 import org.terasology.physics.Physics;
-import org.terasology.physics.shapes.CollisionShapeFactory;
 
 import java.util.Iterator;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.physics.engine;
 
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.Time;
@@ -31,8 +33,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.location.LocationResynchEvent;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.math.JomlUtil;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.network.NetworkComponent;
 import org.terasology.network.NetworkSystem;
@@ -146,7 +147,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
 
     @ReceiveEvent(components = {BlockComponent.class})
     public void onBlockAltered(OnChangedBlock event, EntityRef entity) {
-        physics.awakenArea(event.getBlockPosition().toVector3f(), 0.6f);
+        physics.awakenArea(JomlUtil.from(event.getBlockPosition().toVector3f()), 0.6f);
     }
 
     @ReceiveEvent
@@ -195,7 +196,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
                 body.getLinearVelocity(comp.velocity);
                 body.getAngularVelocity(comp.angularVelocity);
 
-                Vector3f vLocation = Vector3f.zero();
+                Vector3f vLocation = new Vector3f();
                 body.getLocation(vLocation);
 
                 Vector3f vDirection = new Vector3f(comp.velocity);
@@ -207,7 +208,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
                 while (true) {
                     HitResult hitInfo = physics.rayTrace(vLocation, vDirection, fDistanceThisFrame + 0.5f, DEFAULT_COLLISION_GROUP);
                     if (hitInfo.isHit()) {
-                        Block hitBlock = worldProvider.getBlock(hitInfo.getBlockPosition());
+                        Block hitBlock = worldProvider.getBlock(JomlUtil.from(hitInfo.getBlockPosition()));
                         if (hitBlock != null) {
                             Vector3f vTravelledDistance = vLocation.sub(hitInfo.getHitPoint());
                             float fTravelledDistance  = vTravelledDistance.length();
@@ -256,7 +257,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
                 short bCollidesWith = getCollidesWithGroupFlag(pair.b);
                 if ((aCollisionGroup & bCollidesWith) != 0
                         || (pair.a.hasComponent(BlockComponent.class) && !pair.b.hasComponent(BlockComponent.class))) {
-                    pair.b.send(new CollideEvent(pair.a, pair.pointB, pair.pointA, pair.distance, new Vector3f(pair.normal).invert()));
+                    pair.b.send(new CollideEvent(pair.a, pair.pointB, pair.pointA, pair.distance, new Vector3f(pair.normal).mul(-1)));
                 }
             }
         }
@@ -300,7 +301,7 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
                 //TODO after implementing rigidbody interface
                 RigidBody body = physics.getRigidBody(entity);
                 if (body.isActive()) {
-                    entity.send(new LocationResynchEvent(body.getLocation(new Vector3f()), body.getOrientation(new Quat4f())));
+                    entity.send(new LocationResynchEvent(body.getLocation(new Vector3f()), body.getOrientation(new Quaternionf())));
                     entity.send(new PhysicsResynchEvent(body.getLinearVelocity(new Vector3f()), body.getAngularVelocity(new Vector3f())));
                 }
             }

--- a/engine/src/main/java/org/terasology/physics/engine/RigidBody.java
+++ b/engine/src/main/java/org/terasology/physics/engine/RigidBody.java
@@ -16,8 +16,9 @@
 
 package org.terasology.physics.engine;
 
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
+
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 
 /**
  * A rigid body is a physics object whose movement and location is controlled by the physics engine. Rigid bodies move under gravity and bounce off each other and the world.
@@ -59,7 +60,7 @@ public interface RigidBody {
      * @param out output parameter to put the orientation in.
      * @return out, for easy of use.
      */
-    Quat4f getOrientation(Quat4f out);
+    Quaternionf getOrientation(Quaternionf out);
 
     /**
      * Returns the non interpolated location of this body. Note that the
@@ -118,7 +119,7 @@ public interface RigidBody {
      *
      * @param orientation the new rotation.
      */
-    void setOrientation(Quat4f orientation);
+    void setOrientation(Quaternionf orientation);
 
     /**
      * Sets the world location or position.
@@ -134,7 +135,7 @@ public interface RigidBody {
      * @param location
      * @param orientation
      */
-    void setTransform(Vector3f location, Quat4f orientation);
+    void setTransform(Vector3f location, Quaternionf orientation);
 
     /**
      * Active means that the entity is not sleeping, or requesting to sleep.

--- a/engine/src/main/java/org/terasology/physics/events/BlockImpactEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/BlockImpactEvent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.math.geom.Vector3f;
 
 public class BlockImpactEvent extends ImpactEvent {
     public BlockImpactEvent(Vector3f impactPoint, Vector3f impactNormal, Vector3f impactSpeed, float travelDistance, EntityRef impactEntity) {

--- a/engine/src/main/java/org/terasology/physics/events/ChangeVelocityEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/ChangeVelocityEvent.java
@@ -16,8 +16,8 @@
 
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.BroadcastEvent;
 
 /**

--- a/engine/src/main/java/org/terasology/physics/events/CollideEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/CollideEvent.java
@@ -16,9 +16,9 @@
 
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
-import org.terasology.math.geom.Vector3f;
 
 /**
  * TODO Make CollideEvent as a server event.

--- a/engine/src/main/java/org/terasology/physics/events/EntityImpactEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/EntityImpactEvent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.math.geom.Vector3f;
 
 public class EntityImpactEvent extends ImpactEvent {
     public EntityImpactEvent(Vector3f impactPoint, Vector3f impactNormal, Vector3f impactSpeed, float travelDistance, EntityRef impactEntity) {

--- a/engine/src/main/java/org/terasology/physics/events/ForceEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/ForceEvent.java
@@ -16,8 +16,8 @@
 
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.BroadcastEvent;
 
 /**

--- a/engine/src/main/java/org/terasology/physics/events/ImpactEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/ImpactEvent.java
@@ -16,7 +16,8 @@
 
 package org.terasology.physics.events;
 
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
+import org.terasology.math.JomlUtil;
 import org.terasology.network.BroadcastEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
@@ -67,6 +68,6 @@ public class ImpactEvent extends AbstractConsumableEvent {
     }
 
     public Side getSide() {
-        return Side.inDirection(impactNormal);
+        return Side.inDirection(JomlUtil.from(impactNormal));
     }
 }

--- a/engine/src/main/java/org/terasology/physics/events/ImpulseEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/ImpulseEvent.java
@@ -16,8 +16,8 @@
 
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.BroadcastEvent;
 
 /**

--- a/engine/src/main/java/org/terasology/physics/events/PhysicsResynchEvent.java
+++ b/engine/src/main/java/org/terasology/physics/events/PhysicsResynchEvent.java
@@ -16,8 +16,8 @@
 
 package org.terasology.physics.events;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.BroadcastEvent;
 
 /**

--- a/engine/src/main/java/org/terasology/physics/shapes/BoxShape.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/BoxShape.java
@@ -15,7 +15,8 @@
  */
 package org.terasology.physics.shapes;
 
-import org.terasology.math.geom.Vector3f;
+
+import org.joml.Vector3f;
 
 /**
  * Represents a box collision shape in the physics engine.

--- a/engine/src/main/java/org/terasology/physics/shapes/CollisionShape.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/CollisionShape.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.physics.shapes;
 
+import org.joml.Quaternionf;
 import org.terasology.math.AABB;
 import org.terasology.math.Transform;
-import org.terasology.math.geom.Quat4f;
 
 /**
  * The base type representing a collision shape in the physics engine.
@@ -37,5 +37,5 @@ public interface CollisionShape {
      * @param rot The quaternion representation of the rotation.
      * @return The rotated shape.
      */
-    CollisionShape rotate(Quat4f rot);
+    CollisionShape rotate(Quaternionf rot);
 }

--- a/engine/src/main/java/org/terasology/physics/shapes/CollisionShapeFactory.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/CollisionShapeFactory.java
@@ -15,8 +15,7 @@
  */
 package org.terasology.physics.shapes;
 
-import org.terasology.math.geom.Vector3f;
-
+import org.joml.Vector3f;
 import java.util.List;
 
 /**
@@ -45,7 +44,7 @@ public interface CollisionShapeFactory {
      * @return The created unit cube box shape.
      */
     default BoxShape getNewUnitCube() {
-        return getNewBox(Vector3f.one());
+        return getNewBox(new Vector3f(1,1,1));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/physics/shapes/ConvexHullShape.java
+++ b/engine/src/main/java/org/terasology/physics/shapes/ConvexHullShape.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.physics.shapes;
 
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 
 /**
  * Represents a convex hull collision shape in the physics engine.

--- a/engine/src/main/java/org/terasology/world/block/BlockUri.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockUri.java
@@ -162,6 +162,10 @@ public class BlockUri implements Uri, Comparable<BlockUri> {
         return builder.toString();
     }
 
+    public Name name() {
+        return new Name(toString());
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -29,6 +29,7 @@ import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.inventory.events.DropItemEvent;
 import org.terasology.logic.inventory.events.GiveItemEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.events.ImpulseEvent;
 import org.terasology.registry.In;
@@ -135,7 +136,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
                 if (blockDamageModifierComponent != null) {
                     impulsePower = blockDamageModifierComponent.impulsePower;
                 }
-                
+
                 processDropping(item, location, impulsePower);
             }
         }
@@ -182,7 +183,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
 
     private void processDropping(EntityRef item, Vector3i location, float impulsePower) {
         item.send(new DropItemEvent(location.toVector3f()));
-        item.send(new ImpulseEvent(random.nextVector3f(impulsePower)));
+        item.send(new ImpulseEvent(JomlUtil.from(random.nextVector3f(impulsePower))));
     }
 
 }

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.shapes;
 
+import org.terasology.math.JomlUtil;
 import org.terasology.physics.shapes.CollisionShape;
 import com.google.common.collect.Maps;
 import org.terasology.assets.AssetType;
@@ -90,7 +91,7 @@ public class BlockShapeImpl extends BlockShape {
         Rotation simplifiedRot = applySymmetry(rot);
         CollisionShape result = collisionShape.get(simplifiedRot);
         if (result == null && baseCollisionShape != null) {
-            result = baseCollisionShape.rotate(simplifiedRot.getQuat4f());
+            result = baseCollisionShape.rotate(JomlUtil.from(simplifiedRot.getQuat4f()));
             collisionShape.put(simplifiedRot, result);
         }
         return result;

--- a/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
@@ -32,6 +32,7 @@ import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Transform;
 import org.terasology.math.geom.Vector2f;
@@ -49,6 +50,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static org.terasology.physics.engine.PhysicsEngineManager.COLLISION_SHAPE_FACTORY;
 
@@ -148,7 +150,7 @@ public class JsonBlockShapeLoader extends AbstractAssetFileFormat<BlockShapeData
             if (collisionInfo.has(CONVEX_HULL) && collisionInfo.get(CONVEX_HULL).isJsonPrimitive()
                     && collisionInfo.get(CONVEX_HULL).getAsJsonPrimitive().isBoolean()) {
                 List<Vector3f> verts = buildVertList(shape);
-                ConvexHullShape convexHull = COLLISION_SHAPE_FACTORY.getNewConvexHull(verts);
+                ConvexHullShape convexHull = COLLISION_SHAPE_FACTORY.getNewConvexHull(verts.stream().map(JomlUtil::from).collect(Collectors.toList()));
                 shape.setCollisionShape(convexHull);
             } else if (collisionInfo.has(COLLIDERS) && collisionInfo.get(COLLIDERS).isJsonArray()
                     && collisionInfo.get(COLLIDERS).getAsJsonArray().size() > 0) {
@@ -224,7 +226,7 @@ public class JsonBlockShapeLoader extends AbstractAssetFileFormat<BlockShapeData
             }
             extent.absolute();
 
-            return new ColliderInfo(offset, COLLISION_SHAPE_FACTORY.getNewBox(extent));
+            return new ColliderInfo(offset, COLLISION_SHAPE_FACTORY.getNewBox(JomlUtil.from(extent)));
         }
 
         private ColliderInfo processSphereShape(JsonDeserializationContext context, JsonObject colliderDef) {

--- a/modules/Core/src/main/java/org/terasology/core/logic/blockDropGrammar/BlockDropGrammarSystem.java
+++ b/modules/Core/src/main/java/org/terasology/core/logic/blockDropGrammar/BlockDropGrammarSystem.java
@@ -27,6 +27,7 @@ import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.inventory.events.DropItemEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.physics.events.ImpulseEvent;
 import org.terasology.registry.In;
@@ -151,7 +152,7 @@ public class BlockDropGrammarSystem extends BaseComponentSystem {
     private void createDrop(EntityRef item, Vector3f location, boolean applyMovement) {
         item.send(new DropItemEvent(location));
         if (applyMovement) {
-            item.send(new ImpulseEvent(random.nextVector3f(30.0f)));
+            item.send(new ImpulseEvent(JomlUtil.from(random.nextVector3f(30.0f))));
         }
     }
 

--- a/modules/Core/src/main/java/org/terasology/logic/actions/ArrowAction.java
+++ b/modules/Core/src/main/java/org/terasology/logic/actions/ArrowAction.java
@@ -26,6 +26,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.CollisionGroup;
@@ -76,7 +77,7 @@ public class ArrowAction extends BaseComponentSystem {
             Vector3f dir = new Vector3f(event.getDirection());
 
             HitResult result;
-            result = physicsRenderer.rayTrace(position, dir, arrowActionComponent.maxDistance, filter);
+            result = physicsRenderer.rayTrace(JomlUtil.from(position), JomlUtil.from(dir), arrowActionComponent.maxDistance, filter);
 
             Block currentBlock = worldProvider.getBlock(blockPos);
 


### PR DESCRIPTION
This is a conversion of bullet over to JOML with just the main classes and events/components that are associated with bullet. I'll have a couple other pull request in a couple other modules that should resolve some of these problems. 

The basic use case to test this is just throwing a torch or some kind of physics objects and ensuring the behavior is still correct. some physics heavily modules such as carts should also help with this conversion. 

- https://github.com/Terasology/Inventory/pull/6
- https://github.com/Terasology/Sensors/pull/5
- https://github.com/Terasology/SimpleFarming/pull/90
- https://github.com/Terasology/Rails/pull/51
- https://github.com/Terasology/Projectile/pull/7
- https://github.com/Terasology/ModularComputers/pull/5
- https://github.com/Terasology/ItemPipes/pull/13
- https://github.com/Terasology/IRLCorp/pull/21
- https://github.com/Terasology/CombatSystem/pull/47
- https://github.com/Terasology/WoodAndStone/pull/53
- https://github.com/Terasology/Alchemy/pull/9
- https://github.com/Terasology/AdvancedRails/pull/5
- https://github.com/Terasology/AdditionalRails/pull/36

There are some compatibility problems with gookeeper that will need to be fixed: https://github.com/Terasology/GooKeeper