### PR TITLE
fix: AGS selection weirdness

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/advancedGameSetupScreen/AdvancedGameSetupScreen.java
@@ -125,6 +125,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
         for (ModuleSelectionInfo info : sortedModules) {
             info.setExplicitSelection(config.getDefaultModSelection().hasModule(info.getMetadata().getId()));
         }
+        refreshSelection();
 
         filterModules();
     }
@@ -753,9 +754,7 @@ public class AdvancedGameSetupScreen extends CoreScreenLayer {
         if (target.isValidToSelect() && !target.isExplicitSelection()) {
             boolean previouslySelected = target.isSelected();
             target.setExplicitSelection(true);
-            if (!previouslySelected) {
-                refreshSelection();
-            }
+            refreshSelection();
         }
     }
 


### PR DESCRIPTION
- refresh selection on opening so that dependent and explicitly activated modules are colored in addition to selected gameplay module
- refresh selection even if module was previously selected to avoid weirdness for dependent modules being explicitly activated

## Before this fix

There was some weirdness in the Advanced Game Setup (AGS):
* only the selected gameplay module was colored
* dependency modules and other explicitly activated modules (as listed in the config) were not colored
* on double-clicking an already explicitly selected module, the internal state was screwed up resulting in a "Failed to resolve world generator" error on starting the game
* on double-clicking another module (dependent or not, but not explicitly activated), the selection updated correctly
