### PR TITLE
Use new NUI release with some fixes

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -141,8 +141,8 @@ dependencies {
     api group: 'org.terasology.bullet', name: 'tera-bullet', version: '1.3.2'
     api group: 'org.terasology', name: 'splash-screen', version: '1.0.2'
     api group: 'org.terasology.jnlua', name: 'JNLua', version: '0.1.0-SNAPSHOT'
-    api group: 'org.terasology.nui', name: 'nui', version: '1.1.0'
-    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.1.0'
+    api group: 'org.terasology.nui', name: 'nui', version: '1.2.0-SNAPSHOT'
+    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.2.0-SNAPSHOT'
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     api fileTree(dir: 'libs', include: '*.jar')

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     api group: 'org.terasology', name: 'splash-screen', version: '1.0.2'
     api group: 'org.terasology.jnlua', name: 'JNLua', version: '0.1.0-SNAPSHOT'
     api group: 'org.terasology.nui', name: 'nui', version: '1.2.0-SNAPSHOT'
-    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.2.0-SNAPSHOT'
+    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.2.0'
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     api fileTree(dir: 'libs', include: '*.jar')

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
@@ -11,7 +11,6 @@ import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.nui.Border;
-import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 import org.terasology.nui.HorizontalAlign;
 import org.terasology.nui.ScaleMode;

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessCanvasRenderer.java
@@ -12,6 +12,7 @@ import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.nui.Border;
 import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
 import org.terasology.nui.HorizontalAlign;
 import org.terasology.nui.ScaleMode;
 import org.terasology.nui.UITextureRegion;
@@ -50,7 +51,7 @@ public class HeadlessCanvasRenderer implements TerasologyCanvasRenderer {
     }
 
     @Override
-    public void drawLine(int sx, int sy, int ex, int ey, Color color) {
+    public void drawLine(int sx, int sy, int ex, int ey, Colorc color) {
         // Do nothing
     }
 
@@ -65,12 +66,12 @@ public class HeadlessCanvasRenderer implements TerasologyCanvasRenderer {
     }
 
     @Override
-    public void drawTexture(UITextureRegion texture, Color color, ScaleMode mode, Rectanglei absoluteRegion, float ux, float uy, float uw, float uh, float alpha) {
+    public void drawTexture(UITextureRegion texture, Colorc color, ScaleMode mode, Rectanglei absoluteRegion, float ux, float uy, float uw, float uh, float alpha) {
         // Do nothing
     }
 
     @Override
-    public void drawText(String text, Font font, HorizontalAlign hAlign, VerticalAlign vAlign, Rectanglei absoluteRegion, Color color, Color shadowColor,
+    public void drawText(String text, Font font, HorizontalAlign hAlign, VerticalAlign vAlign, Rectanglei absoluteRegion, Colorc color, Colorc shadowColor,
                          float alpha, boolean underlined) {
         // Do nothing
     }

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
@@ -17,7 +17,6 @@ package org.terasology.rendering.assets.font;
 
 import com.google.common.collect.Maps;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 import org.terasology.nui.HorizontalAlign;
 import org.terasology.nui.FontColor;
@@ -31,8 +30,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
-/**
- */
 public class FontMeshBuilder {
 
     private static final float SHADOW_DEPTH = -2;

--- a/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/font/FontMeshBuilder.java
@@ -18,6 +18,7 @@ package org.terasology.rendering.assets.font;
 import com.google.common.collect.Maps;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
 import org.terasology.nui.HorizontalAlign;
 import org.terasology.nui.FontColor;
 import org.terasology.nui.FontUnderline;
@@ -45,7 +46,7 @@ public class FontMeshBuilder {
         this.underlineMaterial = underlineMaterial;
     }
 
-    public Map<Material, Mesh> createTextMesh(Font font, List<String> lines, int width, HorizontalAlign alignment, Color baseColor, Color shadowColor, boolean underline) {
+    public Map<Material, Mesh> createTextMesh(Font font, List<String> lines, int width, HorizontalAlign alignment, Colorc baseColor, Colorc shadowColor, boolean underline) {
         return new Builder(font, lines, width, alignment, baseColor, shadowColor, underline).invoke();
     }
 
@@ -54,7 +55,7 @@ public class FontMeshBuilder {
         private List<String> lines;
         private int width;
         private HorizontalAlign alignment;
-        private Color shadowColor;
+        private Colorc shadowColor;
         private boolean baseUnderline;
 
         private Map<Material, MeshBuilder> meshBuilders = Maps.newLinkedHashMap();
@@ -64,10 +65,10 @@ public class FontMeshBuilder {
         private boolean currentUnderline;
         private int underlineStart = UNKNOWN;
         private int underlineEnd = UNKNOWN;
-        private Deque<Color> previousColors = new ArrayDeque<>();
-        private Color currentColor;
+        private Deque<Colorc> previousColors = new ArrayDeque<>();
+        private Colorc currentColor;
 
-        Builder(Font font, List<String> lines, int width, HorizontalAlign alignment, Color baseColor, Color shadowColor, boolean baseUnderline) {
+        Builder(Font font, List<String> lines, int width, HorizontalAlign alignment, Colorc baseColor, Colorc shadowColor, boolean baseUnderline) {
             this.font = font;
             this.lines = lines;
             this.width = width;
@@ -176,7 +177,7 @@ public class FontMeshBuilder {
             }
         }
 
-        private void addUnderline(MeshBuilder builder, int xStart, int xEnd, int underlineTop, int underlineThickness, Color color, float depth) {
+        private void addUnderline(MeshBuilder builder, int xStart, int xEnd, int underlineTop, int underlineThickness, Colorc color, float depth) {
             float bottom = (float) underlineTop + underlineThickness;
 
             Vector3f v1 = new Vector3f(xStart, underlineTop, depth);
@@ -191,7 +192,7 @@ public class FontMeshBuilder {
             builder.addTexCoord(0, 1);
         }
 
-        private void addCharacter(MeshBuilder builder, FontCharacter character, Color color, float xOffset, float yOffset, float depth) {
+        private void addCharacter(MeshBuilder builder, FontCharacter character, Colorc color, float xOffset, float yOffset, float depth) {
             float top = y + character.getyOffset() + yOffset;
             float bottom = top + character.getHeight() + yOffset;
             float left = x + character.getxOffset() + xOffset;

--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/MeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/MeshBuilder.java
@@ -16,6 +16,7 @@
 package org.terasology.rendering.assets.mesh;
 
 import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
 import org.terasology.utilities.Assets;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.geom.Vector2f;
@@ -97,12 +98,12 @@ public class MeshBuilder {
         return this;
     }
 
-    public MeshBuilder addColor(Color c1, Color... colors) {
+    public MeshBuilder addColor(Colorc c1, Colorc... colors) {
         meshData.getColors().add(c1.rf());
         meshData.getColors().add(c1.gf());
         meshData.getColors().add(c1.bf());
         meshData.getColors().add(c1.af());
-        for (Color c : colors) {
+        for (Colorc c : colors) {
             meshData.getColors().add(c.rf());
             meshData.getColors().add(c.gf());
             meshData.getColors().add(c.bf());

--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/MeshBuilder.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/MeshBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.rendering.assets.mesh;
 
-import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 import org.terasology.utilities.Assets;
 import org.terasology.assets.ResourceUrn;
@@ -23,8 +22,6 @@ import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.module.sandbox.API;
 
-/**
- */
 public class MeshBuilder {
     private static final float[] VERTICES = {
             // Front face
@@ -172,6 +169,4 @@ public class MeshBuilder {
 
         Vector2f map(int vertexIndex, float u, float v);
     }
-
-
 }

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LineRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LineRenderer.java
@@ -18,12 +18,9 @@ package org.terasology.rendering.nui.internal;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
-import org.terasology.math.geom.Rect2i;
-import org.terasology.math.geom.Vector2i;
-import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
 
 import java.nio.FloatBuffer;
-import java.util.Objects;
 
 /**
  *
@@ -49,7 +46,7 @@ public final class LineRenderer {
      * Drawing nearly perfect 2D line segments in OpenGL
      * </a>
      */
-    public static void draw(float x1, float y1, float x2, float y2, float width, Color color, Color background, float alpha) {
+    public static void draw(float x1, float y1, float x2, float y2, float width, Colorc color, Colorc background, float alpha) {
         GL20.glUseProgram(0);
         GL11.glDisable(GL11.GL_CULL_FACE);
         GL11.glEnableClientState(GL11.GL_VERTEX_ARRAY);

--- a/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -29,7 +29,7 @@ import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.nui.Border;
-import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
 import org.terasology.nui.HorizontalAlign;
 import org.terasology.nui.ScaleMode;
 import org.terasology.nui.TextLineBuilder;
@@ -247,7 +247,7 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
     }
 
     @Override
-    public void drawLine(int sx, int sy, int ex, int ey, Color color) {
+    public void drawLine(int sx, int sy, int ex, int ey, Colorc color) {
         LineRenderer.draw(sx, sy, ex, ey, 2, color, color, 0);
     }
 
@@ -272,7 +272,7 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
     }
 
     @Override
-    public void drawTexture(UITextureRegion texture, Color color, ScaleMode mode, Rectanglei absoluteRegionRectangle,
+    public void drawTexture(UITextureRegion texture, Colorc color, ScaleMode mode, Rectanglei absoluteRegionRectangle,
                             float ux, float uy, float uw, float uh, float alpha) {
         if (!((org.terasology.rendering.assets.texture.TextureRegion)texture).getTexture().isLoaded()) {
             return;
@@ -343,7 +343,7 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
 
     @Override
     public void drawText(String text, Font font, HorizontalAlign hAlign, VerticalAlign vAlign, Rectanglei absoluteRegionRectangle,
-                         Color color, Color shadowColor, float alpha, boolean underlined) {
+                         Colorc color, Colorc shadowColor, float alpha, boolean underlined) {
         Rect2i absoluteRegion = JomlUtil.from(absoluteRegionRectangle);
 
         TextCacheKey key = new TextCacheKey(text, font, absoluteRegion.width(), hAlign, color, shadowColor, underlined);
@@ -548,11 +548,11 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
         private final Font font;
         private final int width;
         private final HorizontalAlign alignment;
-        private final Color baseColor;
-        private final Color shadowColor;
+        private final Colorc baseColor;
+        private final Colorc shadowColor;
         private final boolean underlined;
 
-        TextCacheKey(String text, Font font, int maxWidth, HorizontalAlign alignment, Color baseColor, Color shadowColor, boolean underlined) {
+        TextCacheKey(String text, Font font, int maxWidth, HorizontalAlign alignment, Colorc baseColor, Colorc shadowColor, boolean underlined) {
             this.text = text;
             this.font = font;
             this.width = maxWidth;


### PR DESCRIPTION
`nuiNump` ? Oh boy. That branch name is what I get for juggling I guess. Version _bump_ for NUI, that is. At least the branch name will go away, the commit message is more proper ...

I submitted a fix from @DarkWeird via https://github.com/MovingBlocks/TeraNUI/pull/22 which will be used with this PR. It fixes an infinite serialization length issue that would cause clients trying to connect in multiplayer to hang forever and just spam the log. 

Includes #4136

Edit: Wait, didn't notice we had two NUI dependencies in Gradle - adjusting the second as I merge this