### PR TITLE
feat(JOML): Migrate methods of WorldProvider

### DIFF
--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -16,8 +16,10 @@
 package org.terasology;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
@@ -90,6 +92,12 @@ public class MapWorldProvider implements WorldProviderCore {
     }
 
     @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        return blocks.put(JomlUtil.from(pos), type);
+    }
+
+
+    @Override
     public Block getBlock(int x, int y, int z) {
         Vector3i pos = new Vector3i(x, y, z);
         Block block = blocks.get(pos);
@@ -151,12 +159,12 @@ public class MapWorldProvider implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return 0;
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         return 0;
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return 0;

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -17,7 +17,9 @@
 package org.terasology.testUtil;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
@@ -102,7 +104,12 @@ public class WorldProviderCoreStub implements WorldProviderCore {
 
     @Override
     public Block setBlock(Vector3i pos, Block type) {
-        Block old = blocks.put(pos, type);
+        return this.setBlock(JomlUtil.from(pos), type);
+    }
+
+    @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        Block old = blocks.put(JomlUtil.from(pos), type);
         if (old == null) {
             return air;
         }
@@ -142,18 +149,18 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return 0;  //To change body of implemented methods use File | Settings | File Templates.
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         Integer prevValue = getExtraDataLayer(index).put(pos, value);
         return prevValue == null ? 0 : prevValue;
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return getExtraDataLayer(index).getOrDefault(new Vector3i(x, y, z), 0);
     }
-    
+
     private Map<Vector3i, Integer> getExtraDataLayer(int index) {
         while (extraData.size() <= index) {
             extraData.add(Maps.newHashMap());

--- a/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/EntityAwareWorldProviderTest.java
@@ -270,6 +270,16 @@ public class EntityAwareWorldProviderTest extends TerasologyTestingEnvironment {
     }
 
     @Test
+    public void testEntityBecomesTemporaryWhenChangedFromAKeepActiveBlockJoml() {
+        worldProvider.setBlock(new org.joml.Vector3i(), keepActiveBlock);
+        EntityRef blockEntity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
+        worldProvider.setBlock(new org.joml.Vector3i(), airBlock);
+        worldProvider.update(1.0f);
+        assertFalse(blockEntity.isActive());
+    }
+
+
+    @Test
     public void testEntityBecomesTemporaryIfForceBlockActiveComponentRemoved() {
         EntityRef blockEntity = worldProvider.getBlockEntityAt(new Vector3i(0, 0, 0));
         blockEntity.addComponent(new ForceBlockActiveComponent());

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -40,7 +40,7 @@ public interface WorldProvider extends WorldProviderCore {
     boolean isBlockRelevant(Vector3i pos);
 
     /**
-     *
+     * An active block is in a chunk that is available and fully generated.
      * @param pos The position
      * @return Whether the given block is active
      */

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.world;
 
+import org.joml.Vector3fc;
+import org.joml.Vector3ic;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
@@ -41,6 +43,7 @@ public interface WorldProvider extends WorldProviderCore {
      *
      * @param pos The position
      * @return The block value at the given position
+     * @deprecated
      */
     Block getBlock(Vector3f pos);
 
@@ -50,7 +53,24 @@ public interface WorldProvider extends WorldProviderCore {
      * @param pos The position
      * @return The block value at the given position
      */
+    Block getBlock(Vector3fc pos);
+
+    /**
+     * Returns the block value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     * @deprecated
+     */
     Block getBlock(Vector3i pos);
+
+    /**
+     * Returns the block value at the given position.
+     *
+     * @param pos The position
+     * @return The block value at the given position
+     */
+    Block getBlock(Vector3ic pos);
 
     /**
      * Returns the light value at the given position.
@@ -87,7 +107,7 @@ public interface WorldProvider extends WorldProviderCore {
     byte getSunlight(Vector3i pos);
 
     byte getTotalLight(Vector3i pos);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -96,7 +116,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The (index)th extra-data value at the given position
      */
     int getExtraData(int index, Vector3i pos);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -108,7 +128,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The replaced value
      */
     int setExtraData(int index, int x, int y, int z, int value);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -119,7 +139,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The named extra-data value at the given position
      */
     int getExtraData(String fieldName, int x, int y, int z);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -128,7 +148,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The named extra-data value at the given position
      */
     int getExtraData(String fieldName, Vector3i pos);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *
@@ -140,7 +160,7 @@ public interface WorldProvider extends WorldProviderCore {
      * @return The replaced value
      */
     int setExtraData(String fieldName, int x, int y, int z, int value);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -31,12 +31,35 @@ public interface WorldProvider extends WorldProviderCore {
     /**
      * An active block is in a chunk that is available and fully generated.
      *
-     * @param pos
+     * @param pos The position
      * @return Whether the given block is active
+     * @deprecated
      */
     boolean isBlockRelevant(Vector3i pos);
 
+    /**
+     *
+     * @param pos The position
+     * @return Whether the given block is active
+     */
+    boolean isBlockRelevant(Vector3ic pos);
+
+    /**
+     * An active block is in a chunk that is available and fully generated.
+     *
+     * @param pos The position
+     * @return Whether the given block is active
+     * @deprecated
+     */
     boolean isBlockRelevant(Vector3f pos);
+
+    /**
+     * An active block is in a chunk that is available and fully generated.
+     *
+     * @param pos The position
+     * @return Whether the given block is active
+     */
+    boolean isBlockRelevant(Vector3fc pos);
 
     /**
      * Returns the block value at the given position.

--- a/engine/src/main/java/org/terasology/world/WorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/WorldProvider.java
@@ -33,8 +33,10 @@ public interface WorldProvider extends WorldProviderCore {
      *
      * @param pos The position
      * @return Whether the given block is active
-     * @deprecated
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #isBlockRelevant(Vector3ic)}.
      */
+    @Deprecated
     boolean isBlockRelevant(Vector3i pos);
 
     /**
@@ -49,8 +51,10 @@ public interface WorldProvider extends WorldProviderCore {
      *
      * @param pos The position
      * @return Whether the given block is active
-     * @deprecated
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #isBlockRelevant(Vector3fc)}.
      */
+    @Deprecated
     boolean isBlockRelevant(Vector3f pos);
 
     /**
@@ -66,8 +70,10 @@ public interface WorldProvider extends WorldProviderCore {
      *
      * @param pos The position
      * @return The block value at the given position
-     * @deprecated
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #getBlock(Vector3fc)}.
      */
+    @Deprecated
     Block getBlock(Vector3f pos);
 
     /**
@@ -83,8 +89,10 @@ public interface WorldProvider extends WorldProviderCore {
      *
      * @param pos The position
      * @return The block value at the given position
-     * @deprecated
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #getBlock(Vector3ic)}.
      */
+    @Deprecated
     Block getBlock(Vector3i pos);
 
     /**

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -16,6 +16,7 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -97,6 +98,11 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     }
 
     @Override
+    public Block setBlock(Vector3ic pos, Block type) {
+        return base.setBlock(pos, type);
+    }
+
+    @Override
     public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocks) {
         return base.setBlocks(blocks);
     }
@@ -120,12 +126,12 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
     public byte getTotalLight(int x, int y, int z) {
         return base.getTotalLight(x, y, z);
     }
-    
+
     @Override
     public int getExtraData(int index, int x, int y, int z) {
         return base.getExtraData(index, x, y, z);
     }
-    
+
     @Override
     public int setExtraData(int index, Vector3i pos, int value) {
         return base.setExtraData(index, pos, value);

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
@@ -42,6 +43,7 @@ import org.terasology.entitySystem.metadata.ComponentMetadata;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -113,11 +115,16 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
 
     @Override
     public Block setBlock(Vector3i pos, Block type) {
+        return this.setBlock(JomlUtil.from(pos),type);
+    }
+
+    @Override
+    public Block setBlock(Vector3ic pos, Block type) {
         if (GameThread.isCurrentThread()) {
-            EntityRef blockEntity = getBlockEntityAt(pos);
-            Block oldType = super.setBlock(pos, type);
+            EntityRef blockEntity = getBlockEntityAt(JomlUtil.from(pos));
+            Block oldType = super.setBlock(JomlUtil.from(pos), type);
             if (oldType != null) {
-                updateBlockEntity(blockEntity, pos, oldType, type, false, Collections.<Class<? extends Component>>emptySet());
+                updateBlockEntity(blockEntity, JomlUtil.from(pos), oldType, type, false, Collections.<Class<? extends Component>>emptySet());
             }
             return oldType;
         }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -197,4 +197,5 @@ public interface WorldProviderCore {
      * @return an unmodifiable view on the generated relevant regions
      */
     Collection<Region3i> getRelevantRegions();
+
 }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -16,6 +16,7 @@
 package org.terasology.world.internal;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
@@ -100,8 +101,19 @@ public interface WorldProviderCore {
      * @param pos  The world position to change
      * @param type The type of the block to set
      * @return The previous block type. Null if the change failed (because the necessary chunk was not loaded)
+     * @deprecated
      */
     Block setBlock(Vector3i pos, Block type);
+
+
+    /**
+     * Places a block of a specific type at a given position
+     *
+     * @param pos  The world position to change
+     * @param type The type of the block to set
+     * @return The previous block type. Null if the change failed (because the necessary chunk was not loaded)
+     */
+    Block setBlock(Vector3ic pos, Block type);
 
     /**
      * Places all given blocks of specific types at their corresponding positions
@@ -152,7 +164,7 @@ public interface WorldProviderCore {
     byte getSunlight(int x, int y, int z);
 
     byte getTotalLight(int x, int y, int z);
-    
+
     /**
      * Gets one of the per-block custom data values at the given position. Returns 0 outside the view.
      *
@@ -163,7 +175,7 @@ public interface WorldProviderCore {
      * @return The (index)th extra-data value at the given position
      */
     int getExtraData(int index, int x, int y, int z);
-    
+
     /**
      * Sets one of the per-block custom data values at the given position, if it is within the view.
      *

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -101,8 +101,10 @@ public interface WorldProviderCore {
      * @param pos  The world position to change
      * @param type The type of the block to set
      * @return The previous block type. Null if the change failed (because the necessary chunk was not loaded)
-     * @deprecated
+     * @deprecated This is scheduled for removal in an upcoming version
+     *             method will be replaced with JOML implementation {@link #setBlock(Vector3ic, Block)}.
      */
+    @Deprecated
     Block setBlock(Vector3i pos, Block type);
 
 

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -16,6 +16,7 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3fc;
 import org.joml.Vector3ic;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
@@ -66,8 +67,18 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public Block getBlock(Vector3fc pos) {
+        return getBlock(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
+    }
+
+    @Override
     public Block getBlock(Vector3i pos) {
         return core.getBlock(pos.x, pos.y, pos.z);
+    }
+
+    @Override
+    public Block getBlock(Vector3ic pos) {
+        return core.getBlock(pos.x(), pos.y(), pos.z());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -47,8 +47,18 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     }
 
     @Override
+    public boolean isBlockRelevant(Vector3ic pos) {
+        return core.isBlockRelevant(pos.x(), pos.y(), pos.z());
+    }
+
+    @Override
     public boolean isBlockRelevant(Vector3f pos) {
         return isBlockRelevant(new Vector3i(pos, RoundingMode.HALF_UP));
+    }
+
+    @Override
+    public boolean isBlockRelevant(Vector3fc pos) {
+        return isBlockRelevant(new org.joml.Vector3i(pos, org.joml.RoundingMode.HALF_UP));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderWrapper.java
@@ -16,6 +16,7 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3ic;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -51,6 +52,11 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
 
     @Override
     public Block setBlock(Vector3i pos, Block type) {
+        return core.setBlock(pos, type);
+    }
+
+    @Override
+    public Block setBlock(Vector3ic pos, Block type) {
         return core.setBlock(pos, type);
     }
 
@@ -94,27 +100,27 @@ public class WorldProviderWrapper extends AbstractWorldProviderDecorator impleme
     public byte getTotalLight(Vector3i pos) {
         return core.getTotalLight(pos.x, pos.y, pos.z);
     }
-    
+
     public int getExtraData(int index, Vector3i pos) {
         return core.getExtraData(index, pos.x, pos.y, pos.z);
     }
-    
+
     public int setExtraData(int index, int x, int y, int z, int value) {
         return core.setExtraData(index, new Vector3i(x, y, z), value);
     }
-    
+
     public int getExtraData(String fieldName, int x, int y, int z) {
         return core.getExtraData(extraDataManager.getSlotNumber(fieldName), x, y, z);
     }
-    
+
     public int getExtraData(String fieldName, Vector3i pos) {
         return core.getExtraData(extraDataManager.getSlotNumber(fieldName), pos.x, pos.y, pos.z);
     }
-    
+
     public int setExtraData(String fieldName, int x, int y, int z, int value) {
         return core.setExtraData(extraDataManager.getSlotNumber(fieldName), new Vector3i(x, y, z), value);
     }
-    
+
     public int setExtraData(String fieldName, Vector3i pos, int value) {
         return core.setExtraData(extraDataManager.getSlotNumber(fieldName), pos, value);
     }


### PR DESCRIPTION
I will start going through some of the more major systems in Terasology and provide JOML alternatives that we can start to use in place of the teramath implementations. we should be able to start removing the termath methods when these endpoints get updated in module space. I think I will start to do this for some of the more major systems that terasology uses to make the transition easier. Components are another issue that will be harder to address.

These methods are now backed by their joml equivalent so any actions on a given block should be the same from before. I expect breaking blocks and placement of blocks should still work the same regardless. 