### PR TITLE
Render even chunks that are next to unloaded chunks.

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
+import org.terasology.joml.geom.AABBi;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
 import org.terasology.monitoring.PerformanceMonitor;
@@ -110,6 +111,12 @@ class RenderableWorldImpl implements RenderableWorld {
                 Collections.sort(chunksInProximityOfCamera, new ChunkFrontToBackComparator());
             } else {
                 logger.warn("Warning: onChunkLoaded called for a null chunk!");
+            }
+        }
+        for (Vector3ic pos : new BlockRegion(chunkCoordinates).expand(1, 1, 1)) {
+            Chunk chunk = chunkProvider.getChunk(pos);
+            if (chunk != null) {
+                chunk.setDirty(true);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -173,9 +173,6 @@ public class LocalChunkProvider implements ChunkProvider {
         Chunk[] chunks = new Chunk[region.sizeX() * region.sizeY() * region.sizeZ()];
         for (Vector3i chunkPos : region) {
             Chunk chunk = chunkCache.get(chunkPos);
-            if (chunk == null) {
-                return null;
-            }
             chunkPos.sub(region.minX(), region.minY(), region.minZ());
             int index = TeraMath.calculate3DArrayIndex(chunkPos, region.size());
             chunks[index] = chunk;

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -220,9 +220,6 @@ public class RemoteChunkProvider implements ChunkProvider {
         Chunk[] chunks = new Chunk[region.sizeX() * region.sizeY() * region.sizeZ()];
         for (Vector3i chunkPos : region) {
             Chunk chunk = chunkCache.get(chunkPos);
-            if (chunk == null) {
-                return null;
-            }
             chunkPos.sub(region.minX(), region.minY(), region.minZ());
             int index = TeraMath.calculate3DArrayIndex(chunkPos, region.size());
             chunks[index] = chunk;

--- a/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
+++ b/engine/src/main/java/org/terasology/world/internal/ChunkViewCoreImpl.java
@@ -75,15 +75,16 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     // TODO: Review
     @Override
     public Block getBlock(int blockX, int blockY, int blockZ) {
-        if (!blockRegion.contains(blockX, blockY, blockZ)) {
-            return defaultBlock;
+        if (blockRegion.contains(blockX, blockY, blockZ)) {
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                return chunk.getBlock(
+                        Chunks.toRelative(blockX, chunkFilterSize.x),
+                        Chunks.toRelative(blockY, chunkFilterSize.y),
+                        Chunks.toRelative(blockZ, chunkFilterSize.z));
+            }
         }
-
-        int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getBlock(
-                Chunks.toRelative(blockX, chunkFilterSize.x),
-                Chunks.toRelative(blockY, chunkFilterSize.y),
-                Chunks.toRelative(blockZ, chunkFilterSize.z));
+        return defaultBlock;
     }
 
     @Override
@@ -108,22 +109,24 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
 
     @Override
     public byte getSunlight(int blockX, int blockY, int blockZ) {
-        if (!blockRegion.contains(blockX, blockY, blockZ)) {
-            return 0;
+        if (blockRegion.contains(blockX, blockY, blockZ)) {
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                return chunk.getSunlight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())));
+            }
         }
-
-        int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getSunlight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())));
+        return 0;
     }
 
     @Override
     public byte getLight(int blockX, int blockY, int blockZ) {
-        if (!blockRegion.contains(blockX, blockY, blockZ)) {
-            return 0;
+        if (blockRegion.contains(blockX, blockY, blockZ)) {
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                return chunk.getLight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())));
+            }
         }
-
-        int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getLight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())));
+        return 0;
     }
 
     @Override
@@ -134,11 +137,13 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     @Override
     public void setBlock(int blockX, int blockY, int blockZ, Block type) {
         if (blockRegion.contains(blockX, blockY, blockZ)) {
-            int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setBlock(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i()), type);
-        } else {
-            logger.warn("Attempt to modify block outside of the view");
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                chunk.setBlock(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i()), type);
+                return;
+            }
         }
+        logger.warn("Attempt to modify block outside of the view");
     }
 
     @Override
@@ -149,11 +154,13 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     @Override
     public void setLight(int blockX, int blockY, int blockZ, byte light) {
         if (blockRegion.contains(blockX, blockY, blockZ)) {
-            int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setLight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())), light);
-        } else {
-            logger.warn("Attempted to set light at a position not encompassed by the view");
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                chunk.setLight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())), light);
+                return;
+            }
         }
+        logger.warn("Attempted to set light at a position not encompassed by the view");
     }
 
     @Override
@@ -164,11 +171,13 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     @Override
     public void setSunlight(int blockX, int blockY, int blockZ, byte light) {
         if (blockRegion.contains(blockX, blockY, blockZ)) {
-            int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setSunlight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())), light);
-        } else {
-            throw new IllegalStateException("Attempted to modify sunlight though an unlocked view");
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                chunk.setSunlight(JomlUtil.from(Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i())), light);
+                return;
+            }
         }
