### PR TITLE
feat(JOML): Migrate Region3i

### DIFF
--- a/engine-tests/src/test/java/org/terasology/math/Region3iTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/Region3iTest.java
@@ -17,6 +17,7 @@
 package org.terasology.math;
 
 import com.google.common.collect.Sets;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.Test;
 import org.terasology.math.geom.Vector3i;
 
@@ -108,9 +109,9 @@ public class Region3iTest {
             }
         }
 
-        for (Vector3i pos : region) {
-            assertTrue(expected.contains(pos));
-            expected.remove(pos);
+        for (Vector3ic pos : region) {
+            assertTrue(expected.contains(JomlUtil.from(pos)), JomlUtil.from(pos).toString());
+            expected.remove(JomlUtil.from(pos));
         }
 
         assertEquals(0, expected.size(), "All vectors provided");

--- a/engine-tests/src/test/java/org/terasology/world/generator/InternalLightGeneratorTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/generator/InternalLightGeneratorTest.java
@@ -15,12 +15,14 @@
  */
 package org.terasology.world.generator;
 
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.math.Diamond3iIterator;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
@@ -84,44 +86,44 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
         InternalLightProcessor.generateInternalLighting(chunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z))) {
-            byte expectedRegen = (byte) Math.min(ChunkConstants.SIZE_Y - pos.y - 1, ChunkConstants.MAX_SUNLIGHT_REGEN);
-            assertEquals(expectedRegen, chunk.getSunlightRegen(pos));
+        for (Vector3ic pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y, ChunkConstants.SIZE_Z))) {
+            byte expectedRegen = (byte) Math.min(ChunkConstants.SIZE_Y - pos.y() - 1, ChunkConstants.MAX_SUNLIGHT_REGEN);
+            assertEquals(expectedRegen, chunk.getSunlightRegen(JomlUtil.from(pos)));
         }
     }
 
     @Test
     public void testBlockedSunlightRegenPropagationResets() {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 60, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            chunk.setBlock(pos, solidBlock);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 60, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            chunk.setBlock(JomlUtil.from(pos), solidBlock);
         }
         InternalLightProcessor.generateInternalLighting(chunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 61, 0), new Vector3i(ChunkConstants.SIZE_X, 3, ChunkConstants.SIZE_Z))) {
-            byte expectedRegen = (byte) Math.min(ChunkConstants.SIZE_Y - pos.y - 1, ChunkConstants.MAX_SUNLIGHT_REGEN);
-            assertEquals(expectedRegen, chunk.getSunlightRegen(pos));
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 61, 0), new Vector3i(ChunkConstants.SIZE_X, 3, ChunkConstants.SIZE_Z))) {
+            byte expectedRegen = (byte) Math.min(ChunkConstants.SIZE_Y - pos.y() - 1, ChunkConstants.MAX_SUNLIGHT_REGEN);
+            assertEquals(expectedRegen, chunk.getSunlightRegen(JomlUtil.from(pos)));
         }
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 60, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            assertEquals(0, chunk.getSunlightRegen(pos));
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 60, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            assertEquals(0, chunk.getSunlightRegen(JomlUtil.from(pos)));
         }
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 59, ChunkConstants.SIZE_Z))) {
-            byte expectedRegen = (byte) Math.min(60 - pos.y - 1, ChunkConstants.MAX_SUNLIGHT_REGEN);
-            assertEquals(expectedRegen, chunk.getSunlightRegen(pos));
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 59, ChunkConstants.SIZE_Z))) {
+            byte expectedRegen = (byte) Math.min(60 - pos.y() - 1, ChunkConstants.MAX_SUNLIGHT_REGEN);
+            assertEquals(expectedRegen, chunk.getSunlightRegen(JomlUtil.from(pos)));
         }
     }
 
     @Test
     public void testBlockedAtTopSunlightRegenPropagationResets() {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 63, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            chunk.setBlock(pos, solidBlock);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 63, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            chunk.setBlock(JomlUtil.from(pos), solidBlock);
         }
         InternalLightProcessor.generateInternalLighting(chunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - 1, ChunkConstants.SIZE_Z))) {
-            byte expectedRegen = (byte) Math.min(ChunkConstants.SIZE_Y - pos.y - 2, ChunkConstants.MAX_SUNLIGHT_REGEN);
-            assertEquals(expectedRegen, chunk.getSunlightRegen(pos));
+        for (Vector3ic pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - 1, ChunkConstants.SIZE_Z))) {
+            byte expectedRegen = (byte) Math.min(ChunkConstants.SIZE_Y - pos.y() - 2, ChunkConstants.MAX_SUNLIGHT_REGEN);
+            assertEquals(expectedRegen, chunk.getSunlightRegen(JomlUtil.from(pos)));
         }
     }
 
@@ -130,29 +132,29 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
         InternalLightProcessor.generateInternalLighting(chunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - 15,
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - 15,
                 ChunkConstants.SIZE_Z))) {
-            assertEquals(0, chunk.getSunlight(pos));
+            assertEquals(0, chunk.getSunlight(JomlUtil.from(pos)));
         }
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - ChunkConstants.MAX_SUNLIGHT_REGEN,
+        for (Vector3ic pos : Region3i.createFromMinAndSize(Vector3i.zero(), new Vector3i(ChunkConstants.SIZE_X, ChunkConstants.SIZE_Y - ChunkConstants.MAX_SUNLIGHT_REGEN,
                 ChunkConstants.SIZE_Z))) {
-            byte expectedSunlight = (byte) Math.min(ChunkConstants.SIZE_Y - ChunkConstants.SUNLIGHT_REGEN_THRESHOLD - pos.y - 1, ChunkConstants.MAX_SUNLIGHT);
-            assertEquals(expectedSunlight, chunk.getSunlight(pos), () -> "Incorrect lighting at " + pos);
+            byte expectedSunlight = (byte) Math.min(ChunkConstants.SIZE_Y - ChunkConstants.SUNLIGHT_REGEN_THRESHOLD - pos.y() - 1, ChunkConstants.MAX_SUNLIGHT);
+            assertEquals(expectedSunlight, chunk.getSunlight(JomlUtil.from(pos)), () -> "Incorrect lighting at " + pos);
         }
     }
 
     @Test
     public void testBlockedSunlightPropagation() {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 4, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            chunk.setBlock(pos, solidBlock);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 4, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            chunk.setBlock(JomlUtil.from(pos), solidBlock);
         }
         InternalLightProcessor.generateInternalLighting(chunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 5,
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 5,
                 ChunkConstants.SIZE_Z))) {
-            assertEquals(0, chunk.getSunlight(pos), () -> "Incorrect lighting at " + pos);
+            assertEquals(0, chunk.getSunlight(JomlUtil.from(pos)), () -> "Incorrect lighting at " + pos);
         }
     }
 
@@ -161,17 +163,17 @@ public class InternalLightGeneratorTest extends TerasologyTestingEnvironment {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
         InternalLightProcessor.generateInternalLighting(chunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 15,
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 15,
                 ChunkConstants.SIZE_Z))) {
-            assertEquals(15 - pos.y, chunk.getSunlight(pos), () -> "Incorrect lighting at " + pos);
+            assertEquals(15 - pos.y(), chunk.getSunlight(JomlUtil.from(pos)), () -> "Incorrect lighting at " + pos);
         }
     }
 
     @Test
     public void testHorizontalSunlightPropagation() {
         Chunk chunk = new ChunkImpl(0, 0, 0, blockManager, extraDataManager);
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 4, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            chunk.setBlock(pos, solidBlock);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 4, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            chunk.setBlock(JomlUtil.from(pos), solidBlock);
         }
         chunk.setBlock(new Vector3i(16, 4, 16), airBlock);
         InternalLightProcessor.generateInternalLighting(chunk);

--- a/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
@@ -16,12 +16,14 @@
 package org.terasology.world.propagation;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -104,17 +106,17 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            topChunk.setSunlight(pos, ChunkConstants.MAX_SUNLIGHT);
-            topChunk.setSunlightRegen(pos, ChunkConstants.MAX_SUNLIGHT_REGEN);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            topChunk.setSunlight(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT);
+            topChunk.setSunlightRegen(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT_REGEN);
         }
         InternalLightProcessor.generateInternalLighting(bottomChunk);
         propagator.propagateBetween(topChunk, bottomChunk, Side.BOTTOM, true);
         propagator.process();
         sunlightPropagator.process();
