### PR TITLE
Added a double-click listener in UIText - see #3884

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/widgets/UIText.java
@@ -45,6 +45,7 @@ import org.terasology.rendering.nui.events.NUIKeyEvent;
 import org.terasology.rendering.nui.events.NUIMouseClickEvent;
 import org.terasology.rendering.nui.events.NUIMouseDragEvent;
 import org.terasology.rendering.nui.events.NUIMouseReleaseEvent;
+import org.terasology.rendering.nui.events.NUIMouseDoubleClickEvent;
 import org.terasology.utilities.Assets;
 
 import java.awt.Toolkit;
@@ -148,6 +149,23 @@ public class UIText extends WidgetWithOrder {
             if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
                 dragging = false;
             }
+        }
+
+        /**
+         * Defines what to do when the user double-clicks a mouse button while pointing at the widget. More specifically,
+         * it selects all the text, if there is any.
+         *
+         * @param event The event corresponding to the mouse double-click
+         * @return      Whether a left mouse double-click was successfully detected and handled
+         */
+        @Override
+        public boolean onMouseDoubleClick(NUIMouseDoubleClickEvent event) {
+            if (!getText().isEmpty() && event.getMouseButton() == MouseInput.MOUSE_LEFT){
+                setCursorPosition(getText().length());
+                selectionStart = 0;
+                return true;
+            }
+            return false;
         }
     };
 


### PR DESCRIPTION
Hi there! First pull request on a very easy "good first issue"! :smile: 

### Contains

Fixes #3884 : allows the user to select all the text inside a `UIText` by double-clicking on it (adds a `NUIMouseDoubleClickEvent` listener).

### How to test

Find any `UIText`, write some text in it and double-click on it.
