### PR TITLE
feat(rendering): Adjust minimal amount of daylight at night

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/rendering/backdrop/Skysphere.java
@@ -107,7 +107,7 @@ public class Skysphere implements BackdropProvider, BackdropRenderer {
         float daylight = 1.0f;
 
         if (angle < 24.0f) {
-            daylight = 1.0f - (24.0f - angle) / 24.0f;
+            daylight = Math.max(1.0f - (24.0f - angle) / 24.0f, 0.15f);
         }
 
         return daylight;


### PR DESCRIPTION
I'm not sure whether this is just fixing symptoms or the actual root cause... Any input is appreciated. I played around with different values, see screenshot comparison below. The overall brightness is heavily influenced by the combination of video settings, so it's hard to tell whether we can find a one-size-fits-all value.

![terasology_night-brightness](https://user-images.githubusercontent.com/1448874/99262767-a3f7fb80-281e-11eb-81b4-bfd66e84fe03.png)

I also found that we decide on whether to use the "night exposure" values in CoreRendering based on whether the daylight value is 0. This might need adjustment with this change (as daylight will never be 0 afterwards).
