### PR TITLE
feat: Add event to signal that LocalPlayer is fully initialized.

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -58,6 +58,7 @@ import org.terasology.logic.characters.events.ScaleToRequest;
 import org.terasology.logic.characters.interactions.InteractionUtil;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.players.event.LocalPlayerInitializedEvent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.AABB;
 import org.terasology.math.JomlUtil;
@@ -106,6 +107,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     private BindsManager bindsManager;
 
     private Camera playerCamera;
+    private boolean localPlayerInitialized = false;
 
     private float bobFactor;
     private float lastStepDelta;
@@ -139,15 +141,18 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
     @Override
     public void update(float delta) {
-        if (!localPlayer.isValid()) {
-            return;
+        if (!localPlayerInitialized && localPlayer.isValid()) {
+            localPlayer.getClientEntity().send(new LocalPlayerInitializedEvent());
+            localPlayerInitialized = true;
         }
 
-        EntityRef entity = localPlayer.getCharacterEntity();
-        CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
+        if (localPlayerInitialized) {
+            EntityRef entity = localPlayer.getCharacterEntity();
+            CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
 
-        processInput(entity, characterMovementComponent);
-        updateCamera(characterMovementComponent, localPlayer.getViewPosition(), JomlUtil.from(localPlayer.getViewRotation()));
+            processInput(entity, characterMovementComponent);
+            updateCamera(characterMovementComponent, localPlayer.getViewPosition(), JomlUtil.from(localPlayer.getViewRotation()));
+        }
     }
 
     private void processInput(EntityRef entity, CharacterMovementComponent characterMovementComponent) {

--- a/engine/src/main/java/org/terasology/logic/players/event/LocalPlayerInitializedEvent.java
+++ b/engine/src/main/java/org/terasology/logic/players/event/LocalPlayerInitializedEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.players.event;
+
+import org.terasology.entitySystem.event.Event;
+
+/**
+ * This event gets sent when the {@link org.terasology.logic.players.LocalPlayer} object is ready to be used.
+ * <br/>
+ * The object can be injected using {@link org.terasology.registry.In}.
+ * This event corresponds with its isValid() method returning true for the first time.
+ */
+public class LocalPlayerInitializedEvent implements Event {
+}


### PR DESCRIPTION
This PR solves that clients had to poll `LocalPlayer.isValid()` to figure out, when the injected object `LocalPlayer` object was fully initialized.

I added the `LocalPlayerInitializedEvent` to communicate the object's initialization more efficiently to clients. The event is being sent to the client-entity.