### PR TITLE
feat: Particle Pool Sharing

### DIFF
--- a/engine/src/main/java/org/terasology/particles/ParticleSystemManagerImpl.java
+++ b/engine/src/main/java/org/terasology/particles/ParticleSystemManagerImpl.java
@@ -36,6 +36,10 @@ import org.terasology.physics.Physics;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -107,11 +111,16 @@ public class ParticleSystemManagerImpl extends BaseComponentSystem implements Up
     @Override
     public Stream<ParticleRenderingData> getParticleEmittersByDataComponent(Class<? extends Component> particleDataComponent) {
         return particleUpdater.getParticleEmitters().stream()
-                .filter(p -> p.ownerEntity.hasComponent(particleDataComponent))
-                .map(particleEmitterComponent ->
-                        new ParticleRenderingData<>(
-                                particleEmitterComponent.ownerEntity.getComponent(particleDataComponent),
-                                particleEmitterComponent.particlePool
-                        ));
+                .filter(emitter -> emitter.ownerEntity.hasComponent(particleDataComponent))
+                .filter(distinctByKey(emitter -> emitter.particlePool))
+                .map(emitter -> new ParticleRenderingData<>(
+                        emitter.ownerEntity.getComponent(particleDataComponent),
+                        emitter.particlePool
+                ));
+    }
+
+    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+        Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return element -> seen.add(keyExtractor.apply(element));
     }
 }

--- a/engine/src/main/java/org/terasology/particles/ParticleSystemManagerImpl.java
+++ b/engine/src/main/java/org/terasology/particles/ParticleSystemManagerImpl.java
@@ -111,8 +111,8 @@ public class ParticleSystemManagerImpl extends BaseComponentSystem implements Up
     @Override
     public Stream<ParticleRenderingData> getParticleEmittersByDataComponent(Class<? extends Component> particleDataComponent) {
         return particleUpdater.getParticleEmitters().stream()
-                .filter(emitter -> emitter.ownerEntity.hasComponent(particleDataComponent))
-                .filter(distinctByKey(emitter -> emitter.particlePool))
+                .filter(emitter -> emitter.ownerEntity.hasComponent(particleDataComponent))  // filter emitters, whose owning entity has a particleDataComponent
+                .filter(distinctByKey(emitter -> emitter.particlePool))  // filter emitters referencing a unique particle pool
                 .map(emitter -> new ParticleRenderingData<>(
                         emitter.ownerEntity.getComponent(particleDataComponent),
                         emitter.particlePool

--- a/engine/src/main/java/org/terasology/particles/updating/ParticleUpdaterImpl.java
+++ b/engine/src/main/java/org/terasology/particles/updating/ParticleUpdaterImpl.java
@@ -302,6 +302,14 @@ public class ParticleUpdaterImpl implements ParticleUpdater {
         }
     }
 
+    private void updateParticleEmitters(final ParticleEmitterComponent emitter, final float delta) {
+        if (emitter.enabled && (emitter.particleSpawnsLeft == ParticleEmitterComponent.INFINITE_PARTICLE_SPAWNS || emitter.particleSpawnsLeft > 0)) {
+            updateEmitter(emitter, 0, delta); // Emit particles
+        }
+
+        updateEmitterLifeTime(emitter, delta);
+    }
+
     private void updateParticleData(final ParticleEmitterComponent particleSystem, float delta) {
         if (!updatedParticlePools.contains(particleSystem.particlePool)) {
             updateParticles(particleSystem, delta); // Update particle lifetime and Affectors
@@ -313,14 +321,6 @@ public class ParticleUpdaterImpl implements ParticleUpdater {
 
             updatedParticlePools.add(particleSystem.particlePool);
         }
-    }
-
-    private void updateParticleEmitters(final ParticleEmitterComponent partSys, final float delta) {
-        if (partSys.enabled && (partSys.particleSpawnsLeft == ParticleEmitterComponent.INFINITE_PARTICLE_SPAWNS || partSys.particleSpawnsLeft > 0)) {
-            updateEmitter(partSys, 0, delta); // Emit particles
-        }
-
-        updateEmitterLifeTime(partSys, delta);
     }
 
     private void updateEmitterLifeTime(ParticleEmitterComponent emitter, float delta) {


### PR DESCRIPTION
This PR fixes the engine's usage of particle emitters referencing the same particle pool.

It turns out that particle pools could already be shared among multiple `ParticleEmitterComponent`s.
If done, however, the engine would update and render the pools multiple times (once for each particle emitter referencing it).

# Test
Start a new game and verify that block mining causes the expected particles to be emitted.
I'll also add a PR to Terasology/WeatherManager that fixes the module's performance and relies on this one.