-        for (Vector3i pos : ChunkConstants.CHUNK_REGION) {
-            assertEquals(ChunkConstants.MAX_SUNLIGHT, bottomChunk.getSunlight(pos), () -> "Incorrect at position " + pos);
-            assertEquals(ChunkConstants.MAX_SUNLIGHT_REGEN, bottomChunk.getSunlightRegen(pos), () -> "Incorrect at position " + pos);
+        for (Vector3ic pos : ChunkConstants.CHUNK_REGION) {
+            assertEquals(ChunkConstants.MAX_SUNLIGHT, bottomChunk.getSunlight(JomlUtil.from(pos)), () -> "Incorrect at position " + pos);
+            assertEquals(ChunkConstants.MAX_SUNLIGHT_REGEN, bottomChunk.getSunlightRegen(JomlUtil.from(pos)), () -> "Incorrect at position " + pos);
         }
     }
 
@@ -126,15 +128,15 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            topChunk.setSunlight(pos, ChunkConstants.MAX_SUNLIGHT);
-            topChunk.setSunlightRegen(pos, ChunkConstants.MAX_SUNLIGHT_REGEN);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            topChunk.setSunlight(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT);
+            topChunk.setSunlightRegen(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT_REGEN);
         }
         InternalLightProcessor.generateInternalLighting(bottomChunk);
         propagator.propagateBetween(topChunk, bottomChunk, Side.BOTTOM, true);
         propagator.process();
-        for (Vector3i pos : ChunkConstants.CHUNK_REGION) {
-            assertEquals(ChunkConstants.MAX_SUNLIGHT_REGEN, bottomChunk.getSunlightRegen(pos), () -> "Incorrect at position " + pos);
+        for (Vector3ic pos : ChunkConstants.CHUNK_REGION) {
+            assertEquals(ChunkConstants.MAX_SUNLIGHT_REGEN, bottomChunk.getSunlightRegen(JomlUtil.from(pos)), () -> "Incorrect at position " + pos);
         }
     }
 
@@ -146,12 +148,12 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            topChunk.setSunlight(pos, ChunkConstants.MAX_SUNLIGHT);
-            topChunk.setSunlightRegen(pos, ChunkConstants.MAX_SUNLIGHT_REGEN);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            topChunk.setSunlight(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT);
+            topChunk.setSunlightRegen(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT_REGEN);
         }
-        for (Vector3i pos : Region3i.createFromMinMax(new Vector3i(16, 48, 0), new Vector3i(31, 48, 31))) {
-            bottomChunk.setBlock(pos, solid);
+        for (Vector3ic pos : Region3i.createFromMinMax(new Vector3i(16, 48, 0), new Vector3i(31, 48, 31))) {
+            bottomChunk.setBlock(JomlUtil.from(pos), solid);
         }
         InternalLightProcessor.generateInternalLighting(bottomChunk);
 
@@ -174,13 +176,13 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         provider.addChunk(topChunk);
         provider.addChunk(bottomChunk);
 
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
-            topChunk.setSunlight(pos, (byte) 0);
-            topChunk.setSunlightRegen(pos, (byte) 0);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X, 1, ChunkConstants.SIZE_Z))) {
+            topChunk.setSunlight(JomlUtil.from(pos), (byte) 0);
+            topChunk.setSunlightRegen(JomlUtil.from(pos), (byte) 0);
         }
-        for (Vector3i pos : Region3i.createFromMinAndSize(new Vector3i(8, 0, 8), new Vector3i(ChunkConstants.SIZE_X - 16, 1, ChunkConstants.SIZE_Z - 16))) {
-            topChunk.setSunlight(pos, (byte) 0);
-            topChunk.setSunlightRegen(pos, (byte) 32);
+        for (Vector3ic pos : Region3i.createFromMinAndSize(new Vector3i(8, 0, 8), new Vector3i(ChunkConstants.SIZE_X - 16, 1, ChunkConstants.SIZE_Z - 16))) {
+            topChunk.setSunlight(JomlUtil.from(pos), (byte) 0);
+            topChunk.setSunlightRegen(JomlUtil.from(pos), (byte) 32);
         }
         InternalLightProcessor.generateInternalLighting(bottomChunk);
 

--- a/engine-tests/src/test/java/org/terasology/world/propagation/BulkLightPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BulkLightPropagationTest.java
@@ -15,12 +15,14 @@
  */
 package org.terasology.world.propagation;
 
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.math.Diamond3iIterator;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
@@ -305,8 +307,8 @@ public class BulkLightPropagationTest extends TerasologyTestingEnvironment {
     @Test
     public void testRemoveSolidAllowsLight() {
         StubPropagatorWorldView worldView = new StubPropagatorWorldView(testingRegion, air);
-        for (Vector3i pos : Region3i.createFromCenterExtents(new Vector3i(1, 0, 0), new Vector3i(0, 30, 30))) {
-            worldView.setBlockAt(pos, solid);
+        for (Vector3ic pos : Region3i.createFromCenterExtents(new Vector3i(1, 0, 0), new Vector3i(0, 30, 30))) {
+            worldView.setBlockAt(JomlUtil.from(pos), solid);
         }
         worldView.setBlockAt(new Vector3i(0, 0, 0), fullLight);
         BatchPropagator propagator = new StandardBatchPropagator(lightRules, worldView);
@@ -324,8 +326,8 @@ public class BulkLightPropagationTest extends TerasologyTestingEnvironment {
     @Test
     public void testRemoveSolidAndLight() {
         StubPropagatorWorldView worldView = new StubPropagatorWorldView(testingRegion, air);
-        for (Vector3i pos : Region3i.createFromCenterExtents(new Vector3i(1, 0, 0), new Vector3i(0, 30, 30))) {
-            worldView.setBlockAt(pos, solid);
+        for (Vector3ic pos : Region3i.createFromCenterExtents(new Vector3i(1, 0, 0), new Vector3i(0, 30, 30))) {
+            worldView.setBlockAt(JomlUtil.from(pos), solid);
         }
         worldView.setBlockAt(new Vector3i(0, 0, 0), fullLight);
         BatchPropagator propagator = new StandardBatchPropagator(lightRules, worldView);

--- a/engine-tests/src/test/java/org/terasology/world/propagation/BulkSunlightPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BulkSunlightPropagationTest.java
@@ -16,11 +16,13 @@
 package org.terasology.world.propagation;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
@@ -88,15 +90,15 @@ public class BulkSunlightPropagationTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testAllowSunlightVertical() {
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 16, 0), new Vector3i(ChunkConstants.SIZE_X - 1, ChunkConstants.SIZE_Y - 1, ChunkConstants.SIZE_Z - 1))) {
-            regenWorldView.setValueAt(pos, ChunkConstants.MAX_SUNLIGHT_REGEN);
-            lightWorldView.setValueAt(pos, ChunkConstants.MAX_SUNLIGHT);
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 16, 0), new Vector3i(ChunkConstants.SIZE_X - 1, ChunkConstants.SIZE_Y - 1, ChunkConstants.SIZE_Z - 1))) {
+            regenWorldView.setValueAt(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT_REGEN);
+            lightWorldView.setValueAt(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT);
         }
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 15, ChunkConstants.SIZE_Z - 1))) {
-            regenWorldView.setBlockAt(pos, solid);
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 15, ChunkConstants.SIZE_Z - 1))) {
+            regenWorldView.setBlockAt(JomlUtil.from(pos), solid);
         }
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 14, ChunkConstants.SIZE_Z - 1))) {
-            regenWorldView.setValueAt(pos, (byte) (14 - pos.y));
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 14, ChunkConstants.SIZE_Z - 1))) {
+            regenWorldView.setValueAt(JomlUtil.from(pos), (byte) (14 - pos.y()));
         }
 
         regenWorldView.setBlockAt(new Vector3i(16, 15, 16), air);
