### PR TITLE
Replicate NameTagComponent fields to clients, to fix name tag display issues in multiplayer

### DIFF
--- a/engine/src/main/java/org/terasology/logic/nameTags/NameTagComponent.java
+++ b/engine/src/main/java/org/terasology/logic/nameTags/NameTagComponent.java
@@ -17,6 +17,7 @@ package org.terasology.logic.nameTags;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.module.sandbox.API;
+import org.terasology.network.Replicate;
 import org.terasology.rendering.nui.Color;
 
 /**
@@ -29,11 +30,15 @@ import org.terasology.rendering.nui.Color;
 @API
 public class NameTagComponent implements Component {
 
+    @Replicate
     public float yOffset = 0.3f;
 
+    @Replicate
     public String text;
 
+    @Replicate
     public Color textColor = Color.WHITE;
 
+    @Replicate
     public float scale = 1f;
 }


### PR DESCRIPTION
Adds an `@Replicate` annotation to all fields of `NameTagComponent`. This replicates the name tag information from server to clients, so the all clients see newly generated name tags.

### How to test

- Join a host game/join game world with two clients, using a module that dynamically generates name tags. ([Terasology/MetalRenegades](https://github.com/Terasology/MetalRenegades) generates city names this way)
- When the name is generated, it should appear the same on both clients.
