### PR TITLE
Fix the upper half of each chunk behaving strangely.

### DIFF
--- a/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/WorldProviderCoreImpl.java
@@ -275,7 +275,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     public Block getBlock(int x, int y, int z) {
         CoreChunk chunk = chunkProvider.getChunk(Chunks.toChunkPos(x, y, z, new Vector3i()));
         if (chunk != null) {
-            return chunk.getBlock(Chunks.toRelativeX(x), Chunks.toRelativeX(y), Chunks.toRelativeX(z));
+            return chunk.getBlock(Chunks.toRelativeX(x), Chunks.toRelativeY(y), Chunks.toRelativeZ(z));
         }
         return unloadedBlock;
     }


### PR DESCRIPTION
This fixes the bug, introduced in #4408, where calls to `WorldProvider.getBlock` in the top half of a chunk would return the block that's actually in the corresponding position in the bottom half of the chunk. This manifested as various symptoms, e.g. it was often not possible to place blocks in the upper half of a chunk, you could swim 32 blocks above the ocean, and FlowingLiquids would get confused and make the ocean pour down from the sky above it.