### PR TITLE
fix: do not skip setting default world generator

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -268,9 +268,7 @@ public class NewGameScreen extends CoreScreenLayer {
         if (defaultGameplayModule != null) {
             gameplay.setSelection(defaultGameplayModule);
 
-            if (configDefaultModuleName.equalsIgnoreCase(DEFAULT_GAME_TEMPLATE_NAME)) {
-                setDefaultGeneratorOfGameplayModule(defaultGameplayModule);
-            }
+            setDefaultGeneratorOfGameplayModule(defaultGameplayModule);
         } else {
             // Find the first gameplay module that is available.
             for (Module module : moduleManager.getRegistry()) {

--- a/engine/src/main/java/org/terasology/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
+++ b/engine/src/main/java/org/terasology/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
@@ -29,13 +29,13 @@ import java.util.List;
  */
 public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginLibrary {
 
-    private ClassLibrary<WorldGeneratorPlugin> library;
+    private final ClassLibrary<WorldGeneratorPlugin> library;
 
     public DefaultWorldGeneratorPluginLibrary(ModuleEnvironment moduleEnvironment, Context context) {
         library = new DefaultClassLibrary<>(context);
-        for (Class entry : moduleEnvironment.getTypesAnnotatedWith(RegisterPlugin.class)) {
+        for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterPlugin.class)) {
             if (WorldGeneratorPlugin.class.isAssignableFrom(entry)) {
-                library.register(new SimpleUri(moduleEnvironment.getModuleProviding(entry), entry.getSimpleName()), entry);
+                library.register(new SimpleUri(moduleEnvironment.getModuleProviding(entry), entry.getSimpleName()), entry.asSubclass(WorldGeneratorPlugin.class));
             }
         }
     }
@@ -43,7 +43,7 @@ public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginL
     @Override
     public <U extends WorldGeneratorPlugin> List<U> instantiateAllOfType(Class<U> ofType) {
         List<U> result = Lists.newArrayList();
-        for (ClassMetadata classMetadata : library) {
+        for (ClassMetadata<?, ?> classMetadata : library) {
             if (ofType.isAssignableFrom(classMetadata.getType()) && classMetadata.isConstructable() && classMetadata.getType().getAnnotation(RegisterPlugin.class) != null) {
                 U item = ofType.cast(classMetadata.newInstance());
                 if (item != null) {


### PR DESCRIPTION
Fixes #4024. :crossed_fingers: 

oh, and some fixes for raw type warnings that probably don't have anything to do with this error, I was just preemptively fixing warnings I ran in to while debugging in case they would lead me to something.


### How to test

Test gameplay modes _other than_ Josharias Survival. (JS should still work too, of course.)

Make sure you can play the game without going to the advanced setup screen.

Make sure the world type is the one chosen by the module.txt for that mode.

Try without interacting with the Gameplay Template menu at all; get the gameplay mode you're testing to be the default one by removing other types.

Try with a fresh `config.cfg` (move your old one out of the way).
