### PR TITLE
feat(typeHandling): Add SpecificTypeHandlerFactory

### DIFF
--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -40,6 +40,7 @@ import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
 import org.terasology.persistence.typeHandling.extensionTypes.CollisionGroupTypeHandler;
 import org.terasology.physics.CollisionGroup;
 import org.terasology.physics.CollisionGroupManager;
+import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.TypeRegistry;
 import org.terasology.reflection.copy.CopyStrategy;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
@@ -201,7 +202,7 @@ public final class EnvironmentSwitchHandler {
                 if (opt.isPresent()) {
                     TypeHandler instance = InjectionHelper.createWithConstructorInjection(handler, context);
                     InjectionHelper.inject(instance, context);
-                    library.addTypeHandler((Class) opt.get(), instance);
+                    library.addTypeHandler(TypeInfo.of(opt.get()), instance);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/SpecificTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/SpecificTypeHandlerFactory.java
@@ -19,6 +19,11 @@ import org.terasology.reflection.TypeInfo;
 
 import java.util.Optional;
 
+/**
+ * Represents a {@link TypeHandlerFactory} that generates type handlers for a specific type.
+ *
+ * @param <T> The type for which this {@link TypeHandlerFactory} generates type handlers.
+ */
 public abstract class SpecificTypeHandlerFactory<T> implements TypeHandlerFactory {
     protected final TypeInfo<T> type;
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/SpecificTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/SpecificTypeHandlerFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.persistence.typeHandling;
+
+import org.terasology.reflection.TypeInfo;
+
+import java.util.Optional;
+
+public abstract class SpecificTypeHandlerFactory<T> implements TypeHandlerFactory {
+    protected final TypeInfo<T> type;
+
+    public SpecificTypeHandlerFactory(TypeInfo<T> type) {
+        this.type = type;
+    }
+
+    public SpecificTypeHandlerFactory(Class<T> clazz) {
+        this(TypeInfo.of(clazz));
+    }
+
+    @Override
+    public <R> Optional<TypeHandler<R>> create(TypeInfo<R> typeInfo, TypeHandlerContext context) {
+        if (typeInfo.equals(type)) {
+            return Optional.of((TypeHandler<R>) createHandler(context));
+        }
+        return Optional.empty();
+    }
+
+    protected abstract TypeHandler<T> createHandler(TypeHandlerContext context);
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/SpecificTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/SpecificTypeHandlerFactory.java
@@ -43,5 +43,11 @@ public abstract class SpecificTypeHandlerFactory<T> implements TypeHandlerFactor
         return Optional.empty();
     }
 
+    /**
+     * Creates the {@link TypeHandler} for the specific type.
+     *
+     * @param context The context in which to create the {@link TypeHandler}.
+     * @return The created type handler.
+     */
     protected abstract TypeHandler<T> createHandler(TypeHandlerContext context);
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerFactory.java
@@ -42,39 +42,4 @@ public interface TypeHandlerFactory {
      * if the type is not supported by this {@link TypeHandlerFactory}.
      */
     <T> Optional<TypeHandler<T>> create(TypeInfo<T> typeInfo, TypeHandlerContext context);
-
-    /**
-     * Creates a {@link TypeHandlerFactory} that only produces type handlers for the given type
-     * using the given {@link TypeHandler} producer method.
-     * @param type The {@link TypeInfo} describing the type for which the factory generates type handlers
-     * @param handlerProducer The {@link TypeHandler} producer method
-     * @param <R> The type for which the factory generates type handlers
-     * @return The created {@link TypeHandlerFactory}.
-     */
-    static <R> TypeHandlerFactory of(TypeInfo<R> type,
-                                     BiFunction<TypeInfo<R>, TypeHandlerContext, TypeHandler<R>> handlerProducer) {
-        return new TypeHandlerFactory() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public <T> Optional<TypeHandler<T>> create(TypeInfo<T> typeInfo, TypeHandlerContext context) {
-                if (typeInfo.equals(type)) {
-                    return Optional.of((TypeHandler<T>) handlerProducer.apply(type, context));
-                }
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * Creates a {@link TypeHandlerFactory} that only produces type handlers for the given type
-     * using the given {@link TypeHandler} producer method.
-     * @param clazz The {@link Class} of the type for which the factory generates type handlers
-     * @param handlerProducer The {@link TypeHandler} producer method
-     * @param <R> The type for which the factory generates type handlers
-     * @return The created {@link TypeHandlerFactory}.
-     */
-    static <R> TypeHandlerFactory of(Class<R> clazz,
-                                     BiFunction<TypeInfo<R>, TypeHandlerContext, TypeHandler<R>> handlerProducer) {
-        return of(TypeInfo.of(clazz), handlerProducer);
-    }
 }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
@@ -278,7 +278,12 @@ public class TypeHandlerLibrary {
             return false;
         }
 
-        addTypeHandlerFactory(TypeHandlerFactory.of(type, (_t, _c) -> typeHandler));
+        addTypeHandlerFactory(new SpecificTypeHandlerFactory<T>(type) {
+            @Override
+            protected TypeHandler<T> createHandler(TypeHandlerContext context) {
+                return typeHandler;
+            }
+        });
 
         return true;
     }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerLibrary.java
@@ -278,15 +278,7 @@ public class TypeHandlerLibrary {
             return false;
         }
 
-        TypeHandlerFactory factory = new TypeHandlerFactory() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public <R> Optional<TypeHandler<R>> create(TypeInfo<R> typeInfo, TypeHandlerContext context) {
-                return typeInfo.equals(type) ? Optional.of((TypeHandler<R>) typeHandler) : Optional.empty();
-            }
-        };
-
-        addTypeHandlerFactory(factory);
+        addTypeHandlerFactory(TypeHandlerFactory.of(type, (_t, _c) -> typeHandler));
 
         return true;
     }


### PR DESCRIPTION
Adds an abstract class `SpecificTypeHandlerFactory` that can be inherited to reduce boilerplate when creating `TypeHandlerFactories` that create type handlers for a single type.

Also replaces a cast of the type to `Class` with `TypeInfo.of(type)` when registering type handlers using the `@RegisterTypeHandler` annotation.