### PR TITLE
Add subprojects under `libs/` as included builds for easy substitution

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -87,6 +87,7 @@ configurations {
 // TODO: Remove when we don't need to rely on snapshots. Wonder why modules respected this set in root project, engine not so much
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    transitive = false
 }
 
 // Primary dependencies definition

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -162,23 +162,8 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     runtimeOnly group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.21'
 
-    // Dependency on CrashReporter, conditionally either from source or via binary
     // TODO: Consider moving this back to the PC Facade instead of having the engine rely on it?
-    File wouldBeSrcPath = new File(rootDir, 'libs/CrashReporter')
-
-    if (wouldBeSrcPath.exists()) {
-        println "*** Identified CrashReporter source, using that"
-        //compile ':libs:CrashReporter:cr-terasology'
-
-        def targetProject = findProject(':libs:CrashReporter:cr-terasology')
-        println "Found the project? " + targetProject
-        //compile targetProject
-
-        implementation project(':libs:CrashReporter:cr-terasology')
-    } else {
-        logger.debug("*** Setting a CrashReporter binary dependency, not present as source")
-        implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '4.1.0'
-    }
+    implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '4.1.0'
 }
 
 task cacheReflections {

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -87,7 +87,6 @@ configurations {
 // TODO: Remove when we don't need to rely on snapshots. Wonder why modules respected this set in root project, engine not so much
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-    transitive = false
 }
 
 // Primary dependencies definition

--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -99,22 +99,7 @@ dependencies {
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
 
     // TODO: Consider whether we can move the CR dependency back here from the engine, where it is referenced from the main menu
-    // Dependency on CrashReporter, conditionally either from source or via binary
-    File wouldBeSrcPath = new File(rootDir, 'libs/CrashReporter')
-
-    if (wouldBeSrcPath.exists()) {
-        println "*** Identified CrashReporter source, using that"
-        //compile ':libs:CrashReporter:cr-terasology'
-
-        def targetProject = findProject(':libs:CrashReporter:cr-terasology')
-        println "Found the project? " + targetProject
-        //compile targetProject
-
-        implementation project(':libs:CrashReporter:cr-terasology')
-    } else {
-        logger.debug("*** Setting a CrashReporter binary dependency, not present as source")
-        implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '4.1.0'
-    }
+    implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '4.1.0'
 }
 
 // Instructions for packaging a jar file for the PC facade

--- a/libs/subprojects.gradle
+++ b/libs/subprojects.gradle
@@ -5,17 +5,7 @@ new File(rootDir, 'libs').eachDir { possibleSubprojectDir ->
     File buildFile = new File(possibleSubprojectDir, "build.gradle")
     if (buildFile.exists()) {
         println "Library $subprojectName has a build file so counting it as integratable code and sub-projecting it"
-        include subprojectName
-        def subprojectPath = ':' + subprojectName
-        def subproject = project(subprojectPath)
-        subproject.projectDir = possibleSubprojectDir
-
-        // Also look for a nested settings.gradle file in case of embedded libraries with their own sub projects
-        File settingsFile = new File(possibleSubprojectDir, "settings.gradle")
-        if (settingsFile.exists()) {
-            println "Library $subprojectName has a settings file so applying it expecting nested sub projects"
-            apply from: settingsFile
-        }
+        includeBuild possibleSubprojectDir
     } else {
         println "Library dir found without a build.gradle, not including $subprojectName in the Gradle project tree"
     }


### PR DESCRIPTION
Uses `includeBuild` to include subprojects in the `libs/` subdirectory. This lets Gradle easily include and substitute Gradle builds for `engine` (and other) dependencies. More information: https://docs.gradle.org/current/userguide/composite_builds.html

To test, check out a library like `CrashReporter` or `gestalt` in `libs/` (you can use `groovyw lib get` for in house libraries), check out the source of the version required by the `engine`, fix any old Gradle issues/deprecations, and build the Gradle project. `gradlew dependencies` will show the substitution as follows:

```
+--- org.terasology.crashreporter:cr-terasology:4.1.0 -> project :CrashReporter:cr-terasology
```

IntelliJ will also be able to process the substitution and rebuild its indices accordingly. 