### PR TITLE
fix(publish): don't try to figure out the repository to publish to until after the version is set

### DIFF
--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -25,15 +25,22 @@ publishing {
                     deducedPublishRepo = "terasology"
                 }
 
-                if (project.version.toString().endsWith("-SNAPSHOT")) {
-                    deducedPublishRepo += "-snapshot-local"
-                } else {
-                    deducedPublishRepo += "-release-local"
-                }
+                afterEvaluate {
+                    // depends on project.version, so must be delayed until project is configured
+                    if (!project.version || project.version == "unspecified") {
+                        throw new GradleException("Project ${project} does not have a version set yet: ${project.version}")
+                    }
 
-                logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
-                allowInsecureProtocol true
+                    if (project.version.toString().endsWith("-SNAPSHOT")) {
+                        deducedPublishRepo += "-snapshot-local"
+                    } else {
+                        deducedPublishRepo += "-release-local"
+                    }
+
+                    logger.info("The final deduced publish repo is {}", deducedPublishRepo)
+                    url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                    allowInsecureProtocol true
+                }
             }
 
             if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {

--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -8,6 +8,46 @@ apply from: "$rootDir/config/gradle/common.gradle"
 apply plugin: 'maven-publish'
 
 publishing {
+    repositories {
+        maven {
+            name = 'TerasologyOrg'
+
+            if (rootProject.hasProperty("publishRepo")) {
+                // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
+                url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+                allowInsecureProtocol true // 😱
+                logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
+            } else {
+                // Support override from the environment to use a different target publish org
+                String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
+                if (deducedPublishRepo == null || deducedPublishRepo == "") {
+                    // If not then default
+                    deducedPublishRepo = "terasology"
+                }
+
+                if (project.version.toString().endsWith("-SNAPSHOT")) {
+                    deducedPublishRepo += "-snapshot-local"
+                } else {
+                    deducedPublishRepo += "-release-local"
+                }
+
+                logger.info("The final deduced publish repo is {}", deducedPublishRepo)
+                url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                allowInsecureProtocol true
+            }
+
+            if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {
+                credentials {
+                    username = "$mavenUser"
+                    password = "$mavenPass"
+                }
+                authentication {
+                    basic(BasicAuthentication)
+                }
+            }
+        }
+    }
+
     publications {
         "$project.name"(MavenPublication) {
             // Without this we get a .pom with no dependencies
@@ -15,46 +55,6 @@ publishing {
 
             artifact source: sourceJar, classifier: 'sources'
             artifact source: javadocJar, classifier: 'javadoc'
-
-            repositories {
-                maven {
-                    name = 'TerasologyOrg'
-
-                    if (rootProject.hasProperty("publishRepo")) {
-                        // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                        url = "http://artifactory.terasology.org/artifactory/$publishRepo"
-                        allowInsecureProtocol true // 😱
-                        logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
-                    } else {
-                        // Support override from the environment to use a different target publish org
-                        String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
-                        if (deducedPublishRepo == null || deducedPublishRepo == "") {
-                            // If not then default
-                            deducedPublishRepo = "terasology"
-                        }
-
-                        if (project.version.toString().endsWith("-SNAPSHOT")) {
-                            deducedPublishRepo += "-snapshot-local"
-                        } else {
-                            deducedPublishRepo += "-release-local"
-                        }
-
-                        logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                        url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
-                        allowInsecureProtocol true
-                    }
-
-                    if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {
-                        credentials {
-                            username = "$mavenUser"
-                            password = "$mavenPass"
-                        }
-                        authentication {
-                            basic(BasicAuthentication)
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 // Engine tests are split out due to otherwise quirky project dependency issues with module tests extending engine tests
 
@@ -45,11 +32,6 @@ def moduleConfig = slurper.parseText(moduleFile.text)
 
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set differently)
 version = moduleConfig.version
-
-// The only case in which we make non-snapshots is when BRANCH_NAME exists and contains "master" - otherwise snapshots
-if (env.BRANCH_NAME == null || !env.BRANCH_NAME.equals("master")) {
-    version += "-SNAPSHOT"
-}
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
 group = 'org.terasology.engine'


### PR DESCRIPTION
From [#logistics](https://discord.com/channels/270264625419911192/633681387995660303/790717924422844466):

> oddly project.version is not working in publish.gradle for the engine (returns "unspecified")

This PR moves that code in to an `afterEvaluate` block to give it a chance to load the version first. This is the solution offered by the [gradle manual](https://docs.gradle.org/6.7.1/userguide/publishing_maven.html#publishing_maven:deferred_configuration).

### How to test

`gradlew :engine:publish` is the task,  
the condition is when a `publishRepo` gradle property is **not** set.
Brief description of how to test / confirm this PR before merging

[fixme: add more details about how to test and what to look for]
