### PR TITLE
feat(FlowLayout): Add option for right-to-left align

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -35,8 +35,13 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     private List<UIWidget> contents = Lists.newArrayList();
 
     /**
-     * The alignment of widgets; true = left-to-right align, no change / false = right-to-left
-     * This variable shall be set true only within the ui file that the FlowLayout is used
+     * Whether the directional flow of this layout goes from left-to-right and right-to-left.
+     * <p>
+     * The children are laid out from left-to-right by default (false), aligned at the left border of the canvas. If
+     * this toggle is explicitly enabled (true) the children are laid out right-to-left, aligned at the right border of
+     * the canvas.
+     * <p>
+     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
      */
     @LayoutConfig
     private boolean rightToLeftAlign = false;
@@ -136,7 +141,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         return horizontalSpacing;
     }
 
-     /**
+    /**
      * Retrieves the vertical spacing between adjacent widgets in this {@code FlowLayout}.
      *
      * @return The spacing, in pixels

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -69,20 +69,28 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
 
     @Override
     public void onDraw(Canvas canvas) {
-        int filledWidth = 0;
+        int filledWidth = ((leftToRightAlign) ? canvas.size().x : 0);
         int filledHeight = 0;
         int heightOffset = 0;
         for (UIWidget widget : contents) {
             Vector2i size = canvas.calculatePreferredSize(widget);
-            if (filledWidth != 0 && filledWidth + size.x > canvas.size().x) {
+            if(leftToRightAlign) {
+                filledWidth -= size.x;
+            }
+            if (filledWidth != getInitializedWidgetWidth(canvas.size().x, size.x) &&
+                    (filledWidth + size.x > canvas.size().x || filledWidth < 0)) {
                 heightOffset += filledHeight + verticalSpacing;
-                filledWidth = 0;
+                filledWidth = getInitializedWidgetWidth(canvas.size().x, size.x);
                 filledHeight = 0;
             }
             canvas.drawWidget(widget, Rect2i.createFromMinAndSize(filledWidth, heightOffset, size.x, size.y));
-            filledWidth += size.x + horizontalSpacing;
+            filledWidth += ((leftToRightAlign) ? -horizontalSpacing : size.x + horizontalSpacing);
             filledHeight = Math.max(filledHeight, size.y);
         }
+    }
+
+    private int getInitializedWidgetWidth(int canvasSizeX, int widgetSizeX){
+        return (leftToRightAlign) ? canvasSizeX - widgetSizeX : 0;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -35,6 +35,12 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     private List<UIWidget> contents = Lists.newArrayList();
 
     /**
+     * The alignment of widgets
+     */
+    @LayoutConfig
+    private boolean leftToRightAlign = false;
+
+    /**
      * The vertical spacing between adjacent widgets, in pixels
      */
     @LayoutConfig

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -70,7 +70,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
 
     @Override
     public void onDraw(Canvas canvas) {
-        int filledWidth = ((leftToRightAlign) ? canvas.size().x : 0);
+        int filledWidth = getInitializedWidgetWidth(canvas.size().x, 0);
         int filledHeight = 0;
         int heightOffset = 0;
         for (UIWidget widget : contents) {

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -35,7 +35,8 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
     private List<UIWidget> contents = Lists.newArrayList();
 
     /**
-     * The alignment of widgets
+     * The alignment of widgets; true = left-to-right align, no change / false = right-to-left
+     * This variable shall be set true only within the ui file that the FlowLayout is used
      */
     @LayoutConfig
     private boolean leftToRightAlign = false;

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -39,7 +39,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
      * This variable shall be set true only within the ui file that the FlowLayout is used
      */
     @LayoutConfig
-    private boolean leftToRightAlign = false;
+    private boolean rightToLeftAlign = false;
 
     /**
      * The vertical spacing between adjacent widgets, in pixels
@@ -75,7 +75,7 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         int heightOffset = 0;
         for (UIWidget widget : contents) {
             Vector2i size = canvas.calculatePreferredSize(widget);
-            if(leftToRightAlign) {
+            if (rightToLeftAlign) {
                 filledWidth -= size.x;
             }
             if (filledWidth != getInitializedWidgetWidth(canvas.size().x, size.x) &&
@@ -85,13 +85,13 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
                 filledHeight = 0;
             }
             canvas.drawWidget(widget, Rect2i.createFromMinAndSize(filledWidth, heightOffset, size.x, size.y));
-            filledWidth += ((leftToRightAlign) ? -horizontalSpacing : size.x + horizontalSpacing);
+            filledWidth += ((rightToLeftAlign) ? -horizontalSpacing : size.x + horizontalSpacing);
             filledHeight = Math.max(filledHeight, size.y);
         }
     }
 
-    private int getInitializedWidgetWidth(int canvasSizeX, int widgetSizeX){
-        return (leftToRightAlign) ? canvasSizeX - widgetSizeX : 0;
+    private int getInitializedWidgetWidth(int canvasSizeX, int widgetSizeX) {
+        return (rightToLeftAlign) ? canvasSizeX - widgetSizeX : 0;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java
@@ -171,4 +171,33 @@ public class FlowLayout extends CoreLayout<LayoutHint> {
         this.verticalSpacing = spacing;
         return this;
     }
+
+    /**
+     * Whether the directional flow of this layout goes from left-to-right and right-to-left.
+     * <p>
+     * If false, the children are laid out from left-to-right and aligned at the left border of the canvas. If true, the
+     * children are laid out right-to-left and aligned at the right border of the canvas.
+     * <p>
+     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
+     *
+     * @return whether the children are laid out right-to-left and aligned to the right
+     */
+    public boolean isRightToLeftAlign() {
+        return rightToLeftAlign;
+    }
+
+    /**
+     * Set whether the directional flow of this layout goes from left-to-right and right-to-left.
+     * <p>
+     * The children are laid out from left-to-right by default (false), aligned at the left border of the canvas. If
+     * this toggle is explicitly enabled (true) the children are laid out right-to-left, aligned at the right border of
+     * the canvas.
+     * <p>
+     * This toggle can be set programmatically or in {@code .ui} files that use the Flow layout.
+     *
+     * @param rightToLeftAlign  whether the children are laid out right-to-left and aligned to the right
+     */
+    public void setRightToLeftAlign(boolean rightToLeftAlign) {
+        this.rightToLeftAlign = rightToLeftAlign;
+    }
 }


### PR DESCRIPTION
## Contains

### Summary

Enhancement of FlowLayout: option to change the left-to-right align of included items that it has, to a right-to-left align.

### Additions

Added a variable named `rightToLeftAlign`, by which the module chooses which type of aligning to use at its FlowLayout.

#### Before the use of `rightToLeftAlign`

Before reaching the presented changes, I had changed the code as for it to apply only left-to-right alignment. Afterwards, I incorporated the boolean and combined the before and after. Seeing the merged version right away might be tricky to get what is for which alignment, thus, you can check:

 - left-to-right  code here:
https://github.com/MovingBlocks/Terasology/blob/7a86cd19a2f436740c87513166a58acf091897f7/engine/src/main/java/org/terasology/rendering/nui/layouts/FlowLayout.java#L65-L80
 - right-to-left code here:
```java
public void onDraw(Canvas canvas) {
        int filledWidth = canvas.size().x;
        int filledHeight = 0;
        int heightOffset = 0;
        for (UIWidget widget : contents) {
            Vector2i size = canvas.calculatePreferredSize(widget);
            filledWidth -= size.x;
            if (filledWidth != canvas.size().x - size.x && filledWidth < 0) {
                heightOffset += filledHeight + verticalSpacing;
                filledWidth = canvas.size().x - size.x;
                filledHeight = 0;
            }
            canvas.drawWidget(widget, Rect2i.createFromMinAndSize(filledWidth, heightOffset, size.x, size.y));
            filledWidth -= horizontalSpacing;
            filledHeight = Math.max(filledHeight, size.y);
        }
    }
}
```

Basically:
-  anchor point of first item in a row
     - **left-to-right** anchor point is 0
     - **right-to-left** anchor point is the canvas width minus the widget length
 - wrapping
     - **left-to-right** wraps up when the widget's width exceeds the remaining space at the row
     - **right-to-left** wraps up when the next widget's anchor point is below 0 (can't start from outside the FlowLayout!)

### How to test

1. Check https://github.com/Terasology/LightAndShadow/pull/141
2. Start a LAS game
3. Notice the quickslot's items _(should get the 1st result screenshot below)_

_or_ if you don't want to test it with LightAndShadow, you can:

1. Find a `.ui` file that uses a FlowLayout - in which are added **at least** 2 items/widgets
2. add the line `"rightToLeftAlign": true,` right below the line `"type": "flowLayout",`
3. run the module you applied the changes at, and check that flowLayout's included item's aligning. Result should be that items are added from right-to-left instead of the original left-to-right

### Outstanding before merging

I am not that fond of how many times I check if `rightToLeftAlign` boolean is true, but I wanted to avoid repeating the rest of the code as much as possible.

#### Result
![image](https://user-images.githubusercontent.com/48293545/88983903-eb409780-d2d4-11ea-913f-5a3ed54132e4.png) ![image](https://user-images.githubusercontent.com/48293545/88983917-f1367880-d2d4-11ea-96c0-6afd36a49808.png)
