### PR TITLE
feat(JOML): migrate LightComponent

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
+++ b/engine/src/main/java/org/terasology/rendering/logic/LightComponent.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.rendering.logic;
 
-import org.terasology.math.geom.Vector3f;
+import org.joml.Vector3f;
 import org.terasology.network.Replicate;
 import org.terasology.network.ReplicationCheck;
 import org.terasology.reflection.metadata.FieldMetadata;


### PR DESCRIPTION
here is a straightforward migration of LightComponent. the only reference is in CoreRendering and the properties line up from Termath so there are no additional changes that would need to be made in: https://github.com/Terasology/CoreRendering 