### PR TITLE
fix: item pickup radius (again)

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -727,7 +727,7 @@ public class BulletPhysics implements PhysicsEngine {
         CharacterMovementComponent characterMovementComponent =
             entityRef.getComponent(CharacterMovementComponent.class);
         if (characterMovementComponent != null) {
-            return new btCapsuleShape(characterMovementComponent.radius, characterMovementComponent.height);
+            return new btCapsuleShape(characterMovementComponent.pickupRadius, characterMovementComponent.height - 2 * characterMovementComponent.radius);
         }
         logger.error("Creating physics object that requires a ShapeComponent or CharacterMovementComponent, but has " +
             "neither. Entity: {}", entityRef);


### PR DESCRIPTION
It looks like the item pickup radius got broken again in https://github.com/MovingBlocks/Terasology/pull/4139, probably due to incorrect merging. @pollend was that change deliberate? There are some potential issues involving this collider being used for things other than item pickup, but character movement, and world collision, are all based on a separate collider, so it should at least not affect that.