### PR TITLE
fix: security hassle from a plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
+// Needed due to the Copy Artifact plugin deciding to implement an obnoxious security feature that can't simply be turned off
+properties([
+    copyArtifactPermission('*')
+]);
+
 node ("default-java || heavy-java") {
     stage('Checkout') {
         echo "Going to check out the things !"


### PR DESCRIPTION
The very latest version of the "Copy Artifact" plugin decided it wanted to add obnoxious security features you can't easily turn off globally. Bah humbug, get off my lawn, and other old dev grumbles.

No functional effect inside this repo, no real testing needed outside of Jenkins being able to do its thing (which I just tested elsewhere)