### PR TITLE
chore: Couple minor tweaks - logic hardening and memory

### DIFF
--- a/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/logic/behavior/BehaviorSystem.java
@@ -102,6 +102,12 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
         Iterable<EntityRef> entities = entityManager.getEntitiesWith(BehaviorComponent.class);
         for (EntityRef entity : entities) {
             BehaviorComponent behaviorComponent = entity.getComponent(BehaviorComponent.class);
+            // NPE observed in the past, suspected to be about loss of behavior state. Hopefully one skip is OK then resume next tick?
+            // TODO: Highlight this log entry to the telemetry system to gather better data over time
+            if (behaviorComponent.interpreter == null) {
+                logger.warn("Found a null interpreter during tick updates, skipping for entity {}", entity);
+                continue;
+            }
             behaviorComponent.interpreter.tick(delta);
         }
     }

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -127,7 +127,7 @@ val commonConfigure : JavaExec.()-> Unit = {
     classpath(sourceSets["main"].runtimeClasspath)
 
     args("-homedir")
-    jvmArgs("-Xmx1536m")
+    jvmArgs("-Xmx3072m")
 
     if (isMacOS()) {
         args("-noSplash")


### PR DESCRIPTION
Part of some minor observations from recent testing.

* Guards against NPE in some behavior tree code, briefly discussed with @casals as a case where some state might get lost. Ideally we'd also hook up a special monitor for this via telemetry to get more intel about when it happens, how
* Increases default memory when running from Gradle - flying around in settings like Metal Renegades does not appreciate being memory starved. Goes beyond the 32-bit JVM capacity, but we honestly could have probably done that years ago, playing the game on 32-bit is one thing, developing it a whole other thing.