### PR TITLE
feat(JOML): joml migrate wavefront format

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/assets/mesh/ObjMeshFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/mesh/ObjMeshFormat.java
@@ -18,15 +18,15 @@ package org.terasology.rendering.assets.mesh;
 import com.google.common.collect.Lists;
 import gnu.trove.list.TFloatList;
 import gnu.trove.list.TIntList;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.format.AbstractAssetFileFormat;
 import org.terasology.assets.format.AssetDataFile;
 import org.terasology.assets.module.annotations.RegisterAssetFileFormat;
-import org.terasology.math.geom.Vector2f;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -146,7 +146,7 @@ public class ObjMeshFormat extends AbstractAssetFileFormat<MeshData> {
                 }
 
                 if (prefixSplit.length < 2) {
-                    throw new IOException(String.format("Incomplete statement"));
+                    throw new IOException("Incomplete statement");
                 }
 
                 switch (prefix) {


### PR DESCRIPTION
This is a fairly simple migration for .obj wavefront object. There are a couple wavefront objects littered around in module space and in the core engine. The player hand is fairly easy to see and verify that it works correctly in the game. 