### PR TITLE
feat: add retain components component

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,8 +23,12 @@
 *.jar          binary
 *.keystore     binary
 *.png          binary
+*.jpeg	       binary
 *.dll          binary
+*.dylib        binary
 *.pdb          binary
+*.ogg          binary
+*.dbg          binary
 
 gradlew        text eol=lf
 LICENSE        text

--- a/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
@@ -1,11 +1,31 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.terasology.logic.common;
 
 import com.google.api.client.util.Sets;
 import org.terasology.entitySystem.Component;
 
-import java.util.Collections;
 import java.util.Set;
 
+/**
+ * This component is intended to list component classes that are supposed to be retained when placing a block.
+ *
+ * If a block entity has a component that is not part of its prefab, retaining this component results in
+ * the block entity still having this component afterwards. If not retained, it is likely to be removed instead.
+ */
 public class RetainComponentsComponent implements Component {
     public Set<Class<? extends Component>> components = Sets.newHashSet();
 }

--- a/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
@@ -1,0 +1,11 @@
+package org.terasology.logic.common;
+
+import com.google.api.client.util.Sets;
+import org.terasology.entitySystem.Component;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class RetainComponentsComponent implements Component {
+    public Set<Class<? extends Component>> components = Sets.newHashSet();
+}

--- a/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
@@ -15,8 +15,9 @@
  */
 package org.terasology.logic.common;
 
-import com.google.api.client.util.Sets;
+import com.google.common.collect.Sets;
 import org.terasology.entitySystem.Component;
+import org.terasology.network.Replicate;
 
 import java.util.Set;
 
@@ -27,5 +28,6 @@ import java.util.Set;
  * the block entity still having this component afterwards. If not retained, it is likely to be removed instead.
  */
 public class RetainComponentsComponent implements Component {
+    @Replicate
     public Set<Class<? extends Component>> components = Sets.newHashSet();
 }

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -137,10 +137,10 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
                 if (oldBlocks.get(vec) != null) {
                     EntityRef blockEntity = getBlockEntityAt(vec);
 
-                    Set<Class<? extends Component>> retainComponents = Collections.<Class<? extends Component>>emptySet();
-                    if (blockEntity.hasComponent(RetainComponentsComponent.class)) {
-                        retainComponents = blockEntity.getComponent(RetainComponentsComponent.class).components;
-                    }
+                    Set<Class<? extends Component>> retainComponents = Optional.ofNullable(blockEntity.getComponent(RetainComponentsComponent.class))
+                            .map(retainComponentsComponent -> retainComponentsComponent.components)
+                            .orElse(Collections.emptySet());
+
 
                     updateBlockEntity(blockEntity, vec, oldBlocks.get(vec), blocks.get(vec), false, retainComponents);
                 }

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -41,6 +41,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.metadata.ComponentMetadata;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.common.RetainComponentsComponent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
@@ -135,7 +136,13 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
             for (Vector3i vec : oldBlocks.keySet()) {
                 if (oldBlocks.get(vec) != null) {
                     EntityRef blockEntity = getBlockEntityAt(vec);
-                    updateBlockEntity(blockEntity, vec, oldBlocks.get(vec), blocks.get(vec), false, Collections.<Class<? extends Component>>emptySet());
+
+                    Set<Class<? extends Component>> retainComponents = Collections.<Class<? extends Component>>emptySet();
+                    if (blockEntity.hasComponent(RetainComponentsComponent.class)) {
+                        retainComponents = blockEntity.getComponent(RetainComponentsComponent.class).components;
+                    }
+
+                    updateBlockEntity(blockEntity, vec, oldBlocks.get(vec), blocks.get(vec), false, retainComponents);
                 }
             }
             return oldBlocks;

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -137,6 +137,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
                 if (oldBlocks.get(vec) != null) {
                     EntityRef blockEntity = getBlockEntityAt(vec);
 
+                    // check for components to be retained when updating the block entity
                     Set<Class<? extends Component>> retainComponents = Optional.ofNullable(blockEntity.getComponent(RetainComponentsComponent.class))
                             .map(retainComponentsComponent -> retainComponentsComponent.components)
                             .orElse(Collections.emptySet());
@@ -260,10 +261,19 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     /**
      * Transforms a block entity with the change of block type. This is driven from the delta between the old and new
      * block type prefabs, but takes into account changes made to the block entity.
+     * Components contained in `blockEntity` that
+     * <ul>
+     *     <li>are not "common block components" (e.g. `NetworkComponent`)</li>
+     *     <li>don't have `reatinUnalteredOnBlockChange` metadata</li>
+     *     <li>are not listed in the block prefab</li>
+     *     <li>are not listed in the set of components to be retained</li>
+     * </ul>
+     * will be removed.
      *
-     * @param blockEntity The entity to update
-     * @param oldType     The previous type of the block
-     * @param type        The new type of the block
+     * @param blockEntity      The entity to update
+     * @param oldType          The previous type of the block
+     * @param type             The new type of the block
+     * @param retainComponents List of components to be retained
      */
     private void updateBlockEntityComponents(EntityRef blockEntity, Block oldType, Block type, Set<Class<? extends Component>> retainComponents) {
         BlockComponent blockComponent = blockEntity.getComponent(BlockComponent.class);


### PR DESCRIPTION
### Contains

This PR adds `RetainComponentsComponent` which is a component intended to list component classes that are supposed to be retained when placing a block.

Specifying a list of components to be retained when placing a block is necessary as on placing a block, `EntityAwareWorldProvider::updateBlockEntityComponents` removes all components from the entity of the block to be placed that
- are not any of `NetworkComponent`, `BlockComponent`, and `LocationComponent`
- don't have `retainUnalteredOnBlockChange` metadata
- are not listed in the block prefab
- are not in the set of components to be retained
This especially affects components that are added to an entity programmatically, e.g. the `ManualLabor:AssemblyTable` which receives amongst others an `InventoryComponent` in `Machines:MachineCommonSystem` leading to newly placed assembly tables being broken.

The set of component given to `updateBlockEntityComponents` was hard-coded to `emptySet` in `EntityAwareWorldProvider::setBlocks` until now. With this PR there's now a check for `RetainComponentsComponent` in the `blockEntity` in `EntityAwareWorldProvider::setBlocks`.
If it's present, instead of `emptySet`, the set of components to retain that is stored in the `RetainComponentsComponent` component are passed.

### How to test

Broken state:
Programmatically add a component to an entity and observe that it's removed in `EntityAwareWorldProvider::updateBlockEntityComponents`.

Fixed state:
Before adding the new component, create a `RetainComponentsComponent` with this new component and add it to the entity. Observe that it's not removed anymore. Also observe, that the `RetainComponentsComponent` is removed.