### PR TITLE
fix: Gradley weirdness about a Directory/DirectoryProperty thing

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,5 +12,5 @@
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/facades/PC/build.gradle
+++ b/facades/PC/build.gradle
@@ -345,7 +345,7 @@ task distApp (type: Sync) {
     dependsOn rootProject.extractNatives
     dependsOn jar
 
-    into ("$distsDirectory/app")
+    into ("${distsDirectory.get().asFile}/app")
     from ("$rootDir/README.markdown") {
         filter(FixCrLfFilter, eol:FixCrLfFilter.CrLf.newInstance("crlf"))
         rename('README.markdown', 'README')
@@ -384,7 +384,7 @@ task distModules (type: Sync) {
     dependsOn rootProject.moduleJars
 
     // So this is probably a hack, but it works ;-) It does not work if it is in distApp, default "into" quirk ?
-    into("$distsDirectory/app/modules")
+    into("${distsDirectory.get().asFile}/app/modules")
     rootProject.terasologyModules().each {
         from "$rootDir/modules/${it.name}/build/libs"
         include "*.jar"
@@ -395,7 +395,7 @@ task distPCZip (type: Zip) {
     group = "terasology dist"
     dependsOn distApp
     dependsOn distModules
-    from "$distsDirectory/app"
+    from "${distsDirectory.get().asFile}/app"
     archiveFileName = "Terasology.zip"
 }
 


### PR DESCRIPTION
Was causing `gradlew distPCZip` to fail on my Win10 system, despite seemingly working fine in Jenkins, with some "invalid file path" thing as the new `distsDirectory` (replacement for deprecated `distsDi`) would turn into this long awkward property thing, not a directory. I guess maybe somehow on Linux that could translate into a valid directory? Dunno. I figure this'll work on both.

Also let a `.idea/misc.xml` change slip in that keeps toggling in my workspace for some reason. Lets see if it flips back for anybody else