### PR TITLE
feat(BlockRegion): add BlockRegion helpers

### DIFF
--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="PROJECT" />
+  </component>
+</project>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DiscordProjectSettings">
-    <option name="show" value="PROJECT" />
-  </component>
-</project>

--- a/engine-tests/src/test/java/org/terasology/math/BlockRegionTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/BlockRegionTest.java
@@ -17,12 +17,10 @@
 package org.terasology.math;
 
 import com.google.common.collect.Sets;
-import org.joml.AABBi;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.Test;
 import org.terasology.world.block.BlockRegion;
-import org.terasology.world.block.BlockRegionIterable;
 import org.terasology.world.block.BlockRegions;
 
 import java.util.Arrays;
@@ -154,5 +152,27 @@ public class BlockRegionTest {
         assertFalse(region.containsBlock(-1, -1, 0));
         assertFalse(region.containsBlock(-1, -1, -1));
         assertFalse(region.containsBlock(0, -1, -1));
+    }
+
+    @Test
+    public void testCorrectBoundsFlip() {
+        Vector3i min = new Vector3i(0, 0, 0);
+        Vector3i max = new Vector3i(1, 1, 1);
+        BlockRegion region = BlockRegions.createFromMinAndMax(max, min);
+        region.correctBounds();
+
+        assertEquals(min, region.getMin(new Vector3i()));
+        assertEquals(max, region.getMax(new Vector3i()));
+    }
+
+    @Test
+    public void testCorrectBoundsMixed() {
+        Vector3i min = new Vector3i(0, 0, 0);
+        Vector3i max = new Vector3i(1, 1, 1);
+        BlockRegion region = BlockRegions.createFromMinAndMax(1,0,1, 0,1,0);
+        region.correctBounds();
+
+        assertEquals(min, region.getMin(new Vector3i()));
+        assertEquals(max, region.getMax(new Vector3i()));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/math/BlockRegionTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/BlockRegionTest.java
@@ -23,6 +23,7 @@ import org.joml.Vector3ic;
 import org.junit.jupiter.api.Test;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -55,7 +56,8 @@ public class BlockRegionTest {
     @Test
     public void testCreateRegionWithMinMax() {
         List<Vector3i> mins = Arrays.asList(new Vector3i(), new Vector3i(1, 1, 1), new Vector3i(3, 4, 5));
-        List<Vector3i> expectedSize = Arrays.asList(new Vector3i(1, 1, 1), new Vector3i(3, 3, 3), new Vector3i(8, 5, 2));
+        List<Vector3i> expectedSize = Arrays.asList(new Vector3i(1, 1, 1), new Vector3i(3, 3, 3), new Vector3i(8, 5,
+                2));
         List<Vector3i> max = Arrays.asList(new Vector3i(), new Vector3i(3, 3, 3), new Vector3i(10, 8, 6));
         for (int i = 0; i < mins.size(); ++i) {
             BlockRegion region = new BlockRegion(mins.get(i), max.get(i));
@@ -68,10 +70,12 @@ public class BlockRegionTest {
     @Test
     public void testCreateRegionWithBounds() {
         BlockRegion expectedRegion = new BlockRegion(new Vector3i(-2, 4, -16), new Vector3i(4, 107, 0));
-        List<Vector3i> vec1 = Arrays.asList(new Vector3i(-2, 4, -16), new Vector3i(4, 4, -16), new Vector3i(-2, 107, -16), new Vector3i(-2, 4, 0),
-            new Vector3i(4, 107, -16), new Vector3i(4, 4, 0), new Vector3i(-2, 107, 0), new Vector3i(4, 107, 0));
-        List<Vector3i> vec2 = Arrays.asList(new Vector3i(4, 107, 0), new Vector3i(-2, 107, 0), new Vector3i(4, 4, 0), new Vector3i(4, 107, -16),
-            new Vector3i(-2, 4, 0), new Vector3i(-2, 107, -16), new Vector3i(4, 4, -16), new Vector3i(-2, 4, -16));
+        List<Vector3i> vec1 = Arrays.asList(new Vector3i(-2, 4, -16), new Vector3i(4, 4, -16), new Vector3i(-2, 107,
+                        -16), new Vector3i(-2, 4, 0),
+                new Vector3i(4, 107, -16), new Vector3i(4, 4, 0), new Vector3i(-2, 107, 0), new Vector3i(4, 107, 0));
+        List<Vector3i> vec2 = Arrays.asList(new Vector3i(4, 107, 0), new Vector3i(-2, 107, 0), new Vector3i(4, 4, 0),
+                new Vector3i(4, 107, -16),
+                new Vector3i(-2, 4, 0), new Vector3i(-2, 107, -16), new Vector3i(4, 4, -16), new Vector3i(-2, 4, -16));
         for (int i = 0; i < vec1.size(); ++i) {
             BlockRegion target = new BlockRegion().union(vec1.get(i)).union(vec2.get(i));
             assertEquals(expectedRegion, target);
@@ -88,7 +92,7 @@ public class BlockRegionTest {
     public void testIterateRegion() {
         Vector3i min = new Vector3i(2, 5, 7);
         Vector3i max = new Vector3i(10, 11, 12);
-        BlockRegion region = new BlockRegion(min,max);
+        BlockRegion region = new BlockRegion(min, max);
 
         Set<Vector3ic> expected = Sets.newHashSet();
         for (int x = min.x; x <= max.x; ++x) {
@@ -100,7 +104,7 @@ public class BlockRegionTest {
         }
 
 
-        for (Vector3ic pos : BlockRegionIterable.region(region).build()) {
+        for (Vector3ic pos : BlockRegions.iterableInPlace(region)) {
             assertTrue(expected.contains(pos), "unexpected position: " + pos);
             expected.remove(pos);
         }

--- a/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
@@ -17,7 +17,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testSingleBlockRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegions.iterable(region);
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {
@@ -31,7 +31,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testLineOfBlocksRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 0));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegions.iterable(region);
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {
@@ -45,7 +45,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testPlaneOfBlocksRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 1));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegions.iterable(region);
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {
@@ -59,7 +59,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testBoxOfBlocksRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegions.iterable(region);
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {

--- a/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
@@ -1,0 +1,44 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.block;
+
+import com.google.common.collect.ImmutableList;
+import org.joml.Vector3i;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BlockRegionIterableTest {
+
+    @Test
+    public void testSingleBlockRegion() {
+        BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0));
+        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+
+        Assertions.assertEquals(1, ImmutableList.copyOf(iterable).size());
+    }
+
+    @Test
+    public void testLineOfBlocksRegion() {
+        BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 0));
+        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+
+        Assertions.assertEquals(2, ImmutableList.copyOf(iterable).size());
+    }
+
+    @Test
+    public void testPlaneOfBlocksRegion() {
+        BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 1));
+        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+
+        Assertions.assertEquals(4, ImmutableList.copyOf(iterable).size());
+    }
+
+    @Test
+    public void testBoxOfBlocksRegion() {
+        BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1));
+        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+
+        Assertions.assertEquals(8, ImmutableList.copyOf(iterable).size());
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
@@ -5,8 +5,13 @@ package org.terasology.world.block;
 
 import com.google.common.collect.ImmutableList;
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 
 public class BlockRegionIterableTest {
 
@@ -23,7 +28,9 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 0));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        Assertions.assertEquals(2, ImmutableList.copyOf(iterable).size());
+        ImmutableList<Vector3ic> actual = ImmutableList.copyOf(iterable);
+        Assertions.assertEquals(2, actual.size());
+        Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
     }
 
     @Test
@@ -31,7 +38,9 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 1));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        Assertions.assertEquals(4, ImmutableList.copyOf(iterable).size());
+        ImmutableList<Vector3ic> actual = ImmutableList.copyOf(iterable);
+        Assertions.assertEquals(4, actual.size());
+        Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
     }
 
     @Test
