### PR TITLE
groovyw module update-all improvements

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -186,12 +186,15 @@ class common {
      * Update a given item.
      * @param itemName the name of the item to update
      */
-    def updateItem(String itemName) {
+    def updateItem(String itemName, boolean skipRecentUpdates = false) {
         File targetDir = new File(targetDirectory, itemName)
         def searchString = itemName
-        if (itemName.startsWith(".")){
-            // add literal slash for regex start with '.'
-            searchString = "\\$itemName"        
+        if (!Character.isLetterOrDigit(itemName.charAt(0))){   
+            println color ("Skipping update for $itemName: starts with non-alphanumeric symbol", Ansi.YELLOW)
+            return
+        }
+        if(skipRecentUpdates){
+            println color("Continue flag!", Ansi.RED)
         }
         def inGitIgnore = false
         new File(".gitignore").eachLine{ line -> 

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -210,15 +210,9 @@ class common {
             searchString = "\\$itemName"        
         }
         for (file in gitIgnoreFiles) {
-            def relPathString = file.relativePath(new File("."))
-            def relSearchString = searchString
-            if (relPathString.length() > 3){
-                // file.relativePath adds an extra ../ for what we need in the gitignore, trim it off
-                relSearchString = relPathString.substring(3) + '/' + searchString
-            }
             def lines = file as String[]
             for (line in lines){
-                if ((line ==~ relSearchString) || (line ==~ "$relSearchString/")){
+                if ((line ==~ searchString) || (line ==~ "$searchString/")){
                     println("$itemName set to ignore in $file")
                     return true
                 }

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -248,7 +248,7 @@ class common {
                         }
                         print("\n")
                     } else {
-                        println color ("No changes found\n", Ansi.YELLOW)
+                        println color ("No changes found", Ansi.YELLOW)
                     }
                 } catch (GrgitException exception) {
                     println color("Unable to update $itemName, Skipping: ${exception.getMessage()}", Ansi.RED)

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -236,6 +236,20 @@ class common {
                 println color("uncommitted changes. Skipping.", Ansi.YELLOW)
             } else {
                 println color("updating $itemType $itemName", Ansi.GREEN)
+                File targetDirFetchHead = new File("$targetDir/.git/FETCH_HEAD")
+                Date lastUpdate = new Date(targetDirFetchHead.lastModified())
+                def recentlyUpdated = use(groovy.time.TimeCategory){
+                    def timeElapsedSinceUpdate = new Date() - lastUpdate
+                    if (timeElapsedSinceUpdate < 2.minutes){
+                        println color("Skipping update for $itemName: updated within last 2 minutes", Ansi.YELLOW)
+                        return true
+                    } else {
+                        return false
+                    }
+                }
+                if (recentlyUpdated){
+                    return
+                }
                 try {
                     def current_sha = itemGit.log(maxCommits: 1).find().getAbbreviatedId(8)
                     itemGit.pull remote: defaultRemote

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -215,6 +215,20 @@ class common {
                 println color("uncommitted changes. Skipping.", Ansi.YELLOW)
             } else {
                 println color("updating $itemType $itemName", Ansi.GREEN)
+                File targetDirFetchHead = new File("$targetDir/.git/FETCH_HEAD")
+                Date lastUpdate = new Date(targetDirFetchHead.lastModified())
+                def recentlyUpdated = use(groovy.time.TimeCategory){
+                    def timeElapsedSinceUpdate = new Date() - lastUpdate
+                    if (timeElapsedSinceUpdate < 2.minutes){
+                        println color("Skipping update for $itemName: updated within last 2 minutes", Ansi.YELLOW)
+                        return true
+                    } else {
+                        return false
+                    }
+                }
+                if (recentlyUpdated){
+                    return
+                }
                 try {
                     def current_sha = itemGit.log(maxCommits: 1).find().getAbbreviatedId(8)
                     itemGit.pull remote: defaultRemote

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -265,20 +265,6 @@ class common {
                 println color("uncommitted changes. Skipping.", Ansi.YELLOW)
             } else {
                 println color("updating $itemType $itemName", Ansi.GREEN)
-                File targetDirFetchHead = new File("$targetDir/.git/FETCH_HEAD")
-                Date lastUpdate = new Date(targetDirFetchHead.lastModified())
-                def recentlyUpdated = use(groovy.time.TimeCategory){
-                    def timeElapsedSinceUpdate = new Date() - lastUpdate
-                    if (timeElapsedSinceUpdate < 2.minutes){
-                        println color("Skipping update for $itemName: updated within last 2 minutes", Ansi.YELLOW)
-                        return true
-                    } else {
-                        return false
-                    }
-                }
-                if (recentlyUpdated){
-                    return
-                }
                 try {
                     def current_sha = itemGit.log(maxCommits: 1).find().getAbbreviatedId(8)
                     itemGit.pull remote: defaultRemote

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -44,9 +44,6 @@ class common {
     /** For keeping a list of remote items that can be retrieved */
     String[] cachedItemList
 
-     /** For keeping a list of .gitignore files in the project */
-    def gitIgnoreFiles
-
     /**
      * Initialize defaults to match the target item type
      * @param type the type to be initialized
@@ -70,7 +67,6 @@ class common {
         githubTargetHome = githubDefaultHome
         targetDirectory = itemTypeScript.targetDirectory
         itemType = itemTypeScript.itemType
-        gitIgnoreFiles = getGitIgnoreFiles()
     }
 
     /**
@@ -187,48 +183,26 @@ class common {
     }
 
     /**
-     * Get a list of every .gitignore file
-     */
-    def getGitIgnoreFiles(){
-        def gitIgnoreFiles = []
-        new File('.').eachFileRecurse{ file -> 
-            if (file.getAbsolutePath() ==~ ".*\\.gitignore"){
-                gitIgnoreFiles.add(file)
-            }
-        }
-        return gitIgnoreFiles
-    }
-
-    /**
-     * Check if a given item is ignored in a .gitignore
-     * @param itemName the name of the item to check
-     */
-    def isInGitIgnore(String itemName){
-        def searchString = itemName
-        if (itemName.startsWith(".")){
-            // add literal slash for regex matching if itemName start with '.'
-            searchString = "\\$itemName"        
-        }
-        for (file in gitIgnoreFiles) {
-            def lines = file as String[]
-            for (line in lines){
-                if ((line ==~ searchString) || (line ==~ "$searchString/")){
-                    println("$itemName set to ignore in $file")
-                    return true
-                }
-            }
-        }
-        return false
-    }
-
-    /**
      * Update a given item.
      * @param itemName the name of the item to update
      */
     def updateItem(String itemName) {
         File targetDir = new File(targetDirectory, itemName)
-        
-        if (isInGitIgnore(itemName)){
+        def searchString = itemName
+        if (itemName.startsWith(".")){
+            // add literal slash for regex start with '.'
+            searchString = "\\$itemName"        
+        }
+        def inGitIgnore = false
+        new File(".gitignore").eachLine{ line -> 
+            // match if line is exactly same os itemName or has trailing '/' but
+            // not if has further subdirectories
+            if ((line ==~ searchString) || (line ==~ "$searchString/")){
+                inGitIgnore = true
+                return
+            }
+        }
+        if (inGitIgnore){
             println color("Skipping update for $itemName: in gitignore", Ansi.YELLOW)
             return
         }

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -216,7 +216,26 @@ class common {
             } else {
                 println color("updating $itemType $itemName", Ansi.GREEN)
                 try {
+                    def current_sha = itemGit.log(maxCommits: 1).find().getAbbreviatedId(8)
                     itemGit.pull remote: defaultRemote
+                    def post_update_sha = itemGit.log(maxCommits: 1).find().getAbbreviatedId(8)
+                        
+                    if (current_sha != post_update_sha){
+                        println color("Updating $current_sha..$post_update_sha", Ansi.GREEN)
+                        def commits = itemGit.log {range(current_sha, post_update_sha)}
+                        for (commit in commits){
+                            println("----${commit.getAbbreviatedId(8)}----")
+                            def diff = itemGit.show(commit: commit.id)
+                            print("added: ${diff.added.size()}, ")
+                            print("copied: ${diff.copied.size()}, ")
+                            print("modified: ${diff.modified.size()}, ")
+                            print("removed: ${diff.removed.size()}, ")
+                            println("renamed: ${diff.renamed.size()}")
+                        }
+                        print("\n")
+                    } else {
+                        println color ("No changes found\n", Ansi.YELLOW)
+                    }
                 } catch (GrgitException exception) {
                     println color("Unable to update $itemName, Skipping: ${exception.getMessage()}", Ansi.RED)
                 }

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -188,6 +188,24 @@ class common {
      */
     def updateItem(String itemName) {
         File targetDir = new File(targetDirectory, itemName)
+        def searchString = itemName
+        if (itemName.startsWith(".")){
+            // add literal slash for regex start with '.'
+            searchString = "\\$itemName"        
+        }
+        def inGitIgnore = false
+        new File(".gitignore").eachLine{ line -> 
+            // match if line is exactly same os itemName or has trailing '/' but
+            // not if has further subdirectories
+            if ((line ==~ searchString) || (line ==~ "$searchString/")){
+                inGitIgnore = true
+                return
+            }
+        }
+        if (inGitIgnore){
+            println color("Skipping update for $itemName: in gitignore", Ansi.YELLOW)
+            return
+        }
         if (!targetDir.exists()) {
             println color("$itemType \"$itemName\" not found", Ansi.RED)
             return

--- a/config/groovy/util.groovy
+++ b/config/groovy/util.groovy
@@ -117,8 +117,14 @@ switch (cleanerArgs[0]) {
     case "update-all":
         println "We're updating every $itemType"
         println "List of local entries: ${common.retrieveLocalItems()}"
-        for (item in common.retrieveLocalItems()) {
-            common.updateItem(item)
+        if (cleanerArgs.contains("--continue")) {
+            for (item in common.retrieveLocalItems()) {
+                common.updateItem(item, true)
+            }
+        } else {
+            for (item in common.retrieveLocalItems()) {
+                common.updateItem(item)
+            }
         }
         break
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #3661 ~~Parts 1 and 2~~ (now fixes all three parts)

### Notes:
- I would have rather done a full diff of everything that changed in an update instead of listing the file changes per commit, but grgit doesn't seem to have the diff capability on anything other than single commits until this PR is merged https://github.com/ajoberstar/grgit/pull/318

- I'm not fully sold that skipping an update is the best approach if a module has recently been updated. Running a few extra git-fetches in the event an update needs to be re-run isn't _that_ expensive in the grand scheme, and personally I'd rather be able to ensure I have the latest by re-running the pull. Maybe some sort of "force update" option would be a good compromise here? So skip updating the module unless something like -f was passed?

- ~~I didn't understand Part 3 of the issue~~

### How to test

#### Skip updating module if recently updated:
`cd modules/<module name>`
`git pull`
`cd ../..`
`groovyw module update-all`

#### Simulate updating with 5 commits:
`cd modules/<module name>`
`git reset --hard HEAD~5`
`cd ../..`
`groovyw module update-all`

#### Confirm subdirectories in .gitignore do not block parent directory
in .gitignore change `.settings/` to `.settings/hide`
Confirm that .settings is no longer ignored in groovyw module update-all

### Sample output
In the sample screenshot we see:
- .Settings is ignored due to being in the .gitignore 
- CakeLie already up to date
-  CoreSampleGameplay recently updated within 2 minutes, so skip
-  Health pulls 5 commits  to update
-  ModuleTestingEnvironment already up to date

(Image updated with .Settings skipped to honor .gitignore)
![update-all-output](https://user-images.githubusercontent.com/35314989/83363651-11939680-a369-11ea-96e4-d613fd2cdc70.png)

