### PR TITLE
feat: Only show "augmentation" modules initially

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -138,9 +138,11 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
             seed.setText(new FastRandom().nextString(32));
         }
 
-        // skip loading module configs, unselect all checkboxes by default
+        // skip loading module configs, limit shown modules to "augmentation" category
         selectModulesConfig = new SelectModulesConfig();
-        selectModulesConfig.getSelectedStandardModuleExtensions().forEach(selectModulesConfig::unselectStandardModuleExtension);
+        selectModulesConfig.getSelectedStandardModuleExtensions()
+                .forEach(selectModulesConfig::unselectStandardModuleExtension);
+        selectModulesConfig.toggleStandardModuleExtensionSelected(StandardModuleExtension.IS_AUGMENTATION);
 
         dependencyResolver = new DependencyResolver(moduleManager.getRegistry());
 


### PR DESCRIPTION
This will only show modules from the "augmentation" category in the
advanced game setup to slim down the overwhelming list a bit.

- Game mode modules should be selected via the game play drop down even
  before entering detailed setup
- Game modes often come with their default world generator tailored for
  the game mode, thus fiddling with that is also an "advanced" use case
- Special modules are ... special
- Libraries only make sense in combination with other modules anyways
- Assets may be part of that list in addition to augmentation modules...

![image](https://user-images.githubusercontent.com/1448874/82564971-f317e900-9b79-11ea-8965-61e50bcb1c91.png)
