### PR TITLE
Derive player height from CharacterMovementComponent instead of BoxShapeComponent

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterMovementComponent.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterMovementComponent.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 /**
  * This component is attached to all character entities. It governs movement and stores
- * associated paramenters. <br/>
+ * associated paramenters, and can be used instead of a CapsuleShapeComponent by the physics system to define the collision shape. <br/>
  * The {@link AliveCharacterComponent} should necessarily be attached to the character entity for the movement systems to work.
  */
 public final class CharacterMovementComponent implements Component {

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -29,17 +29,12 @@ import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.AABB;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.SpiralIterable;
 import org.terasology.math.TeraMath;
-import org.terasology.physics.components.shapes.BoxShapeComponent;
-import org.terasology.physics.components.shapes.CapsuleShapeComponent;
-import org.terasology.physics.components.shapes.CylinderShapeComponent;
-import org.terasology.physics.components.shapes.HullShapeComponent;
-import org.terasology.physics.components.shapes.SphereShapeComponent;
 import org.terasology.world.WorldProvider;
 
 import java.util.Optional;
@@ -99,30 +94,9 @@ public class PlayerFactory {
     }
 
     private float getHeightOf(ComponentContainer prefab) {
-        BoxShapeComponent box = prefab.getComponent(BoxShapeComponent.class);
-        if (box != null) {
-            return box.extents.getY();
-        }
-
-        CylinderShapeComponent cylinder = prefab.getComponent(CylinderShapeComponent.class);
-        if (cylinder != null) {
-            return cylinder.height;
-        }
-
-        CapsuleShapeComponent capsule = prefab.getComponent(CapsuleShapeComponent.class);
-        if (capsule != null) {
-            return capsule.height;
-        }
-
-        SphereShapeComponent sphere = prefab.getComponent(SphereShapeComponent.class);
-        if (sphere != null) {
-            return sphere.radius * 2.0f;
-        }
-
-        HullShapeComponent hull = prefab.getComponent(HullShapeComponent.class);
-        if (hull != null) {
-            AABB aabb = hull.sourceMesh.getAABB();
-            return aabb.maxY() - aabb.minY();
+        CharacterMovementComponent movementComponent = prefab.getComponent(CharacterMovementComponent.class);
+        if (movementComponent != null) {
+            return movementComponent.height;
         }
 
         logger.warn("entity {} does not have any known extent specification - using default", prefab);

--- a/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
+++ b/engine/src/main/java/org/terasology/logic/players/PlayerFactory.java
@@ -99,7 +99,7 @@ public class PlayerFactory {
             return movementComponent.height;
         }
 
-        logger.warn("entity {} does not have any known extent specification - using default", prefab);
+        logger.warn("entity {} does not have a CharacterMovementComponent - using default height", prefab);
         return 1.0f;
     }
 


### PR DESCRIPTION
As the player prefab no longer actually has a BoxShapeComponent, the check for whether there's enough space to spawn the player should instead use the size defined in the CharacterMovementComponent, which is kept more up-to-date anyway if the player height changes.

This avoids the warning `[main] WARN  o.t.logic.players.PlayerFactory - entity org.terasology.entitySystem.entity.EntityBuilder@55158884 does not have any known extent specification - using default`, and the corresponding very minor risk of the player spawning with their head in a block if they have a greater than usual height.