### PR TITLE
feat(JOML): migrate assertions with joml-ext

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     implementation("org.junit.jupiter:junit-jupiter-params:5.5.2")
     implementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.2.0'
 
+    implementation("org.terasology.joml-ext:joml-test:1.0.0-SNAPSHOT")
+
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.2")
 
     implementation group: 'junit', name: 'junit', version: '4.12'

--- a/engine-tests/src/test/java/org/terasology/logic/location/LocationComponentTest.java
+++ b/engine-tests/src/test/java/org/terasology/logic/location/LocationComponentTest.java
@@ -24,11 +24,13 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.TeraMath;
-import org.terasology.testUtil.TeraAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.terasology.joml.test.VectorAssert.assertEquals;
+import static org.terasology.joml.test.QuaternionAssert.assertEquals;
+
 
 /**
  */
@@ -71,7 +73,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
     @Test
     public void testSetLocalRotation() {
         loc.setLocalRotation(yawRotation);
-        TeraAssert.assertEquals(yawRotation, JomlUtil.from(loc.getLocalRotation()), 0.0001f);
+        assertEquals(yawRotation, JomlUtil.from(loc.getLocalRotation()), 0.0001f);
     }
 
     @Test
@@ -93,7 +95,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         LocationComponent parent = giveParent();
         loc.setLocalPosition(pos1);
         parent.setLocalRotation(yawRotation);
-        TeraAssert.assertEquals(new Vector3f(pos1.z, pos1.y, -pos1.x), loc.getWorldPosition(new Vector3f()), 0.00001f);
+        assertEquals(new Vector3f(pos1.z, pos1.y, -pos1.x), loc.getWorldPosition(new Vector3f()), 0.00001f);
     }
 
     @Test
@@ -113,7 +115,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         parent.setLocalPosition(pos2);
         parent.setLocalRotation(yawRotation);
 
-        TeraAssert.assertEquals(new Vector3f(8, 7, 2), loc.getWorldPosition(new Vector3f()), 0.00001f);
+        assertEquals(new Vector3f(8, 7, 2), loc.getWorldPosition(new Vector3f()), 0.00001f);
     }
 
     @Test
@@ -127,7 +129,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         LocationComponent parent = giveParent();
         loc.setLocalRotation(pitchRotation);
         parent.setLocalRotation(yawRotation);
-        TeraAssert.assertEquals(yawPitch, loc.getWorldRotation(new Quaternionf()), 0.0001f);
+        assertEquals(yawPitch, loc.getWorldRotation(new Quaternionf()), 0.0001f);
     }
 
     @Test
@@ -147,7 +149,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
     @Test
     public void testSetWorldPositionWorksWithNoParent() {
         loc.setWorldPosition(pos1);
-        TeraAssert.assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.0001f);
+        assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.0001f);
     }
 
     @Test
@@ -155,7 +157,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         LocationComponent parent = giveParent();
         parent.setLocalPosition(pos1);
         loc.setWorldPosition(pos1plus2);
-        TeraAssert.assertEquals(pos2, JomlUtil.from(loc.getLocalPosition()), 0.0001f);
+        assertEquals(pos2, JomlUtil.from(loc.getLocalPosition()), 0.0001f);
         assertEquals(pos1plus2, loc.getWorldPosition(new Vector3f()));
     }
 
@@ -164,7 +166,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         LocationComponent parent = giveParent();
         parent.setLocalScale(2.0f);
         loc.setWorldPosition(pos1);
-        TeraAssert.assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.0001f);
+        assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.0001f);
     }
 
     @Test
@@ -172,7 +174,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         LocationComponent parent = giveParent();
         parent.setLocalRotation(yawRotation);
         loc.setWorldPosition(pos1);
-        TeraAssert.assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.000001f);
     }
 
     @Test
@@ -189,13 +191,13 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         Location.attachChild(firstEntity, secondEntity);
         second.setLocalPosition(new Vector3f(1, 0, 0));
         first.setLocalRotation(yawRotation);