+        throw new IllegalStateException("Attempted to set sunlight at a position not encompassed by the view");
     }
 
     @Override
@@ -178,12 +187,13 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
 
     @Override
     public int getExtraData(int index, int blockX, int blockY, int blockZ) {
-        if (!blockRegion.contains(blockX, blockY, blockZ)) {
-            return 0;
+        if (blockRegion.contains(blockX, blockY, blockZ)) {
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                return chunk.getExtraData(index, Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i()));
+            }
         }
-
-        int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-        return chunks[chunkIndex].getExtraData(index, Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i()));
+        return 0;
     }
 
     @Override
@@ -194,33 +204,34 @@ public class ChunkViewCoreImpl implements ChunkViewCore {
     @Override
     public void setExtraData(int index, int blockX, int blockY, int blockZ, int value) {
         if (blockRegion.contains(blockX, blockY, blockZ)) {
-            int chunkIndex = relChunkIndex(blockX, blockY, blockZ);
-            chunks[chunkIndex].setExtraData(index, Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i()), value);
-        } else {
-            throw new IllegalStateException("Attempted to modify extra data though an unlocked view");
+            Chunk chunk = chunks[relChunkIndex(blockX, blockY, blockZ)];
+            if (chunk != null) {
+                chunk.setExtraData(index, Chunks.toRelative(blockX, blockY, blockZ, chunkFilterSize, new Vector3i()), value);
+            }
         }
+        throw new IllegalStateException("Attempted to modify extra data at a position not encompassed by the view");
     }
 
     @Override
     public void setDirtyAround(Vector3ic blockPos) {
-        BlockRegion tmp = new BlockRegion(blockPos).expand(1, 1, 1);
-        for (Vector3ic pos : Chunks.toChunkRegion(tmp, tmp)) {
-            chunks[pos.x() + offset.x + chunkRegion.getSizeX() * (pos.z() + offset.z)].setDirty(true);
-        }
+        setDirtyAround(new BlockRegion(blockPos));
     }
 
     @Override
     public void setDirtyAround(BlockRegionc region) {
         BlockRegion tmp = new BlockRegion(region).expand(1, 1, 1);
-        for (Vector3ic pos : Chunks.toChunkRegion(tmp, chunkPower, tmp)) {
-            chunks[pos.x() + offset.x + chunkRegion.getSizeX() * (pos.z() + offset.z)].setDirty(true);
+        for (Vector3ic pos : Chunks.toChunkRegion(tmp, tmp)) {
+            Chunk chunk = chunks[TeraMath.calculate3DArrayIndex(pos.x() + offset.x, pos.y() + offset.y, pos.z() + offset.z, JomlUtil.from(chunkRegion.getSize(new Vector3i())))];
+            if (chunk != null) {
+                chunk.setDirty(true);
+            }
         }
     }
 
     @Override
     public boolean isValidView() {
         for (Chunk chunk : chunks) {
-            if (chunk.isDisposed()) {
+            if (chunk != null && chunk.isDisposed()) {
                 return false;
             }
         }


### PR DESCRIPTION
The mesh of each chunk may depend on the contents of the adjacent chunks, for example, the lighting of a block face that is on the edge of a chunk depends on the light value in the adjacent chunk. Before this PR, chunks would only be rendered if the adjacent chunk was loaded, and the mesh would be perfect straight away. With this PR, every chunk is rendered as soon as it loads, as if adjacent unloaded chunks were full of dark air, then if the adjacent chunk is loaded, the mesh is replaced to take into account the new information.

This has several effects:
- Chunks generally become visible faster. This is particularly noticable when first loading a world when world generation is slow, as the first chunk that's created (generally the one containing the player) can render as soon as it's ready, rather than having to wait for all 26 chunks around it.
- There should never be a situation where a chunk is loaded but not visible.
- The ratio of visible chunks to loaded chunks is higher, so low view distances should be more efficient for the amount of the world that's visible.
- Sometimes chunk meshes have to be generated more times. This is a slight decrease in efficiency, but I don't think chunk mesh generation is actually that expensive.
- The edge of the loaded region of the world is usually opaque (at least underground) rather than transparent, as the sides of blocks facing into unloaded chunks are rendered. If a chunk is unloaded, then the meshes of adjacent chunks may not be updated, so there may be holes in the surface in those cases, but it looks like this is rare. This makes it harder for the player to see caves and things that shouldn't be visible if the world is loading slowly.
- I expect that it will make debugging slightly easier in some cases, as it will be easier to see which chunks are loaded.

When testing this, it subjectively seemed like world generation, and chunks becoming available, was faster.

I've tested this with FlowingLiquids and not noticed any problems in that case either (as that's the only module I know that has a non-trivial interaction with chunk mesh generation).