### PR TITLE
feat: Add ModifiableValue type

### DIFF
--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ModifiableValueTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ModifiableValueTypeHandler.java
@@ -1,0 +1,29 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.persistence.typeHandling.extensionTypes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.PersistedDataSerializer;
+import org.terasology.persistence.typeHandling.RegisterTypeHandler;
+import org.terasology.utilities.modifiable.ModifiableValue;
+
+import java.util.Optional;
+
+@RegisterTypeHandler
+public class ModifiableValueTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<ModifiableValue> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifiableValueTypeHandler.class);
+
+    @Override
+    public PersistedData serializeNonNull(ModifiableValue value, PersistedDataSerializer serializer) {
+        return serializer.serialize(value.getValue());
+    }
+
+    @Override
+    public Optional<ModifiableValue> deserialize(PersistedData data) {
+        return Optional.of(new ModifiableValue(data.getAsArray().getAsFloatArray().get(0)));
+    }
+}

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ModifiableValueTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ModifiableValueTypeHandler.java
@@ -14,6 +14,14 @@ import org.terasology.utilities.modifiable.ModifiableValue;
 
 import java.util.Optional;
 
+/**
+ * The ModifiableValue type is deserialized from prefabs directly from the corresponding component values.
+ * <b>Only</b> the base value is to be specified in the prefabs, this will deserialize into a ModifiableValue type,
+ * with set preModifier=0, multiplier=1, postModifier=0.
+ * "<field_name>": <base_value>
+ * It is not recommended to set the modifiers in the prefab but it can be done via an unlabeled array.
+ * "<field_name>": [<base_value>, <pre_modifier>, <multiplier>, <post_modifier>]
+ */
 @RegisterTypeHandler
 public class ModifiableValueTypeHandler extends org.terasology.persistence.typeHandling.TypeHandler<ModifiableValue> {
 
@@ -21,8 +29,8 @@ public class ModifiableValueTypeHandler extends org.terasology.persistence.typeH
 
     @Override
     public PersistedData serializeNonNull(ModifiableValue value, PersistedDataSerializer serializer) {
-        return serializer.serialize(value.getBaseValue(), value.getPreModifiers(), value.getMultipliers(),
-                value.getPostModifiers());
+        return serializer.serialize(value.getBaseValue(), value.getPreModifier(), value.getMultiplier(),
+                value.getPostModifier());
     }
 
     @Override
@@ -32,10 +40,10 @@ public class ModifiableValueTypeHandler extends org.terasology.persistence.typeH
             if (vals.isNumberArray()) {
                 TFloatList floatList = vals.getAsFloatArray();
                 ModifiableValue modifiableValue = new ModifiableValue(floatList.get(0));
-                if (floatList.size() > 1) {
-                    modifiableValue.setPreModifiers(floatList.get(1));
-                    modifiableValue.setMultipliers(floatList.get(2));
-                    modifiableValue.setPostModifiers(floatList.get(3));
+                if (floatList.size() == 4) {
+                    modifiableValue.setPreModifier(floatList.get(1));
+                    modifiableValue.setMultiplier(floatList.get(2));
+                    modifiableValue.setPostModifier(floatList.get(3));
                 }
                 return Optional.of(modifiableValue);
             }

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ModifiableValueTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/extensionTypes/ModifiableValueTypeHandler.java
@@ -27,25 +27,19 @@ public class ModifiableValueTypeHandler extends org.terasology.persistence.typeH
 
     @Override
     public Optional<ModifiableValue> deserialize(PersistedData data) {
-        if (!data.isArray()) {
-            return Optional.empty();
+        if (data.isArray()) {
+            PersistedDataArray vals = data.getAsArray();
+            if (vals.isNumberArray()) {
+                TFloatList floatList = vals.getAsFloatArray();
+                ModifiableValue modifiableValue = new ModifiableValue(floatList.get(0));
+                if (floatList.size() > 1) {
+                    modifiableValue.setPreModifiers(floatList.get(1));
+                    modifiableValue.setMultipliers(floatList.get(2));
+                    modifiableValue.setPostModifiers(floatList.get(3));
+                }
+                return Optional.of(modifiableValue);
+            }
         }
-
-        PersistedDataArray vals = data.getAsArray();
-
-        if (!vals.isNumberArray() || (vals.size() != 3 && vals.size()!=1)) {
-            return Optional.empty();
-        }
-
-        TFloatList floatList = vals.getAsFloatArray();
-        ModifiableValue modifiableValue = new ModifiableValue(floatList.get(0));
-
-        if (vals.size() != 1) {
-            modifiableValue.setPreModifiers(floatList.get(1));
-            modifiableValue.setMultipliers(floatList.get(2));
-            modifiableValue.setPostModifiers(floatList.get(3));
-        }
-
-        return Optional.of(modifiableValue);
+        return Optional.empty();
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -18,6 +18,9 @@ public class ModifiableValue {
     private float postModifiers;
 
     public ModifiableValue(float baseValue) {
+        preModifiers = 0f;
+        multipliers = 1f;
+        postModifiers = 1f;
         this.baseValue = baseValue;
     }
 

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -6,14 +6,14 @@ package org.terasology.utilities.modifiable;
 /**
  * A helper type to get and modify the value of a component without changing its actual value
  * <p>
- * The result value is guaranteed to be greater or equal to zero.
- * Components using this type must mention so in their javadoc.
+ * The result value is guaranteed to be greater or equal to zero. Components using this type must mention so in their
+ * javadoc.
  * </p>
  */
 public class ModifiableValue {
     private final float baseValue;
 
-    private float modifiers;
+    private float preModifiers;
     private float multipliers;
     private float postModifiers;
 
@@ -25,16 +25,19 @@ public class ModifiableValue {
         return baseValue;
     }
 
-    public void multiply(float amount) {
-        multipliers*=amount;
+    public ModifiableValue multiply(float amount) {
+        multipliers += amount;
+        return this;
     }
 
-    public void add(float amount) {
-        modifiers+=amount;
+    public ModifiableValue preAdd(float amount) {
+        preModifiers += amount;
+        return this;
     }
 
-    public void postAdd(float amount) {
-        postModifiers+=amount;
+    public ModifiableValue postAdd(float amount) {
+        postModifiers += amount;
+        return this;
     }
 
     /**
@@ -48,6 +51,6 @@ public class ModifiableValue {
      * <emph>The result value is guaranteed to be non-negative!</emph>
      */
     public float getValue() {
-        return baseValue + modifiers * multipliers + postModifiers;
+        return (baseValue + preModifiers) * multipliers + postModifiers;
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -1,0 +1,99 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.utilities.modifiable;
+
+import gnu.trove.iterator.TFloatIterator;
+import gnu.trove.list.TFloatList;
+import gnu.trove.list.array.TFloatArrayList;
+
+/**
+ * A helper type to get and modify the value of a component without changing its actual value
+ * <p>
+ * The result value is guaranteed to be greater or equal to zero.
+ * Components using this type must mention so in their javadoc.
+ * </p>
+ */
+public class ModifiableValue {
+    private final float baseValue;
+
+    private TFloatList modifiers = new TFloatArrayList();
+    private TFloatList multipliers = new TFloatArrayList();
+    private TFloatList postModifiers = new TFloatArrayList();
+
+    public ModifiableValue(float baseValue) {
+        this.baseValue = baseValue;
+    }
+
+    public float getBaseValue() {
+        return baseValue;
+    }
+
+    public void multiply(float amount) {
+        this.multipliers.add(amount);
+    }
+
+    public void add(float amount) {
+        modifiers.add(amount);
+    }
+
+    public void postAdd(float amount) {
+        postModifiers.add(amount);
+    }
+
+    /**
+     * Calculates the result value from the base value and given modifiers and multipliers.
+     * <p>
+     * The value is calculated based on the following formula:
+     * <pre>
+     * result = max(0, <baseValue> + Σ <modifier> * Π <multiplier> + Σ <postModifier>)
+     * </pre>
+     *
+     * <emph>The result value is guaranteed to be non-negative!</emph>
+     */
+    public float getValue() {
+        return Math.max(0, baseValue + modifiers.sum() * product(multipliers) + postModifiers.sum());
+    }
+
+    public TFloatList getModifiers() {
+        return modifiers;
+    }
+
+    public void setModifiers(TFloatList modifiers) {
+        this.modifiers = modifiers;
+    }
+
+    public TFloatList getMultipliers() {
+        return multipliers;
+    }
+
+    public void setMultipliers(TFloatList multipliers) {
+        this.multipliers = multipliers;
+    }
+
+    public TFloatList getPostModifiers() {
+        return postModifiers;
+    }
+
+    public void setPostModifiers(TFloatList postModifiers) {
+        this.postModifiers = postModifiers;
+    }
+
+    /**
+     * Calculate the product of all values in the given list.
+     * <p>
+     * A static helper dual to {@code TFloatList#sum()}.
+     *
+     * @param multipliers the list of multipliers to calculate the product of.
+     * @return the product of all values. 1 if the list is empty.
+     */
+    private static float product(TFloatList multipliers) {
+        float multiplierProduct = 1f;
+        TFloatIterator multiplierIter = multipliers.iterator();
+        while (multiplierIter.hasNext()) {
+            multiplierProduct *= multiplierIter.next();
+        }
+        return multiplierProduct;
+    }
+
+}

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -29,7 +29,7 @@ public class ModifiableValue {
     }
 
     public ModifiableValue multiply(float amount) {
-        multipliers += amount;
+        multipliers *= amount;
         return this;
     }
 

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -3,12 +3,15 @@
 
 package org.terasology.utilities.modifiable;
 
+import org.terasology.module.sandbox.API;
+
 /**
  * A helper type to get and modify the value of a component without changing its actual value.
  * <p>
  * Components using this type must mention so in their javadoc so all modifiers are added correctly.
  * </p>
  */
+@API
 public class ModifiableValue {
     private final float baseValue;
 

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -20,10 +20,10 @@ public class ModifiableValue {
     private float postModifiers;
 
     public ModifiableValue(float baseValue) {
-        preModifiers = 0f;
-        multipliers = 1f;
-        postModifiers = 0f;
-        this.baseValue = baseValue;
+        preModifiers=0;
+        multipliers=1;
+        postModifiers=0;
+        this.baseValue=baseValue;
     }
 
     public float getBaseValue() {
@@ -57,5 +57,29 @@ public class ModifiableValue {
      */
     public float getValue() {
         return (baseValue + preModifiers) * multipliers + postModifiers;
+    }
+
+    public float getPreModifiers() {
+        return preModifiers;
+    }
+
+    public float getPostModifiers() {
+        return postModifiers;
+    }
+
+    public float getMultipliers() {
+        return multipliers;
+    }
+
+    public void setPreModifiers(float preModifiers){
+        this.preModifiers=preModifiers;
+    }
+
+    public void setMultipliers(float multipliers){
+        this.multipliers=multipliers;
+    }
+
+    public void setPostModifiers(float postModifiers){
+        this.postModifiers=postModifiers;
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -15,15 +15,15 @@ import org.terasology.module.sandbox.API;
 public class ModifiableValue {
     private final float baseValue;
 
-    private float preModifiers;
-    private float multipliers;
-    private float postModifiers;
+    private float preModifier;
+    private float multiplier;
+    private float postModifier;
 
     public ModifiableValue(float baseValue) {
-        preModifiers=0;
-        multipliers=1;
-        postModifiers=0;
-        this.baseValue=baseValue;
+        preModifier = 0;
+        multiplier = 1;
+        postModifier = 0;
+        this.baseValue = baseValue;
     }
 
     public float getBaseValue() {
@@ -31,22 +31,22 @@ public class ModifiableValue {
     }
 
     public ModifiableValue multiply(float amount) {
-        multipliers *= amount;
+        multiplier *= amount;
         return this;
     }
 
     public ModifiableValue preAdd(float amount) {
-        preModifiers += amount;
+        preModifier += amount;
         return this;
     }
 
     public ModifiableValue postAdd(float amount) {
-        postModifiers += amount;
+        postModifier += amount;
         return this;
     }
 
     /**
-     * Calculates the result value from the base value and given modifiers and multipliers.
+     * Calculates the result value from the base value and given modifiers and multiplier.
      * <p>
      * The value is calculated based on the following formula:
      * <pre>
@@ -56,30 +56,48 @@ public class ModifiableValue {
      * <emph>non-negativity of the value is not ensured and must be checked by the system if needed</emph>
      */
     public float getValue() {
-        return (baseValue + preModifiers) * multipliers + postModifiers;
+        return (baseValue + preModifier) * multiplier + postModifier;
     }
 
-    public float getPreModifiers() {
-        return preModifiers;
+    public float getPreModifier() {
+        return preModifier;
     }
 
-    public float getPostModifiers() {
-        return postModifiers;
+    public float getPostModifier() {
+        return postModifier;
     }
 
-    public float getMultipliers() {
-        return multipliers;
+    public float getMultiplier() {
+        return multiplier;
     }
 
-    public void setPreModifiers(float preModifiers){
-        this.preModifiers=preModifiers;
+    /**
+     * Setter method used to set the preModifier at once.
+     * It is only used for setting the modifier during the Deserialization process.
+     * For any modification, use the preAdd() method instead.
+     * @param preModifier the preModifier to set for the component data.
+     */
+    public void setPreModifier(float preModifier) {
+        this.preModifier = preModifier;
     }
 
-    public void setMultipliers(float multipliers){
-        this.multipliers=multipliers;
+    /**
+     * Setter method used to set the multiplier at once.
+     * It is only used for setting the multiplier during the Deserialization process.
+     * For any modification, use the multiply() method instead.
+     * @param multiplier the multiplier to set for the component data.
+     */
+    public void setMultiplier(float multiplier) {
+        this.multiplier = multiplier;
     }
 
-    public void setPostModifiers(float postModifiers){
-        this.postModifiers=postModifiers;
+    /**
+     * Setter method used to set the postModifier at once.
+     * It is only used for setting the postModifier during the Deserialization process.
+     * For any modification, use the postAdd() method instead.
+     * @param postModifier the postModifier to set for the component data.
+     */
+    public void setPostModifier(float postModifier) {
+        this.postModifier = postModifier;
     }
 }

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -4,10 +4,9 @@
 package org.terasology.utilities.modifiable;
 
 /**
- * A helper type to get and modify the value of a component without changing its actual value
+ * A helper type to get and modify the value of a component without changing its actual value.
  * <p>
- * The result value is guaranteed to be greater or equal to zero. Components using this type must mention so in their
- * javadoc.
+ * Components using this type must mention so in their javadoc so all modifiers are added correctly.
  * </p>
  */
 public class ModifiableValue {
@@ -48,10 +47,10 @@ public class ModifiableValue {
      * <p>
      * The value is calculated based on the following formula:
      * <pre>
-     * result = max(0, <baseValue> + Σ <modifier> * Π <multiplier> + Σ <postModifier>)
+     * result = (<baseValue> + Σ <modifier>) * Π <multiplier> + Σ <postModifier>
      * </pre>
      *
-     * <emph>The result value is guaranteed to be non-negative!</emph>
+     * <emph>non-negativity of the value is not ensured and must be checked by the system if needed</emph>
      */
     public float getValue() {
         return (baseValue + preModifiers) * multipliers + postModifiers;

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -3,10 +3,6 @@
 
 package org.terasology.utilities.modifiable;
 
-import gnu.trove.iterator.TFloatIterator;
-import gnu.trove.list.TFloatList;
-import gnu.trove.list.array.TFloatArrayList;
-
 /**
  * A helper type to get and modify the value of a component without changing its actual value
  * <p>
@@ -17,9 +13,9 @@ import gnu.trove.list.array.TFloatArrayList;
 public class ModifiableValue {
     private final float baseValue;
 
-    private TFloatList modifiers = new TFloatArrayList();
-    private TFloatList multipliers = new TFloatArrayList();
-    private TFloatList postModifiers = new TFloatArrayList();
+    private float modifiers;
+    private float multipliers;
+    private float postModifiers;
 
     public ModifiableValue(float baseValue) {
         this.baseValue = baseValue;
@@ -30,15 +26,15 @@ public class ModifiableValue {
     }
 
     public void multiply(float amount) {
-        this.multipliers.add(amount);
+        multipliers*=amount;
     }
 
     public void add(float amount) {
-        modifiers.add(amount);
+        modifiers+=amount;
     }
 
     public void postAdd(float amount) {
-        postModifiers.add(amount);
+        postModifiers+=amount;
     }
 
     /**
@@ -52,48 +48,6 @@ public class ModifiableValue {
      * <emph>The result value is guaranteed to be non-negative!</emph>
      */
     public float getValue() {
-        return Math.max(0, baseValue + modifiers.sum() * product(multipliers) + postModifiers.sum());
+        return baseValue + modifiers * multipliers + postModifiers;
     }
-
-    public TFloatList getModifiers() {
-        return modifiers;
-    }
-
-    public void setModifiers(TFloatList modifiers) {
-        this.modifiers = modifiers;
-    }
-
-    public TFloatList getMultipliers() {
-        return multipliers;
-    }
-
-    public void setMultipliers(TFloatList multipliers) {
-        this.multipliers = multipliers;
-    }
-
-    public TFloatList getPostModifiers() {
-        return postModifiers;
-    }
-
-    public void setPostModifiers(TFloatList postModifiers) {
-        this.postModifiers = postModifiers;
-    }
-
-    /**
-     * Calculate the product of all values in the given list.
-     * <p>
-     * A static helper dual to {@code TFloatList#sum()}.
-     *
-     * @param multipliers the list of multipliers to calculate the product of.
-     * @return the product of all values. 1 if the list is empty.
-     */
-    private static float product(TFloatList multipliers) {
-        float multiplierProduct = 1f;
-        TFloatIterator multiplierIter = multipliers.iterator();
-        while (multiplierIter.hasNext()) {
-            multiplierProduct *= multiplierIter.next();
-        }
-        return multiplierProduct;
-    }
-
 }

--- a/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/utilities/modifiable/ModifiableValue.java
@@ -20,7 +20,7 @@ public class ModifiableValue {
     public ModifiableValue(float baseValue) {
         preModifiers = 0f;
         multipliers = 1f;
-        postModifiers = 1f;
+        postModifiers = 0f;
         this.baseValue = baseValue;
     }
 


### PR DESCRIPTION
### Contains

Added a ModifiableValue type to the engine which can be used by Components so that Systems changing the values of these components do not affect the real values but rather add PreModifiers, multipliers and PostModifiers which can then form a mathematically correct altered value. This PR is a result of a discussion with @skaldarnar @jellysnake @ktksan and @e-aakash after https://github.com/MovingBlocks/Terasology/pull/4063#issue-443423710 .
Components must now mention whether their data is to be modified in-place / if the data is modified via an AbstractModifiableEvent / if the data members are of ModifiableValue type, in their respective Javadocs
This PR also includes a TypeHandler to handle proper deserialization and serialization of ModifiableValue from prefabs and to persist the data across saves.

### How to use

Add the ModifiableValue type as the datatype of the data members of a component so that the value of the component can be modified correctly with different modifying systems acting on the component, without changing the base value of the component. An initial value can be given via the constructor and the .getValue() method can be used to get the value of the ModifiableValue type variable at any point 

### Outstanding before merging

- [x] Javadoc
- [x] Testing of the type with existing components
- [x] Further discussion on immutable values/return types