-        TeraAssert.assertEquals(new Vector3f(0, 0, -1), second.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(new Vector3f(0, 0, -1), second.getWorldPosition(new Vector3f()), 0.000001f);
         Location.attachChild(secondEntity, thirdEntity);
         second.setLocalRotation(pitchRotation);
         third.setLocalPosition(new Vector3f(0, 0, 0));
-        TeraAssert.assertEquals(new Vector3f(0, 0, -1), third.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(new Vector3f(0, 0, -1), third.getWorldPosition(new Vector3f()), 0.000001f);
         third.setLocalPosition(new Vector3f(0, 0, 1));
-        TeraAssert.assertEquals(new Vector3f(0.5f * (float) Math.sqrt(2), -0.5f * (float) Math.sqrt(2), -1), third.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(new Vector3f(0.5f * (float) Math.sqrt(2), -0.5f * (float) Math.sqrt(2), -1), third.getWorldPosition(new Vector3f()), 0.000001f);
 
     }
 
@@ -206,7 +208,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         parent.setLocalScale(2.0f);
         parent.setLocalPosition(pos2);
         loc.setWorldPosition(pos1);
-        TeraAssert.assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(pos1, loc.getWorldPosition(new Vector3f()), 0.000001f);
     }
 
     @Test
@@ -227,8 +229,8 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
     @Test
     public void testSetWorldRotationWorksWithNoParent() {
         loc.setWorldRotation(yawRotation);
-        TeraAssert.assertEquals(yawRotation, loc.getWorldRotation(new Quaternionf()), 0.0001f);
-        TeraAssert.assertEquals(yawRotation, JomlUtil.from(loc.getLocalRotation()), 0.0001f);
+        assertEquals(yawRotation, loc.getWorldRotation(new Quaternionf()), 0.0001f);
+        assertEquals(yawRotation, JomlUtil.from(loc.getLocalRotation()), 0.0001f);
     }
 
     @Test
@@ -236,7 +238,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         LocationComponent parent = giveParent();
         parent.setLocalRotation(yawRotation);
         loc.setWorldRotation(yawPitch);
-        TeraAssert.assertEquals(yawPitch, loc.getWorldRotation(new Quaternionf()), 0.0001f);
+        assertEquals(yawPitch, loc.getWorldRotation(new Quaternionf()), 0.0001f);
     }
 
     @Test
@@ -248,7 +250,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         loc.setWorldPosition(new Vector3f(2, 0, 0));
         Location.attachChild(parentEntity, entity);
 
-        TeraAssert.assertEquals(new Vector3f(2, 0, 0), loc.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(new Vector3f(2, 0, 0), loc.getWorldPosition(new Vector3f()), 0.000001f);
     }
 
     @Test
@@ -261,7 +263,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         Location.attachChild(parentEntity, entity);
         Location.removeChild(parentEntity, entity);
 
-        TeraAssert.assertEquals(new Vector3f(2, 0, 0), loc.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(new Vector3f(2, 0, 0), loc.getWorldPosition(new Vector3f()), 0.000001f);
     }
 
     @Test
@@ -277,7 +279,7 @@ public class LocationComponentTest extends TerasologyTestingEnvironment {
         when(parentEntity.getComponent(LocationComponent.class)).thenReturn(null);
         when(parentEntity.exists()).thenReturn(false);
 
-        TeraAssert.assertEquals(new Vector3f(2, 0, 0), loc.getWorldPosition(new Vector3f()), 0.000001f);
+        assertEquals(new Vector3f(2, 0, 0), loc.getWorldPosition(new Vector3f()), 0.000001f);
     }
 
 

--- a/engine-tests/src/test/java/org/terasology/math/RotationTest.java
+++ b/engine-tests/src/test/java/org/terasology/math/RotationTest.java
@@ -20,9 +20,9 @@ import org.joml.Quaternionf;
 import org.junit.jupiter.api.Test;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.testUtil.TeraAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.terasology.joml.test.QuaternionAssert.assertEquals;
 
 /**
  */
@@ -46,14 +46,14 @@ public class RotationTest {
 
     @Test
     public void testOrientation() {
-        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(90.0f * TeraMath.DEG_TO_RAD,0,0), Rotation.rotate(Yaw.CLOCKWISE_90).orientation(),0.001f);
-        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(180.0f * TeraMath.DEG_TO_RAD,0,0), Rotation.rotate(Yaw.CLOCKWISE_180).orientation(),0.001f);
+        assertEquals(new Quaternionf().rotationYXZ(90.0f * TeraMath.DEG_TO_RAD,0,0), Rotation.rotate(Yaw.CLOCKWISE_90).orientation(),0.001f);
+        assertEquals(new Quaternionf().rotationYXZ(180.0f * TeraMath.DEG_TO_RAD,0,0), Rotation.rotate(Yaw.CLOCKWISE_180).orientation(),0.001f);
 
