### PR TITLE
fix: disable behavior editor for clients in multiplayer

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -58,7 +58,7 @@ import java.util.Optional;
  * <p/>
  * Modifications made to a behavior tree will reflect to all entities using this tree.
  */
-@RegisterSystem(RegisterMode.AUTHORITY)
+@RegisterSystem(RegisterMode.ALWAYS)
 @Share(BehaviorSystem.class)
 public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 

--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -58,7 +58,7 @@ import java.util.Optional;
  * <p/>
  * Modifications made to a behavior tree will reflect to all entities using this tree.
  */
-@RegisterSystem(RegisterMode.ALWAYS)
+@RegisterSystem(RegisterMode.AUTHORITY)
 @Share(BehaviorSystem.class)
 public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 

--- a/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorTreeClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/nui/BehaviorTreeClientSystem.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.terasology.logic.behavior.nui;
 
 import org.terasology.entitySystem.entity.EntityRef;
@@ -21,25 +22,27 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.ButtonState;
+import org.terasology.logic.console.Console;
+import org.terasology.logic.console.CoreMessageType;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
-import org.terasology.rendering.nui.NUIManager;
 
-/**
- * Opens the bt editor screen.
- *
- */
-@RegisterSystem(RegisterMode.AUTHORITY)
-public class BehaviorTreeEditorSystem extends BaseComponentSystem {
+@RegisterSystem(RegisterMode.REMOTE_CLIENT)
+public class BehaviorTreeClientSystem extends BaseComponentSystem {
 
     @In
-    private NUIManager nuiManager;
+    private Console console;
 
+    /**
+     * Called when a remote client presses F5 to open the Behavior Editor
+     * @param event F5 press
+     * @param entity the character entity reference
+     */
     @ReceiveEvent(components = ClientComponent.class)
     public void onToggleConsole(BTEditorButton event, EntityRef entity) {
         if (event.getState() == ButtonState.DOWN) {
-            nuiManager.toggleScreen("engine:behaviorEditorScreen");
-            event.consume();
+            console.addMessage("Behavior Editor is only available to the Host or on Singleplayer", CoreMessageType.CHAT);
         }
     }
+
 }


### PR DESCRIPTION

### Contains

This PR fixes #3607 which would throw a NPE when the player would open a dropdown in the Behavior Editor as a client in multiplayer. This is a temporary fix for use until a system is developed to handle client to server behavior editing. It disables the Behavior Editor screen for machines in REMOTE_CLIENT mode an enables it only for AUTHORITY mode. If in REMOTE_CLIENT mode, when you attempt to open the editor a chat message pops up saying, "Behavior Editor is only available to the Host or on Singleplayer". 

### How to test

Join a multiplayer game with WildAnimals enabled. Try pressing F5, instead of opening the editor it will send the chat message.