@@ -114,15 +116,15 @@ public class BulkSunlightPropagationTest extends TerasologyTestingEnvironment {
 
     @Test
     public void testStopSunlightVertical() {
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 16, 0), new Vector3i(ChunkConstants.SIZE_X - 1, ChunkConstants.SIZE_Y - 1, ChunkConstants.SIZE_Z - 1))) {
-            regenWorldView.setValueAt(pos, ChunkConstants.MAX_SUNLIGHT_REGEN);
-            lightWorldView.setValueAt(pos, ChunkConstants.MAX_SUNLIGHT);
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 16, 0), new Vector3i(ChunkConstants.SIZE_X - 1, ChunkConstants.SIZE_Y - 1, ChunkConstants.SIZE_Z - 1))) {
+            regenWorldView.setValueAt(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT_REGEN);
+            lightWorldView.setValueAt(JomlUtil.from(pos), ChunkConstants.MAX_SUNLIGHT);
         }
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 15, ChunkConstants.SIZE_Z - 1))) {
-            regenWorldView.setBlockAt(pos, solid);
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 15, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 15, ChunkConstants.SIZE_Z - 1))) {
+            regenWorldView.setBlockAt(JomlUtil.from(pos), solid);
         }
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 14, ChunkConstants.SIZE_Z - 1))) {
-            regenWorldView.setValueAt(pos, (byte) (14 - pos.y));
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 14, ChunkConstants.SIZE_Z - 1))) {
+            regenWorldView.setValueAt(JomlUtil.from(pos), (byte) (14 - pos.y()));
         }
 
         regenWorldView.setBlockAt(new Vector3i(16, 15, 16), air);
@@ -133,9 +135,9 @@ public class BulkSunlightPropagationTest extends TerasologyTestingEnvironment {
         propagator.process(new BlockChange(new Vector3i(16, 15, 16), air, solid));
         sunlightPropagator.process(new BlockChange(new Vector3i(16, 15, 16), air, solid));
 
-        for (Vector3i pos : Region3i.createBounded(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 15, ChunkConstants.SIZE_Z - 1))) {
-            assertEquals(Math.max(0, 14 - pos.y), regenWorldView.getValueAt(pos), "Incorrect value at " + pos);
-            assertEquals(0, lightWorldView.getValueAt(pos), "Incorrect value at " + pos);
+        for (Vector3ic pos : Region3i.createBounded(new Vector3i(0, 0, 0), new Vector3i(ChunkConstants.SIZE_X - 1, 15, ChunkConstants.SIZE_Z - 1))) {
+            assertEquals(Math.max(0, 14 - pos.y()), regenWorldView.getValueAt(JomlUtil.from(pos)), "Incorrect value at " + pos);
+            assertEquals(0, lightWorldView.getValueAt(JomlUtil.from(pos)), "Incorrect value at " + pos);
         }
     }
 

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -16,9 +16,11 @@
 package org.terasology.engine.subsystem.headless.renderer;
 
 import com.google.common.collect.Lists;
