### PR TITLE
feat: Remove weird features near the origin from BrownianNoise

### DIFF
--- a/engine/src/main/java/org/terasology/utilities/procedural/BrownianNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/BrownianNoise.java
@@ -76,6 +76,10 @@ public class BrownianNoise extends AbstractNoise {
 
             workingX *= (float) getLacunarity();
             workingY *= (float) getLacunarity();
+
+            // Include random offsets so that the origins of all the octaves don't all add up and make a weird feature there.
+            workingX += 10 * other.noise(i + 0.5f, 0.5f);
+            workingY += 10 * other.noise(-i - 0.5f, -0.5f);
         }
 
         return result * scale;


### PR DESCRIPTION
BrownianNoise works by adding several scaled copies of the same base noise function together. Generally this works well, but it can lead to weird features at the origin, where all of the copies are aligned (the value at the origin in always 0, and it tends to have a very large gradient there). This PR fixes that, by shifting each of the copies by random amounts relative to each other. This has the effect that the spawn point is no longer always on a biome boundary and surrounded by cliffs.

I've gotten so used to the usual surrounded-by-cliffs style of spawn plateau that I don't usually notice how weird it is, but when I tested this PR, this is the spawn plateau I got:
![flatSpawnArea](https://user-images.githubusercontent.com/25589515/100528066-60af6c80-31d0-11eb-88ed-48adf6ef3e6c.png)
