### PR TITLE
Update for Fluid PR 19

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/tiles/BlockTile.java
+++ b/engine/src/main/java/org/terasology/world/block/tiles/BlockTile.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.module.sandbox.API;
 
 import java.awt.image.BufferedImage;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.function.Consumer;
 
 /**
  */
+@API
 public class BlockTile extends Asset<TileData> {
     private BufferedImage[] images;
     private boolean autoBlock;


### PR DESCRIPTION
Update for compatibility with https://github.com/Terasology/Fluid/pull/19. Add BlockTile to the API, as Fluid needs access to it in order to attach liquid blocks' textures to the corresponding fluids.