### PR TITLE
feat(JOML): Migrate PlayerFactory

### DIFF
--- a/engine/src/main/java/org/terasology/logic/location/Location.java
+++ b/engine/src/main/java/org/terasology/logic/location/Location.java
@@ -37,13 +37,16 @@ public class Location extends BaseComponentSystem {
 
     /**
      * Attaches an entity to another entity. Both must have location components.
-     * This method sets the child's relative offset and rotation to the
+     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
      *
-     * @param parent
-     * @param child
-     * @param offset
-     * @param relativeRotation
+     * @param parent           entity that will be the parent Location to the child
+     * @param child            entity will be attached relative to the parent
+     * @param offset           relative position from parent
+     * @param relativeRotation relative rotation from parent
+     * @deprecated This is scheduled for removal in an upcoming version
+     * method will be replaced with JOML implementation {@link #attachChild(EntityRef, EntityRef, Vector3fc, Quaternionfc, float)}.
      */
+    @Deprecated
     public static void attachChild(EntityRef parent, EntityRef child, Vector3f offset, Quat4f relativeRotation, float relativeScale) {
         LocationComponent childLoc = child.getComponent(LocationComponent.class);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
@@ -64,20 +67,46 @@ public class Location extends BaseComponentSystem {
     }
 
     /**
-     * attaches a child entity relative to another entity based off of the relative location
-     * @param parent
-     * @param child
-     * @param offset
-     * @param relativeRotation
-     * @deprecated
+     * Attaches an entity to another entity. Both must have location components.
+     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
+     *
+     * @param parent           entity with a {@link LocationComponent}
+     * @param child            entity with a {@link LocationComponent} attach to the parent
+     * @param offset           relative position from parent
+     * @param relativeRotation relative rotation from parent
+     * @deprecated This is scheduled for removal in an upcoming version
+     * method will be replaced with JOML implementation {@link #attachChild(EntityRef, EntityRef, Vector3fc, Quaternionfc)}.
      */
     @Deprecated
     public static void attachChild(EntityRef parent, EntityRef child, Vector3f offset, Quat4f relativeRotation) {
         attachChild(parent, child, offset, relativeRotation, 1f);
     }
 
+    /**
+     * Attaches an entity to another entity. Both must have location components.
+     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
+     *
+     * @param parent           entity with a {@link LocationComponent}
+     * @param child            entity with a {@link LocationComponent} attach to the parent
+     * @param offset           relative position from parent
+     * @param relativeRotation relative rotation from parent
+     **/
     public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation) {
         attachChild(parent, child, JomlUtil.from(offset), JomlUtil.from(relativeRotation), 1f);
+    }
+
+    /**
+     * Attaches an entity to another entity. Both must have location components.
+     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
+     *
+     * @param parent           entity with a {@link LocationComponent}
+     * @param child            entity with a {@link LocationComponent} attach to the parent
+     * @param offset           relative position from parent
+     * @param relativeRotation relative rotation from parent
+     * @param relativeScale    relative scale from parent
+     **/
+    public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation, float relativeScale) {
+        attachChild(parent, child, JomlUtil.from(offset), JomlUtil.from(relativeRotation), relativeScale);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/location/Location.java
+++ b/engine/src/main/java/org/terasology/logic/location/Location.java
@@ -16,12 +16,15 @@
 
 package org.terasology.logic.location;
 
+import org.joml.Quaternionfc;
+import org.joml.Vector3fc;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 
@@ -60,8 +63,21 @@ public class Location extends BaseComponentSystem {
         }
     }
 
