### PR TITLE
fix: Explode tool explosion sound behavior

### DIFF
--- a/modules/Core/assets/prefabs/explodeTool.prefab
+++ b/modules/Core/assets/prefabs/explodeTool.prefab
@@ -9,8 +9,5 @@
     },
     "ExplosionAction": {
         "relativeTo": "Target"
-    },
-    "PlaySoundAction": {
-        "sounds": ["CoreAssets:Explode1", "CoreAssets:Explode2", "CoreAssets:Explode3", "CoreAssets:Explode4", "CoreAssets:Explode5"]
     }
 }


### PR DESCRIPTION
This PR fixes issue #198

The explosion tool caused an explosion sound effect on activation, even when no target was selected and therefore no explosion was occurring.

I solved the issue by removing the `PlaySoundAction`-Component from the `explosionTool`.

To test, start a new game using the Core Gameplay template.
The explode tool (the dynamite stick) should not cause any sound effect when activated while not pointing at a block within interaction range.
In case a target block is selected, an explosion including the sound effect should occur as expected.