### PR TITLE
fix(tests): reduce timing-based test failures on CI

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class GameProviderTest {
-    private static final int TIMESTAMP_DELAY = 500;
+    private static final int TIMESTAMP_DELAY = 1000;
     private static final String DEFAULT_GAME_NAME = "Game";
     private static final Path TMP_SAVES_FOLDER_PATH =
             Paths.get("out", "test", "engine-tests", "tmp", "saves").toAbsolutePath();


### PR DESCRIPTION
The `getNextGameNameWithNumber` test in `GameProviderTest.java` sporadically fails on the CI due to timing issues leading to games being saved with the same timestamp.
Locally this test consistently succeeds.

Increasing the `TIMESTAMP_DELAY` used to wait in-between to saving actions to 1 second (1000ms) hopefully reduces or helps to completely avoid timing-based failures of this test.