### PR TITLE
fix(Particles): disable particles, when driver or GPU not supports OpenGL 3.3

### DIFF
--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -259,9 +259,6 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                 GLContext.getCapabilities().OpenGL15,
                 GLContext.getCapabilities().OpenGL20,
                 GLContext.getCapabilities().OpenGL21,   // needed as we use GLSL 1.20
-                GLContext.getCapabilities().OpenGL30,
-                GLContext.getCapabilities().OpenGL32,
-                GLContext.getCapabilities().OpenGL33,
 
                 GLContext.getCapabilities().GL_ARB_framebuffer_object,  // Extensions eventually included in
                 GLContext.getCapabilities().GL_ARB_texture_float,       // OpenGl 3.0 according to

--- a/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/lwjgl/LwjglGraphics.java
@@ -269,9 +269,6 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                 "OpenGL15",
                 "OpenGL20",
                 "OpenGL21",
-                "OpenGL30",
-                "OpenGL32",
-                "OpenGL33",
                 "GL_ARB_framebuffer_object",
                 "GL_ARB_texture_float",
                 "GL_ARB_half_float_pixel"};

--- a/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
+++ b/engine/src/main/java/org/terasology/particles/rendering/SpriteParticleRenderer.java
@@ -20,6 +20,7 @@ import org.joml.Vector3f;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GLContext;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.lwjgl.LwjglDisplayDevice;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -113,6 +114,9 @@ public class SpriteParticleRenderer implements RenderSystem {
 
     @Override
     public void renderAlphaBlend() {
+        if(!GLContext.getCapabilities().OpenGL33) {
+            return;
+        }
         PerspectiveCamera camera = (PerspectiveCamera) worldRenderer.getActiveCamera();
         Vector3f cameraPosition = camera.getPosition();
         Matrix4f viewProjection = new Matrix4f(camera.getViewProjectionMatrix())

--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -21,6 +21,7 @@ import org.lwjgl.Sys;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL20;
+import org.lwjgl.opengl.GLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.utilities.Assets;
@@ -102,7 +103,11 @@ public class ShaderManagerLwjgl implements ShaderManager {
         addShaderProgram("toneMapping");
         addShaderProgram("sky");
         addShaderProgram("chunk");
-        addShaderProgram("particle");
+        if (GLContext.getCapabilities().OpenGL33) { //TODO remove this "if" when rendering will use OpenGL3 by default
+            addShaderProgram("particle");
+        } else {
+            logger.warn("Your GPU or driver not supports OpenGL 3.3 , particles disabled");
+        }
         addShaderProgram("shadowMap");
         addShaderProgram("lightBufferPass");
         addShaderProgram("lightGeometryPass");


### PR DESCRIPTION

### Contains

particles disabled when GPU or Driver not supports OpenGL 3.3 (Mesa driver issue, possible Mac OS)
Remove, when shaderland and rendering will work on OpenGL 3+

