### PR TITLE
fix: Increase connection timeout for clients as heavier module setups can take a while

### DIFF
--- a/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
+++ b/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
@@ -60,7 +60,7 @@ public class ClientConnectionHandler extends SimpleChannelUpstreamHandler {
     private long lengthReceived;
     private Timer timeoutTimer = new Timer();
     private long timeoutPoint = System.currentTimeMillis();
-    private final long timeoutThreshold = 10000;
+    private final long timeoutThreshold = 60000;
     private Channel channel;
 
     /**


### PR DESCRIPTION
Our JS (now including ClimateConditions, WildAnimals, etc) play test server was taking too long for clients to successfully connect before timing out. This seems to fix it.