-        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,90.0f * TeraMath.DEG_TO_RAD,0), Rotation.rotate(Pitch.CLOCKWISE_90).orientation(),0.001f);
-        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,180.0f * TeraMath.DEG_TO_RAD,0), Rotation.rotate(Pitch.CLOCKWISE_180).orientation(),0.001f);
+        assertEquals(new Quaternionf().rotationYXZ(0,90.0f * TeraMath.DEG_TO_RAD,0), Rotation.rotate(Pitch.CLOCKWISE_90).orientation(),0.001f);
+        assertEquals(new Quaternionf().rotationYXZ(0,180.0f * TeraMath.DEG_TO_RAD,0), Rotation.rotate(Pitch.CLOCKWISE_180).orientation(),0.001f);
 
-        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,0,90.0f * TeraMath.DEG_TO_RAD), Rotation.rotate(Roll.CLOCKWISE_90).orientation(),0.001f);
-        TeraAssert.assertEquals(new Quaternionf().rotationYXZ(0,0,180.0f * TeraMath.DEG_TO_RAD), Rotation.rotate(Roll.CLOCKWISE_180).orientation(),0.001f);
+        assertEquals(new Quaternionf().rotationYXZ(0,0,90.0f * TeraMath.DEG_TO_RAD), Rotation.rotate(Roll.CLOCKWISE_90).orientation(),0.001f);
+        assertEquals(new Quaternionf().rotationYXZ(0,0,180.0f * TeraMath.DEG_TO_RAD), Rotation.rotate(Roll.CLOCKWISE_180).orientation(),0.001f);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/persistence/serializers/VectorTypeSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/serializers/VectorTypeSerializerTest.java
@@ -17,6 +17,9 @@ import org.terasology.persistence.typeHandling.TypeHandlerLibraryImpl;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.testUtil.TeraAssert;
 
+import static org.terasology.joml.test.VectorAssert.assertEquals;
+
+
 import java.io.IOException;
 
 public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
@@ -66,9 +69,9 @@ public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
 
         TestObject2 o = gsonSerializer.fromJson(data, new TypeInfo<TestObject2>() {
         });
-        TeraAssert.assertEquals(o.v1, new org.joml.Vector3f(1.0f, 2.0f, 3.0f), .00001f);
-        TeraAssert.assertEquals(o.v2, new org.joml.Vector4f(1.0f, 2.0f, 3.0f, 5.0f), .00001f);
-        TeraAssert.assertEquals(o.v3, new org.joml.Vector2f(1.0f, 2.0f), .00001f);
+        assertEquals(o.v1, new org.joml.Vector3f(1.0f, 2.0f, 3.0f), .00001f);
+        assertEquals(o.v2, new org.joml.Vector4f(1.0f, 2.0f, 3.0f, 5.0f), .00001f);
+        assertEquals(o.v3, new org.joml.Vector2f(1.0f, 2.0f), .00001f);
     }
 
     @Test
@@ -87,9 +90,9 @@ public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
         TestObject1 o = gsonSerializer.fromJson(data, new TypeInfo<TestObject1>() {
         });
 
