### PR TITLE
doc: Add docs and contracts for AbstractValueModifiableEvent

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
@@ -20,6 +20,9 @@ import gnu.trove.list.TFloatList;
 import gnu.trove.list.array.TFloatArrayList;
 
 /**
+ * A generic event for getting a value for a property.
+ *
+ * @see AbstractValueModifiableEvent
  */
 public abstract class AbstractValueModifiableEvent implements Event {
     private float baseValue;
@@ -48,10 +51,17 @@ public abstract class AbstractValueModifiableEvent implements Event {
         postModifiers.add(amount);
     }
 
+    /**
+     * Calculates the result value from the base value and given modifiers and multipliers.
+     * 
+     * The value is calculated base on the following formula:
+     * <pre>
+     * result = max(0, <baseValue> + Σ <modifier>) * Π <multiplier> + Σ <postModifier>
+     * </pre>
+     *
+     * <emph>Note that the value range of result is not restricted!</emph>
+     */
     public float getResultValue() {
-        // For now, add all modifiers and multiply by all multipliers. Negative modifiers cap to zero, but negative
-        // multipliers remain.
-
         float result = baseValue;
         TFloatIterator modifierIter = modifiers.iterator();
         while (modifierIter.hasNext()) {

--- a/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
@@ -64,7 +64,7 @@ public abstract class AbstractValueModifiableEvent implements Event {
      * <p>
      * The value is calculated based on the following formula:
      * <pre>
-     * result = max(0, <baseValue> + Σ <modifier> * Π <multiplier> + Σ <postModifier>)
+     * result = max(0, (<baseValue> + Σ <modifier>) * Π <multiplier> + Σ <postModifier>)
      * </pre>
      *
      * <emph>The result value is guaranteed to be non-negative!</emph>
@@ -73,7 +73,7 @@ public abstract class AbstractValueModifiableEvent implements Event {
         //TODO(skaldarnar): Based on a discussion in https://github.com/MovingBlocks/Terasology/pull/4063 we may want
         // to lift the guarantee/restriction that the result value needs to be non-negative. Systems are still free to
         // apply this restriction if needed.
-        return Math.max(0, baseValue + modifiers.sum() * product(multipliers) + postModifiers.sum());
+        return Math.max(0, (baseValue + modifiers.sum()) * product(multipliers) + postModifiers.sum());
     }
 
     public TFloatList getModifiers() {

--- a/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/AbstractValueModifiableEvent.java
@@ -21,11 +21,11 @@ import gnu.trove.list.array.TFloatArrayList;
 
 /**
  * A generic event for getting a value for a property.
- *
- * @see AbstractValueModifiableEvent
+ * <p>
+ * The result value is guaranteed to be greater or equal to zero.
  */
 public abstract class AbstractValueModifiableEvent implements Event {
-    private float baseValue;
+    private final float baseValue;
 
     private TFloatList modifiers = new TFloatArrayList();
     private TFloatList multipliers = new TFloatArrayList();
@@ -47,38 +47,33 @@ public abstract class AbstractValueModifiableEvent implements Event {
         modifiers.add(amount);
     }
 
+    /**
+     * @deprecated please use {@link #postAdd(float)} instead.
+     */
+    @Deprecated
     public void addPostMultiply(float amount) {
+        postAdd(amount);
+    }
+
+    public void postAdd(float amount) {
         postModifiers.add(amount);
     }
 
     /**
      * Calculates the result value from the base value and given modifiers and multipliers.
-     * 
-     * The value is calculated base on the following formula:
+     * <p>
+     * The value is calculated based on the following formula:
      * <pre>
-     * result = max(0, <baseValue> + Σ <modifier>) * Π <multiplier> + Σ <postModifier>
+     * result = max(0, <baseValue> + Σ <modifier> * Π <multiplier> + Σ <postModifier>)
      * </pre>
      *
-     * <emph>Note that the value range of result is not restricted!</emph>
+     * <emph>The result value is guaranteed to be non-negative!</emph>
      */
     public float getResultValue() {
-        float result = baseValue;
-        TFloatIterator modifierIter = modifiers.iterator();
-        while (modifierIter.hasNext()) {
-            result += modifierIter.next();
-        }
-        result = Math.max(0, result);
-
-        TFloatIterator multiplierIter = multipliers.iterator();
-        while (multiplierIter.hasNext()) {
-            result *= multiplierIter.next();
-        }
-
-        final TFloatIterator postModifierIter = postModifiers.iterator();
-        while (postModifierIter.hasNext()) {
-            result += postModifierIter.next();
-        }
-        return result;
+        //TODO(skaldarnar): Based on a discussion in https://github.com/MovingBlocks/Terasology/pull/4063 we may want
+        // to lift the guarantee/restriction that the result value needs to be non-negative. Systems are still free to
+        // apply this restriction if needed.
+        return Math.max(0, baseValue + modifiers.sum() * product(multipliers) + postModifiers.sum());
     }
 
     public TFloatList getModifiers() {
@@ -103,5 +98,22 @@ public abstract class AbstractValueModifiableEvent implements Event {
 
     public void setPostModifiers(TFloatList postModifiers) {
         this.postModifiers = postModifiers;
+    }
+
+    /**
+     * Calculate the product of all values in the given list.
+     * <p>
+     * A static helper dual to {@code TFloatList#sum()}.
+     *
+     * @param multipliers the list of multipliers to calculate the product of.
+     * @return the product of all values. 1 if the list is empty.
+     */
+    private static float product(TFloatList multipliers) {
+        float multiplierProduct = 1f;
+        TFloatIterator multiplierIter = multipliers.iterator();
+        while (multiplierIter.hasNext()) {
+            multiplierProduct *= multiplierIter.next();
+        }
+        return multiplierProduct;
     }
 }


### PR DESCRIPTION
This PR follows from https://github.com/Terasology/ClimateConditions/pull/17#discussion_r448634606 (thanks to @ktksan).

The lack of documentation makes it hard to spot quirky or unexpected behavior. In this particular case, I'd like to start a discussion to change the implementation.

Currently the result value is computed as 
```
result = max(0, <baseValue> + Σ <modifier>) * Π <multiplier> + Σ <postModifier>
```
which is counter-intuitive for many reasons (and I don't know why Marcin implemented it this way).

At first I thought that capping the value to be positive holds for the result value in general, but that's not true - only the first set of _modifiers_ is guaranteed to result in a value greater or equal to zero, both _multipliers_ and _post-modifiers_ can move the result to negative numbers.

## Options

1. Ensure that the result value is _always non-negative_. This can be achieved in different ways and it needs to be clearly documented how the value is computed.
    ```
    result = max(0, <baseValue> + Σ <modifier> * Π <multiplier> + Σ <postModifier>)
    result = max(0, max(0, max(0, <baseValue> + Σ <modifier>) * Π <multiplier>) + Σ <postModifier>)
    ...
    ```
2. Simplify the computation without any restrictions to domain or range. All modifiers and multipliers can be zero or negative, and the result is just computed as
    ```
    result = <baseValue> + Σ <modifier> * Π <multiplier> + Σ <postModifier>
    ```
    Any system using the result value is responsible to cap it if necessary.

## Proposal

I'd propose to go for **Option 2 - Simplify** to make the usage more intuitive and fail-safe. However, I don't know whether there are any implications. However, if any system relies on the fact that the result is capped to be non-negative that's a bug even right now... 🙄 