### PR TITLE
JOML method replacements for (WorldProvider, BlockEntityRegistry)

### DIFF
--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -16,6 +16,7 @@
 package org.terasology;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
 import org.terasology.math.Region3i;
@@ -90,6 +91,11 @@ public class MapWorldProvider implements WorldProviderCore {
     }
 
     @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        return null;
+    }
+
+    @Override
     public Block getBlock(int x, int y, int z) {
         Vector3i pos = new Vector3i(x, y, z);
         Block block = blocks.get(pos);
@@ -133,7 +139,17 @@ public class MapWorldProvider implements WorldProviderCore {
     }
 
     @Override
+    public ChunkViewCore getLocalView(Vector3ic chunkPos) {
+        return null;
+    }
+
+    @Override
     public ChunkViewCore getWorldViewAround(Vector3i chunk) {
+        return null;
+    }
+
+    @Override
+    public ChunkViewCore getWorldViewAround(Vector3ic chunk) {
         return null;
     }
 
@@ -151,12 +167,17 @@ public class MapWorldProvider implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return 0;
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         return 0;
     }
-    
+
+    @Override
+    public int setExtraData(int index, Vector3ic pos, int value) {
+        return 0;
+    }
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return 0;

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -17,6 +17,7 @@
 package org.terasology.testUtil;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -86,8 +87,18 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     }
 
     @Override
+    public ChunkViewCore getLocalView(Vector3ic chunkPos) {
+        return null;
+    }
+
+    @Override
     public ChunkViewCore getWorldViewAround(Vector3i chunk) {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public ChunkViewCore getWorldViewAround(Vector3ic chunk) {
+        return null;
     }
 
     @Override
@@ -107,6 +118,11 @@ public class WorldProviderCoreStub implements WorldProviderCore {
             return air;
         }
         return old;
+    }
+
+    @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        return null;
     }
 
     @Override
@@ -142,18 +158,23 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return 0;  //To change body of implemented methods use File | Settings | File Templates.
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         Integer prevValue = getExtraDataLayer(index).put(pos, value);
         return prevValue == null ? 0 : prevValue;
     }
-    
+
+    @Override
+    public int setExtraData(int index, Vector3ic pos, int value) {
+        return 0;
+    }
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return getExtraDataLayer(index).getOrDefault(new Vector3i(x, y, z), 0);
     }
