### PR TITLE
fix(BlockRegion): correct center calculation for BlockRegion

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -443,9 +443,9 @@ public class BlockRegion {
      */
     public Vector3f center(Vector3f dest) {
         return dest.set(
-                (aabb.maxX - aabb.minX) / 2.0f,
-                (aabb.maxY - aabb.minY) / 2.0f,
-                (aabb.maxZ - aabb.minZ) / 2.0f
+                aabb.minX + ((aabb.maxX - aabb.minX) / 2.0f),
+                aabb.minY + ((aabb.maxY - aabb.minY) / 2.0f),
+                aabb.minZ + ((aabb.maxZ - aabb.minZ) / 2.0f)
         );
     }
 


### PR DESCRIPTION
this center method was only calculating the extent of a region. this produced off center structures in MetalRenegades. 

![offcenter](https://user-images.githubusercontent.com/854359/101269112-02c6db80-3720-11eb-8ec1-5d9887f51ec7.png)
