### PR TITLE
feat(FlowLayout): add option for vertical spacing

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -20,6 +20,7 @@ import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.CoreLayout;
+import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.LayoutHint;
 import org.terasology.rendering.nui.UIWidget;
 
@@ -31,6 +32,12 @@ import java.util.List;
 public class FlowLayout extends CoreLayout<LayoutHint> {
 
     private List<UIWidget> contents = Lists.newArrayList();
+
+    /**
+     * The vertical spacing between adjacent widgets, in pixels
+     */
+    @LayoutConfig
+    private int verticalSpacing;
 
     @Override
     public void addWidget(UIWidget element, LayoutHint hint) {
@@ -62,6 +69,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             canvas.drawWidget(widget, Rect2i.createFromMinAndSize(filledWidth, heightOffset, size.x, size.y));
             filledWidth += size.x;
             filledHeight = Math.max(filledHeight, size.y);
+            heightOffset += verticalSpacing;
         }
     }
 
@@ -83,7 +91,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             }
         }
         result.x = Math.max(result.x, filledWidth);
-        result.y += filledHeight;
+        result.y += filledHeight + verticalSpacing * (contents.size() - 1);
 
         return result;
     }
@@ -96,5 +104,25 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     @Override
     public Iterator<UIWidget> iterator() {
         return contents.iterator();
+    }
+
+    /**
+     * Retrieves the spacing between adjacent widgets in this {@code FlowLayout}.
+     *
+     * @return The spacing, in pixels
+     */
+    public int getVerticalSpacing() {
+        return verticalSpacing;
+    }
+
+    /**
+     * Sets the spacing betweeen adjacent widgets in this {@code FlowLayout}.
+     *
+     * @param spacing The spacing, in pixels
+     * @return This {@code FlowLayout}
+     */
+    public FlowLayout setVerticalSpacing(int spacing) {
+        this.verticalSpacing = spacing;
+        return this;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -63,8 +63,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         for (UIWidget widget : contents) {
             Vector2i size = canvas.calculatePreferredSize(widget);
             if (filledWidth != 0 && filledWidth + size.x > canvas.size().x) {
-                heightOffset += filledHeight;
-                heightOffset += verticalSpacing;
+                heightOffset += filledHeight + verticalSpacing;
                 filledWidth = 0;
                 filledHeight = 0;
             }
@@ -83,7 +82,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             Vector2i size = canvas.calculatePreferredSize(widget);
             if (filledWidth != 0 && filledWidth + size.x > sizeHint.x) {
                 result.x = Math.max(result.x, filledWidth);
-                result.y += filledHeight;
+                result.y += filledHeight + verticalSpacing;
                 filledWidth = size.x;
                 filledHeight = size.y;
             } else {
@@ -92,7 +91,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             }
         }
         result.x = Math.max(result.x, filledWidth);
-        result.y += filledHeight + verticalSpacing * (contents.size() - 1);
+        result.y += filledHeight;
 
         return result;
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -71,7 +71,6 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             canvas.drawWidget(widget, Rect2i.createFromMinAndSize(filledWidth, heightOffset, size.x, size.y));
             filledWidth += size.x;
             filledHeight = Math.max(filledHeight, size.y);
-            heightOffset += verticalSpacing;
         }
     }
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -107,7 +107,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     }
 
     /**
-     * Retrieves the spacing between adjacent widgets in this {@code FlowLayout}.
+     * Retrieves the vertical spacing between adjacent widgets in this {@code FlowLayout}.
      *
      * @return The spacing, in pixels
      */
@@ -116,7 +116,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     }
 
     /**
-     * Sets the spacing betweeen adjacent widgets in this {@code FlowLayout}.
+     * Sets the vertical spacing between adjacent widgets in this {@code FlowLayout}.
      *
      * @param spacing The spacing, in pixels
      * @return This {@code FlowLayout}

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -64,6 +64,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             Vector2i size = canvas.calculatePreferredSize(widget);
             if (filledWidth != 0 && filledWidth + size.x > canvas.size().x) {
                 heightOffset += filledHeight;
+                heightOffset += verticalSpacing;
                 filledWidth = 0;
                 filledHeight = 0;
             }

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
+ *
  */
 public class FlowLayout extends CoreLayout<LayoutHint> {
 
@@ -61,7 +62,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         int heightOffset = 0;
         for (UIWidget widget : contents) {
             Vector2i size = canvas.calculatePreferredSize(widget);
-            if (filledWidth != 0 && filledWidth + size.x  > canvas.size().x) {
+            if (filledWidth != 0 && filledWidth + size.x > canvas.size().x) {
                 heightOffset += filledHeight;
                 filledWidth = 0;
                 filledHeight = 0;
@@ -80,7 +81,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         int filledHeight = 0;
         for (UIWidget widget : contents) {
             Vector2i size = canvas.calculatePreferredSize(widget);
-            if (filledWidth != 0 && filledWidth + size.x  > sizeHint.x) {
+            if (filledWidth != 0 && filledWidth + size.x > sizeHint.x) {
                 result.x = Math.max(result.x, filledWidth);
                 result.y += filledHeight;
                 filledWidth = size.x;


### PR DESCRIPTION
### Contains

#### Summary

Enhancement of FlowLayout: the option to put vertical spacing in between the items included withing that FlowLayout.

#### Additions

Added a variable named `verticalSpacing`, which can be set within the UI file that used a `FlowLayout`. I used `RowLayout.java`'s implementation of `horizontalSpacing`.

### How to test

#### Steps

1. Get an up-to-date version of the LightAndShadow module
2. Go to file `LightAndShadow/overrides/Inventory/ui/hud/inventoryHud/ui`
3. Find where the `"flowLayout"` is located at, and add the line `"verticalSpacing": 10,` _(or any number instead of `10`)_. Place the line somewhere between lines with `"type"` and `"contents"`, e.g. like this:
```JSON
"type": "flowLayout",
"id": "toolbar",
"verticalSpacing": 10,
"contents": [
```
4. Run your build and create/open a LaS game
5. Notice the spacing between the quickslot slots

#### Result

There should be spacing in between the slots, like the image below:

![image](https://user-images.githubusercontent.com/48293545/87860035-a61a7e00-c942-11ea-8992-5d32c06f1530.png)

### Outstanding before merging

**Q:** Should I add the feature to add horizontal spacing as well, considering it is probably done similarly? If yes, should this PR be merged, and then make a new one for the other new feature?
