### PR TITLE
add missing absolute value for box collider extent

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletBoxShape.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/shapes/BulletBoxShape.java
@@ -32,7 +32,7 @@ public class BulletBoxShape extends BulletCollisionShape implements BoxShape {
     @Override
     public CollisionShape rotate(Quaternionf rot) {
         Vector3f halfExtentsWithMargin = new Vector3f(boxShape.getHalfExtentsWithMargin());
-        return new BulletBoxShape(halfExtentsWithMargin.rotate(rot));
+        return new BulletBoxShape(halfExtentsWithMargin.rotate(rot).absolute());
     }
 
     @Override


### PR DESCRIPTION
box colliders had negative extent so they never worked correctly when certain objects were placed in the world. this can be verified with the door in the default template. It should be possible to walk into / open and close the door where it used to be an object missing all collision. 