### PR TITLE
Seed ui and save issues

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameManifestProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameManifestProvider.java
@@ -79,11 +79,12 @@ public class GameManifestProvider {
         if (universeWrapper.getTargetWorld() != null) {
             uri = universeWrapper.getTargetWorld().getWorldGenerator().getUri();
             seed = universeWrapper.getTargetWorld().getWorldGenerator().getWorldSeed();
-            gameManifest.setSeed(seed);
         } else {
             uri = config.getWorldGeneration().getDefaultGenerator();
             seed = universeWrapper.getSeed();
         }
+        gameManifest.setSeed(seed);
+
         String targetWorldName = "";
         if (universeWrapper.getTargetWorld() != null) {
             targetWorldName = universeWrapper.getTargetWorld().getWorldName().toString();

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -515,7 +515,6 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
                 universeWrapper.setSeed(seed.getText());
                 saveConfiguration();
                 final GameManifest gameManifest = GameManifestProvider.createGameManifest(universeWrapper, moduleManager, config);
-                gameManifest.setSeed(seed.getText());
                 if (gameManifest != null) {
                     gameEngine.changeState(new StateLoading(gameManifest, (universeWrapper.getLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
                 } else {

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -515,6 +515,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
                 universeWrapper.setSeed(seed.getText());
                 saveConfiguration();
                 final GameManifest gameManifest = GameManifestProvider.createGameManifest(universeWrapper, moduleManager, config);
+                gameManifest.setSeed(seed.getText());
                 if (gameManifest != null) {
                     gameEngine.changeState(new StateLoading(gameManifest, (universeWrapper.getLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));
                 } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

## Summary

### Result

Seed value gets saved at the save file of the created world.

### Original Issue 

* Seed value was not getting saved at the world's save file, thus:
    * Correct seed value did not appear on Game Details Screen (it was never saved in the first place)

The problem seemed to be that the `gameManifest` never gets the seed value.

Closes #3915 
Closes #3929 
Possibly also Closes #3883 

## Contents

### Changes

* Added the seed value `seed` at the `gameManifest`.

## How to test

1. Create different games through the Advanced Game Settings by either adding your seed value, **or** by keeping the generated one
2. Follow the How to reproduce issue #3915 **or** How to reproduce issue #3929  


