### PR TITLE
chore(gradle): remove mavenLocal from project repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,6 @@ repositories {
     // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
     jcenter()
     mavenCentral()
-    mavenLocal()
 
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
     maven {

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 // language
 apply plugin: 'java'
@@ -40,9 +27,6 @@ tasks.withType(JavaCompile) {
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    // For development so you can publish binaries locally and have them grabbed from there
-    mavenLocal()
-
     // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
     jcenter()
     mavenCentral()


### PR DESCRIPTION
Gradle's user guide [discourages the use of mavenLocal](https://docs.gradle.org/6.7.1/userguide/declaring_repositories.html#sec:case-for-maven-local). The section heading is “The case for mavenLocal()” but the text is thoroughly _against_ its use whenever possible.

I believe this project is now working sufficiently well with [included builds](https://github.com/MovingBlocks/Terasology/blob/5cfb0c66f5457d16cffe1246a697314ccc1cd328/libs/subprojects.settings.gradle#L4) that it no longer requires mavenLocal —  
but I hope for input on that, because I don't know everyone's workflows.

### Contains

Removes `mavenLocal` as a place to check for dependencies.


### How to test

Test your workflows that depend on in-development versions of libraries, e.g. TeraNUI or gestalt.

