### PR TITLE
chore (idea): ignore some user-specific plugin data

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -37,5 +37,8 @@ workspace.xml
 # Discord preferences don't need sharing
 /discord.xml
 
+# CodeStream's webViewContext looks like local state
+/codestream.xml
+
 # Automatically created when the checkout directy name is different from git origin?
 /.name

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -5,6 +5,8 @@
 workspace.xml
 *.iws
 
+/caches
+
 # Shelf is where it put changes you're not ready to share. (it's like git stash)
 /shelf
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -32,5 +32,8 @@ workspace.xml
 # Ignore Sonar linting, if set up locally
 /sonarlint/
 
+# Discord preferences don't need sharing
+/discord.xml
+
 # Automatically created when the checkout directy name is different from git origin?
 /.name


### PR DESCRIPTION
A few gitignores.

Some of these are present in other branches but hadn't found their way to `develop` yet. I cherry-picked them to this much simpler branch for ease of merge.