### PR TITLE
feat(JOML): remove deprecated API in favor of JOML for BlockFamily

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/AttachedToSurfaceFamily.java
@@ -1,25 +1,11 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
 import org.terasology.math.Pitch;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -85,11 +71,6 @@ public class AttachedToSurfaceFamily extends AbstractBlockFamily {
     @Override
     public Block getBlockForPlacement(BlockPlacementData data) {
         return blocks.get(data.attachmentSide);
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        return blocks.get(attachmentSide);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/BlockFamily.java
@@ -1,23 +1,8 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
 import org.terasology.assets.ResourceUrn;
-import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockUri;
 
@@ -47,18 +32,6 @@ public interface BlockFamily {
      * @return The appropriate block
      */
     Block getBlockForPlacement(BlockPlacementData data);
-
-    /**
-     * Get the block that is appropriate for placement in the given situation
-     *
-     * @param location            The location where the block is going to be placed.
-     * @param attachmentSide      The side of the block which this block is being attached to, e.g. Top if the block is being placed on the ground
-     * @param direction           A secondary direction after the attachment side that determines the facing of the block.
-     * @return The appropriate block
-     * @deprecated This method is scheduled for removal, use this one instead: {@link #getBlockForPlacement(BlockPlacementData)}.
-     */
-    @Deprecated
-    Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction);
 
     /**
      * @return The base block defining the block group. Can be used for orientation-irrelevant behaviours

--- a/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/CeilingSupportingHorizontalFamily.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
@@ -21,7 +8,6 @@ import org.terasology.math.Roll;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.Yaw;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -128,15 +114,6 @@ public class CeilingSupportingHorizontalFamily extends AbstractBlockFamily {
 
         Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
         return blocks.get(ExtendedSide.getExtendedSideFor(mainSide, blockDirection));
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (attachmentSide == Side.BOTTOM) {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.BOTTOM, direction));
-        } else {
-            return blocks.get(ExtendedSide.getExtendedSideFor(Side.TOP, direction));
-        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/FreeformFamily.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
@@ -20,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -85,21 +71,6 @@ public class FreeformFamily extends AbstractBlockFamily implements SideDefinedBl
             Side blockDirection = Side.inDirection(-data.viewingDirection.x(), 0, -data.viewingDirection.z());
             return blocks.get(blockDirection);
         }
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (archetypeBlock == null) {
-            if (attachmentSide.isHorizontal()) {
-                return blocks.get(attachmentSide);
-            }
-            if (direction != null) {
-                return blocks.get(direction);
-            } else {
-                return blocks.get(Side.FRONT);
-            }
-        }
-        return archetypeBlock;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/HorizontalFamily.java
@@ -1,24 +1,10 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Maps;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
@@ -90,18 +76,6 @@ public class HorizontalFamily extends AbstractBlockFamily implements SideDefined
     }
 
     @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        if (attachmentSide.isHorizontal()) {
-            return blocks.get(attachmentSide);
-        }
-        if (direction != null) {
-            return blocks.get(direction);
-        } else {
-            return blocks.get(Side.FRONT);
-        }
-    }
-
-    @Override
     public Block getArchetypeBlock() {
         return blocks.get(this.getArchetypeSide());
     }
@@ -138,6 +112,4 @@ public class HorizontalFamily extends AbstractBlockFamily implements SideDefined
         }
         return null;
     }
-
-
 }

--- a/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/MultiConnectFamily.java
@@ -1,32 +1,16 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
 import com.google.common.collect.Sets;
 import gnu.trove.map.TByteObjectMap;
 import gnu.trove.map.hash.TByteObjectHashMap;
-import org.joml.Vector3f;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.math.JomlUtil;
 import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.SideBitFlag;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.naming.Name;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
@@ -78,21 +62,6 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
      */
     public MultiConnectFamily(BlockFamilyDefinition definition, BlockBuilderHelper blockBuilder) {
         super(definition, blockBuilder);
-    }
-
-    /**
-     * A condition to return true if the block should have a connection on the given side
-     *
-     * @param blockLocation The position of the block in question
-     * @param connectSide The side to determine connection for
-     *
-     * @return A boolean indicating if the block should connect on the given side
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #connectionCondition(Vector3ic, Side)}.
-     */
-    @Deprecated
-    protected boolean connectionCondition(Vector3i blockLocation, Side connectSide) {
-        return connectionCondition(JomlUtil.from(blockLocation), connectSide);
     }
 
     /**
@@ -180,20 +149,11 @@ public abstract class MultiConnectFamily extends AbstractBlockFamily implements 
     public Block getBlockForPlacement(BlockPlacementData data) {
         byte connections = 0;
         for (Side connectSide : SideBitFlag.getSides(getConnectionSides())) {
-            if (this.connectionCondition(JomlUtil.from(data.blockPosition), connectSide)) {
+            if (this.connectionCondition(data.blockPosition, connectSide)) {
                 connections += SideBitFlag.getSide(connectSide);
             }
         }
         return blocks.get(connections);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-        BlockPlacementData data = new BlockPlacementData(JomlUtil.from(location), attachmentSide, new Vector3f());
-        return getBlockForPlacement(data);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/SymmetricFamily.java
@@ -1,22 +1,7 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.block.family;
 
-import org.terasology.math.Side;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
 import org.terasology.world.block.BlockUri;
@@ -54,11 +39,6 @@ public class SymmetricFamily extends AbstractBlockFamily {
 
     @Override
     public Block getBlockForPlacement(BlockPlacementData data) {
-        return block;
-    }
-
-    @Override
-    public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
         return block;
     }
 

--- a/engine/src/main/java/org/terasology/world/block/family/UpdatesWithNeighboursFamily.java
+++ b/engine/src/main/java/org/terasology/world/block/family/UpdatesWithNeighboursFamily.java
@@ -16,24 +16,12 @@
 package org.terasology.world.block.family;
 
 import org.joml.Vector3ic;
-import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.world.block.Block;
 
 /**
  * Interface for Block family that gets updated by a change in a neighbor block.
  */
 public interface UpdatesWithNeighboursFamily extends BlockFamily {
-    /**
-     * Update called when a neighbor block changes
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #getBlockForNeighborUpdate(Vector3ic, Block)}.
-     **/
-    @Deprecated
-    default Block getBlockForNeighborUpdate(Vector3i location, Block oldBlock) {
-        return getBlockForNeighborUpdate(JomlUtil.from(location), oldBlock);
-    }
-
     /**
      * Update the block when a neighbor changes
      *


### PR DESCRIPTION
The removes the deprecated method `BlockFamily#getBlockForPlacement` taking individual arguments in favor of fully migrating to `BlockPlacementData`.
This allows for all BlockFamilies to become JOML-free.

Contributes to #3832
