### PR TITLE
feat(JOML): migrate WorldProviderCore#isBlockRelevant

### DIFF
--- a/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
+++ b/engine-tests/src/main/java/org/terasology/MapWorldProvider.java
@@ -26,6 +26,7 @@ import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
+import org.terasology.world.block.BlockRegionc;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
@@ -84,6 +85,11 @@ public class MapWorldProvider implements WorldProviderCore {
 
     @Override
     public boolean isRegionRelevant(Region3i region) {
+        return false;
+    }
+
+    @Override
+    public boolean isRegionRelevant(BlockRegionc region) {
         return false;
     }
 

--- a/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/WorldProviderCoreStub.java
@@ -25,6 +25,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
+import org.terasology.world.block.BlockRegionc;
 import org.terasology.world.internal.ChunkViewCore;
 import org.terasology.world.internal.WorldInfo;
 import org.terasology.world.internal.WorldProviderCore;
@@ -101,6 +102,11 @@ public class WorldProviderCoreStub implements WorldProviderCore {
     @Override
     public boolean isRegionRelevant(Region3i region) {
         return true;
+    }
+
+    @Override
+    public boolean isRegionRelevant(BlockRegionc region) {
+        return false;
     }
 
     @Override

--- a/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
@@ -16,6 +16,7 @@
 package org.terasology.world.propagation;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.terasology.TerasologyTestingEnvironment;
@@ -250,6 +251,11 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
 
         @Override
         public boolean isChunkReady(Vector3i pos) {
+            return false;
+        }
+
+        @Override
+        public boolean isChunkReady(Vector3ic pos) {
             return false;
         }
 

--- a/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
@@ -3,6 +3,7 @@
 
 package org.terasology.world.chunks;
 
+import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.internal.ChunkViewCore;
@@ -68,6 +69,12 @@ public interface ChunkProvider {
      * @return Whether this chunk is available and ready for use
      */
     boolean isChunkReady(Vector3i pos);
+
+    /**
+     * @param pos
+     * @return Whether this chunk is available and ready for use
+     */
+    boolean isChunkReady(Vector3ic pos);
 
     /**
      * Returns the chunk at the given position if possible.

--- a/engine/src/main/java/org/terasology/world/chunks/Chunks.java
+++ b/engine/src/main/java/org/terasology/world/chunks/Chunks.java
@@ -186,7 +186,7 @@ public final class Chunks {
      * @param dest will hold the result
      * @return dest
      */
-    public static BlockRegion toChunkRegion(BlockRegion region, int chunkX, int chunkY, int chunkZ, BlockRegion dest) {
+    public static BlockRegion toChunkRegion(BlockRegionc region, int chunkX, int chunkY, int chunkZ, BlockRegion dest) {
         return dest.
             set(toChunkPos(region.minX(), chunkX), toChunkPos(region.minY(), chunkY), toChunkPos(region.minZ(), chunkZ),
                 toChunkPos(region.maxX(), chunkX), toChunkPos(region.maxY(), chunkY), toChunkPos(region.maxZ(), chunkZ));
@@ -213,7 +213,7 @@ public final class Chunks {
      * @param dest will hold the result
      * @return dest
      */
-    public static BlockRegion toChunkRegion(BlockRegion region, BlockRegion dest) {
+    public static BlockRegion toChunkRegion(BlockRegionc region, BlockRegion dest) {
         return toChunkRegion(region, Chunks.POWER_X, Chunks.POWER_Y, Chunks.POWER_Z, dest);
     }
 

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -10,6 +10,7 @@ import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.TShortObjectMap;
 import gnu.trove.map.hash.TShortObjectHashMap;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.Component;
@@ -468,6 +469,11 @@ public class LocalChunkProvider implements ChunkProvider {
     @Override
     public boolean isChunkReady(Vector3i pos) {
         return isChunkReady(chunkCache.get(pos));
+    }
+
+    @Override
+    public boolean isChunkReady(Vector3ic pos) {
+        return isChunkReady(chunkCache.get(JomlUtil.from(pos)));
     }
 
     private boolean isChunkReady(Chunk chunk) {

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -6,6 +6,7 @@ package org.terasology.world.chunks.remoteChunkProvider;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
+import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -146,6 +147,12 @@ public class RemoteChunkProvider implements ChunkProvider {
     @Override
     public boolean isChunkReady(Vector3i pos) {
         Chunk chunk = chunkCache.get(pos);
+        return chunk != null && chunk.isReady();
+    }
+
+    @Override
+    public boolean isChunkReady(Vector3ic pos) {
+        Chunk chunk = chunkCache.get(JomlUtil.from(pos));
         return chunk != null && chunk.isReady();
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
+++ b/engine/src/main/java/org/terasology/world/internal/AbstractWorldProviderDecorator.java
@@ -23,6 +23,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
+import org.terasology.world.block.BlockRegionc;
 import org.terasology.world.time.WorldTime;
 
 import java.util.Collection;
@@ -90,6 +91,11 @@ public class AbstractWorldProviderDecorator implements WorldProviderCore {
 
     @Override
     public boolean isRegionRelevant(Region3i region) {
+        return base.isRegionRelevant(region);
+    }
+
+    @Override
+    public boolean isRegionRelevant(BlockRegionc region) {
         return base.isRegionRelevant(region);
     }
 

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCore.java
@@ -23,6 +23,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.world.WorldChangeListener;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
+import org.terasology.world.block.BlockRegionc;
 import org.terasology.world.time.WorldTime;
 
 import java.util.Collection;
@@ -95,6 +96,8 @@ public interface WorldProviderCore {
     boolean isBlockRelevant(int x, int y, int z);
 
     boolean isRegionRelevant(Region3i region);
+
+    boolean isRegionRelevant(BlockRegionc region);
 
     /**
      * Places a block of a specific type at a given position

--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -21,8 +21,10 @@ import org.terasology.world.WorldChangeListener;
 import org.terasology.world.WorldComponent;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
+import org.terasology.world.block.BlockRegionc;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkProvider;
+import org.terasology.world.chunks.Chunks;
 import org.terasology.world.chunks.CoreChunk;
 import org.terasology.world.chunks.LitChunk;
 import org.terasology.world.chunks.ManagedChunk;
@@ -163,6 +165,16 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     @Override
     public boolean isRegionRelevant(Region3i region) {
         for (Vector3i chunkPos : ChunkMath.calcChunkPos(region)) {
+            if (!chunkProvider.isChunkReady(chunkPos)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isRegionRelevant(BlockRegionc region) {
+        for (Vector3ic chunkPos : Chunks.toChunkRegion(region, new BlockRegion(BlockRegion.INVALID))) {
             if (!chunkProvider.isChunkReady(chunkPos)) {
                 return false;
             }


### PR DESCRIPTION
I migrated the logic for isRegionRelevant. would this be ideal or would we just want to migrate it all together then bother with the intermediary step. 

- [ ] https://github.com/Terasology/FlexiblePathfinding/pull/14