### PR TITLE
feat(JOML): add orientation for Rotation

### DIFF
--- a/engine-tests/src/test/java/org/terasology/math/RotationTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/RotationTest.java
@@ -16,9 +16,11 @@
 package org.terasology.math;
 
 import com.google.common.collect.Iterables;
+import org.joml.Quaternionf;
 import org.junit.jupiter.api.Test;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.testUtil.TeraAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,6 +42,18 @@ public class RotationTest {
 
         assertEquals(Side.LEFT, Rotation.rotate(Yaw.CLOCKWISE_90).rotate(Side.FRONT));
         assertEquals(Side.TOP, Rotation.rotate(Yaw.CLOCKWISE_90).rotate(Side.TOP));
+    }
+
+    @Test
+    public void testOrientation() {
+        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(90.0f * TeraMath.DEG_TO_RAD,0,0), Rotation.rotate(Yaw.CLOCKWISE_90).orientation(),0.001f);
+        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(180.0f * TeraMath.DEG_TO_RAD,0,0), Rotation.rotate(Yaw.CLOCKWISE_180).orientation(),0.001f);
+
+        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,90.0f * TeraMath.DEG_TO_RAD,0), Rotation.rotate(Pitch.CLOCKWISE_90).orientation(),0.001f);
+        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,180.0f * TeraMath.DEG_TO_RAD,0), Rotation.rotate(Pitch.CLOCKWISE_180).orientation(),0.001f);
+
+        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,0,90.0f * TeraMath.DEG_TO_RAD), Rotation.rotate(Roll.CLOCKWISE_90).orientation(),0.001f);
+        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,0,180.0f * TeraMath.DEG_TO_RAD), Rotation.rotate(Roll.CLOCKWISE_180).orientation(),0.001f);
     }
 
     @Test

--- a/engine/src/main/java/org/terasology/math/Rotation.java
+++ b/engine/src/main/java/org/terasology/math/Rotation.java
@@ -15,11 +15,12 @@
  */
 package org.terasology.math;
 
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import gnu.trove.map.TByteObjectMap;
 import gnu.trove.map.hash.TByteObjectHashMap;
+import org.joml.Quaternionf;
+import org.joml.Quaternionfc;
 import org.terasology.math.geom.Quat4f;
 
 import java.util.Arrays;
@@ -41,6 +42,7 @@ public final class Rotation {
     private final Yaw yaw;
     private final Pitch pitch;
     private final Roll roll;
+    private final Quaternionfc rotation;
 
     /**
      * The index used by .rotate(), among others. Ranges from 0 to 63 (4^3-1).
@@ -52,6 +54,7 @@ public final class Rotation {
         this.yaw = yaw;
         this.roll = roll;
         this.index = indexFor(yaw, pitch, roll);
+        this.rotation = new Quaternionf().rotationYXZ(yaw.getRadians(), pitch.getRadians(), roll.getRadians());
     }
 
     public static Rotation none() {
@@ -184,9 +187,24 @@ public final class Rotation {
         return roll;
     }
 
+    /**
+     *
+     * @return
+     * @deprecated This method is scheduled for removal in an upcoming version.
+     *             Use the JOML implementation instead: {@link #orientation()}.
+     */
+    @Deprecated
     public Quat4f getQuat4f() {
-        Quat4f rotation = new Quat4f(yaw.getRadians(), pitch.getRadians(), roll.getRadians());
-        rotation.normalize();
+        Quat4f temp = new Quat4f(yaw.getRadians(), pitch.getRadians(), roll.getRadians());
+        temp.normalize();
+        return temp;
+    }
+
+    /**
+     * The orientation of the current Rotation
+     * @return The orientation
+     */
+    public Quaternionfc orientation() {
         return rotation;
     }
 


### PR DESCRIPTION
this is a squash from the change in: https://github.com/MovingBlocks/Terasology/pull/4124

This is a simple change for the orientation of the Rotation. This is just an api change that should help with migrating changes for JOML. this adds an orientation method that returns the Quaternionf instead of Quat4f (termath) . there are no direct impacts at the moment and should work in omega since I only deprecate the old method. I also updated the test case to test for consistency.  