### PR TITLE
fix: Add logic check to allow visible water under other blocks

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -142,6 +142,10 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             return false;
         }
 
+        if (currentBlock.isWater() && (side == Side.TOP) && !blockToCheck.isWater()){
+            return true;
+        }
+
         return currentBlock.isWaving() != blockToCheck.isWaving() || blockToCheck.getMeshGenerator() == null
                 || !blockToCheck.isFullSide(side.reverse()) || (!currentBlock.isTranslucent() && blockToCheck.isTranslucent());
 

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -141,7 +141,10 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
         if (currentBlock.isLiquid() && blockToCheck.isLiquid()) {
             return false;
         }
-
+        
+        //TODO: This only fixes the "water under block" issue of the top side not being rendered. (see bug #3889)
+        //Note: originally tried .isLiquid() instead of isWater for both checks, but IntelliJ was warning that
+        //      !blockToCheck.isWater() is always true, may need further investigation
         if (currentBlock.isWater() && (side == Side.TOP) && !blockToCheck.isWater()){
             return true;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes bug #3889

### How to test

Verify water surface is visible when under other block as in below photos:

Before:
![Before](https://user-images.githubusercontent.com/35314989/80318624-662b7b00-87d9-11ea-8a8d-f1806d8e87b8.png)

After
![after](https://user-images.githubusercontent.com/35314989/80318628-69bf0200-87d9-11ea-9ac4-db165fc4c5c3.png)
