### PR TITLE
feat(JOML): Migrate Particle System

### DIFF
--- a/engine/src/main/java/org/terasology/particles/ParticleData.java
+++ b/engine/src/main/java/org/terasology/particles/ParticleData.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.particles;
 
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector4f;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
+import org.joml.Vector4f;
 import org.terasology.module.sandbox.API;
 
 /**

--- a/engine/src/main/java/org/terasology/particles/components/ParticleDataSpriteComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/ParticleDataSpriteComponent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.particles.components;
 
+import org.joml.Vector2f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector2f;
 import org.terasology.module.sandbox.API;
 import org.terasology.rendering.assets.texture.Texture;
 

--- a/engine/src/main/java/org/terasology/particles/components/affectors/AccelerationAffectorComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/affectors/AccelerationAffectorComponent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.particles.components.affectors;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.module.sandbox.API;
 import org.terasology.network.Replicate;
 

--- a/engine/src/main/java/org/terasology/particles/components/generators/ColorRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/generators/ColorRangeGeneratorComponent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.particles.components.generators;
 
+import org.joml.Vector4f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector4f;
 import org.terasology.module.sandbox.API;
 
 /**

--- a/engine/src/main/java/org/terasology/particles/components/generators/PositionRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/generators/PositionRangeGeneratorComponent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.particles.components.generators;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.module.sandbox.API;
 
 /**

--- a/engine/src/main/java/org/terasology/particles/components/generators/ScaleRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/generators/ScaleRangeGeneratorComponent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.particles.components.generators;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.module.sandbox.API;
 
 /**

--- a/engine/src/main/java/org/terasology/particles/components/generators/TextureOffsetGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/generators/TextureOffsetGeneratorComponent.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.particles.components.generators;
 
+import org.joml.Vector2f;
+import org.joml.Vector2i;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector2i;
 import org.terasology.module.sandbox.API;
 import org.terasology.rendering.assets.texture.Texture;
 
@@ -60,12 +60,12 @@ public class TextureOffsetGeneratorComponent implements Component {
      * @param validTextures Indices of the valid textures
      */
     public TextureOffsetGeneratorComponent(final Texture atlas, final Vector2i atlasSize, final Vector2i[] validTextures) {
-        final float textureWidth = atlas.getWidth() / (float) atlasSize.getX();
-        final float textureHeight = atlas.getHeight() / (float) atlasSize.getY();
+        final float textureWidth = atlas.getWidth() / (float) atlasSize.x();
+        final float textureHeight = atlas.getHeight() / (float) atlasSize.y();
 
         Function<Vector2i, Vector2f> absolute2Relative = (absolute) -> new Vector2f(
-                absolute.getX() * textureWidth,
-                absolute.getY() * textureHeight
+                absolute.x() * textureWidth,
+                absolute.y() * textureHeight
         );
 
         this.validOffsets = new LinkedList<>();

--- a/engine/src/main/java/org/terasology/particles/components/generators/VelocityRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/generators/VelocityRangeGeneratorComponent.java
@@ -15,8 +15,8 @@
  */
 package org.terasology.particles.components.generators;
 
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.module.sandbox.API;
 
 /**

--- a/engine/src/main/java/org/terasology/particles/functions/generators/ColorRangeGeneratorFunction.java
+++ b/engine/src/main/java/org/terasology/particles/functions/generators/ColorRangeGeneratorFunction.java
@@ -34,9 +34,9 @@ public final class ColorRangeGeneratorFunction extends GeneratorFunction<ColorRa
                            final ParticleData particleData,
                            final Random random
     ) {
-        particleData.color.setX(random.nextFloat(component.minColorComponents.x(), component.maxColorComponents.x()));
-        particleData.color.setY(random.nextFloat(component.minColorComponents.y(), component.maxColorComponents.y()));
-        particleData.color.setZ(random.nextFloat(component.minColorComponents.z(), component.maxColorComponents.z()));
-        particleData.color.setW(random.nextFloat(component.minColorComponents.w(), component.maxColorComponents.w()));
+        particleData.color.set(random.nextFloat(component.minColorComponents.x(), component.maxColorComponents.x()),
+            random.nextFloat(component.minColorComponents.y(), component.maxColorComponents.y()),
+            random.nextFloat(component.minColorComponents.z(), component.maxColorComponents.z()),
+            random.nextFloat(component.minColorComponents.w(), component.maxColorComponents.w()));
     }
 }

--- a/engine/src/main/java/org/terasology/particles/functions/generators/TextureOffsetGeneratorFunction.java
+++ b/engine/src/main/java/org/terasology/particles/functions/generators/TextureOffsetGeneratorFunction.java
@@ -38,6 +38,6 @@ public class TextureOffsetGeneratorFunction extends GeneratorFunction<TextureOff
 
         final int randomOffsetIndex = random.nextInt(component.validOffsets.size());
         final Vector2f randomOffset = component.validOffsets.get(randomOffsetIndex);
-        particleData.textureOffset.set(randomOffset.x(), randomOffset.y());
+        particleData.textureOffset.set(randomOffset);
     }
 }

--- a/engine/src/main/java/org/terasology/particles/functions/generators/TextureOffsetGeneratorFunction.java
+++ b/engine/src/main/java/org/terasology/particles/functions/generators/TextureOffsetGeneratorFunction.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.particles.functions.generators;
 
-import org.terasology.math.geom.Vector2f;
+import org.joml.Vector2f;
 import org.terasology.particles.ParticleData;
 import org.terasology.particles.ParticleDataMask;
 import org.terasology.particles.components.generators.TextureOffsetGeneratorComponent;
@@ -35,9 +35,9 @@ public class TextureOffsetGeneratorFunction extends GeneratorFunction<TextureOff
         if (component.validOffsets.size() == 0) {
             return;
         }
-        
+
         final int randomOffsetIndex = random.nextInt(component.validOffsets.size());
         final Vector2f randomOffset = component.validOffsets.get(randomOffsetIndex);
-        particleData.textureOffset.set(randomOffset.getX(), randomOffset.getY());
+        particleData.textureOffset.set(randomOffset.x(), randomOffset.y());
     }
 }

--- a/engine/src/main/java/org/terasology/particles/functions/generators/VelocityRangeGeneratorFunction.java
+++ b/engine/src/main/java/org/terasology/particles/functions/generators/VelocityRangeGeneratorFunction.java
@@ -32,8 +32,9 @@ public final class VelocityRangeGeneratorFunction extends GeneratorFunction<Velo
     public void onEmission(final VelocityRangeGeneratorComponent component,
                            final ParticleData particleData,
                            final Random random) {
-        particleData.velocity.setX(random.nextFloat(component.minVelocity.x(), component.maxVelocity.x()));
-        particleData.velocity.setY(random.nextFloat(component.minVelocity.y(), component.maxVelocity.y()));
-        particleData.velocity.setZ(random.nextFloat(component.minVelocity.z(), component.maxVelocity.z()));
+        particleData.velocity.set(
+            random.nextFloat(component.minVelocity.x(), component.maxVelocity.x()),
+            random.nextFloat(component.minVelocity.y(), component.maxVelocity.y()),
+            random.nextFloat(component.minVelocity.z(), component.maxVelocity.z()));
     }
 }

--- a/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
+++ b/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
@@ -99,7 +99,7 @@ public class SpriteParticleRenderer implements RenderSystem {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);
             glBindTexture(GL11.GL_TEXTURE_2D, particleSystem.particleData.texture.getId());
 
-            material.setFloat2("texSize", particleSystem.particleData.textureSize.getX(), particleSystem.particleData.textureSize.getY());
+            material.setFloat2("texSize", particleSystem.particleData.textureSize.x(), particleSystem.particleData.textureSize.y());
         }
 
         glPushMatrix();

--- a/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
+++ b/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
@@ -99,7 +99,7 @@ public class SpriteParticleRenderer implements RenderSystem {
             GL13.glActiveTexture(GL13.GL_TEXTURE0);
             glBindTexture(GL11.GL_TEXTURE_2D, particleSystem.particleData.texture.getId());
 
-            material.setFloat2("texSize", particleSystem.particleData.textureSize.x(), particleSystem.particleData.textureSize.y());
+            material.setFloat2("texSize", particleSystem.particleData.textureSize);
         }
 
         glPushMatrix();

--- a/engine/src/main/java/org/terasology/particles/updating/ParticleUpdaterImpl.java
+++ b/engine/src/main/java/org/terasology/particles/updating/ParticleUpdaterImpl.java
@@ -20,6 +20,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableList;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.particles.ParticleDataMask;
@@ -193,7 +194,7 @@ class ParticleUpdaterImpl implements ParticleUpdater {
         );
 
         particleEmitter.particlePool.temporaryParticleData.position.add(
-                particleEmitter.locationComponent.getWorldPosition()
+            JomlUtil.from(particleEmitter.locationComponent.getWorldPosition())
         );
 
         particleEmitter.particlePool.storeTemporaryDataAt(index, ParticleDataMask.ALL.toInt());


### PR DESCRIPTION
A lot of the logic was pretty straightforward so moving the particle system over to JOML was not too bad. There are not a lot of dependencies from this part of the codebase so moving over the rest of the components is fairly trivial when compared to other parts of the engine. This mostly focuses on porting over particles in the engine. 

Modules:
- https://github.com/Terasology/Health/pull/40

## Test
- download health module: ` ./groovyw module recurse Health` and use branch from https://github.com/Terasology/Health/pull/40
- create core world and verify that particles behave correctly when breaking blocks. 