### PR TITLE
perf: simplified check for rendering ready.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -380,10 +380,6 @@ class RenderableWorldImpl implements RenderableWorld {
         return chunk.isReady();
     }
 
-    private boolean areSurroundingChunksLoaded(RenderableChunk chunk) {
-        return worldProvider.getWorldViewAround(chunk.getPosition()) != null;
-    }
-
     private boolean isChunkVisibleFromMainLight(RenderableChunk chunk) {
         return isChunkVisible(shadowMapCamera, chunk); //TODO: find an elegant way
     }

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -377,7 +377,7 @@ class RenderableWorldImpl implements RenderableWorld {
     }
 
     private boolean isChunkValidForRender(RenderableChunk chunk) {
-        return chunk.isReady() && areSurroundingChunksLoaded(chunk);
+        return chunk.isReady();
     }
 
     private boolean areSurroundingChunksLoaded(RenderableChunk chunk) {


### PR DESCRIPTION
### Contains

Remove unnecessary check for rendering ready.
Removed condition saves 10ms-15ms. (activity "Queueing Visible Chunks" takes ~18ms)
Removed condition check that near chunks ready too. It's useless because LightMerger(chunk final loading) made it valid for rendering early.

Fixes #4007 

### How to test
Try compare FPS changes :(
Or compare "Queueing Visible Chunks" activity changes.
