### PR TITLE
fix: NPE in BehaviorEditor when on multiplayer client

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -58,7 +58,7 @@ import java.util.Optional;
  * <p/>
  * Modifications made to a behavior tree will reflect to all entities using this tree.
  */
-@RegisterSystem(RegisterMode.AUTHORITY)
+@RegisterSystem(RegisterMode.ALWAYS)
 @Share(BehaviorSystem.class)
 public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 


### PR DESCRIPTION
### Contains

Fixes issue [#3607 ](https://github.com/MovingBlocks/Terasology/issues/3607) that was causing NPE in BehaviorEditorScreen when joining multiplayer worlds. The BehaviorSystem was not registered in these situation because it was registered with RegisterMode.AUTHORITY, which only registers for the host in multiplayer.

### How to test

Join a mulitplayer world with WildAnimals enabled (not as a host). Spawn in some deer. Hit F5, and then try to open the dropdown menu in the top left of the screen. Game should now work as expected
