### PR TITLE
Don't serialize particle pools.

### DIFF
--- a/engine/src/main/java/org/terasology/particles/components/ParticleEmitterComponent.java
+++ b/engine/src/main/java/org/terasology/particles/components/ParticleEmitterComponent.java
@@ -94,7 +94,7 @@ public class ParticleEmitterComponent implements Component {
     /**
      * This emitter's particle pool.
      */
-    public ParticlePool particlePool;
+    public transient ParticlePool particlePool;
 
     /**
      * Maps Generator component -> Function that processes that Generator

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/coreTypes/ObjectFieldMapTypeHandler.java
@@ -68,9 +68,14 @@ public class ObjectFieldMapTypeHandler<T> extends TypeHandler<T> {
 
             if (!Objects.equals(val, Defaults.defaultValue(field.getType()))) {
                 TypeHandler handler = entry.getValue();
-                PersistedData fieldValue = handler.serialize(val, serializer);
-                if (fieldValue != null) {
-                    mappedData.put(getFieldName(field), fieldValue);
+                try {
+                    PersistedData fieldValue = handler.serialize(val, serializer);
+                    if (fieldValue != null) {
+                        mappedData.put(getFieldName(field), fieldValue);
+                    }
+                } catch (StackOverflowError e) {
+                    logger.error("Likely circular reference in field {}.", field);
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
Fixes #4031. There are `FloatBuffer`s in the `ParticlePool` which don't interact well with the serialization system, so I just marked the `ParticlePool` fields in `ParticleEmitterComponent` as `transient`, so that it's excluded from serialization. Particle systems seem to persist after saving and re-loading anyway. I haven't really looked into how that works.

Also I left in the debugging output that I used to find where the error was: detect `StackOverflowError`s in `ObjectFieldMapTypeHandler`, and output the field names.
