### PR TITLE
feat(AGS): by default show only locally present modules

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -138,11 +138,11 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
             seed.setText(new FastRandom().nextString(32));
         }
 
-        // skip loading module configs, limit shown modules to "augmentation" category
+        // skip loading module configs, limit shown modules to locally present ones
         selectModulesConfig = new SelectModulesConfig();
         selectModulesConfig.getSelectedStandardModuleExtensions()
                 .forEach(selectModulesConfig::unselectStandardModuleExtension);
-        selectModulesConfig.toggleStandardModuleExtensionSelected(StandardModuleExtension.IS_AUGMENTATION);
+        selectModulesConfig.toggleIsLocalOnlySelected();
 
         dependencyResolver = new DependencyResolver(moduleManager.getRegistry());
 


### PR DESCRIPTION
- this includes modules present as source _and_ as .jar
- https://github.com/MovingBlocks/Terasology/pull/3973 set the default to augmentation which is a perfect match for the player-workflow, but as long as the main workflow is dev/test and not player, local makes more sense