@@ -39,6 +48,20 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        Assertions.assertEquals(8, ImmutableList.copyOf(iterable).size());
+        ImmutableList<Vector3ic> actual = ImmutableList.copyOf(iterable);
+        Assertions.assertEquals(8, actual.size());
+        Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
+    }
+
+    private List<Vector3ic> expectedPositions(BlockRegion region) {
+        List<Vector3ic> result = new ArrayList<>(region.getSizeX() * region.getSizeY() * region.getSizeZ());
+        for (int x = region.getMinX(); x <= region.getMaxX(); x++) {
+            for (int y = region.getMinY(); y <= region.getMaxY(); y++) {
+                for (int z = region.getMinZ(); z <= region.getMaxZ(); z++) {
+                    result.add(new Vector3i(x, y, z));
+                }
+            }
+        }
+        return result;
     }
 }

--- a/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
@@ -3,7 +3,6 @@
 
 package org.terasology.world.block;
 
-import com.google.common.collect.ImmutableList;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.Assertions;
@@ -20,7 +19,13 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        Assertions.assertEquals(1, ImmutableList.copyOf(iterable).size());
+        List<Vector3ic> actual = new ArrayList<>();
+        for (Vector3ic vector3ic : iterable) {
+            actual.add(new Vector3i(vector3ic));
+        }
+
+        Assertions.assertEquals(1, actual.size());
+        Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
     }
 
     @Test
@@ -28,7 +33,11 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 0));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        ImmutableList<Vector3ic> actual = ImmutableList.copyOf(iterable);
+        List<Vector3ic> actual = new ArrayList<>();
+        for (Vector3ic vector3ic : iterable) {
+            actual.add(new Vector3i(vector3ic));
+        }
+
         Assertions.assertEquals(2, actual.size());
         Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
     }
@@ -38,7 +47,11 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 1));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        ImmutableList<Vector3ic> actual = ImmutableList.copyOf(iterable);
+        List<Vector3ic> actual = new ArrayList<>();
+        for (Vector3ic vector3ic : iterable) {
+            actual.add(new Vector3i(vector3ic));
+        }
+
         Assertions.assertEquals(4, actual.size());
         Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
     }
@@ -48,7 +61,11 @@ public class BlockRegionIterableTest {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1));
         BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
 
-        ImmutableList<Vector3ic> actual = ImmutableList.copyOf(iterable);
+        List<Vector3ic> actual = new ArrayList<>();
+        for (Vector3ic vector3ic : iterable) {
+            actual.add(new Vector3i(vector3ic));
+        }
+
         Assertions.assertEquals(8, actual.size());
         Assertions.assertEquals(new HashSet<>(expectedPositions(region)), new HashSet<>(actual));
     }

--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -22,7 +22,7 @@ import org.terasology.world.block.BeforeDeactivateBlocks;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
-import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.block.OnActivatedBlocks;
 import org.terasology.world.block.OnAddedBlocks;
 import org.terasology.world.chunks.Chunk;
