### PR TITLE
slab stacking, block family refactor

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/AbstractBlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AbstractBlockFamily.java
@@ -16,7 +16,12 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Sets;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.terasology.math.JomlUtil;
+import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
+import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.BlockUri;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.shapes.BlockShape;
@@ -28,11 +33,6 @@ public abstract class AbstractBlockFamily implements BlockFamily {
 
     private BlockUri uri;
     private Set<String> categories = Sets.newHashSet();
-
-    protected AbstractBlockFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
-        setBlockUri(new BlockUri(definition.getUrn()));
-        setCategory(definition.getCategories());
-    }
 
     protected AbstractBlockFamily(BlockFamilyDefinition definition, BlockBuilderHelper blockBuilder) {
         setBlockUri(new BlockUri(definition.getUrn()));
@@ -49,6 +49,29 @@ public abstract class AbstractBlockFamily implements BlockFamily {
         uri = newUri;
     }
 
+
+    @Override
+    public BlockPlacement calculateBlockPlacement(BlockPlacementData blockPlacementData) {
+        Vector3i position = calculateStandardAttachmentPosition(blockPlacementData);
+
+        Block block = getBlockForPlacement(blockPlacementData, position);
+
+        return new BlockPlacement(position, block);
+    }
+
+    /**
+     * Get the block that is appropriate for placement in the given situation,
+     * which is determined by the provided block placement data.
+     *
+     * @param data block placement data
+     * @return The appropriate block
+     */
+    protected abstract Block getBlockForPlacement(BlockPlacementData data, Vector3ic position);
+
+    protected Vector3i calculateStandardAttachmentPosition(BlockPlacementData blockPlacementData) {
+        Vector3ic attachmentDirection = blockPlacementData.attachmentSide.direction();
+        return blockPlacementData.targetPosition.add(attachmentDirection, new Vector3i());
+    }
 
     @Override
     public BlockUri getURI() {
@@ -68,6 +91,11 @@ public abstract class AbstractBlockFamily implements BlockFamily {
     @Override
     public boolean hasCategory(String category) {
         return categories.contains(category.toLowerCase(Locale.ENGLISH));
+    }
+
+    @Override
+    public boolean canBlockReplace(Block targetBlock, Block replacingBlock) {
+        return targetBlock.isReplacementAllowed() && !targetBlock.isTargetable();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.math.Pitch;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
@@ -38,12 +39,11 @@ import java.util.Map;
         @MultiSection(name = "sides", coversSection = "front", appliesToSections = {"front", "left", "right", "back"})})
 public class AttachedToSurfaceFamily extends AbstractBlockFamily {
 
-
     private Map<Side, Block> blocks = Maps.newEnumMap(Side.class);
     private Block archetype;
 
     public AttachedToSurfaceFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
-        super(definition, shape, blockBuilder);
+        super(definition, blockBuilder);
         throw new UnsupportedOperationException("Freeform blocks not supported");
     }
 
@@ -83,13 +83,8 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
     }
 
     @Override
-    public Block getBlockForPlacement(BlockPlacementData data) {
+    protected Block getBlockForPlacement(BlockPlacementData data, Vector3ic position) {
         return blocks.get(data.attachmentSide);
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        return blocks.get(attachmentSide);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.family;
 
+import org.joml.Vector3ic;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
@@ -40,25 +41,13 @@ public interface BlockFamily {
     String getDisplayName();
 
     /**
-     * Get the block that is appropriate for placement in the given situation,
-     * which is determined by the provided block placement data.
+     * Ask the block family to calculate where to place a new block when the block
+     * family is the target block.
      *
-     * @param data block placement data
-     * @return The appropriate block
+     * @param blockPlacementData context data needed to make the placement decision.
+     * @return the block and position
      */
-    Block getBlockForPlacement(BlockPlacementData data);
-
-    /**
-     * Get the block that is appropriate for placement in the given situation
-     *
-     * @param location            The location where the block is going to be placed.
-     * @param attachmentSide      The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
-     * @param direction           A secondary direction after the attachment side that determines the facing of the block.
-     * @return The appropriate block
-     * @deprecated This method is scheduled for removal, use this one instead: {@link #getBlockForPlacement(BlockPlacementData)}.
-     */
-    @Deprecated
-    Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction);
+    BlockPlacement calculateBlockPlacement(BlockPlacementData blockPlacementData);
 
     /**
      * @return The base block defining the block group. Can be used for orientation-irrelevant behaviours
@@ -82,6 +71,14 @@ public interface BlockFamily {
      * @return An iterator over the categories this block family belongs to
      */
     Iterable<String> getCategories();
+
+    /**
+     * The BlockFamily can determine if a replacingBlock can be
+     * @param targetBlock       Block that would be replaced.
+     * @param replacingBlock    Block that would replace the targetBlock.
+     * @return whether the block family will permit the replacement
+     */
+    boolean canBlockReplace(Block targetBlock, Block replacingBlock);
 
     /**
      * @param category

--- a/engine/src/main/java/org/terasology/world/block/family/BlockPlacement.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockPlacement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.world.block.family;
+
+import org.joml.Vector3ic;
+
+import org.terasology.world.block.Block;
+
+/**
+ * A class representing a placement decision about what block to place and where.
+ */
+public class BlockPlacement {
+    public final Vector3ic position;
+    public final Block block;
+
+    public BlockPlacement(Vector3ic position, Block block) {
+        this.position = position;
+        this.block = block;
+
+        assert(block != null);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockPlacementData.java
@@ -20,9 +20,13 @@ import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
-import org.joml.Vector3i;
 import org.joml.Vector3ic;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockComponent;
 
 /**
  * BlockPlacementData represents data that is useful for determining the orientation of new block.
@@ -32,9 +36,19 @@ import org.terasology.math.Side;
 public class BlockPlacementData {
 
     /**
-     * The block position, at which the block is supposed to be placed at
+     * The target entity (a block) to which this block is being attached or replaced.
      */
-    public final Vector3ic blockPosition;
+    public final EntityRef target;
+
+    /**
+     * The target block to which this block is being attached or replaced.
+     */
+    public final Block targetBlock;
+
+    /**
+     * The position of the target block to which the new block is being attached.
+     */
+    public final Vector3ic targetPosition;
 
     /**
      * The block side, this block is being attached to, e.g. Top if the block is being placed on the ground
@@ -52,24 +66,18 @@ public class BlockPlacementData {
     public final Vector2fc relativeAttachmentPosition;
 
     /**
-     * @param blockPosition     The block position, at which the block is supposed to be placed at
-     * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
-     * @param viewingDirection  The players viewing direction
-     */
-    public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection) {
-        this(blockPosition, attachmentSide, viewingDirection, new Vector2f());
-    }
-
-    /**
-     * @param blockPosition     The block position, at which the block is supposed to be placed at
+     * @param target    The target block indicated by the placement
      * @param attachmentSide    The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
      * @param viewingDirection  The players viewing direction
      * @param relativeAttachmentPosition The position on the block surface that the user aimed at when placing the block. A vector in the range (0..1, 0..1)
      */
-    public BlockPlacementData(Vector3ic blockPosition, Side attachmentSide, Vector3fc viewingDirection, Vector2fc relativeAttachmentPosition) {
-        this.blockPosition = new Vector3i(Preconditions.checkNotNull(blockPosition));
+    public BlockPlacementData(EntityRef target, Side attachmentSide, Vector3fc viewingDirection,
+                              Vector2fc relativeAttachmentPosition, WorldProvider worldProvider) {
+        this.target = Preconditions.checkNotNull(target);
         this.attachmentSide = Preconditions.checkNotNull(attachmentSide);
         this.viewingDirection = new Vector3f(Preconditions.checkNotNull(viewingDirection));
         this.relativeAttachmentPosition = new Vector2f(Preconditions.checkNotNull(relativeAttachmentPosition));
+        this.targetPosition = JomlUtil.from(target.getComponent(BlockComponent.class).position);
+        this.targetBlock = worldProvider.getBlock(targetPosition.x(), targetPosition.y(), targetPosition.z());
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.math.Pitch;
 import org.terasology.math.Roll;
 import org.terasology.math.Rotation;
@@ -121,22 +122,20 @@ public class CeilingSupportingHorizontalFamily extends AbstractBlockFamily {
     }
 
     @Override
-    public Block getBlockForPlacement(BlockPlacementData data) {
+    protected void setBlockUri(BlockUri newUri) {
+        super.setBlockUri(newUri);
+    }
+
+    @Override
+    protected Block getBlockForPlacement(BlockPlacementData data, Vector3ic position) {
         boolean upsideDownPlacement = data.attachmentSide == Side.BOTTOM
                 || data.attachmentSide != Side.TOP && data.relativeAttachmentPosition.y() > 0.5;
         final Side mainSide = upsideDownPlacement ? Side.BOTTOM : Side.TOP;
 
         Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
-        return blocks.get(ExtendedSide.getExtendedSideFor(mainSide, blockDirection));
-    }
+        Block block = blocks.get(ExtendedSide.getExtendedSideFor(mainSide, blockDirection));
 
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (attachmentSide == Side.BOTTOM) {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.BOTTOM, direction));
-        } else {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.TOP, direction));
-        }
+        return block;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.Rotation;
@@ -44,7 +45,7 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
     private Block archetypeBlock;
 
     public FreeformFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
-        super(definition, shape, blockBuilder);
+        super(definition, blockBuilder);
         BlockUri uri;
         if (CUBE_SHAPE_URN.equals(shape.getUrn())) {
             uri = new BlockUri(definition.getUrn());
@@ -74,7 +75,7 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
     }
 
     @Override
-    public Block getBlockForPlacement(BlockPlacementData data) {
+    protected Block getBlockForPlacement(BlockPlacementData data, Vector3ic position) {
         if (archetypeBlock != null) {
             return archetypeBlock;
         }
@@ -85,21 +86,6 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
             Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
             return blocks.get(blockDirection);
         }
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (archetypeBlock == null) {
-            if (attachmentSide.isHorizontal()) {
-                return blocks.get(attachmentSide);
-            }
-            if (direction != null) {
-                return blocks.get(direction);
-            } else {
-                return blocks.get(Side.FRONT);
-            }
-        }
-        return archetypeBlock;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
@@ -15,19 +15,25 @@
  */
 package org.terasology.world.block.family;
 
+import com.google.api.client.util.StringUtils;
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
+import org.terasology.registry.In;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
+import org.terasology.world.block.BlockComponent;
+import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockUri;
 import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.shapes.BlockShape;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Block group for blocks that can be oriented around the vertical axis.
@@ -39,39 +45,70 @@ import java.util.Map;
         @MultiSection(name = "topBottom", coversSection = "top", appliesToSections = {"top", "bottom"}),
         @MultiSection(name = "sides", coversSection = "front", appliesToSections = {"front", "left", "right", "back"})})
 public class HorizontalFamily extends AbstractBlockFamily implements SideDefinedBlockFamily {
-    private Map<Side, Block> blocks = Maps.newEnumMap(Side.class);
+    private final Map<Side, Block> blocks = Maps.newEnumMap(Side.class);
+
+    private final Optional<BlockUri> fullBlockUri;
+
+    @In
+    private BlockManager blockManager;
 
     public HorizontalFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
-        super(definition, shape, blockBuilder);
-        BlockUri uri;
-        if (CUBE_SHAPE_URN.equals(shape.getUrn())) {
-            uri = new BlockUri(definition.getUrn());
-        } else {
-            uri = new BlockUri(definition.getUrn(), shape.getUrn());
-        }
-        for (Rotation rot : Rotation.horizontalRotations()) {
-            Side side = rot.rotate(Side.FRONT);
-            Block block = blockBuilder.constructTransformedBlock(definition, shape, side.toString().toLowerCase(Locale.ENGLISH), rot,
-                    new BlockUri(uri, new Name(side.name())), this);
-            if (block == null) {
-                throw new IllegalArgumentException("Missing block for side: " + side.toString());
-            }
-            blocks.put(side, block);
-        }
-        setBlockUri(uri);
+        this(definition, Optional.ofNullable(shape), blockBuilder);
     }
 
     public HorizontalFamily(BlockFamilyDefinition definition, BlockBuilderHelper blockBuilder) {
-        super(definition, blockBuilder);
-        BlockUri uri = new BlockUri(definition.getUrn());
-        for (Rotation rot : Rotation.horizontalRotations()) {
-            Side side = rot.rotate(Side.FRONT);
+        this(definition, Optional.empty(), blockBuilder);
+    }
 
-            Block block = blockBuilder.constructTransformedBlock(definition, side.toString().toLowerCase(Locale.ENGLISH), rot, new BlockUri(uri, new Name(side.name())), this);
-            if (block == null) {
-                throw new IllegalArgumentException("Missing block for side: " + side.toString());
+    private HorizontalFamily(BlockFamilyDefinition definition, Optional<BlockShape> shape, BlockBuilderHelper blockBuilder) {
+        super(definition, blockBuilder);
+        fullBlockUri = Optional.ofNullable(definition.getData().getSection("top").getFullBlock()).map(BlockUri::new);
+
+        calculateBlockUri(definition, shape);
+
+        Rotation.horizontalRotations().forEach(rot -> calculateBlockForRotation(rot, definition, shape, blockBuilder));
+    }
+
+    private void calculateBlockForRotation(Rotation rot, BlockFamilyDefinition definition,
+                                           Optional<BlockShape> shape, BlockBuilderHelper blockBuilder) {
+        Side side = rot.rotate(Side.FRONT);
+        Block block;
+
+        BlockUri sideBlockUri = new BlockUri(getURI(), new Name(side.name()));
+
+        if (shape.isPresent()) {
+            block = blockBuilder.constructTransformedBlock(
+                    definition,
+                    shape.get(),
+                    side.toString().toLowerCase(Locale.ENGLISH),
+                    rot,
+                    sideBlockUri,
+                    this);
+        } else {
+            block = blockBuilder.constructTransformedBlock(
+                    definition,
+                    side.toString().toLowerCase(Locale.ENGLISH),
+                    rot,
+                    sideBlockUri,
+                    this);
+        }
+
+        if (block == null) {
+            throw new IllegalArgumentException("Missing block for side: " + side.toString());
+        }
+
+        blocks.put(side, block);
+    }
+
+    private void calculateBlockUri(BlockFamilyDefinition definition, Optional<BlockShape> shape) {
+        if (shape.isPresent()) {
+            if (CUBE_SHAPE_URN.equals(shape.get().getUrn())) {
+                setBlockUri(new BlockUri(definition.getUrn()));
+            } else {
+                setBlockUri(new BlockUri(definition.getUrn(), shape.get().getUrn()));
             }
-            blocks.put(side, block);
+        } else {
+            setBlockUri(new BlockUri(definition.getUrn()));
         }
     }
 
@@ -80,24 +117,40 @@ public class HorizontalFamily extends AbstractBlockFamily implements SideDefined
     }
 
     @Override
-    public Block getBlockForPlacement(BlockPlacementData data) {
+    public boolean canBlockReplace(Block targetBlock, Block replacingBlock) {
+        if (fullBlockUri.isPresent() && replacingBlock.getURI().getFamilyUri().equals(fullBlockUri.get())) {
+            return true;
+        } else {
+            return super.canBlockReplace(targetBlock, replacingBlock);
+        }
+    }
+
+    @Override
+    public BlockPlacement calculateBlockPlacement(BlockPlacementData data) {
+        BlockUri targetUri = data.target.getComponent(BlockComponent.class).block.getURI().getFamilyUri();
+
+        if (fullBlockUri.isPresent() && targetUri.equals(getURI()) && data.attachmentSide == Side.TOP) {
+
+            Side side = data.targetBlock.getRotation().rotate(Side.FRONT);
+            BlockUri sideUri = new BlockUri(fullBlockUri.get(), new Name(side.name()));
+            Optional<Block> sideBlock = Optional.ofNullable(blockManager.getBlock(sideUri));
+
+            Block block = sideBlock.orElseGet(() -> blockManager.getBlock(fullBlockUri.get()));
+            assert(block != null);
+
+            return new BlockPlacement(data.targetPosition, block);
+        } else {
+            return super.calculateBlockPlacement(data);
+        }
+    }
+
+    @Override
+    protected Block getBlockForPlacement(BlockPlacementData data, Vector3ic position) {
         if (data.attachmentSide.isHorizontal()) {
             return blocks.get(data.attachmentSide);
         } else {
             Side secondaryDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
             return blocks.get(secondaryDirection);
-        }
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (attachmentSide.isHorizontal()) {
-            return blocks.get(attachmentSide);
-        }
-        if (direction != null) {
-            return blocks.get(direction);
-        } else {
-            return blocks.get(Side.FRONT);
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import gnu.trove.map.TByteObjectMap;
 import gnu.trove.map.hash.TByteObjectHashMap;
 import org.joml.Vector3f;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.JomlUtil;
@@ -66,7 +67,7 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      * @param blockBuilder The builder to make the blocks for the family
      */
     public MultiConnectFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
-        super(definition, shape, blockBuilder);
+        super(definition, blockBuilder);
     }
 
     /**
@@ -161,23 +162,16 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      * {@inheritDoc}
      */
     @Override
-    public Block getBlockForPlacement(BlockPlacementData data) {
+    protected Block getBlockForPlacement(BlockPlacementData data, Vector3ic position) {
+        Vector3i location = JomlUtil.from(position);
+
         byte connections = 0;
         for (Side connectSide : SideBitFlag.getSides(getConnectionSides())) {
-            if (this.connectionCondition(JomlUtil.from(data.blockPosition), connectSide)) {
+            if (this.connectionCondition(location, connectSide)) {
                 connections += SideBitFlag.getSide(connectSide);
             }
         }
         return blocks.get(connections);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        BlockPlacementData data = new BlockPlacementData(JomlUtil.from(location), null, new Vector3f());
-        return getBlockForPlacement(data);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.family;
 
+import org.joml.Vector3ic;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
@@ -34,7 +35,7 @@ public class SymmetricFamily extends AbstractBlockFamily {
     private Block block;
 
     public SymmetricFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
-        super(definition, shape, blockBuilder);
+        super(definition, blockBuilder);
         BlockUri uri;
         if (CUBE_SHAPE_URN.equals(shape.getUrn())) {
             uri = new BlockUri(definition.getUrn());
@@ -53,12 +54,7 @@ public class SymmetricFamily extends AbstractBlockFamily {
     }
 
     @Override
-    public Block getBlockForPlacement(BlockPlacementData data) {
-        return block;
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
+    protected Block getBlockForPlacement(BlockPlacementData data, Vector3ic position) {
         return block;
     }
 

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
@@ -218,6 +218,8 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
             setBoolean(data::setWater, jsonObject, "water");
             setBoolean(data::setGrass, jsonObject, "grass");
             setBoolean(data::setIce, jsonObject, "ice");
+
+            setString(data::setFullBlock, jsonObject, "fullBlock");
         }
 
         private <T> void readBlockPartMap(JsonObject jsonObject, String singleName,

--- a/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
@@ -66,6 +66,7 @@ public class SectionDefinitionData {
     private boolean water;
     private boolean grass;
     private boolean ice;
+    private String fullBlock;
 
     public SectionDefinitionData() {
     }
@@ -108,6 +109,8 @@ public class SectionDefinitionData {
         this.water = other.water;
         this.grass = other.grass;
         this.ice = other.ice;
+
+        this.fullBlock = other.fullBlock;
     }
 
     public String getDisplayName() {
@@ -334,5 +337,13 @@ public class SectionDefinitionData {
 
     public void setIce(boolean ice) {
         this.ice = ice;
+    }
+
+    public String getFullBlock() {
+        return fullBlock;
+    }
+
+    public void setFullBlock(String fullBlock) {
+        this.fullBlock = fullBlock;
     }
 }


### PR DESCRIPTION
The main intention of this commit is to permit the horizontal block
family to stack correctly.  In other voxel worlds, half blocks can
be replaced in the voxel with a full block of a similar type (wood
slab with full wood block).  This commit does not attempt to handle
placing blocks on the underside since that requires a little more
work on the physics and targeting systems for blocks.

One observation about the state of the situation is that a lot of
the block placement decision making is done by BlockItemSystem
instead of the block families.  This commit takes the position that
these decisions should be parameterized by the target block family
and the placing block family.

While refactoring to move some of this power to BlockFamily, some
of the previous deprecated or vestigial constructors and methods
were also cleaned up.  Some of this looked to be unreachable
code.

This commit was tested by modifying the core assets library to have
CoreAssets:HalfPlank with a fullBlock := CoreAssets:Plank.

<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Brief description of what the PR does like "Fixes #12345"

### How to test

Brief description of how to test / confirm this PR before merging

### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [ ] Need to consider use case x
- [ ] Still have to adjust the wiki doc
- [ ] Will need translation work
