### PR TITLE
tweak sort for validating chunk n^2 cost

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
@@ -58,7 +58,7 @@ public class ChunkRelevanceRegion {
     }
 
     public Vector3i getCenter() {
-        return new Vector3i(center);
+        return center;
     }
 
     public void setRelevanceDistance(Vector3i distance) {

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/RelevanceSystem.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/RelevanceSystem.java
@@ -171,8 +171,9 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
         } finally {
             regionLock.writeLock().unlock();
         }
+
         StreamSupport.stream(region.getCurrentRegion().spliterator(), false)
-//                .sorted(new PositionRelevanceComparator()) <-- this is n^2 cost. not sure why this needs to be sorted like this.
+                .sorted(new PositionRelevanceComparator()) //<-- this is n^2 cost. not sure why this needs to be sorted like this.
                 .forEach(
                         pos -> {
                             Chunk chunk = chunkProvider.getChunk(pos);
@@ -252,10 +253,14 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
 
         regionLock.readLock().lock();
         try {
+
             for (ChunkRelevanceRegion region : regions.values()) {
                 int dist = distFromRegion(chunk, region.getCenter());
                 if (dist < score) {
                     score = dist;
+                }
+                if (score == 0) {
+                    break;
                 }
             }
             return score;

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/RelevanceSystem.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/RelevanceSystem.java
@@ -172,7 +172,7 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
             regionLock.writeLock().unlock();
         }
         StreamSupport.stream(region.getCurrentRegion().spliterator(), false)
-                .sorted(new PositionRelevanceComparator())
+//                .sorted(new PositionRelevanceComparator()) <-- this is n^2 cost. not sure why this needs to be sorted like this.
                 .forEach(
                         pos -> {
                             Chunk chunk = chunkProvider.getChunk(pos);


### PR DESCRIPTION
this sort for chunk relevance adds an n^2 cost to the search. since it will try to sort the current chunks against all possible nearby chunks. this function only add the chunk from the region if its valid or creates a new chunk if its not available. This same problem is also apparent with  `ChunkTaskRelevanceComparator`. Some better strategies would need to be setup if there are a lot of relevant entities. 

```
 Chunk chunk = chunkProvider.getChunk(pos);
                            if (chunk != null) {
                                region.checkIfChunkIsRelevant(chunk);
                            } else {
                                chunkProvider.createOrLoadChunk(pos);
                            }
```