### PR TITLE
chore: set the default copyright header to something shorter

### DIFF
--- a/.idea/copyright/TerasologyEngine__old_.xml
+++ b/.idea/copyright/TerasologyEngine__old_.xml
@@ -3,6 +3,6 @@
     <option name="allowReplaceRegexp" value="20\d\d" />
     <option name="keyword" value="Copyright.+Moving\s?Blocks" />
     <option name="notice" value="Copyright &amp;#36;today.year MovingBlocks&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    https://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
-    <option name="myName" value="TerasologyEngine" />
+    <option name="myName" value="TerasologyEngine (old)" />
   </copyright>
 </component>

--- a/.idea/copyright/TerasologyEngine_brief.xml
+++ b/.idea/copyright/TerasologyEngine_brief.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="allowReplaceRegexp" value="20\d\d" />
+    <option name="keyword" value="Copyright.*Moving\s?Blocks" />
+    <option name="notice" value="Copyright &amp;#36;today.year MovingBlocks&#10;SPDX-License-Identifier: Apache-2.0" />
+    <option name="myName" value="TerasologyEngine-brief" />
+  </copyright>
+</component>

--- a/.idea/copyright/TerasologyEngine_brief.xml
+++ b/.idea/copyright/TerasologyEngine_brief.xml
@@ -1,8 +1,0 @@
-<component name="CopyrightManager">
-  <copyright>
-    <option name="allowReplaceRegexp" value="20\d\d" />
-    <option name="keyword" value="Copyright.*Moving\s?Blocks" />
-    <option name="notice" value="Copyright &amp;#36;today.year MovingBlocks&#10;SPDX-License-Identifier: Apache-2.0" />
-    <option name="myName" value="TerasologyEngine-brief" />
-  </copyright>
-</component>

--- a/.idea/copyright/Terasology_Foundation.xml
+++ b/.idea/copyright/Terasology_Foundation.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="allowReplaceRegexp" value="20\d\d" />
+    <option name="keyword" value="Copyright.*(Moving\s?Blocks|Terasology)" />
+    <option name="notice" value="Copyright &amp;#36;today.year The Terasology Foundation&#10;SPDX-License-Identifier: Apache-2.0" />
+    <option name="myName" value="Terasology Foundation" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,7 +1,10 @@
 <component name="CopyrightManager">
-  <settings default="TerasologyEngine">
+  <settings default="TerasologyEngine-brief">
     <LanguageOptions name="Properties">
       <option name="fileTypeOverride" value="1" />
+    </LanguageOptions>
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="block" value="false" />
     </LanguageOptions>
   </settings>
 </component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,5 +1,5 @@
 <component name="CopyrightManager">
-  <settings default="TerasologyEngine-brief">
+  <settings default="Terasology Foundation">
     <LanguageOptions name="Properties">
       <option name="fileTypeOverride" value="1" />
     </LanguageOptions>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2020 MovingBlocks
+// Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 MovingBlocks
+// SPDX-License-Identifier: Apache-2.0
 
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 MovingBlocks
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     `kotlin-dsl`

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2020 MovingBlocks
+// Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 plugins {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,16 +1,2 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2020 MovingBlocks
+// SPDX-License-Identifier: Apache-2.0

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,2 +1,2 @@
-// Copyright 2020 MovingBlocks
+// Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2020 MovingBlocks
+// Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 plugins {

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 MovingBlocks
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     id("terasology-module")


### PR DESCRIPTION
Apache says this is a "shorter variant you may use."

https://www.apache.org/foundation/license-faq.html#Apply-My-Software

this PR makes no attempt to change _all_ the existing copyright headers, but does do a few of the high-level files to set an example.
