### PR TITLE
fix: Increase item pickup range

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterMovementComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterMovementComponent.java
@@ -41,6 +41,8 @@ public final class CharacterMovementComponent implements Component {
     public float radius = 0.3f;
     public CollisionGroup collisionGroup = StandardCollisionGroup.CHARACTER;
     public List<CollisionGroup> collidesWith = Lists.<CollisionGroup>newArrayList(StandardCollisionGroup.WORLD, StandardCollisionGroup.SENSOR);
+    @Range(min = 0, max = 5)
+    public float pickupRadius = 1.5f;
 
     // Speed settings
     @Replicate(FieldReplicateType.SERVER_TO_OWNER)

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -673,7 +673,7 @@ public class BulletPhysics implements PhysicsEngine {
         }
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
         if (characterMovementComponent != null) {
-            return new CapsuleShape(characterMovementComponent.radius, characterMovementComponent.height);
+            return new CapsuleShape(characterMovementComponent.pickupRadius, characterMovementComponent.height);
         }
         logger.error("Creating physics object that requires a ShapeComponent or CharacterMovementComponent, but has neither. Entity: {}", entity);
         throw new IllegalArgumentException("Creating physics object that requires a ShapeComponent or CharacterMovementComponent, but has neither. Entity: " + entity);

--- a/engine/src/main/resources/assets/prefabs/player/player.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/player.prefab
@@ -20,11 +20,6 @@
   },
   "VisualCharacter": {
   },
-  // the CapsuleShape is used to detect item entities for pickup. The actual character collider is generated programmatically.
-  "CapsuleShape": {
-    "height" : 4,
-    "radius" : 1.5
-  },
   "Trigger": {
     "detectGroups": [
       "engine:debris",

--- a/engine/src/main/resources/assets/prefabs/player/player.prefab
+++ b/engine/src/main/resources/assets/prefabs/player/player.prefab
@@ -20,6 +20,11 @@
   },
   "VisualCharacter": {
   },
+  // the CapsuleShape is used to detect item entities for pickup. The actual character collider is generated programmatically.
+  "CapsuleShape": {
+    "height" : 4,
+    "radius" : 1.5
+  },
   "Trigger": {
     "detectGroups": [
       "engine:debris",


### PR DESCRIPTION
The code for extending item pickup range beyond the character collider was already present, but was broken accidentally in [#3907](https://github.com/MovingBlocks/Terasology/pull/3907/files/d8689f1710fb567d6ddfa3f2f9e6d4d09aedd768#diff-65b44f3586a2bf7259ca4594f2521535), so this requires very little change.