### PR TITLE
refactor(FlowLayout): Use same code path for drawing and calculating size

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -35,18 +35,6 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     private List<UIWidget> contents = Lists.newArrayList();
 
     /**
-     * Whether the directional flow of this layout goes from left-to-right and right-to-left.
-     * <p>
-     * The children are laid out from left-to-right by default (false), aligned at the left border of the canvas. If
-     * this toggle is explicitly enabled (true) the children are laid out right-to-left, aligned at the right border of
-     * the canvas.
-     * <p>
-     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
-     */
-    @LayoutConfig
-    private boolean rightToLeftAlign = false;
-
-    /**
      * The vertical spacing between adjacent widgets, in pixels
      */
     @LayoutConfig
@@ -75,49 +63,64 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
 
     @Override
     public void onDraw(Canvas canvas) {
-        int filledWidth = getInitializedWidgetWidth(canvas.size().x, 0);
-        int filledHeight = 0;
-        int heightOffset = 0;
-        for (UIWidget widget : contents) {
-            Vector2i size = canvas.calculatePreferredSize(widget);
-            if (rightToLeftAlign) {
-                filledWidth -= size.x;
-            }
-            if (filledWidth != getInitializedWidgetWidth(canvas.size().x, size.x) &&
-                    (filledWidth + size.x > canvas.size().x || filledWidth < 0)) {
-                heightOffset += filledHeight + verticalSpacing;
-                filledWidth = getInitializedWidgetWidth(canvas.size().x, size.x);
-                filledHeight = 0;
-            }
-            canvas.drawWidget(widget, Rect2i.createFromMinAndSize(filledWidth, heightOffset, size.x, size.y));
-            filledWidth += ((rightToLeftAlign) ? -horizontalSpacing : size.x + horizontalSpacing);
-            filledHeight = Math.max(filledHeight, size.y);
-        }
-    }
-
-    private int getInitializedWidgetWidth(int canvasSizeX, int widgetSizeX) {
-        return (rightToLeftAlign) ? canvasSizeX - widgetSizeX : 0;
+        layout(canvas, canvas.size(), true);
     }
 
     @Override
     public Vector2i getPreferredContentSize(Canvas canvas, Vector2i sizeHint) {
+        return layout(canvas, sizeHint, false);
+    }
+
+    /**
+     * Applies the flow layout to its children, arranging them in a directional flow.
+     * <p>
+     * The layout algorithm will wrap elements to a new line if adding them in the same line would exceed the bounding
+     * size. The first element of a row is placed regardless of its size, and thus may exceed the bounding size. The
+     * Flow layout attempts to stay within the preferred width, but will add new lines until all widgets have been laid
+     * out.
+     * <p>
+     * If the preferred bounding size is wider than the preferred size of the widest child the Flow layout guarantees to
+     * fit into the preferred width. There is no guarantee for the actual height.
+     *
+     * @param canvas the canvas to draw to and/or calculate sizes for
+     * @param boundingSize the boundary for this layout, may be a canvas size or a size hint
+     * @param draw whether to actually draw the widgets to the canvas
+     * @return the computed bounding box size for when arranging the widget
+     */
+    private Vector2i layout(Canvas canvas, Vector2i boundingSize, boolean draw) {
+        // current bounding box for the widgets already laid out
         Vector2i result = new Vector2i();
-        int filledWidth = 0;
-        int filledHeight = 0;
+        // current "cursor" position, always where the next widget is to be placed?
+        int widthOffset = 0;
+        // current "cursor" position, always where the next widget is to be placed
+        int heightOffset = 0;
+        // local maximum for row height
+        int rowHeight = 0;
+
         for (UIWidget widget : contents) {
             Vector2i size = canvas.calculatePreferredSize(widget);
-            if (filledWidth != 0 && filledWidth + size.x > sizeHint.x) {
-                result.x = Math.max(result.x, filledWidth);
-                result.y += filledHeight + verticalSpacing;
-                filledWidth = size.x + horizontalSpacing;
-                filledHeight = size.y;
+
+            if (widthOffset != 0 && widthOffset + horizontalSpacing + size.x <= boundingSize.x) {
+                // place widget in the current row
+                widthOffset += horizontalSpacing;
             } else {
-                filledWidth += size.x + horizontalSpacing;
-                filledHeight = Math.max(filledHeight, size.y);
+                // we need to wrap the row
+                result.x = Math.max(result.x, widthOffset);
+                result.y += rowHeight + verticalSpacing;
+                heightOffset = result.y;
+                widthOffset = 0;
+                rowHeight = 0;
             }
+
+            if (draw) {
+                canvas.drawWidget(widget, Rect2i.createFromMinAndSize(widthOffset, heightOffset, size.x, size.y));
+            }
+            widthOffset += size.x;
+            rowHeight = Math.max(rowHeight, size.y);
         }
-        result.x = Math.max(result.x, filledWidth);
-        result.y += filledHeight;
+
+        result.x = Math.max(result.x, widthOffset);
+        result.y += rowHeight;
 
         return result;
     }
@@ -170,34 +173,5 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     public FlowLayout setVerticalSpacing(int spacing) {
         this.verticalSpacing = spacing;
         return this;
-    }
-
-    /**
-     * Whether the directional flow of this layout goes from left-to-right and right-to-left.
-     * <p>
-     * If false, the children are laid out from left-to-right and aligned at the left border of the canvas. If true, the
-     * children are laid out right-to-left and aligned at the right border of the canvas.
-     * <p>
-     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
-     *
-     * @return whether the children are laid out right-to-left and aligned to the right
-     */
-    public boolean isRightToLeftAlign() {
-        return rightToLeftAlign;
-    }
-
-    /**
-     * Set whether the directional flow of this layout goes from left-to-right and right-to-left.
-     * <p>
-     * The children are laid out from left-to-right by default (false), aligned at the left border of the canvas. If
-     * this toggle is explicitly enabled (true) the children are laid out right-to-left, aligned at the right border of
-     * the canvas.
-     * <p>
-     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
-     *
-     * @param rightToLeftAlign  whether the children are laid out right-to-left and aligned to the right
-     */
-    public void setRightToLeftAlign(boolean rightToLeftAlign) {
-        this.rightToLeftAlign = rightToLeftAlign;
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -37,7 +37,7 @@ import java.util.List;
  * rendered but will take up space.
  * <p>
  * The layout may be styled as other widgets with {@link org.terasology.rendering.nui.skin.UISkin}.
- *
+ * <p>
  * The Flow layout can be configured in UI assets ({@code .ui} files):
  * <pre>
  * {@code
@@ -53,6 +53,9 @@ import java.util.List;
  */
 public class FlowLayout extends CoreLayout<LayoutHint> {
 
+    /**
+     * The ordered list of widgets to be arranged in the flow direction.
+     */
     private List<UIWidget> contents = Lists.newArrayList();
 
     /**
@@ -61,16 +64,16 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     @LayoutConfig
     private int verticalSpacing;
 
-    @Override
-    public void addWidget(UIWidget element, LayoutHint hint) {
-        contents.add(element);
-    }
-
     /**
      * The horizontal spacing between adjacent widgets, in pixels
      */
     @LayoutConfig
     private int horizontalSpacing;
+
+    @Override
+    public void addWidget(UIWidget element, LayoutHint hint) {
+        contents.add(element);
+    }
 
     @Override
     public void removeWidget(UIWidget element) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -59,6 +59,15 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     @LayoutConfig
     private int horizontalSpacing;
 
+    /**
+     * Whether the directional flow of this layout goes from left-to-right or right-to-left.
+     * <p>
+     * The children are laid out from left-to-right by default (false), aligned at the left border of the canvas. If
+     * this toggle is explicitly enabled (true) the children are laid out right-to-left, aligned at the right border of
+     * the canvas.
+     * <p>
+     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
+     */
     @LayoutConfig
     private Binding<Boolean> rightToLeftAlign = new DefaultBinding<>(false);
 
@@ -129,7 +138,8 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             }
 
             if (draw) {
-                canvas.drawWidget(widget, Rect2i.createFromMinAndSize(widthOffset, heightOffset, size.x, size.y));
+                int xPosition = isRightToLeftAlign() ? canvas.size().x - widthOffset - size.x : widthOffset;
+                canvas.drawWidget(widget, Rect2i.createFromMinAndSize(xPosition, heightOffset, size.x, size.y));
             }
             widthOffset += size.x;
             rowHeight = Math.max(rowHeight, size.y);
@@ -191,18 +201,50 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         return this;
     }
 
+    /**
+     * Whether the directional flow of this layout goes from left-to-right or right-to-left.
+     * <p>
+     * If false, the children are laid out from left-to-right and aligned at the left border of the canvas. If true, the
+     * children are laid out right-to-left and aligned at the right border of the canvas.
+     * <p>
+     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
+     *
+     * @return whether the children are laid out right-to-left or aligned to the right
+     */
     public boolean isRightToLeftAlign() {
         return rightToLeftAlign.get();
     }
 
+    /**
+     * Set whether the directional flow of this layout goes from left-to-right or right-to-left.
+     * <p>
+     * The children are laid out from left-to-right by default (false), aligned at the left border of the canvas. If
+     * this toggle is explicitly enabled (true) the children are laid out right-to-left, aligned at the right border of
+     * the canvas.
+     * <p>
+     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
+     *
+     * @param rightToLeftAlign whether the children are laid out right-to-left and aligned to the right
+     */
     public void setRightToLeftAlign(boolean rightToLeftAlign) {
         this.rightToLeftAlign.set(rightToLeftAlign);
     }
 
+    /**
+     * Bind whether the directional flow of this layout goes from left-to-right or right-to-left with given binding.
+     * <p>
+     * The directional will change whenever the given binding changes it's value. See {@link #isRightToLeftAlign()} for
+     * more details on the directional flow.
+     *
+     * @param binding the binding defining whether to to align children right-to-left or left-to-right.
+     */
     public void bindRightToLeftAlign(Binding<Boolean> binding) {
         this.rightToLeftAlign = binding;
     }
 
+    /**
+     * Clear any binding to the the right-to-left align property and reset to the default value (false).
+     */
     public void clearRightToLeftAlignBinding() {
         this.rightToLeftAlign = new DefaultBinding<>(false);
     }

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -28,7 +28,28 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
+ * The Flow layout arranges its children in a directional flow that wraps at the layout's boundary, very much like words
+ * wrap at the end of a line when writing a text. The children are laid out in row in the flow direction, each widget
+ * sized by its preferred size. The individual elements are top-aligned, and wrapped at the first element that does not
+ * fit in the row.
+ * <p>
+ * Flow lays out each managed child regardless of the child's visible property value - invisible children won't be
+ * rendered but will take up space.
+ * <p>
+ * The layout may be styled as other widgets with {@link org.terasology.rendering.nui.skin.UISkin}.
  *
+ * The Flow layout can be configured in UI assets ({@code .ui} files):
+ * <pre>
+ * {@code
+ * {
+ *   "type": "FlowLayout",
+ *   "verticalSpacing": 8,
+ *   "horizontalSpacing": 24,
+ *   "contents": [...]
+ *   // all properties of AbstractWidget
+ * }
+ * }
+ * </pre>
  */
 public class FlowLayout extends CoreLayout<LayoutHint> {
 

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.rendering.nui.layouts;
 
 import com.google.common.collect.Lists;

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -127,7 +127,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
             if (widthOffset != 0 && widthOffset + horizontalSpacing + size.x <= boundingSize.x) {
                 // place widget in the current row
                 widthOffset += horizontalSpacing;
-            } else {
+            } else if (widthOffset != 0) {
                 // we need to wrap the row
                 result.x = Math.max(result.x, widthOffset);
                 result.y += rowHeight + verticalSpacing;

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -10,6 +10,8 @@ import org.terasology.rendering.nui.CoreLayout;
 import org.terasology.rendering.nui.LayoutConfig;
 import org.terasology.rendering.nui.LayoutHint;
 import org.terasology.rendering.nui.UIWidget;
+import org.terasology.rendering.nui.databinding.Binding;
+import org.terasology.rendering.nui.databinding.DefaultBinding;
 
 import java.util.Iterator;
 import java.util.List;
@@ -56,6 +58,9 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
      */
     @LayoutConfig
     private int horizontalSpacing;
+
+    @LayoutConfig
+    private Binding<Boolean> rightToLeftAlign = new DefaultBinding<>(false);
 
     @Override
     public void addWidget(UIWidget element, LayoutHint hint) {
@@ -184,5 +189,21 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     public FlowLayout setVerticalSpacing(int spacing) {
         this.verticalSpacing = spacing;
         return this;
+    }
+
+    public boolean isRightToLeftAlign() {
+        return rightToLeftAlign.get();
+    }
+
+    public void setRightToLeftAlign(boolean rightToLeftAlign) {
+        this.rightToLeftAlign.set(rightToLeftAlign);
+    }
+
+    public void bindRightToLeftAlign(Binding<Boolean> binding) {
+        this.rightToLeftAlign = binding;
+    }
+
+    public void clearRightToLeftAlignBinding() {
+        this.rightToLeftAlign = new DefaultBinding<>(false);
     }
 }


### PR DESCRIPTION
With this PR the Flow layout uses the same code path to compute the preferred size and to actually draw the widgets on screen. @stefaniamak faced a couple of quirks where the computed size was different from the layout chosen by `onDraw` when adding horizontal and vertical spacing (#4089 and #4090).

In addition, this PR fixes a few Checkstyle rules and adds more JavaDoc, partially taken from the documentation at https://terasology.org/TeraNUI/layouts/flow-layout.html.

I've only tested this PR with Light and Shadow locally. Should do another round of testing with other game modes to see if everything still works as expected.