### PR TITLE
resolved entityref issue

### DIFF
--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -85,8 +85,11 @@ public final class EnvironmentSwitchHandler {
             }
         }
 
-        TypeHandlerLibrary typeHandlerLibrary = context.get(TypeHandlerLibrary.class);
+        // Resolved typeHandler bug with inventory disappearing
+        // https://github.com/Terasology/JoshariasSurvival/issues/31
+        TypeHandlerLibrary typeHandlerLibrary = TypeHandlerLibrary.forModuleEnvironment(moduleManager,typeRegistry);
         typeHandlerLibrary.addTypeHandler(CollisionGroup.class, new CollisionGroupTypeHandler(context.get(CollisionGroupManager.class)));
+        context.put(TypeHandlerLibrary.class, typeHandlerLibrary);
 
         // Entity System Library
         EntitySystemLibrary library = new EntitySystemLibrary(context, typeHandlerLibrary);


### PR DESCRIPTION
This resolve the issue from: https://github.com/Terasology/JoshariasSurvival/issues/31

I'm not quite sure the exact cause but EnvironmentSwitchHandler adds a new typehandler to the context. I guess there is some hidden thread issue were not aware of but this seems to resolve the problem for the moment. we need a more permanent fix to resolve this at some point in the future. 

## Testing
- create a new default world
- view inventory
- exit world and reload
- inventory should still be there!!