### PR TITLE
build(templates): Add JUnit 5 params dependency

### DIFF
--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -138,6 +138,7 @@ dependencies {
     }
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.2"
     testImplementation "org.mockito:mockito-junit-jupiter:3.2.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.2"
 

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     }
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.6.2"
     testImplementation "org.mockito:mockito-junit-jupiter:3.2.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.2"
 


### PR DESCRIPTION
Found while working on https://github.com/Terasology/Inventory/pull/10,
which uses shiny JUnit 5 parameterized tests.