### PR TITLE
fix(gradle-server): restore missing suffix for jvmarg -Xmx

### DIFF
--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -255,7 +255,7 @@ tasks.register<JavaExec>("server") {
     main = mainClassName
     workingDir = rootDir
     args = listOf("-headless", "-homedir=$localServerDataPath")
-    jvmArgs = listOf("-Xmx1536")
+    jvmArgs = listOf("-Xmx1536m")
 
     // Classpath: PC itself, engine classes, engine dependencies. Not modules or natives since the engine finds those
     classpath(sourceSets["main"].output.classesDirs)


### PR DESCRIPTION
### Contains

Fix jvmArgs for `server` gradle task. 
Bug prevent server to start with error:
```
Error occurred during initialization of VM
Too small maximum heap
```
introduced in #4175

### How to test

1. Checkout it
2. run `server` task.
3. check that server started (any output from server)
