### PR TITLE
chore: more descriptive error message on spawn failure

### DIFF
--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -93,7 +93,9 @@ public class PlayerFactory {
         EntityBuilder builder = entityManager.newBuilder("engine:player");
         float extraSpace = 0.5f;  // spawn a little bit above the ground
         float entityHeight = getHeightOf(builder) + extraSpace;
-        return findSpawnPos(JomlUtil.from(locationComponent.getWorldPosition()), entityHeight).get(); // TODO: Handle Optional being empty
+        return findSpawnPos(JomlUtil.from(locationComponent.getWorldPosition()), entityHeight)
+                // TODO: Handle Optional being empty
+                .orElseThrow(() -> new RuntimeException("Failed to find an acceptable spawn location."));
     }
 
     private float getHeightOf(ComponentContainer prefab) {


### PR DESCRIPTION
This changes an error message from being a NoSuchElementException to

> java.lang.RuntimeException: Failed to find an acceptable spawn location.

is RuntimeException the right thing to use for this?

NoSuchElementException is a direct subclass of RuntimeException so it's probably not very wrong, but maybe we have a more fitting type for this kind of thing.