### PR TITLE
fix: moving on typing, typing keybind in console/chat

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -146,8 +146,8 @@ dependencies {
     api group: 'org.terasology', name: 'splash-screen', version: '1.1.0-SNAPSHOT'
     api group: 'org.terasology.jnlua', name: 'JNLua', version: '0.1.0-SNAPSHOT'
     api group: 'org.terasology.jnbullet', name: 'JNBullet', version: '1.0.2'
-    api group: 'org.terasology.nui', name: 'nui', version: '1.3.0'
-    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.3.0'
+    api group: 'org.terasology.nui', name: 'nui', version: '1.4.0-SNAPSHOT'
+    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.4.0-SNAPSHOT'
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     api fileTree(dir: 'libs', include: '*.jar')

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -146,8 +146,8 @@ dependencies {
     api group: 'org.terasology', name: 'splash-screen', version: '1.1.0-SNAPSHOT'
     api group: 'org.terasology.jnlua', name: 'JNLua', version: '0.1.0-SNAPSHOT'
     api group: 'org.terasology.jnbullet', name: 'JNBullet', version: '1.0.2'
-    api group: 'org.terasology.nui', name: 'nui', version: '1.4.0-SNAPSHOT'
-    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.4.0-SNAPSHOT'
+    api group: 'org.terasology.nui', name: 'nui', version: '1.3.1'
+    api group: 'org.terasology.nui', name: 'nui-reflect', version: '1.3.1'
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     api fileTree(dir: 'libs', include: '*.jar')

--- a/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
+++ b/engine/src/main/java/org/terasology/logic/chat/ChatSystem.java
@@ -38,8 +38,8 @@ import org.terasology.logic.console.suggesters.OnlineUsernameSuggester;
 import org.terasology.logic.console.ui.NotificationOverlay;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.network.ClientComponent;
-import org.terasology.registry.In;
 import org.terasology.nui.FontColor;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class ChatSystem extends BaseComponentSystem {
 
     @ReceiveEvent(components = ClientComponent.class)
     public void onToggleChat(ChatButton event, EntityRef entity) {
-        if (event.getState() == ButtonState.DOWN) {
+        if (event.getState() == ButtonState.UP) {
             nuiManager.pushScreen(CHAT_UI);
             overlay.setVisible(false);
             event.consume();

--- a/engine/src/main/java/org/terasology/logic/console/ConsoleSystem.java
+++ b/engine/src/main/java/org/terasology/logic/console/ConsoleSystem.java
@@ -56,7 +56,7 @@ public class ConsoleSystem extends BaseComponentSystem {
 
     @ReceiveEvent(components = ClientComponent.class, priority = EventPriority.PRIORITY_CRITICAL)
     public void onToggleConsole(ConsoleButton event, EntityRef entity) {
-        if (event.getState() == ButtonState.DOWN) {
+        if (event.getState() == ButtonState.UP) {
             nuiManager.toggleScreen("engine:console");
             overlay.setVisible(false);
             event.consume();


### PR DESCRIPTION
### Contains

Bump up nui dep version to next SNAPSHOT ( https://github.com/MovingBlocks/TeraNUI/pull/35)

Change opening console and chat from DOWN key event to UP key event - prevent typing keybind key to chat/console.
 

### How to test

1.a. merge and publish https://github.com/MovingBlocks/TeraNUI/pull/35
   or
1.b. clone TeraNUI with PR#35.

2. Start game.
3. Open console or chat.
4. Check that you have clear UIText (commit `fix typing bindkey as first char in chat or console )
5. type keys, which haves bindings to moving keys (`WASD` on `QWERTY` Layout)
6. Check that you not moved, while typing at step 5.

### Outstanding
* [x] - merge https://github.com/MovingBlocks/TeraNUI/pull/35
