### PR TITLE
Fix: Make the chunk relevance region iterator actually terminate

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
@@ -203,8 +203,10 @@ public class ChunkRelevanceRegion {
 
     private class NeededChunksIterator implements Iterator<Vector3i> {
         Vector3i nextChunkPos;
+        Iterator<Vector3ic> allPositions;
 
         NeededChunksIterator() {
+            allPositions = currentRegion.iterator();
             calculateNext();
         }
 
@@ -227,7 +229,8 @@ public class ChunkRelevanceRegion {
 
         private void calculateNext() {
             nextChunkPos = null;
-            for (Vector3ic regionPosition : currentRegion) {
+            while (allPositions.hasNext()) {
+                Vector3ic regionPosition = allPositions.next();
                 if (!relevantChunks.contains(regionPosition)) {
                     nextChunkPos = new Vector3i(regionPosition);
                     return;


### PR DESCRIPTION
Only return each position from the iterator once, rather than repeatedly returning it, possibly forever, or possibly busy-looping until the chunk is complete. Fix for #4385.