### PR TITLE
fix: allow game to quit without waiting for registry updater thread

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.rendering.nui.layers.mainMenu.advancedGameSetupScreen;
 
+import ch.qos.logback.classic.pattern.TargetLengthBasedClassNameAbbreviator;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,8 +132,11 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
     @Override
     public void initialise() {
         setAnimationSystem(MenuAnimationSystems.createDefaultSwipeAnimation());
-        remoteModuleRegistryUpdater = Executors.newSingleThreadExecutor()
-                .submit(moduleManager.getInstallManager().updateRemoteRegistry());
+        remoteModuleRegistryUpdater = Executors.newSingleThreadExecutor(
+                new ThreadFactoryBuilder()
+                        .setNameFormat(new TargetLengthBasedClassNameAbbreviator(36).abbreviate(getClass().getName()) + "-%d")
+                        .setDaemon(true)
+                        .build()).submit(moduleManager.getInstallManager().updateRemoteRegistry());
 
         final UIText seed = find("seed", UIText.class);
         if (seed != null) {


### PR DESCRIPTION
This fixes #3940. The thread that was holding things up there was this one that's updating the mod registry.

### How to test

* Start Terasology. Push the _Exit Terasology_ button quickly, before everything has time to settle.
* Make sure the window not only closed, but the process has quit as well. i.e. you see "process finished with exit code 0" in intellij or "build successful" and a return to the command line from the gradle task.


### Outstanding before merging

- [ ] use a more convenient and readable thread runner