### PR TITLE
fix: dispose physic's natives, stop threads.

### DIFF
--- a/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
+++ b/engine/src/main/java/org/terasology/network/internal/ClientConnectionHandler.java
@@ -81,6 +81,7 @@ public class ClientConnectionHandler extends ChannelInboundHandlerAdapter {
                         logger.error("Server timeout threshold of {} ms exceeded.", timeoutThreshold);
                     }
                 }
+                Thread.currentThread().stop();
             }
         }, timeoutThreshold + 200);
     }

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.physics.bullet;
 
 import com.badlogic.gdx.physics.bullet.collision.ClosestRayResultCallback;
@@ -158,6 +145,10 @@ public class BulletPhysics implements PhysicsEngine {
     public void dispose() {
         this.discreteDynamicsWorld.dispose();
         this.dispatcher.dispose();
+        this.defaultCollisionConfiguration.dispose();
+        this.entityTriggers.forEach((k,v) -> v.dispose());
+        this.entityRigidBodies.forEach((k,v)-> v.dispose());
+        this.ghostPairCallback.dispose();
     }
 
     @Override
@@ -589,7 +580,7 @@ public class BulletPhysics implements PhysicsEngine {
     private void removeCollider(btCollisionObject collider) {
         discreteDynamicsWorld.removeCollisionObject(collider);
 //        collider.getCollisionShape().dispose();
-//        collider.dispose();
+        collider.dispose();
     }
 
     /**

--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -579,7 +579,6 @@ public class BulletPhysics implements PhysicsEngine {
 
     private void removeCollider(btCollisionObject collider) {
         discreteDynamicsWorld.removeCollisionObject(collider);
-//        collider.getCollisionShape().dispose();
         collider.dispose();
     }
 

--- a/engine/src/main/java/org/terasology/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -96,7 +96,9 @@ public class ChunkProcessingPipeline {
                 onStageDone(future, chunkProcessingInfo);
             }
         } catch (InterruptedException e) {
-            logger.error("Reactor thread was interrupted", e);
+            if (!executor.isTerminated()) {
+                logger.error("Reactor thread was interrupted", e);
+            }
             reactor.interrupt();
         }
     }
@@ -225,10 +227,10 @@ public class ChunkProcessingPipeline {
 
     public void shutdown() {
         executor.shutdown();
-
         chunkProcessingInfoMap.keySet().forEach(this::stopProcessingAt);
         chunkProcessingInfoMap.clear();
         executor.getQueue().clear();
+        reactor.interrupt();
     }
 
     public void restart() {


### PR DESCRIPTION
### Contains

Free resources for MTE.
related to https://github.com/Terasology/ModuleTestingEnvironment/issues/30

dispose physic's natives(holds TerasologyEngine)
stop threads(holds TerasologyEngine)

### How to test

1. Run MTE test with client connection in loop
2. measure memory usage.
