### PR TITLE
chore: remove some of the most noisy debug logs

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
@@ -310,7 +310,6 @@ public class EventSystemImpl implements EventSystem {
     private void networkReplicate(EntityRef entity, Event event) {
         EventMetadata metadata = eventLibrary.getMetadata(event);
         if (metadata != null && metadata.isNetworkEvent()) {
-            logger.debug("Replicating event: {}", event);
             switch (metadata.getNetworkEventType()) {
                 case BROADCAST:
                     broadcastEvent(entity, event, metadata);

--- a/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
+++ b/engine/src/main/java/org/terasology/logic/characters/KinematicCharacterMover.java
@@ -658,7 +658,6 @@ public class KinematicCharacterMover implements CharacterMover {
                 if (input.isFirstRun()) {
                     Vector3f landVelocity = new Vector3f(JomlUtil.from(state.getVelocity()));
                     landVelocity.y += (distanceMoved.y / moveDelta.y) * (endVelocity.y - state.getVelocity().y);
-                    logger.debug("Landed at " + landVelocity);
                     entity.send(new VerticalCollisionEvent(state.getPosition(), JomlUtil.from(landVelocity)));
                 }
                 state.setGrounded(true);
@@ -691,7 +690,6 @@ public class KinematicCharacterMover implements CharacterMover {
                 if (input.isFirstRun()) {
                     Vector3f hitVelocity = new Vector3f(JomlUtil.from(state.getVelocity()));
                     hitVelocity.y += (distanceMoved.y / moveDelta.y) * (endVelocity.y - state.getVelocity().y);
-                    logger.debug("Hit at " + hitVelocity);
                     entity.send(new VerticalCollisionEvent(state.getPosition(), JomlUtil.from(hitVelocity)));
                 }
                 endVelocity.y = -0.0f * endVelocity.y;
@@ -726,7 +724,6 @@ public class KinematicCharacterMover implements CharacterMover {
             Vector3f hitVelocity = new Vector3f(JomlUtil.from(state.getVelocity()));
             hitVelocity.x += (distanceMoved.x / moveDelta.x) * (endVelocity.x - state.getVelocity().x);
             hitVelocity.z += (distanceMoved.z / moveDelta.z) * (endVelocity.z - state.getVelocity().z);
-            logger.debug("Hit at " + hitVelocity);
             entity.send(new HorizontalCollisionEvent(state.getPosition(), JomlUtil.from(hitVelocity)));
         }
         state.getVelocity().set(JomlUtil.from(endVelocity));

--- a/engine/src/main/java/org/terasology/logic/nameTags/PlayerNameTagSystem.java
+++ b/engine/src/main/java/org/terasology/logic/nameTags/PlayerNameTagSystem.java
@@ -42,7 +42,7 @@ import org.terasology.registry.In;
  */
 @RegisterSystem(RegisterMode.CLIENT)
 public class PlayerNameTagSystem extends BaseComponentSystem {
-    private static final Logger logger = LoggerFactory.getLogger(NameTagClientSystem.class);
+    private static final Logger logger = LoggerFactory.getLogger(PlayerNameTagSystem.class);
 
     @In
     private NetworkSystem networkSystem;

--- a/engine/src/main/java/org/terasology/logic/players/ThirdPersonRemoteClientSystem.java
+++ b/engine/src/main/java/org/terasology/logic/players/ThirdPersonRemoteClientSystem.java
@@ -246,12 +246,10 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
 
         // Make a set of all held items that exist so we can review them and later toss any no longer needed
         Set<EntityRef> heldItemsForReview = Sets.newHashSet(entityManager.getEntitiesWith(ItemIsRemotelyHeldComponent.class));
-        logger.debug("As we start update we got the following known remote items to consider: {}", heldItemsForReview);
 
         // Note that the inclusion of PlayerCharacterComponent excludes "characters" like Gooey. In the future such critters may also want held items
         for (EntityRef remotePlayer : entityManager.getEntitiesWith(CharacterComponent.class, PlayerCharacterComponent.class)) {
             if (relatesToLocalPlayer(remotePlayer)) {
-                logger.debug("ThirdPersonRemoteClientSystem's update is ignoring the local player: {}", remotePlayer);
                 continue;
             }
 
@@ -260,26 +258,20 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
             Iterator<EntityRef> heldItermsIterator = heldItemsForReview.iterator();
             while (heldItermsIterator.hasNext()) {
                 EntityRef heldItemCandidate = heldItermsIterator.next();
-                logger.debug("Checking heldItemCandidate {} for remote player {}", heldItemCandidate, remotePlayer);
                 ItemIsRemotelyHeldComponent itemIsRemotelyHeldComponent = heldItemCandidate.getComponent(ItemIsRemotelyHeldComponent.class);
-                logger.debug("The held item's owner is {}", itemIsRemotelyHeldComponent.remotePlayer);
                 if (itemIsRemotelyHeldComponent.remotePlayer.equals(remotePlayer)) {
-                    logger.debug("Looks like we got a match for an existing item! Removing it from the set and processing it");
                     currentHeldItem = heldItemCandidate;
                     heldItermsIterator.remove();
                     break;
                 }
             }
 
-            logger.debug("After searching for an existing held item the set is now: {}", heldItemsForReview);
 
             // If an associated held item entity does *not* exist yet, consider making one if the player has an item selected
             if (currentHeldItem == EntityRef.NULL) {
-                logger.debug("During update we hit a player without a current held item entity. Checking {} to see if we should make one", remotePlayer);
                 if (remotePlayer.hasComponent(CharacterHeldItemComponent.class)) {
                     CharacterHeldItemComponent characterHeldItemComponent = remotePlayer.getComponent(CharacterHeldItemComponent.class);
                     if (characterHeldItemComponent != null && !characterHeldItemComponent.selectedItem.equals(EntityRef.NULL)) {
-                        logger.debug("Yep that player holds an item. Calling linkHeldItemLocationForRemotePlayer with item {}", characterHeldItemComponent.selectedItem);
                         linkHeldItemLocationForRemotePlayer(remotePlayer.getComponent(CharacterHeldItemComponent.class).selectedItem, remotePlayer);
                     }
                 }
@@ -318,7 +310,6 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
         }
 
         heldItemsForReview.forEach(remainingHeldItem -> {
-            logger.debug("After processing held items still had {} - destroying it", remainingHeldItem);
             if (remainingHeldItem.exists()) {
                 remainingHeldItem.destroy();
             }
@@ -353,22 +344,18 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
      */
     private boolean relatesToLocalPlayer(EntityRef entity) {
         if (entity == null || entity.equals(EntityRef.NULL)) {
-            logger.debug("checkForLocalPlayer given a bad entity (null or NullEntityRef - can't relate that to a local player!");
             return false;
         }
 
         if (entity.equals(localPlayer.getClientEntity())) {
-            logger.debug("checkForLocalPlayer found a match to the localPlayer client entity! {}", entity);
             return true;
         }
 
         if (entity.equals(localPlayer.getCharacterEntity())) {
-            logger.debug("checkForLocalPlayer found a match to the localPlayer character entity! {}", entity);
             return true;
         }
 
         if (entity.equals(localPlayer.getClientInfoEntity())) {
-            logger.debug("checkForLocalPlayer found a match to the localPlayer client info entity! {}", entity);
             return true;
         }
 
@@ -384,12 +371,10 @@ public class ThirdPersonRemoteClientSystem extends BaseComponentSystem implement
 
             if (controller != null) {
                 if (controller.equals(localPlayer.getClientEntity())) {
-                    logger.debug("checkForLocalPlayer found its entity to be a character whose controller matched the localPlayer client entity! {}", controller);
                     return true;
                 }
 
                 if (controller.equals(networkSystemProvidedClientEntity)) {
-                    logger.debug("checkForLocalPlayer found its entity to be a character controller matching the network system provided local client entity! {}", controller);
                     return true;
                 }
             }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -283,7 +283,6 @@ public class LocalChunkProvider implements ChunkProvider {
     private void checkForUnload() {
         PerformanceMonitor.startActivity("Unloading irrelevant chunks");
         int unloaded = 0;
-        logger.debug("Compacting cache");
         Iterator<org.joml.Vector3ic> iterator = Iterators.concat(
                 Iterators.transform(chunkCache.keySet().iterator(), v -> new org.joml.Vector3i(v.x, v.y, v.z)),
                 loadingPipeline.getProcessingPosition().iterator());

--- a/facades/PC/src/main/resources/logback.xml
+++ b/facades/PC/src/main/resources/logback.xml
@@ -48,5 +48,6 @@
   <logger name="org.terasology" level="${logOverrideLevel:-info}" />
   <logger name="org.reflections.Reflections" level="${logOverrideLevel:-error}" />
   <logger name="com.snowplowanalytics" level="${logOverrideLevel:-error}" />
+  <logger name="io.netty" level="${logOverrideLevel:-warn}" />
   
 </configuration>


### PR DESCRIPTION
**Problem:** There was a lot of noise in our logs, especially on DEBUG level which is used by IntelliJ as default. This was particularly spamming from `update()` methods.

**Solutions:** Remove those debug logs, which often look like `println`-debug statements to keep track of where the execution flow goes without the need to actually step through everything in the debugger.
