### PR TITLE
feat: BlockFamily API enhancement

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -16,8 +16,6 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
-import org.joml.Vector2fc;
-import org.joml.Vector3fc;
 import org.terasology.math.Pitch;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
@@ -85,8 +83,8 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
     }
 
     @Override
-    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
-        return blocks.get(attachmentSide);
+    public Block getBlockForPlacement(BlockPlacementData data) {
+        return blocks.get(data.attachmentSide);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -16,6 +16,8 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector2fc;
+import org.joml.Vector3fc;
 import org.terasology.math.Pitch;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
@@ -80,6 +82,11 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
         } else {
             archetype = blocks.get(Side.FRONT);
         }
+    }
+
+    @Override
+    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+        return blocks.get(attachmentSide);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.world.block.family;
 
-import org.joml.Vector2fc;
-import org.joml.Vector3fc;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -42,14 +40,13 @@ public interface BlockFamily {
     String getDisplayName();
 
     /**
-     * Get the block that is appropriate for placement in the given situation
+     * Get the block that is appropriate for placement in the given situation,
+     * which is determined by the provided block placement data.
      *
-     * @param position          The block position, at which the block is going to be placed at.
-     * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
-     * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A value between (0, 0) and (1, 1).
+     * @param data block placement data
      * @return The appropriate block
      */
-    Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition);
+    Block getBlockForPlacement(BlockPlacementData data);
 
     /**
      * Get the block that is appropriate for placement in the given situation
@@ -58,7 +55,7 @@ public interface BlockFamily {
      * @param attachmentSide      The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
      * @param direction           A secondary direction after the attachment side that determines the facing of the block.
      * @return The appropriate block
-     * @deprecated This method is scheduled for removal, use this one instead: {@link #getBlockForPlacement(Vector3i, Side, Vector3fc, Vector2fc)}.
+     * @deprecated This method is scheduled for removal, use this one instead: {@link #getBlockForPlacement(BlockPlacementData)}.
      */
     @Deprecated
     Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction);

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.world.block.family;
 
+import org.joml.Vector2fc;
+import org.joml.Vector3fc;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -42,11 +44,23 @@ public interface BlockFamily {
     /**
      * Get the block that is appropriate for placement in the given situation
      *
+     * @param position          The block position, at which the block is going to be placed at.
+     * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
+     * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A value between (0, 0) and (1, 1).
+     * @return The appropriate block
+     */
+    Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition);
+
+    /**
+     * Get the block that is appropriate for placement in the given situation
+     *
      * @param location            The location where the block is going to be placed.
      * @param attachmentSide      The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
      * @param direction           A secondary direction after the attachment side that determines the facing of the block.
      * @return The appropriate block
+     * @deprecated This method is scheduled for removal, use this one instead: {@link #getBlockForPlacement(Vector3i, Side, Vector3fc, Vector2fc)}.
      */
+    @Deprecated
     Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction);
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.family;
 
+import com.google.common.base.Preconditions;
 import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector3f;
