### PR TITLE
fix: InputSystem#getInputsForBindButton was throwing NPE

### DIFF
--- a/engine/src/main/java/org/terasology/input/InputSystem.java
+++ b/engine/src/main/java/org/terasology/input/InputSystem.java
@@ -12,7 +12,6 @@ import org.terasology.engine.SimpleUri;
 import org.terasology.engine.Time;
 import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.engine.subsystem.config.BindsManager;
-import org.terasology.engine.subsystem.config.BindsSubsystem;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -77,9 +76,6 @@ public class InputSystem extends BaseComponentSystem {
 
     @In
     private CameraTargetSystem targetSystem;
-
-    @In
-    private BindsSubsystem bindsSubsystem;
 
     private MouseDevice mouse = new NullMouseDevice();
     private KeyboardDevice keyboard = new NullKeyboardDevice();
@@ -311,15 +307,15 @@ public class InputSystem extends BaseComponentSystem {
      */
     private void updateBindState(BindableButton bind, Input input, boolean pressed, float delta, boolean consumed) {
         bind.updateBindState(
-            input,
-            pressed,
-            delta, inputEntities,
-            targetSystem.getTarget(),
-            targetSystem.getTargetBlockPosition(),
-            targetSystem.getHitPosition(),
-            targetSystem.getHitNormal(),
-            consumed,
-            time.getGameTimeInMs());
+                input,
+                pressed,
+                delta, inputEntities,
+                targetSystem.getTarget(),
+                targetSystem.getTargetBlockPosition(),
+                targetSystem.getHitPosition(),
+                targetSystem.getHitNormal(),
+                consumed,
+                time.getGameTimeInMs());
     }
 
     public void simulateTextInput(String text) {
@@ -403,9 +399,9 @@ public class InputSystem extends BaseComponentSystem {
     private void processBindAxis(float delta) {
         for (AbstractBindableAxis axis : bindsManager.getAxisBinds()) {
             axis.update(inputEntities, delta, targetSystem.getTarget(),
-                JomlUtil.from(targetSystem.getTargetBlockPosition()),
-                JomlUtil.from(targetSystem.getHitPosition()),
-                JomlUtil.from(targetSystem.getHitNormal()));
+                    JomlUtil.from(targetSystem.getTargetBlockPosition()),
+                    JomlUtil.from(targetSystem.getHitPosition()),
+                    JomlUtil.from(targetSystem.getHitNormal()));
         }
     }
 
@@ -477,7 +473,8 @@ public class InputSystem extends BaseComponentSystem {
      */
     private boolean sendMouseEvent(MouseInput button, boolean buttonDown, Vector2i jomlposition, float delta) {
         MouseButtonEvent event;
-        org.terasology.math.geom.Vector2i position = new org.terasology.math.geom.Vector2i(jomlposition.x, jomlposition.y);
+        org.terasology.math.geom.Vector2i position = new org.terasology.math.geom.Vector2i(jomlposition.x,
+                jomlposition.y);
         switch (button) {
             case NONE:
                 return false;
@@ -508,7 +505,8 @@ public class InputSystem extends BaseComponentSystem {
      * @return True if the event has been consumed by an event listener, false otherwise.
      */
     private boolean sendMouseWheelEvent(Vector2i pos, int wheelTurns, float delta) {
-        MouseWheelEvent mouseWheelEvent = new MouseWheelEvent(new org.terasology.math.geom.Vector2i(pos.x, pos.y) , wheelTurns, delta);
+        MouseWheelEvent mouseWheelEvent = new MouseWheelEvent(new org.terasology.math.geom.Vector2i(pos.x, pos.y),
+                wheelTurns, delta);
         return send(mouseWheelEvent);
     }
 
@@ -537,9 +535,9 @@ public class InputSystem extends BaseComponentSystem {
     private void setupTarget(InputEvent event) {
         if (targetSystem.isTargetAvailable()) {
             event.setTargetInfo(targetSystem.getTarget(),
-                JomlUtil.from(targetSystem.getTargetBlockPosition()),
-                JomlUtil.from(targetSystem.getHitPosition()),
-                JomlUtil.from(targetSystem.getHitNormal()));
+                    JomlUtil.from(targetSystem.getTargetBlockPosition()),
+                    JomlUtil.from(targetSystem.getHitPosition()),
+                    JomlUtil.from(targetSystem.getHitNormal()));
         }
     }
 
@@ -554,13 +552,15 @@ public class InputSystem extends BaseComponentSystem {
     }
 
     /**
-     * API-exposed caller to {@link BindsSubsystem#getInputsForBindButton(SimpleUri)}. TODO: Restored for API reasons,
-     * may be duplicating code elsewhere. Should be reviewed.
+     * API-exposed caller to {@link BindsManager#getBindsConfig()} and
+     * {@link org.terasology.config.BindsConfig#getBinds(SimpleUri)}.
+     * <p>
+     * TODO: Restored for API reasons, may be duplicating code elsewhere. Should be reviewed.
      *
      * @param bindId the ID.
      * @return a list of keyboard/mouse inputs that trigger the binding.
      */
     public List<Input> getInputsForBindButton(SimpleUri bindId) {
-        return bindsSubsystem.getInputsForBindButton(bindId);
+        return bindsManager.getBindsConfig().getBinds(bindId);
     }
 }


### PR DESCRIPTION
I think the only usage of that API wrapper method (in Omega) is in Dialogs where it is used to get the associated bind for an action to display it as a hint to the user.

https://github.com/Terasology/Dialogs/blob/5a0073966afc66f18bc1d7220c7b49c8c053d9c2/src/main/java/org/terasology/dialogs/DialogSystem.java#L190

This was throwing a NPE for a while, resulting in the hint not showing up. This PR fixes that.