### PR TITLE
feat(JOML): Migrate JOML for MultiConnectFamily and UpdateWithNeighboursFamily

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/UpdatesWithNeighboursFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/UpdatesWithNeighboursFamily.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.family;
 
+import org.joml.Vector3ic;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
@@ -24,6 +25,14 @@ import org.terasology.world.block.Block;
 public interface UpdatesWithNeighboursFamily extends BlockFamily {
     /**
      * Update called when a neighbor block changes
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #getBlockForNeighborUpdate(Vector3ic, Block)}.
      **/
+    @Deprecated
     Block getBlockForNeighborUpdate(Vector3i location, Block oldBlock);
+
+    /**
+     * Update called when a neighbor block changes
+     **/
+    Block getBlockForNeighborUpdate(Vector3ic location, Block oldBlock);
 }


### PR DESCRIPTION
This is change to migrate block families to JOML. This will require changes across multiple modules. the general change is fairly straightforward since the other systems already have JOML methods that should help with migrating this code without minimal code change. 