### PR TITLE
fix: prevent NPE during movement interpolation

### DIFF
--- a/engine/src/main/java/org/terasology/logic/characters/CharacterMovementSystemUtility.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterMovementSystemUtility.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.characters;
 
+import com.google.common.collect.Lists;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -89,7 +90,11 @@ public final class CharacterMovementSystemUtility {
             return movementComponent;
         });
 
-        setPhysicsLocation(entity, newPos);
+        // BulletPhysics requires the entity to have both these components. This is not clear from the interfaces we're
+        // using, but the exception thrown in 'BulletPhysics#createCharacterCollider' is pretty self-explanatory...
+        if (entity.hasAllComponents(Lists.newArrayList(CharacterMovementComponent.class, LocationComponent.class))) {
+            setPhysicsLocation(entity, newPos);
+        }
     }
 
     public void setToExtrapolateState(EntityRef entity, CharacterStateEvent state, long time) {

--- a/engine/src/main/java/org/terasology/logic/characters/CharacterMovementSystemUtility.java
+++ b/engine/src/main/java/org/terasology/logic/characters/CharacterMovementSystemUtility.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2015 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.characters;
 
 import org.joml.Quaternionf;
@@ -80,24 +67,27 @@ public final class CharacterMovementSystemUtility {
         float t = (float) (time - a.getTime()) / (b.getTime() - a.getTime());
         Vector3f newPos = JomlUtil.from(a.getPosition()).lerp(JomlUtil.from(b.getPosition()),t);
         Quaternionf newRot = JomlUtil.from(a.getRotation()).nlerp(JomlUtil.from(b.getRotation()),t);
-        LocationComponent location = entity.getComponent(LocationComponent.class);
-        location.setWorldPosition(JomlUtil.from(newPos));
-        location.setWorldRotation(JomlUtil.from(newRot));
-        entity.saveComponent(location);
 
-        CharacterMovementComponent movementComponent = entity.getComponent(CharacterMovementComponent.class);
-        movementComponent.mode = a.getMode();
-        movementComponent.setVelocity(JomlUtil.from(a.getVelocity()));
-        movementComponent.grounded = a.isGrounded();
-        if (b.getFootstepDelta() < a.getFootstepDelta()) {
-            movementComponent.footstepDelta = t * (1 + b.getFootstepDelta() - a.getFootstepDelta()) + a.getFootstepDelta();
-            if (movementComponent.footstepDelta > 1) {
-                movementComponent.footstepDelta -= 1;
+        entity.updateComponent(LocationComponent.class, location -> {
+            location.setWorldPosition(JomlUtil.from(newPos));
+            location.setWorldRotation(JomlUtil.from(newRot));
+            return location;
+        });
+
+        entity.updateComponent(CharacterMovementComponent.class, movementComponent -> {
+            movementComponent.mode = a.getMode();
+            movementComponent.setVelocity(JomlUtil.from(a.getVelocity()));
+            movementComponent.grounded = a.isGrounded();
+            if (b.getFootstepDelta() < a.getFootstepDelta()) {
+                movementComponent.footstepDelta = t * (1 + b.getFootstepDelta() - a.getFootstepDelta()) + a.getFootstepDelta();
+                if (movementComponent.footstepDelta > 1) {
+                    movementComponent.footstepDelta -= 1;
+                }
+            } else {
+                movementComponent.footstepDelta = t * (b.getFootstepDelta() - a.getFootstepDelta()) + a.getFootstepDelta();
             }
-        } else {
-            movementComponent.footstepDelta = t * (b.getFootstepDelta() - a.getFootstepDelta()) + a.getFootstepDelta();
-        }
-        entity.saveComponent(movementComponent);
+            return movementComponent;
+        });
 
         setPhysicsLocation(entity, newPos);
     }

--- a/engine/src/main/java/org/terasology/world/chunks/pipeline/PositionFuture.java
+++ b/engine/src/main/java/org/terasology/world/chunks/pipeline/PositionFuture.java
@@ -3,7 +3,6 @@
 
 package org.terasology.world.chunks.pipeline;
 
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3ic;
 
 import java.util.concurrent.ExecutionException;
@@ -51,7 +50,7 @@ public class PositionFuture<T> implements RunnableFuture<T> {
     }
 
     @Override
-    public T get(long timeout, @NotNull TimeUnit unit) throws InterruptedException, ExecutionException,
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
             TimeoutException {
         return delegate.get(timeout, unit);
     }


### PR DESCRIPTION
**Problem:** Killing a mob in a multi-player game as connected client lead to a NPE in the `CharacterMovementSystemUtility`. I suspect this is because we try to interpolate the movement of the mob even though we already removed components (like the `CharacterMovementComponent`) from the entity. 

**Solution:** Make use of `updateComponent` functional API to only update the respective component if it is present. Otherwise, nothing will happen. 

**Question:** This (maybe) only fixes a symptom. The interpolation is called for entries in a field called `playerStates`, but those actually contain NPC entities such as the deer or sheep. Basically, all entities with `CharacterMovementComponent`, `LocationComponent`, and `AliveCharacterComponent` are considered for movement prediction. Is this intended? The entity is supposed to be removed from `playerStates` on destruction - so why do we still try to interpolate movement when the entity was just killed?