-    
+
     private Map<Vector3i, Integer> getExtraDataLayer(int index) {
         while (extraData.size() <= index) {
             extraData.add(Maps.newHashMap());

--- a/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
+++ b/engine/src/main/java/org/terasology/world/BlockEntityRegistry.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.world;
 
+import org.joml.Vector3fc;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.geom.Vector3f;
@@ -45,8 +47,30 @@ public interface BlockEntityRegistry {
      *
      * @param blockPosition
      * @return The block entity for the location if it exists, or the null entity
+     * @deprecated
      */
     EntityRef getExistingBlockEntityAt(Vector3i blockPosition);
+
+    /**
+     * This method returns the block entity at the given location, but will not produce a temporary entity if
+     * one isn't currently in memory.
+     *
+     * @param blockPosition
+     * @return The block entity for the location if it exists, or the null entity
+     */
+    EntityRef getExistingBlockEntityAt(Vector3ic blockPosition);
+
+
+    /**
+     * This method is the same as setBlock, except if the old and new block types are part of the same family the
+     * entity will be force updated (usually they are not in this situation).
+     *
+     * @param position
+     * @param type
+     * @return The previous block type, or null if the change failed due to the chunk not being available
+     * @deprecated
+     */
+    Block setBlockForceUpdateEntity(Vector3i position, Block type);
 
     /**
      * This method is the same as setBlock, except if the old and new block types are part of the same family the
@@ -56,7 +80,19 @@ public interface BlockEntityRegistry {
      * @param type
      * @return The previous block type, or null if the change failed due to the chunk not being available
      */
-    Block setBlockForceUpdateEntity(Vector3i position, Block type);
+    Block setBlockForceUpdateEntity(Vector3ic position, Block type);
+
+
+    /**
+     * This method is the same as setBlock, except the specified components are not altered during the update
+     *
+     * @param position
+     * @param type
+     * @param components
+     * @return The previous block type, or null if the change failed due to the chunk not being available
+     * @deprecated
+     */
+    Block setBlockRetainComponent(Vector3i position, Block type, Class<? extends Component>... components);
 
     /**
      * This method is the same as setBlock, except the specified components are not altered during the update
@@ -66,35 +102,75 @@ public interface BlockEntityRegistry {
      * @param components
      * @return The previous block type, or null if the change failed due to the chunk not being available
      */
-    Block setBlockRetainComponent(Vector3i position, Block type, Class<? extends Component>... components);
+    Block setBlockRetainComponent(Vector3ic position, Block type, Class<? extends Component>... components);
+
+
+    /**
+     * @param position
+     * @return The block entity for the location, creating it if it doesn't exist
+     * @deprecated
+     */
+    EntityRef getBlockEntityAt(Vector3f position);
 
     /**
      * @param position
      * @return The block entity for the location, creating it if it doesn't exist
      */
-    EntityRef getBlockEntityAt(Vector3f position);
+    EntityRef getBlockEntityAt(Vector3fc position);
+
 
     /**
      * @param blockPosition
      * @return The block entity for the location, creating it if it doesn't exist
+     * @deprecated
      */
     EntityRef getBlockEntityAt(Vector3i blockPosition);
 
     /**
      * @param blockPosition
+     * @return The block entity for the location, creating it if it doesn't exist
+     */
+    EntityRef getBlockEntityAt(Vector3ic blockPosition);
+
+
+    /**
+     * @param blockPosition
      * @return The block controller entity for this location, or block entity if it exists.
+     * @deprecated
      */
     EntityRef getExistingEntityAt(Vector3i blockPosition);
 
     /**
      * @param blockPosition
+     * @return The block controller entity for this location, or block entity if it exists.
+     */
+    EntityRef getExistingEntityAt(Vector3ic blockPosition);
+
+
+    /**
+     * @param blockPosition
      * @return The block controller entity for this location, or block entity.
+     * @deprecated
      */
     EntityRef getEntityAt(Vector3i blockPosition);
+
+    /**
+     * @param blockPosition
+     * @return The block controller entity for this location, or block entity.
+     */
+    EntityRef getEntityAt(Vector3ic blockPosition);
+
+
+    /**
+     * @param blockPos
+     * @return Whether the entity at this position is permanent
+     * @deprecated
+     */
+    boolean hasPermanentBlockEntity(Vector3i blockPos);
 
     /**
      * @param blockPos
      * @return Whether the entity at this position is permanent
      */
-    boolean hasPermanentBlockEntity(Vector3i blockPos);
+    boolean hasPermanentBlockEntity(Vector3ic blockPos);
 }

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -15,10 +15,13 @@
  */
 package org.terasology.world;
 
+import org.joml.Vector3fc;
+import org.joml.Vector3ic;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.internal.WorldProviderCore;
+
 
 /**
  * Provides the basic interface for all world providers.
@@ -29,18 +32,41 @@ public interface WorldProvider extends WorldProviderCore {
     /**
      * An active block is in a chunk that is available and fully generated.
      *
-     * @param pos
+     * @param pos position of block in the world
      * @return Whether the given block is active
+     * @deprecated
      */
     boolean isBlockRelevant(Vector3i pos);
 
+    /**
+     * An active block is in a chunk that is available and fully generated.
+     *
+     * @param pos position of block in the world
+     * @return Whether the given block is active
+     */
+    boolean isBlockRelevant(Vector3ic pos);
+
+    /**
+     * An active block is in a chunk that is available and fully generated.
+     * @param pos position of block in the world rounded {@link java.math.RoundingMode.HALF_UP}
+     * @return Whether the given block is active
+     * @deprecated
+     */
     boolean isBlockRelevant(Vector3f pos);
+
+    /**
+     * An active block is in a chunk that is available and fully generated.
+     * @param pos position of block in world rounded {@link org.joml.RoundingMode.HALF_UP}
+     * @return Whether the given block is active
+     */
+    boolean isBlockRelevant(Vector3fc pos);
 
     /**
      * Returns the block value at the given position.
      *
      * @param pos The position
      * @return The block value at the given position
+     * @deprecated
      */
     Block getBlock(Vector3f pos);
 
@@ -50,15 +76,52 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos The position
      * @return The block value at the given position
      */
+    Block getBlock(Vector3fc pos);
+
+    /**
+     * Returns the block value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     * @deprecated
+     */
     Block getBlock(Vector3i pos);
+
+    /**
+     * Returns the block value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     */
+    Block getBlock(Vector3ic pos);
+
 
     /**
      * Returns the light value at the given position.
      *
      * @param pos The position
      * @return The block value at the given position
+     * @deprecated
      */
     byte getLight(Vector3f pos);
+
+    /**
+     * Returns the light value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     *
+     */
+    byte getLight(Vector3fc pos);
+
+    /**
+     * Returns the sunlight value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     * @deprecated
+     */
+    byte getSunlight(Vector3f pos);
 
     /**
      * Returns the sunlight value at the given position.
@@ -66,9 +129,16 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos The position
      * @return The block value at the given position
      */
-    byte getSunlight(Vector3f pos);
+    byte getSunlight(Vector3fc pos);
 
-    byte getTotalLight(Vector3f pos);
+    /**
+     * Returns the light value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     * @deprecated
+     */
+    byte getLight(Vector3i pos);
 
     /**
      * Returns the light value at the given position.
@@ -76,7 +146,8 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos The position
      * @return The block value at the given position
      */
-    byte getLight(Vector3i pos);
+    byte getLight(Vector3ic pos);
+
 
     /**
      * Returns the sunlight value at the given position.
@@ -86,8 +157,48 @@ public interface WorldProvider extends WorldProviderCore {
      */
     byte getSunlight(Vector3i pos);
 
+    /**
+     * Returns the sunlight value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     * @deprecated
+     */
+    byte getSunlight(Vector3ic pos);
+
+    /**
+     * @deprecated
+     * @param pos
+     * @return
+     */
     byte getTotalLight(Vector3i pos);
-    
+
+    byte getTotalLight(Vector3ic pos);
+
+    /**
+     * @deprecated
+     * @param pos
+     * @return
+     */
+    byte getTotalLight(Vector3f pos);
+
+    /**
+     *
+     * @param pos
+     * @return
+     */
+    byte getTotalLight(Vector3fc pos);
+
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param index The index of the extra data field
+     * @param pos
+     * @return The (index)th extra-data value at the given position
+     * @deprecated
+     */
+    int getExtraData(int index, Vector3i pos);
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -95,8 +206,8 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos
      * @return The (index)th extra-data value at the given position
      */
-    int getExtraData(int index, Vector3i pos);
-    
+    int getExtraData(int index, Vector3ic pos);
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -108,7 +219,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The replaced value
      */
     int setExtraData(int index, int x, int y, int z, int value);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -119,7 +230,17 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The named extra-data value at the given position
      */
     int getExtraData(String fieldName, int x, int y, int z);
-    
+
+    /**
+     * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
+     *
+     * @param fieldName The name of the extra-data field
+     * @param pos
+     * @return The named extra-data value at the given position
+     * @deprecated
+     */
+    int getExtraData(String fieldName, Vector3i pos);
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -127,8 +248,8 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos
      * @return The named extra-data value at the given position
      */
-    int getExtraData(String fieldName, Vector3i pos);
-    
+    int getExtraData(String fieldName, Vector3ic pos);
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -140,7 +261,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The replaced value
      */
     int setExtraData(String fieldName, int x, int y, int z, int value);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -148,6 +269,18 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos
      * @param value
      * @return The replaced value
+     * @deprecated
      */
     int setExtraData(String fieldName, Vector3i pos, int value);
+
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param fieldName The name of the extra-data field
+     * @param pos
+     * @param value
+     * @return The replaced value
+     *
+     */
+    int setExtraData(String fieldName, Vector3ic pos, int value);
 }

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -16,6 +16,7 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -77,8 +78,18 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     }
 
     @Override
