### PR TITLE
feat(joml): migrate BlockAppearance

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/assets/texture/BasicTextureRegion.java
+++ b/engine/src/main/java/org/terasology/rendering/assets/texture/BasicTextureRegion.java
@@ -17,11 +17,11 @@ package org.terasology.rendering.assets.texture;
 
 import org.joml.Rectanglef;
 import org.joml.Rectanglei;
+import org.joml.Vector2fc;
 import org.joml.Vector2i;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Rect2f;
-import org.terasology.math.geom.Vector2f;
 
 /**
  */
@@ -34,8 +34,8 @@ public class BasicTextureRegion implements TextureRegion {
         this.region = JomlUtil.from(region);
     }
 
-    public BasicTextureRegion(Texture texture, Vector2f offset, Vector2f size) {
-        this(texture, Rect2f.createFromMinAndSize(offset, size));
+    public BasicTextureRegion(Texture texture, Vector2fc offset, Vector2fc size) {
+        this(texture, Rect2f.createFromMinAndSize(JomlUtil.from(offset), JomlUtil.from(size)));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/BlockAppearance.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockAppearance.java
@@ -17,8 +17,8 @@ package org.terasology.world.block;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-
-import org.terasology.math.geom.Vector2f;
+import org.joml.Vector2f;
+import org.joml.Vector2fc;
 import org.terasology.world.block.shapes.BlockMeshPart;
 
 import java.util.EnumMap;
@@ -31,7 +31,7 @@ import java.util.Map;
 public class BlockAppearance {
 
     private Map<BlockPart, BlockMeshPart> blockParts;
-    private Map<BlockPart, Vector2f> textureAtlasPos = new EnumMap<>(BlockPart.class);
+    private Map<BlockPart, Vector2fc> textureAtlasPos = new EnumMap<>(BlockPart.class);
 
     public BlockAppearance() {
         blockParts = Maps.newEnumMap(BlockPart.class);
@@ -41,7 +41,7 @@ public class BlockAppearance {
         }
     }
 
-    public BlockAppearance(Map<BlockPart, BlockMeshPart> blockParts, Map<BlockPart, Vector2f> textureAtlasPos) {
+    public BlockAppearance(Map<BlockPart, BlockMeshPart> blockParts, Map<BlockPart, ? extends Vector2fc> textureAtlasPos) {
         Preconditions.checkNotNull(blockParts);
         Preconditions.checkNotNull(textureAtlasPos);
         this.blockParts = blockParts;
@@ -55,8 +55,7 @@ public class BlockAppearance {
         return blockParts.get(part);
     }
 
-    public Vector2f getTextureAtlasPos(BlockPart part) {
+    public Vector2fc getTextureAtlasPos(BlockPart part) {
         return new Vector2f(textureAtlasPos.get(part));
     }
-
 }

--- a/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
+++ b/engine/src/main/java/org/terasology/world/block/internal/BlockBuilder.java
@@ -17,11 +17,12 @@ package org.terasology.world.block.internal;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import org.joml.Quaternionf;
+import org.joml.Vector2f;
 import org.terasology.math.JomlUtil;
-import org.terasology.utilities.Assets;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector2f;
+import org.terasology.utilities.Assets;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockAppearance;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -188,15 +189,16 @@ public class BlockBuilder implements BlockBuilderHelper {
                 atlasPos = new Vector2f();
                 frameCount = 1;
             } else {
-                atlasPos = worldAtlas.getTexCoords(tile, shape.getMeshPart(part) != null);
+                atlasPos = JomlUtil.from(worldAtlas.getTexCoords(tile, shape.getMeshPart(part) != null));
                 frameCount = tile.getLength();
             }
             BlockPart targetPart = part.rotate(rot);
             textureAtlasPositions.put(targetPart, atlasPos);
             if (shape.getMeshPart(part) != null) {
                 meshParts.put(targetPart,
-                    shape.getMeshPart(part).rotate(JomlUtil.from(rot.getQuat4f())).mapTexCoords(JomlUtil.from(atlasPos),
-                    worldAtlas.getRelativeTileSize(), frameCount));
+                    shape.getMeshPart(part)
+                            .rotate(rot.orientation().get(new Quaternionf()))
+                            .mapTexCoords(atlasPos, worldAtlas.getRelativeTileSize(), frameCount));
             }
         }
         return new BlockAppearance(meshParts, textureAtlasPositions);


### PR DESCRIPTION
Contributes to #3832

Tested with Metal Renegades which should use all modules affected by this PR.

## Module PRs

All branches named `joml/migrate-BlockAppearance`.

- Terasology/Behaviors#60
- Terasology/Health#60
- Terasology/Minimap#21