@@ -95,11 +95,18 @@ class LocalChunkProviderTest {
         BlockRegion extentsRegion = new BlockRegion(
                 chunkPosition.x - radius, chunkPosition.y - radius, chunkPosition.z - radius,
                 chunkPosition.x + radius, chunkPosition.y + radius, chunkPosition.z + radius);
-        BlockRegionIterable.region(extentsRegion).subtract(
-                new BlockRegion( // remove center. we takes future for it already.
-                        chunkPosition.x, chunkPosition.y, chunkPosition.z,
-                        chunkPosition.x, chunkPosition.y, chunkPosition.z)
-        ).build().iterator().forEachRemaining(chunkPos -> chunkProvider.createOrLoadChunk(JomlUtil.from(chunkPos)));
+
+
+        BlockRegion subtract = new BlockRegion( // remove center. we takes future for it already.
+                chunkPosition.x, chunkPosition.y, chunkPosition.z,
+                chunkPosition.x, chunkPosition.y, chunkPosition.z);
+
+        BlockRegions.iterableInPlace(extentsRegion).iterator()
+                .forEachRemaining(pos -> {
+                    if (!pos.equals(JomlUtil.from(chunkPosition))) {
+                        chunkProvider.createOrLoadChunk(JomlUtil.from(pos));
+                    }
+                });
         return chunkFuture;
     }
 

