### PR TITLE
set correct class for Share in CollectiveBehaviorSystem

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/CollectiveBehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/CollectiveBehaviorSystem.java
@@ -57,7 +57,7 @@ import java.util.*;
  * Modifications made to a behavior tree will reflect to all entities using this tree.
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
-@Share(BehaviorSystem.class)
+@Share(CollectiveBehaviorSystem.class)
 public class CollectiveBehaviorSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
     public static final Name BEHAVIORS = new Name("Behaviors");
     private static final Logger logger = LoggerFactory.getLogger(BehaviorSystem.class);


### PR DESCRIPTION
### Contains

Pinging @casals since he's got the only commit to this file.

Small change to correct the registration class for CollectiveBehaviorSystem

The same class is used to register the vanilla BehaviorSystem: https://github.com/MovingBlocks/Terasology/blob/95f8881bd82398ab7b175f916aa53a78b1ef25c9/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java#L62

This causes a race condition where the class that gets injected varies depending on class load order. Since CollectiveBehaviorSystem doesn't actually extend BehaviorSystem this causes a cast failure exception during injection, in addition to other unexpected bad things.

### How to test

I got this sporadically while loading FlexibleMovementTestbed and going to the behavior editor (F5). Doesn't always reproduce. Should in theory happen sometimes when loading CoreGameplay but I couldn't get it to trigger with that module.