### PR TITLE
feat(JOML): Migrate side#getVector3i() to direction()

### DIFF
--- a/engine-tests/src/test/java/org/terasology/math/SideTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/SideTest.java
@@ -26,7 +26,7 @@ public class SideTest {
     @Test
     public void testSideInDirection() {
         for (Side side : Side.getAllSides()) {
-            assertEquals(side, Side.inDirection(side.getVector3i().x, side.getVector3i().y, side.getVector3i().z));
+            assertEquals(side, Side.inDirection(side.direction().x(), side.direction().y(), side.direction().z()));
         }
     }
 

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -259,7 +259,7 @@ public class KinematicCharacterMover implements CharacterMover {
                 //If any of our sides are near a climbable block, check if we are near to the side
                 Vector3i myPos = new Vector3i(worldPos, org.joml.RoundingMode.HALF_UP);
                 Vector3i climbBlockPos = new Vector3i(side, org.joml.RoundingMode.HALF_UP);
-                Vector3i dir = new Vector3i(JomlUtil.from(block.getDirection().getVector3i()));
+                Vector3i dir = new Vector3i(block.getDirection().direction());
                 float currentDistance = 10f;
 
                 if (dir.x != 0 && Math.abs(worldPos.x - climbBlockPos.x + dir.x * .5f) < movementComp.radius + 0.1f) {

--- a/engine/src/main/java/org/terasology/logic/location/ImmutableBlockLocation.java
+++ b/engine/src/main/java/org/terasology/logic/location/ImmutableBlockLocation.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.logic.location;
 
+import org.joml.Vector3ic;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 
@@ -34,8 +35,8 @@ public class ImmutableBlockLocation {
     }
 
     public ImmutableBlockLocation move(Side side) {
-        final Vector3i directionVector = side.getVector3i();
-        return new ImmutableBlockLocation(x + directionVector.x, y + directionVector.y, z + directionVector.z);
+        final Vector3ic directionVector = side.direction();
+        return new ImmutableBlockLocation(x + directionVector.x(), y + directionVector.y(), z + directionVector.z());
     }
 
     public Vector3i toVector3i() {

--- a/engine/src/main/java/org/terasology/math/ChunkMath.java
+++ b/engine/src/main/java/org/terasology/math/ChunkMath.java
@@ -406,27 +406,27 @@ public final class ChunkMath {
      * @return
      */
     public static Region3i getEdgeRegion(Region3i region, Side side) {
-        Vector3i sideDir = side.getVector3i();
+        Vector3ic sideDir = side.direction();
         Vector3i min = region.min();
         Vector3i max = region.max();
         Vector3i edgeMin = new Vector3i(min);
         Vector3i edgeMax = new Vector3i(max);
-        if (sideDir.x < 0) {
+        if (sideDir.x() < 0) {
             edgeMin.x = min.x;
             edgeMax.x = min.x;
-        } else if (sideDir.x > 0) {
+        } else if (sideDir.x() > 0) {
             edgeMin.x = max.x;
             edgeMax.x = max.x;
-        } else if (sideDir.y < 0) {
+        } else if (sideDir.y() < 0) {
             edgeMin.y = min.y;
             edgeMax.y = min.y;
-        } else if (sideDir.y > 0) {
+        } else if (sideDir.y() > 0) {
             edgeMin.y = max.y;
             edgeMax.y = max.y;
-        } else if (sideDir.z < 0) {
+        } else if (sideDir.z() < 0) {
             edgeMin.z = min.z;
             edgeMax.z = min.z;
-        } else if (sideDir.z > 0) {
+        } else if (sideDir.z() > 0) {
             edgeMin.z = max.z;
             edgeMax.z = max.z;
         }

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Maps;
 import org.joml.Vector3ic;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.assets.mesh.Mesh;
 import org.terasology.world.ChunkView;
 import org.terasology.world.block.Block;

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -16,6 +16,7 @@
 package org.terasology.rendering.primitives;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -44,8 +45,8 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
         // Gather adjacent blocks
         final Map<Side, Block> adjacentBlocks = Maps.newEnumMap(Side.class);
         for (Side side : Side.getAllSides()) {
-            Vector3i offset = side.getVector3i();
-            Block blockToCheck = view.getBlock(x + offset.x, y + offset.y, z + offset.z);
+            Vector3ic offset = side.direction();
+            Block blockToCheck = view.getBlock(x + offset.x(), y + offset.y(), z + offset.z());
             adjacentBlocks.put(side, blockToCheck);
         }
         for (final Side side : Side.getAllSides()) {
@@ -65,8 +66,8 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
                     final Block topBlock = adjacentBlocks.get(Side.TOP);
                     // Draw horizontal sides if visible from below
                     if (topBlock.isLiquid() && Side.horizontalSides().contains(side)) {
-                        final Vector3i offset = side.getVector3i();
-                        final Block adjacentAbove = view.getBlock(x + offset.x, y + 1, z + offset.z);
+                        final Vector3ic offset = side.direction();
+                        final Block adjacentAbove = view.getBlock(x + offset.x(), y + 1, z + offset.z());
                         final Block adjacent = adjacentBlocks.get(side);
 
                         if (adjacent.isLiquid() && !adjacentAbove.isLiquid()) {
@@ -141,7 +142,7 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
         if (currentBlock.isLiquid() && blockToCheck.isLiquid()) {
             return false;
         }
-        
+
         //TODO: This only fixes the "water under block" issue of the top side not being rendered. (see bug #3889)
         //Note: originally tried .isLiquid() instead of isWater for both checks, but IntelliJ was warning that
         //      !blockToCheck.isWater() is always true, may need further investigation


### PR DESCRIPTION
I migrated getVector3i to direction.  direction better describes the a side then getVector3i but this is an API change. There is no direct impact to modules and the change is pretty straightforward. The other way to go about this is change the API and resolve it across all the modules.