### PR TITLE
fix: casing fix for homedir arg from Gradle

### DIFF
--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -126,7 +126,7 @@ val commonConfigure : JavaExec.()-> Unit = {
 
     classpath(sourceSets["main"].runtimeClasspath)
 
-    args("-homeDir")
+    args("-homedir")
     jvmArgs("-Xmx1536m")
 
     if (isMacOS()) {


### PR DESCRIPTION
Love tiny PRs? This is the PR for you!

https://github.com/MovingBlocks/Terasology/commit/8bb63016b9bdc0b47808bcddd9735a7272c9912a improved on the run execs in Gradle to avoid a bunch of duplication, but accidentally switched `-homedir` to `-homeDir` which meant the engine couldn't recognize the argument and always defaulted your game data dir to system default.

Coincidentally this is superseded by #4157 changing all the args around anyway, but this fixes it minimally for right now.

To test: Run the game via Gradle, such as with `gradlew game` and make sure the `-homedir` argument was accepted (top of game logging, or make sure you have a save game then go to new game and check that the save path is inside your workspace)