+    /**
+     * attaches a child entity relative to another entity based off of the relative location
+     * @param parent
+     * @param child
+     * @param offset
+     * @param relativeRotation
+     * @deprecated
+     */
+    @Deprecated
     public static void attachChild(EntityRef parent, EntityRef child, Vector3f offset, Quat4f relativeRotation) {
         attachChild(parent, child, offset, relativeRotation, 1f);
+    }
+
+    public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation) {
+        attachChild(parent, child, JomlUtil.from(offset), JomlUtil.from(relativeRotation), 1f);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -21,6 +21,7 @@ import org.joml.Vector2ic;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.ComponentContainer;
@@ -148,7 +149,7 @@ public class PlayerFactory {
      * @param height the height of the entity to spawn
      * @return the topmost solid block <code>null</code> if none was found
      */
-    private Vector3i findOpenVerticalPosition(Vector3i spawnPos, float height) {
+    private Vector3i findOpenVerticalPosition(Vector3ic spawnPos, float height) {
         int consecutiveAirBlocks = 0;
         Vector3i newSpawnPos = new Vector3i(spawnPos);
 
@@ -162,7 +163,7 @@ public class PlayerFactory {
                 }
 
                 if (consecutiveAirBlocks >= height) {
-                    newSpawnPos.sub(0,consecutiveAirBlocks,0);
+                    newSpawnPos.y -= consecutiveAirBlocks;
                     return newSpawnPos;
                 }
                 newSpawnPos.add(0, 1, 0);

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -36,6 +36,7 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.logic.players.event.RespawnRequestEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -248,7 +249,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
         EntityRef playerCharacter = client.character;
         LocationComponent location = playerCharacter.getComponent(LocationComponent.class);
         PlayerFactory playerFactory = new PlayerFactory(entityManager, worldProvider);
-        Vector3f spawnPosition = playerFactory.findSpawnPositionFromLocationComponent(location);
+        Vector3f spawnPosition = JomlUtil.from(playerFactory.findSpawnPositionFromLocationComponent(location));
 
         playerCharacter.addComponent(new AliveCharacterComponent());
         playerCharacter.send(new CharacterTeleportEvent(spawnPosition));

--- a/engine/src/main/java/org/terasology/math/JomlUtil.java
+++ b/engine/src/main/java/org/terasology/math/JomlUtil.java
@@ -20,6 +20,7 @@ import org.joml.Matrix3fc;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Quaternionf;
+import org.joml.Quaternionfc;
 import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector2ic;
@@ -102,7 +103,7 @@ public class JomlUtil {
         return new org.joml.Vector3i(vec.x(), vec.y(), vec.z());
     }
 
-    public static Quat4f from(Quaternionf quat) {
+    public static Quat4f from(Quaternionfc quat) {
         return new Quat4f(quat.x(), quat.y(), quat.z(), quat.w());
     }
 

--- a/engine/src/main/java/org/terasology/math/SpiralIterable.java
+++ b/engine/src/main/java/org/terasology/math/SpiralIterable.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.math;
+
+import com.google.common.base.Preconditions;
+import org.joml.Vector2i;
+import org.joml.Vector2ic;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * An {@link Iterable} that iterates in
+ * a square-shapes spiral around the central point (inclusive).
+ * <br><br>
+ * The iteration starts in positive x direction.
+ * <br><br>
+ * The iterating vector is reused. <b>Do not attempt to store the instance</b> e.g. in a collection.
+ * @author Martin Steiger
+ */
+public class SpiralIterable implements Iterable<Vector2ic>{
+
+    /**
+     * (MAX_SIDELEN * 2 + 1) ^2 must be < Integer.MAX_VALUE
+     */
+    private static final int MAX_RADIUS = 23169;
+
+    private final Vector2ic center;
+    private final boolean clockwise;
+    private final int maxArea;
+    private final int scale;
+
+    /**
+     * @param center the spiral center
+     * @param clockwise true for clockwise iteration, false for counter-clockwise
+     * @param scale the scale of the iteration (positive integer)
+     * @param maxRadius the maximum radius of the spiral [0..23169] (inclusive)
+     */
+    private SpiralIterable(Vector2ic center, boolean clockwise, int scale, int maxRadius) {
+        Preconditions.checkArgument(scale > 0, "scale must be > 0");
+        Preconditions.checkArgument(maxRadius >= 0, "maxRadius must be >= 0");
+        Preconditions.checkArgument(maxRadius <= MAX_RADIUS, "maxRadius must be <= " + MAX_RADIUS);
+
+        int sideLen = maxRadius * 2 + 1;
+
+        this.scale = scale;
+        this.center = center;
+        this.maxArea = sideLen * sideLen;
+        this.clockwise = clockwise;
+    }
+
+    /**
+     * Iterates in clock-wise orientation around the given point.
+     * The point will be the first iterated point.
+     * @param center the spiral center
+     */
+    public static SpiralIterable.Builder clockwise(Vector2ic center) {
+        return new SpiralIterable.Builder(center, true);
+    }
+
+    /**
+     * Iterates in clock-wise orientation around the given point.
+     * The point will be the first iterated point.
+     * @param center the spiral center
+     */
+    public static SpiralIterable.Builder counterClockwise(Vector2ic center) {
+        return new SpiralIterable.Builder(center, false);
+    }
+
+    @Override
+    public Iterator<Vector2ic> iterator() {
+
+        return new Iterator<Vector2ic>() {
+            private int radius = 1;
+            private int leg;
+            private int x = -1;
+            private int y;
+            private int index;
+
+            private Vector2i pos = new Vector2i();
+
+            @Override
+            public Vector2ic next() {
+                if (index >= maxArea) {
+                    throw new NoSuchElementException("radius has been reached");
+                }
+
+                switch (leg) {
+                    case 0:
+                        ++x;
+                        if (x == radius) {
+                            ++leg;
+                        }
+                        break;
+                    case 1:
+                        ++y;
+                        if (y == radius) {
+                            ++leg;
+                        }
+                        break;
+                    case 2:
+                        --x;
+                        if (-x == radius) {
+                            ++leg;
+                        }
+                        break;
+                    case 3:
+                        --y;
+                        if (-y == radius) {
+                            leg = 0;
+                            ++radius;
+                        }
+                        break;
+                }
+
+                index++;
+                int finalX = center.x() + x * scale;
+                int finalY = center.y() + (clockwise ? y : -y) * scale;
+                pos.set(finalX, finalY);
+                return pos;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return index < maxArea;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("remove");
+            }
+        };
+    }
+
+    public static final class Builder {
+
+        private final Vector2ic center;
+        private final boolean clockwise;
+        private int maxRadius = MAX_RADIUS;
+        private int scale = 1;
+
+        private Builder(Vector2ic center, boolean clockwise) {
+            this.clockwise = clockwise;
+            this.center = center;
+        }
+
+        /**
+         * Default value is 23169.
+         * @param newRadius the maximum radius of the spiral [0..23169] (inclusive)
+         * @return this
+         */
+        public SpiralIterable.Builder maxRadius(int newRadius) {
+            this.maxRadius = newRadius;
+            return this;
+        }
+
+        /**
+         * Default value is 1.
+         * @param newScale the scale of the iteration (positive integer)
+         * @return this
+         */
+        public SpiralIterable.Builder scale(int newScale) {
+            this.scale = newScale;
+            return this;
+        }
+
+        public SpiralIterable build() {
+            return new SpiralIterable(center, clockwise, scale, maxRadius);
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/math/SpiralIterable.java
+++ b/engine/src/main/java/org/terasology/math/SpiralIterable.java
@@ -28,7 +28,6 @@ import java.util.NoSuchElementException;
  * The iteration starts in positive x direction.
  * <br><br>
  * The iterating vector is reused. <b>Do not attempt to store the instance</b> e.g. in a collection.
- * @author Martin Steiger
  */
 public class SpiralIterable implements Iterable<Vector2ic>{
 
@@ -89,7 +88,7 @@ public class SpiralIterable implements Iterable<Vector2ic>{
             private int y;
             private int index;
 
-            private Vector2i pos = new Vector2i();
+            private final Vector2i pos = new Vector2i();
 
             @Override
             public Vector2ic next() {


### PR DESCRIPTION
I ported over character spawning logic to JOML. I moved `SpiralIterable` to math and I also added added and deprecated `attachChild` in Location. The changes should be functionally the same from the old code. Do we want to move `SpiralIterable`to a different namespace is the place I'm using ok? 

## How to Test
- create a new world
- player should spawn without issue