### PR TITLE
Mark new chunks ready before triggering OnChunkLoaded events.

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -197,6 +197,7 @@ public class LocalChunkProvider implements ChunkProvider {
             return; // TODO move it in pipeline;
         }
         chunkCache.put(chunk.getPosition(), chunk);
+        chunk.markReady();
         //TODO, it is not clear if the activate/addedBlocks event logic is correct.
         //See https://github.com/MovingBlocks/Terasology/issues/3244
         ChunkStore store = this.storageManager.loadChunkStore(chunk.getPosition());
@@ -244,7 +245,6 @@ public class LocalChunkProvider implements ChunkProvider {
             worldEntity.send(new OnChunkGenerated(chunk.getPosition()));
         }
         worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
-        chunk.markReady();
     }
 
     private void generateQueuedEntities(EntityStore store) {

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -80,12 +80,12 @@ public class RemoteChunkProvider implements ChunkProvider {
                                 .collect(Collectors.toSet())
                 ))
                 .addStage(ChunkTaskProvider.create("", chunk -> {
-                    listener.onChunkReady(chunk.getPosition());
                     Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
                     if (oldChunk != null) {
                         oldChunk.dispose();
                     }
                     chunk.markReady();
+                    listener.onChunkReady(chunk.getPosition());
                     worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
                 }));
 

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -81,12 +81,12 @@ public class RemoteChunkProvider implements ChunkProvider {
                 ))
                 .addStage(ChunkTaskProvider.create("", chunk -> {
                     listener.onChunkReady(chunk.getPosition());
-                    worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
                     Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
                     if (oldChunk != null) {
                         oldChunk.dispose();
                     }
                     chunk.markReady();
+                    worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
                 }));
 
         ChunkMonitor.fireChunkProviderInitialized(this);


### PR DESCRIPTION
Because the `OnChunkLoaded` event is created in world generation threads, rather than the main thread, it usually executes after `processReadyChunk` is finished, but occasionally it doesn't. The chunk only becomes readable (i.e. `getChunk` and `getBlock` will start working inside its bounds) when `chunk.markReady` is called, which used to happen at the end of `processReadyChunk`. This meant that occasionally, the event handler for `OnChunkLoaded` would not actually be able to read that chunk. This led to issues like that `NullPointerException` in `VoxelWorldSystem` and some chunks being invisible, both of which should now be fixed. (A similar issue sometimes still happens sometimes when a world is unloaded: a chunk's `OnChunkLoaded` event may not run until after the chunk has been unloaded, but that matters less because it's being unloaded anyway.)

Moving the entirety of `processReadyChunk` to the main thread would likely make this area less error prone, but I'm a lot less confident that that change wouldn't break anything else. The small change that I have made has the virtue that what happens with the change is pretty much what used to happen already most of the time, so we can be very confident that it makes things more correct.