### PR TITLE
feat(JOML): add BlockRegion#center

### DIFF
--- a/engine/src/main/java/org/terasology/math/JomlUtil.java
+++ b/engine/src/main/java/org/terasology/math/JomlUtil.java
@@ -41,6 +41,7 @@ import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Rect2f;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.world.block.BlockRegion;
 
 public class JomlUtil {
 
@@ -127,6 +128,12 @@ public class JomlUtil {
     public static AABBf from(AABB aabb) {
         return new AABBf(aabb.minX(), aabb.minY(), aabb.minZ(), aabb.maxX(), aabb.maxY(), aabb.maxZ());
     }
+
+
+    public static BlockRegion from(Region3i aabb) {
+        return new BlockRegion(aabb.minX(), aabb.minY(), aabb.minZ(), aabb.maxX(), aabb.maxY(), aabb.maxZ());
+    }
+
 
     public static Rectanglei from(Rect2i rect) {
         return new Rectanglei(rect.minX(), rect.minY(), rect.maxX(), rect.maxY());

--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -26,6 +26,7 @@ import org.joml.Rayf;
 import org.joml.RoundingMode;
 import org.joml.Spheref;
 import org.joml.Vector2f;
+import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
@@ -402,6 +403,20 @@ public class BlockRegion {
      */
     public boolean containsBlock(Vector3ic pos) {
         return containsBlock(pos.x(), pos.y(), pos.z());
+    }
+
+    /**
+     * the center of the region
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    public Vector3f center(Vector3f dest) {
+        return dest.set(
+            (aabb.maxX - aabb.minX) / 2.0f,
+            (aabb.maxY - aabb.minY) / 2.0f,
+            (aabb.maxZ - aabb.minZ) / 2.0f
+        );
     }
 
     /**


### PR DESCRIPTION
I added a center function for BlockRegion and updated the API for the ore generation to use BlockRegion and JOML. At the moment the two modules that use CustomOreGeneration are Minesweeper and AnotherWorld. just verifying that those generate correctly seems more then ideal to see if these changes are implemented correctly.  