### PR TITLE
build: save build time by not checking jcenter for terasology dependencies

### DIFF
--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -48,12 +48,6 @@ repositories {
             allowInsecureProtocol true  // 😱
         }
     }
-
-    maven {
-        name "snowplow (pre-0.9)"
-        url "http://maven.snplow.com/releases"
-        allowInsecureProtocol true  // 😱
-    }
 }
 
 dependencies {

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -27,9 +27,16 @@ tasks.withType(JavaCompile) {
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-    jcenter()
-    mavenCentral()
+    // External libs - jcenter is Bintray and a superset of Maven Central
+    jcenter {
+        content {
+            // This is first choice for most java dependencies, but assume we'll need to check our
+            // own repository for things from our own organization.
+            // (This is an optimization so gradle doesn't try to find our hundreds of modules
+            // in jcenter.)
+            excludeGroupByRegex(/org\.terasology(\..+)?/)
+        }
+    }
 
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
     maven {


### PR DESCRIPTION
This removes unnecessary repositories from common.gradle  
and changes the configuration so gradle does not look in jcenter for any `org.terasology` dependency.

### How to test

I was using `gradlew :modules:JoshariasSurvival:clean game --refresh-dependencies --scan` (with JoshariasSurvival as the _only_ module source checked out in `modules/`, so gradle has to get all the dependencies from remote instead of local subprojects).

It's not _quite_ sufficient as a test of how long things take with an empty cache, because gradle has cached some stuff somewhere that is not reset by `--refresh-dependencies`.

One place where the difference is clear is on the build scan under the Performance / Network Activity tab. Before this change, there were a lot more requests to jcenter for all the modules that aren't there, which it then had to repeat and fail on maven central before getting to our artifactory.

This is a performance optimization for something I'm not sure anyone asked to be optimized, so treat it with some skepticism while reviewing it!
