### PR TITLE
feat(JOML): migrate OnBlockItemPlaced

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/world/block/items/BlockItemSystem.java
@@ -29,7 +29,6 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.characters.KinematicCharacterMover;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.ItemComponent;
-import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
 import org.terasology.network.NetworkSystem;
 import org.terasology.physics.Physics;
@@ -102,7 +101,7 @@ public class BlockItemSystem extends BaseComponentSystem {
                 PlaceBlocks placeBlocks = new PlaceBlocks(placementPos, block, event.getInstigator());
                 worldProvider.getWorldEntity().send(placeBlocks);
                 if (!placeBlocks.isConsumed()) {
-                    item.send(new OnBlockItemPlaced(JomlUtil.from(placementPos), blockEntityRegistry.getBlockEntityAt(placementPos), event.getInstigator()));
+                    item.send(new OnBlockItemPlaced(placementPos, blockEntityRegistry.getBlockEntityAt(placementPos), event.getInstigator()));
                 } else {
                     event.consume();
                 }

--- a/engine/src/main/java/org/terasology/world/block/items/OnBlockItemPlaced.java
+++ b/engine/src/main/java/org/terasology/world/block/items/OnBlockItemPlaced.java
@@ -1,23 +1,12 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.items;
 
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.geom.Vector3i;
+import org.terasology.math.JomlUtil;
 
 /**
  * This event gets called whenever a block item is placed in the world
@@ -26,10 +15,10 @@ public class OnBlockItemPlaced implements Event {
     /**
      * The position where the block is placed
      */
-    private Vector3i position;
+    private Vector3i position = new Vector3i();
 
     /**
-     *  The entity corresponding to the placed block
+     * The entity corresponding to the placed block
      */
     private EntityRef placedBlock;
 
@@ -38,25 +27,56 @@ public class OnBlockItemPlaced implements Event {
      */
     private EntityRef instigator = EntityRef.NULL;
 
+    /**
+     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
+     *     {@link #OnBlockItemPlaced(Vector3ic, EntityRef, EntityRef)}.
+     */
     @Deprecated
-    public OnBlockItemPlaced(Vector3i pos, EntityRef placedBlock) {
-        this.position = pos;
+    public OnBlockItemPlaced(org.terasology.math.geom.Vector3i pos, EntityRef placedBlock) {
+        this.position = JomlUtil.from(pos);
         this.placedBlock = placedBlock;
     }
 
-    public OnBlockItemPlaced(Vector3i pos, EntityRef placedBlock, EntityRef instigator) {
-        this.position = pos;
+    /**
+     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
+     *     {@link #OnBlockItemPlaced(Vector3ic, EntityRef, EntityRef)}.
+     */
+    @Deprecated
+    public OnBlockItemPlaced(org.terasology.math.geom.Vector3i pos, EntityRef placedBlock, EntityRef instigator) {
+        this.position = JomlUtil.from(pos);
         this.placedBlock = placedBlock;
         this.instigator = instigator;
     }
-    public Vector3i getPosition() {
-        return new Vector3i(position);
+
+    /**
+     *
+     * @param pos the position that the block is placed
+     * @param placedBlock the block that is placed
+     * @param instigator the entity that places the block. A block placed without an instigator can be specified with {@link EntityRef#NULL}
+     */
+    public OnBlockItemPlaced(Vector3ic pos, EntityRef placedBlock, EntityRef instigator) {
+        this.position.set(pos);
+        this.placedBlock = placedBlock;
+        this.instigator = instigator;
     }
 
+    /**
+     * @return world position of the placed block
+     */
+    public Vector3ic getPosition() {
+        return position;
+    }
+
+    /**
+     * @return The entity linked to the given block
+     */
     public EntityRef getPlacedBlock() {
         return placedBlock;
     }
 
+    /**
+     * @return the entity that placed the block
+     */
     public EntityRef getInstigator() {
         return instigator;
     }


### PR DESCRIPTION
Migrates the event handler for OnBlockItemPlaced. I migrated the whole event since the only changes would need to be made in FlowingLiquid, GooeyDefence, JS and Signalling. 
- [ ] https://github.com/Terasology/FlowingLiquids/pull/23
- [ ] https://github.com/Terasology/GooeyDefence/pull/50
- [ ] https://github.com/Terasology/JoshariasSurvival/pull/48
- [ ] https://github.com/Terasology/Signalling/pull/23