--- a/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/BlockRegionTypeHandler.java
+++ b/engine/src/main/java/org/terasology/persistence/typeHandling/mathTypes/BlockRegionTypeHandler.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 public class BlockRegionTypeHandler extends TypeHandler<BlockRegion> {
     private static final String MIN_FIELD = "min";
     private static final String MAX_FIELD = "max";
+    private static final String SIZE_FIELD = "size";
 
     public BlockRegionTypeHandler() {
     }
@@ -36,9 +37,13 @@ public class BlockRegionTypeHandler extends TypeHandler<BlockRegion> {
             PersistedDataMap map = data.getAsValueMap();
 
             PersistedDataArray minDataArr = map.get(MIN_FIELD).getAsArray();
-            PersistedDataArray maxDataArr = map.get(MIN_FIELD).getAsArray();
-
             TIntList minArr = minDataArr.getAsIntegerArray();
+            if(map.has(SIZE_FIELD)) {
+                PersistedDataArray sizedataArray = map.get(SIZE_FIELD).getAsArray();
+                TIntList sizeArr = sizedataArray.getAsIntegerArray();
+                return Optional.of(new BlockRegion(minArr.get(0), minArr.get(1), minArr.get(2), minArr.get(0) + sizeArr.get(0) - 1, minArr.get(1) + sizeArr.get(1) - 1, minArr.get(2) + sizeArr.get(2) - 1));
+            }
+            PersistedDataArray maxDataArr = map.get(MAX_FIELD).getAsArray();
             TIntList maxArr = maxDataArr.getAsIntegerArray();
 
             return Optional.of(new BlockRegion(minArr.get(0), minArr.get(1), minArr.get(2), maxArr.get(0), maxArr.get(1), maxArr.get(2)));

--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block;
 
 import org.joml.AABBf;
@@ -44,7 +31,6 @@ public class BlockRegion {
     public final AABBi aabb = new AABBi();
 
     public BlockRegion() {
-        this.setMin(0, 0, 0).setMax(0, 0, 0);
     }
 
     public BlockRegion(BlockRegion source) {

--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -33,8 +33,8 @@ import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 
 /**
- * is a bounded box describing blocks contained within.
- * A {@link BlockRegion} is described and backed by an {@link AABBi}
+ * is a bounded box describing blocks contained within. A {@link BlockRegion} is described and backed by an {@link
+ * AABBi}
  */
 public class BlockRegion {
 
@@ -44,6 +44,7 @@ public class BlockRegion {
     public final AABBi aabb = new AABBi();
 
     public BlockRegion() {
+        this.setMin(0, 0, 0).setMax(0, 0, 0);
     }
 
     public BlockRegion(BlockRegion source) {
@@ -54,10 +55,18 @@ public class BlockRegion {
         aabb.set(source);
     }
 
+    /**
+     * Deprecated in favor of {@link org.terasology.world.block.BlockRegions#createFromMinAndMax(Vector3ic, Vector3ic)}
+     */
+    @Deprecated
     public BlockRegion(Vector3ic min, Vector3ic max) {
         this(min.x(), min.y(), min.z(), max.x(), max.y(), max.z());
     }
 
+    /**
+     * Deprecated in favor of {@link org.terasology.world.block.BlockRegions#createFromMinAndMax(Vector3ic, Vector3ic)}
+     */
+    @Deprecated
     public BlockRegion(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
         this.setMin(minX, minY, minZ).setMax(maxX, maxY, maxZ);
     }
@@ -82,22 +91,28 @@ public class BlockRegion {
     public Vector3i getMax(Vector3i dest) {
         return dest.set(aabb.maxX - 1, aabb.maxY - 1, aabb.maxZ - 1);
     }
+
     /**
      * the maximum coordinate of the second block x
+     *
      * @return the minimum coordinate x
      */
     public int getMaxX() {
         return this.aabb.maxX - 1;
     }
+
     /**
      * the maximum coordinate of the second block y
+     *
      * @return the minimum coordinate y
      */
     public int getMaxY() {
         return this.aabb.maxY - 1;
     }
+
     /**
      * the maximum coordinate of the second block z
+     *
      * @return the minimum coordinate z
      */
     public int getMaxZ() {
@@ -106,13 +121,16 @@ public class BlockRegion {
 
     /**
      * the minimum coordinate of the first block x
+     *
      * @return the minimum coordinate x
      */
     public int getMinX() {
         return this.aabb.minX;
     }
+
     /**
      * the minimum coordinate of the first block y
+     *
      * @return the minimum coordinate y
      */
     public int getMinY() {
@@ -121,6 +139,7 @@ public class BlockRegion {
 
     /**
      * the minimum coordinate of the first block z
+     *
      * @return the minimum coordinate z
      */
     public int getMinZ() {
@@ -176,7 +195,9 @@ public class BlockRegion {
     }
 
     /**
-     * Set <code>this</code> to the union of <code>this</code> and the given {@link EntityRef} associated with a block <code>p</code>.
+     * Set <code>this</code> to the union of <code>this</code> and the given {@link EntityRef} associated with a block
+     * <code>p</code>.
+     *
      * @param blockRef entityRef that describes a block
      * @param dest will hold the result
      * @return dest
@@ -200,11 +221,12 @@ public class BlockRegion {
     }
 
     /**
-     * Compute the union of <code>this</code> and the given block <code>(x, y, z)</code> and stores the result in <code>dest</code>
+     * Compute the union of <code>this</code> and the given block <code>(x, y, z)</code> and stores the result in
+     * <code>dest</code>
      *
-     * @param x    the x coordinate of the block
-     * @param y    the y coordinate of the block
-     * @param z    the z coordinate of the block
+     * @param x the x coordinate of the block
+     * @param y the y coordinate of the block
+     * @param z the z coordinate of the block
      * @param dest will hold the result
      * @return dest
      */
@@ -220,7 +242,9 @@ public class BlockRegion {
     }
 
     /**
-     * Compute the union of <code>this</code> and the given block <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     * Compute the union of <code>this</code> and the given block <code>(x, y, z)</code> and store the result in
+     * <code>dest</code>.
+     *
      * @param pos the position of the block
      * @param dest will hold the result
      * @return dest
@@ -252,7 +276,7 @@ public class BlockRegion {
     }
 
     /**
-     *  Set <code>this</code> to the union of <code>this</code> and <code>other</code>.
+     * Set <code>this</code> to the union of <code>this</code> and <code>other</code>.
      *
      * @param other the other {@link AABBi}
      * @return this
@@ -263,8 +287,8 @@ public class BlockRegion {
     }
 
     /**
-     * Ensure that the minimum coordinates are strictly less than or equal to the maximum coordinates by swapping
-     * them if necessary.
+     * Ensure that the minimum coordinates are strictly less than or equal to the maximum coordinates by swapping them
+     * if necessary.
      *
      * @return this
      */
@@ -275,6 +299,7 @@ public class BlockRegion {
 
     /**
      * set the size of the block region from minimum.
+     *
      * @param x the x coordinate to set the size
      * @param y the y coordinate to set the size
      * @param z the z coordinate to set the size
@@ -289,6 +314,7 @@ public class BlockRegion {
 
     /**
      * set the size of the block region from minimum.
+     *
      * @param size the size to set the {@link BlockRegion}
      * @return this
      */
@@ -298,11 +324,13 @@ public class BlockRegion {
 
     /**
      * the number of blocks for the +x, +y, +z from the minimum to the maximum
+     *
      * @param dest will hold the result
      * @return dest
      */
     public Vector3i getSize(Vector3i dest) {
-        return dest.set(this.aabb.maxX - this.aabb.minX, this.aabb.maxY - this.aabb.minY, this.aabb.maxZ - this.aabb.minZ);
+        return dest.set(this.aabb.maxX - this.aabb.minX, this.aabb.maxY - this.aabb.minY,
+                this.aabb.maxZ - this.aabb.minZ);
     }
 
     /**
@@ -334,9 +362,10 @@ public class BlockRegion {
 
     /**
      * Translate <code>this</code> by the given vector <code>xyz</code>.
-     * @param x  the x coordinate to translate by
-     * @param y  the y coordinate to translate by
-     * @param z  the z coordinate to translate by
+     *
+     * @param x the x coordinate to translate by
+     * @param y the y coordinate to translate by
+     * @param z the z coordinate to translate by
      * @return this
      */
     public BlockRegion translate(int x, int y, int z) {
@@ -346,7 +375,8 @@ public class BlockRegion {
 
     /**
      * Translate <code>this</code> by the given vector <code>xyz</code>.
-     * @param xyz  the vector to translate by
+     *
+     * @param xyz the vector to translate by
      * @param dest will hold the result
      * @return dest
      */
@@ -358,8 +388,7 @@ public class BlockRegion {
     /**
      * Translate <code>this</code> by the given vector <code>xyz</code>.
      *
-     * @param xyz
-     *          the vector to translate by
+     * @param xyz the vector to translate by
      * @return this
      */
     public BlockRegion translate(Vector3ic xyz) {
@@ -372,8 +401,7 @@ public class BlockRegion {
      * <p>
      * The matrix in <code>m</code> <i>must</i> be {@link Matrix4fc#isAffine() affine}.
      *
-     * @param m
-     *          the affine transformation matrix
+     * @param m the affine transformation matrix
      * @return this
      */
     public BlockRegion transform(Matrix4fc m) {
@@ -386,8 +414,7 @@ public class BlockRegion {
      * <p>
      * The matrix in <code>m</code> <i>must</i> be {@link Matrix4fc#isAffine() affine}.
      *
-     * @param m
-     *          the affine transformation matrix
+     * @param m the affine transformation matrix
      * @return this
      */
     public BlockRegion transform(Matrix4fc m, BlockRegion dest) {
@@ -398,7 +425,7 @@ public class BlockRegion {
     /**
      * Test whether the block <code>(x, y, z)</code> lies inside this BlockRegion.
      *
-     * @param pos  the coordinates of the block
+     * @param pos the coordinates of the block
      * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
      */
     public boolean containsBlock(Vector3ic pos) {
@@ -413,9 +440,9 @@ public class BlockRegion {
      */
     public Vector3f center(Vector3f dest) {
         return dest.set(
-            (aabb.maxX - aabb.minX) / 2.0f,
-            (aabb.maxY - aabb.minY) / 2.0f,
-            (aabb.maxZ - aabb.minZ) / 2.0f
+                (aabb.maxX - aabb.minX) / 2.0f,
+                (aabb.maxY - aabb.minY) / 2.0f,
+                (aabb.maxZ - aabb.minZ) / 2.0f
         );
     }
 
@@ -478,7 +505,9 @@ public class BlockRegion {
     /**
      * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
      * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     * Reference:
+     * <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a>
+     * ("Geometric Approach - Testing Boxes II")
      *
      * @param a the x factor in the plane equation
      * @param b the y factor in the plane equation
@@ -493,7 +522,9 @@ public class BlockRegion {
     /**
      * Test whether the given plane intersects this AABB.
      * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     * Reference:
+     * <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a>
+     * ("Geometric Approach - Testing Boxes II")
      *
      * @param plane the plane
      * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
@@ -536,7 +567,9 @@ public class BlockRegion {
      * Test whether this AABB intersects the given sphere with equation
      * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
      * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     * Reference:
+     * <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
      * @param centerX the x coordinate of the center of the sphere
      * @param centerY the y coordinate of the center of the sphere
      * @param centerZ the z coordinate of the center of the sphere
@@ -544,13 +577,15 @@ public class BlockRegion {
      * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
      */
     public boolean intersectsSphere(float centerX, float centerY, float centerZ, float radiusSquared) {
-        return Intersectionf.testAabSphere(aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ, centerX, centerY, centerZ, radiusSquared);
+        return Intersectionf.testAabSphere(aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ, centerX,
+                centerY, centerZ, radiusSquared);
     }
 
     /**
      * Test whether this AABB intersects the given sphere.
      * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     * Reference:
+     * <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
      *
      * @param sphere the sphere
      * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
@@ -560,8 +595,8 @@ public class BlockRegion {
     }
 
     /**
-     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB.
+     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX,
+     * dirY, dirZ)</code> intersects this AABB.
      * <p>
      * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
      * <p>
@@ -576,7 +611,8 @@ public class BlockRegion {
      * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
      */
     public boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ) {
-        return Intersectionf.testRayAab(originX, originY, originZ, dirX, dirY, dirZ, aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ);
+        return Intersectionf.testRayAab(originX, originY, originZ, dirX, dirY, dirZ, aabb.minX, aabb.minY, aabb.minZ,
+                aabb.maxX, aabb.maxY, aabb.maxZ);
     }
 
     /**
@@ -594,8 +630,8 @@ public class BlockRegion {
     }
 
     /**
-     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X,
+     * p1Y, p1Z)</code> intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
      * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
      * <p>
      * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
@@ -608,21 +644,23 @@ public class BlockRegion {
      * @param p1X the x coordinate of the line segment's second end point
      * @param p1Y the y coordinate of the line segment's second end point
      * @param p1Z the z coordinate of the line segment's second end point
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     * @param result a vector which will hold the resulting values of the parameter
+     *         <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *         iff the line segment intersects this AABB
+     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or {@link
+     *         Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or {@link
+     *         Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on
+     *         an edge or a side of this AABB
      */
     public int intersectLineSegment(float p0X, float p0Y, float p0Z, float p1X, float p1Y, float p1Z, Vector2f result) {
-        return Intersectionf.intersectLineSegmentAab(p0X, p0Y, p0Z, p1X, p1Y, p1Z, aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ, result);
+        return Intersectionf.intersectLineSegmentAab(p0X, p0Y, p0Z, p1X, p1Y, p1Z, aabb.minX, aabb.minY, aabb.minZ,
+                aabb.maxX, aabb.maxY, aabb.maxZ, result);
     }
 
     /**
-     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter
+     * <i>t</i> in the ray equation
      * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
      * <p>
      * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
@@ -630,14 +668,14 @@ public class BlockRegion {
      * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
      *
      * @param lineSegment the line segment
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     * @param result a vector which will hold the resulting values of the parameter
+     *         <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *         iff the line segment intersects this AABB
+     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or {@link
+     *         Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or {@link
+     *         Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on
+     *         an edge or a side of this AABB
      */
     public int intersectLineSegment(LineSegmentf lineSegment, Vector2f result) {
         return Intersectionf.intersectLineSegmentAab(lineSegment, aabb, result);
@@ -654,6 +692,7 @@ public class BlockRegion {
 
     /**
      * calculate the BlockRegion that is intersected between another region
+     *
      * @param other the other BlockRegion
      * @param dest holds the result
      * @return dest
@@ -684,6 +723,27 @@ public class BlockRegion {
      */
     public BlockRegion addExtents(int extentX, int extentY, int extentZ) {
         return addExtents(extentX, extentY, extentZ, this);
+    }
+
+    /**
+     * Adds extend for each face of a BlockRegion.
+     *
+     * @param extents extents to grow each face
+     * @param dest holds the result
+     * @return dest
+     */
+    public BlockRegion addExtents(Vector3ic extents, BlockRegion dest) {
+        return addExtents(extents.x(), extents.y(), extents.z(), dest);
+    }
+
+    /**
+     * Adds extend for each face of a BlockRegion.
+     *
+     * @param extents the coordinates to grow the extents
+     * @return this
+     */
+    public BlockRegion addExtents(Vector3ic extents) {
+        return addExtents(extents.x(), extents.y(), extents.z(), this);
     }
 
     /**
@@ -746,6 +806,6 @@ public class BlockRegion {
     @Override
     public String toString() {
         return "(" + this.aabb.minX + " " + this.aabb.minY + " " + this.aabb.minZ + ") < " +
-            "(" + (this.aabb.maxX - 1) + " " + (this.aabb.maxY - 1) + " " + (this.aabb.maxZ - 1) + ")";
+                "(" + (this.aabb.maxX - 1) + " " + (this.aabb.maxY - 1) + " " + (this.aabb.maxZ - 1) + ")";
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -279,7 +279,24 @@ public class BlockRegion {
      * @return this
      */
     public BlockRegion correctBounds() {
-        this.aabb.correctBounds();
+        // NOTE: this is basically the same as AABBi#correctBounds, but adjusted for off-by-one semantics here in
+        //       BlockRegion for the max value.
+        int tmp;
+        if (this.aabb.minX > this.aabb.maxX - 1) {
+            tmp = this.aabb.minX;
+            this.aabb.minX = this.aabb.maxX - 1;
+            this.aabb.maxX = tmp + 1;
+        }
+        if (this.aabb.minY > this.aabb.maxY - 1) {
+            tmp = this.aabb.minY;
+            this.aabb.minY = this.aabb.maxY - 1;
+            this.aabb.maxY = tmp + 1;
+        }
+        if (this.aabb.minZ > this.aabb.maxZ - 1) {
+            tmp = this.aabb.minZ;
+            this.aabb.minZ = this.aabb.maxZ - 1;
+            this.aabb.maxZ = tmp + 1;
+        }
         return this;
     }
 

--- a/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
@@ -2,25 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block;
 
-import com.google.common.collect.Lists;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 
 import java.util.Iterator;
-import java.util.List;
 
 public class BlockRegionIterable implements Iterable<Vector3ic> {
 
     private final BlockRegion region;
-    private List<BlockRegion> subtract;
 
-    private BlockRegionIterable(BlockRegion region, List<BlockRegion> subtract) {
+    BlockRegionIterable(BlockRegion region) {
         this.region = region;
-        this.subtract = subtract;
-    }
-
-    public static BlockRegionIterable.Builder region(BlockRegion region) {
-        return new BlockRegionIterable.Builder(region);
     }
 
     @Override
@@ -29,34 +21,18 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
             private Vector3i current = null;
             private final Vector3i next = new Vector3i(region.getMinX(), region.getMinY(), region.getMinZ());
 
-            public boolean isValid(Vector3ic test) {
-                if (subtract != null) {
-                    for (BlockRegion blockRegion : subtract) {
-                        if (blockRegion.containsBlock(test)) {
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            }
-
             public boolean findNext() {
                 if (current.equals(next)) {
-                    do {
-                        next.z++;
-                        if (next.z > region.getMaxZ()) {
-                            next.z = region.getMinZ();
-                            next.y++;
-                            if (next.y > region.getMaxY()) {
-                                next.y = region.getMinY();
-                                next.x++;
-                            }
+                    next.z++;
+                    if (next.z > region.getMaxZ()) {
+                        next.z = region.getMinZ();
+                        next.y++;
+                        if (next.y > region.getMaxY()) {
+                            next.y = region.getMinY();
+                            next.x++;
                         }
-                        if (!region.containsBlock(next)) {
-                            return false;
-                        }
-                    } while (!isValid(next));
-                    return true;
+                    }
+                    return region.containsBlock(next);
                 }
                 return true;
             }
@@ -90,26 +66,5 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
                 return next;
             }
         };
-    }
-
-    public static final class Builder {
-        private final BlockRegion region;
-        private List<BlockRegion> subtract;
-
-        private Builder(BlockRegion region) {
-            this.region = region;
-        }
-
-        public BlockRegionIterable.Builder subtract(BlockRegion reg) {
-            if (subtract == null) {
-                subtract = Lists.newArrayList();
-            }
-            subtract.add(reg);
-            return this;
-        }
-
-        public BlockRegionIterable build() {
-            return new BlockRegionIterable(region, subtract);
-        }
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
@@ -27,7 +27,7 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
     public Iterator<Vector3ic> iterator() {
         return new Iterator<Vector3ic>() {
             private Vector3i current = null;
-            private final Vector3i next = new Vector3i(region.aabb.minX, region.aabb.minY, region.aabb.minZ);
+            private final Vector3i next = new Vector3i(region.getMinX(), region.getMinY(), region.getMinZ());
 
             public boolean isValid(Vector3ic test) {
                 if (subtract != null) {
@@ -44,11 +44,11 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
                 if (current.equals(next)) {
                     do {
                         next.z++;
-                        if (next.z >= region.aabb.maxZ) {
-                            next.z = region.aabb.minZ;
+                        if (next.z > region.getMaxZ()) {
+                            next.z = region.getMinZ();
                             next.y++;
-                            if (next.y >= region.aabb.maxY) {
-                                next.y = region.aabb.minY;
+                            if (next.y > region.getMaxY()) {
+                                next.y = region.getMinY();
                                 next.x++;
                             }
                         }
@@ -87,7 +87,7 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
                     return null;
                 }
                 current.set(next);
-                return next;
+                return current;
             }
         };
     }

--- a/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block;
 
 import com.google.common.collect.Lists;

--- a/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
@@ -87,7 +87,7 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
                     return null;
                 }
                 current.set(next);
-                return current;
+                return next;
             }
         };
     }

--- a/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
@@ -70,7 +70,7 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
                 if (current.equals(next)) {
                     return findNext();
                 }
-                return !region.containsBlock(next);
+                return region.containsBlock(next);
             }
 
             @Override

--- a/engine/src/main/java/org/terasology/world/block/BlockRegions.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegions.java
@@ -1,0 +1,59 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.block;
+
+import org.joml.RoundingMode;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+
+public class BlockRegions {
+    private BlockRegions() {
+    }
+
+    /**
+     * Creates a new region spanning the smallest axis-aligned bounding box (AABB) containing both, min and max
+     *
+     * @return new block region
+     */
+    public static BlockRegion createFromMinAndMax(Vector3ic min, Vector3ic max) {
+        return new BlockRegion().setMin(min).setMax(max);
+    }
+
+    /**
+     * Creates a new region spanning the smallest axis-aligned bounding box (AABB) containing both, min and max
+     *
+     * @return new block region
+     */
+    public static BlockRegion createFromMinAndMax(int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
+        return new BlockRegion().setMin(minX, minY, minZ).setMax(maxX, maxY, maxZ);
+    }
+
+    /**
+     * Creates a new region centered around {@code center} extending each side by {@code extents}. The resulting
+     * axis-aligned bounding box (AABB) will have a size of {@code 2 * extents}
+     *
+     * @return new block region
+     */
+    public static BlockRegion createFromCenterAndExtents(Vector3ic center, Vector3ic extents) {
+        return new BlockRegion().translate(center).addExtents(extents);
+    }
+
+    /**
+     * Creates a new region centered around {@code center} extending each side by {@code extents}. The computed min is
+     * rounded up (ceil), the computed max is rounded down (floor). Thus, the resulting axis-aligned bounding box (AABB)
+     * will only include integer points that are within the floating point area and have a size of {@code <= 2 *
+     * extents}
+     *
+     * @return new block region
+     */
+    public static BlockRegion createFromCenterAndExtents(Vector3fc center, Vector3fc extents) {
+        Vector3f min = center.sub(extents, new Vector3f());
+        Vector3f max = center.add(extents, new Vector3f());
+
+        return new BlockRegion().setMin(new Vector3i(min, RoundingMode.CEILING)).setMax(new Vector3i(max,
+                RoundingMode.FLOOR));
+    }
+}

--- a/engine/src/main/java/org/terasology/world/block/BlockRegions.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegions.java
@@ -9,7 +9,7 @@ import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 
-public class BlockRegions {
+public final class BlockRegions {
     private BlockRegions() {
     }
 
@@ -38,7 +38,7 @@ public class BlockRegions {
      * @return new block region
      */
     public static BlockRegion createFromCenterAndExtents(Vector3ic center, Vector3ic extents) {
-        return new BlockRegion().translate(center).addExtents(extents);
+        return new BlockRegion().setMin(center).setMax(center).addExtents(extents);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/BlockRegions.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegions.java
@@ -40,7 +40,7 @@ public final class BlockRegions {
      * @return new block region
      */
     public static BlockRegion createFromCenterAndExtents(Vector3ic center, Vector3ic extents) {
-        return new BlockRegion().setMin(center).setMax(center).addExtents(extents);
+        return new BlockRegion().union(center).addExtents(extents);
     }
 
     /**
@@ -55,8 +55,9 @@ public final class BlockRegions {
         Vector3f min = center.sub(extents, new Vector3f());
         Vector3f max = center.add(extents, new Vector3f());
 
-        return new BlockRegion().setMin(new Vector3i(min, RoundingMode.CEILING)).setMax(new Vector3i(max,
-                RoundingMode.FLOOR));
+        return new BlockRegion()
+                .setMin(new Vector3i(min, RoundingMode.CEILING))
+                .setMax(new Vector3i(max, RoundingMode.FLOOR));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/BlockRegions.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegions.java
@@ -9,6 +9,8 @@ import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 
+import java.util.Iterator;
+
 public final class BlockRegions {
     private BlockRegions() {
     }
@@ -55,5 +57,46 @@ public final class BlockRegions {
 
         return new BlockRegion().setMin(new Vector3i(min, RoundingMode.CEILING)).setMax(new Vector3i(max,
                 RoundingMode.FLOOR));
+    }
+
+    /**
+     * An iterable over the blocks in the block region, where each position is wrapped in a new {@link Vector3i}.
+     * <p>
+     * If you only need the elements of the block region in the local context of the iterator step without modifications
+     * you may want to consider using {@link #iterableInPlace(BlockRegion)} instead.
+     *
+     * @param region the region to iterate over
+     */
+    public static Iterable<Vector3i> iterable(BlockRegion region) {
+        return () -> {
+            Iterator<Vector3ic> itr = iterableInPlace(region).iterator();
+            return new Iterator<Vector3i>() {
+                @Override
+                public boolean hasNext() {
+                    return itr.hasNext();
+                }
+
+                @Override
+                public Vector3i next() {
+                    return new Vector3i(itr.next());
+                }
+            };
+        };
+    }
+
+    /**
+     * An iterable over the blocks in the block region, where the same {@link Vector3ic} is reused to avoid GC.
+     * <p>
+     * Use this iterable for performance optimized iterations where the positions are only needed within the context of
+     * the iterator sequence.
+     * <p>
+     * Do not store the elements directly or use them outside the context of the iterator as they will change when the
+     * iterator is advanced. You may create new vectors from the elements if necessary, or use {@link
+     * #iterable(BlockRegion)} instead.
+     *
+     * @param region the region to iterate over
+     */
+    public static Iterable<Vector3ic> iterableInPlace(BlockRegion region) {
+        return new BlockRegionIterable(region);
     }
 }

--- a/engine/src/main/java/org/terasology/world/block/regions/BlockRegionComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/BlockRegionComponent.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.world.block.regions;
 

--- a/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/regions/BlockRegionSystem.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.regions;
 
 import org.terasology.entitySystem.entity.EntityRef;

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -31,8 +31,7 @@ import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.block.BeforeDeactivateBlocks;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.BlockRegion;
-import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.block.OnActivatedBlocks;
 import org.terasology.world.block.OnAddedBlocks;
 import org.terasology.world.chunks.Chunk;
@@ -448,10 +447,10 @@ public class LocalChunkProvider implements ChunkProvider {
                             Chunk[] localchunks = chunks.toArray(new Chunk[0]);
                             return new LightMerger().merge(localchunks);
                         },
-                        pos -> StreamSupport.stream(BlockRegionIterable.region(new BlockRegion(
+                        pos -> StreamSupport.stream(BlockRegions.iterableInPlace(BlockRegions.createFromMinAndMax(
                                 pos.x() - 1, pos.y() - 1, pos.z() - 1,
                                 pos.x() + 1, pos.y() + 1, pos.z() + 1
-                        )).build().spliterator(), false)
+                        )).spliterator(), false)
                                 .map(org.joml.Vector3i::new)
                                 .collect(Collectors.toSet())
                 ))
@@ -489,10 +488,10 @@ public class LocalChunkProvider implements ChunkProvider {
                             Chunk[] localchunks = chunks.toArray(new Chunk[0]);
                             return new LightMerger().merge(localchunks);
                         },
-                        pos -> StreamSupport.stream(BlockRegionIterable.region(new BlockRegion(
+                        pos -> StreamSupport.stream(BlockRegions.iterableInPlace(BlockRegions.createFromMinAndMax(
                                 pos.x() - 1, pos.y() - 1, pos.z() - 1,
                                 pos.x() + 1, pos.y() + 1, pos.z() + 1
-                        )).build().spliterator(), false)
+                        )).spliterator(), false)
                                 .map(org.joml.Vector3i::new)
                                 .collect(Collectors.toCollection(Sets::newLinkedHashSet))
                 ))

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -19,6 +19,7 @@ import org.terasology.monitoring.chunk.ChunkMonitor;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
@@ -76,10 +77,10 @@ public class RemoteChunkProvider implements ChunkProvider {
                             Chunk[] localchunks = chunks.toArray(new Chunk[0]);
                             return new LightMerger().merge(localchunks);
                         },
-                        pos -> StreamSupport.stream(BlockRegionIterable.region(new BlockRegion(
+                        pos -> StreamSupport.stream(BlockRegions.iterableInPlace(BlockRegions.createFromMinAndMax(
                                 pos.x() - 1, pos.y() - 1, pos.z() - 1,
                                 pos.x() + 1, pos.y() + 1, pos.z() + 1
-                        )).build().spliterator(), false)
+                        )).spliterator(), false)
                                 .map(org.joml.Vector3i::new)
                                 .collect(Collectors.toSet())
                 ))

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -25,6 +25,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.LitChunk;
 
@@ -337,7 +338,7 @@ public class StandardBatchPropagator implements BatchPropagator {
             }
         }
 
-        for (Vector3ic pos : BlockRegionIterable.region(edgeRegion).build()) {
+        for (Vector3ic pos : BlockRegions.iterableInPlace(edgeRegion)) {
             int depthIndex = indexProvider.getIndexFor(JomlUtil.from(pos));
             int adjacentDepth = adjDepth[depthIndex];
             for (int i = adjacentDepth; i < depths[depthIndex]; ++i) {


### PR DESCRIPTION
### Changes

- add `createFromMinAndMax` and `createFromCenterAndExtents` helpers
- deprecate BlockRegion constructors from min and max in favor of new helpers
- add tests for `BlockRegion` and `BlockRegionIterable` 
- add helper methods to create iterables for BlockRegions

### Module PRs

- https://github.com/Terasology/DynamicCities/pull/73
- https://github.com/Terasology/ClimateConditions/pull/38
- https://github.com/Terasology/StructureTemplates/pull/47
- https://github.com/Terasology/CombatSystem/pull/61
- https://github.com/Terasology/MetalRenegades/pull/117

---

Co-authored-by: Tobias Nett <skaldarnar@googlemail.com>
Co-authored-by: Michael Pollind <mpollind@gmail.com>