### PR TITLE
Change how LWJGL path is set. Improves compat with newer JRE

### DIFF
--- a/.idea/runConfigurations/TerasologyPC__permissive_security_.xml
+++ b/.idea/runConfigurations/TerasologyPC__permissive_security_.xml
@@ -4,7 +4,7 @@
     <module name="Terasology.facades.PC.main" />
     <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport -permissiveSecurity" />
     <shortenClasspath name="MANIFEST" />
-    <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m" />
+    <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m -Djava.library.path=$TERASOLOGY_NATIVES$" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.terasology.engine.*" />

--- a/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
+++ b/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
@@ -21,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.paths.PathManager;
 
+import java.nio.file.Path;
+
 /**
  * Helper class to have LWJGL loading logic in a central spot
  *
@@ -40,18 +42,21 @@ public final class LWJGLHelper {
     }
 
     private static void initLibraryPaths() {
+        final Path path;
         switch (LWJGLUtil.getPlatform()) {
             case LWJGLUtil.PLATFORM_MACOSX:
-                NativeHelper.addLibraryPath(PathManager.getInstance().getNativesPath().resolve("macosx"));
+                path = PathManager.getInstance().getNativesPath().resolve("macosx");
                 break;
             case LWJGLUtil.PLATFORM_LINUX:
-                NativeHelper.addLibraryPath(PathManager.getInstance().getNativesPath().resolve("linux"));
+                path = PathManager.getInstance().getNativesPath().resolve("linux");
                 break;
             case LWJGLUtil.PLATFORM_WINDOWS:
-                NativeHelper.addLibraryPath(PathManager.getInstance().getNativesPath().resolve("windows"));
+                path = PathManager.getInstance().getNativesPath().resolve("windows");
                 break;
             default:
                 throw new UnsupportedOperationException("Unsupported operating system: " + LWJGLUtil.getPlatformName());
         }
+
+        System.setProperty("org.lwjgl.librarypath", path.toAbsolutePath().toString());
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
+++ b/engine/src/main/java/org/terasology/utilities/LWJGLHelper.java
@@ -57,6 +57,8 @@ public final class LWJGLHelper {
                 throw new UnsupportedOperationException("Unsupported operating system: " + LWJGLUtil.getPlatformName());
         }
 
-        System.setProperty("org.lwjgl.librarypath", path.toAbsolutePath().toString());
+        final String natives = path.toAbsolutePath().toString();
+        System.setProperty("org.lwjgl.librarypath", natives);
+        System.setProperty("net.java.games.input.librarypath", natives);  // libjinput
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/NativeHelper.java
+++ b/engine/src/main/java/org/terasology/utilities/NativeHelper.java
@@ -16,14 +16,8 @@
 
 package org.terasology.utilities;
 
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.lang.reflect.Field;
-import java.nio.file.Path;
-import java.util.List;
 
 /**
  */
@@ -37,31 +31,6 @@ public final class NativeHelper {
     private NativeHelper() {
     }
 
-    public static void addLibraryPath(Path libPath) {
-        try {
-            String envPath = System.getProperty("java.library.path");
-
-            if (envPath == null || envPath.isEmpty()) {
-                System.setProperty("java.library.path", libPath.toAbsolutePath().toString());
-            } else {
-                System.setProperty("java.library.path", libPath.toAbsolutePath().toString() + File.pathSeparator + envPath);
-            }
-
-            final Field usrPathsField = ClassLoader.class.getDeclaredField("usr_paths");
-            usrPathsField.setAccessible(true);
-
-            List<String> paths = Lists.newArrayList((String[]) usrPathsField.get(null));
-            if (paths.contains(libPath.toAbsolutePath().toString())) {
-                return;
-            }
-            paths.add(0, libPath.toAbsolutePath().toString()); // Add to beginning, to override system libraries
-
-            usrPathsField.set(null, paths.toArray(new String[paths.size()]));
-        } catch (Exception e) {
-            logger.error("Couldn't link static libraries. ", e);
-            System.exit(1);
-        }
-    }
 
     public static boolean isWin64() {
 
@@ -113,7 +82,7 @@ public final class NativeHelper {
     }
 
     public static String getOpenVRLibPath() {
-        logger.debug("OS string" + OS.toString());
+        logger.debug("OS string" + OS);
         if (isWindows()) {
             return USER_DIRECTORY + "\\openvr_natives\\" + getOsString();
         }

--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -1,14 +1,54 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // The PC facade is responsible for the primary distribution - a plain Java application runnable on PCs
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config
 apply from: "$rootDir/config/gradle/publish.gradle"
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.apache.tools.ant.filters.FixCrLfFilter
 import java.text.SimpleDateFormat;
 import groovy.json.JsonBuilder
 
 def dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
 dateTimeFormat.timeZone = TimeZone.getTimeZone("UTC")
+
+
+/**
+ * The subdirectory for this development environment.
+ *
+ * Only use this to run local processes. When building releases, you will be targeting other
+ * operating systems in addition to your own.
+ *
+ * @return
+ */
+def String nativeSubdirectoryName() {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return "windows"
+    } else if (Os.isFamily(Os.FAMILY_MAC)) {
+        return "macosx"
+    } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+        return "linux"
+    } else {
+        logger.warn("What kind of libraries do you use on this? {}", System.properties["os.name"])
+        return "UNKNOWN"
+    }
+}
+
 
 ext {
     // Default path to store server data if running headless via Gradle
@@ -100,6 +140,8 @@ task game(type:JavaExec) {
     workingDir = rootDir
     args "-homedir"
     jvmArgs ["-Xmx1536m"]
+
+    systemProperty("java.library.path", rootProject.file(dirNatives + "/" + nativeSubdirectoryName()))
 
     // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
     classpath sourceSets.main.output.classesDirs


### PR DESCRIPTION
We had our own NativeHelper code to try to manipulate private variables on the classloader. It didn't work very well across JRE versions, as seen in #3742. Fortunately, [LWJGL has its own mechanism for dealing with library paths](http://wiki.lwjgl.org/wiki/LWJGL_Hidden_Switches.html#Hidden_Switches).

In specific, this PR addresses the error that appeared in logs as:

```
ERROR o.terasology.utilities.NativeHelper - Couldn't link static libraries.
java.lang.NoSuchFieldException: usr_paths
at java.base/java.lang.Class.getDeclaredField
at org.terasology.utilities.NativeHelper.addLibraryPath
```

### How to test

* Run Terasology in a Java 8 environment.
* Run Terasology in a Java 14 environment.

If it still works under Java 8, and it gets to the main screen in Java 14, that's better than it was before!

The other things in `natives/` could potentially be affected by this. That includes what, OpenAL, controller support, and _Lua?_
