### PR TITLE
fix: index out of bounds in `GLTFAnimationFormat`

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/gltf/GLTFAnimationFormat.java
+++ b/engine/src/main/java/org/terasology/rendering/gltf/GLTFAnimationFormat.java
@@ -211,7 +211,7 @@ public class GLTFAnimationFormat extends GLTFCommonFormat<MeshAnimationBundleDat
 
         public void updateFrame(float time, MeshAnimationFrame frame) {
             int upperFrame = 0;
-            while (upperFrame < times.size() && times.get(upperFrame) < time) {
+            while (upperFrame < times.size() - 1 && times.get(upperFrame) < time) {
                 upperFrame++;
             }
             int lowerFrame = Math.max(0, upperFrame - 1);


### PR DESCRIPTION
## Current Situation

```java
public void updateFrame(float time, MeshAnimationFrame frame) {
    int upperFrame = 0;
    while (upperFrame < times.size() && times.get(upperFrame) < time) {
        upperFrame++;
    }
```
(https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/rendering/gltf/GLTFAnimationFormat.java#L212-L216)

In `updateFrame`, `upperFrame` is initialized to 0 and then increased if was smaller than the size of the `TFloatList times` and some other condition. This can lead to `upperFrame == times.size()`.

In the case where I faced the index out of bounds error, `TFloatList times` was the same size as `List<T> data`. This means, `upperFrame` could became equal to `data.size()` as well.

Now `lowerFrame` is set to the maximum of 0 and `upperFrame - 1` in https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/rendering/gltf/GLTFAnimationFormat.java#L217 .

Further below, we see
```java
if (upperFrame == lowerFrame) {
    interpolator.interpolate(data.get(lowerFrame), data.get(lowerFrame), 0, target);
} else {
    float t = (time - times.get(lowerFrame)) / (times.get(upperFrame) - times.get(lowerFrame));
    interpolator.interpolate(data.get(lowerFrame), data.get(upperFrame), t, target);
}
```
(https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/rendering/gltf/GLTFAnimationFormat.java#L219-L224)

Due to how `lowerFrame` is set, the `if` condition can only be true if `upperFrame == lowerFrame == 0`.
In all other cases, the `else` branch will be executed.
As we can see, in that branch both `TFloatList times` and `List<T> data` will be accessed with index `upperFrame`. If indeed `upperFrame` equals the size of one or both of them, we'll run into an index out of bounds error.


## Proposed Solution

As we try to access `times` and `data` with index `upperFrame` in all cases where `upperFrame != 0`, IMO we should not be able to increase `upperFrame` up to the size of `times`. That's why, I propose to change the while condition to

```java
public void updateFrame(float time, MeshAnimationFrame frame) {
    int upperFrame = 0;
    while (upperFrame < times.size() - 1 && times.get(upperFrame) < time) {
        upperFrame++;
    }
```


## How to Reproduce

1. Checkout https://github.com/Terasology/LightAndShadowResources/pull/62
2. Start Terasology and try to start LightAndShadow
3. Observe the index-out-of-bounds error when the game tries to load the [red|black]Queen or [red|black]King prefabs.

If you'd like to use the debugger, you can set a conditional breakpoint at [`if (upperFrame == lowerFrame) {`](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/rendering/gltf/GLTFAnimationFormat.java#L219), conditioned to `upperFrame == 41` and when it breaks observe that `data.size() == times.size() == 41`.