### PR TITLE
fix: chunk border rendering

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
@@ -21,6 +21,7 @@ import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.AABB;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
+import org.terasology.module.sandbox.API;
 import org.terasology.registry.CoreRegistry;
 
 import static org.lwjgl.opengl.GL11.GL_BLEND;
@@ -45,6 +46,7 @@ import static org.lwjgl.opengl.GL11.glVertex3f;
 /**
  * Renderer for an AABB.
  */
+@API
 public class AABBRenderer implements BlockOverlayRenderer {
     private int displayListWire = -1;
     private int displayListSolid = -1;


### PR DESCRIPTION
This PR fixes issue #[10](https://github.com/Terasology/CoreRendering/issues/10) in the CoreRendering module.

### Test
- Start a new game
- enter Debug mode using F3
- enable chunk rendering by pressing F8

Chunks should become visible as wire frames.

### Note
In case it doesn't work, try deleting the directory "engine/build" to force the reflection to be processed for the next build.