@@ -66,9 +67,9 @@ public class BlockPlacementData {
      * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A vector in the range (0..1, 0..1)
      */
     public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
-        this.blockPosition = new Vector3i(blockPosition);
-        this.attachmentSide = attachmentSide;
-        this.viewingDirection = new Vector3f(viewingDirection);
-        this.relativeAttachmentPosition = new Vector2f(relativeAttachmentPosition);
+        this.blockPosition = new Vector3i(Preconditions.checkNotNull(blockPosition));
+        this.attachmentSide = Preconditions.checkNotNull(attachmentSide);
+        this.viewingDirection = new Vector3f(Preconditions.checkNotNull(viewingDirection));
+        this.relativeAttachmentPosition = new Vector2f(Preconditions.checkNotNull(relativeAttachmentPosition));
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block.family;
+
+import org.joml.Vector2f;
+import org.joml.Vector2fc;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.terasology.math.Side;
+
+/**
+ * BlockPlacementData represents data that is useful for determining the orientation of new block.
+ * The data is supposed to be derived from the players state when placing the block.
+ * BlockPlacementData is immutable.
+ */
+public class BlockPlacementData {
+
+    public final Vector3ic blockPosition;
+    public final Side attachmentSide;
+    public final Vector3fc viewingDirection;
+    public final Vector2fc relativeAttachmentPosition;
+
+    /**
+     * @param blockPosition     The block position, at which the block is going to be placed at.
+     * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
+     */
+    public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection) {
+        this(blockPosition, attachmentSide, viewingDirection, new Vector2f());
+    }
+
+    /**
+     * @param blockPosition     The block position, at which the block is going to be placed at.
+     * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
+     * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A value between (0, 0) and (1, 1).
+     */
+    public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+        this.blockPosition = new Vector3i(blockPosition);
+        this.attachmentSide = attachmentSide;
+        this.viewingDirection = new Vector3f(viewingDirection);
+        this.relativeAttachmentPosition = new Vector2f(relativeAttachmentPosition);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
@@ -30,23 +30,40 @@ import org.terasology.math.Side;
  */
 public class BlockPlacementData {
 
+    /**
+     * The block position, at which the block is supposed to be placed at
+     */
     public final Vector3ic blockPosition;
+
+    /**
+     * The block side, this block is being attached to, e.g. Top if the block is being placed on the ground
+     */
     public final Side attachmentSide;
+
+    /**
+     * The player's viewing direction
+     */
     public final Vector3fc viewingDirection;
+
+    /**
+     * The position on the block surface that the user aimed at when placing the block. A vector in the range (0..1, 0..1)
+     */
     public final Vector2fc relativeAttachmentPosition;
 
     /**
-     * @param blockPosition     The block position, at which the block is going to be placed at.
+     * @param blockPosition     The block position, at which the block is supposed to be placed at
      * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
+     * @param viewingDirection  The players viewing direction
      */
     public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection) {
         this(blockPosition, attachmentSide, viewingDirection, new Vector2f());
     }
 
     /**
-     * @param blockPosition     The block position, at which the block is going to be placed at.
+     * @param blockPosition     The block position, at which the block is supposed to be placed at
      * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
-     * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A value between (0, 0) and (1, 1).
+     * @param viewingDirection  The players viewing direction
+     * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A vector in the range (0..1, 0..1)
      */
     public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
         this.blockPosition = new Vector3i(blockPosition);

--- a/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
@@ -16,13 +16,8 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
-import org.joml.Vector2fc;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.math.ChunkMath;
-import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -79,11 +74,17 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
     }
 
     @Override
