### PR TITLE
fix: Add type handler for `Class<? extends Component>` 

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityManager.java
@@ -535,12 +535,6 @@ public class PojoEntityManager implements EngineEntityManager {
         Preconditions.checkNotNull(component);
         Optional<Component> oldComponent = getPool(entityId).map(pool -> pool.getComponentStore().put(entityId, component));
 
-        if (!oldComponent.isPresent()) {
-            notifyComponentAdded(getEntity(entityId), component.getClass());
-        } else {
-            logger.error("Adding a component ({}) over an existing component for entity {}", component.getClass(), entityId);
-            notifyComponentChanged(getEntity(entityId), component.getClass());
-        }
         if (eventSystem != null) {
             EntityRef entityRef = getEntity(entityId);
             if (!oldComponent.isPresent()) {
@@ -550,6 +544,14 @@ public class PojoEntityManager implements EngineEntityManager {
                 eventSystem.send(entityRef, OnChangedComponent.newInstance(), component);
             }
         }
+
+        if (!oldComponent.isPresent()) {
+            notifyComponentAdded(getEntity(entityId), component.getClass());
+        } else {
+            logger.error("Adding a component ({}) over an existing component for entity {}", component.getClass(), entityId);
+            notifyComponentChanged(getEntity(entityId), component.getClass());
+        }
+
         return component;
     }
 

--- a/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
@@ -29,5 +29,5 @@ import java.util.Set;
  */
 public class RetainComponentsComponent implements Component {
     @Replicate
-    public Set<String> componentTypeNames = Sets.newHashSet();
+    public Set<Class<? extends Component>> components = Sets.newHashSet();
 }

--- a/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
@@ -29,5 +29,5 @@ import java.util.Set;
  */
 public class RetainComponentsComponent implements Component {
     @Replicate
-    public Set<Class<? extends Component>> components = Sets.newHashSet();
+    public Set<String> componentTypeNames = Sets.newHashSet();
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
@@ -23,7 +23,6 @@ import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.module.ModuleManager;
-import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.IntegerRange;
 import org.terasology.math.geom.Quat4f;
@@ -37,7 +36,6 @@ import org.terasology.persistence.typeHandling.coreTypes.BooleanTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.ByteArrayTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.ByteTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.CharacterTypeHandler;
-import org.terasology.persistence.typeHandling.extensionTypes.ComponentClassTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.DoubleTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.FloatTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.IntTypeHandler;
@@ -64,14 +62,14 @@ import org.terasology.persistence.typeHandling.mathTypes.Vector2iTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector3fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector3iTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.Vector4fTypeHandler;
+import org.terasology.persistence.typeHandling.mathTypes.factories.Rect2fTypeHandlerFactory;
+import org.terasology.persistence.typeHandling.mathTypes.factories.Rect2iTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyQuat4fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector2fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector2iTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector3fTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector3iTypeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.legacy.LegacyVector4fTypeHandler;
-import org.terasology.persistence.typeHandling.mathTypes.factories.Rect2fTypeHandlerFactory;
-import org.terasology.persistence.typeHandling.mathTypes.factories.Rect2iTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.reflection.ModuleEnvironmentSandbox;
 import org.terasology.persistence.typeHandling.reflection.ReflectionsSandbox;
 import org.terasology.persistence.typeHandling.reflection.SerializationSandbox;
@@ -144,12 +142,11 @@ public class TypeHandlerLibrary {
         addTypeHandlerFactory(new ArrayTypeHandlerFactory());
         addTypeHandler(byte[].class, new ByteArrayTypeHandler());
 
-        //addTypeHandler(new TypeInfo<Class<? extends Component>>() {},new ComponentClassTypeHandler());
-
         addTypeHandlerFactory(new EnumTypeHandlerFactory());
         addTypeHandlerFactory(new CollectionTypeHandlerFactory(constructorLibrary));
         addTypeHandlerFactory(new StringMapTypeHandlerFactory());
 
+        addTypeHandlerFactory(new ComponentClassTypeHandlerFactory());
     }
 
     /**
@@ -219,8 +216,6 @@ public class TypeHandlerLibrary {
         serializationLibrary.addTypeHandlerFactory(new Rect2fTypeHandlerFactory());
         serializationLibrary.addTypeHandler(Prefab.class, new PrefabTypeHandler());
         serializationLibrary.addTypeHandler(IntegerRange.class, new IntegerRangeHandler());
-
-        //serializationLibrary.addTypeHandlerFactory(new ComponentClassTypeHandlerFactory());
     }
 
     /**
@@ -417,7 +412,7 @@ public class TypeHandlerLibrary {
      *
      * @param typeInfo The {@link TypeInfo} describing the base type for which to return a
      *                 {@link TypeHandler}.
-     * @param <T> The base type for which to return a {@link TypeHandler}.
+     * @param <T>      The base type for which to return a {@link TypeHandler}.
      */
     public <T> TypeHandler<T> getBaseTypeHandler(TypeInfo<T> typeInfo) {
         TypeHandler<T> delegateHandler = getTypeHandler(typeInfo).orElse(null);

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
@@ -23,6 +23,7 @@ import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.IntegerRange;
 import org.terasology.math.geom.Quat4f;
@@ -36,6 +37,7 @@ import org.terasology.persistence.typeHandling.coreTypes.BooleanTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.ByteArrayTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.ByteTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.CharacterTypeHandler;
+import org.terasology.persistence.typeHandling.extensionTypes.ComponentClassTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.DoubleTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.FloatTypeHandler;
 import org.terasology.persistence.typeHandling.coreTypes.IntTypeHandler;
@@ -53,6 +55,7 @@ import org.terasology.persistence.typeHandling.extensionTypes.NameTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.PrefabTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.TextureRegionTypeHandler;
 import org.terasology.persistence.typeHandling.extensionTypes.factories.AssetTypeHandlerFactory;
+import org.terasology.persistence.typeHandling.extensionTypes.factories.ComponentClassTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.extensionTypes.factories.TextureRegionAssetTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.mathTypes.IntegerRangeHandler;
 import org.terasology.persistence.typeHandling.mathTypes.QuaternionfTypeHandler;
@@ -141,6 +144,8 @@ public class TypeHandlerLibrary {
         addTypeHandlerFactory(new ArrayTypeHandlerFactory());
         addTypeHandler(byte[].class, new ByteArrayTypeHandler());
 
+        //addTypeHandler(new TypeInfo<Class<? extends Component>>() {},new ComponentClassTypeHandler());
+
         addTypeHandlerFactory(new EnumTypeHandlerFactory());
         addTypeHandlerFactory(new CollectionTypeHandlerFactory(constructorLibrary));
         addTypeHandlerFactory(new StringMapTypeHandlerFactory());
@@ -210,11 +215,12 @@ public class TypeHandlerLibrary {
         serializationLibrary.addTypeHandler(org.joml.Vector3i.class, new Vector3iTypeHandler());
         serializationLibrary.addTypeHandler(org.joml.Vector2i.class, new Vector2iTypeHandler());
 
-
         serializationLibrary.addTypeHandlerFactory(new Rect2iTypeHandlerFactory());
         serializationLibrary.addTypeHandlerFactory(new Rect2fTypeHandlerFactory());
         serializationLibrary.addTypeHandler(Prefab.class, new PrefabTypeHandler());
         serializationLibrary.addTypeHandler(IntegerRange.class, new IntegerRangeHandler());
+
+        //serializationLibrary.addTypeHandlerFactory(new ComponentClassTypeHandlerFactory());
     }
 
     /**

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ComponentClassTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ComponentClassTypeHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.extensionTypes;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
+
+public class ComponentClassTypeHandler extends StringRepresentationTypeHandler<Class<? extends Component>> {
+
+    @Override
+    public String getAsString(Class<? extends Component> item) {
+        return item.getName();
+    }
+
+    @Override
+    public Class<? extends Component> getFromString(String representation) {
+        try {
+            final Class<? extends Component> clazz = Class.forName(representation).asSubclass(Component.class);
+            return clazz;
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/factories/ComponentClassTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/factories/ComponentClassTypeHandlerFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling.extensionTypes.factories;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.PersistedDataSerializer;
+import org.terasology.persistence.typeHandling.SpecificTypeHandlerFactory;
+import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
+import org.terasology.persistence.typeHandling.TypeHandler;
+import org.terasology.persistence.typeHandling.TypeHandlerContext;
+import org.terasology.reflection.TypeInfo;
+
+import java.util.Optional;
+
+public class ComponentClassTypeHandlerFactory extends SpecificTypeHandlerFactory<Class<? extends Component>> {
+
+    public ComponentClassTypeHandlerFactory() {
+        super(new TypeInfo<Class<? extends Component>>() {});
+    }
+
+    @Override
+    protected TypeHandler<Class<? extends Component>> createHandler(TypeHandlerContext context) {
+        return new ComponentClassTypeHandler(context);
+    }
+
+    class ComponentClassTypeHandler extends StringRepresentationTypeHandler<Class<? extends Component>> {
+
+        TypeHandlerContext context;
+
+        public ComponentClassTypeHandler(final TypeHandlerContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public String getAsString(Class<? extends Component> item) {
+            return context.getSandbox().getSubTypeIdentifier(item, Component.class);
+        }
+
+        @Override
+        public Class<? extends Component> getFromString(String representation) {
+            return context.getSandbox().findSubTypeOf(representation, Component.class).orElse(null);
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator implements BlockEntityRegistry, UpdateSubscriberSystem, EntityChangeSubscriber {
     private static final Logger logger = LoggerFactory.getLogger(EntityAwareWorldProvider.class);
@@ -150,16 +149,6 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
             return oldBlocks;
         }
         return null;
-    }
-
-    private <T> Optional<Class<? extends T>> classFromName(final String className, Class<T> interfaceClass) {
-        Class<? extends T> clazz = null;
-        try {
-            clazz = Class.forName(className).asSubclass(interfaceClass);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        }
-        return Optional.ofNullable(clazz);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -139,18 +139,10 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
                     EntityRef blockEntity = getBlockEntityAt(vec);
 
                     // check for components to be retained when updating the block entity
-                    final Set<String> classNamesToRetain =
-                            Optional.ofNullable(blockEntity.getComponent(RetainComponentsComponent.class))
-                                    .map(retainComponentsComponent -> retainComponentsComponent.componentTypeNames)
-                                    .orElse(Collections.emptySet());
-
-
                     final Set<Class<? extends Component>> retainComponents =
-                            classNamesToRetain.stream()
-                                    .map(className -> classFromName(className, Component.class))
-                                    .filter(Optional::isPresent)
-                                    .map(Optional::get)
-                                    .collect(Collectors.toSet());
+                            Optional.ofNullable(blockEntity.getComponent(RetainComponentsComponent.class))
+                                    .map(retainComponentsComponent -> retainComponentsComponent.components)
+                                    .orElse(Collections.emptySet());
 
                     updateBlockEntity(blockEntity, vec, oldBlocks.get(vec), blocks.get(vec), false, retainComponents);
                 }


### PR DESCRIPTION
Follow up to https://github.com/MovingBlocks/Terasology/pull/3910

Potential fix for this oversight: https://github.com/Terasology/Machines/pull/29#issuecomment-620378868

I tried to write a `TypeHandler` for `Class<? extends Component>` (see https://github.com/Terasology/Machines/pull/29#issuecomment-620846792) but failed adding it to the type handler library.

Not sure what the best/easiest/recommended way to go forward is ... 🙄 

@Cervator @jdrueckert would be great if you could test this ... The set should be filled like this now:

```java
retainComponents.componentTypeNames.add(InventoryAccessComponent.class.getName());
```