### PR TITLE
added RetainComponentsComponent check to SetBlock

### DIFF
--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -125,8 +125,12 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
         if (GameThread.isCurrentThread()) {
             EntityRef blockEntity = getBlockEntityAt(JomlUtil.from(pos));
             Block oldType = super.setBlock(pos, type);
+            final Set<Class<? extends Component>> retainComponents =
+                    Optional.ofNullable(blockEntity.getComponent(RetainComponentsComponent.class))
+                            .map(retainComponentsComponent -> retainComponentsComponent.components)
+                            .orElse(Collections.emptySet());
             if (oldType != null) {
-                updateBlockEntity(blockEntity, JomlUtil.from(pos), oldType, type, false, Collections.<Class<? extends Component>>emptySet());
+                updateBlockEntity(blockEntity, JomlUtil.from(pos), oldType, type, false, retainComponents);
             }
             return oldType;
         }


### PR DESCRIPTION
### Contains
Added RetainComponentsComponent check to setBlock so it calls the updateBlockEntity method with the correct RetainComponents set and not an empty set

### How to test
Add components to RetainComponentsComponent in some module and then update the entity via WorldProvider.setBlock(). The components added should be retained after the update.