### PR TITLE
feat(JOML): migrate block

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,5 +12,5 @@
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,5 +12,5 @@
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayerSystem.java
@@ -378,7 +378,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
                 if (blockComp != null || blockRegion != null) {
                     Vector3f blockPos = location.getWorldPosition();
                     Block block = worldProvider.getBlock(blockPos);
-                    aabb = block.getBounds(blockPos);
+                    aabb = JomlUtil.from(block.getBounds(JomlUtil.from(blockPos)));
                 } else {
                     MeshComponent mesh = target.getComponent(MeshComponent.class);
                     if (mesh != null && mesh.mesh != null) {

--- a/engine/src/main/java/org/terasology/physics/engine/VoxelWorldSystem.java
+++ b/engine/src/main/java/org/terasology/physics/engine/VoxelWorldSystem.java
@@ -32,7 +32,6 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.StandardCollisionGroup;
 import org.terasology.physics.bullet.BulletPhysics;
@@ -108,7 +107,7 @@ public class VoxelWorldSystem extends BaseComponentSystem {
         if (!registred.contains(id)) {
             btCollisionShape shape = ((BulletCollisionShape) block.getCollisionShape()).underlyingShape;
             btVoxelInfo info = new btVoxelInfo(shape != null && block.isTargetable(),
-                shape != null && !block.isPenetrable(), id, shape, JomlUtil.from(block.getCollisionOffset()),
+                shape != null && !block.isPenetrable(), id, shape, block.getCollisionOffset(),
                 block.getFriction(), block.getRestitution(), block.getFriction());
             wrapper.setVoxelInfo(info);
             registred.add(id);

--- a/engine/src/main/java/org/terasology/world/block/Block.java
+++ b/engine/src/main/java/org/terasology/world/block/Block.java
@@ -16,18 +16,20 @@
 package org.terasology.world.block;
 
 import com.google.common.collect.Maps;
+import org.joml.AABBf;
+import org.joml.Quaternionf;
+import org.joml.RoundingMode;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
-import org.terasology.math.AABB;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.TeraMath;
 import org.terasology.math.Transform;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.Mesh;
@@ -42,7 +44,6 @@ import org.terasology.world.block.shapes.BlockMeshPart;
 import org.terasology.world.block.sounds.BlockSounds;
 import org.terasology.world.chunks.ChunkConstants;
 
-import java.math.RoundingMode;
 import java.util.Map;
 import java.util.Optional;
 
@@ -125,7 +126,7 @@ public final class Block {
     /* Collision */
     private CollisionShape collisionShape;
     private Vector3f collisionOffset;
-    private AABB bounds = AABB.createEmpty();
+    private AABBf bounds = new AABBf();
 
     public short getId() {
         return id;
@@ -582,7 +583,7 @@ public final class Block {
     public void setCollision(Vector3f offset, CollisionShape shape) {
         collisionShape = shape;
         collisionOffset = offset;
-        bounds = JomlUtil.from(shape.getAABB(new Transform(offset, new Quat4f(0, 0, 0, 1), 1.0f)));
+        bounds = shape.getAABB(new Transform(JomlUtil.from(offset), JomlUtil.from(new Quaternionf()), 1.0f));
     }
 
     public CollisionShape getCollisionShape() {
@@ -593,11 +594,11 @@ public final class Block {
         return collisionOffset;
     }
 
-    public AABB getBounds(Vector3i pos) {
-        return bounds.move(pos.toVector3f());
+    public AABBf getBounds(Vector3ic pos) {
+        return new AABBf(bounds).translate(pos.x(), pos.y(), pos.z());
     }
 
-    public AABB getBounds(Vector3f floatPos) {
+    public AABBf getBounds(Vector3f floatPos) {
         return getBounds(new Vector3i(floatPos, RoundingMode.HALF_UP));
     }
 

--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.world.block.items;
 
+import org.joml.AABBf;
 import org.joml.Vector2f;
 import org.joml.Vector3fc;
 import org.terasology.audio.AudioManager;
@@ -54,8 +55,8 @@ import java.util.Map;
 public class BlockItemSystem extends BaseComponentSystem {
 
     /**
-     * Margin and other allowed penetration is also 0.03 or 0.04.
-     * Since precision is only float it needs to be that high.
+     * Margin and other allowed penetration is also 0.03 or 0.04. Since precision is only float it needs to be that
+     * high.
      */
     private static final float ADDITIONAL_ALLOWED_PENETRATION = 0.4f;
 
@@ -94,7 +95,7 @@ public class BlockItemSystem extends BaseComponentSystem {
 
         Vector2f relativeAttachmentPosition = getRelativeAttachmentPosition(event);
         Block block = blockFamily.getBlockForPlacement(new BlockPlacementData(
-                JomlUtil.from(placementPos), surfaceSide, event.getDirection(), relativeAttachmentPosition
+            JomlUtil.from(placementPos), surfaceSide, event.getDirection(), relativeAttachmentPosition
         ));
 
         if (canPlaceBlock(block, targetBlock, placementPos)) {
@@ -128,10 +129,12 @@ public class BlockItemSystem extends BaseComponentSystem {
      * Returns the position at which the block side was hit, relative to the side.
      * <p/>
      * The specified hit position is expected to be on the surface of the cubic block at the specified position.
-     * Example: The front side was hit right in the center.
-     * The result will be (0.5, 0.5), representing the relative hit position on the side's surface.
+     * Example: The front side was hit right in the center. The result will be (0.5, 0.5), representing the relative hit
+     * position on the side's surface.
+     *
      * @param hitPosition the hit position
-     * @param blockPosition the block position relative to its center (block (0, 0, 0) has block position (0.5, 0.5, 0.5))
+     * @param blockPosition the block position relative to its center (block (0, 0, 0) has block position (0.5, 0.5,
+     *     0.5))
      * @return the 2D hit position relative to the side that was hit
      */
     private Vector2f getSideHitPosition(Vector3fc hitPosition, Vector3fc blockPosition) {
@@ -189,9 +192,9 @@ public class BlockItemSystem extends BaseComponentSystem {
         // Prevent players from placing blocks inside their bounding boxes
         if (!block.isPenetrable()) {
             Physics physics = CoreRegistry.get(Physics.class);
-            AABB blockBounds = block.getBounds(blockPos);
-            Vector3f min = new Vector3f(blockBounds.getMin());
-            Vector3f max = new Vector3f(blockBounds.getMax());
+            AABBf blockBounds = block.getBounds(JomlUtil.from(blockPos));
+            Vector3f min = new Vector3f(blockBounds.minX, blockBounds.minY, blockBounds.minZ);
+            Vector3f max = new Vector3f(blockBounds.maxX, blockBounds.maxY, blockBounds.maxZ);
 
             /**
              * Characters can enter other solid objects/blocks for certain amount. This is does to detect collsion

--- a/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/BlockFamilyDefinitionFormat.java
@@ -30,18 +30,18 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+import org.joml.Vector3f;
 import org.terasology.assets.Asset;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.prefab.Prefab;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector4f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.gson.CaseInsensitiveEnumTypeAdapterFactory;
-import org.terasology.utilities.gson.legacy.LegacyVector3fTypeAdapter;
-import org.terasology.utilities.gson.legacy.LegacyVector4fTypeAdapter;
+import org.terasology.utilities.gson.Vector3fTypeAdapter;
+import org.terasology.utilities.gson.Vector4fTypeAdapter;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.family.BlockFamilyLibrary;
@@ -81,8 +81,8 @@ public class BlockFamilyDefinitionFormat extends AbstractAssetFileFormat<BlockFa
                 .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
                 .registerTypeAdapterFactory(new AssetTypeAdapterFactory(assetManager))
                 .registerTypeAdapter(BlockFamilyDefinitionData.class, new BlockFamilyDefinitionDataHandler())
-                .registerTypeAdapter(Vector3f.class, new LegacyVector3fTypeAdapter())
-                .registerTypeAdapter(Vector4f.class, new LegacyVector4fTypeAdapter())
+                .registerTypeAdapter(Vector3f.class, new Vector3fTypeAdapter())
+                .registerTypeAdapter(Vector4f.class, new Vector4fTypeAdapter())
                 .registerTypeAdapter(Class.class, new BlockFamilyHandler())
                 .create();
     }

--- a/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
+++ b/engine/src/main/java/org/terasology/world/block/loader/SectionDefinitionData.java
@@ -16,7 +16,7 @@
 package org.terasology.world.block.loader;
 
 import com.google.common.collect.Maps;
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 import org.terasology.module.sandbox.API;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.shapes.BlockShape;

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShape.java
@@ -15,13 +15,13 @@
  */
 package org.terasology.world.block.shapes;
 
-import org.terasology.physics.shapes.CollisionShape;
+import org.joml.Vector3f;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.world.block.BlockPart;
 
 /**

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeData.java
@@ -15,11 +15,11 @@
  */
 package org.terasology.world.block.shapes;
 
-import org.terasology.physics.shapes.CollisionShape;
 import com.google.common.collect.Maps;
+import org.joml.Vector3f;
 import org.terasology.assets.AssetData;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.utilities.collection.EnumBooleanMap;
 import org.terasology.world.block.BlockPart;
 

--- a/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/BlockShapeImpl.java
@@ -15,17 +15,17 @@
  */
 package org.terasology.world.block.shapes;
 
-import org.terasology.math.JomlUtil;
-import org.terasology.physics.shapes.CollisionShape;
 import com.google.common.collect.Maps;
+import org.joml.Vector3f;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Pitch;
 import org.terasology.math.Roll;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.Yaw;
-import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.shapes.CollisionShape;
 import org.terasology.utilities.collection.EnumBooleanMap;
 import org.terasology.world.block.BlockPart;
 
@@ -103,7 +103,7 @@ public class BlockShapeImpl extends BlockShape {
         if (simplifiedRot.equals(Rotation.none())) {
             return new Vector3f(baseCollisionOffset);
         }
-        return simplifiedRot.getQuat4f().rotate(baseCollisionOffset, new Vector3f());
+        return JomlUtil.from(simplifiedRot.getQuat4f()).transform(baseCollisionOffset, new Vector3f());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
+++ b/engine/src/main/java/org/terasology/world/block/shapes/JsonBlockShapeLoader.java
@@ -193,13 +193,13 @@ public class JsonBlockShapeLoader extends AbstractAssetFileFormat<BlockShapeData
             if (colliders.size() > 1) {
                 ColliderInfo info = processCompoundShape(colliders);
                 shape.setCollisionShape(info.collisionShape);
-                shape.setCollisionOffset(JomlUtil.from(info.offset));
+                shape.setCollisionOffset(info.offset);
             } else if (colliders.size() == 1) {
                 shape.setCollisionShape(colliders.get(0).collisionShape);
-                shape.setCollisionOffset(JomlUtil.from(colliders.get(0).offset));
+                shape.setCollisionOffset(colliders.get(0).offset);
             } else {
                 shape.setCollisionShape(COLLISION_SHAPE_FACTORY.getNewUnitCube());
-                shape.setCollisionOffset(JomlUtil.from(new Vector3f(0, 0, 0)));
+                shape.setCollisionOffset(new Vector3f(0, 0, 0));
                 shape.setCollisionSymmetric(true);
             }
         }


### PR DESCRIPTION
I migrated block along with the de-serilization. this mainly affects the tint of the block and the bounds assigned to the block from the collider. The image below is a list of prefab with blocks with assigned tints that can be used to verify. The collider is a bit harder to verify if it is correct or not.

![image](https://user-images.githubusercontent.com/854359/94759200-1e92b780-0354-11eb-805c-521f83638f0c.png)




