### PR TITLE
fix: Removed Google+ link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,5 +59,4 @@ For more on developing/modding see the [wiki!](https://github.com/MovingBlocks/T
 * [Reddit](http://www.reddit.com/r/Terasology)
 * [Twitter](https://twitter.com/Terasology)
 * [Facebook](http://www.facebook.com/pages/Terasology/248329655219905)
-* [G+](https://plus.google.com/b/103835217961917018533)
 * [Discord](https://discord.gg/4uKbB8J)


### PR DESCRIPTION
Removed Google+ link as the web page lo longer exists.

<!-- Thanks for submitting a pull request for Terasology! :-)
Removed Google+ link as Google+ has been discontinued and the link does not lead anywhere. 