### PR TITLE
chore(JOML): remove unused imports (Region3i) and update copyright

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/generation/facets/BaseBooleanFacetTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/generation/facets/BaseBooleanFacetTest.java
@@ -16,7 +16,6 @@
 
 package org.terasology.world.generation.facets;
 
-import org.terasology.math.Region3i;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.facets.base.BaseBooleanFieldFacet3D;

--- a/engine-tests/src/test/java/org/terasology/world/generation/facets/BaseObjectFacetTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/generation/facets/BaseObjectFacetTest.java
@@ -16,7 +16,6 @@
 
 package org.terasology.world.generation.facets;
 
-import org.terasology.math.Region3i;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.facets.base.BaseObjectFacet3D;

--- a/engine/src/main/java/org/terasology/logic/selection/ApplyBlockSelectionEvent.java
+++ b/engine/src/main/java/org/terasology/logic/selection/ApplyBlockSelectionEvent.java
@@ -1,24 +1,10 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.selection;
 
-import org.terasology.module.sandbox.API;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.Region3i;
+import org.terasology.module.sandbox.API;
 import org.terasology.world.block.BlockRegion;
 
 /**

--- a/engine/src/main/java/org/terasology/logic/selection/MovableSelectionEndEvent.java
+++ b/engine/src/main/java/org/terasology/logic/selection/MovableSelectionEndEvent.java
@@ -1,23 +1,9 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.logic.selection;
 
-import org.terasology.module.sandbox.API;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.Region3i;
+import org.terasology.module.sandbox.API;
 import org.terasology.world.block.BlockRegion;
 
 /**

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -1,25 +1,8 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.chunks;
 
-import org.joml.Vector3fc;
 import org.joml.Vector3ic;
-import org.terasology.audio.AudioEndListener;
-import org.terasology.audio.StaticSound;
-import org.terasology.math.Region3i;
 import org.terasology.math.geom.BaseVector3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.module.sandbox.API;

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkRelevanceRegion.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.world.chunks.internal;
 
@@ -23,9 +10,6 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.ChunkMath;
-import org.terasology.math.JomlUtil;
-import org.terasology.math.Region3i;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.chunks.Chunk;
 import org.terasology.world.chunks.ChunkRegionListener;

--- a/engine/src/main/java/org/terasology/world/generation/RegionImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/RegionImpl.java
@@ -1,23 +1,9 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.generation;
 
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
-import org.terasology.math.Region3i;
 import org.terasology.utilities.collection.TypeMap;
 import org.terasology.world.block.BlockRegion;
 

--- a/engine/src/main/java/org/terasology/world/generation/World.java
+++ b/engine/src/main/java/org/terasology/world/generation/World.java
@@ -1,21 +1,7 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.generation;
 
-import org.terasology.math.Region3i;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.chunks.CoreChunk;
 

--- a/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
@@ -1,23 +1,9 @@
-/*
- * Copyright 2014 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.generation;
 
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
-import org.terasology.math.Region3i;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.chunks.CoreChunk;
 


### PR DESCRIPTION
If I saw it correctly, there is not public API left where you must use `Region3i` with the engine anymore (we still have some deprecated APIs but offer the non-deprecated variant with `BlockRegion` in that case). :partying_face: 

Contributes to #3832
