### PR TITLE
add toBlockMapping utility

### DIFF
--- a/engine/src/main/java/org/terasology/math/JomlUtil.java
+++ b/engine/src/main/java/org/terasology/math/JomlUtil.java
@@ -42,7 +42,11 @@ import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Rect2f;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class JomlUtil {
     private JomlUtil() {
@@ -236,5 +240,9 @@ public final class JomlUtil {
 
     public static Rectanglef rectanglefFromMinAndSize(float minX, float minY, float width, float height) {
         return new Rectanglef(minX, minY, minX + width, minY + height);
+    }
+
+    public static Map<org.terasology.math.geom.Vector3i, Block> blockMap(Map<Vector3i, Block> maps) {
+        return maps.entrySet().stream().collect(Collectors.toMap(k -> JomlUtil.from(k.getKey()), Map.Entry::getValue));
     }
 }


### PR DESCRIPTION
I added this quick block mapping utility for intermediary mapping between a map of joml vector block maps to a termath vector and block map. 

PR: https://github.com/Terasology/IRLCorp/pull/30