### PR TITLE
fix(#4319): add attchmentSide to getBlockForPlacement

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -191,7 +191,7 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      */
     @Override
     public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        BlockPlacementData data = new BlockPlacementData(JomlUtil.from(location), null, new Vector3f());
+        BlockPlacementData data = new BlockPlacementData(JomlUtil.from(location), attachmentSide, new Vector3f());
         return getBlockForPlacement(data);
     }
 


### PR DESCRIPTION
pass attachmentSide to getBlockForPlacement for MultiConnectFamily.

Fixes https://github.com/MovingBlocks/Terasology/issues/4319