### PR TITLE
set fallback to engine:default rather than Behaviors:fallback

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/core/BehaviorTreeBuilder.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/core/BehaviorTreeBuilder.java
@@ -142,7 +142,7 @@ public class BehaviorTreeBuilder implements JsonDeserializer<BehaviorNode>, Json
                     String uri = in.nextString();
                     AssetManager assetManager = CoreRegistry.get(AssetManager.class);
                     return assetManager.getAsset(new ResourceUrn(uri), BehaviorTree.class)
-                            .orElse(assetManager.getAsset(new ResourceUrn("Behaviors:fallback"), BehaviorTree.class).get());
+                            .orElse(assetManager.getAsset(new ResourceUrn("engine:default"), BehaviorTree.class).get());
 
                 }
             });


### PR DESCRIPTION
### Contains

A fix for a pretty specific bug found while removing the Behaviors module dependency from FlexibleMovementTestbed.

The engine tries to fallback in some cases to a behavior tree with URI "Behaviors:fallback". Under certain failure scenarios without the Behaviors module loaded this will crash during loading.

### How to test

Get https://github.com/kaen/FlexibleMovementTestbed/ and its dependencies

Checkout the FlexibleMovement branch https://github.com/kaen/FlexibleMovement/tree/feature/new-behaviors

Start new game with FlexibleMovementTestbed gameplay module and default settings.

Without this change you get the following crash:

```
09:26:19.157 [main] INFO  o.t.e.prefab.internal.PrefabFormat - Attempting to deserialize prefab FlexibleMovementTestbed:testBase with inputs [/FlexibleMovementTestbed/assets/prefabs/testBase.prefab]
09:26:19.341 [main] ERROR o.t.u.gson.UriTypeAdapterFactory - URI type interface org.terasology.engine.Uri lacks String constructor
09:26:19.351 [main] ERROR o.terasology.engine.TerasologyEngine - Uncaught exception, attempting clean game shutdown
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:148)
	at org.terasology.logic.behavior.core.BehaviorTreeBuilder$1.read(BehaviorTreeBuilder.java:145)
	at org.terasology.logic.behavior.core.BehaviorTreeBuilder$1.read(BehaviorTreeBuilder.java:129)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:116)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:216)
	at com.google.gson.Gson.fromJson(Gson.java:879)
	at com.google.gson.Gson.fromJson(Gson.java:944)
	at com.google.gson.Gson$1.deserialize(Gson.java:138)
	at org.terasology.logic.behavior.core.BehaviorTreeBuilder.getCompositeNode(BehaviorTreeBuilder.java:240)
	at org.terasology.logic.behavior.core.BehaviorTreeBuilder.deserialize(BehaviorTreeBuilder.java:159)
	at org.terasology.logic.behavior.core.BehaviorTreeBuilder.deserialize(BehaviorTreeBuilder.java:61)
	at com.google.gson.TreeTypeAdapter.read(TreeTypeAdapter.java:58)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
	at com.google.gson.Gson.fromJson(Gson.java:879)
... snip ...
```

With the change the game loads happily and correctly uses the fallback.
