### PR TITLE
Attach new Kotlin source for a Gradle build plugin used with modules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-node ("default-java") {
+node ("default-java || heavy-java") {
     stage('Checkout') {
         echo "Going to check out the things !"
         checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ node ("default-java") {
     stage('Build') {
         // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
         sh './gradlew --console=plain clean extractConfig extractNatives distForLauncher'
-        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, build/resources/main/org/terasology/version/versionInfo.properties, natives/**'
+        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, build/resources/main/org/terasology/version/versionInfo.properties, natives/**, buildSrc/src/**, buildSrc/*.kts'
     }
     stage('Publish') {
         if (env.BRANCH_NAME.equals("master") || env.BRANCH_NAME.equals("develop")) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,14 +19,14 @@ node ("default-java") {
         }
     }
     stage('Analytics') {
-        sh "./gradlew --console=plain check javadoc"
+        sh "./gradlew --console=plain check spotbugsmain javadoc"
     }
     stage('Record') {
         junit testResults: '**/build/test-results/test/*.xml',  allowEmptyResults: true
         recordIssues tool: javaDoc()
         step([$class: 'JavadocArchiver', javadocDir: 'engine/build/docs/javadoc', keepAll: false])
         recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
-        recordIssues tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true)
+        recordIssues tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true)
         recordIssues tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
         recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
     }

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -152,6 +152,15 @@ spotbugs {
     excludeFilter = new File(rootDir, "config/metrics/findbugs/findbugs-exclude.xml")
 }
 
+spotbugsMain {
+    reports {
+        xml {
+            enabled = true
+            destination = file("$buildDir/reports/spotbugs/main/spotbugs.xml")
+        }
+    }
+}
+
 // TODO: Temporary until javadoc has been fixed for Java 8 everywhere
 javadoc {
     failOnError = false

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -1,5 +1,25 @@
 // Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
+// Since SpotBugs and SonarQube in the legacy style have external dependencies we have to have this block here.
+// Alternatively we untangle and update the common.gradle / Kotlin Gradle plugin stuff or just remove these two
+buildscript {
+    repositories {
+        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
+        jcenter()
+        mavenCentral()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
+    }
+
+    dependencies {
+        //Spotbugs
+        classpath("gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.0")
+
+        // SonarQube / Cloud scanning
+        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8")
+    }
+}
 
 plugins {
     id("terasology-module")


### PR DESCRIPTION
Fixes broken module builds after the `buildSrc` dir was added, but not made available to module.

Actually just one half of the fix, will push the other half to https://github.com/MovingBlocks/ModuleJteConfig after merging this and testing a bit more