### PR TITLE
feat(JOML): migrate FirstPeronHeldItem/Mount/Transform Component

### DIFF
--- a/engine/src/main/java/org/terasology/input/cameraTarget/PlayerTargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/PlayerTargetSystem.java
@@ -71,7 +71,7 @@ public class PlayerTargetSystem extends BaseComponentSystem implements UpdateSub
     public void update(float delta) {
         EntityRef charEntity = player.getCharacterEntity();
         if (charEntity.exists()) {
-            Vector3f cameraPos = player.getViewPosition(new org.joml.Vector3f());
+            Vector3f cameraPos = player.getViewPosition(new Vector3f());
             CharacterComponent charComp = charEntity.getComponent(CharacterComponent.class);
 
             if (charComp != null) {

--- a/engine/src/main/java/org/terasology/input/cameraTarget/PlayerTargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/PlayerTargetSystem.java
@@ -16,6 +16,8 @@
 
 package org.terasology.input.cameraTarget;
 
+import org.joml.Vector3f;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -24,8 +26,7 @@ import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.players.FirstPersonHeldItemMountPointComponent;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.PlayerTargetChangedEvent;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
+import org.terasology.math.JomlUtil;
 import org.terasology.physics.Physics;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
@@ -62,7 +63,7 @@ public class PlayerTargetSystem extends BaseComponentSystem implements UpdateSub
      * Get the position of the block that is currently targeted.
      * @return the position of the block, as a Vector3i
      */
-    public Vector3i getTargetBlockPosition() {
+    public Vector3ic getTargetBlockPosition() {
         return targetSystem.getTargetBlockPosition();
     }
 
@@ -70,16 +71,16 @@ public class PlayerTargetSystem extends BaseComponentSystem implements UpdateSub
     public void update(float delta) {
         EntityRef charEntity = player.getCharacterEntity();
         if (charEntity.exists()) {
-            Vector3f cameraPos = player.getViewPosition();
+            Vector3f cameraPos = player.getViewPosition(new org.joml.Vector3f());
             CharacterComponent charComp = charEntity.getComponent(CharacterComponent.class);
 
             if (charComp != null) {
-                Vector3f dir = player.getViewDirection();
+                Vector3f dir = player.getViewDirection(new Vector3f());
                 float maxDist = charComp.interactionRange;
                 FirstPersonHeldItemMountPointComponent heldItemMountPoint = player.getCameraEntity().getComponent(FirstPersonHeldItemMountPointComponent.class);
                 if (heldItemMountPoint != null && heldItemMountPoint.isTracked()) {
                     maxDist = heldItemMountPoint.translate.length() + 0.25f;
-                    dir = heldItemMountPoint.translate.normalize();
+                    dir = new Vector3f(heldItemMountPoint.translate).normalize();
                 }
                 if (targetSystem.updateTarget(cameraPos, dir, maxDist)) {
                     EntityRef oldTarget = targetSystem.getPreviousTarget();

--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -18,11 +18,12 @@ package org.terasology.input.cameraTarget;
 
 import java.util.Arrays;
 
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.CollisionGroup;
 import org.terasology.physics.HitResult;
 import org.terasology.physics.Physics;
@@ -50,7 +51,7 @@ public class TargetSystem {
      * a null reference (isTargetAvailable() would have returned false in this case).
      * @return the target block position in world coordinates, a vector of 3 integers.
      */
-    public Vector3i getTargetBlockPosition() {
+    public Vector3ic getTargetBlockPosition() {
         return targetBlockPos;
     }
 
@@ -76,7 +77,7 @@ public class TargetSystem {
             target = blockRegistry.getEntityAt(targetBlockPos);
         }
 
-        HitResult hitInfo = physics.rayTrace(JomlUtil.from(pos), JomlUtil.from(dir), maxDist, filter);
+        HitResult hitInfo = physics.rayTrace(pos, dir, maxDist, filter);
         EntityRef newTarget = hitInfo.getEntity();
 
         if (hitInfo.isWorldHit()) {
@@ -85,7 +86,7 @@ public class TargetSystem {
                     return false;
                 }
             }
-            targetBlockPos = JomlUtil.from(hitInfo.getBlockPosition());
+            targetBlockPos = hitInfo.getBlockPosition();
         } else {
             if (target.equals(newTarget)) {
                 return false;
@@ -98,7 +99,7 @@ public class TargetSystem {
 
         LocationComponent location = target.getComponent(LocationComponent.class);
         if (location != null && targetBlockPos != null) {
-            location.setLocalPosition(targetBlockPos.toVector3f());
+            location.setLocalPosition(new Vector3f(targetBlockPos));
         }
 
         return true;

--- a/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
+++ b/engine/src/main/java/org/terasology/input/cameraTarget/TargetSystem.java
@@ -82,7 +82,7 @@ public class TargetSystem {
 
         if (hitInfo.isWorldHit()) {
             if (targetBlockPos != null) {
-                if (targetBlockPos.equals(JomlUtil.from(hitInfo.getBlockPosition()))) {
+                if (targetBlockPos.equals(hitInfo.getBlockPosition())) {
                     return false;
                 }
             }

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonClientSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.logic.players;
 
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityBuilder;
@@ -34,8 +36,6 @@ import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.TeraMath;
-import org.terasology.math.geom.Quat4f;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.logic.VisualComponent;
@@ -84,12 +84,12 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
         // link the mount point entity to the camera
         Location.removeChild(camera, firstPersonHeldItemMountPointComponent.mountPointEntity);
         Location.attachChild(camera, firstPersonHeldItemMountPointComponent.mountPointEntity,
-                firstPersonHeldItemMountPointComponent.translate,
-                new Quat4f(
-                        TeraMath.DEG_TO_RAD * firstPersonHeldItemMountPointComponent.rotateDegrees.y,
-                        TeraMath.DEG_TO_RAD * firstPersonHeldItemMountPointComponent.rotateDegrees.x,
-                        TeraMath.DEG_TO_RAD * firstPersonHeldItemMountPointComponent.rotateDegrees.z),
-                firstPersonHeldItemMountPointComponent.scale);
+            firstPersonHeldItemMountPointComponent.translate,
+            new Quaternionf().rotationYXZ(
+                TeraMath.DEG_TO_RAD * firstPersonHeldItemMountPointComponent.rotateDegrees.y,
+                TeraMath.DEG_TO_RAD * firstPersonHeldItemMountPointComponent.rotateDegrees.x,
+                TeraMath.DEG_TO_RAD * firstPersonHeldItemMountPointComponent.rotateDegrees.z),
+            firstPersonHeldItemMountPointComponent.scale);
     }
 
     @ReceiveEvent
@@ -183,7 +183,7 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
 
                 Location.attachChild(mountPointComponent.mountPointEntity, currentHeldItem,
                         heldItemTransformComponent.translate,
-                        new Quat4f(
+                        new Quaternionf().rotationYXZ(
                                 TeraMath.DEG_TO_RAD * heldItemTransformComponent.rotateDegrees.y,
                                 TeraMath.DEG_TO_RAD * heldItemTransformComponent.rotateDegrees.x,
                                 TeraMath.DEG_TO_RAD * heldItemTransformComponent.rotateDegrees.z),
@@ -231,7 +231,7 @@ public class FirstPersonClientSystem extends BaseComponentSystem implements Upda
         }
         float addPitch = 15f * animateAmount;
         float addYaw = 10f * animateAmount;
-        locationComponent.setLocalRotation(new Quat4f(
+        locationComponent.setLocalRotation(new Quaternionf().rotationYXZ(
                 TeraMath.DEG_TO_RAD * (mountPointComponent.rotateDegrees.y + addYaw),
                 TeraMath.DEG_TO_RAD * (mountPointComponent.rotateDegrees.x + addPitch),
                 TeraMath.DEG_TO_RAD * mountPointComponent.rotateDegrees.z));

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemMountPointComponent.java
@@ -16,12 +16,12 @@
 package org.terasology.logic.players;
 
 import org.joml.Matrix4f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.Owns;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.TeraMath;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Quat4f;
 
 /**
  * Only used by the client side so that held items can be positioned in line with the camera
@@ -30,9 +30,9 @@ public class FirstPersonHeldItemMountPointComponent implements Component {
 
     @Owns
     public EntityRef mountPointEntity = EntityRef.NULL;
-    public Vector3f rotateDegrees = Vector3f.zero();
-    public Vector3f translate = Vector3f.zero();
-    public Quat4f rotationQuaternion;
+    public Vector3f rotateDegrees = new Vector3f();
+    public Vector3f translate = new Vector3f();
+    public Quaternionf rotationQuaternion;
     public float scale = 1f;
 
     private boolean trackingDataReceived;

--- a/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemTransformComponent.java
+++ b/engine/src/main/java/org/terasology/logic/players/FirstPersonHeldItemTransformComponent.java
@@ -15,11 +15,11 @@
  */
 package org.terasology.logic.players;
 
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 import org.terasology.rendering.logic.VisualComponent;
 
 public class FirstPersonHeldItemTransformComponent implements VisualComponent {
-    public Vector3f rotateDegrees = Vector3f.zero();
-    public Vector3f translate = Vector3f.zero();
+    public Vector3f rotateDegrees = new Vector3f();
+    public Vector3f translate = new Vector3f();
     public float scale = 1f;
 }

--- a/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/BlockCommands.java
@@ -18,6 +18,7 @@ package org.terasology.world.block.entity;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import org.joml.Vector3f;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityManager;
@@ -203,7 +204,7 @@ public class BlockCommands extends BaseComponentSystem {
         EntityRef gazeEntity = GazeAuthoritySystem.getGazeEntityForCharacter(playerEntity);
         LocationComponent gazeLocation = gazeEntity.getComponent(LocationComponent.class);
         Set<ResourceUrn> matchingUris = Assets.resolveAssetUri(uri, BlockFamilyDefinition.class);
-        targetSystem.updateTarget(gazeLocation.getWorldPosition(), gazeLocation.getWorldDirection(), maxDistance);
+        targetSystem.updateTarget(gazeLocation.getWorldPosition(new Vector3f()), gazeLocation.getWorldDirection(new Vector3f()), maxDistance);
         EntityRef target = targetSystem.getTarget();
         BlockComponent targetLocation = target.getComponent(BlockComponent.class);
         if (matchingUris.size() == 1) {


### PR DESCRIPTION
This is a continuation of changes for https://github.com/MovingBlocks/Terasology/pull/4177 and https://github.com/MovingBlocks/Terasology/pull/4162 . This migrates FirstPersonHeldItem and any classes associated with this component. This is self contained and has no impact on omega. 

This mainly affects held items and targeting blocks.