### PR TITLE
fix(GameProvider): prevent creating game with duplicate name

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -228,11 +228,11 @@ public class GameProviderTest {
         mimicGameName("Custom");
         // special waiter... Savegames use Map with FileTime as key...
         // then game saving there counts as one FileTime, and survive only one. too fast.
-        Thread.sleep(10);
+        Thread.sleep(1000);
         mimicGameName("Custom 1");
-        Thread.sleep(10); // there too
+        Thread.sleep(1000); // there too
         mimicGameName("Custom 2");
-        Thread.sleep(10); // there too
+        Thread.sleep(1000); // there too
         final String name = GameProvider.getNextGameName("Custom 1");
 
         assertNotNull(name);

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -228,9 +228,9 @@ public class GameProviderTest {
         mimicGameName("Custom");
         // special waiter... Savegames use Map with FileTime as key...
         // then game saving there counts as one FileTime, and survive only one. too fast.
-        Thread.sleep(2);
+        Thread.sleep(10);
         mimicGameName("Custom 1");
-        Thread.sleep(2); // there too
+        Thread.sleep(10); // there too
         mimicGameName("Custom 2");
         final String name = GameProvider.getNextGameName("Custom 1");
 

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -232,6 +232,7 @@ public class GameProviderTest {
         mimicGameName("Custom 1");
         Thread.sleep(10); // there too
         mimicGameName("Custom 2");
+        Thread.sleep(10); // there too
         final String name = GameProvider.getNextGameName("Custom 1");
 
         assertNotNull(name);

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -226,13 +226,8 @@ public class GameProviderTest {
     @Test
     public void getNextGameNameWithNumber() throws IOException, InterruptedException {
         mimicGameName("Custom");
-        // special waiter... Savegames use Map with FileTime as key...
-        // then game saving there counts as one FileTime, and survive only one. too fast.
-        Thread.sleep(1000);
         mimicGameName("Custom 1");
-        Thread.sleep(1000); // there too
         mimicGameName("Custom 2");
-        Thread.sleep(1000); // there too
         final String name = GameProvider.getNextGameName("Custom 1");
 
         assertNotNull(name);
@@ -248,11 +243,16 @@ public class GameProviderTest {
         bw.close();
     }
 
+    /**
+     * Creates an empty folder with given name {@code gameName} to mimic a save game.
+     * At the end waits a bit to make sure save games don't clash due to equal timestamp.
+     */
     private void mimicGameName(String gameName) throws IOException {
         Path customSaveFolder = TMP_SAVES_FOLDER_PATH.resolve(gameName);
         Files.createDirectories(customSaveFolder);
         Path manifestFilePath = customSaveFolder.resolve(GameManifest.DEFAULT_FILE_NAME);
         writeToFile(manifestFilePath, MANIFEST_EXAMPLE.replace(DEFAULT_GAME_NAME, gameName));
+        Thread.sleep(50);
     }
 
 }

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class GameProviderTest {
-    private static final int TIMESTAMP_DELAY = 200;
+    private static final int TIMESTAMP_DELAY = 500;
     private static final String DEFAULT_GAME_NAME = "Game";
     private static final Path TMP_SAVES_FOLDER_PATH =
             Paths.get("out", "test", "engine-tests", "tmp", "saves").toAbsolutePath();

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class GameProviderTest {
-    private static final int TIMESTAMP_DELAY = 100;
+    private static final int TIMESTAMP_DELAY = 200;
     private static final String DEFAULT_GAME_NAME = "Game";
     private static final Path TMP_SAVES_FOLDER_PATH =
             Paths.get("out", "test", "engine-tests", "tmp", "saves").toAbsolutePath();

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class GameProviderTest {
-    private static final int TIMESTAMP_DELAY = 50;
+    private static final int TIMESTAMP_DELAY = 100;
     private static final String DEFAULT_GAME_NAME = "Game";
     private static final Path TMP_SAVES_FOLDER_PATH =
             Paths.get("out", "test", "engine-tests", "tmp", "saves").toAbsolutePath();

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.game.GameManifest;
 
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class GameProviderTest {
+    private static final int TIMESTAMP_DELAY = 50;
     private static final String DEFAULT_GAME_NAME = "Game";
     private static final Path TMP_SAVES_FOLDER_PATH =
             Paths.get("out", "test", "engine-tests", "tmp", "saves").toAbsolutePath();
@@ -54,6 +57,8 @@ public class GameProviderTest {
     private static final Path TMP_RECORD_GAME_PATH = TMP_RECORDS_FOLDER_PATH.resolve(DEFAULT_GAME_NAME);
     private static final String GAME_MANIFEST_JSON = "gameManifest.json";
     private static String MANIFEST_EXAMPLE;
+
+    private static final Logger logger = LoggerFactory.getLogger(GameProviderTest.class);
 
     @BeforeAll
     public static void init()
@@ -226,8 +231,12 @@ public class GameProviderTest {
     @Test
     public void getNextGameNameWithNumber() throws IOException, InterruptedException {
         mimicGameName("Custom");
+        // wait to make sure save games don't clash due to equal timestamp
+        Thread.sleep(TIMESTAMP_DELAY);
         mimicGameName("Custom 1");
+        Thread.sleep(TIMESTAMP_DELAY);
         mimicGameName("Custom 2");
+        Thread.sleep(TIMESTAMP_DELAY);
         final String name = GameProvider.getNextGameName("Custom 1");
 
         assertNotNull(name);
@@ -245,14 +254,12 @@ public class GameProviderTest {
 
     /**
      * Creates an empty folder with given name {@code gameName} to mimic a save game.
-     * At the end waits a bit to make sure save games don't clash due to equal timestamp.
      */
-    private void mimicGameName(String gameName) throws IOException, InterruptedException {
+    private void mimicGameName(String gameName) throws IOException {
         Path customSaveFolder = TMP_SAVES_FOLDER_PATH.resolve(gameName);
         Files.createDirectories(customSaveFolder);
         Path manifestFilePath = customSaveFolder.resolve(GameManifest.DEFAULT_FILE_NAME);
         writeToFile(manifestFilePath, MANIFEST_EXAMPLE.replace(DEFAULT_GAME_NAME, gameName));
-        Thread.sleep(50);
     }
 
 }

--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -247,7 +247,7 @@ public class GameProviderTest {
      * Creates an empty folder with given name {@code gameName} to mimic a save game.
      * At the end waits a bit to make sure save games don't clash due to equal timestamp.
      */
-    private void mimicGameName(String gameName) throws IOException {
+    private void mimicGameName(String gameName) throws IOException, InterruptedException {
         Path customSaveFolder = TMP_SAVES_FOLDER_PATH.resolve(gameName);
         Files.createDirectories(customSaveFolder);
         Path manifestFilePath = customSaveFolder.resolve(GameManifest.DEFAULT_FILE_NAME);

--- a/engine-tests/src/test/resources/gameManifest.json
+++ b/engine-tests/src/test/resources/gameManifest.json
@@ -1,5 +1,5 @@
 {
-  "title": "Game 1",
+  "title": "Game",
   "seed": "naqrhaKV1lUofG7PLIJcOfDlUiPs3Jmp",
   "time": 37047,
   "registeredBlockFamilies": [],

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameManifestProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/GameManifestProvider.java
@@ -58,7 +58,7 @@ public class GameManifestProvider {
     public static GameManifest createGameManifest(final UniverseWrapper universeWrapper, final ModuleManager moduleManager, final Config config) {
         GameManifest gameManifest = new GameManifest();
         if (StringUtils.isNotBlank(universeWrapper.getGameName())) {
-            gameManifest.setTitle(universeWrapper.getGameName());
+            gameManifest.setTitle(GameProvider.getNextGameName(universeWrapper.getGameName()));
         } else {
             gameManifest.setTitle(GameProvider.getNextGameName());
         }

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/NewGameScreen.java
@@ -155,7 +155,7 @@ public class NewGameScreen extends CoreScreenLayer {
             if (gameName.getText().isEmpty()) {
                 universeWrapper.setGameName(GameProvider.getNextGameName());
             }
-            universeWrapper.setGameName(gameName.getText());
+            universeWrapper.setGameName(GameProvider.getNextGameName(gameName.getText()));
             if (gameplay.getOptions().isEmpty()) {
                 logger.error("No gameplay modules present");
                 MessagePopup errorPopup = getManager().pushScreen(MessagePopup.ASSET_URI, MessagePopup.class);

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProvider.java
@@ -116,11 +116,7 @@ public final class GameProvider {
      * GameProvider#DEFAULT_GAME_NAME_PREFIX} for resolve.
      */
     public static String getNextGameName() {
-        String nextGameName = getNextGameName(DEFAULT_GAME_NAME_PREFIX);
-        if (nextGameName.equals(DEFAULT_GAME_NAME_PREFIX)) {
-            return nextGameName + 1;
-        }
-        return nextGameName;
+        return getNextGameName(DEFAULT_GAME_NAME_PREFIX);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/NumberedGameName.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/NumberedGameName.java
@@ -1,0 +1,82 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.rendering.nui.layers.mainMenu.savedGames;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A simple data class to represent numbered game names.
+ * <p>
+ * Takes care of parsing strings as numbered game names, e.g., to check for colliding names or extracting the next free
+ * game number.
+ *
+ * @see GameProvider
+ */
+public class NumberedGameName {
+
+    final String namePrefix;
+    final Optional<Integer> number;
+
+    public NumberedGameName(String namePrefix, Optional<Integer> number) {
+        this.namePrefix = namePrefix;
+        this.number = number;
+    }
+
+    /**
+     * Parse a given string as numbered game name according to the following regular expression:
+     * <p>
+     * <pre>
+     *     "^(.*?)(\\d+)?$"
+     * </pre>
+     * These examples will be parsed as follows:
+     * <pre>
+     *      "Gooey's 1st Game"  -> ("Gooey's 1st Game", None)
+     *      "Gooey 42"          -> ("Gooey", Optional(42))
+     *      "42"                -> ("42", None)
+     * </pre>
+     * <p>
+     * The input string will be trimmed before matching.
+     *
+     * @param fullName the full game name
+     * @return the parsed numbered game name, the number may be {@code Optional::empty}
+     */
+    static NumberedGameName fromString(String fullName) {
+        final Pattern p = Pattern.compile("^(.*?)(\\d+)?$");
+        Matcher matcher = p.matcher(fullName.trim());
+
+        String prefix;
+        Optional<Integer> number;
+
+        if (matcher.start(2) > 0) {
+            prefix = matcher.group(1);
+            number = Optional.of(Integer.parseInt(matcher.group(2)));
+        } else {
+            prefix = matcher.group(0); // the whole string
+            number = Optional.empty();
+        }
+
+        return new NumberedGameName(prefix, number);
+    }
+
+    /**
+     * A textual representation of a numbered game version.
+     * <p>
+     * The number is appended with a single space as delimiter to the name prefix. If the number is not present, only
+     * the name prefix will be returned.
+     *
+     * <pre>
+     *      ("Gooey's 1st Game", None)  -> "Gooey's 1st Game"
+     *      ("Gooey", Optional(42))     -> "Gooey 42"
+     *      ("42", None)                -> "42"
+     * </pre>
+     *
+     * @return a textual representation of the numbered game version
+     */
+    @Override
+    public String toString() {
+        return namePrefix + number.map(i -> " " + i).orElse("");
+    }
+}

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/NumberedGameName.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/NumberedGameName.java
@@ -21,7 +21,7 @@ public class NumberedGameName {
     final Optional<Integer> number;
 
     public NumberedGameName(String namePrefix, Optional<Integer> number) {
-        this.namePrefix = namePrefix;
+        this.namePrefix = namePrefix.trim();
         this.number = number;
     }
 
@@ -47,18 +47,20 @@ public class NumberedGameName {
         final Pattern p = Pattern.compile("^(.*?)(\\d+)?$");
         Matcher matcher = p.matcher(fullName.trim());
 
-        String prefix;
-        Optional<Integer> number;
+        if (matcher.find()) {
+            String prefix;
+            Optional<Integer> number;
 
-        if (matcher.start(2) > 0) {
-            prefix = matcher.group(1);
-            number = Optional.of(Integer.parseInt(matcher.group(2)));
-        } else {
-            prefix = matcher.group(0); // the whole string
-            number = Optional.empty();
+            if (matcher.start(2) > 0) {
+                prefix = matcher.group(1);
+                number = Optional.of(Integer.parseInt(matcher.group(2)));
+            } else {
+                prefix = matcher.group(0); // the whole string
+                number = Optional.empty();
+            }
+            return new NumberedGameName(prefix, number);
         }
-
-        return new NumberedGameName(prefix, number);
+        throw new IllegalArgumentException("Unexpected error: Cannot parse '" + fullName + "' as numbered game name.");
     }
 
     /**


### PR DESCRIPTION
### Contains
Fixes #3982 

Custom game name works like Default game name prefix ("Game") now.
If you create game with name as previously created new game will have name "<previous> <index>"
If previously created game name already have index, then that index will be incremented.

### How to test

1. create game with name "X"
2. exit to main menu
3. create game with name "X" again
4. check save games. You have save games "X" and "X 1" now.

