### PR TITLE
Comment out a bit more VR stuff to avoid a native resolution issue in module standalone workspaces

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
@@ -15,21 +15,18 @@
  */
 package org.terasology.logic.players;
 
-import jopenvr.VRControllerState_t;
 import org.joml.Matrix4f;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.Owns;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.rendering.openvrprovider.ControllerListener;
 import org.terasology.math.geom.Quat4f;
-import org.terasology.rendering.openvrprovider.OpenVRProvider;
 
 /**
  * Only used by the client side so that held items can be positioned in line with the camera
  */
-public class FirstPersonHeldItemMountPointComponent implements Component, ControllerListener {
+public class FirstPersonHeldItemMountPointComponent implements Component {
 
     @Owns
     public EntityRef mountPointEntity = EntityRef.NULL;
@@ -57,18 +54,6 @@ public class FirstPersonHeldItemMountPointComponent implements Component, Contro
      */
     public boolean isTracked() {
         return trackingDataReceived;
-    }
-    
-    /**
-     * A callback target for the controller listener. This callback triggers when a button is pressed on the controllers.
-     * It's currently ignored by this class. This method and the below method are both designed to be called in their
-     * roles as listeners, and not really part of the public interface of this class.
-     * @param stateBefore - the state before the state change.
-     * @param stateAfter - the state after the state change.
-     * @param nController - the hand index, 0 for left and 1 for right.
-     */
-    public void buttonStateChanged(VRControllerState_t stateBefore, VRControllerState_t stateAfter, int nController) {
-        // nothing for now
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
@@ -63,6 +63,7 @@ public class FirstPersonHeldItemMountPointComponent implements Component {
      * @param pose - the controller pose - a homogenous transformation matrix.
      * @param handIndex - the hand index - 0 for left and 1 for right.
      */
+    /* commented out due to a natives issue and VR not working at the moment anyway
     public void poseChanged(Matrix4f pose, int handIndex) {
         // do nothing for the second controller
         // TODO: put a hand for the second controller.
@@ -79,4 +80,5 @@ public class FirstPersonHeldItemMountPointComponent implements Component {
             rotationQuaternion.set(jomlQuaternion.x, jomlQuaternion.y, jomlQuaternion.z, jomlQuaternion.w);
         }
     }
+    */
 }

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
@@ -63,7 +63,8 @@ public class FirstPersonHeldItemMountPointComponent implements Component {
      * @param pose - the controller pose - a homogenous transformation matrix.
      * @param handIndex - the hand index - 0 for left and 1 for right.
      */
-    /* commented out due to a natives issue and VR not working at the moment anyway
+    //TODO: commented out due to a natives issue and VR not working at the moment anyway
+    /*
     public void poseChanged(Matrix4f pose, int handIndex) {
         // do nothing for the second controller
         // TODO: put a hand for the second controller.


### PR DESCRIPTION
The way we build modules standalone has tended to have a fair share of quirks since the Gradle from this engine workspace gets reused in clever/evil/dumb ways. But long story short one such quirk goes away with this PR, even if it is only a workaround for #3415. Really #2611 and making VR work again should be the proper fix, which would improve handling the OpenVR natives files and so on.

In the meantime this gets us one step closer to better _advanced_ tests in module jobs in Jenkins or anywhere else other than a full engine workspace + modules. Normal unit tests are fine, but those requiring a running game environment tend to be more tricky.

See https://github.com/Terasology/ModuleTestingEnvironment/issues/12 for the next problem I've encountered. 

Testing this is problematic, really can only test in a local workspace that the game acts normally. To test it more properly need to try a standalone module workspace which that MTE issue can explain, but even so that relies on a binary version of the engine. As of this writing the most recent one from Nanoware/Terasology will correctly show what this PR changes, while the most recent one from MovingBlocks/Terasology will show the old issue.