-        TeraAssert.assertEquals(o.v1, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
-        TeraAssert.assertEquals(o.v2, new org.joml.Vector2f(12f, 13f), .00001f);
-        TeraAssert.assertEquals(o.v3, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+        assertEquals(o.v1, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        assertEquals(o.v2, new org.joml.Vector2f(12f, 13f), .00001f);
+        assertEquals(o.v3, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
 
     }
 
@@ -109,9 +112,9 @@ public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
         TestObject1 o = protobufSerializer.fromBytes(data, new TypeInfo<TestObject1>() {
         });
 
-        TeraAssert.assertEquals(o.v1, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
-        TeraAssert.assertEquals(o.v2, new org.joml.Vector2f(12f, 13f), .00001f);
-        TeraAssert.assertEquals(o.v3, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+        assertEquals(o.v1, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        assertEquals(o.v2, new org.joml.Vector2f(12f, 13f), .00001f);
+        assertEquals(o.v3, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
 
     }
 
@@ -135,9 +138,9 @@ public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
         TeraAssert.assertEquals(o.v2, new Vector2f(12f, 13f), .00001f);
         TeraAssert.assertEquals(o.v3, new Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
 
-        TeraAssert.assertEquals(o.v11, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
-        TeraAssert.assertEquals(o.v22, new org.joml.Vector2f(12f, 13f), .00001f);
-        TeraAssert.assertEquals(o.v33, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+        assertEquals(o.v11, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        assertEquals(o.v22, new org.joml.Vector2f(12f, 13f), .00001f);
+        assertEquals(o.v33, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
     }
 
     @Test
@@ -160,9 +163,9 @@ public class VectorTypeSerializerTest extends ModuleEnvironmentTest {
         TeraAssert.assertEquals(o.v2, new Vector2f(12f, 13f), .00001f);
         TeraAssert.assertEquals(o.v3, new Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
 
-        TeraAssert.assertEquals(o.v11, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
-        TeraAssert.assertEquals(o.v22, new org.joml.Vector2f(12f, 13f), .00001f);
-        TeraAssert.assertEquals(o.v33, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
+        assertEquals(o.v11, new org.joml.Vector3f(11.5f, 13.15f, 3), .00001f);
+        assertEquals(o.v22, new org.joml.Vector2f(12f, 13f), .00001f);
+        assertEquals(o.v33, new org.joml.Vector4f(12, 12.2f, 3f, 15.5f), .00001f);
     }
 
 }

--- a/engine-tests/src/test/java/org/terasology/persistence/typeHandling/event/VectorEventSerializer.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/typeHandling/event/VectorEventSerializer.java
@@ -28,7 +28,8 @@ import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.reflection.reflect.ReflectionReflectFactory;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
-import org.terasology.testUtil.TeraAssert;
+
+import static org.terasology.joml.test.VectorAssert.assertEquals;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -105,12 +106,12 @@ public class VectorEventSerializer {
         EntityData.Event ev = serializer.serialize(a);
         Event dev = serializer.deserialize(ev);
         assumeTrue(dev instanceof Vector3fTestEvent);
-        TeraAssert.assertEquals(((Vector3fTestEvent) dev).v1, new Vector3f(1.0f, 2.0f, 3.0f), .00001f);
-        TeraAssert.assertEquals(((Vector3fTestEvent) dev).v2, new Vector4f(1.0f, 2.0f, 3.0f, 5.0f), .00001f);
-        TeraAssert.assertEquals(((Vector3fTestEvent) dev).v3, new Vector2f(1.0f, 2.0f), .00001f);
+        assertEquals(((Vector3fTestEvent) dev).v1, new Vector3f(1.0f, 2.0f, 3.0f), .00001f);
+        assertEquals(((Vector3fTestEvent) dev).v2, new Vector4f(1.0f, 2.0f, 3.0f, 5.0f), .00001f);
+        assertEquals(((Vector3fTestEvent) dev).v3, new Vector2f(1.0f, 2.0f), .00001f);
 
-        TeraAssert.assertEquals(((Vector3fTestEvent) dev).v1c, new Vector3f(1.0f, 1.0f, 1.0f), .00001f);
-        TeraAssert.assertEquals(((Vector3fTestEvent) dev).v2c, new Vector4f(1.0f, 1.0f, 2.0f, 2.0f), .00001f);
-        TeraAssert.assertEquals(((Vector3fTestEvent) dev).v3c, new Vector2f(1.0f, 1.0f), .00001f);
+        assertEquals(((Vector3fTestEvent) dev).v1c, new Vector3f(1.0f, 1.0f, 1.0f), .00001f);
+        assertEquals(((Vector3fTestEvent) dev).v2c, new Vector4f(1.0f, 1.0f, 2.0f, 2.0f), .00001f);
+        assertEquals(((Vector3fTestEvent) dev).v3c, new Vector2f(1.0f, 1.0f), .00001f);
     }
 }


### PR DESCRIPTION
this migrates the assertion logic from these TeraMath methods to the methods provided by joml-ext. 

we need to include this PR: https://github.com/MovingBlocks/joml-ext/pull/13 