### PR TITLE
fix/Make the height of the shapes derived from CharacterMovementComponents more consistent.

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -673,7 +673,7 @@ public class BulletPhysics implements PhysicsEngine {
         }
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
         if (characterMovementComponent != null) {
-            return new CapsuleShape(characterMovementComponent.pickupRadius, characterMovementComponent.height);
+            return new CapsuleShape(characterMovementComponent.pickupRadius, characterMovementComponent.height - 2 * characterMovementComponent.radius);
         }
         logger.error("Creating physics object that requires a ShapeComponent or CharacterMovementComponent, but has neither. Entity: {}", entity);
         throw new IllegalArgumentException("Creating physics object that requires a ShapeComponent or CharacterMovementComponent, but has neither. Entity: " + entity);


### PR DESCRIPTION
The height in the CharacterMovementComponent is the total height of the capsule shape that the physics system uses for the character, including the hemispherical caps, whereas the height in the CapsuleShape is only the height of the cylinder portion of the capsule. As the CapsuleShape derived in this method is only actually used to detect things like picking up items, rather than the character's physics, it doesn't matter that much, but it's neater if the trigger capsule is properly concentric with the collider capsule.