### PR TITLE
chore(joml): remove `dest` param from `get*` methods

### DIFF
--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.joml.Quaternionf;
 import org.joml.Quaternionfc;
 import org.joml.Vector3fc;
+import org.joml.Vector3i;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.Direction;
@@ -134,7 +135,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
     /**
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getLocalDirection(org.joml.Vector3f)}.
+     *     {@link #getLocalDirectionConst()}.
      */
     @Deprecated
     public Vector3f getLocalDirection() {
@@ -144,13 +145,12 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     /**
-     * gets the local direction of the given entity in
-     *
-     * @param dest will hold the result
-     * @return dest
+     * gets the local direction of the given entity
      */
-    public org.joml.Vector3f getLocalDirection(org.joml.Vector3f dest) {
-        return dest.set(Direction.FORWARD.asVector3i()).rotate(JomlUtil.from(getLocalRotation()));
+    public org.joml.Vector3fc getLocalDirectionConst() {
+        org.joml.Vector3f dest = new org.joml.Vector3f();
+        dest.set(Direction.FORWARD.asVector3i()).rotate(JomlUtil.from(getLocalRotation()));
+        return dest;
     }
 
 
@@ -173,7 +173,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
     /**
      * @return A new vector containing the world location.
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldPosition(org.joml.Vector3f)}.
+     *     {@link #getWorldPositionConst()}.
      */
     @Deprecated
     public Vector3f getWorldPosition() {
@@ -184,21 +184,17 @@ public final class LocationComponent implements Component, ReplicationCheck {
      * @param output
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldPosition(org.joml.Vector3f)}.
+     *     {@link #getWorldPositionConst()}.
      */
     @Deprecated
     public Vector3f getWorldPosition(Vector3f output) {
-        output.set(JomlUtil.from(getWorldPosition(new org.joml.Vector3f())));
+        output.set(JomlUtil.from(getWorldPositionConst()));
         return output;
     }
 
-    /**
-     * get the world position
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
-    public org.joml.Vector3f getWorldPosition(org.joml.Vector3f dest) {
+    // TODO: rename to `getWorldPosition` after removal of deprecated method
+    public org.joml.Vector3fc getWorldPositionConst() {
+        org.joml.Vector3f dest = new org.joml.Vector3f();
         dest.set(JomlUtil.from(position));
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         while (parentLoc != null) {
@@ -228,7 +224,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
 
     /**
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldDirection(org.joml.Vector3f)}.
+     *     {@link #getWorldDirectionConst()}.
      */
     @Deprecated
     public Vector3f getWorldDirection() {
@@ -237,9 +233,10 @@ public final class LocationComponent implements Component, ReplicationCheck {
         return result;
     }
 
-
-    public org.joml.Vector3f getWorldDirection(org.joml.Vector3f dest) {
-        return dest.set(Direction.FORWARD.asVector3f()).rotate(JomlUtil.from(getWorldRotation()));
+    public org.joml.Vector3fc getWorldDirectionConst() {
+        org.joml.Vector3f dest = new org.joml.Vector3f();
+        dest.set(Direction.FORWARD.asVector3f()).rotate(JomlUtil.from(getWorldRotation()));
+        return dest;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -106,7 +106,7 @@ public class LocalPlayer {
     /**
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getPosition(org.joml.Vector3f)}.
+     *     {@link #getPositionConst()}.
      */
     @Deprecated
     public Vector3f getPosition() {
@@ -117,7 +117,7 @@ public class LocalPlayer {
      * @param out
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getPosition(org.joml.Vector3f)}.
+     *     {@link #getPositionConst()}.
      */
     @Deprecated
     public Vector3f getPosition(Vector3f out) {
@@ -130,14 +130,14 @@ public class LocalPlayer {
 
     /**
      * the position of the local player
-     *
-     * @param dest will hold the result
-     * @return dest
      */
-    public org.joml.Vector3f getPosition(org.joml.Vector3f dest) {
+    // TODO: rename to `getPosition` after removal of deprecated method
+    public org.joml.Vector3fc getPositionConst() {
         LocationComponent location = getCharacterEntity().getComponent(LocationComponent.class);
+        org.joml.Vector3f dest = new org.joml.Vector3f();
         if (location != null) {
-            org.joml.Vector3f result = location.getWorldPosition(new org.joml.Vector3f());
+            org.joml.Vector3f result = new org.joml.Vector3f();
+            result.set(location.getWorldPositionConst());
             if (result.isFinite()) { //TODO: MP finite check seems to hide a larger underlying problem
                 dest.set(result);
             }
@@ -184,7 +184,7 @@ public class LocalPlayer {
      * @param out
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getViewPosition(org.joml.Vector3f)}.
+     *     {@link #getViewPositionConst()}.
      */
     @Deprecated
     public Vector3f getViewPosition(Vector3f out) {
@@ -201,25 +201,25 @@ public class LocalPlayer {
     }
 
     /**
-     * position of camera if one is present else use {@link #getPosition(org.joml.Vector3f)}
-     *
-     * @param dest will hold the result
-     * @return dest
+     * position of camera if one is present else use {@link #getPositionConst()}
      */
-    public org.joml.Vector3f getViewPosition(org.joml.Vector3f dest) {
+    // TODO: rename to `getViewPosition` after removal of deprecated method
+    public org.joml.Vector3fc getViewPositionConst() {
+        org.joml.Vector3f dest = new org.joml.Vector3f();
         ClientComponent clientComponent = getClientEntity().getComponent(ClientComponent.class);
         if (clientComponent == null) {
             return dest;
         }
         LocationComponent location = clientComponent.camera.getComponent(LocationComponent.class);
         if (location != null) {
-            org.joml.Vector3f result = location.getWorldPosition(new org.joml.Vector3f());
+            org.joml.Vector3f result = new org.joml.Vector3f();
+            result.set(location.getWorldPositionConst());
             if (result.isFinite()) { //TODO: MP finite check seems to hide a larger underlying problem
                 dest.set(result);
                 return dest;
             }
         }
-        return getPosition(dest);
+        return getPositionConst();
     }
 
     /**
@@ -242,7 +242,7 @@ public class LocalPlayer {
     }
 
     /**
-     * orientation of camera if one is present else use {@link #getPosition(org.joml.Vector3f)}
+     * orientation of camera if one is present else use {@link #getPositionConst()}
      *
      * @param dest will hold the result
      * @return dest
@@ -265,19 +265,19 @@ public class LocalPlayer {
 
     /**
      * forward view direction of camera view
-     *
-     * @param dest will hold the result
-     * @return dest
      */
-    public org.joml.Vector3f getViewDirection(org.joml.Vector3f dest) {
+    // TODO: rename to `getViewDirection` after removal of deprecated method
+    public org.joml.Vector3fc getViewDirectionConst() {
+        org.joml.Vector3f dest = new org.joml.Vector3f();
         Quaternionf rot = getViewRotation(new Quaternionf());
-        return rot.transform(Direction.FORWARD.asVector3f(), dest);
+        rot.transform(Direction.FORWARD.asVector3f(), dest);
+        return dest;
     }
 
     /**
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getViewDirection(org.joml.Vector3f)}
+     *     {@link #getViewDirectionConst()}
      */
     @Deprecated
     public Vector3f getViewDirection() {
@@ -290,7 +290,7 @@ public class LocalPlayer {
     /**
      * @return
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getVelocity(org.joml.Vector3f)}
+     *     {@link #getVelocityConst()}
      */
     @Deprecated
     public Vector3f getVelocity() {
@@ -301,7 +301,9 @@ public class LocalPlayer {
         return new Vector3f();
     }
 
-    public org.joml.Vector3f getVelocity(org.joml.Vector3f dest) {
+    // TODO: rename to `getVelocity` after removal of deprecated method
+    public org.joml.Vector3fc getVelocityConst() {
+        org.joml.Vector3f dest = new org.joml.Vector3f();
         CharacterMovementComponent movement = getCharacterEntity().getComponent(CharacterMovementComponent.class);
         if (movement != null) {
             return dest.set(movement.getVelocity());
@@ -344,8 +346,10 @@ public class LocalPlayer {
     private boolean activateTargetOrOwnedEntity(EntityRef usedOwnedEntity) {
         EntityRef character = getCharacterEntity();
         CharacterComponent characterComponent = character.getComponent(CharacterComponent.class);
-        org.joml.Vector3f direction = getViewDirection(new org.joml.Vector3f());
-        org.joml.Vector3f originPos = getViewPosition(new org.joml.Vector3f());
+        org.joml.Vector3f direction = new org.joml.Vector3f();
+        org.joml.Vector3f originPos = new org.joml.Vector3f();
+        direction.set(getViewDirectionConst());
+        originPos.set(getViewPositionConst());
         if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.RECORDING) {
             this.directionAndOriginPosRecorderList.getTargetOrOwnedEntityDirectionAndOriginPosRecorder().add(direction, originPos);
         } else if (recordAndReplayCurrentStatus.getStatus() == RecordAndReplayStatus.REPLAYING) {

--- a/engine/src/main/java/org/terasology/world/block/BlockComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockComponent.java
@@ -49,7 +49,7 @@ public final class BlockComponent implements Component {
     /**
      * @deprecated Deprecated on 21/Sep/2018, because it is error prone (no defensive copy) and needlessly verbose.
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getPosition(org.joml.Vector3i)}.
+     *     {@link #getPositionConst()}.
      */
     @Deprecated
     public Vector3i getPosition() {
@@ -82,15 +82,9 @@ public final class BlockComponent implements Component {
         return block;
     }
 
-    /**
-     * get the position
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
-    public org.joml.Vector3i getPosition(org.joml.Vector3i dest) {
-        dest.set(JomlUtil.from(position));
-        return dest;
+    // TODO: rename to `getPosition` after removal of deprecated method
+    public org.joml.Vector3ic getPositionConst() {
+        return JomlUtil.from(position);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -43,18 +43,16 @@ public interface CoreChunk {
     /**
      * @return Position of the chunk in world, where units of distance from origin are blocks
      * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getPosition(org.joml.Vector3i)}.
+     *             Use the JOML implementation instead: {@link #getPositionConst()}.
      */
     @Deprecated
     Vector3i getPosition();
 
     /**
      * Position of the chunk in world, where units of distance from origin are blocks
-     *
-     * @param dest will hold the result
-     * @return dest
      */
-    org.joml.Vector3i getPosition(org.joml.Vector3i dest);
+    // TODO: rename to `getPosition` after removal of deprecated method
+    org.joml.Vector3ic getPositionConst();
 
     /**
      * Returns block at given position relative to the chunk.
@@ -194,7 +192,7 @@ public interface CoreChunk {
      *
      * @return Offset of this chunk from world center in chunks
      * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getChunkWorldOffset(org.joml.Vector3i)}.
+     *             Use the JOML implementation instead: {@link #getChunkWorldOffsetConst()}.
      */
     @Deprecated
     Vector3i getChunkWorldOffset();
@@ -204,7 +202,8 @@ public interface CoreChunk {
      *
      * @return Offset of this chunk from world center in chunks
      */
-    org.joml.Vector3i getChunkWorldOffset(org.joml.Vector3i pos);
+    // TODO: rename to `getChunkWorldOffset` after removal of deprecated method
+    org.joml.Vector3ic getChunkWorldOffsetConst();
 
 
     /**

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -21,6 +21,7 @@ import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.AABB;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.BaseVector3i;
 import org.terasology.math.geom.Vector3f;
@@ -113,8 +114,9 @@ public class ChunkImpl implements Chunk {
     }
 
     @Override
-    public org.joml.Vector3i getPosition(org.joml.Vector3i dest) {
-        return dest.set(chunkPos.x,chunkPos.y,chunkPos.z);
+    // TODO: rename to `getPosition` after removal of deprecated method
+    public org.joml.Vector3ic getPositionConst() {
+        return JomlUtil.from(chunkPos);
     }
 
     @Override
@@ -282,8 +284,9 @@ public class ChunkImpl implements Chunk {
     }
 
     @Override
-    public org.joml.Vector3i getChunkWorldOffset(org.joml.Vector3i dest) {
-        return dest.set(getChunkWorldOffsetX(), getChunkWorldOffsetY(), getChunkWorldOffsetZ());
+    // TODO: rename to `getChunkWorldOffset` after removal of deprecated method
+    public org.joml.Vector3ic getChunkWorldOffsetConst() {
+        return new org.joml.Vector3i(getChunkWorldOffsetX(), getChunkWorldOffsetY(), getChunkWorldOffsetZ());
     }
 
     @Override


### PR DESCRIPTION
- return constant, e.g. `Vector3fc` instead of `Vector3f`
- method naming will require refactoring after removal of deprecated methods but the behaviour on caller side can stay the same