### PR TITLE
fix(concurrency): make TaskProcessor threads daemon-threads by default

### DIFF
--- a/engine/src/main/java/org/terasology/utilities/concurrency/TaskProcessor.java
+++ b/engine/src/main/java/org/terasology/utilities/concurrency/TaskProcessor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,6 +43,7 @@ final class TaskProcessor<T extends Task> implements Runnable {
         boolean running = true;
         Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
         Thread.currentThread().setName(name);
+        Thread.currentThread().setDaemon(true);
         while (running) {
             try {
                 T task = queue.take();


### PR DESCRIPTION
This makes all of TaskMaster's threads (the TaskProcessors) be daemon threads by default.

Daemon threads can not prevent the application from shutting down.

Related to deadlock-on-exit issues such as #3996. (All the non-daemon threads named in that issue are TaskProcessor threads.)


### Outstanding before merging

This is a naive patch, it applies this setting in the place unconditionally. I hope someone reviews this and explains which uses we need consider before making such a global change!