### PR TITLE
fix(network): fix server info request and ping error handling

### DIFF
--- a/engine/src/main/java/org/terasology/network/PingService.java
+++ b/engine/src/main/java/org/terasology/network/PingService.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.network;
 
@@ -49,7 +36,6 @@ public class PingService implements Callable<Long> {
             // root privileges under some operating systems
             sock.connect(endpoint, timeout);
             Instant end = Instant.now();
-            sock.close();
             long millis = Duration.between(start, end).toMillis();
             return millis;
         }

--- a/engine/src/main/java/org/terasology/network/ServerInfoService.java
+++ b/engine/src/main/java/org/terasology/network/ServerInfoService.java
@@ -42,7 +42,16 @@ public class ServerInfoService implements AutoCloseable {
         ChannelFuture connectCheck = bootstrap.connect(remoteAddress)
                 .addListener(connectFuture -> {
                     if (!connectFuture.isSuccess()) {
-                        resultFuture.setException(connectFuture.cause().getCause());
+                        if (connectFuture.cause() != null && connectFuture.cause().getCause() != null) {
+                            // java's network exception.
+                            resultFuture.setException(connectFuture.cause().getCause());
+                        } else if (connectFuture.cause() != null) {
+                            // netty's exception, if it is not java's
+                            resultFuture.setException(connectFuture.cause());
+                        } else {
+                            // fallback exception when connecting not success.
+                            resultFuture.setException(new RuntimeException("Cannot connect to server"));
+                        }
                     }
                 });
         Channel channel = connectCheck.channel();


### PR DESCRIPTION
### Contains

fix server info request and ping error handling (restore error showing when requiests  server info).

Fix over netty4 migration.
I used blocking request for server info request. change it on async and add handler on connection stage failing.

### How to test

1. Open Terasology.
2. Go to `Join Server`
3. Click on several disabled servers
4. server info should render as red text: `Connection failed` (restoring previous behavior)
