### PR TITLE
fix: prevent crash entering rendering settings with no renderers

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/rendering/RenderingModuleRegistry.java
+++ b/engine/src/main/java/org/terasology/engine/module/rendering/RenderingModuleRegistry.java
@@ -16,7 +16,6 @@
 package org.terasology.engine.module.rendering;
 
 import org.terasology.context.Context;
-import org.terasology.module.Module;
 import org.terasology.module.ModuleEnvironment;
 import org.terasology.module.sandbox.API;
 import org.terasology.naming.Name;
@@ -73,7 +72,6 @@ public class RenderingModuleRegistry {
      * For use everywhere to get last ordered list of {@link ModuleRendering} instances.
      * @return list of {@link ModuleRendering} instances
      */
-    @Nullable
     public List<ModuleRendering> getOrderedRenderingModules() {
         return this.orderedModuleRenderingInstances;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/RenderingModuleSettingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/RenderingModuleSettingScreen.java
@@ -75,10 +75,9 @@ public class RenderingModuleSettingScreen extends CoreScreenLayer implements UIS
 
         renderingModuleRegistry = context.get(RenderingModuleRegistry.class);
 
-        renderingModuleRegistry.updateRenderingModulesOrder(moduleEnvironment, subContext);
-        orderedModuleRenderingInstances = renderingModuleRegistry.getOrderedRenderingModules();
+        orderedModuleRenderingInstances = renderingModuleRegistry.updateRenderingModulesOrder(moduleEnvironment, subContext);
 
-        if (orderedModuleRenderingInstances == null || orderedModuleRenderingInstances.isEmpty()) {
+        if (orderedModuleRenderingInstances.isEmpty()) {
             logger.error("No rendering module found!");
             GameEngine gameEngine = context.get(GameEngine.class);
             gameEngine.changeState(new StateMainMenu("No rendering module installed, unable to render. Try enabling CoreRendering."));

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/RenderingModuleSettingScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/RenderingModuleSettingScreen.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.context.Context;
+import org.terasology.engine.GameEngine;
+import org.terasology.engine.modes.StateMainMenu;
 import org.terasology.engine.module.rendering.RenderingModuleRegistry;
 import org.terasology.i18n.TranslationSystem;
 import org.terasology.module.ModuleEnvironment;
@@ -75,6 +77,13 @@ public class RenderingModuleSettingScreen extends CoreScreenLayer implements UIS
 
         renderingModuleRegistry.updateRenderingModulesOrder(moduleEnvironment, subContext);
         orderedModuleRenderingInstances = renderingModuleRegistry.getOrderedRenderingModules();
+
+        if (orderedModuleRenderingInstances == null || orderedModuleRenderingInstances.isEmpty()) {
+            logger.error("No rendering module found!");
+            GameEngine gameEngine = context.get(GameEngine.class);
+            gameEngine.changeState(new StateMainMenu("No rendering module installed, unable to render. Try enabling CoreRendering."));
+            return;
+        }
 
         renderingModuleInfo = find("modulesInfo", UIText.class);
         recalculateOrder = find("update", UIButton.class);

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.rendering.world;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
@@ -42,22 +40,17 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.ShaderManager;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.backdrop.BackdropProvider;
-
 import org.terasology.rendering.cameras.OpenVRStereoCamera;
 import org.terasology.rendering.cameras.PerspectiveCamera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
-import org.terasology.engine.module.rendering.RenderingModuleRegistry;
-import org.terasology.rendering.dag.Node;
 import org.terasology.rendering.dag.ModuleRendering;
+import org.terasology.rendering.dag.Node;
 import org.terasology.rendering.dag.RenderGraph;
 import org.terasology.rendering.dag.RenderPipelineTask;
 import org.terasology.rendering.dag.RenderTaskListGenerator;
-
 import org.terasology.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.rendering.opengl.FBO;
-
 import org.terasology.rendering.opengl.ScreenGrabber;
-
 import org.terasology.rendering.opengl.fbms.DisplayResolutionDependentFbo;
 import org.terasology.rendering.openvrprovider.OpenVRProvider;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
@@ -65,8 +58,9 @@ import org.terasology.utilities.Assets;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.chunks.ChunkProvider;
 
-import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
+import java.util.List;
 
+import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
 import static org.lwjgl.opengl.GL11.glDisable;
 import static org.lwjgl.opengl.GL11.glViewport;
 
@@ -213,8 +207,9 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         // registry not populated by new ModuleRendering instances in UI, populate now
         if (renderingModuleRegistry.getOrderedRenderingModules().isEmpty()) {
-            renderingModuleRegistry.updateRenderingModulesOrder(context.get(ModuleManager.class).getEnvironment(), context);
-            if(renderingModuleRegistry.getOrderedRenderingModules().isEmpty()) {
+            List<ModuleRendering> renderingModules = renderingModuleRegistry.updateRenderingModulesOrder(
+                    context.get(ModuleManager.class).getEnvironment(), context);
+            if (renderingModules.isEmpty()) {
                 GameEngine gameEngine = context.get(GameEngine.class);
                 gameEngine.changeState(new StateMainMenu("No rendering module loaded, unable to render. Try enabling CoreRendering."));
             }


### PR DESCRIPTION
It crashed when going through the advanced game setup and trying to enter the render settings scene.