### PR TITLE
feat(JOML): Migrate BackdropProvider and Skysphere

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/backdrop/BackdropProvider.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/BackdropProvider.java
@@ -15,7 +15,8 @@
  */
 package org.terasology.rendering.backdrop;
 
-import org.terasology.math.geom.Vector3f;
+
+import org.joml.Vector3f;
 
 /**
  * Implementations of this interface provide read and/or write access to the backdrop,

--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -15,12 +15,12 @@
  */
 package org.terasology.rendering.backdrop;
 
+import org.joml.Vector3f;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Sphere;
 import org.terasology.context.Context;
 import org.terasology.utilities.Assets;
 import org.terasology.math.TeraMath;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.nui.properties.Range;
@@ -130,7 +130,7 @@ public class Skysphere implements BackdropProvider, BackdropRenderer {
 
         // Moonlight flip
         if (moonlightFlip && sunDirection.y < 0.0f) {
-            sunDirection.scale(-1.0f);
+            sunDirection.mul(-1.0f);
         }
 
         return sunDirection;


### PR DESCRIPTION
The methods in this PR are migrated over in the process of fixing the problem with light shafts in https://github.com/Terasology/CoreRendering/pull/20. Testing this in an omega workspace and verifying it with a couple different modules should be sufficient.