### PR TITLE
JOML migration for AudioManager

### DIFF
--- a/engine/src/main/java/org/terasology/audio/AudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/AudioManager.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.audio;
 
-import org.joml.Quaternionf;
+import org.joml.Quaternionfc;
 import org.joml.Vector3fc;
 import org.terasology.assets.AssetFactory;
 import org.terasology.math.geom.Quat4f;
@@ -134,11 +134,11 @@ public interface AudioManager {
      * @param orientation The new orientation (in a quaternion)
      * @param velocity The new velocity
      * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #updateListener(Vector3fc, Quaternionf, Vector3fc)}.
+     *             Use the JOML implementation instead: {@link #updateListener(Vector3fc, Quaternionfc, Vector3fc)}.
      */
     @Deprecated
     void updateListener(Vector3f position, Quat4f orientation, Vector3f velocity);
-    void updateListener(Vector3fc position, Quaternionf orientation, Vector3fc velocity);
+    void updateListener(Vector3fc position, Quaternionfc orientation, Vector3fc velocity);
 
     /**
      * Gracefully destroy audio subsystem.

--- a/engine/src/main/java/org/terasology/audio/AudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/AudioManager.java
@@ -53,8 +53,6 @@ public interface AudioManager {
     void playSound(StaticSound sound, Vector3f position);
     void playSound(StaticSound sound, Vector3fc position);
 
-    @Deprecated
-    void playSound(StaticSound sound, Vector3f position, float volume);
     void playSound(StaticSound sound, Vector3fc position, float volume);
 
     @Deprecated

--- a/engine/src/main/java/org/terasology/audio/AudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/AudioManager.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.audio;
 
+import org.joml.Quaternionf;
+import org.joml.Vector3fc;
 import org.terasology.assets.AssetFactory;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
@@ -47,11 +49,17 @@ public interface AudioManager {
 
     void playSound(StaticSound sound, float volume, int priority);
 
+    @Deprecated
     void playSound(StaticSound sound, Vector3f position);
+    void playSound(StaticSound sound, Vector3fc position);
 
+    @Deprecated
     void playSound(StaticSound sound, Vector3f position, float volume);
+    void playSound(StaticSound sound, Vector3fc position, float volume);
 
+    @Deprecated
     void playSound(StaticSound sound, Vector3f position, float volume, int priority);
+    void playSound(StaticSound sound, Vector3fc position, float volume, int priority);
 
     /**
      * Plays a sound at an specified point and volume.
@@ -61,8 +69,12 @@ public interface AudioManager {
      * @param volume The volume
      * @param priority The priority with which this sound should play. Higher values means this sound will be able to override others.
      * @param endListener The listener to call when the sound is finished
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #playSound(StaticSound, Vector3fc, float, int, AudioEndListener)}.
      */
+    @Deprecated
     void playSound(StaticSound sound, Vector3f position, float volume, int priority, AudioEndListener endListener);
+    void playSound(StaticSound sound, Vector3fc position, float volume, int priority, AudioEndListener endListener);
 
     /**
      * Plays music once, this does not have a direction unlike playSound.
@@ -123,8 +135,12 @@ public interface AudioManager {
      * @param position The new position
      * @param orientation The new orientation (in a quaternion)
      * @param velocity The new velocity
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #updateListener(Vector3fc, Quaternionf, Vector3fc)}.
      */
+    @Deprecated
     void updateListener(Vector3f position, Quat4f orientation, Vector3f velocity);
+    void updateListener(Vector3fc position, Quaternionf orientation, Vector3fc velocity);
 
     /**
      * Gracefully destroy audio subsystem.

--- a/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
@@ -16,7 +16,7 @@
 
 package org.terasology.audio.nullAudio;
 
-import org.joml.Quaternionf;
+import org.joml.Quaternionfc;
 import org.joml.Vector3fc;
 import org.terasology.assets.AssetFactory;
 import org.terasology.audio.AudioEndListener;
@@ -106,7 +106,7 @@ public class NullAudioManager implements AudioManager {
     }
 
     @Override
-    public void updateListener(Vector3fc position, Quaternionf orientation, Vector3fc velocity) {
+    public void updateListener(Vector3fc position, Quaternionfc orientation, Vector3fc velocity) {
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
@@ -16,6 +16,8 @@
 
 package org.terasology.audio.nullAudio;
 
+import org.joml.Quaternionf;
+import org.joml.Vector3fc;
 import org.terasology.assets.AssetFactory;
 import org.terasology.audio.AudioEndListener;
 import org.terasology.audio.AudioManager;
@@ -56,7 +58,15 @@ public class NullAudioManager implements AudioManager {
     }
 
     @Override
+    public void playSound(StaticSound sound, Vector3fc position) {
+    }
+
+    @Override
     public void playSound(StaticSound sound, Vector3f position, float volume) {
+    }
+
+    @Override
+    public void playSound(StaticSound sound, Vector3fc position, float volume) {
     }
 
     @Override
@@ -64,7 +74,15 @@ public class NullAudioManager implements AudioManager {
     }
 
     @Override
+    public void playSound(StaticSound sound, Vector3fc position, float volume, int priority) {
+    }
+
+    @Override
     public void playSound(StaticSound sound, Vector3f position, float volume, int priority, AudioEndListener endListener) {
+    }
+
+    @Override
+    public void playSound(StaticSound sound, Vector3fc position, float volume, int priority, AudioEndListener endListener) {
     }
 
     @Override
@@ -89,6 +107,10 @@ public class NullAudioManager implements AudioManager {
 
     @Override
     public void updateListener(Vector3f position, Quat4f orientation, Vector3f velocity) {
+    }
+
+    @Override
+    public void updateListener(Vector3fc position, Quaternionf orientation, Vector3fc velocity) {
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
+++ b/engine/src/main/java/org/terasology/audio/nullAudio/NullAudioManager.java
@@ -62,10 +62,6 @@ public class NullAudioManager implements AudioManager {
     }
 
     @Override
-    public void playSound(StaticSound sound, Vector3f position, float volume) {
-    }
-
-    @Override
     public void playSound(StaticSound sound, Vector3fc position, float volume) {
     }
 

--- a/engine/src/main/java/org/terasology/audio/openAL/BaseSoundSource.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/BaseSoundSource.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.audio.openAL;
 
+import org.joml.Vector3fc;
 import org.lwjgl.openal.AL10;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.Sound;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3f;
 
 import static org.lwjgl.openal.AL10.AL_FALSE;
@@ -44,9 +46,9 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
     private float targetGain = 1.0f;
     private boolean fade;
 
-    private Vector3f position = new Vector3f();
-    private Vector3f velocity = new Vector3f();
-    private Vector3f direction = new Vector3f();
+    private final org.joml.Vector3f position = new org.joml.Vector3f();
+    private final org.joml.Vector3f velocity = new org.joml.Vector3f();
+    private final org.joml.Vector3f direction = new org.joml.Vector3f();
 
     private boolean absolutePosition;
 
@@ -146,19 +148,27 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
 
     @Override
     public Vector3f getVelocity() {
-        return velocity;
+        return JomlUtil.from(velocity);
+    }
+
+    @Override
+    public org.joml.Vector3f getVelocity(org.joml.Vector3f dest) {
+        return dest.set(velocity);
     }
 
     @Override
     public SoundSource<T> setVelocity(Vector3f value) {
-        if (value == null || this.velocity.equals(value)) {
+        return setVelocity(JomlUtil.from(value));
+    }
+
+    @Override
+    public SoundSource<T> setVelocity(Vector3fc value) {
+        if (velocity.equals(value)) {
             return this;
         }
 
-        this.velocity.set(value);
-
-        AL10.alSource3f(getSourceId(), AL10.AL_VELOCITY, value.x, value.y, value.z);
-
+        velocity.set(value);
+        AL10.alSource3f(getSourceId(), AL10.AL_VELOCITY, velocity.x, velocity.y, velocity.z);
         OpenALException.checkState("Setting sound source velocity");
 
         return this;
@@ -166,18 +176,26 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
 
     @Override
     public Vector3f getPosition() {
-        return position;
+        return JomlUtil.from(position);
+    }
+
+    public org.joml.Vector3f getPosition(org.joml.Vector3f dest) {
+        return dest.set(position);
     }
 
     @Override
-    public SoundSource<T> setPosition(Vector3f value) {
-        if (value == null || this.position.equals(value)) {
+    public SoundSource<T> setPosition(Vector3f position) {
+        return setPosition(JomlUtil.from(position));
+    }
+
+    @Override
+    public SoundSource<T> setPosition(Vector3fc value) {
+        if (position.equals(value)) {
             return this;
         }
 
-        this.position.set(value);
-        alSource3f(getSourceId(), AL10.AL_POSITION, value.x, value.y, value.z);
-
+        position.set(value);
+        alSource3f(getSourceId(), AL10.AL_POSITION, position.x, position.y, position.z);
         OpenALException.checkState("Changing sound position");
 
         return this;
@@ -185,22 +203,30 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
 
     @Override
     public SoundSource<T> setDirection(Vector3f value) {
-        if (value == null || this.direction.equals(value)) {
+        return setDirection(JomlUtil.from(value));
+    }
+
+    @Override
+    public SoundSource<T> setDirection(Vector3fc value) {
+        if (direction.equals(value)) {
             return this;
         }
 
-        AL10.alSource3f(getSourceId(), AL10.AL_DIRECTION, value.x, value.y, value.z);
-
+        direction.set(value);
+        AL10.alSource3f(getSourceId(), AL10.AL_DIRECTION, direction.x, direction.y, direction.z);
         OpenALException.checkState("Setting sound source direction");
-
-        this.direction.set(value);
 
         return this;
     }
 
     @Override
     public Vector3f getDirection() {
-        return direction;
+        return JomlUtil.from(direction);
+    }
+
+    @Override
+    public org.joml.Vector3f getDirection(org.joml.Vector3f dest) {
+        return dest.set(direction);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/audio/openAL/BaseSoundSource.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/BaseSoundSource.java
@@ -15,12 +15,11 @@
  */
 package org.terasology.audio.openAL;
 
+import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.lwjgl.openal.AL10;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.Sound;
-import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Vector3f;
 
 import static org.lwjgl.openal.AL10.AL_FALSE;
 import static org.lwjgl.openal.AL10.AL_GAIN;
@@ -46,9 +45,9 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
     private float targetGain = 1.0f;
     private boolean fade;
 
-    private final org.joml.Vector3f position = new org.joml.Vector3f();
-    private final org.joml.Vector3f velocity = new org.joml.Vector3f();
-    private final org.joml.Vector3f direction = new org.joml.Vector3f();
+    private final Vector3f position = new Vector3f();
+    private final Vector3f velocity = new Vector3f();
+    private final Vector3f direction = new Vector3f();
 
     private boolean absolutePosition;
 
@@ -147,18 +146,8 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
     }
 
     @Override
-    public Vector3f getVelocity() {
-        return JomlUtil.from(velocity);
-    }
-
-    @Override
-    public org.joml.Vector3f getVelocity(org.joml.Vector3f dest) {
-        return dest.set(velocity);
-    }
-
-    @Override
-    public SoundSource<T> setVelocity(Vector3f value) {
-        return setVelocity(JomlUtil.from(value));
+    public Vector3fc getVelocity() {
+        return velocity;
     }
 
     @Override
@@ -174,18 +163,8 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
         return this;
     }
 
-    @Override
-    public Vector3f getPosition() {
-        return JomlUtil.from(position);
-    }
-
-    public org.joml.Vector3f getPosition(org.joml.Vector3f dest) {
-        return dest.set(position);
-    }
-
-    @Override
-    public SoundSource<T> setPosition(Vector3f position) {
-        return setPosition(JomlUtil.from(position));
+    public Vector3fc getPosition() {
+        return position;
     }
 
     @Override
@@ -202,11 +181,6 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
     }
 
     @Override
-    public SoundSource<T> setDirection(Vector3f value) {
-        return setDirection(JomlUtil.from(value));
-    }
-
-    @Override
     public SoundSource<T> setDirection(Vector3fc value) {
         if (direction.equals(value)) {
             return this;
@@ -220,13 +194,8 @@ public abstract class BaseSoundSource<T extends Sound<?>> implements SoundSource
     }
 
     @Override
-    public Vector3f getDirection() {
-        return JomlUtil.from(direction);
-    }
-
-    @Override
-    public org.joml.Vector3f getDirection(org.joml.Vector3f dest) {
-        return dest.set(direction);
+    public Vector3fc getDirection() {
+        return direction;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/audio/openAL/OpenALManager.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/OpenALManager.java
@@ -16,7 +16,7 @@
 package org.terasology.audio.openAL;
 
 import com.google.common.collect.Maps;
-import org.joml.Quaternionf;
+import org.joml.Quaternionfc;
 import org.joml.Vector3fc;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.LWJGLException;
@@ -267,7 +267,7 @@ public class OpenALManager implements AudioManager {
     }
 
     @Override
-    public void updateListener(Vector3fc position, Quaternionf orientation, Vector3fc velocity) {
+    public void updateListener(Vector3fc position, Quaternionfc orientation, Vector3fc velocity) {
         AL10.alListener3f(AL10.AL_VELOCITY, velocity.x(), velocity.y(), velocity.z());
 
         OpenALException.checkState("Setting listener velocity");

--- a/engine/src/main/java/org/terasology/audio/openAL/OpenALManager.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/OpenALManager.java
@@ -170,11 +170,6 @@ public class OpenALManager implements AudioManager {
     }
 
     @Override
-    public void playSound(StaticSound sound, Vector3f position, float volume) {
-        playSound(sound, JomlUtil.from(position), volume);
-    }
-
-    @Override
     public void playSound(StaticSound sound, Vector3fc position, float volume) {
         playSound(sound, position, volume, PRIORITY_NORMAL);
     }
@@ -315,11 +310,6 @@ public class OpenALManager implements AudioManager {
                 }
             }
         }
-    }
-
-    @Deprecated
-    protected boolean checkDistance(Vector3f soundPosition) {
-        return checkDistance(JomlUtil.from(soundPosition));
     }
 
     protected boolean checkDistance(Vector3fc soundPosition) {

--- a/engine/src/main/java/org/terasology/audio/openAL/SoundSource.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/SoundSource.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.audio.openAL;
 
+import org.joml.Vector3fc;
 import org.terasology.audio.Sound;
 import org.terasology.math.geom.Vector3f;
 
@@ -79,46 +80,70 @@ public interface SoundSource<T extends Sound<?>> {
      *
      * @param pos
      * @return
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #setPosition(Vector3fc)}.
      */
+    @Deprecated
     SoundSource<T> setPosition(Vector3f pos);
+    SoundSource<T> setPosition(Vector3fc pos);
 
     /**
      * Returns sound position in space
      *
      * @return
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #getPosition(org.joml.Vector3f)}.
      */
+    @Deprecated
     Vector3f getPosition();
+    org.joml.Vector3f getPosition(org.joml.Vector3f dest);
 
     /**
      * Set sound source velocity
      * Sound source velocity used for doppler effect calculation
      *
      * @param velocity
-     * @return
+     * @return the sound source
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #setVelocity(Vector3fc)}.
      */
+    @Deprecated
     SoundSource<T> setVelocity(Vector3f velocity);
+    SoundSource<T> setVelocity(Vector3fc velocity);
 
     /**
      * Returns sound source velocity
      *
      * @return
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #getVelocity(org.joml.Vector3f)}.
      */
+    @Deprecated
     Vector3f getVelocity();
+    org.joml.Vector3f getVelocity(org.joml.Vector3f dest);
 
     /**
      * Set sound source direction in cartesian coordinates
      *
      * @param direction
      * @return
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #setDirection(Vector3fc)}.
      */
+    @Deprecated
     SoundSource<T> setDirection(Vector3f direction);
+    SoundSource<T> setDirection(Vector3fc direction);
 
     /**
      * Returns sound source direction in cartesian coordinates
      *
      * @return
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #getDirection(org.joml.Vector3f)}.
      */
+    @Deprecated
     Vector3f getDirection();
+    org.joml.Vector3f getDirection(org.joml.Vector3f dest);
 
     /**
      * Returns sound source pitch

--- a/engine/src/main/java/org/terasology/audio/openAL/SoundSource.java
+++ b/engine/src/main/java/org/terasology/audio/openAL/SoundSource.java
@@ -17,7 +17,6 @@ package org.terasology.audio.openAL;
 
 import org.joml.Vector3fc;
 import org.terasology.audio.Sound;
-import org.terasology.math.geom.Vector3f;
 
 /**
  * Interface for a sound that includes the data required for relative sound positioning.
@@ -80,23 +79,15 @@ public interface SoundSource<T extends Sound<?>> {
      *
      * @param pos
      * @return
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #setPosition(Vector3fc)}.
      */
-    @Deprecated
-    SoundSource<T> setPosition(Vector3f pos);
     SoundSource<T> setPosition(Vector3fc pos);
 
     /**
      * Returns sound position in space
      *
      * @return
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getPosition(org.joml.Vector3f)}.
      */
-    @Deprecated
-    Vector3f getPosition();
-    org.joml.Vector3f getPosition(org.joml.Vector3f dest);
+    Vector3fc getPosition();
 
     /**
      * Set sound source velocity
@@ -104,46 +95,30 @@ public interface SoundSource<T extends Sound<?>> {
      *
      * @param velocity
      * @return the sound source
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #setVelocity(Vector3fc)}.
      */
-    @Deprecated
-    SoundSource<T> setVelocity(Vector3f velocity);
     SoundSource<T> setVelocity(Vector3fc velocity);
 
     /**
      * Returns sound source velocity
      *
      * @return
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getVelocity(org.joml.Vector3f)}.
      */
-    @Deprecated
-    Vector3f getVelocity();
-    org.joml.Vector3f getVelocity(org.joml.Vector3f dest);
+    Vector3fc getVelocity();
 
     /**
      * Set sound source direction in cartesian coordinates
      *
      * @param direction
-     * @return
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #setDirection(Vector3fc)}.
+     * @return the sound source
      */
-    @Deprecated
-    SoundSource<T> setDirection(Vector3f direction);
     SoundSource<T> setDirection(Vector3fc direction);
 
     /**
      * Returns sound source direction in cartesian coordinates
      *
      * @return
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getDirection(org.joml.Vector3f)}.
      */
-    @Deprecated
-    Vector3f getDirection();
-    org.joml.Vector3f getDirection(org.joml.Vector3f dest);
+    Vector3fc getDirection();
 
     /**
      * Returns sound source pitch
@@ -156,7 +131,7 @@ public interface SoundSource<T extends Sound<?>> {
      * Sets sound source pitch
      *
      * @param pitch
-     * @return
+     * @return the sound source
      */
     SoundSource<T> setPitch(float pitch);
 
@@ -176,7 +151,7 @@ public interface SoundSource<T extends Sound<?>> {
      * Set sound source gain
      *
      * @param gain
-     * @return
+     * @return the sound source
      */
     SoundSource<T> setGain(float gain);
 
@@ -192,7 +167,7 @@ public interface SoundSource<T extends Sound<?>> {
      * WARNING! This will cause UnsupportedOperationException on streaming sounds
      *
      * @param looping
-     * @return
+     * @return the sound source
      */
     SoundSource<T> setLooping(boolean looping);
 
@@ -200,7 +175,7 @@ public interface SoundSource<T extends Sound<?>> {
      * Set source of sound (samples)
      *
      * @param sound
-     * @return
+     * @return the sound source
      */
     SoundSource<T> setAudio(T sound);
 
@@ -215,7 +190,7 @@ public interface SoundSource<T extends Sound<?>> {
      * Fade source smoothly
      *
      * @param targetGain
-     * @return
+     * @return the sound source
      */
     SoundSource<T> fade(float targetGain);
 


### PR DESCRIPTION
This PR migrates the AudioManager and related classes to JOML.

Every method I converted without keeping the original was unused throughout the engine and all major modules.
(the only module I couldn't check was FlexibleMovement, which seems to be broken for unrelated reasons atm)

To verify, run the game and check if the sound is working as usual.