### PR TITLE
ci(subsystems): Make TypeHandlerLibrary publishable with engine's version

### DIFF
--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 apply(from = "$rootDir/config/gradle/publish.gradle")
 
-group = "org.terasology"
+group = "org.terasology.subsystems"
 version = project(":engine").version
 
 dependencies {

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -6,7 +6,10 @@ plugins {
     `java-library`
 }
 
-apply(from = "$rootDir/config/gradle/common.gradle")
+apply(from = "$rootDir/config/gradle/publish.gradle")
+
+group = "org.terasology"
+version = project(":engine").version
 
 dependencies {
     implementation("org.slf4j:slf4j-api:1.7.21")


### PR DESCRIPTION
### Contains

Fix single module building in Jenkins.


### How to test

1. invoke `gradle publish`
2. check that you have artifact `org.terasology:TypeHandlerLibrary:<engine version>` in repo

### Outstanding before merging

- [ ] Check how it works in jenkins ()