### PR TITLE
fix: Prevent NPE in ModuleDetailsScreen

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
@@ -313,15 +313,14 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
 
             @Override
             public void draw(DependencyInfo value, Canvas canvas) {
-                if (moduleManager.getRegistry().getLatestModuleVersion(value.getId()) == null) {
+                Module module = moduleManager.getRegistry().getLatestModuleVersion(value.getId());
+
+                if (module == null || !(value.versionRange().contains(module.getVersion()))) {
                     canvas.setMode("invalid");
                 } else {
                     canvas.setMode("available");
                 }
-                Version version = moduleManager.getRegistry().getLatestModuleVersion(value.getId()).getVersion();
-                if (!(value.versionRange().contains(version))) {
-                    canvas.setMode("invalid");
-                }
+
                 canvas.drawText(getString(value), canvas.getRegion());
             }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
@@ -76,9 +76,9 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
 
     private static final Logger logger = LoggerFactory.getLogger(ModuleDetailsScreen.class);
 
-    private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     private static final String DEFAULT_GITHUB_MODULE_URL = "https://github.com/Terasology/";
-    private static final List INTERNAL_MODULES = Arrays.asList("engine", "BuilderSampleGameplay");
+    private static final List<String> INTERNAL_MODULES = Arrays.asList("engine", "BuilderSampleGameplay");
     @In
     private ModuleManager moduleManager;
     @In
@@ -166,7 +166,9 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
 
         if (!isScreenValid()) {
             final MessagePopup popup = getManager().createScreen(MessagePopup.ASSET_URI, MessagePopup.class);
-            popup.setMessage(translationSystem.translate("${engine:menu#game-details-errors-message-title}"), translationSystem.translate("${engine:menu#game-details-errors-message-body}"));
+            popup.setMessage(
+                    translationSystem.translate("${engine:menu#game-details-errors-message-title}"),
+                    translationSystem.translate("${engine:menu#game-details-errors-message-body}"));
             popup.subscribeButton(e -> triggerBackAnimation());
             getManager().pushScreen(popup);
             // disable child widgets
@@ -487,7 +489,7 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
                 .findFirst()
                 .map(Module::getMetadata)
                 .map(RemoteModuleExtension::getLastUpdated)
-                .map(dateFormat::format)
+                .map(DATE_FORMAT::format)
                 .orElse("");
     }
 


### PR DESCRIPTION
Fixes #3981

Even though we did check against `null` in the first place, we nevertheless accessed this possible `null` value a couple of lines later 🙄
This is fixed by simplifying the way we set the canvas mode.

![image](https://user-images.githubusercontent.com/1448874/82761176-fec51300-9df8-11ea-98b5-26f32138012b.png)

