### PR TITLE
fix: Move the final stage of chunk loading back to the main thread.

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -256,7 +256,7 @@ class LocalChunkProviderTest {
                             .filter((e) -> e instanceof BeforeDeactivateBlocks)
                             .map((e) -> (BeforeDeactivateBlocks) e)
                             .findFirst().isPresent()) {
-                        chunkProvider.beginUpdate();
+                        chunkProvider.update();
                         blockEventCaptor = ArgumentCaptor.forClass(Event.class);
                         verify(blockAtBlockManager.getEntity(), atLeast(1)).send(blockEventCaptor.capture());
 

--- a/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/propagation/BetweenChunkPropagationTest.java
@@ -39,7 +39,6 @@ import org.terasology.world.block.tiles.NullWorldAtlas;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.ChunkProvider;
-import org.terasology.world.chunks.ChunkRegionListener;
 import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.world.chunks.internal.ChunkImpl;
 import org.terasology.world.internal.ChunkViewCore;
@@ -240,12 +239,7 @@ public class BetweenChunkPropagationTest extends TerasologyTestingEnvironment {
         }
 
         @Override
-        public void completeUpdate() {
-            // do nothing
-        }
-
-        @Override
-        public void beginUpdate() {
+        public void update() {
             // do nothing
         }
 

--- a/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitCharacterSpawn.java
+++ b/engine/src/main/java/org/terasology/engine/modes/loadProcesses/AwaitCharacterSpawn.java
@@ -55,8 +55,7 @@ public class AwaitCharacterSpawn extends VariableStepLoadProcess {
             client.character.send(new AwaitedLocalCharacterSpawnEvent());
             return true;
         } else {
-            chunkProvider.completeUpdate();
-            chunkProvider.beginUpdate();
+            chunkProvider.update();
         }
         return false;
     }

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -101,8 +101,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
 
         // Free unused space
         PerformanceMonitor.startActivity("Update Chunk Cache");
-        chunkProvider.completeUpdate();
-        chunkProvider.beginUpdate();
+        chunkProvider.update();
         PerformanceMonitor.endActivity();
 
         PerformanceMonitor.startActivity("Update Close Chunks");

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -137,8 +137,7 @@ class RenderableWorldImpl implements RenderableWorld {
     public boolean pregenerateChunks() {
         boolean pregenerationIsComplete = true;
 
-        chunkProvider.completeUpdate();
-        chunkProvider.beginUpdate();
+        chunkProvider.update();
 
         RenderableChunk chunk;
         ChunkMesh newMesh;
@@ -172,16 +171,12 @@ class RenderableWorldImpl implements RenderableWorld {
     @Override
     public void update() {
 
-        PerformanceMonitor.startActivity("Complete chunk update");
-        chunkProvider.completeUpdate();
-        PerformanceMonitor.endActivity();
-
         PerformanceMonitor.startActivity("Update Lighting");
         worldProvider.processPropagation();
         PerformanceMonitor.endActivity();
 
-        PerformanceMonitor.startActivity("Begin chunk update");
-        chunkProvider.beginUpdate();
+        PerformanceMonitor.startActivity("Chunk update");
+        chunkProvider.update();
         PerformanceMonitor.endActivity();
 
         PerformanceMonitor.startActivity("Update Close Chunks");

--- a/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/ChunkProvider.java
@@ -44,14 +44,9 @@ public interface ChunkProvider {
     void setWorldEntity(EntityRef entity);
 
     /**
-     * Finish adding any pending chunks
-     */
-    void completeUpdate();
-
-    /**
      * Updates the near cache based on the movement of the caching entities
      */
-    void beginUpdate();
+    void update();
 
     /**
      * @param pos the chunk coordinates

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -111,7 +111,9 @@ public class RemoteChunkProvider implements ChunkProvider {
                 oldChunk.dispose();
             }
             chunk.markReady();
-            listener.onChunkReady(chunk.getPosition());
+            if (listener != null) {
+                listener.onChunkReady(chunk.getPosition());
+            }
             worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
         }
     }

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -55,6 +55,7 @@ import java.util.stream.StreamSupport;
 public class RemoteChunkProvider implements ChunkProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(RemoteChunkProvider.class);
+    private final BlockingQueue<Chunk> readyChunks = Queues.newLinkedBlockingQueue();
     private final BlockingQueue<Vector3i> invalidateChunks = Queues.newLinkedBlockingQueue();
     private final Map<Vector3i, Chunk> chunkCache = Maps.newHashMap();
     private final BlockManager blockManager;
@@ -80,15 +81,7 @@ public class RemoteChunkProvider implements ChunkProvider {
                                 .map(org.joml.Vector3i::new)
                                 .collect(Collectors.toSet())
                 ))
-                .addStage(ChunkTaskProvider.create("", chunk -> {
-                    Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
-                    if (oldChunk != null) {
-                        oldChunk.dispose();
-                    }
-                    chunk.markReady();
-                    listener.onChunkReady(chunk.getPosition());
-                    worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
-                }));
+                .addStage(ChunkTaskProvider.create("", readyChunks::add));
 
         ChunkMonitor.fireChunkProviderInitialized(this);
     }
@@ -107,14 +100,19 @@ public class RemoteChunkProvider implements ChunkProvider {
     }
 
     @Override
-    public void completeUpdate() {
-        //TODO remove this
-    }
-
-    @Override
-    public void beginUpdate() {
+    public void update() {
         if (listener != null) {
             checkForUnload();
+        }
+        Chunk chunk;
+        while ((chunk = readyChunks.poll()) != null) {
+            Chunk oldChunk = chunkCache.put(chunk.getPosition(), chunk);
+            if (oldChunk != null) {
+                oldChunk.dispose();
+            }
+            chunk.markReady();
+            listener.onChunkReady(chunk.getPosition());
+            worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
         }
     }
 


### PR DESCRIPTION
The final stage of chunk loading, where the chunk is actually added to the ChunkProvider, its entities are created, and the OnChunkLoad event runs, needs to happen on the main thread in order to avoid concurrency issues, because it affects data that other systems running on the main thread have access to. This reverts a little bit of #4140, which moved this onto the chunk loading threads in the first place.

I have actually seen some specific issues that this fixes (e.g. OnChunkLoad event handlers running after that chunk has already been unloaded), but because the relevant code (`processReadyChunk`) could overlap with anything depending on the exact timing, the problem could potentially manifest in many different ways.