### PR TITLE
feat(JOML): Migrate direction

### DIFF
--- a/engine/src/main/java/org/terasology/math/Direction.java
+++ b/engine/src/main/java/org/terasology/math/Direction.java
@@ -17,6 +17,8 @@
 package org.terasology.math;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3fc;
+import org.joml.Vector3ic;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 
@@ -116,13 +118,36 @@ public enum Direction {
 
     /**
      * @return The vector3i in the direction of the side. Do not modify.
+     * @deprecated This method is scheduled for removal in an upcoming version. Use the JOML implementation instead:
+     *     {@link #vector3i()} .
      */
+    @Deprecated
     public Vector3i getVector3i() {
         return new Vector3i(vector3iDir);
     }
 
+    /**
+     * @return
+     * @deprecated This method is scheduled for removal in an upcoming version. Use the JOML implementation instead:
+     *     {@link #vector3f()}.
+     */
+    @Deprecated
     public Vector3f getVector3f() {
         return new Vector3f(vector3fDir);
+    }
+
+    /**
+     * @return The {@link Vector3ic} in the direction of the side. Do not modify.
+     */
+    public Vector3ic vector3i() {
+        return JomlUtil.from(vector3iDir);
+    }
+
+    /**
+     * @return The {@link Vector3fc} in the direction of the side. Do not modify.
+     */
+    public Vector3fc vector3f() {
+        return JomlUtil.from(vector3fDir);
     }
 
     /**
@@ -131,5 +156,4 @@ public enum Direction {
     public Direction reverse() {
         return REVERSE_MAP.get(this);
     }
-
 }

--- a/engine/src/main/java/org/terasology/math/Direction.java
+++ b/engine/src/main/java/org/terasology/math/Direction.java
@@ -119,7 +119,7 @@ public enum Direction {
     /**
      * @return The vector3i in the direction of the side. Do not modify.
      * @deprecated This method is scheduled for removal in an upcoming version. Use the JOML implementation instead:
-     *     {@link #vector3i()} .
+     *     {@link #vector3ic()} .
      */
     @Deprecated
     public Vector3i getVector3i() {
@@ -129,7 +129,7 @@ public enum Direction {
     /**
      * @return
      * @deprecated This method is scheduled for removal in an upcoming version. Use the JOML implementation instead:
-     *     {@link #vector3f()}.
+     *     {@link #vector3fc()}.
      */
     @Deprecated
     public Vector3f getVector3f() {
@@ -139,14 +139,14 @@ public enum Direction {
     /**
      * @return The {@link Vector3ic} in the direction of the side. Do not modify.
      */
-    public Vector3ic vector3i() {
+    public Vector3ic vector3ic() {
         return JomlUtil.from(vector3iDir);
     }
 
     /**
      * @return The {@link Vector3fc} in the direction of the side. Do not modify.
      */
-    public Vector3fc vector3f() {
+    public Vector3fc vector3fc() {
         return JomlUtil.from(vector3fDir);
     }
 


### PR DESCRIPTION
I'm not too sure about this change. getVector3i and getVector3f are used all throughout the engine and modules. I could either add an additional method and deprecate the older methods or just try swap everything in one go? The change is pretty straightforward otherwise. This is an API change so there is no direct impact to the engine at the moment. 