### PR TITLE
refactor(BlockItemFactory): remove code dupes; add doc; retain components

### DIFF
--- a/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
+++ b/engine/src/main/java/org/terasology/logic/common/RetainComponentsComponent.java
@@ -22,10 +22,11 @@ import org.terasology.network.Replicate;
 import java.util.Set;
 
 /**
- * This component is intended to list component classes that are supposed to be retained when placing a block.
- *
- * If a block entity has a component that is not part of its prefab, retaining this component results in
- * the block entity still having this component afterwards. If not retained, it is likely to be removed instead.
+ * This component is intended to list component classes that are supposed to be retained when converting between blocks
+ * and block items.
+ * <p>
+ * If a block (item) entity has a component that is not part of its prefab, retaining this component results in the block
+ * entity still having this component afterwards. If not retained, it is likely to be removed instead.
  */
 public class RetainComponentsComponent implements Component {
     @Replicate

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * A factory to create new <emph>block items</emph> for a {@link BlockFamily}.
+ * A factory to create new <em>block items</em> for a {@link BlockFamily}.
  * <p>
  * A <strong>block item</strong> is an entity guaranteed to have the following components.
  * <ul>

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
@@ -56,10 +56,34 @@ public class BlockItemFactory {
         this.entityManager = entityManager;
     }
 
+    /**
+     * Create a new block item for the given {@link BlockFamily}.
+     * <p>
+     * Attempts to resolve the corresponding block prefab to retrieve a list of potential components to add. The item
+     * quantity defaults to 1.
+     * <p>
+     * Use {@link #newBuilder(BlockFamily, int)} if you want to modify the block item entity's properties
+     * before it gets created.
+     *
+     * @param blockFamily block family to create the block item builder for
+     * @return the block item entity
+     */
     public EntityRef newInstance(BlockFamily blockFamily) {
         return newInstance(blockFamily, 1);
     }
 
+    /**
+     * Create a new block item for the given {@link BlockFamily} and item quantity.
+     * <p>
+     * Attempts to resolve the corresponding block prefab to retrieve a list of potential components to add.
+     * <p>
+     * Use {@link #newBuilder(BlockFamily, int)} if you want to modify the block item entity's properties before it gets
+     * created.
+     *
+     * @param blockFamily block family to create the block item builder for
+     * @param quantity item quantity (see {@link ItemComponent#stackCount}); constrained to [0...128)
+     * @return the block item entity
+     */
     public EntityRef newInstance(BlockFamily blockFamily, int quantity) {
         if (blockFamily == null) {
             return EntityRef.NULL;
@@ -68,6 +92,19 @@ public class BlockItemFactory {
         return builder.build();
     }
 
+    /**
+     * Create a new block item for the given {@link BlockFamily}, with {@code blockEntity} as reference entity to retain
+     * components from.
+     * <p>
+     * The item quantity defaults to 1.
+     * <p>
+     * Use {@link #newBuilder(BlockFamily, EntityRef, int)} if you want to modify the block item entity's properties
+     * before it gets created.
+     *
+     * @param blockFamily block family to create the block item builder for
+     * @param blockEntity reference block entity to retain components from
+     * @return the block item entity
+     */
     public EntityRef newInstance(BlockFamily blockFamily, EntityRef blockEntity) {
         if (blockFamily == null) {
             return EntityRef.NULL;
@@ -77,11 +114,9 @@ public class BlockItemFactory {
     }
 
     /**
-     * Create a new block item builder for the given {@link BlockFamily} and item quantity, with {@code blockEntity} as
-     * reference entity to retain components from.
+     * Create a new block item builder for the given {@link BlockFamily} and item quantity.
      * <p>
-     * This method attempts to resolve the corresponding block prefab to retrieve a list of potential components to
-     * add.
+     * Attempts to resolve the corresponding block prefab to retrieve a list of potential components to add.
      * <p>
      * Use this method if you want to modify the block item entity's properties before it gets created.
      *

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
@@ -50,8 +50,14 @@ import java.util.Set;
  * @see RetainComponentsComponent
  */
 public class BlockItemFactory {
-    private EntityManager entityManager;
+    private final EntityManager entityManager;
 
+    /**
+     * Instantiate new block item factory with the given entity manager.
+     *
+     * @param entityManager entity manager to create new {@link EntityBuilder}s and copy components from
+     *         reference entities or prefabs to the new block items
+     */
     public BlockItemFactory(EntityManager entityManager) {
         this.entityManager = entityManager;
     }
@@ -62,8 +68,8 @@ public class BlockItemFactory {
      * Attempts to resolve the corresponding block prefab to retrieve a list of potential components to add. The item
      * quantity defaults to 1.
      * <p>
-     * Use {@link #newBuilder(BlockFamily, int)} if you want to modify the block item entity's properties
-     * before it gets created.
+     * Use {@link #newBuilder(BlockFamily, int)} if you want to modify the block item entity's properties before it gets
+     * created.
      *
      * @param blockFamily block family to create the block item builder for
      * @return the block item entity

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemFactory.java
@@ -16,7 +16,7 @@
 package org.terasology.world.block.items;
 
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
+import com.google.common.primitives.SignedBytes;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.ComponentContainer;
 import org.terasology.entitySystem.entity.EntityBuilder;
@@ -136,7 +136,7 @@ public class BlockItemFactory {
                         .map(p -> ((ComponentContainer) p))
                         .orElse(EntityRef.NULL);
 
-        return createBuilder(blockFamily, components, (byte) Ints.constrainToRange(quantity, 0, Byte.MAX_VALUE));
+        return createBuilder(blockFamily, components, SignedBytes.saturatedCast(quantity));
     }
 
     /**
@@ -151,7 +151,7 @@ public class BlockItemFactory {
      * @return a pre-populated entity builder for a block item entity
      */
     public EntityBuilder newBuilder(BlockFamily blockFamily, EntityRef blockEntity, int quantity) {
-        return createBuilder(blockFamily, blockEntity, (byte) Ints.constrainToRange(quantity, 0, Byte.MAX_VALUE));
+        return createBuilder(blockFamily, blockEntity, SignedBytes.saturatedCast(quantity));
     }
 
     /**


### PR DESCRIPTION
Reduces code duplication in `BlockItemFactory` and unifies the way block items are created when using `BlockItemFactory::newInstance` and `BlockItemFactory::newBuilder`.

Block item creation now also takes `RetainComponentsComponent` into account when copying components from a reference entity or block prefab to the block item. 

📘 Also, full addition of JavaDoc for `BlockItemFactory`.