### PR TITLE
feat: Improve block placement of ceiling-supporting family

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
@@ -122,13 +122,9 @@ public class CeilingSupportingHorizontalFamily extends AbstractBlockFamily {
 
     @Override
     public Block getBlockForPlacement(BlockPlacementData data) {
-        Side mainSide = Side.TOP;
-
         boolean upsideDownPlacement = data.attachmentSide == Side.BOTTOM
                 || data.attachmentSide != Side.TOP && data.relativeAttachmentPosition.y() > 0.5;
-        if (upsideDownPlacement) {
-            mainSide = Side.BOTTOM;
-        }
+        final Side mainSide = upsideDownPlacement ? Side.BOTTOM : Side.TOP;
 
         Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
         return blocks.get(ExtendedSide.getExtendedSideFor(mainSide, blockDirection));

--- a/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
@@ -34,8 +34,8 @@ import java.util.Map;
 /**
  * Rotates a block to either be upright or upside down and always face the player.
  * <p>
- * If the block is placed onto a BOTTOM side (i.e. the ceiling), the block will be upside down and face the player horizontally.
- * Placement on any other side will cause the block to simply face the player horizontally.
+ * The block will be placed upside down, if it's either being attached to a BOTTOM side (i.e. the ceiling),
+ * or if it's being attached to the upper half of any horizontal side (LEFT, RIGHT, FRONT, BACK).
  */
 @RegisterBlockFamily("ceilingSupportingHorizontal")
 public class CeilingSupportingHorizontalFamily extends AbstractBlockFamily {
@@ -122,13 +122,16 @@ public class CeilingSupportingHorizontalFamily extends AbstractBlockFamily {
 
     @Override
     public Block getBlockForPlacement(BlockPlacementData data) {
-        Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
+        Side mainSide = Side.TOP;
 
-        if (data.attachmentSide == Side.BOTTOM) {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.BOTTOM, blockDirection));
-        } else {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.TOP, blockDirection));
+        boolean upsideDownPlacement = data.attachmentSide == Side.BOTTOM
+                || data.attachmentSide != Side.TOP && data.relativeAttachmentPosition.y() > 0.5;
+        if (upsideDownPlacement) {
+            mainSide = Side.BOTTOM;
         }
+
+        Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
+        return blocks.get(ExtendedSide.getExtendedSideFor(mainSide, blockDirection));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -91,16 +91,9 @@ public class BlockItemSystem extends BaseComponentSystem {
         Vector3i placementPos = new Vector3i(targetBlock);
         placementPos.add(surfaceSide.getVector3i());
 
-        Vector3f targetPosition = event.getTargetLocation();
-        Vector2f relativePlacementPosition;
-        if (targetPosition != null) {
-            relativePlacementPosition = getSideHitPosition(event.getHitPosition(), targetPosition);
-        } else {
-            relativePlacementPosition = new Vector2f();
-        }
-
+        Vector2f relativeAttachmentPosition = getRelativeAttachmentPosition(event);
         Block block = blockFamily.getBlockForPlacement(new BlockPlacementData(
-                JomlUtil.from(placementPos), surfaceSide, JomlUtil.from(event.getDirection()), relativePlacementPosition
+                JomlUtil.from(placementPos), surfaceSide, JomlUtil.from(event.getDirection()), relativeAttachmentPosition
         ));
 
         if (canPlaceBlock(block, targetBlock, placementPos)) {
@@ -121,9 +114,19 @@ public class BlockItemSystem extends BaseComponentSystem {
         }
     }
 
+    private Vector2f getRelativeAttachmentPosition(ActivateEvent event) {
+        Vector3f targetPosition = event.getTargetLocation();
+        if (event.getHitPosition() != null && targetPosition != null) {
+            return getSideHitPosition(event.getHitPosition(), targetPosition);
+        } else {
+            return new Vector2f();
+        }
+    }
+
     /**
      * Returns the position at which the block side was hit, relative to the side.
      * <p/>
+     * The specified hit position is expected to be on the surface of the cubic block at the specified position.
      * Example: The front side was hit right in the center.
      * The result will be (0.5, 0.5), representing the relative hit position on the side's surface.
      * @param hitPosition the hit position


### PR DESCRIPTION
This PR improves the block placement behavior of the `CeilingSupportingHorizontalFamily`

Previously the only way to place blocks upside down, using this block family, was to attach them to a BOTTOM side. This PR makes it possible to achieve the same thing, targeting horizontal sides.
This prevents the player from having to build a temporary support structure to simply have a ceiling available, to use for the placement of a new block.

Upside down block placement, is done if any of these conditions are met:
* the target side is a BOTTOM side
* the target side is horizontal (FRONT, BACK, LEFT, RIGHT) and the player targeted the upper half of the side when placing the block

### Test
Assign the above-mentioned block family to a furnace by adding the following line to the furnace.block json file:
`"family": "ceilingSupportingHorizontal",`

Add furnaces to your inventory using the following command:
`give furnace 10`
Attach them to different block sides and verify that the placement behaves as described above.