### PR TITLE
Add informative popup if starting game without modules

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -156,6 +156,11 @@ public class NewGameScreen extends CoreScreenLayer {
                 universeWrapper.setGameName(GameProvider.getNextGameName());
             }
             universeWrapper.setGameName(gameName.getText());
+            if (gameplay.getOptions().isEmpty()) {
+                logger.error("No gameplay modules present");
+                MessagePopup errorPopup = getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class);
+                errorPopup.setMessage("Error", "Can't create new game without modules!");
+            }
             GameManifest gameManifest = GameManifestProvider.createGameManifest(universeWrapper, moduleManager, config);
             if (gameManifest != null) {
                 gameEngine.changeState(new StateLoading(gameManifest, (isLoadingAsServer()) ? NetworkMode.DEDICATED_SERVER : NetworkMode.NONE));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fixes #4034 . Adds an informative popup if one is trying to start a game without any gameplay modules.

### How to test

You can test the code by trying to start a game without having any modules.
