### PR TITLE
Migrate Omega package from old Jenkins to new, with some minor cleanup / label improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,17 @@ node ("heavy-java") {
         } else {
             println "Running on a branch other than 'master' or 'develop' bypassing publishing"
         }
+
+        // Trigger the Omega dist job to repackage a game zip with modules
+        if (env.JOB_NAME.equals("Terasology/engine/develop")) {
+            build job: 'Terasology/Omega/develop', wait: false
+        } else if (env.JOB_NAME.equals("Terasology/engine/master")) {
+            build job: 'Terasology/Omega/master', wait: false
+        } else if (env.JOB_NAME.equals("Nanoware/Terasology/develop")) {
+            build job: 'Nanoware/Omega/develop', wait: false
+        } else if (env.JOB_NAME.equals("Nanoware/Terasology/master")) {
+            build job: 'Nanoware/Omega/master', wait: false
+        }
     }
     stage('Analytics') {
         sh "./gradlew --console=plain check spotbugsmain javadoc"

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -31,18 +31,8 @@ ext {
     startDateTimeString = dateTimeFormat.format(new Date())
     versionInfoFileDir = new File(buildDir, 'classes/org/terasology/version')
     versionInfoFile = new File(versionInfoFileDir, 'versionInfo.properties')
-    versionFileName = 'VERSION'
     versionBase = new File(templatesDir, "version.txt").text.trim()
     displayVersion = versionBase
-}
-
-def convertGitBranch = { gitBranch ->
-    if (gitBranch != null) {
-        // Remove "origin/" from "origin/develop"
-        gitBranch.substring(gitBranch.lastIndexOf("/") + 1)
-    } else {
-        ""
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -174,7 +164,7 @@ jar {
             def manifestClasspath = "$subDirLibs/" + configurations."${sourceSets.main.runtimeClasspathConfigurationName}".collect {
                 it.getName()
             }.join(" $subDirLibs/")
-            attributes("Class-Path": manifestClasspath, "Implementation-Title": "Terasology-" + project.name, "Implementation-Version": env.BUILD_NUMBER + ", " + convertGitBranch(env.GIT_BRANCH) + ", " + env.BUILD_ID + ", " + displayVersion)
+            attributes("Class-Path": manifestClasspath, "Implementation-Title": "Terasology", "Implementation-Version": displayVersion + ", engine v" + version + " , build number " + env.BUILD_NUMBER)
         }
     }
 }
@@ -229,10 +219,10 @@ group = 'org.terasology.engine'
 
 println "Version for $project.name loaded as $version for group $group"
 
-// This version info file actually goes inside the built jar and can be used at runtime
+// This version info file actually goes inside the built jar and can be used at runtime - *if* building in Jenkins (JOB_NAME set)
 task createVersionInfoFile {
     inputs.property('dateTime', startDateTimeString)
-    onlyIf { env.BUILD_URL != null }
+    onlyIf { env.JOB_NAME != null }
     doLast {
         versionInfoFileDir.mkdirs()
         ant.propertyfile(file: versionInfoFile) {
@@ -241,8 +231,6 @@ task createVersionInfoFile {
             ant.entry(key: 'buildTag', value: env.BUILD_TAG)
             ant.entry(key: 'buildUrl', value: env.BUILD_URL)
             ant.entry(key: 'jobName', value: env.JOB_NAME)
-            ant.entry(key: 'gitBranch', value: convertGitBranch(env.GIT_BRANCH))
-            ant.entry(key: 'gitCommit', value: env.GIT_COMMIT)
             ant.entry(key: 'dateTime', value: startDateTimeString)
             ant.entry(key: 'displayVersion', value: displayVersion)
             ant.entry(key: 'engineVersion', value: version)
@@ -250,8 +238,7 @@ task createVersionInfoFile {
     }
 }
 
-
-//TODO: Remove it  when gestalt will can to handle ProtectionDomain without classes (Resources)
+//TODO: Remove this when gestalt can handle ProtectionDomain without classes (Resources)
 task copyResourcesToClasses(type: Copy) {
     from sourceSets.main.output.resourcesDir
     into sourceSets.main.output.classesDirs.first()

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -210,7 +210,6 @@ tasks.register<Copy>("createVersionFile") {
     expand(mapOf(
         "buildNumber" to env["BUILD_NUMBER"],
         "buildUrl" to env["BUILD_URL"],
-        "gitBranch" to env["GIT_BRANCH"],
         "dateTime" to startDateTimeString,
         "displayVersion" to displayVersion
     ))

--- a/templates/VERSION
+++ b/templates/VERSION
@@ -4,7 +4,6 @@ Terasology - Version
 Jenkins:
   URL: ${buildUrl}
   Build number: ${buildNumber}
-GIT branch: ${gitBranch}
 Created at: ${dateTime}
 
 http://terasology.org

--- a/templates/version.txt
+++ b/templates/version.txt
@@ -1,1 +1,1 @@
-alpha
+alpha-18


### PR DESCRIPTION
### Contains

Newer replacement for #4231. Updates the engine repo just a little to prepare for a move to the new Jenkins which uses pipeline jobs, folders, and other fun things. Also includes the versioning updates noted in the older PR - I fully acknowledge that's a temporary state that'll likely change again, but I have scoped this down to where it is primarily just the migration plus a bit of assorted cleanup / clarifications. Hope that's OK until we come up with bigger and better methods for versioning and packaging.

### How to test

See #4231 - primarily tested in Jenkins, but won't show full "live" results until after it is merged. See for instance http://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/ to see a new school Omega zip having been packaged. It runs and shows the new version label stuff on the main menu, but has plenty of module quirks (JS and something else was red, not really important for this PR)

Additionally http://jenkins.terasology.io/teraorg/job/Terasology/job/Omega/job/PR-10/ should actually also work - but will miss the version label updates till the engine `develop` branch is updated. PR Omega zips! For the Index repo, anyway - we could probably even map those to engine PRs somehow. Right now anything not `master` or `develop` for either Terasology or Nanoware will default to using the regular engine job's `develop` branch for the build harness

### Outstanding before merging

- [x] Jobs in Jenkins must be ready - http://jenkins.terasology.io/teraorg/job/Terasology/job/Omega/
- [x] With the Omega dist job being a multi-branch pipeline now any change to any branch _there_ will also trigger a build (packaging) of an Omega zip. That in theory would result in an identical set of version info for the game client, yet different modules (particularly if the commit to the Index repo was a change to the module lineup). That may just be a thing to ignore for now until we have a better packaging approach yet. The most obvious alternative would have the Omega packager update the engine's `versionInfo.properties` which may not be desired. Same thing also happens on a manually triggered rebuild.
  - One option here could just be to exclude `master` in the Index repo. Extra dev builds are fine, really just want to avoid extra release builds. A release build for the engine will still trigger a release build for Omega automatically. Created issue to handle: https://github.com/MovingBlocks/InfraPlayground/issues/17
- [x] Merge https://github.com/Terasology/Index/pull/11 - but unsure how now. It targets the `develop` branch, which has an open PR to the `master` branch, so it might be bad to squash-merge the one into the other 🤔 

### Outstanding _after_ merging

- [ ] Update release management page in wiki to indicate the tiny step of bumping the alpha increment in `templates/version.txt` till we entirely replace that setup with something else.
- [ ] Reset the Nanoware `develop` and `master` branches - I used both of them and did local testing for the branch sensitive stuff. Topic branch is still there as well but needed extra bits in the `Jenkinsfile` to use
- [ ] Also reset the master branch for Nanoware/Index and again only update it when we do the next game Omega release
- [ ] After merging this **only** push module lineup changes to the `develop` branch for Terasology/Index, until the next game release. At that point update the `master` branch which should trigger the first ever release Omega from the new Jenkins (don't want to merge into and update `master` until then). See https://github.com/Terasology/Index/pull/10
- [ ] After merging this and being sure we have good zips in the new Jenkins we need to update the launcher to pick up stuff from there instead of the old Jenkins. @skaldarnar noted https://github.com/MovingBlocks/TerasologyLauncher/pull/609 should have some stuff for that and it shouldn't be much work to hook back up
- [ ] After *that* is done and the launcher no longer needs the _old_ Jenkins we are about ready to decommission it - there are a last few tiny jobs I could probably prep real quick, but this effort is the biggest reason that poor old butler still lives
- [ ] Consider the priority and desire for an Omega PR paired with an engine PR rather than using our standard `develop` build for the engine
- [ ] Flip the config for http://jenkins.terasology.io/teraorg/job/Terasology/job/Omega/ back to ignore branches used as origin for a PR. Since `develop` is being PRed to `master` the actual _branch_ is being ignored, which we don't want. One-time quirk.
- [ ] Unrelated but discovered through testing here: Consider the impact of the Jenkins master becoming a bottleneck for reporting results to during a build storm