### PR TITLE
fix: Respawn dead player after exiting the game

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -177,7 +177,7 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
             characterComp.controller = entity;
             character.saveComponent(characterComp);
             character.setOwner(entity);
-            if (!character.hasComponent(AliveCharacterComponent.class)) {          
+            if (!character.hasComponent(AliveCharacterComponent.class)) {
                 respawnPlayer(entity);
             }
             Location.attachChild(character, entity, new Vector3f(), new Quat4f(0, 0, 0, 1));

--- a/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerSystem.java
@@ -177,8 +177,8 @@ public class PlayerSystem extends BaseComponentSystem implements UpdateSubscribe
             characterComp.controller = entity;
             character.saveComponent(characterComp);
             character.setOwner(entity);
-            if (!character.hasComponent(AliveCharacterComponent.class)) {
-                character.addComponent(new AliveCharacterComponent());
+            if (!character.hasComponent(AliveCharacterComponent.class)) {          
+                respawnPlayer(entity);
             }
             Location.attachChild(character, entity, new Vector3f(), new Quat4f(0, 0, 0, 1));
         } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #3300

### How to test

- Load/create game with health module
- Enable hjump cheat
- Jump to your doom
- Choose "Exit Terasology"
- Re-open the game and load the same save
- Should now have full health instead of 0

NOTE: currently, trying to test using 'kill' in the cheat menu causes an OpenALException at "Setting listener orientation" when attempting to re-spawn. Use the high-jump or another method to cause player death. 