### PR TITLE
feat(player): increase player's eye height 0.7 >>> 0.85

### DIFF
--- a/engine/src/main/java/org/terasology/config/PlayerConfig.java
+++ b/engine/src/main/java/org/terasology/config/PlayerConfig.java
@@ -31,7 +31,7 @@ public class PlayerConfig extends AbstractSubscribable {
 
     private static final float DEFAULT_PLAYER_HEIGHT = 1.8f;
 
-    private static final float DEFAULT_PLAYER_EYE_HEIGHT = 0.7f;
+    private static final float DEFAULT_PLAYER_EYE_HEIGHT = 0.85f;
 
     private static final boolean DEFAULT_DISCORD_PRESENCE = true;
 


### PR DESCRIPTION
It felt a bit weird to be able to jump 2 blocks high, but barely being able to look over one block o.O Increased the eye height a bit to adjust for that.