+import org.joml.Vector3ic;
 import org.terasology.config.Config;
 import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayerSystem;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -215,8 +217,8 @@ public class HeadlessWorldRenderer implements WorldRenderer {
             if (chunksInProximity.size() == 0 || force || pendingChunks) {
                 // just add all visible chunks
                 chunksInProximity.clear();
-                for (Vector3i chunkPosition : viewRegion) {
-                    RenderableChunk c = chunkProvider.getChunk(chunkPosition);
+                for (Vector3ic chunkPosition : viewRegion) {
+                    RenderableChunk c = chunkProvider.getChunk(JomlUtil.from(chunkPosition));
                     if (c != null && worldProvider.getLocalView(c.getPosition()) != null) {
                         chunksInProximity.add(c);
                     } else {
@@ -226,10 +228,10 @@ public class HeadlessWorldRenderer implements WorldRenderer {
             } else {
                 Region3i oldRegion = Region3i.createFromCenterExtents(chunkPos, new Vector3i(viewingDistance.x / 2, viewingDistance.y / 2, viewingDistance.z / 2));
 
-                Iterator<Vector3i> chunksForRemove = oldRegion.subtract(viewRegion);
+                Iterator<Vector3ic> chunksForRemove = oldRegion.subtract(viewRegion);
                 // remove
                 while (chunksForRemove.hasNext()) {
-                    Vector3i r = chunksForRemove.next();
+                    Vector3i r = JomlUtil.from(chunksForRemove.next());
                     RenderableChunk c = chunkProvider.getChunk(r);
                     if (c != null) {
                         chunksInProximity.remove(c);
@@ -238,8 +240,8 @@ public class HeadlessWorldRenderer implements WorldRenderer {
                 }
 
                 // add
-                for (Vector3i chunkPosition : viewRegion) {
-                    RenderableChunk c = chunkProvider.getChunk(chunkPosition);
+                for (Vector3ic chunkPosition : viewRegion) {
+                    RenderableChunk c = chunkProvider.getChunk(JomlUtil.from(chunkPosition));
                     if (c != null && worldProvider.getLocalView(c.getPosition()) != null) {
                         chunksInProximity.add(c);
                     } else {

--- a/engine/src/main/java/org/terasology/math/Region3i.java
+++ b/engine/src/main/java/org/terasology/math/Region3i.java
@@ -20,8 +20,6 @@ import org.joml.Math;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
-import org.terasology.audio.AudioEndListener;
-import org.terasology.audio.StaticSound;
 import org.terasology.math.geom.BaseVector3f;
 import org.terasology.math.geom.BaseVector3i;
 import org.terasology.math.geom.Vector3f;

--- a/engine/src/main/java/org/terasology/math/Region3i.java
+++ b/engine/src/main/java/org/terasology/math/Region3i.java
@@ -382,6 +382,13 @@ public final class Region3i implements Iterable<Vector3ic> {
         return maxZ - 1;
     }
 
+    /**
+     * Get the minimum corner of the given component
+     *
+     * @param component the component within <code>[0..2]</code>
+     * @return the minimum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within [0..2]
+     */
     public int getMin(int component) throws IllegalArgumentException {
         switch (component) {
             case 0:
@@ -398,9 +405,10 @@ public final class Region3i implements Iterable<Vector3ic> {
 
     /**
      * get component for maximum coordinate
-     * @param component
-     * @return
-     * @throws IllegalArgumentException
+     *
+     * @param component the component within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within [0..2]
      */
     public int getMax(int component) throws IllegalArgumentException {
         switch (component) {
@@ -419,6 +427,7 @@ public final class Region3i implements Iterable<Vector3ic> {
      * @param other
      * @return The region that is encompassed by both this and other. If they
      * do not overlap then the empty region is returned
+     * @deprecated
      */
     public Region3i intersect(Region3i other) {
         org.terasology.math.geom.Vector3i intersectMin = min();
@@ -497,6 +506,12 @@ public final class Region3i implements Iterable<Vector3ic> {
         return inflate(pos.x(), pos.y(), pos.z(), dest);
     }
 
+    /**
+     * inflate region from each surface by (+x, +y, +z) from pos
+     *
+     * @param pos components used for inflate
+     * @return this
+     */
     public Region3i inflate(Vector3ic pos) {
         return inflate(pos.x(), pos.y(), pos.z(), this);
     }
@@ -505,13 +520,18 @@ public final class Region3i implements Iterable<Vector3ic> {
      * inflate region by the amount and write to dest
      *
      * @param amount amount to inflate region
-     * @param dest
-     * @return
+     * @param dest region to write to
+     * @return dest
      */
     public Region3i inflate(int amount, Region3i dest) {
         return inflate(amount, amount, amount, dest);
     }
 
+    /**
+     *
+     * @param amount amount to inflate region
+     * @return this
+     */
     public Region3i inflate(int amount) {
         return inflate(amount, amount, amount, this);
     }
@@ -702,6 +722,7 @@ public final class Region3i implements Iterable<Vector3ic> {
      *
      * @param x    the x coordinate to translate by
      * @param y    the y coordinate to translate by
+     * @param z    the z coordinate to translate by
      * @param dest will hold the result
      * @return dest
      */
@@ -713,6 +734,20 @@ public final class Region3i implements Iterable<Vector3ic> {
         dest.maxY = maxY + y;
         dest.maxZ = maxZ + z;
         return dest;
+    }
+
+    public Region3i translate(Vector3ic pos, Region3i dest) {
+        return this.translate(pos.x(), pos.y(), pos.z(), dest);
+    }
+
+    /**
+     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param pos the vector to translate by
+     * @return this
+     */
+    public Region3i translate(Vector3ic pos) {
+        return this.translate(pos.x(), pos.y(), pos.z(), this);
     }
 
     /**
@@ -732,7 +767,8 @@ public final class Region3i implements Iterable<Vector3ic> {
      * @param offset
      * @return A copy of the region offset by the given value
      * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #translate(int, int, int)}.
+     *             Use the JOML implementation instead: {@link #translate(Vector3ic)}.
+     *             Note: {@link #translate(Vector3ic)} modifies this
      */
     @Deprecated
     public Region3i move(BaseVector3i offset) {
@@ -745,7 +781,10 @@ public final class Region3i implements Iterable<Vector3ic> {
     /**
      * @param pos
      * @return Whether this region includes pos
-     */
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #testPoint(Vector3ic)}.
+     **/
+    @Deprecated
     public boolean encompasses(BaseVector3i pos) {
         return encompasses(pos.getX(), pos.getY(), pos.getZ());
     }
@@ -758,7 +797,7 @@ public final class Region3i implements Iterable<Vector3ic> {
      * @return
      * @deprecated This method is scheduled for removal in an upcoming version.
      *              Use the JOML implementation instead: {@link #testPoint(int, int, int)}.
-     */
+     **/
     @Deprecated
     public boolean encompasses(int x, int y, int z) {
         return (x >= minX) && (y >= minY) && (z >= minZ) && (x < maxX) && (y < maxY) && (z < maxZ);

--- a/engine/src/main/java/org/terasology/math/Region3i.java
+++ b/engine/src/main/java/org/terasology/math/Region3i.java
@@ -17,12 +17,12 @@
 package org.terasology.math;
 
 import org.joml.Math;
+import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.math.geom.BaseVector3f;
 import org.terasology.math.geom.BaseVector3i;
-import org.terasology.math.geom.Vector3f;
 
 import java.util.Iterator;
 

--- a/engine/src/main/java/org/terasology/math/Region3i.java
+++ b/engine/src/main/java/org/terasology/math/Region3i.java
@@ -16,10 +16,11 @@
 
 package org.terasology.math;
 
+import org.joml.Vector2i;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.terasology.math.geom.BaseVector3f;
 import org.terasology.math.geom.BaseVector3i;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 
 import java.util.Iterator;
 
@@ -27,7 +28,7 @@ import java.util.Iterator;
  * Describes an axis-aligned bounded space in 3D integer.
  *
  */
-public final class Region3i implements Iterable<Vector3i> {
+public final class Region3i implements Iterable<Vector3ic> {
 
     /**
      * @deprecated As of 24 sep 2018, because it is error prone.
@@ -37,18 +38,78 @@ public final class Region3i implements Iterable<Vector3i> {
     @Deprecated
     public static final Region3i EMPTY = Region3i.empty();
 
-    private final Vector3i min = new Vector3i();
-    private final Vector3i size = new Vector3i();
-
     /**
-     * Constructs an empty Region with size (0,0,0).
+     * The x coordinate of the minimum corner.
      */
-    private Region3i() {
+    public int minX = Integer.MAX_VALUE;
+    /**
+     * The y coordinate of the minimum corner.
+     */
+    public int minY = Integer.MAX_VALUE;
+    /**
+     * The z coordinate of the minimum corner.
+     */
+    public int minZ = Integer.MAX_VALUE;
+    /**
+     * The x coordinate of the maximum corner.
+     */
+    public int maxX = Integer.MIN_VALUE;
+    /**
+     * The y coordinate of the maximum corner.
+     */
+    public int maxY = Integer.MIN_VALUE;
+    /**
+     * The z coordinate of the maximum corner.
+     */
+    public int maxZ = Integer.MIN_VALUE;
+
+
+    @Deprecated
+    private Region3i(BaseVector3i min, BaseVector3i size) {
+        this.minX = min.x();
+        this.minY = min.y();
+        this.minZ = min.z();
+
+        this.maxX = min.x() + size.x();
+        this.maxY = min.y() + size.y();
+        this.maxZ = min.z() + size.z();
     }
 
-    private Region3i(BaseVector3i min, BaseVector3i size) {
-        this.min.set(min);
-        this.size.set(size);
+    public Region3i(Region3i source) {
+        this.minX = source.minX;
+        this.minY = source.minY;
+        this.minZ = source.minZ;
+
+        this.maxX = source.maxX;
+        this.maxY = source.maxY;
+        this.maxZ = source.maxZ;
+    }
+
+    public Region3i(Vector3ic min, Vector3ic max){
+        this.minX = min.x();
+        this.minY = min.y();
+        this.minZ = min.z();
+
+        this.maxX = max.x();
+        this.maxY = max.y();
+        this.maxZ = max.z();
+    }
+
+    public Region3i(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
+        this.minX = minX;
+        this.minY = minY;
+        this.minZ = minZ;
+        this.maxX = maxX;
+        this.maxY = maxY;
+        this.maxZ = maxZ;
+    }
+
+    public boolean isValid() {
+        return (minX < maxX) && (minY < maxY) && (minZ < maxZ);
+    }
+
+    public boolean isEmpty() {
+        return (maxX - minX) == 0 && (maxY - minY) == 0 && (maxZ - minZ) == 0;
     }
 
     /**
@@ -56,7 +117,7 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return An empty Region3i
      */
     public static Region3i empty() {
-        return new Region3i();
+        return new Region3i(0,0,0,0,0,0);
     }
 
     /**
@@ -78,12 +139,12 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return a new region base on the center point and extents size
      */
     public static Region3i createFromCenterExtents(BaseVector3f center, BaseVector3f extents) {
-        Vector3f min = new Vector3f(center.x() - extents.x(), center.y() - extents.y(), center.z() - extents.z());
-        Vector3f max = new Vector3f(center.x() + extents.x(), center.y() + extents.y(), center.z() + extents.z());
+        org.terasology.math.geom.Vector3f min = new org.terasology.math.geom.Vector3f(center.x() - extents.x(), center.y() - extents.y(), center.z() - extents.z());
+        org.terasology.math.geom.Vector3f max = new org.terasology.math.geom.Vector3f(center.x() + extents.x(), center.y() + extents.y(), center.z() + extents.z());
         max.x = max.x - Math.ulp(max.x);
         max.y = max.y - Math.ulp(max.y);
         max.z = max.z - Math.ulp(max.z);
-        return createFromMinMax(new Vector3i(min), new Vector3i(max));
+        return createFromMinMax(new org.terasology.math.geom.Vector3i(min), new org.terasology.math.geom.Vector3i(max));
     }
 
     /**
@@ -93,8 +154,8 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return a new region base on the center point and extents size
      */
     public static Region3i createFromCenterExtents(BaseVector3i center, BaseVector3i extents) {
-        Vector3i min = new Vector3i(center.x() - extents.x(), center.y() - extents.y(), center.z() - extents.z());
-        Vector3i max = new Vector3i(center.x() + extents.x(), center.y() + extents.y(), center.z() + extents.z());
+        org.terasology.math.geom.Vector3i min = new org.terasology.math.geom.Vector3i(center.x() - extents.x(), center.y() - extents.y(), center.z() - extents.z());
+        org.terasology.math.geom.Vector3i max = new org.terasology.math.geom.Vector3i(center.x() + extents.x(), center.y() + extents.y(), center.z() + extents.z());
         return createFromMinMax(min, max);
     }
 
@@ -105,8 +166,8 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return a new region base on the center point and extents size
      */
     public static Region3i createFromCenterExtents(BaseVector3i center, int extent) {
-        Vector3i min = new Vector3i(center.x() - extent, center.y() - extent, center.z() - extent);
-        Vector3i max = new Vector3i(center.x() + extent, center.y() + extent, center.z() + extent);
+        org.terasology.math.geom.Vector3i min = new org.terasology.math.geom.Vector3i(center.x() - extent, center.y() - extent, center.z() - extent);
+        org.terasology.math.geom.Vector3i max = new org.terasology.math.geom.Vector3i(center.x() + extent, center.y() + extent, center.z() + extent);
         return createFromMinMax(min, max);
     }
 
@@ -117,9 +178,9 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return a new region base on vertex a and b
      */
     public static Region3i createBounded(BaseVector3i a, BaseVector3i b) {
-        Vector3i min = new Vector3i(a);
+        org.terasology.math.geom.Vector3i min = new org.terasology.math.geom.Vector3i(a);
         min.min(b);
-        Vector3i max = new Vector3i(a);
+        org.terasology.math.geom.Vector3i max = new org.terasology.math.geom.Vector3i(a);
         max.max(b);
         return createFromMinMax(min, max);
     }
@@ -131,7 +192,7 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return a new region base on min and max point
      */
     public static Region3i createFromMinMax(BaseVector3i min, BaseVector3i max) {
-        Vector3i size = new Vector3i(max.x() - min.x() + 1, max.y() - min.y() + 1, max.z() - min.z() + 1);
+        org.terasology.math.geom.Vector3i size = new org.terasology.math.geom.Vector3i(max.x() - min.x() + 1, max.y() - min.y() + 1, max.z() - min.z() + 1);
         if (size.x <= 0 || size.y <= 0 || size.z <= 0) {
             return empty();
         }
@@ -139,81 +200,86 @@ public final class Region3i implements Iterable<Vector3i> {
     }
 
     public static Region3i createEncompassing(Region3i a, Region3i b) {
-        if (a.isEmpty()) {
+        if (a.isValid()) {
             return b;
         }
-        if (b.isEmpty()) {
+        if (b.isValid()) {
             return a;
         }
-        Vector3i min = a.min();
-        min.min(b.min());
-        Vector3i max = a.max();
-        max.max(b.max());
-        return createFromMinMax(min, max);
+
+        return new Region3i(a).union(b.minX, b.minY, b.minZ).union(b.maxX, b.maxY, b.maxZ);
+//
+//        if (a.isEmpty()) {
+//            return b;
+//        }
+//        if (b.isEmpty()) {
+//            return a;
+//        }
+//        Vector3i min = a.min();
+//        min.min(b.min());
+//        Vector3i max = a.max();
+//        max.max(b.max());
+//        return createFromMinMax(min, max);
     }
 
-    public boolean isEmpty() {
-        return size.x + size.y + size().z == 0;
-    }
 
     /**
      * @return The smallest vector in the region
      */
-    public Vector3i min() {
-        return new Vector3i(min);
+    public org.terasology.math.geom.Vector3i min() {
+        return new org.terasology.math.geom.Vector3i(minX, minY, minZ);
     }
 
     public int minX() {
-        return min.x;
+        return minX;
     }
 
     public int minY() {
-        return min.y;
+        return minY;
     }
 
     public int minZ() {
-        return min.z;
+        return minZ;
     }
 
     /**
      * @return The size of the region
+     * @deprecated
      */
-    public Vector3i size() {
-        return new Vector3i(size);
+    @Deprecated
+    public org.terasology.math.geom.Vector3i size() {
+        return new org.terasology.math.geom.Vector3i(sizeX(), sizeY(), sizeZ());
     }
 
     public int sizeX() {
-        return size.x;
+        return maxX - minX;
     }
 
     public int sizeY() {
-        return size.y;
+        return maxY - minY;
     }
 
     public int sizeZ() {
-        return size.z;
+        return maxZ - minZ;
     }
 
     /**
      * @return The largest vector in the region
      */
-    public Vector3i max() {
-        Vector3i max = new Vector3i(min);
-        max.add(size);
-        max.sub(1, 1, 1);
-        return max;
+    public org.terasology.math.geom.Vector3i max() {
+        return new org.terasology.math.geom.Vector3i(maxX(),maxY(),maxZ());
     }
 
     public int maxX() {
-        return min.x + size.x - 1;
+        return maxX - 1;
     }
 
     public int maxY() {
-        return min.y + size.y - 1;
+        return maxY - 1;
     }
 
     public int maxZ() {
-        return min.z + size.z - 1;
+        return maxZ - 1;
     }
 
     /**
@@ -222,21 +288,72 @@ public final class Region3i implements Iterable<Vector3i> {
      * do not overlap then the empty region is returned
      */
     public Region3i intersect(Region3i other) {
-        Vector3i intersectMin = min();
+        org.terasology.math.geom.Vector3i intersectMin = min();
         intersectMin.max(other.min());
-        Vector3i intersectMax = max();
+        org.terasology.math.geom.Vector3i intersectMax = max();
         intersectMax.min(other.max());
 
         return createFromMinMax(intersectMin, intersectMax);
     }
 
-    /**
-     * @param other
-     * @return An iterator over the positions in this region that aren't in other
-     */
-    public Iterator<Vector3i> subtract(Region3i other) {
-        return new SubtractiveIterator(other);
+
+
+    public Region3i inflate(int x, int y, int z, Region3i dest) {
+        dest.minX = (this.minX - x);
+        dest.minY = (this.minY - y);
+        dest.minZ = (this.minZ - z);
+        dest.maxX = (this.minX + x);
+        dest.maxY = (this.minY + y);
+        dest.maxZ = (this.minZ + z);
+        return this;
     }
+
+    public Region3i inflate(Vector3ic pos, Region3i dest) {
+        return inflate(pos.x(), pos.y(), pos.z(), dest);
+    }
+
+    public Region3i inflate(Vector3ic pos) {
+        return inflate(pos.x(), pos.y(), pos.z(), this);
+    }
+
+    public Region3i inflate(int amount, Region3i dest) {
+        return inflate(amount, amount, amount, dest);
+    }
+
+    public Region3i inflate(int amount) {
+        return inflate(amount, amount, amount, this);
+    }
+
+    public Region3i union(Vector3ic pos, Region3i dest) {
+        return union(pos.x(), pos.y(), pos.z(), dest);
+    }
+
+    public Region3i union(Vector3ic pos) {
+        return union(pos.x(), pos.y(), pos.z(), this);
+    }
+
+    public Region3i union(int x, int y, int z, Region3i dest) {
+        dest.minX = this.minX < x ? this.minX : x;
+        dest.minY = this.minY < y ? this.minY : y;
+        dest.minZ = this.minZ < z ? this.minZ : z;
+        dest.maxX = this.maxX > x ? this.maxX : x;
+        dest.maxY = this.maxY > y ? this.maxY : y;
+        dest.maxZ = this.maxZ > z ? this.maxZ : z;
+        return dest;
+    }
+
+    public Region3i union(int x, int y, int z) {
+        return union(x, y, z, this);
+    }
+
+
+    public boolean testPoint(Vector3ic p) {
+        return testPoint(p.x(), p.y(), p.z());
+    }
+    public boolean testPoint(int x, int y, int z){
+        return (x >= minX) && (y >= minY) && (z >= minZ) && (x < maxX) && (y < maxY) && (z < maxZ);
+    }
+
 
     /**
      * Creates a new region that is the same as this region but expanded in all directions by the given amount
@@ -245,25 +362,25 @@ public final class Region3i implements Iterable<Vector3i> {
      * @return A new region
      */
     public Region3i expand(int amount) {
-        Vector3i expandedMin = min();
+        org.terasology.math.geom.Vector3i expandedMin = min();
         expandedMin.sub(amount, amount, amount);
-        Vector3i expandedMax = max();
+        org.terasology.math.geom.Vector3i expandedMax = max();
         expandedMax.add(amount, amount, amount);
         return createFromMinMax(expandedMin, expandedMax);
     }
 
     public Region3i expand(BaseVector3i amount) {
-        Vector3i expandedMin = min();
+        org.terasology.math.geom.Vector3i expandedMin = min();
         expandedMin.sub(amount);
-        Vector3i expandedMax = max();
+        org.terasology.math.geom.Vector3i expandedMax = max();
         expandedMax.add(amount);
         return createFromMinMax(expandedMin, expandedMax);
     }
 
     public Region3i expandToContain(BaseVector3i adjPos) {
-        Vector3i expandedMin = min();
+        org.terasology.math.geom.Vector3i expandedMin = min();
         expandedMin.min(adjPos);
-        Vector3i expandedMax = max();
+        org.terasology.math.geom.Vector3i expandedMax = max();
         expandedMax.max(adjPos);
         return createFromMinMax(expandedMin, expandedMax);
     }
@@ -271,22 +388,25 @@ public final class Region3i implements Iterable<Vector3i> {
     /**
      * @return The position at the center of the region
      */
-    public Vector3f center() {
-        Vector3f result = min.toVector3f();
-        Vector3f halfSize = size.toVector3f();
+    public org.terasology.math.geom.Vector3f center() {
+        org.terasology.math.geom.Vector3f result = new org.terasology.math.geom.Vector3f(minX, minY, minZ);
+        org.terasology.math.geom.Vector3f halfSize = new org.terasology.math.geom.Vector3f(sizeX(), sizeY(), sizeZ());
         halfSize.scale(0.5f);
         result.add(halfSize);
         return result;
     }
+
+
 
     /**
      * @param offset
      * @return A copy of the region offset by the given value
      */
     public Region3i move(BaseVector3i offset) {
-        Vector3i newMin = min();
+        org.terasology.math.geom.Vector3i newMin = min();
         newMin.add(offset);
-        return Region3i.createFromMinAndSize(newMin, size);
+        return Region3i.createFromMinAndSize(newMin,
+            new org.terasology.math.geom.Vector3i(sizeX(), sizeY(), sizeZ()));
     }
 
     /**
@@ -298,28 +418,84 @@ public final class Region3i implements Iterable<Vector3i> {
     }
 
     public boolean encompasses(int x, int y, int z) {
-        return (x >= min.x) && (y >= min.y) && (z >= min.z) && (x < min.x + size.x) && (y < min.y + size.y) && (z < min.z + size.z);
+        return (x >= minX) && (y >= minY) && (z >= minZ) && (x < maxX) && (y < maxY) && (z < maxZ);
+//        return (x >= min.x) && (y >= min.y) && (z >= min.z) && (x < min.x + size.x) && (y < min.y + size.y) && (z < min.z + size.z);
     }
 
     /**
      * @param pos
      * @return The nearest position within the region to the given pos.
      */
-    public Vector3i getNearestPointTo(BaseVector3i pos) {
-        Vector3i result = new Vector3i(pos);
+    public org.terasology.math.geom.Vector3i getNearestPointTo(BaseVector3i pos) {
+        org.terasology.math.geom.Vector3i result = new org.terasology.math.geom.Vector3i(pos);
         result.min(max());
-        result.max(min);
+        result.max(new org.terasology.math.geom.Vector3i(minX, minY, minZ));
         return result;
     }
 
     @Override
-    public Iterator<Vector3i> iterator() {
-        return new Region3iIterator();
+    public Iterator<Vector3ic> iterator() {
+        return new Iterator<Vector3ic>() {
+            private final Vector3i pos = new Vector3i(minX,minY,minZ);
+            private final int[] p = {minX,minY,minZ};
+            @Override
+            public boolean hasNext() {
+                return p[0] < maxX;
+            }
+
+            @Override
+            public Vector3ic next() {
+                pos.set(p[0],p[1],p[2]);
+                p[2]++;
+                if (p[2] >= maxZ) {
+                    p[2] = minZ;
+                    p[1]++;
+                    if (p[1] >= maxY) {
+                        p[1] = minY;
+                        p[0]++;
+                    }
+                }
+                return pos;
+            }
+        };
+    }
+
+    /**
+     * @param other
+     * @return An iterator over the positions in this region that aren't in other
+     */
+    public Iterator<Vector3ic> subtract(Region3i other) {
+        Iterator<Vector3ic> it =  new Iterator<Vector3ic>() {
+            private final Region3i region = new Region3i(other);
+            private Vector3i current = new Vector3i();
+            private Vector3ic next = null;
+            private Iterator<Vector3ic> innerIterator = iterator();
+
+            @Override
+            public boolean hasNext() {
+                return next != null;
+            }
+
+            @Override
+            public Vector3ic next() {
+                if(next != null) current.set(next);
+                while (innerIterator.hasNext()) {
+                    next = innerIterator.next();
+                    if (!region.testPoint(next)) {
+                        return current;
+                    }
+                }
+                next = null;
+                return current;
+            }
+        };
+        it.next();
+        return it;
     }
 
     @Override
     public String toString() {
-        return "(Min: " + min + ", Size: " + size + ")";
+        return "(Min: [" + minX + "," + minY + "," + minZ + "], Max: [" + maxX + "," + maxY + "," + maxZ + "])";
     }
 
     @Override
@@ -329,7 +505,8 @@ public final class Region3i implements Iterable<Vector3i> {
         }
         if (obj instanceof Region3i) {
             Region3i other = (Region3i) obj;
-            return min.equals(other.min) && size.equals(other.size);
+            return other.minX == this.minX && other.minY == this.minY && other.minZ == this.minZ
+                && other.maxX == this.maxX && other.maxY == this.maxY && other.maxZ == this.maxZ;
         }
         return false;
     }
@@ -337,80 +514,12 @@ public final class Region3i implements Iterable<Vector3i> {
     @Override
     public int hashCode() {
         int hash = 37;
-        hash += 37 * hash + min.hashCode();
-        hash += 37 * hash + size.hashCode();
+        hash += 37 * hash + minX;
+        hash += 37 * hash + minY;
+        hash += 37 * hash + minZ;
+        hash += 37 * hash + maxX;
+        hash += 37 * hash + maxY;
+        hash += 37 * hash + maxZ;
         return hash;
-    }
-
-    private class Region3iIterator implements Iterator<Vector3i> {
-        Vector3i pos;
-
-         Region3iIterator() {
-            this.pos = new Vector3i();
-        }
-
-        @Override
-        public boolean hasNext() {
-            return pos.x < size.x;
-        }
-
-        @Override
-        public Vector3i next() {
-            Vector3i result = new Vector3i(pos.x + min.x, pos.y + min.y, pos.z + min.z);
-            pos.z++;
-            if (pos.z >= size.z) {
-                pos.z = 0;
-                pos.y++;
-                if (pos.y >= size.y) {
-                    pos.y = 0;
-                    pos.x++;
-                }
-            }
-            return result;
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("Not supported.");
-        }
-    }
-
-    private class SubtractiveIterator implements Iterator<Vector3i> {
-        private Iterator<Vector3i> innerIterator;
-        private Vector3i next;
-        private Region3i other;
-
-         SubtractiveIterator(Region3i other) {
-            this.other = other;
-            innerIterator = iterator();
-            updateNext();
-        }
-
-        private void updateNext() {
-            while (innerIterator.hasNext()) {
-                next = innerIterator.next();
-                if (!other.encompasses(next)) {
-                    return;
-                }
-            }
-            next = null;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return next != null;
-        }
-
-        @Override
-        public Vector3i next() {
-            Vector3i result = new Vector3i(next);
-            updateNext();
-            return result;
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException();
-        }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.world;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
@@ -142,12 +143,12 @@ class RenderableWorldImpl implements RenderableWorld {
         RenderableChunk chunk;
         ChunkMesh newMesh;
         ChunkView localView;
-        for (Vector3i chunkCoordinates : calculateRenderableRegion(renderingConfig.getViewDistance())) {
-            chunk = chunkProvider.getChunk(chunkCoordinates);
+        for (Vector3ic chunkCoordinates : calculateRenderableRegion(renderingConfig.getViewDistance())) {
+            chunk = chunkProvider.getChunk(JomlUtil.from(chunkCoordinates));
             if (chunk == null) {
                 pregenerationIsComplete = false;
             } else if (chunk.isDirty()) {
-                localView = worldProvider.getLocalView(chunkCoordinates);
+                localView = worldProvider.getLocalView(JomlUtil.from(chunkCoordinates));
                 if (localView == null) {
                     continue;
                 }
@@ -200,9 +201,9 @@ class RenderableWorldImpl implements RenderableWorld {
             Vector3i chunkPosition;
             RenderableChunk chunk;
 
-            Iterator<Vector3i> chunksToRemove = renderableRegion.subtract(newRenderableRegion);
+            Iterator<Vector3ic> chunksToRemove = renderableRegion.subtract(newRenderableRegion);
             while (chunksToRemove.hasNext()) {
-                chunkPosition = chunksToRemove.next();
+                chunkPosition = JomlUtil.from(chunksToRemove.next());
                 Iterator<RenderableChunk> nearbyChunks = chunksInProximityOfCamera.iterator();
                 while (nearbyChunks.hasNext()) {
                     chunk = nearbyChunks.next();
@@ -215,9 +216,9 @@ class RenderableWorldImpl implements RenderableWorld {
             }
 
             boolean chunksHaveBeenAdded = false;
-            Iterator<Vector3i> chunksToAdd = newRenderableRegion.subtract(renderableRegion);
+            Iterator<Vector3ic> chunksToAdd = newRenderableRegion.subtract(renderableRegion);
             while (chunksToAdd.hasNext()) {
-                chunkPosition = chunksToAdd.next();
+                chunkPosition = JomlUtil.from(chunksToAdd.next());
                 chunk = chunkProvider.getChunk(chunkPosition);
                 if (chunk != null) {
                     chunksInProximityOfCamera.add(chunk);

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockEntitySystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.entity;
 
+import org.joml.Vector3ic;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.StaticSound;
 import org.terasology.audio.events.PlaySoundEvent;
@@ -29,6 +30,7 @@ import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.inventory.events.DropItemEvent;
 import org.terasology.logic.inventory.events.GiveItemEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.events.ImpulseEvent;
 import org.terasology.registry.In;
@@ -101,9 +103,9 @@ public class BlockEntitySystem extends BaseComponentSystem {
                 BlockRegionComponent blockRegion = entity.getComponent(BlockRegionComponent.class);
                 if (blockComponent.dropBlocksInRegion) {
                     // loop through all the blocks in this region and drop them
-                    for (Vector3i location : blockRegion.region) {
+                    for (Vector3ic location : blockRegion.region) {
                         Block blockInWorld = worldProvider.getBlock(location);
-                        commonDefaultDropsHandling(event, entity, location, blockInWorld.getBlockFamily().getArchetypeBlock());
+                        commonDefaultDropsHandling(event, entity, JomlUtil.from(location), blockInWorld.getBlockFamily().getArchetypeBlock());
                     }
                 } else {
                     // just drop the ActAsBlock block
@@ -135,7 +137,7 @@ public class BlockEntitySystem extends BaseComponentSystem {
                 if (blockDamageModifierComponent != null) {
                     impulsePower = blockDamageModifierComponent.impulsePower;
                 }
-                
+
                 processDropping(item, location, impulsePower);
             }
         }

--- a/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.regions;
 
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -22,6 +23,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.health.DoDestroyEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
@@ -41,8 +43,8 @@ public class BlockRegionSystem extends BaseComponentSystem {
     // trivial priority so that all other logic can happen to the region before erasing the blocks in the region
     @ReceiveEvent(priority = EventPriority.PRIORITY_TRIVIAL)
     public void onDestroyed(DoDestroyEvent event, EntityRef entity, BlockRegionComponent blockRegion) {
-        for (Vector3i blockPosition : blockRegion.region) {
-            worldProvider.setBlock(blockPosition, blockManager.getBlock(BlockManager.AIR_ID));
+        for (Vector3ic blockPosition : blockRegion.region) {
+            worldProvider.setBlock(JomlUtil.from(blockPosition), blockManager.getBlock(BlockManager.AIR_ID));
         }
     }
 }

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
@@ -18,9 +18,11 @@ package org.terasology.world.chunks.internal;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.chunks.Chunk;
@@ -198,7 +200,7 @@ public class ChunkRelevanceRegion {
 
     private class NeededChunksIterator implements Iterator<Vector3i> {
         Vector3i nextChunkPos;
-        Iterator<Vector3i> regionPositions = currentRegion.iterator();
+        Iterator<Vector3ic> regionPositions = currentRegion.iterator();
 
         NeededChunksIterator() {
             calculateNext();
@@ -224,9 +226,9 @@ public class ChunkRelevanceRegion {
         private void calculateNext() {
             nextChunkPos = null;
             while (regionPositions.hasNext() && nextChunkPos == null) {
-                Vector3i candidate = regionPositions.next();
+                Vector3ic candidate = regionPositions.next();
                 if (!relevantChunks.contains(candidate)) {
-                    nextChunkPos = candidate;
+                    nextChunkPos = JomlUtil.from(candidate);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
@@ -227,7 +227,7 @@ public class ChunkRelevanceRegion {
             nextChunkPos = null;
             while (regionPositions.hasNext() && nextChunkPos == null) {
                 Vector3ic candidate = regionPositions.next();
-                if (!relevantChunks.contains(candidate)) {
+                if (!relevantChunks.contains(JomlUtil.from(candidate))) {
                     nextChunkPos = JomlUtil.from(candidate);
                 }
             }

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -19,11 +19,13 @@ package org.terasology.world.chunks.remoteChunkProvider;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
@@ -164,8 +166,8 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
     }
 
     private boolean makeChunkAvailable(final Chunk chunk) {
-        for (Vector3i pos : Region3i.createFromCenterExtents(chunk.getPosition(), 1)) {
-            if (chunkCache.get(pos) == null) {
+        for (Vector3ic pos : Region3i.createFromCenterExtents(chunk.getPosition(), 1)) {
+            if (chunkCache.get(JomlUtil.from(pos)) == null) {
                 return false;
             }
         }
@@ -252,13 +254,14 @@ public class RemoteChunkProvider implements ChunkProvider, GeneratingChunkProvid
 
     private ChunkViewCore createWorldView(Region3i region, Vector3i offset) {
         Chunk[] chunks = new Chunk[region.sizeX() * region.sizeY() * region.sizeZ()];
-        for (Vector3i chunkPos : region) {
-            Chunk chunk = chunkCache.get(chunkPos);
+        for (Vector3ic chunkPos : region) {
+            org.joml.Vector3i pos = new org.joml.Vector3i(chunkPos);
+            Chunk chunk = chunkCache.get(JomlUtil.from(chunkPos));
             if (chunk == null) {
                 return null;
             }
-            chunkPos.sub(region.minX(), region.minY(), region.minZ());
-            int index = TeraMath.calculate3DArrayIndex(chunkPos, region.size());
+            pos.sub(region.minX(), region.minY(), region.minZ());
+            int index = TeraMath.calculate3DArrayIndex(JomlUtil.from(pos), region.size());
             chunks[index] = chunk;
         }
         return new ChunkViewCoreImpl(chunks, region, offset, blockManager.getBlock(BlockManager.AIR_ID));

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -16,6 +16,7 @@
 
 package org.terasology.world.internal;
 
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.ChunkMath;
@@ -201,8 +202,8 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
 
     @Override
     public void setDirtyAround(Vector3i blockPos) {
-        for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(blockPos, 1)) {
-            chunks[pos.x + offset.x + chunkRegion.size().x * (pos.z + offset.z)].setDirty(true);
+        for (Vector3ic pos : ChunkMath.getChunkRegionAroundWorldPos(blockPos, 1)) {
+            chunks[pos.x() + offset.x + chunkRegion.size().x * (pos.z() + offset.z)].setDirty(true);
         }
     }
 
@@ -216,8 +217,8 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
         Vector3i minChunk = ChunkMath.calcChunkPos(minPos, chunkPower);
         Vector3i maxChunk = ChunkMath.calcChunkPos(maxPos, chunkPower);
 
-        for (Vector3i pos : Region3i.createFromMinMax(minChunk, maxChunk)) {
-            chunks[pos.x + offset.x + chunkRegion.size().x * (pos.z + offset.z)].setDirty(true);
+        for (Vector3ic pos : Region3i.createFromMinMax(minChunk, maxChunk)) {
+            chunks[pos.x() + offset.x + chunkRegion.size().x * (pos.z() + offset.z)].setDirty(true);
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -471,29 +471,29 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
     public void onBlockRegionActivated(OnActivatedComponent event, EntityRef entity) {
         BlockRegionComponent regionComp = entity.getComponent(BlockRegionComponent.class);
         blockRegions.put(entity, regionComp.region);
-        for (Vector3i pos : regionComp.region) {
-            blockRegionLookup.put(pos, entity);
+        for (Vector3ic pos : regionComp.region) {
+            blockRegionLookup.put(JomlUtil.from(pos), entity);
         }
     }
 
     @ReceiveEvent(components = {BlockRegionComponent.class})
     public void onBlockRegionChanged(OnChangedComponent event, EntityRef entity) {
         Region3i oldRegion = blockRegions.get(entity);
-        for (Vector3i pos : oldRegion) {
-            blockRegionLookup.remove(pos);
+        for (Vector3ic pos : oldRegion) {
+            blockRegionLookup.remove(JomlUtil.from(pos));
         }
         BlockRegionComponent regionComp = entity.getComponent(BlockRegionComponent.class);
         blockRegions.put(entity, regionComp.region);
-        for (Vector3i pos : regionComp.region) {
-            blockRegionLookup.put(pos, entity);
+        for (Vector3ic pos : regionComp.region) {
+            blockRegionLookup.put(JomlUtil.from(pos), entity);
         }
     }
 
     @ReceiveEvent(components = {BlockRegionComponent.class})
     public void onBlockRegionDeactivated(BeforeDeactivateComponent event, EntityRef entity) {
         Region3i oldRegion = blockRegions.get(entity);
-        for (Vector3i pos : oldRegion) {
-            blockRegionLookup.remove(pos);
+        for (Vector3ic pos : oldRegion) {
+            blockRegionLookup.remove(JomlUtil.from(pos));
         }
         blockRegions.remove(entity);
     }

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -258,8 +258,8 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     }
 
     private void setDirtyChunksNear(Vector3i pos0) {
-        for (Vector3i pos : ChunkMath.getChunkRegionAroundWorldPos(pos0, 1)) {
-            RenderableChunk dirtiedChunk = chunkProvider.getChunk(pos);
+        for (Vector3ic pos : ChunkMath.getChunkRegionAroundWorldPos(pos0, 1)) {
+            RenderableChunk dirtiedChunk = chunkProvider.getChunk(JomlUtil.from(pos));
             if (dirtiedChunk != null) {
                 dirtiedChunk.setDirty(true);
             }

--- a/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
+++ b/engine/src/main/java/org/terasology/world/propagation/AbstractFullWorldView.java
@@ -15,7 +15,9 @@
  */
 package org.terasology.world.propagation;
 
+import org.joml.Vector3ic;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.Chunk;
@@ -66,8 +68,8 @@ public abstract class AbstractFullWorldView implements PropagatorWorldView {
     @Override
     public void setValueAt(Vector3i pos, byte value) {
         setValueAt(getChunk(pos), ChunkMath.calcBlockPos(pos.x, pos.y, pos.z), value);
-        for (Vector3i affectedChunkPos : ChunkMath.getChunkRegionAroundWorldPos(pos, 1)) {
-            Chunk dirtiedChunk = chunkProvider.getChunk(affectedChunkPos);
+        for (Vector3ic affectedChunkPos : ChunkMath.getChunkRegionAroundWorldPos(pos, 1)) {
+            Chunk dirtiedChunk = chunkProvider.getChunk(JomlUtil.from(affectedChunkPos));
             if (dirtiedChunk != null) {
                 dirtiedChunk.setDirty(true);
             }

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -17,7 +17,9 @@ package org.terasology.world.propagation;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.joml.Vector3ic;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -332,13 +334,13 @@ public class StandardBatchPropagator implements BatchPropagator {
             }
         }
 
-        for (Vector3i pos : edgeRegion) {
-            int depthIndex = indexProvider.getIndexFor(pos);
+        for (Vector3ic pos : edgeRegion) {
+            int depthIndex = indexProvider.getIndexFor(JomlUtil.from(pos));
             int adjacentDepth = adjDepth[depthIndex];
             for (int i = adjacentDepth; i < depths[depthIndex]; ++i) {
                 adjPos.set(side.getVector3i());
                 adjPos.mul(i + 1);
-                adjPos.add(pos);
+                adjPos.add(JomlUtil.from(pos));
                 adjPos.add(chunkEdgeDeltas.get(side));
                 byte value = rules.getValue(adjChunk, adjPos);
                 if (value > 1) {

--- a/modules/BuilderSampleGameplay/src/main/java/org/terasology/BuilderSampleGameplay/world/BuilderWorldRasterizer.java
+++ b/modules/BuilderSampleGameplay/src/main/java/org/terasology/BuilderSampleGameplay/world/BuilderWorldRasterizer.java
@@ -15,7 +15,9 @@
  */
 package org.terasology.BuilderSampleGameplay.world;
 
+import org.joml.Vector3ic;
 import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.block.Block;
@@ -39,12 +41,12 @@ public class BuilderWorldRasterizer implements WorldRasterizer {
     @Override
     public void generateChunk(CoreChunk chunk, Region chunkRegion) {
         SurfaceHeightFacet surfaceHeightFacet = chunkRegion.getFacet(SurfaceHeightFacet.class);
-        for (Vector3i position : chunkRegion.getRegion()) {
-            float surfaceHeight = surfaceHeightFacet.getWorld(position.x, position.z);
-            if (position.y < surfaceHeight - 1) {
-                chunk.setBlock(ChunkMath.calcBlockPos(position), dirt);
-            } else if (position.y < surfaceHeight) {
-                chunk.setBlock(ChunkMath.calcBlockPos(position), grass);
+        for (Vector3ic position : chunkRegion.getRegion()) {
+            float surfaceHeight = surfaceHeightFacet.getWorld(position.x(), position.z());
+            if (position.y() < surfaceHeight - 1) {
+                chunk.setBlock(ChunkMath.calcBlockPos(JomlUtil.from(position)), dirt);
+            } else if (position.y() < surfaceHeight) {
+                chunk.setBlock(ChunkMath.calcBlockPos(JomlUtil.from(position)), grass);
             }
         }
     }

--- a/modules/Core/src/main/java/org/terasology/core/debug/BlockPlacementBenchmark.java
+++ b/modules/Core/src/main/java/org/terasology/core/debug/BlockPlacementBenchmark.java
@@ -18,8 +18,10 @@ package org.terasology.core.debug;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.joml.Vector3ic;
 import org.terasology.context.Context;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldProvider;
@@ -53,12 +55,12 @@ class BlockPlacementBenchmark extends AbstractBenchmarkInstance {
     public void runStep() {
         if (useSetBlocksInsteadOfSetBlock) {
             Map<Vector3i, Block> blocksToPlace = new HashMap<>();
-            for (Vector3i v : region3i) {
-                blocksToPlace.put(v, blockToPlace);
+            for (Vector3ic v : region3i) {
+                blocksToPlace.put(JomlUtil.from(v), blockToPlace);
             }
             worldProvider.setBlocks(blocksToPlace);
         } else {
-            for (Vector3i v : region3i) {
+            for (Vector3ic v : region3i) {
                 worldProvider.setBlock(v, blockToPlace);
             }
         }

--- a/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
+++ b/modules/Core/src/main/java/org/terasology/core/world/generator/rasterizers/SolidRasterizer.java
@@ -15,10 +15,12 @@
  */
 package org.terasology.core.world.generator.rasterizers;
 
+import org.joml.Vector3ic;
 import org.terasology.biomesAPI.Biome;
 import org.terasology.biomesAPI.BiomeRegistry;
 import org.terasology.core.world.CoreBiome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3i;
@@ -68,9 +70,9 @@ public class SolidRasterizer implements WorldRasterizer {
         int seaLevel = seaLevelFacet.getSeaLevel();
 
         Vector2i pos2d = new Vector2i();
-        for (Vector3i pos : ChunkConstants.CHUNK_REGION) {
-            pos2d.set(pos.x, pos.z);
-            int posY = pos.y + chunk.getChunkWorldOffsetY();
+        for (Vector3ic pos : ChunkConstants.CHUNK_REGION) {
+            pos2d.set(pos.x(), pos.z());
+            int posY = pos.y() + chunk.getChunkWorldOffsetY();
 
             // Check for an optional depth for this layer - if defined stop generating below that level
             if (surfaceDepthFacet != null && posY < surfaceDepthFacet.get(pos2d)) {
@@ -78,24 +80,24 @@ public class SolidRasterizer implements WorldRasterizer {
             }
 
             Biome biome = biomeFacet.get(pos2d);
-            biomeRegistry.setBiome(biome, chunk, pos.x, pos.y, pos.z);
+            biomeRegistry.setBiome(biome, chunk, pos.x(), pos.y(), pos.z());
 
-            float density = solidityFacet.get(pos);
+            float density = solidityFacet.get(JomlUtil.from(pos));
 
             if (density >= 32) {
-                chunk.setBlock(pos, stone);
+                chunk.setBlock(JomlUtil.from(pos), stone);
             } else if (density >= 0) {
                 int depth = TeraMath.floorToInt(surfaceFacet.get(pos2d)) - posY;
                 Block block = getSurfaceBlock(depth, posY,
                         biome,
                         seaLevel);
-                chunk.setBlock(pos, block);
+                chunk.setBlock(JomlUtil.from(pos), block);
             } else {
                 // fill up terrain up to sealevel height with water or ice
                 if (posY == seaLevel && CoreBiome.SNOW == biome) {
-                    chunk.setBlock(pos, ice);
+                    chunk.setBlock(JomlUtil.from(pos), ice);
                 } else if (posY <= seaLevel) {         // either OCEAN or SNOW
-                    chunk.setBlock(pos, water);
+                    chunk.setBlock(JomlUtil.from(pos), water);
 //                }
                 }
             }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

This is a migration of `Region3i` to JOML. the process it a bit more complication and Its kind of a combination of Deprecating and replacing the implementation in the engine. If we add an AABBi type object to joml then will probably just deprecate `Region3i`. https://github.com/JOML-CI/JOML/issues/234 

- I use min and max to define Region3i vs min and size. 
- max is subtracted by 1 so I kept that the same so the class would be compatible but going forward `getMin(int component)` and `getMax(int component)`
- minX, minY, minZ, maxZ, maxY, maxZ public. 
- `createFromCenterExtents` can be accomplished by `new Region3i(0,0,0,0,0,0).inflate(3,3,3)`
- iterator and subtract reuses the same vector

### Modules

- https://github.com/Terasology/Health/pull/41