-    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
-        Vector3f attachmentSideNormal = new org.joml.Vector3f(attachmentSide.direction());
-        Side direction = ChunkMath.getSecondaryPlacementDirection(JomlUtil.from(viewingDirection), JomlUtil.from(attachmentSideNormal));
+    public Block getBlockForPlacement(BlockPlacementData data) {
+        if (archetypeBlock != null) {
+            return archetypeBlock;
+        }
 
-        return getBlockForPlacement(position, attachmentSide, direction);
+        if (data.attachmentSide.isHorizontal()) {
+            return blocks.get(data.attachmentSide);
+        } else {
+            Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
+            return blocks.get(blockDirection);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
@@ -16,8 +16,13 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector2fc;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -73,6 +78,13 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
         throw new UnsupportedOperationException("Shape expected");
     }
 
+    @Override
+    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+        Vector3f attachmentSideNormal = new org.joml.Vector3f(attachmentSide.direction());
+        Side direction = ChunkMath.getSecondaryPlacementDirection(JomlUtil.from(viewingDirection), JomlUtil.from(attachmentSideNormal));
+
+        return getBlockForPlacement(position, attachmentSide, direction);
+    }
 
     @Override
     public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {

--- a/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
@@ -16,6 +16,8 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector2fc;
+import org.joml.Vector3fc;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -77,6 +79,16 @@ public class HorizontalFamily extends AbstractBlockFamily implements SideDefined
 
     protected Side getArchetypeSide() {
         return Side.FRONT;
+    }
+
+    @Override
+    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+        if (attachmentSide.isHorizontal()) {
+            return blocks.get(attachmentSide);
+        } else {
+            Side secondaryDirection = Side.inDirection(-viewingDirection.x(), 0, -viewingDirection.z());
+            return blocks.get(secondaryDirection);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
@@ -16,8 +16,6 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
-import org.joml.Vector2fc;
-import org.joml.Vector3fc;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -82,11 +80,11 @@ public class HorizontalFamily extends AbstractBlockFamily implements SideDefined
     }
 
     @Override
-    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
-        if (attachmentSide.isHorizontal()) {
-            return blocks.get(attachmentSide);
+    public Block getBlockForPlacement(BlockPlacementData data) {
+        if (data.attachmentSide.isHorizontal()) {
+            return blocks.get(data.attachmentSide);
         } else {
-            Side secondaryDirection = Side.inDirection(-viewingDirection.x(), 0, -viewingDirection.z());
+            Side secondaryDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
             return blocks.get(secondaryDirection);
         }
     }

--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -18,6 +18,8 @@ package org.terasology.world.block.family;
 import com.google.common.collect.Sets;
 import gnu.trove.map.TByteObjectMap;
 import gnu.trove.map.hash.TByteObjectHashMap;
+import org.joml.Vector2fc;
+import org.joml.Vector3fc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.Rotation;
@@ -156,24 +158,25 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
     }
 
     /**
-     * Using the location of the block, the side the block is being attached to and the direction the block is being placed in,
-     * determine what block should be placed.
-     * 
-     * @param location The location of where the block will be placed
-     * @param attachmentSide The side that the new block is being placed on
-     * @param direction The direction the block is being placed in
-     * 
-     * @return The block from the family to be placed
+     * {@inheritDoc}
      */
     @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
+    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
         byte connections = 0;
         for (Side connectSide : SideBitFlag.getSides(getConnectionSides())) {
-            if (this.connectionCondition(location, connectSide)) {
+            if (this.connectionCondition(position, connectSide)) {
                 connections += SideBitFlag.getSide(connectSide);
             }
         }
         return blocks.get(connections);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
+        return getBlockForPlacement(location, null, null, null);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -18,10 +18,10 @@ package org.terasology.world.block.family;
 import com.google.common.collect.Sets;
 import gnu.trove.map.TByteObjectMap;
 import gnu.trove.map.hash.TByteObjectHashMap;
-import org.joml.Vector2fc;
-import org.joml.Vector3fc;
+import org.joml.Vector3f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.SideBitFlag;
@@ -161,10 +161,10 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      * {@inheritDoc}
      */
     @Override
-    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+    public Block getBlockForPlacement(BlockPlacementData data) {
         byte connections = 0;
         for (Side connectSide : SideBitFlag.getSides(getConnectionSides())) {
-            if (this.connectionCondition(position, connectSide)) {
+            if (this.connectionCondition(JomlUtil.from(data.blockPosition), connectSide)) {
                 connections += SideBitFlag.getSide(connectSide);
             }
         }
@@ -176,7 +176,8 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      */
     @Override
     public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        return getBlockForPlacement(location, null, null, null);
+        BlockPlacementData data = new BlockPlacementData(JomlUtil.from(location), null, new Vector3f());
+        return getBlockForPlacement(data);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.world.block.family;
 
+import org.joml.Vector2fc;
+import org.joml.Vector3fc;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
@@ -23,7 +25,7 @@ import org.terasology.world.block.BlockUri;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.shapes.BlockShape;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * The standard block family consisting of a single symmetrical block that doesn't have unique rotations.
@@ -52,6 +54,10 @@ public class SymmetricFamily extends AbstractBlockFamily {
         block = blockBuilder.constructSimpleBlock(definition, new BlockUri(definition.getUrn()), this);
     }
 
+    @Override
+    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+        return block;
+    }
 
     @Override
     public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
@@ -74,6 +80,6 @@ public class SymmetricFamily extends AbstractBlockFamily {
 
     @Override
     public Iterable<Block> getBlocks() {
-        return Arrays.asList(block);
+        return Collections.singletonList(block);
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.world.block.family;
 
-import org.joml.Vector2fc;
-import org.joml.Vector3fc;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
@@ -55,7 +53,7 @@ public class SymmetricFamily extends AbstractBlockFamily {
     }
 
     @Override
-    public Block getBlockForPlacement(Vector3i position, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
+    public Block getBlockForPlacement(BlockPlacementData data) {
         return block;
     }
 

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -15,8 +15,7 @@
  */
 package org.terasology.world.block.items;
 
-import org.terasology.telemetry.GamePlayStatsComponent;
-import org.terasology.utilities.Assets;
+import org.joml.Vector2f;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -28,7 +27,7 @@ import org.terasology.logic.characters.KinematicCharacterMover;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.math.AABB;
-import org.terasology.math.ChunkMath;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -37,6 +36,8 @@ import org.terasology.physics.Physics;
 import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
+import org.terasology.telemetry.GamePlayStatsComponent;
+import org.terasology.utilities.Assets;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
@@ -76,9 +77,8 @@ public class BlockItemSystem extends BaseComponentSystem {
         }
 
         BlockItemComponent blockItem = item.getComponent(BlockItemComponent.class);
-        BlockFamily type = blockItem.blockFamily;
+        BlockFamily blockFamily = blockItem.blockFamily;
         Side surfaceSide = Side.inDirection(event.getHitNormal());
-        Side secondaryDirection = ChunkMath.getSecondaryPlacementDirection(event.getDirection(), event.getHitNormal());
 
         BlockComponent blockComponent = event.getTarget().getComponent(BlockComponent.class);
         if (blockComponent == null) {
@@ -90,7 +90,9 @@ public class BlockItemSystem extends BaseComponentSystem {
         Vector3i placementPos = new Vector3i(targetBlock);
         placementPos.add(surfaceSide.getVector3i());
 
-        Block block = type.getBlockForPlacement(placementPos, surfaceSide, secondaryDirection);
+        Block block = blockFamily.getBlockForPlacement(
+                placementPos, surfaceSide, JomlUtil.from(event.getDirection()), new Vector2f()
+        );
 
         if (canPlaceBlock(block, targetBlock, placementPos)) {
             // TODO: Fix this for changes.
@@ -103,7 +105,7 @@ public class BlockItemSystem extends BaseComponentSystem {
                     event.consume();
                 }
             }
-            recordBlockPlaced(event, type);
+            recordBlockPlaced(event, blockFamily);
             event.getInstigator().send(new PlaySoundEvent(Assets.getSound("engine:PlaceBlock").get(), 0.5f));
         } else {
             event.consume();

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.world.block.items;
 
-import org.joml.Vector2f;
 import org.terasology.audio.AudioManager;
 import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -44,6 +43,7 @@ import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.entity.placement.PlaceBlocks;
 import org.terasology.world.block.family.BlockFamily;
+import org.terasology.world.block.family.BlockPlacementData;
 
 import java.util.Map;
 
@@ -90,9 +90,9 @@ public class BlockItemSystem extends BaseComponentSystem {
         Vector3i placementPos = new Vector3i(targetBlock);
         placementPos.add(surfaceSide.getVector3i());
 
-        Block block = blockFamily.getBlockForPlacement(
-                placementPos, surfaceSide, JomlUtil.from(event.getDirection()), new Vector2f()
-        );
+        Block block = blockFamily.getBlockForPlacement(new BlockPlacementData(
+                JomlUtil.from(placementPos), surfaceSide, JomlUtil.from(event.getDirection())
+        ));
 
         if (canPlaceBlock(block, targetBlock, placementPos)) {
             // TODO: Fix this for changes.


### PR DESCRIPTION
This PR enhances the `BlockFamily` interface to accept additional data for determining the orientation of new blocks.
The requirement was introduced by this PR: #3978.

The new data contains the players viewing direction and optionally the relative position, the player aimed at when placing the block (on the attachment side). This information can be used, for example, to turn blocks upside down when attached to the upper half of a block side.

The old `getBlockForPlacement()` method got deprecated in favor of the new one.

### Test
Place some Chests and Doors, and other blocks. Verify that their placement behavior has not changed.