### PR TITLE
feat(JOML): migrate `Location` system and (parts of) `LocationComponent` 

### DIFF
--- a/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/internal/PojoEntityPool.java
@@ -138,10 +138,10 @@ public class PojoEntityPool implements EngineEntityPool {
         }
 
         if (position != null) {
-            loc.setWorldPosition(position);
+            loc.setWorldPosition(JomlUtil.from(position));
         }
         if (rotation != null) {
-            loc.setWorldRotation(rotation);
+            loc.setWorldRotation(JomlUtil.from(rotation));
         }
 
         return builder.build();

--- a/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
+++ b/engine/src/main/java/org/terasology/entitySystem/sectors/SectorUtil.java
@@ -82,7 +82,7 @@ public final class SectorUtil {
     /**
      * Watched chunks are defined as the union of:
      * <ul>
-     *     <li>The chunk in which the {@link LocationComponent#getWorldPosition()} resides, if any</li>
+     *     <li>The chunk in which the {@link LocationComponent#getWorldPosition(Vector3f)} resides, if any</li>
      *     <li>The set of chunks in {@link SectorRegionComponent#chunks}, if any</li>
      * </ul>
      *

--- a/engine/src/main/java/org/terasology/logic/inventory/events/DropItemEvent.java
+++ b/engine/src/main/java/org/terasology/logic/inventory/events/DropItemEvent.java
@@ -15,9 +15,9 @@
  */
 package org.terasology.logic.inventory.events;
 
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.network.ServerEvent;
 
 /**
@@ -25,24 +25,16 @@ import org.terasology.network.ServerEvent;
  */
 @ServerEvent
 public class DropItemEvent implements Event {
-    private Vector3f position;
+    private Vector3f position = new Vector3f();
 
     public DropItemEvent() {
     }
 
-    /**
-     * @deprecated This method is scheduled for removal in an upcoming version.
-     *             Use the JOML implementation instead: {@link #DropItemEvent(org.joml.Vector3f)}.
-     */
-    public DropItemEvent(Vector3f position) {
-        this.position = position;
+    public DropItemEvent(Vector3fc position) {
+        this.position.set(position);
     }
 
-    public DropItemEvent(org.joml.Vector3f position) {
-        this.position = JomlUtil.from(position);
-    }
-
-    public Vector3f getPosition() {
+    public Vector3fc getPosition() {
         return position;
     }
 }

--- a/engine/src/main/java/org/terasology/logic/location/Location.java
+++ b/engine/src/main/java/org/terasology/logic/location/Location.java
@@ -25,7 +25,6 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 
 import java.util.Iterator;
@@ -39,15 +38,26 @@ public class Location extends BaseComponentSystem {
      * Attaches an entity to another entity. Both must have location components.
      * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
      *
-     * @param parent           entity that will be the parent Location to the child
-     * @param child            entity will be attached relative to the parent
+     * @param parent           entity with a {@link LocationComponent}
+     * @param child            entity with a {@link LocationComponent} attach to the parent
      * @param offset           relative position from parent
      * @param relativeRotation relative rotation from parent
-     * @deprecated This is scheduled for removal in an upcoming version
-     * method will be replaced with JOML implementation {@link #attachChild(EntityRef, EntityRef, Vector3fc, Quaternionfc, float)}.
-     */
-    @Deprecated
-    public static void attachChild(EntityRef parent, EntityRef child, Vector3f offset, Quat4f relativeRotation, float relativeScale) {
+     **/
+    public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation) {
+        attachChild(parent, child, offset, relativeRotation, 1f);
+    }
+
+    /**
+     * Attaches an entity to another entity. Both must have location components.
+     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
+     *
+     * @param parent           entity with a {@link LocationComponent}
+     * @param child            entity with a {@link LocationComponent} attach to the parent
+     * @param offset           relative position from parent
+     * @param relativeRotation relative rotation from parent
+     * @param relativeScale    relative scale from parent
+     **/
+    public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation, float relativeScale) {
         LocationComponent childLoc = child.getComponent(LocationComponent.class);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (childLoc != null && parentLoc != null && !childLoc.getParent().equals(parent)) {
@@ -64,49 +74,6 @@ public class Location extends BaseComponentSystem {
             child.saveComponent(childLoc);
             parent.saveComponent(parentLoc);
         }
-    }
-
-    /**
-     * Attaches an entity to another entity. Both must have location components.
-     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
-     *
-     * @param parent           entity with a {@link LocationComponent}
-     * @param child            entity with a {@link LocationComponent} attach to the parent
-     * @param offset           relative position from parent
-     * @param relativeRotation relative rotation from parent
-     * @deprecated This is scheduled for removal in an upcoming version
-     * method will be replaced with JOML implementation {@link #attachChild(EntityRef, EntityRef, Vector3fc, Quaternionfc)}.
-     */
-    @Deprecated
-    public static void attachChild(EntityRef parent, EntityRef child, Vector3f offset, Quat4f relativeRotation) {
-        attachChild(parent, child, offset, relativeRotation, 1f);
-    }
-
-    /**
-     * Attaches an entity to another entity. Both must have location components.
-     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
-     *
-     * @param parent           entity with a {@link LocationComponent}
-     * @param child            entity with a {@link LocationComponent} attach to the parent
-     * @param offset           relative position from parent
-     * @param relativeRotation relative rotation from parent
-     **/
-    public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation) {
-        attachChild(parent, child, JomlUtil.from(offset), JomlUtil.from(relativeRotation), 1f);
-    }
-
-    /**
-     * Attaches an entity to another entity. Both must have location components.
-     * This method sets the child's relative offset and rotation to the parent {@link LocationComponent}
-     *
-     * @param parent           entity with a {@link LocationComponent}
-     * @param child            entity with a {@link LocationComponent} attach to the parent
-     * @param offset           relative position from parent
-     * @param relativeRotation relative rotation from parent
-     * @param relativeScale    relative scale from parent
-     **/
-    public static void attachChild(EntityRef parent, EntityRef child, Vector3fc offset, Quaternionfc relativeRotation, float relativeScale) {
-        attachChild(parent, child, JomlUtil.from(offset), JomlUtil.from(relativeRotation), relativeScale);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/location/Location.java
+++ b/engine/src/main/java/org/terasology/logic/location/Location.java
@@ -17,6 +17,7 @@
 package org.terasology.logic.location;
 
 import org.joml.Quaternionfc;
+import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
@@ -24,8 +25,6 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.math.JomlUtil;
-import org.terasology.math.geom.Vector3f;
 
 import java.util.Iterator;
 
@@ -87,7 +86,7 @@ public class Location extends BaseComponentSystem {
         LocationComponent childLoc = child.getComponent(LocationComponent.class);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (childLoc != null && parentLoc != null && !childLoc.getParent().equals(parent)) {
-            Vector3f oldWorldPos = childLoc.getWorldPosition();
+            Vector3f oldWorldPos = childLoc.getWorldPosition(new Vector3f());
             LocationComponent oldParentLoc = childLoc.getParent().getComponent(LocationComponent.class);
             if (oldParentLoc != null) {
                 oldParentLoc.children.remove(child);
@@ -105,7 +104,7 @@ public class Location extends BaseComponentSystem {
         LocationComponent childLoc = child.getComponent(LocationComponent.class);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (childLoc != null && parentLoc != null && childLoc.getParent().equals(parent)) {
-            Vector3f oldWorldPos = childLoc.getWorldPosition();
+            Vector3f oldWorldPos = childLoc.getWorldPosition(new Vector3f());
             parentLoc.children.remove(child);
             childLoc.parent = EntityRef.NULL;
             childLoc.setWorldPosition(oldWorldPos);
@@ -124,7 +123,7 @@ public class Location extends BaseComponentSystem {
             EntityRef child = childIterator.next();
             LocationComponent childLoc = child.getComponent(LocationComponent.class);
             if (childLoc != null) {
-                Vector3f oldWorldPos = childLoc.getWorldPosition();
+                Vector3f oldWorldPos = childLoc.getWorldPosition(new Vector3f());
                 childLoc.parent = EntityRef.NULL;
                 childLoc.setWorldPosition(oldWorldPos);
                 child.saveComponent(childLoc);
@@ -135,8 +134,8 @@ public class Location extends BaseComponentSystem {
 
     @ReceiveEvent(netFilter = RegisterMode.REMOTE_CLIENT)
     public void onResyncLocation(LocationResynchEvent event, EntityRef entityRef, LocationComponent locationComponent) {
-        locationComponent.setWorldPosition(JomlUtil.from(event.getPosition()));
-        locationComponent.setWorldRotation(JomlUtil.from(event.getRotation()));
+        locationComponent.setWorldPosition(event.getPosition());
+        locationComponent.setWorldRotation(event.getRotation());
         entityRef.saveComponent(locationComponent);
     }
 }

--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -53,15 +53,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     public LocationComponent() {
     }
 
-    /**
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #LocationComponent(Vector3fc)}.
-     */
-    @Deprecated
-    public LocationComponent(Vector3f position) {
-        setLocalPosition(position);
-    }
-
     public LocationComponent(Vector3fc position) {
         setLocalPosition(position);
     }
@@ -74,7 +65,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     public Quat4f getLocalRotation() {
         return rotation;
     }
-
 
     /**
      * @param newQuat
@@ -97,7 +87,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
         rotation.set(JomlUtil.from(rot));
     }
 
-
     /**
      * @return The position of this component relative to any parent. Can be directly modified to update the component
      *     TODO: make this readonly Vector3fc -- Michael Pollind
@@ -117,7 +106,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
         position.set(pos);
     }
 
-
     /**
      * the local position of this location component
      *
@@ -129,18 +117,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     /**
-     * @return
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getLocalDirection(org.joml.Vector3f)}.
-     */
-    @Deprecated
-    public Vector3f getLocalDirection() {
-        Vector3f result = Direction.FORWARD.getVector3f();
-        getLocalRotation().rotate(result, result);
-        return result;
-    }
-
-    /**
      * gets the local direction of the given entity in
      *
      * @param dest will hold the result
@@ -149,7 +125,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     public org.joml.Vector3f getLocalDirection(org.joml.Vector3f dest) {
         return dest.set(Direction.FORWARD.asVector3i()).rotate(JomlUtil.from(getLocalRotation()));
     }
-
 
     /**
      * set the local scale
@@ -174,19 +149,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
      */
     @Deprecated
     public Vector3f getWorldPosition() {
-        return getWorldPosition(new Vector3f());
-    }
-
-    /**
-     * @param output
-     * @return
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldPosition(org.joml.Vector3f)}.
-     */
-    @Deprecated
-    public Vector3f getWorldPosition(Vector3f output) {
-        output.set(JomlUtil.from(getWorldPosition(new org.joml.Vector3f())));
-        return output;
+        return JomlUtil.from(getWorldPosition(new org.joml.Vector3f()));
     }
 
     /**
@@ -233,7 +196,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
         getWorldRotation().rotate(result, result);
         return result;
     }
-
 
     public org.joml.Vector3f getWorldDirection(org.joml.Vector3f dest) {
         return dest.set(Direction.FORWARD.asVector3f()).rotate(JomlUtil.from(getWorldRotation()));

--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -67,17 +67,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     /**
-     * @param newQuat
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #setLocalRotation(Quaternionfc)}.
-     */
-    @Deprecated
-    public void setLocalRotation(Quat4f newQuat) {
-        lastRotation.set(rotation);
-        rotation.set(newQuat);
-    }
-
-    /**
      * set the current local rotation of the component
      *
      * @param rot local rotation
@@ -236,16 +225,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     /**
-     * @param value
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #setWorldPosition(Vector3fc)}.
-     */
-    @Deprecated
-    public void setWorldPosition(Vector3f value) {
-        this.setWorldPosition(JomlUtil.from(value));
-    }
-
-    /**
      * set the world position of the {@link LocationComponent}
      *
      * @param pos position to set
@@ -260,18 +239,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
             rot.inverse(parentLoc.getWorldRotation());
             rot.rotate(this.position, this.position);
         }
-    }
-
-    /**
-     * set the world rotation of the {@link LocationComponent}
-     *
-     * @param value
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #setWorldRotation(Quaternionfc)}.
-     */
-    @Deprecated
-    public void setWorldRotation(Quat4f value) {
-        this.setWorldRotation(JomlUtil.from(value));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -96,17 +96,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     /**
-     * @param pos
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #setLocalPosition(Vector3fc)}.
-     */
-    @Deprecated
-    public void setLocalPosition(Vector3f pos) {
-        lastPosition.set(position);
-        position.set(pos);
-    }
-
-    /**
      * the local position of this location component
      *
      * @param pos position to set

--- a/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/logic/location/LocationComponent.java
@@ -121,16 +121,6 @@ public final class LocationComponent implements Component, ReplicationCheck {
     }
 
     /**
-     * @return A new vector containing the world location.
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldPosition(org.joml.Vector3f)}.
-     */
-    @Deprecated
-    public Vector3f getWorldPosition() {
-        return JomlUtil.from(getWorldPosition(new org.joml.Vector3f()));
-    }
-
-    /**
      * get the world position
      *
      * @param dest will hold the result
@@ -164,38 +154,8 @@ public final class LocationComponent implements Component, ReplicationCheck {
         out.mul(new Matrix4f().translationRotateScale(JomlUtil.from(position), JomlUtil.from(rotation), scale));
     }
 
-    /**
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldDirection(org.joml.Vector3f)}.
-     */
-    @Deprecated
-    public Vector3f getWorldDirection() {
-        Vector3f result = Direction.FORWARD.getVector3f();
-        getWorldRotation().rotate(result, result);
-        return result;
-    }
-
     public org.joml.Vector3f getWorldDirection(org.joml.Vector3f dest) {
-        return dest.set(Direction.FORWARD.asVector3f()).rotate(JomlUtil.from(getWorldRotation()));
-    }
-
-    /**
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldRotation(Quaternionf)}.
-     */
-    @Deprecated
-    public Quat4f getWorldRotation() {
-        return getWorldRotation(new Quat4f(0, 0, 0, 1));
-    }
-
-    /**
-     * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #getWorldRotation(Quaternionf)}.
-     */
-    @Deprecated
-    public Quat4f getWorldRotation(Quat4f output) {
-        output.set(JomlUtil.from(getWorldRotation(new Quaternionf())));
-        return output;
+        return dest.set(Direction.FORWARD.asVector3f()).rotate(getWorldRotation(new Quaternionf()));
     }
 
     /**
@@ -233,10 +193,10 @@ public final class LocationComponent implements Component, ReplicationCheck {
         setLocalPosition(pos);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (parentLoc != null) {
-            this.position.sub(parentLoc.getWorldPosition());
+            this.position.sub(JomlUtil.from(parentLoc.getWorldPosition(new org.joml.Vector3f())));
             this.position.scale(1f / parentLoc.getWorldScale());
             Quat4f rot = new Quat4f(0, 0, 0, 1);
-            rot.inverse(parentLoc.getWorldRotation());
+            rot.inverse(JomlUtil.from(parentLoc.getWorldRotation(new Quaternionf())));
             rot.rotate(this.position, this.position);
         }
     }
@@ -250,7 +210,7 @@ public final class LocationComponent implements Component, ReplicationCheck {
         setLocalRotation(value);
         LocationComponent parentLoc = parent.getComponent(LocationComponent.class);
         if (parentLoc != null) {
-            Quat4f worldRot = parentLoc.getWorldRotation();
+            Quat4f worldRot = JomlUtil.from(parentLoc.getWorldRotation(new Quaternionf()));
             worldRot.inverse();
             this.rotation.mul(worldRot, this.rotation);
         }

--- a/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/logic/players/LocalPlayer.java
@@ -13,6 +13,7 @@ import org.terasology.logic.characters.events.ActivationPredicted;
 import org.terasology.logic.characters.events.ActivationRequest;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.Direction;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.network.ClientComponent;
 import org.terasology.physics.HitResult;
@@ -113,11 +114,7 @@ public class LocalPlayer {
      */
     @Deprecated
     public Quat4f getRotation() {
-        LocationComponent location = getCharacterEntity().getComponent(LocationComponent.class);
-        if (location == null || Float.isNaN(location.getWorldPosition(new Vector3f()).x)) {
-            return new Quat4f(Quat4f.IDENTITY);
-        }
-        return location.getWorldRotation();
+        return JomlUtil.from(getRotation(new Quaternionf()));
     }
 
     /**
@@ -166,16 +163,7 @@ public class LocalPlayer {
      */
     @Deprecated
     public Quat4f getViewRotation() {
-        ClientComponent clientComponent = getClientEntity().getComponent(ClientComponent.class);
-        if (clientComponent == null) {
-            return new Quat4f(Quat4f.IDENTITY);
-        }
-        LocationComponent location = clientComponent.camera.getComponent(LocationComponent.class);
-        if (location == null || Float.isNaN(location.getWorldPosition(new Vector3f()).x)) {
-            return getRotation();
-        }
-
-        return location.getWorldRotation();
+        return JomlUtil.from(getViewRotation(new Quaternionf()));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/block/BlockComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockComponent.java
@@ -33,7 +33,7 @@ public final class BlockComponent implements Component {
     }
     /**
      * @deprecated This is scheduled for removal in an upcoming version method will be replaced with JOML implementation
-     *     {@link #BlockComponent(Block, org.joml.Vector3i)}.
+     *     {@link #BlockComponent(Block, org.joml.Vector3ic)}.
      */
     @Deprecated
     public BlockComponent(Block block, Vector3i pos) {
@@ -41,7 +41,7 @@ public final class BlockComponent implements Component {
         this.position.set(pos);
     }
 
-    public BlockComponent(Block block, org.joml.Vector3i pos) {
+    public BlockComponent(Block block, org.joml.Vector3ic pos) {
         this.block = block;
         this.position.set(JomlUtil.from(pos));
     }

--- a/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/world/internal/EntityAwareWorldProvider.java
@@ -265,7 +265,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
             EntityRef blockEntity = getExistingBlockEntityAt(blockPosition);
             if ((!blockEntity.exists() || !blockEntity.hasComponent(NetworkComponent.class)) && isBlockRelevant(blockPosition.x(), blockPosition.y(), blockPosition.z())) {
                 Block block = getBlock(blockPosition.x(), blockPosition.y(), blockPosition.z());
-                blockEntity = createBlockEntity(JomlUtil.from(blockPosition), block);
+                blockEntity = createBlockEntity(blockPosition, block);
             }
             return blockEntity;
         }
@@ -375,9 +375,9 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
         }
     }
 
-    private EntityRef createBlockEntity(Vector3i blockPosition, Block block) {
+    private EntityRef createBlockEntity(Vector3ic blockPosition, Block block) {
         EntityBuilder builder = entityManager.newBuilder(block.getPrefab().orElse(null));
-        builder.addComponent(new LocationComponent(blockPosition.toVector3f()));
+        builder.addComponent(new LocationComponent(new org.joml.Vector3f(blockPosition)));
         builder.addComponent(new BlockComponent(block, blockPosition));
         boolean isTemporary = isTemporaryBlock(builder, block);
         if (!isTemporary && !builder.hasComponent(NetworkComponent.class)) {
@@ -392,7 +392,7 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator imp
             blockEntity = builder.build();
         }
 
-        blockEntityLookup.put(new Vector3i(blockPosition), blockEntity);
+        blockEntityLookup.put(JomlUtil.from(blockPosition), blockEntity);
         return blockEntity;
     }
 


### PR DESCRIPTION
* feat(JOML): migrate `LocationComponent#getWorldPosition`
* feat(JOML): migrate `LocationComponent` constructor
* feat(JOML): fully migrate `Location
* feat(JOML): migrate deprecated `LocationComponent#getWorldPosition/Rotation/Direction`

This removes all `@Depreacted` methods using TeraMath from `LocationComponent` and migrates `Location` system to JOML.

There is still direct access to the `math.geom` members of `LocationComponent` (to be migrated in a follow-up PR).

## Requires

- [x] - https://github.com/Terasology/Behaviors/pull/66
- [x] - https://github.com/Terasology/Compass/pull/8
- [x] - https://github.com/Terasology/DynamicCities/pull/85
- [x] - https://github.com/Terasology/Furnishings/pull/8
- [x] - https://github.com/Terasology/ItemRendering/pull/16
- [x] - https://github.com/Terasology/Machines/pull/48
- [x] - https://github.com/Terasology/MetalRenegades/pull/135
- [x] - https://github.com/Terasology/StaticCities/pull/23
- [x] - https://github.com/Terasology/WoodAndStone/pull/71
- [x] - https://github.com/Terasology/WorkstationCrafting/pull/24


Contributes to #3832
