### PR TITLE
add standard and performant options for blockregion iteration

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/block/BlockRegionIterableTest.java
@@ -17,7 +17,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testSingleBlockRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 0, 0));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegionIterable.region(region).build();
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {
@@ -31,7 +31,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testLineOfBlocksRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 0));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegionIterable.region(region).build();
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {
@@ -45,7 +45,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testPlaneOfBlocksRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(0, 1, 1));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegionIterable.region(region).build();
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {
@@ -59,7 +59,7 @@ public class BlockRegionIterableTest {
     @Test
     public void testBoxOfBlocksRegion() {
         BlockRegion region = BlockRegions.createFromMinAndMax(new Vector3i(0, 0, 0), new Vector3i(1, 1, 1));
-        BlockRegionIterable iterable = BlockRegionIterable.region(region).build();
+        Iterable<Vector3i> iterable = BlockRegionIterable.region(region).build();
 
         List<Vector3ic> actual = new ArrayList<>();
         for (Vector3ic vector3ic : iterable) {

--- a/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegionIterable.java
@@ -3,6 +3,7 @@
 package org.terasology.world.block;
 
 import com.google.common.collect.Lists;
+import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 
@@ -108,7 +109,37 @@ public class BlockRegionIterable implements Iterable<Vector3ic> {
             return this;
         }
 
-        public BlockRegionIterable build() {
+        /**
+         * iterator where each instance is wrapped by a new vector3i
+         * @return
+         */
+        public Iterable<Vector3i> build() {
+            BlockRegionIterable iterable = new BlockRegionIterable(region, subtract);
+            return new Iterable<Vector3i>() {
+                @NotNull
+                @Override
+                public Iterator<Vector3i> iterator() {
+                    Iterator<Vector3ic> itr = iterable.iterator();
+                    return new Iterator<Vector3i>() {
+                        @Override
+                        public boolean hasNext() {
+                            return itr.hasNext();
+                        }
+
+                        @Override
+                        public Vector3i next() {
+                            return new Vector3i(itr.next());
+                        }
+                    };
+                }
+            };
+        }
+
+        /**
+         * iterable with a single vector that is reused to avoid GC
+         * @return
+         */
+        public Iterable<Vector3ic> buildWithReuse() {
             return new BlockRegionIterable(region, subtract);
         }
     }


### PR DESCRIPTION
Here is a tweak to how the iterator works. I kind of wanted to keep the type handling to avoid bugs. implementation is a bit more complex but I think this should work well. 