+    public ChunkViewCore getLocalView(Vector3ic chunkPos) {
+        return base.getLocalView(chunkPos);
+    }
+
+    @Override
     public ChunkViewCore getWorldViewAround(Vector3i chunk) {
         return base.getWorldViewAround(chunk);
+    }
+
+    @Override
+    public ChunkViewCore getWorldViewAround(Vector3ic chunk) {
+        return null;
     }
 
     @Override
@@ -94,6 +105,11 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     @Override
     public Block setBlock(Vector3i pos, Block type) {
         return base.setBlock(pos, type);
+    }
+
+    @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        return null;
     }
 
     @Override
@@ -120,15 +136,20 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return base.getTotalLight(x, y, z);
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return base.getExtraData(index, x, y, z);
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         return base.setExtraData(index, pos, value);
+    }
+
+    @Override
+    public int setExtraData(int index, Vector3ic pos, int value) {
+        return 0;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -16,6 +16,7 @@
 package org.terasology.world.internal;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -72,14 +73,29 @@ public interface WorldProviderCore {
     /**
      * @param chunkPos
      * @return A world view centered on the desired chunk, with the surrounding chunks present.
+     * @deprecated
      */
     ChunkViewCore getLocalView(Vector3i chunkPos);
+
+    /**
+     * @param chunkPos
+     * @return A world view centered on the desired chunk, with the surrounding chunks present.
+     */
+    ChunkViewCore getLocalView(Vector3ic chunkPos);
+
+    /**
+     * @param chunk
+     * @return A world view of the chunks around the desired chunk, uncentered.
+     * @deprecated
+     */
+    ChunkViewCore getWorldViewAround(Vector3i chunk);
 
     /**
      * @param chunk
      * @return A world view of the chunks around the desired chunk, uncentered.
      */
-    ChunkViewCore getWorldViewAround(Vector3i chunk);
+    ChunkViewCore getWorldViewAround(Vector3ic chunk);
+
 
 
     /**
@@ -100,8 +116,18 @@ public interface WorldProviderCore {
      * @param pos  The world position to change
      * @param type The type of the block to set
      * @return The previous block type. Null if the change failed (because the necessary chunk was not loaded)
+     * @deprecated
      */
     Block setBlock(Vector3i pos, Block type);
+
+    /**
+     * Places a block of a specific type at a given position
+     *
+     * @param pos  The world position to change
+     * @param type The type of the block to set
+     * @return The previous block type. Null if the change failed (because the necessary chunk was not loaded)
+     */
+    Block setBlock(Vector3ic pos, Block type);
 
     /**
      * Places all given blocks of specific types at their corresponding positions
@@ -111,6 +137,7 @@ public interface WorldProviderCore {
      * @param blocks A mapping from world position to change to the type of block to set
      * @return A mapping from world position to previous block type.
      * The value of a map entry is Null if the change failed (because the necessary chunk was not loaded)
+     * @deprecated
      */
     default Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
         Map<Vector3i, Block> resultMap = Maps.newHashMap();
@@ -152,7 +179,7 @@ public interface WorldProviderCore {
     byte getSunlight(int x, int y, int z);
 
     byte getTotalLight(int x, int y, int z);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -163,7 +190,18 @@ public interface WorldProviderCore {
      * @return The (index)th extra-data value at the given position
      */
     int getExtraData(int index, int x, int y, int z);
-    
+
+    /**
+     * Sets one of the per-block custom data values at the given position, if it is within the view.
+     *
+     * @param index The index of the extra data field
+     * @param pos
+     * @param value
+     * @return The replaced value
+     * @deprecated
+     */
+    int setExtraData(int index, Vector3i pos, int value);
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -172,7 +210,8 @@ public interface WorldProviderCore {
      * @param value
      * @return The replaced value
      */
-    int setExtraData(int index, Vector3i pos, int value);
+    int setExtraData(int index, Vector3ic pos, int value);
+
 
     /**
      * Disposes this world provider.

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -21,11 +21,13 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.OnChangedBlock;
@@ -163,8 +165,18 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     @Override
+    public ChunkViewCore getLocalView(Vector3ic chunkPos) {
+        return chunkProvider.getLocalView(JomlUtil.from(chunkPos));
+    }
+
+    @Override
     public ChunkViewCore getWorldViewAround(Vector3i chunk) {
         return chunkProvider.getSubviewAroundChunk(chunk);
+    }
+
+    @Override
+    public ChunkViewCore getWorldViewAround(Vector3ic chunk) {
+        return null;
     }
 
     @Override
@@ -210,6 +222,11 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        return null;
+    }
+
+    @Override
     public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
         /*
          * Hint: This method has a benchmark available in the BenchmarkScreen, The screen can be opened ingame via the
@@ -249,7 +266,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
 
         return result;
     }
-    
+
     private void setDirtyChunksNear(Vector3i pos0) {
         for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(pos0, 1)) {
             RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
@@ -268,7 +285,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             }
         }
     }
-    
+
     private void notifyExtraDataChanged(int index, Vector3i pos, int newData, int oldData) {
         // TODO: Change to match block , if those changes are made.
         synchronized (listeners) {
@@ -343,6 +360,11 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             }
             return oldValue;
         }
+        return 0;
+    }
+
+    @Override
+    public int setExtraData(int index, Vector3ic pos, int value) {
         return 0;
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -16,6 +16,9 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3fc;
+import org.joml.Vector3ic;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -45,8 +48,18 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public boolean isBlockRelevant(Vector3ic pos) {
+        return core.isBlockRelevant(pos.x(), pos.y(), pos.z());
+    }
+
+    @Override
     public boolean isBlockRelevant(Vector3f pos) {
         return isBlockRelevant(new Vector3i(pos, RoundingMode.HALF_UP));
+    }
+
+    @Override
+    public boolean isBlockRelevant(Vector3fc pos) {
+        return isBlockRelevant(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
     }
 
     @Override
@@ -60,8 +73,18 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public Block getBlock(Vector3fc pos) {
+        return getBlock(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
+    }
+
+    @Override
     public Block getBlock(Vector3i pos) {
         return core.getBlock(pos.x, pos.y, pos.z);
+    }
+
+    @Override
+    public Block getBlock(Vector3ic pos) {
+        return core.getBlock(pos.x(), pos.y(), pos.z());
     }
 
     @Override
@@ -70,8 +93,18 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public byte getLight(Vector3ic pos) {
+        return core.getLight(pos.x(), pos.y(), pos.z());
+    }
+
+    @Override
     public byte getLight(Vector3f pos) {
         return getLight(new Vector3i(pos, RoundingMode.HALF_UP));
+    }
+
+    @Override
+    public byte getLight(Vector3fc pos) {
+        return getLight(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
     }
 
     @Override
@@ -80,8 +113,18 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public byte getSunlight(Vector3fc pos) {
+        return getSunlight(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
+    }
+
+    @Override
     public byte getTotalLight(Vector3f pos) {
         return getTotalLight(new Vector3i(pos, RoundingMode.HALF_UP));
+    }
+
+    @Override
+    public byte getTotalLight(Vector3fc pos) {
+        return getTotalLight(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
     }
 
 
@@ -91,32 +134,57 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public byte getSunlight(Vector3ic pos) {
+        return core.getSunlight(pos.x(), pos.y(), pos.z());
+    }
+
+    @Override
     public byte getTotalLight(Vector3i pos) {
         return core.getTotalLight(pos.x, pos.y, pos.z);
     }
-    
+
+    @Override
+    public byte getTotalLight(Vector3ic pos) {
+        return core.getTotalLight(pos.x(), pos.y(), pos.z());
+    }
+
     public int getExtraData(int index, Vector3i pos) {
         return core.getExtraData(index, pos.x, pos.y, pos.z);
     }
-    
+
+    @Override
+    public int getExtraData(int index, Vector3ic pos) {
+        return core.getExtraData(index, pos.x(), pos.y(), pos.z());
+    }
+
     public int setExtraData(int index, int x, int y, int z, int value) {
         return core.setExtraData(index, new Vector3i(x, y, z), value);
     }
-    
+
     public int getExtraData(String fieldName, int x, int y, int z) {
         return core.getExtraData(extraDataManager.getSlotNumber(fieldName), x, y, z);
     }
-    
+
     public int getExtraData(String fieldName, Vector3i pos) {
         return core.getExtraData(extraDataManager.getSlotNumber(fieldName), pos.x, pos.y, pos.z);
     }
-    
+
+    @Override
+    public int getExtraData(String fieldName, Vector3ic pos) {
+        return core.getExtraData(extraDataManager.getSlotNumber(fieldName), pos.x(), pos.y(), pos.z());
+    }
+
     public int setExtraData(String fieldName, int x, int y, int z, int value) {
         return core.setExtraData(extraDataManager.getSlotNumber(fieldName), new Vector3i(x, y, z), value);
     }
-    
+
     public int setExtraData(String fieldName, Vector3i pos, int value) {
         return core.setExtraData(extraDataManager.getSlotNumber(fieldName), pos, value);
+    }
+
+    @Override
+    public int setExtraData(String fieldName, Vector3ic pos, int value) {
+        return core.setExtraData(extraDataManager.getSlotNumber(fieldName), JomlUtil.from(pos), value);
     }
 
     @Override


### PR DESCRIPTION
I will start going through some of the more major systems in Terasology and provide JOML alternatives that we can start to use in place of the teramath implementations. we should be able to start removing the termath methods when these endpoints get updated in module space. I think I will start to do this for some of the more major systems that terasology uses to make the transition easier. Components are another issue that will be harder to address. 



