### PR TITLE
feat(JOML): remove deprecated methods for blockfamily

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/entity/neighbourUpdate/NeighbourBlockFamilyUpdateSystem.java
@@ -16,6 +16,7 @@
 package org.terasology.world.block.entity.neighbourUpdate;
 
 import com.google.common.collect.Sets;
+import org.joml.Vector3i;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -24,8 +25,8 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.OnChangedBlock;
@@ -80,7 +81,7 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
             return;
         }
 
-        processUpdateForBlockLocation(blockComponent.position);
+        processUpdateForBlockLocation(JomlUtil.from(blockComponent.position));
     }
 
     private void notifyNeighboursOfChangedBlocks() {
@@ -100,9 +101,9 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
     @ReceiveEvent(components = {BlockComponent.class})
     public void blockUpdate(OnChangedBlock event, EntityRef blockEntity) {
         if (largeBlockUpdateCount > 0) {
-            blocksUpdatedInLargeBlockUpdate.add(event.getBlockPosition());
+            blocksUpdatedInLargeBlockUpdate.add(JomlUtil.from(event.getBlockPosition()));
         } else {
-            Vector3i blockLocation = event.getBlockPosition();
+            Vector3i blockLocation = JomlUtil.from(event.getBlockPosition());
             processUpdateForBlockLocation(blockLocation);
         }
     }
@@ -110,7 +111,7 @@ public class NeighbourBlockFamilyUpdateSystem extends BaseComponentSystem implem
     private void processUpdateForBlockLocation(Vector3i blockLocation) {
         for (Side side : Side.getAllSides()) {
             Vector3i neighborLocation = new Vector3i(blockLocation);
-            neighborLocation.add(side.getVector3i());
+            neighborLocation.add(side.direction());
             if (worldProvider.isBlockRelevant(neighborLocation)) {
                 Block neighborBlock = worldProvider.getBlock(neighborLocation);
                 final BlockFamily blockFamily = neighborBlock.getBlockFamily();

--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -88,11 +88,6 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
     }
 
     @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        return blocks.get(attachmentSide);
-    }
-
-    @Override
     public Block getArchetypeBlock() {
         return archetype;
     }

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
@@ -16,8 +16,6 @@
 package org.terasology.world.block.family;
 
 import org.terasology.assets.ResourceUrn;
-import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockUri;
 
@@ -47,18 +45,6 @@ public interface BlockFamily {
      * @return The appropriate block
      */
     Block getBlockForPlacement(BlockPlacementData data);
-
-    /**
-     * Get the block that is appropriate for placement in the given situation
-     *
-     * @param location            The location where the block is going to be placed.
-     * @param attachmentSide      The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
-     * @param direction           A secondary direction after the attachment side that determines the facing of the block.
-     * @return The appropriate block
-     * @deprecated This method is scheduled for removal, use this one instead: {@link #getBlockForPlacement(BlockPlacementData)}.
-     */
-    @Deprecated
-    Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction);
 
     /**
      * @return The base block defining the block group. Can be used for orientation-irrelevant behaviours

--- a/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
@@ -21,7 +21,6 @@ import org.terasology.math.Roll;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.Yaw;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -128,15 +127,6 @@ public class CeilingSupportingHorizontalFamily extends AbstractBlockFamily {
 
         Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
         return blocks.get(ExtendedSide.getExtendedSideFor(mainSide, blockDirection));
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (attachmentSide == Side.BOTTOM) {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.BOTTOM, direction));
-        } else {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.TOP, direction));
-        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -85,21 +84,6 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
             Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
             return blocks.get(blockDirection);
         }
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (archetypeBlock == null) {
-            if (attachmentSide.isHorizontal()) {
-                return blocks.get(attachmentSide);
-            }
-            if (direction != null) {
-                return blocks.get(direction);
-            } else {
-                return blocks.get(Side.FRONT);
-            }
-        }
-        return archetypeBlock;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
@@ -18,7 +18,6 @@ package org.terasology.world.block.family;
 import com.google.common.collect.Maps;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -86,18 +85,6 @@ public class HorizontalFamily extends AbstractBlockFamily implements SideDefined
         } else {
             Side secondaryDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
             return blocks.get(secondaryDirection);
-        }
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (attachmentSide.isHorizontal()) {
-            return blocks.get(attachmentSide);
-        }
-        if (direction != null) {
-            return blocks.get(direction);
-        } else {
-            return blocks.get(Side.FRONT);
         }
     }
 

--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -18,15 +18,12 @@ package org.terasology.world.block.family;
 import com.google.common.collect.Sets;
 import gnu.trove.map.TByteObjectMap;
 import gnu.trove.map.hash.TByteObjectHashMap;
-import org.joml.Vector3f;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.SideBitFlag;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
@@ -80,18 +77,6 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
         super(definition, blockBuilder);
     }
 
-    /**
-     * A condition to return true if the block should have a connection on the given side
-     *
-     * @param blockLocation The position of the block in question
-     * @param connectSide The side to determine connection for
-     *
-     * @return A boolean indicating if the block should connect on the given side
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #connectionCondition(Vector3ic, Side)}.
-     */
-    @Deprecated
-    protected abstract boolean connectionCondition(Vector3i blockLocation, Side connectSide);
 
     /**
      * A condition to return true if the block should have a connection on the given side
@@ -179,21 +164,13 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
     public Block getBlockForPlacement(BlockPlacementData data) {
         byte connections = 0;
         for (Side connectSide : SideBitFlag.getSides(getConnectionSides())) {
-            if (this.connectionCondition(JomlUtil.from(data.blockPosition), connectSide)) {
+            if (this.connectionCondition(data.blockPosition, connectSide)) {
                 connections += SideBitFlag.getSide(connectSide);
             }
         }
         return blocks.get(connections);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        BlockPlacementData data = new BlockPlacementData(JomlUtil.from(location), null, new Vector3f());
-        return getBlockForPlacement(data);
-    }
 
     /**
      * Update the block then a neighbor changes
@@ -203,17 +180,6 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      *
      * @return The block from the family to be placed
      */
-    @Override
-    public Block getBlockForNeighborUpdate(Vector3i location, Block oldBlock) {
-        byte connections = 0;
-        for (Side connectSide : SideBitFlag.getSides(getConnectionSides())) {
-            if (this.connectionCondition(location, connectSide)) {
-                connections += SideBitFlag.getSide(connectSide);
-            }
-        }
-        return blocks.get(connections);
-    }
-
     @Override
     public Block getBlockForNeighborUpdate(Vector3ic location, Block oldBlock) {
         byte connections = 0;

--- a/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.world.block.family;
 
-import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
 import org.terasology.world.block.BlockUri;
@@ -54,11 +52,6 @@ public class SymmetricFamily extends AbstractBlockFamily {
 
     @Override
     public Block getBlockForPlacement(BlockPlacementData data) {
-        return block;
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
         return block;
     }
 

--- a/engine/src/main/java/org/terasology/world/block/family/UpdatesWithNeighboursFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/UpdatesWithNeighboursFamily.java
@@ -16,21 +16,12 @@
 package org.terasology.world.block.family;
 
 import org.joml.Vector3ic;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 /**
  * Interface for Block family that gets updated by a change in a neighbor block.
  */
 public interface UpdatesWithNeighboursFamily extends BlockFamily {
-    /**
-     * Update called when a neighbor block changes
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getBlockForNeighborUpdate(Vector3ic, Block)}.
-     **/
-    @Deprecated
-    Block getBlockForNeighborUpdate(Vector3i location, Block oldBlock);
-
     /**
      * Update called when a neighbor block changes
      **/


### PR DESCRIPTION
I want to remove all the extra methods from blockfamily and migrate everything over in one go. just a lot more trouble trying to working around all the inheritance. BlockPlacmentData stuff is a lot more trouble to use. I just want to use a couple method calls but wrapping it in another object seems a bit much. 