### PR TITLE
feat: Enable extreme render distances using LOD chunks

### DIFF
--- a/engine-tests/src/test/java/org/terasology/world/Zones/LayeredZoneRegionFunctionTest.java
+++ b/engine-tests/src/test/java/org/terasology/world/Zones/LayeredZoneRegionFunctionTest.java
@@ -78,7 +78,7 @@ public class LayeredZoneRegionFunctionTest {
         borders.put(ElevationFacet.class, new Border3D(0, 0, 0));
 
         region = new RegionImpl(new BlockRegion(0, 0, 0).expand(4, 4, 4),
-                facetProviderChains, borders);
+                facetProviderChains, borders, 1);
     }
 
     @Test

--- a/engine/src/main/java/org/terasology/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/config/RenderingConfig.java
@@ -38,6 +38,7 @@ public class RenderingConfig extends AbstractSubscribable {
     public static final String RESOLUTION = "Resolution";
     public static final String ANIMATED_MENU = "AnimatedMenu";
     public static final String VIEW_DISTANCE = "viewDistance";
+    public static final String CHUNK_LODS = "chunkLods";
     public static final String FLICKERING_LIGHT = "FlickeringLight";
     public static final String ANIMATE_GRASS = "AnimateGrass";
     public static final String ANIMATE_WATER = "AnimateWater";
@@ -87,6 +88,7 @@ public class RenderingConfig extends AbstractSubscribable {
     private Resolution resolution;
     private boolean animatedMenu;
     private ViewDistance viewDistance;
+    private float chunkLods;
     private boolean flickeringLight;
     private boolean animateGrass;
     private boolean animateWater;
@@ -269,6 +271,16 @@ public class RenderingConfig extends AbstractSubscribable {
         ViewDistance oldDistance = this.viewDistance;
         this.viewDistance = viewDistance;
         propertyChangeSupport.firePropertyChange(VIEW_DISTANCE, oldDistance, viewDistance);
+    }
+
+    public float getChunkLods() {
+        return chunkLods;
+    }
+
+    public void setChunkLods(float chunkLods) {
+        float oldLods = this.chunkLods;
+        this.chunkLods = chunkLods;
+        propertyChangeSupport.firePropertyChange(CHUNK_LODS, oldLods, chunkLods);
     }
 
     public boolean isFlickeringLight() {

--- a/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -142,7 +142,7 @@ public class HeadlessWorldRenderer implements WorldRenderer {
     }
 
     @Override
-    public void setViewDistance(ViewDistance viewDistance) {
+    public void setViewDistance(ViewDistance viewDistance, int chunkLods) {
         // TODO Auto-generated method stub
 
     }

--- a/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
@@ -126,13 +126,8 @@ public class AABBRenderer implements BlockOverlayRenderer {
         if (displayListWire == -1) {
             generateDisplayListWire();
         }
-        Vector3f center = aabb.center(new Vector3f());
-        glPushMatrix();
-        //glTranslated(0f, center.y, 0f);
 
         glCallList(displayListWire);
-
-        glPopMatrix();
     }
 
     public void renderSolidLocally() {

--- a/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/AABBRenderer.java
@@ -93,7 +93,7 @@ public class AABBRenderer implements BlockOverlayRenderer {
         glPushMatrix();
         Vector3f cameraPosition = CoreRegistry.get(LocalPlayer.class).getViewPosition(new Vector3f());
         Vector3f center = aabb.center(new Vector3f());
-        glTranslated(center.x - cameraPosition.x, -cameraPosition.y, center.z - cameraPosition.z);
+        glTranslated(center.x - cameraPosition.x, center.y - cameraPosition.y, center.z - cameraPosition.z);
 
         renderLocally();
 
@@ -128,7 +128,7 @@ public class AABBRenderer implements BlockOverlayRenderer {
         }
         Vector3f center = aabb.center(new Vector3f());
         glPushMatrix();
-        glTranslated(0f, center.y, 0f);
+        //glTranslated(0f, center.y, 0f);
 
         glCallList(displayListWire);
 

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -187,7 +187,8 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
 
     private void updateFarClippingDistance() {
         float distance = renderingConfig.getViewDistance().getChunkDistance().x() * Chunks.SIZE_X * (1 << (int) renderingConfig.getChunkLods());
-        zFar = distance * 2;
+        zFar = Math.max(distance, 500) * 2;
+        // distance is an estimate of how far away the farthest chunks are, and the minimum bound is to ensure that the sky is visible.
     }
 
     public void propertyChange(PropertyChangeEvent propertyChangeEvent) {

--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -11,6 +11,7 @@ import org.terasology.engine.subsystem.DisplayDevice;
 import org.terasology.math.TeraMath;
 import org.terasology.rendering.nui.layers.mainMenu.videoSettings.CameraSetting;
 import org.terasology.world.WorldProvider;
+import org.terasology.world.chunks.Chunks;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -48,6 +49,9 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
         this.cameraSettings = renderingConfig.getCameraSettings();
 
         displayDevice.subscribe(DISPLAY_RESOLUTION_CHANGE, this);
+        renderingConfig.subscribe(RenderingConfig.VIEW_DISTANCE, this);
+        renderingConfig.subscribe(RenderingConfig.CHUNK_LODS, this);
+        updateFarClippingDistance();
     }
 
     @Override
@@ -181,10 +185,22 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
         bobbingVerticalOffsetFactor = f;
     }
 
+    private void updateFarClippingDistance() {
+        float distance = renderingConfig.getViewDistance().getChunkDistance().x() * Chunks.SIZE_X * (1 << (int) renderingConfig.getChunkLods());
+        zFar = distance * 2;
+    }
+
     public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
-        if (propertyChangeEvent.getPropertyName().equals(DISPLAY_RESOLUTION_CHANGE)) {
-            cachedFov = -1; // Invalidate the cache, so that matrices get regenerated.
-            updateMatrices();
+        switch (propertyChangeEvent.getPropertyName()) {
+            case DISPLAY_RESOLUTION_CHANGE:
+                cachedFov = -1; // Invalidate the cache, so that matrices get regenerated.
+                updateMatrices();
+                return;
+            case RenderingConfig.VIEW_DISTANCE:
+            case RenderingConfig.CHUNK_LODS:
+                updateFarClippingDistance();
+                return;
+            default:
         }
     }
 }

--- a/engine/src/main/java/org/terasology/rendering/cameras/SubmersibleCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/SubmersibleCamera.java
@@ -24,7 +24,7 @@ public abstract class SubmersibleCamera extends Camera {
 
     /* Used for Underwater Checks */
     private WorldProvider worldProvider;
-    private RenderingConfig renderingConfig;
+    RenderingConfig renderingConfig;
 
     public SubmersibleCamera(WorldProvider worldProvider, RenderingConfig renderingConfig) {
         this.worldProvider = worldProvider;

--- a/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -154,6 +154,15 @@ public class VideoSettingsScreen extends CoreScreenLayer {
             fovSlider.bindValue(BindHelper.bindBeanProperty("fieldOfView", config.getRendering(), Float.TYPE));
         }
 
+        final UISlider chunkLodSlider = find("chunkLods", UISlider.class);
+        if (chunkLodSlider != null) {
+            chunkLodSlider.setIncrement(1);
+            chunkLodSlider.setPrecision(0);
+            chunkLodSlider.setMinimum(0);
+            chunkLodSlider.setRange(10);
+            chunkLodSlider.bindValue(BindHelper.bindBeanProperty("chunkLods", config.getRendering(), Float.TYPE));
+        }
+
         final UISlider frameLimitSlider = find("frameLimit", UISlider.class);
         if (frameLimitSlider != null) {
             frameLimitSlider.setIncrement(5.0f);

--- a/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -145,8 +145,12 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
         //TODO: This only fixes the "water under block" issue of the top side not being rendered. (see bug #3889)
         //Note: originally tried .isLiquid() instead of isWater for both checks, but IntelliJ was warning that
         //      !blockToCheck.isWater() is always true, may need further investigation
-        if (currentBlock.isWater() && (side == Side.TOP) && !blockToCheck.isWater()){
+        if (currentBlock.isWater() && (side == Side.TOP) && !blockToCheck.isWater()) {
             return true;
+        }
+
+        if (blockToCheck.getURI().toString().equals("engine:unloaded")) {
+            return false;
         }
 
         return currentBlock.isWaving() != blockToCheck.isWaving() || blockToCheck.getMeshGenerator() == null

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
@@ -17,6 +17,7 @@ package org.terasology.rendering.primitives;
 
 import com.google.common.base.Stopwatch;
 import gnu.trove.iterator.TIntIterator;
+import gnu.trove.list.TFloatList;
 import org.lwjgl.BufferUtils;
 import org.terasology.engine.subsystem.lwjgl.GLBufferPool;
 import org.terasology.math.Direction;
@@ -45,6 +46,10 @@ public final class ChunkTessellator {
     }
 
     public ChunkMesh generateMesh(ChunkView chunkView, int meshHeight, int verticalOffset) {
+        return generateMesh(chunkView, meshHeight, verticalOffset, 1);
+    }
+
+    public ChunkMesh generateMesh(ChunkView chunkView, int meshHeight, int verticalOffset, float scale) {
         PerformanceMonitor.startActivity("GenerateMesh");
         ChunkMesh mesh = new ChunkMesh(bufferPool);
 
@@ -65,7 +70,7 @@ public final class ChunkTessellator {
         mesh.setTimeToGenerateBlockVertices((int) watch.elapsed(TimeUnit.MILLISECONDS));
 
         watch.reset().start();
-        generateOptimizedBuffers(chunkView, mesh);
+        generateOptimizedBuffers(chunkView, mesh, scale);
         watch.stop();
         mesh.setTimeToGenerateOptimizedBuffers((int) watch.elapsed(TimeUnit.MILLISECONDS));
         statVertexArrayUpdateCount++;
@@ -74,7 +79,7 @@ public final class ChunkTessellator {
         return mesh;
     }
 
-    private void generateOptimizedBuffers(ChunkView chunkView, ChunkMesh mesh) {
+    private void generateOptimizedBuffers(ChunkView chunkView, ChunkMesh mesh, float scale) {
         PerformanceMonitor.startActivity("OptimizeBuffers");
 
         for (ChunkMesh.RenderType type : ChunkMesh.RenderType.values()) {
@@ -97,9 +102,9 @@ public final class ChunkTessellator {
                         elements.vertices.get(i * 3 + 2));
 
                 /* POSITION */
-                elements.finalVertices.put(Float.floatToIntBits(vertexPos.x));
-                elements.finalVertices.put(Float.floatToIntBits(vertexPos.y));
-                elements.finalVertices.put(Float.floatToIntBits(vertexPos.z));
+                elements.finalVertices.put(Float.floatToIntBits(vertexPos.x * scale));
+                elements.finalVertices.put(Float.floatToIntBits(vertexPos.y * scale));
+                elements.finalVertices.put(Float.floatToIntBits(vertexPos.z * scale));
 
                 /* UV0 - TEX DATA 0.xy */
                 elements.finalVertices.put(Float.floatToIntBits(elements.tex.get(i * 2)));

--- a/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
+++ b/engine/src/main/java/org/terasology/rendering/primitives/ChunkTessellator.java
@@ -56,10 +56,10 @@ public final class ChunkTessellator {
 
         final Stopwatch watch = Stopwatch.createStarted();
 
-        // The mesh extends into the borders in the horizontal directions, but not vertically, in order to cover gaps between LOD chunks of different scales, but also avoid multiple overlapping ocean surfaces.
+        // The mesh extends into the borders in the horizontal directions, but not vertically upwards, in order to cover gaps between LOD chunks of different scales, but also avoid multiple overlapping ocean surfaces.
         for (int x = 0; x < Chunks.SIZE_X; x++) {
             for (int z = 0; z < Chunks.SIZE_Z; z++) {
-                for (int y = border * 2; y < Chunks.SIZE_Y - border * 2; y++) {
+                for (int y = 0; y < Chunks.SIZE_Y - border * 2; y++) {
                     Block block = chunkView.getBlock(x, y, z);
                     if (block != null && block.getMeshGenerator() != null) {
                         block.getMeshGenerator().generateChunkMesh(chunkView, mesh, x, y, z);

--- a/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
+++ b/engine/src/main/java/org/terasology/rendering/world/ChunkMeshUpdateManager.java
@@ -170,7 +170,7 @@ public final class ChunkMeshUpdateManager {
                  */
                 c.setDirty(false);
                 if (chunkView.isValidView()) {
-                    newMesh = tessellator.generateMesh(chunkView, ChunkConstants.SIZE_Y, 0);
+                    newMesh = tessellator.generateMesh(chunkView);
 
                     c.setPendingMesh(newMesh);
                     ChunkMonitor.fireChunkTessellated(c.getPosition(new org.joml.Vector3i()), newMesh);

--- a/engine/src/main/java/org/terasology/rendering/world/RenderQueuesHelper.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderQueuesHelper.java
@@ -38,4 +38,15 @@ public class RenderQueuesHelper {
         this.chunksAlphaReject = chunksAlphaReject;
         this.chunksAlphaBlend = chunksAlphaBlend;
     }
+
+    /**
+     * Remove any remaining data from all queues, to avoid a memory leak in the case that the nodes using that data aren't present.
+     */
+    public void clear() {
+        chunksOpaque.clear();
+        chunksOpaqueShadow.clear();
+        chunksOpaqueReflection.clear();
+        chunksAlphaReject.clear();
+        chunksAlphaBlend.clear();
+    }
 }

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorld.java
@@ -36,7 +36,7 @@ public interface RenderableWorld {
 
     boolean updateChunksInProximity(BlockRegion renderableRegion);
 
-    boolean updateChunksInProximity(ViewDistance viewDistance);
+    boolean updateChunksInProximity(ViewDistance viewDistance, int chunkLods);
 
     void generateVBOs();
 

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -247,7 +247,7 @@ class RenderableWorldImpl implements RenderableWorld {
 
     @Override
     public boolean updateChunksInProximity(ViewDistance newViewDistance, int chunkLods) {
-        if (newViewDistance != currentViewDistance) {
+        if (newViewDistance != currentViewDistance || chunkLods != lodChunkProvider.getChunkLods()) {
             logger.info("New Viewing Distance: {}", newViewDistance);
             currentViewDistance = newViewDistance;
             lodChunkProvider.updateRenderableRegion(newViewDistance, chunkLods, calcCameraCoordinatesInChunkUnits());

--- a/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/RenderableWorldImpl.java
@@ -121,6 +121,9 @@ class RenderableWorldImpl implements RenderableWorld {
             if (chunk != null) {
                 chunksInProximityOfCamera.add(chunk);
                 Collections.sort(chunksInProximityOfCamera, new ChunkFrontToBackComparator());
+                if (lodChunkProvider != null) {
+                    lodChunkProvider.onRealChunkLoaded(chunkCoordinates);
+                }
             } else {
                 logger.warn("Warning: onChunkLoaded called for a null chunk!");
             }
@@ -130,9 +133,6 @@ class RenderableWorldImpl implements RenderableWorld {
             if (chunk != null) {
                 chunk.setDirty(true);
             }
-        }
-        if (lodChunkProvider != null) {
-            lodChunkProvider.onRealChunkLoaded(chunkCoordinates);
         }
     }
 
@@ -287,9 +287,7 @@ class RenderableWorldImpl implements RenderableWorld {
      */
     private Vector3i calcCameraCoordinatesInChunkUnits() {
         org.joml.Vector3f cameraCoordinates = playerCamera.getPosition();
-        return new Vector3i((int) (cameraCoordinates.x() / ChunkConstants.SIZE_X),
-                (int) (cameraCoordinates.y() / ChunkConstants.SIZE_Y),
-                (int) (cameraCoordinates.z() / ChunkConstants.SIZE_Z));
+        return Chunks.toChunkPos(cameraCoordinates, new Vector3i());
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRenderer.java
@@ -167,8 +167,9 @@ public interface WorldRenderer {
      * Sets how far from the camera chunks are kept in memory and displayed.
      *
      * @param viewDistance a viewDistance value.
+     * @param chunkLods the number of LOD levels to display beyond the loaded chunks.
      */
-    void setViewDistance(ViewDistance viewDistance);
+    void setViewDistance(ViewDistance viewDistance, int chunkLods);
 
     /**
      * Returns the intensity of the light at a given location due to the combination of main light (sun or moon)

--- a/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/rendering/world/WorldRendererImpl.java
@@ -56,7 +56,6 @@ import org.terasology.rendering.openvrprovider.OpenVRProvider;
 import org.terasology.rendering.world.viewDistance.ViewDistance;
 import org.terasology.utilities.Assets;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.chunks.ChunkProvider;
 
 import java.util.List;
 
@@ -168,7 +167,7 @@ public final class WorldRendererImpl implements WorldRenderer {
         LocalPlayerSystem localPlayerSystem = context.get(LocalPlayerSystem.class);
         localPlayerSystem.setPlayerCamera(playerCamera);
 
-        renderableWorld = new RenderableWorldImpl(worldProvider, context.get(ChunkProvider.class), bufferPool, playerCamera);
+        renderableWorld = new RenderableWorldImpl(context, bufferPool, playerCamera);
         renderQueues = renderableWorld.getRenderQueues();
 
         initRenderingSupport();
@@ -393,8 +392,8 @@ public final class WorldRendererImpl implements WorldRenderer {
     }
 
     @Override
-    public void setViewDistance(ViewDistance viewDistance) {
-        renderableWorld.updateChunksInProximity(viewDistance);
+    public void setViewDistance(ViewDistance viewDistance, int chunkLods) {
+        renderableWorld.updateChunksInProximity(viewDistance, chunkLods);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/rendering/world/viewDistance/ClientViewDistanceSystem.java
+++ b/engine/src/main/java/org/terasology/rendering/world/viewDistance/ClientViewDistanceSystem.java
@@ -56,27 +56,35 @@ public class ClientViewDistanceSystem extends BaseComponentSystem {
     @In
     private LocalPlayer localPlayer;
 
-    private PropertyChangeListener propertyChangeListener;
+    private PropertyChangeListener viewDistanceListener;
+    private PropertyChangeListener chunkLodsListener;
 
     private TranslationSystem translationSystem;
 
     @Override
     public void initialise() {
-        propertyChangeListener = evt -> {
+        viewDistanceListener = evt -> {
             if (evt.getPropertyName().equals(RenderingConfig.VIEW_DISTANCE)) {
                 onChangeViewDistanceChange();
             }
         };
-        config.getRendering().subscribe(propertyChangeListener);
+        config.getRendering().subscribe(viewDistanceListener);
+        chunkLodsListener = evt -> {
+            if (evt.getPropertyName().equals(RenderingConfig.CHUNK_LODS)) {
+                onChangeViewDistanceChange();
+            }
+        };
+        config.getRendering().subscribe(chunkLodsListener);
 
         translationSystem = new TranslationSystemImpl(context);
     }
 
     public void onChangeViewDistanceChange() {
         ViewDistance viewDistance = config.getRendering().getViewDistance();
+        int chunkLods = (int) config.getRendering().getChunkLods();
 
         if (worldRenderer != null) {
-            worldRenderer.setViewDistance(viewDistance);
+            worldRenderer.setViewDistance(viewDistance, chunkLods);
         }
 
         EntityRef clientEntity = localPlayer.getClientEntity();
@@ -85,7 +93,7 @@ public class ClientViewDistanceSystem extends BaseComponentSystem {
 
     @Override
     public void shutdown() {
-        config.getRendering().unsubscribe(propertyChangeListener);
+        config.getRendering().unsubscribe(viewDistanceListener);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/utilities/procedural/SubSampledNoise.java
+++ b/engine/src/main/java/org/terasology/utilities/procedural/SubSampledNoise.java
@@ -80,8 +80,12 @@ public class SubSampledNoise extends AbstractNoise {
     }
 
     public float[] noise(BlockAreac area) {
+        return noise(area, 1);
+    }
+
+    public float[] noise(BlockAreac area, float scale) {
         BlockArea fullRegion = determineRequiredRegion(area);
-        float[] keyData = getKeyValues(fullRegion);
+        float[] keyData = getKeyValues(fullRegion, scale);
         float[] fullData = mapExpand(keyData, fullRegion);
         return getSubset(fullData, fullRegion, area);
     }
@@ -120,7 +124,7 @@ public class SubSampledNoise extends AbstractNoise {
         return fullData;
     }
 
-    private float[] getKeyValues(BlockAreac fullRegion) {
+    private float[] getKeyValues(BlockAreac fullRegion, float scale) {
         int xDim = fullRegion.getSizeX() / sampleRate + 1;
         int yDim = fullRegion.getSizeY() / sampleRate + 1;
         float[] fullData = new float[xDim * yDim];
@@ -128,7 +132,7 @@ public class SubSampledNoise extends AbstractNoise {
             for (int x = 0; x < xDim; x++) {
                 int actualX = x * sampleRate + fullRegion.minX();
                 int actualY = y * sampleRate + fullRegion.minY();
-                fullData[x + y * xDim] = source.noise(zoom.x * actualX, zoom.y * actualY);
+                fullData[x + y * xDim] = source.noise(zoom.x * scale * actualX, zoom.y * scale * actualY);
             }
         }
 
@@ -168,8 +172,12 @@ public class SubSampledNoise extends AbstractNoise {
     }
 
     public float[] noise(BlockRegion region) {
+        return noise(region, 1);
+    }
+
+    public float[] noise(BlockRegion region, float scale) {
         BlockRegion fullRegion = determineRequiredRegion(region);
-        float[] keyData = getKeyValues(fullRegion);
+        float[] keyData = getKeyValues(fullRegion, scale);
         float[] fullData = mapExpand(keyData, fullRegion);
         return getSubset(fullData, fullRegion, region);
     }
@@ -222,7 +230,7 @@ public class SubSampledNoise extends AbstractNoise {
         return fullData;
     }
 
-    private float[] getKeyValues(BlockRegion fullRegion) {
+    private float[] getKeyValues(BlockRegion fullRegion, float scale) {
         int xDim = fullRegion.getSizeX() / sampleRate + 1;
         int yDim = fullRegion.getSizeY() / sampleRate + 1;
         int zDim = fullRegion.getSizeZ() / sampleRate + 1;
@@ -233,7 +241,7 @@ public class SubSampledNoise extends AbstractNoise {
                     int actualX = x * sampleRate + fullRegion.minX();
                     int actualY = y * sampleRate + fullRegion.minY();
                     int actualZ = z * sampleRate + fullRegion.minZ();
-                    fullData[x + xDim * (y + yDim * z)] = source.noise(zoom.x * actualX, zoom.y * actualY, zoom.z * actualZ);
+                    fullData[x + xDim * (y + yDim * z)] = source.noise(zoom.x * scale * actualX, zoom.y * scale * actualY, zoom.z * scale * actualZ);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/world/RelevanceRegionComponent.java
+++ b/engine/src/main/java/org/terasology/world/RelevanceRegionComponent.java
@@ -23,5 +23,4 @@ import org.terasology.entitySystem.Component;
 public class RelevanceRegionComponent implements Component {
 
     public Vector3i distance = new Vector3i(1, 1, 1);
-
 }

--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -111,9 +111,6 @@ public class BlockRegion implements BlockRegionc {
 
     // -- ITERABLE ---------------------------------------------------------------------------------------------------//
 
-    /**
-     * All of the integer points inside this region. It returns the same vector every time, modifying its fields.
-     */
     @Override
     public Iterator<Vector3ic> iterator() {
         if (!isValid()) {

--- a/engine/src/main/java/org/terasology/world/block/BlockRegion.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockRegion.java
@@ -111,6 +111,9 @@ public class BlockRegion implements BlockRegionc {
 
     // -- ITERABLE ---------------------------------------------------------------------------------------------------//
 
+    /**
+     * All of the integer points inside this region. It returns the same vector every time, modifying its fields.
+     */
     @Override
     public Iterator<Vector3ic> iterator() {
         if (!isValid()) {

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -209,23 +209,23 @@ public interface CoreChunk {
 
 
     /**
-     * Returns X offset of this chunk to the world center (0:0:0), with one unit being one chunk.
+     * Returns X offset of this chunk to the world center (0:0:0), with one unit being one block.
      *
-     * @return X offset of this chunk from world center in chunks
+     * @return X offset of this chunk from world center in blocks
      */
     int getChunkWorldOffsetX();
 
     /**
-     * Returns Y offset of this chunk to the world center (0:0:0), with one unit being one chunk.
+     * Returns Y offset of this chunk to the world center (0:0:0), with one unit being one block.
      *
-     * @return Y offset of this chunk from world center in chunks
+     * @return Y offset of this chunk from world center in blocks
      */
     int getChunkWorldOffsetY();
 
     /**
-     * Returns Z offset of this chunk to the world center (0:0:0), with one unit being one chunk.
+     * Returns Z offset of this chunk to the world center (0:0:0), with one unit being one block.
      *
-     * @return Z offset of this chunk from world center in chunks
+     * @return Z offset of this chunk from world center in blocks
      */
     int getChunkWorldOffsetZ();
 

--- a/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/CoreChunk.java
@@ -42,7 +42,7 @@ import org.terasology.world.block.BlockRegion;
 public interface CoreChunk {
 
     /**
-     * @return Position of the chunk in world, where units of distance from origin are blocks
+     * @return Position of the chunk in world, where units of distance from origin are chunks
      * @deprecated This method is scheduled for removal in an upcoming version.
      *             Use the JOML implementation instead: {@link #getPosition(org.joml.Vector3i)}.
      */
@@ -50,7 +50,7 @@ public interface CoreChunk {
     Vector3i getPosition();
 
     /**
-     * Position of the chunk in world, where units of distance from origin are blocks
+     * Position of the chunk in world, where units of distance from origin are chunks
      *
      * @param dest will hold the result
      * @return dest
@@ -191,9 +191,9 @@ public interface CoreChunk {
     int getExtraData(int index, Vector3ic pos);
 
     /**
-     * Returns offset of this chunk to the world center (0:0:0), with one unit being one chunk.
+     * Returns offset of this chunk to the world center (0:0:0), with one unit being one block.
      *
-     * @return Offset of this chunk from world center in chunks
+     * @return Offset of this chunk from world center in blocks
      * @deprecated This method is scheduled for removal in an upcoming version.
      *             Use the JOML implementation instead: {@link #getChunkWorldOffset(org.joml.Vector3i)}.
      */
@@ -201,9 +201,9 @@ public interface CoreChunk {
     Vector3i getChunkWorldOffset();
 
     /**
-     * Returns offset of this chunk to the world center (0:0:0), with one unit being one chunk.
+     * Returns offset of this chunk to the world center (0:0:0), with one unit being one block.
      *
-     * @return Offset of this chunk from world center in chunks
+     * @return Offset of this chunk from world center in blocks
      */
     org.joml.Vector3i getChunkWorldOffset(org.joml.Vector3i pos);
 

--- a/engine/src/main/java/org/terasology/world/chunks/LodChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/LodChunk.java
@@ -8,7 +8,6 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.joml.geom.AABBf;
 import org.terasology.joml.geom.AABBfc;
-import org.terasology.joml.geom.AABBi;
 import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.BaseVector3i;
 import org.terasology.rendering.primitives.ChunkMesh;
@@ -20,12 +19,14 @@ import org.terasology.world.block.BlockRegion;
  */
 public class LodChunk implements RenderableChunk {
     private static final String UNSUPPORTED_MESSAGE = "LOD chunks can only be used for certain rendering-related operations.";
+    public final int scale;
     private Vector3ic position;
     private ChunkMesh mesh;
 
-    public LodChunk(Vector3ic pos, ChunkMesh mesh) {
+    public LodChunk(Vector3ic pos, ChunkMesh mesh, int scale) {
         position = pos;
         this.mesh = mesh;
+        this.scale = scale;
     }
 
     @Override
@@ -51,7 +52,7 @@ public class LodChunk implements RenderableChunk {
     @Override
     public AABBfc getAABB() {
         Vector3f min = new Vector3f(getChunkWorldOffset(new Vector3i()));
-        return new AABBf(min, new Vector3f(Chunks.CHUNK_SIZE).add(min));
+        return new AABBf(min, new Vector3f(Chunks.CHUNK_SIZE).mul(1 << scale).add(min));
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/chunks/LodChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/LodChunk.java
@@ -1,0 +1,318 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.chunks;
+
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.terasology.joml.geom.AABBf;
+import org.terasology.joml.geom.AABBfc;
+import org.terasology.joml.geom.AABBi;
+import org.terasology.math.JomlUtil;
+import org.terasology.math.geom.BaseVector3i;
+import org.terasology.rendering.primitives.ChunkMesh;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockRegion;
+
+/**
+ * A static, far away chunk that has only the data needed for rendering.
+ */
+public class LodChunk implements RenderableChunk {
+    private static final String UNSUPPORTED_MESSAGE = "LOD chunks can only be used for certain rendering-related operations.";
+    private Vector3ic position;
+    private ChunkMesh mesh;
+
+    public LodChunk(Vector3ic pos, ChunkMesh mesh) {
+        position = pos;
+        this.mesh = mesh;
+    }
+
+    @Override
+    public org.terasology.math.geom.Vector3i getPosition() {
+        return JomlUtil.from(position);
+    }
+
+    @Override
+    public Vector3i getPosition(Vector3i dest) {
+        return dest.set(position);
+    }
+
+    @Override
+    public org.terasology.math.geom.Vector3i getChunkWorldOffset() {
+        return JomlUtil.from(position).mul(Chunks.SIZE_X, Chunks.SIZE_Y, Chunks.SIZE_Z);
+    }
+
+    @Override
+    public Vector3i getChunkWorldOffset(Vector3i dest) {
+        return position.mul(Chunks.CHUNK_SIZE, dest);
+    }
+
+    @Override
+    public AABBfc getAABB() {
+        Vector3f min = new Vector3f(getChunkWorldOffset(new Vector3i()));
+        return new AABBf(min, new Vector3f(Chunks.CHUNK_SIZE).add(min));
+    }
+
+    @Override
+    public boolean isAnimated() {
+        return false;
+    }
+
+    @Override
+    public void setAnimated(boolean animated) {
+    }
+
+    @Override
+    public boolean isDirty() {
+        return false;
+    }
+
+    @Override
+    public boolean hasMesh() {
+        return true;
+    }
+
+    @Override
+    public ChunkMesh getMesh() {
+        return mesh;
+    }
+
+    @Override
+    public void setMesh(ChunkMesh newMesh) {
+        mesh = newMesh;
+    }
+
+    @Override
+    public void disposeMesh() {
+        if (mesh != null) {
+            mesh.dispose();
+            mesh = null;
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        return mesh != null;
+    }
+
+    @Override
+    public Block getBlock(BaseVector3i pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Block getBlock(Vector3ic pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Block getBlock(int x, int y, int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Block setBlock(int x, int y, int z, Block block) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Block setBlock(BaseVector3i pos, Block block) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Block setBlock(Vector3ic pos, Block block) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void setExtraData(int index, int x, int y, int z, int value) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void setExtraData(int index, BaseVector3i pos, int value) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void setExtraData(int index, Vector3ic pos, int value) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getExtraData(int index, int x, int y, int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getExtraData(int index, BaseVector3i pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getExtraData(int index, Vector3ic pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getChunkWorldOffsetX() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getChunkWorldOffsetY() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getChunkWorldOffsetZ() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public org.terasology.math.geom.Vector3i chunkToWorldPosition(BaseVector3i blockPos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Vector3i chunkToWorldPosition(Vector3ic blockPos, Vector3i dest) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public org.terasology.math.geom.Vector3i chunkToWorldPosition(int x, int y, int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public Vector3i chunkToWorldPosition(int x, int y, int z, Vector3i dest) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int chunkToWorldPositionX(int x) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int chunkToWorldPositionY(int y) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int chunkToWorldPositionZ(int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getChunkSizeX() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getChunkSizeY() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getChunkSizeZ() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public BlockRegion getRegion() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public int getEstimatedMemoryConsumptionInBytes() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public ChunkBlockIterator getBlockIterator() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public byte getSunlight(BaseVector3i pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public byte getSunlight(int x, int y, int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean setSunlight(BaseVector3i pos, byte amount) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean setSunlight(int x, int y, int z, byte amount) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public byte getSunlightRegen(BaseVector3i pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public byte getSunlightRegen(int x, int y, int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean setSunlightRegen(BaseVector3i pos, byte amount) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean setSunlightRegen(int x, int y, int z, byte amount) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public byte getLight(BaseVector3i pos) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public byte getLight(int x, int y, int z) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean setLight(BaseVector3i pos, byte amount) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean setLight(int x, int y, int z, byte amount) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void setDirty(boolean dirty) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void setPendingMesh(ChunkMesh newPendingMesh) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean hasPendingMesh() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public ChunkMesh getPendingMesh() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/LodChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/LodChunkProvider.java
@@ -218,6 +218,9 @@ public class LodChunkProvider {
         for (Thread thread : generationThreads) {
             thread.interrupt();
         }
+        for (LodChunk chunk : chunks.values()) {
+            chunk.disposeMesh();
+        }
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/chunks/LodChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/LodChunkProvider.java
@@ -1,0 +1,204 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.chunks;
+
+import com.google.common.collect.Queues;
+import gnu.trove.list.TFloatList;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.context.Context;
+import org.terasology.math.JomlUtil;
+import org.terasology.rendering.primitives.ChunkMesh;
+import org.terasology.rendering.primitives.ChunkTessellator;
+import org.terasology.rendering.world.viewDistance.ViewDistance;
+import org.terasology.world.ChunkView;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.BlockRegion;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
+import org.terasology.world.chunks.internal.ChunkImpl;
+import org.terasology.world.generation.impl.EntityBufferImpl;
+import org.terasology.world.generator.WorldGenerator;
+import org.terasology.world.internal.ChunkViewCoreImpl;
+import org.terasology.world.propagation.light.InternalLightProcessor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.PriorityBlockingQueue;
+
+public class LodChunkProvider {
+    private static final Logger logger = LoggerFactory.getLogger(LodChunkProvider.class);
+
+    private ChunkProvider chunkProvider;
+    private BlockManager blockManager;
+    private ExtraBlockDataManager extraDataManager;
+    private ChunkTessellator tessellator;
+    private WorldGenerator generator;
+
+    private Vector3i center;
+    private ViewDistance viewDistanceSetting;
+    private int chunkLods;
+    private BlockRegion loadedRegion = new BlockRegion(BlockRegion.INVALID); // The chunks that may be actually loaded, which therefore don't need LOD chunks.
+    private BlockRegion lodRegion = new BlockRegion(BlockRegion.INVALID);
+    private Set<Vector3ic> requiredChunks; // All of the LOD chunks that are meant to exist.
+    private Map<Vector3i, LodChunk> chunks;
+    private ClosenessComparator nearby;
+
+    // Communication with the generation threads.
+    private PriorityBlockingQueue<Vector3ic> neededChunks;
+    private BlockingQueue<LodChunk> readyChunks = Queues.newLinkedBlockingQueue();
+    private List<Thread> generationThreads = new ArrayList<>();
+
+    public LodChunkProvider(Context context, ChunkTessellator tessellator, ViewDistance viewDistance, int chunkLods, Vector3i center) {
+        chunkProvider = context.get(ChunkProvider.class);
+        blockManager = context.get(BlockManager.class);
+        extraDataManager = context.get(ExtraBlockDataManager.class);
+        generator = context.get(WorldGenerator.class);
+        this.tessellator = tessellator;
+        viewDistanceSetting = viewDistance;
+        this.chunkLods = chunkLods;
+        this.center = center;
+        requiredChunks = new HashSet<>();
+        chunks = new HashMap<>();
+        nearby = new ClosenessComparator(center);
+        neededChunks = new PriorityBlockingQueue<>(11, nearby);
+        for (int i = 0; i < 2; i++) {
+            Thread thread = new Thread(this::createChunks, "LOD Chunk Generation " + i);
+            thread.start();
+            generationThreads.add(thread);
+        }
+    }
+
+    private void createChunks() {
+        Block unloaded = blockManager.getBlock(BlockManager.UNLOADED_ID);
+        try {
+            while (true) { // TODO: add exit condition.
+                Vector3ic pos = neededChunks.take();
+                Chunk chunk = new ChunkImpl(JomlUtil.from(pos), blockManager, extraDataManager);
+                generator.createChunk(chunk, new EntityBufferImpl());
+                InternalLightProcessor.generateInternalLighting(chunk);
+                tintChunk(chunk);
+                ChunkView view = new ChunkViewCoreImpl(new Chunk[]{chunk}, new BlockRegion(chunk.getPosition(new Vector3i())), new Vector3i(), unloaded);
+                ChunkMesh mesh = tessellator.generateMesh(view, Chunks.SIZE_Y, 0);
+                readyChunks.add(new LodChunk(pos, mesh));
+            }
+        } catch (InterruptedException ignored) { }
+    }
+
+    private void processReadyChunks() {
+        while (!readyChunks.isEmpty()) {
+            LodChunk chunk = readyChunks.remove();
+            Vector3i pos = chunk.getPosition(new Vector3i());
+            if (requiredChunks.contains(pos)) { // The relevant region may have been updated since this chunk was requested.
+                chunk.getMesh().generateVBOs();
+                chunks.put(pos, chunk);
+            }
+        }
+    }
+
+    public void update(Vector3i newCenter) {
+        updateRenderableRegion(viewDistanceSetting, chunkLods, newCenter);
+        processReadyChunks();
+    }
+
+    public void updateRenderableRegion(ViewDistance newViewDistance, int newChunkLods, Vector3i newCenter) {
+        viewDistanceSetting = newViewDistance;
+        center = newCenter;
+        chunkLods = newChunkLods;
+        nearby.pos = center;
+        Vector3i viewDistance = new Vector3i(newViewDistance.getChunkDistance()).div(2);
+        Vector3i lodViewDistance = new Vector3i(viewDistance).mul(chunkLods == 0 ? 0 : 1 << chunkLods);
+        BlockRegion newLoadedRegion = new BlockRegion(center).expand(viewDistance.sub(1, 1, 1));
+        BlockRegion newLodRegion = new BlockRegion(center).expand(lodViewDistance);
+        if (!newLoadedRegion.equals(loadedRegion) || !newLodRegion.equals(lodRegion)) {
+            // Remove previously present chunks.
+            Iterator<Vector3ic> requiredChunkIt = requiredChunks.iterator();
+            while (requiredChunkIt.hasNext()) {
+                Vector3ic pos = requiredChunkIt.next();
+                if (!newLodRegion.contains(pos)) {
+                    // Although removeChunk also includes requiredChunks.remove(pos), it is necessary to actually remove it via the iterator first, to avoid a concurrent modification exception.
+                    requiredChunkIt.remove();
+                    removeChunk(pos);
+                }
+            }
+
+            // Add new chunks.
+            for (Vector3ic pos : newLodRegion) {
+                if (!newLoadedRegion.contains(pos) && !requiredChunks.contains(pos) && chunkProvider.getChunk(pos) == null) {
+                    addChunk(new Vector3i(pos));
+                }
+            }
+        }
+        lodRegion = newLodRegion;
+        loadedRegion = newLoadedRegion;
+    }
+
+    public void onRealChunkUnloaded(Vector3ic pos) {
+        if (lodRegion.contains(pos) && !loadedRegion.contains(pos)) {
+            addChunk(pos);
+        }
+    }
+
+    private void addChunk(Vector3ic pos) {
+        requiredChunks.add(pos);
+        neededChunks.add(pos);
+    }
+
+    public void onRealChunkLoaded(Vector3ic pos) {
+        if (requiredChunks.contains(pos)) {
+            removeChunk(pos);
+        }
+    }
+
+    private void removeChunk(Vector3ic pos) {
+        requiredChunks.remove(pos);
+        neededChunks.remove(pos);
+        LodChunk chunk = chunks.remove(pos);
+        if (chunk != null) {
+            chunk.disposeMesh();
+        }
+    }
+
+    public Collection<LodChunk> getChunks() {
+        return chunks.values();
+    }
+
+    public void shutdown() {
+        for (Thread thread : generationThreads) {
+            thread.interrupt();
+        }
+    }
+
+    /**
+     * Make the chunk a bit darker, so that it can be visually distinguished from an ordinary chunk.
+     */
+    private void tintChunk(Chunk chunk) {
+        for (Vector3ic pos : Chunks.CHUNK_REGION) {
+            chunk.setSunlight(JomlUtil.from(pos), (byte) (0.75f * chunk.getSunlight(JomlUtil.from(pos))));
+        }
+    }
+
+    private static class ClosenessComparator implements Comparator<Vector3ic> {
+        Vector3i pos;
+
+        ClosenessComparator(Vector3i pos) {
+            this.pos = pos;
+        }
+
+        @Override
+        public int compare(Vector3ic x0, Vector3ic x1) {
+            return Long.compare(x0.distanceSquared(pos), x1.distanceSquared(pos));
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/LodChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/LodChunkProvider.java
@@ -124,7 +124,7 @@ public class LodChunkProvider {
         chunkLods = newChunkLods;
         nearby.pos = center;
         Vector3i viewDistance = new Vector3i(newViewDistance.getChunkDistance()).div(2);
-        Vector3i centerOffset = new Vector3i(1 - Math.abs(viewDistance.x % 2), 1 - Math.abs(viewDistance.y % 2), 1 - Math.abs(viewDistance.z % 2));
+        Vector3i altViewDistance = viewDistance.add(1 - Math.abs(viewDistance.x % 2), 1 - Math.abs(viewDistance.y % 2), 1 - Math.abs(viewDistance.z % 2), new Vector3i());
         BlockRegion newPossiblyLoadedRegion = new BlockRegion(newCenter).expand(viewDistance);
         BlockRegion newProbablyLoadedRegion =  new BlockRegion(newPossiblyLoadedRegion).expand(-1, -1, -1);
         BlockRegion[] newLodRegions = new BlockRegion[newChunkLods == 0 ? 0 : 1 + newChunkLods];
@@ -133,8 +133,8 @@ public class LodChunkProvider {
             if (i == 0) {
                 newLodRegions[i] = new BlockRegion(newPossiblyLoadedRegion);
             } else {
-                // By adding centerOffset, we ensure that every time a chunk boundary is crossed, at most a single lodRegion changes (except possibly for lodRegions[0], which is more closely tied to the renderable region).
-                newLodRegions[i] = new BlockRegion(scaleDown(center, i)).translate(centerOffset).expand(viewDistance);
+                // By making viewDistance odd, we ensure that every time a chunk boundary is crossed, at most a single lodRegion changes (except possibly for lodRegions[0], which is more closely tied to the renderable region).
+                newLodRegions[i] = new BlockRegion(scaleDown(center, i)).expand(altViewDistance);
             }
             Vector3i min = newLodRegions[i].getMin(new Vector3i());
             Vector3i max = newLodRegions[i].getMax(new Vector3i());

--- a/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/ChunkImpl.java
@@ -60,7 +60,8 @@ public class ChunkImpl implements Chunk {
     private static final DecimalFormat PERCENT_FORMAT = new DecimalFormat("0.##");
     private static final DecimalFormat SIZE_FORMAT = new DecimalFormat("#,###");
 
-    private final Vector3i chunkPos = new Vector3i();
+    protected final Vector3i chunkPos = new Vector3i();
+    protected BlockRegion region;
 
     private BlockManager blockManager;
 
@@ -74,7 +75,6 @@ public class ChunkImpl implements Chunk {
     private volatile TeraArray[] extraDataSnapshots;
 
     private AABBf aabb = new AABBf();
-    private BlockRegion region;
 
     private boolean disposed;
     private boolean ready;

--- a/engine/src/main/java/org/terasology/world/chunks/internal/PreLodChunk.java
+++ b/engine/src/main/java/org/terasology/world/chunks/internal/PreLodChunk.java
@@ -1,0 +1,38 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.chunks.internal;
+
+import org.joml.Vector3i;
+import org.terasology.math.JomlUtil;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.BlockRegion;
+import org.terasology.world.chunks.Chunks;
+import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
+
+/**
+ * A chunk that has a full set of data, but will be turned into
+ * a LOD chunk later.
+ */
+public class PreLodChunk extends ChunkImpl {
+    public PreLodChunk(Vector3i pos, BlockManager blockManager, ExtraBlockDataManager extraDataManager) {
+        super(JomlUtil.from(pos), blockManager, extraDataManager);
+        Vector3i min = Chunks.CHUNK_SIZE.sub(2, 4, 2, new Vector3i()).mul(pos).sub(1, 2, 1);
+        region = new BlockRegion(min, min.add(Chunks.CHUNK_SIZE, new Vector3i()));
+    }
+
+    @Override
+    public int getChunkWorldOffsetX() {
+        return chunkPos.x * (Chunks.SIZE_X - 2) - 1;
+    }
+
+    @Override
+    public int getChunkWorldOffsetY() {
+        return chunkPos.y * (Chunks.SIZE_Y - 4) - 2;
+    }
+
+    @Override
+    public int getChunkWorldOffsetZ() {
+        return chunkPos.z * (Chunks.SIZE_Z - 2) - 1;
+    }
+}

--- a/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -441,7 +442,7 @@ public class LocalChunkProvider implements ChunkProvider {
         loadingPipeline = new ChunkProcessingPipeline(this::getChunk, relevanceSystem.createChunkTaskComporator());
         loadingPipeline.addStage(
                 ChunkTaskProvider.create("Chunk generate internal lightning",
-                        InternalLightProcessor::generateInternalLighting))
+                        (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
                 .addStage(ChunkTaskProvider.create("Chunk deflate", Chunk::deflate))
                 .addStage(ChunkTaskProvider.createMulti("Light merging",
                         chunks -> {
@@ -484,7 +485,7 @@ public class LocalChunkProvider implements ChunkProvider {
         loadingPipeline = new ChunkProcessingPipeline(this::getChunk, relevanceSystem.createChunkTaskComporator());
         loadingPipeline.addStage(
                 ChunkTaskProvider.create("Chunk generate internal lightning",
-                        InternalLightProcessor::generateInternalLighting))
+                        (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
                 .addStage(ChunkTaskProvider.create("Chunk deflate", Chunk::deflate))
                 .addStage(ChunkTaskProvider.createMulti("Light merging",
                         chunks -> {

--- a/engine/src/main/java/org/terasology/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
@@ -141,6 +142,7 @@ public class ChunkProcessingPipeline {
                             chunkProcessingInfo.getPosition(), stageName),
                     e);
             chunkProcessingInfo.getExternalFuture().setException(e);
+        } catch (CancellationException ignored) {
         }
     }
 
@@ -258,6 +260,10 @@ public class ChunkProcessingPipeline {
      */
     public void stopProcessingAt(Vector3ic pos) {
         ChunkProcessingInfo removed = chunkProcessingInfoMap.remove(pos);
+        if (removed == null) {
+            return;
+        }
+
         removed.getExternalFuture().cancel(true);
 
         Future<Chunk> currentFuture = removed.getCurrentFuture();

--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -70,7 +71,7 @@ public class RemoteChunkProvider implements ChunkProvider {
 
         loadingPipeline.addStage(
                 ChunkTaskProvider.create("Chunk generate internal lightning",
-                        InternalLightProcessor::generateInternalLighting))
+                        (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
                 .addStage(ChunkTaskProvider.create("Chunk deflate", Chunk::deflate))
                 .addStage(ChunkTaskProvider.createMulti("Light merging",
                         chunks -> {

--- a/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generation/BaseFacetedWorldGenerator.java
@@ -17,6 +17,7 @@ package org.terasology.world.generation;
 
 import org.terasology.engine.SimpleUri;
 import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generator.ScalableWorldGenerator;
 import org.terasology.world.generator.WorldConfigurator;
 import org.terasology.world.generator.WorldGenerator;
 import org.terasology.world.zones.Zone;
@@ -26,7 +27,7 @@ import java.util.List;
 /**
  * The most commonly used implementation of {@link WorldGenerator} based on the idea of Facets
  */
-public abstract class BaseFacetedWorldGenerator implements WorldGenerator {
+public abstract class BaseFacetedWorldGenerator implements ScalableWorldGenerator {
 
     protected WorldBuilder worldBuilder;
 
@@ -73,6 +74,11 @@ public abstract class BaseFacetedWorldGenerator implements WorldGenerator {
     @Override
     public void createChunk(CoreChunk chunk, EntityBuffer buffer) {
         world.rasterizeChunk(chunk, buffer);
+    }
+
+    @Override
+    public void createChunk(CoreChunk chunk, EntityBuffer buffer, float scale) {
+        world.rasterizeChunk(chunk, buffer, scale);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/world/generation/RegionImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/RegionImpl.java
@@ -31,15 +31,17 @@ public class RegionImpl implements Region, GeneratingRegion {
     private final BlockRegion region;
     private final ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains;
     private final Map<Class<? extends WorldFacet>, Border3D> borders;
+    private final float scale;
 
     private final TypeMap<WorldFacet> generatingFacets = TypeMap.create();
     private final Set<FacetProvider> processedProviders = Sets.newHashSet();
     private final TypeMap<WorldFacet> generatedFacets = TypeMap.create();
 
-    public RegionImpl(BlockRegion region, ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains, Map<Class<? extends WorldFacet>, Border3D> borders) {
+    public RegionImpl(BlockRegion region, ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains, Map<Class<? extends WorldFacet>, Border3D> borders, float scale) {
         this.region = region;
         this.facetProviderChains = facetProviderChains;
         this.borders = borders;
+        this.scale = scale;
     }
 
     @Override
@@ -47,7 +49,11 @@ public class RegionImpl implements Region, GeneratingRegion {
         T facet = generatedFacets.get(dataType);
         if (facet == null) {
             facetProviderChains.get(dataType).stream().filter(provider -> !processedProviders.contains(provider)).forEach(provider -> {
-                provider.process(this);
+                if (scale == 1) {
+                    provider.process(this);
+                } else {
+                    ((ScalableFacetProvider) provider).process(this, scale);
+                }
                 processedProviders.add(provider);
             });
             facet = generatingFacets.get(dataType);

--- a/engine/src/main/java/org/terasology/world/generation/ScalableFacetProvider.java
+++ b/engine/src/main/java/org/terasology/world/generation/ScalableFacetProvider.java
@@ -1,0 +1,12 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.generation;
+
+public interface ScalableFacetProvider extends FacetProvider {
+    void process(GeneratingRegion region, float scale);
+
+    default void process(GeneratingRegion region) {
+        process(region, 1);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/generation/ScalableWorldRasterizer.java
+++ b/engine/src/main/java/org/terasology/world/generation/ScalableWorldRasterizer.java
@@ -1,0 +1,15 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.generation;
+
+import org.terasology.world.chunks.CoreChunk;
+
+public interface ScalableWorldRasterizer extends WorldRasterizer {
+    void generateChunk(CoreChunk chunk, Region chunkRegion, float scale);
+
+    @Override
+    default void generateChunk(CoreChunk chunk, Region chunkRegion) {
+        generateChunk(chunk, chunkRegion, 1);
+    }
+}

--- a/engine/src/main/java/org/terasology/world/generation/World.java
+++ b/engine/src/main/java/org/terasology/world/generation/World.java
@@ -25,7 +25,11 @@ import java.util.Set;
  */
 public interface World {
 
-    Region getWorldData(BlockRegion region);
+    Region getWorldData(BlockRegion region, float scale);
+
+    default Region getWorldData(BlockRegion region) {
+        return getWorldData(region, 1);
+    }
 
     /**
      * @return the sea level, measured in blocks. May be used for setting
@@ -34,6 +38,8 @@ public interface World {
     int getSeaLevel();
 
     void rasterizeChunk(CoreChunk chunk, EntityBuffer buffer);
+
+    void rasterizeChunk(CoreChunk chunk, EntityBuffer buffer, float scale);
 
     /**
      * @return a <b>new</b> set containing all facet classes

--- a/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldBuilder.java
@@ -102,9 +102,19 @@ public class WorldBuilder extends ProviderStore {
         for (FacetProvider provider : providersList) {
             provider.setSeed(seed);
         }
-        ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains = determineProviderChains();
-        List<WorldRasterizer> orderedRasterizers = ensureRasterizerOrdering();
-        return new WorldImpl(providerChains, orderedRasterizers, entityProviders, determineBorders(providerChains, orderedRasterizers), seaLevel);
+        ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains = determineProviderChains(false);
+        ListMultimap<Class<? extends WorldFacet>, FacetProvider> scalableProviderChains = determineProviderChains(true);
+        List<WorldRasterizer> orderedRasterizers = ensureRasterizerOrdering(providerChains, false);
+        List<WorldRasterizer> scalableRasterizers = ensureRasterizerOrdering(scalableProviderChains, true);
+        return new WorldImpl(
+            providerChains,
+            scalableProviderChains,
+            orderedRasterizers,
+            scalableRasterizers,
+            entityProviders,
+            determineBorders(providerChains, orderedRasterizers),
+            seaLevel
+        );
     }
 
     private Map<Class<? extends WorldFacet>, Border3D> determineBorders(ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains, List<WorldRasterizer> worldRasterizers) {
@@ -170,7 +180,7 @@ public class WorldBuilder extends ProviderStore {
         return borders;
     }
 
-    private ListMultimap<Class<? extends WorldFacet>, FacetProvider> determineProviderChains() {
+    private ListMultimap<Class<? extends WorldFacet>, FacetProvider> determineProviderChains(boolean scalable) {
         ListMultimap<Class<? extends WorldFacet>, FacetProvider> result = ArrayListMultimap.create();
         Set<Class<? extends WorldFacet>> facets = new LinkedHashSet<>();
         for (FacetProvider provider : providersList) {
@@ -186,7 +196,7 @@ public class WorldBuilder extends ProviderStore {
             }
         }
         for (Class<? extends WorldFacet> facet : facets) {
-            determineProviderChainFor(facet, result);
+            determineProviderChainFor(facet, result, scalable);
             if (logger.isDebugEnabled()) {
                 StringBuilder text = new StringBuilder(facet.getSimpleName());
                 text.append(" --> ");
@@ -204,7 +214,7 @@ public class WorldBuilder extends ProviderStore {
         return result;
     }
 
-    private void determineProviderChainFor(Class<? extends WorldFacet> facet, ListMultimap<Class<? extends WorldFacet>, FacetProvider> result) {
+    private void determineProviderChainFor(Class<? extends WorldFacet> facet, ListMultimap<Class<? extends WorldFacet>, FacetProvider> result, boolean scalable) {
         if (result.containsKey(facet)) {
             return;
         }
@@ -216,19 +226,31 @@ public class WorldBuilder extends ProviderStore {
         // first add all @Produces facet providers
         FacetProvider producer = null;
         for (FacetProvider provider : providersList) {
-            if (producesFacet(provider, facet)) {
+            if (producesFacet(provider, facet) && (!scalable || provider instanceof ScalableFacetProvider)) {
                 if (producer != null) {
                     logger.warn("Facet already produced by {} and overwritten by {}", producer, provider);
                 }
                 // add all required facets for producing provider
                 for (Facet requirement : requiredFacets(provider)) {
-                    determineProviderChainFor(requirement.value(), result);
-                    orderedProviders.addAll(result.get(requirement.value()));
+                    determineProviderChainFor(requirement.value(), result, scalable);
+                    List<FacetProvider> requirementChain = result.get(requirement.value());
+                    if (requirementChain != null) {
+                        orderedProviders.addAll(requirementChain);
+                    } else {
+                        facetCalculationInProgress.remove(facet);
+                        return;
+                    }
                 }
                 // add all updated facets for producing provider
                 for (Facet updated : updatedFacets(provider)) {
-                    determineProviderChainFor(updated.value(), result);
-                    orderedProviders.addAll(result.get(updated.value()));
+                    determineProviderChainFor(updated.value(), result, scalable);
+                    List<FacetProvider> requirementChain = result.get(updated.value());
+                    if (requirementChain != null) {
+                        orderedProviders.addAll(requirementChain);
+                    } else {
+                        facetCalculationInProgress.remove(facet);
+                        return;
+                    }
                 }
                 orderedProviders.add(provider);
                 producer = provider;
@@ -236,15 +258,25 @@ public class WorldBuilder extends ProviderStore {
         }
 
         if (producer == null) {
-            logger.warn("No facet provider found that produces {}", facet);
+            if (!scalable) {
+                logger.warn("No facet provider found that produces {}", facet);
+            }
+            facetCalculationInProgress.remove(facet);
+            return;
         }
 
         // then add all @Updates facet providers
-        providersList.stream().filter(provider -> updatesFacet(provider, facet)).forEach(provider -> {
+        providersList.stream().filter(provider -> updatesFacet(provider, facet) && (!scalable || provider instanceof ScalableFacetProvider)).forEach(provider -> {
+            Set<FacetProvider> localOrderedProviders = Sets.newLinkedHashSet();
             // add all required facets for updating provider
             for (Facet requirement : requiredFacets(provider)) {
-                determineProviderChainFor(requirement.value(), result);
-                orderedProviders.addAll(result.get(requirement.value()));
+                determineProviderChainFor(requirement.value(), result, scalable);
+                List<FacetProvider> requirementChain = result.get(requirement.value());
+                if (requirementChain != null) {
+                    localOrderedProviders.addAll(result.get(requirement.value()));
+                } else {
+                    return;
+                }
             }
             // the provider updates this and other facets
             // just add producers for the other facets
@@ -252,10 +284,15 @@ public class WorldBuilder extends ProviderStore {
                 for (FacetProvider fp : providersList) {
                     // only add @Produces providers to avoid infinite recursion
                     if (producesFacet(fp, updated.value())) {
-                        orderedProviders.add(fp);
+                        if (!scalable || fp instanceof ScalableFacetProvider) {
+                            localOrderedProviders.add(fp);
+                        } else {
+                            return;
+                        }
                     }
                 }
             }
+            orderedProviders.addAll(localOrderedProviders);
             orderedProviders.add(provider);
         });
         result.putAll(facet, orderedProviders);
@@ -301,7 +338,7 @@ public class WorldBuilder extends ProviderStore {
     // Ensure that rasterizers that must run after others are in the correct order. This ensures that blocks from
     // the dependent raterizer are not being overwritten by any antecedent rasterizer.
     // TODO: This will only handle first-order dependencies and does not check for circular dependencies
-    private List<WorldRasterizer> ensureRasterizerOrdering() {
+    private List<WorldRasterizer> ensureRasterizerOrdering(ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains, boolean scalable) {
         List<WorldRasterizer> orderedRasterizers = Lists.newArrayList();
 
         Set<Class<? extends WorldRasterizer>> addedRasterizers = new HashSet<>();
@@ -318,19 +355,34 @@ public class WorldBuilder extends ProviderStore {
                 // Add all antecedents to the list first
                 antecedents.forEach(dependency -> {
                     if (!addedRasterizers.contains(dependency.getClass())) {
-                        orderedRasterizers.add(dependency);
+                        tryAddRasterizer(orderedRasterizers, dependency, providerChains, scalable);
                         addedRasterizers.add(dependency.getClass());
                     }
                 });
 
                 // Then add this one
-                orderedRasterizers.add(rasterizer);
+                tryAddRasterizer(orderedRasterizers, rasterizer, providerChains, scalable);
             } else if (!addedRasterizers.contains(rasterizer.getClass())) {
-                orderedRasterizers.add(rasterizer);
+                tryAddRasterizer(orderedRasterizers, rasterizer, providerChains, scalable);
                 addedRasterizers.add(rasterizer.getClass());
             }
         }
         return orderedRasterizers;
+    }
+
+    private void tryAddRasterizer(List<WorldRasterizer> orderedRasterizers, WorldRasterizer rasterizer, ListMultimap<Class<? extends WorldFacet>, FacetProvider> providerChains, boolean scalable) {
+        if (scalable && !(rasterizer instanceof ScalableWorldRasterizer)) {
+            return;
+        }
+        Requires requires = rasterizer.getClass().getAnnotation(Requires.class);
+        if (requires != null) {
+            for (Facet facet : requires.value()) {
+                if (!providerChains.containsKey(facet.value())) {
+                    return;
+                }
+            }
+        }
+        orderedRasterizers.add(rasterizer);
     }
 
 

--- a/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
+++ b/engine/src/main/java/org/terasology/world/generation/WorldImpl.java
@@ -31,26 +31,32 @@ import java.util.Set;
  */
 public class WorldImpl implements World {
     private final ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains;
+    private final ListMultimap<Class<? extends WorldFacet>, FacetProvider> scalableFacetProviderChains;
     private final List<WorldRasterizer> worldRasterizers;
+    private final List<WorldRasterizer> scalableWorldRasterizers;
     private final List<EntityProvider> entityProviders;
     private final Map<Class<? extends WorldFacet>, Border3D> borders;
     private final int seaLevel;
 
     public WorldImpl(ListMultimap<Class<? extends WorldFacet>, FacetProvider> facetProviderChains,
+                     ListMultimap<Class<? extends WorldFacet>, FacetProvider> scalableFacetProviderChains,
                      List<WorldRasterizer> worldRasterizers,
+                     List<WorldRasterizer> scalableWorldRasterizers,
                      List<EntityProvider> entityProviders,
                      Map<Class<? extends WorldFacet>, Border3D> borders,
                      int seaLevel) {
         this.facetProviderChains = facetProviderChains;
+        this.scalableFacetProviderChains = scalableFacetProviderChains;
         this.worldRasterizers = worldRasterizers;
+        this.scalableWorldRasterizers = scalableWorldRasterizers;
         this.entityProviders = entityProviders;
         this.borders = borders;
         this.seaLevel = seaLevel;
     }
 
     @Override
-    public Region getWorldData(BlockRegion region) {
-        return new RegionImpl(region, facetProviderChains, borders);
+    public Region getWorldData(BlockRegion region, float scale) {
+        return new RegionImpl(region, scale == 1 ? facetProviderChains : scalableFacetProviderChains, borders, scale);
     }
 
     @Override
@@ -60,9 +66,20 @@ public class WorldImpl implements World {
 
     @Override
     public void rasterizeChunk(CoreChunk chunk, EntityBuffer buffer) {
-        Region chunkRegion = getWorldData(chunk.getRegion());
+        Region chunkRegion = getWorldData(chunk.getRegion(), 1);
         for (WorldRasterizer rasterizer : worldRasterizers) {
             rasterizer.generateChunk(chunk, chunkRegion);
+        }
+        for (EntityProvider entityProvider : entityProviders) {
+            entityProvider.process(chunkRegion, buffer);
+        }
+    }
+
+    @Override
+    public void rasterizeChunk(CoreChunk chunk, EntityBuffer buffer, float scale) {
+        Region chunkRegion = getWorldData(chunk.getRegion(), scale);
+        for (WorldRasterizer rasterizer : scalableWorldRasterizers) {
+            ((ScalableWorldRasterizer) rasterizer).generateChunk(chunk, chunkRegion, scale);
         }
         for (EntityProvider entityProvider : entityProviders) {
             entityProvider.process(chunkRegion, buffer);

--- a/engine/src/main/java/org/terasology/world/generator/ScalableWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/world/generator/ScalableWorldGenerator.java
@@ -1,0 +1,17 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.world.generator;
+
+import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generation.EntityBuffer;
+
+public interface ScalableWorldGenerator extends WorldGenerator {
+    /**
+     * Generates all contents of given chunk
+     * @param chunk Chunk to generate
+     * @param buffer Buffer to queue entities to spawn to
+     * @param scale The scale to generate at (larger numbers make the world's features smaller)
+     */
+    void createChunk(CoreChunk chunk, EntityBuffer buffer, float scale);
+}

--- a/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/PropagationRules.java
@@ -61,9 +61,10 @@ public interface PropagationRules {
      * @param existingValue The value to propagate
      * @param side          The side the value is leaving by
      * @param from          The block the value is leaving
+     * @param scale         The scale of the chunk
      * @return The new value to set at the block position
      */
-    byte propagateValue(byte existingValue, Side side, Block from);
+    byte propagateValue(byte existingValue, Side side, Block from, int scale);
 
     /**
      * @return The maximum value possible for this data

--- a/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/StandardBatchPropagator.java
@@ -28,6 +28,7 @@ public class StandardBatchPropagator implements BatchPropagator {
 
     private PropagationRules rules;
     private PropagatorWorldView world;
+    private int scale;
 
     /* Queues are stored in reverse order. Ie, strongest light is 0. */
     private Set<Vector3ic>[] reduceQueues;
@@ -36,8 +37,13 @@ public class StandardBatchPropagator implements BatchPropagator {
     private Map<Side, Vector3ic> chunkEdgeDeltas = Maps.newEnumMap(Side.class);
 
     public StandardBatchPropagator(PropagationRules rules, PropagatorWorldView world) {
+        this(rules, world, 1);
+    }
+
+    public StandardBatchPropagator(PropagationRules rules, PropagatorWorldView world, int scale) {
         this.world = world;
         this.rules = rules;
+        this.scale = scale;
 
         for (Side side : Side.getAllSides()) {
             Vector3i delta = new Vector3i(side.direction());
@@ -116,7 +122,7 @@ public class StandardBatchPropagator implements BatchPropagator {
                 reduce(blockChangePosition, existingValue);
                 side.getAdjacentPos(blockChangePosition, adjPos);
                 byte adjValue = world.getValueAt(adjPos);
-                if (adjValue == rules.propagateValue(existingValue, side, blockChange.getFrom())) {
+                if (adjValue == rules.propagateValue(existingValue, side, blockChange.getFrom(), scale)) {
                     reduce(adjPos, adjValue);
                 }
 
@@ -157,7 +163,7 @@ public class StandardBatchPropagator implements BatchPropagator {
         Vector3i adjPos = new Vector3i();
         for (Side side : Side.getAllSides()) {
             /* Handle this value being reset to the default by updating sides as needed */
-            byte expectedValue = rules.propagateValue(oldValue, side, block);
+            byte expectedValue = rules.propagateValue(oldValue, side, block, scale);
             if (rules.canSpreadOutOf(block, side)) {
                 side.getAdjacentPos(pos, adjPos);
                 byte adjValue = world.getValueAt(adjPos);
@@ -225,7 +231,7 @@ public class StandardBatchPropagator implements BatchPropagator {
         Block block = world.getBlockAt(pos);
         Vector3i adjPos = new Vector3i();
         for (Side side : Side.getAllSides()) {
-            byte propagatedValue = rules.propagateValue(value, side, block);
+            byte propagatedValue = rules.propagateValue(value, side, block, scale);
 
             if (rules.canSpreadOutOf(block, side)) {
                 side.getAdjacentPos(pos, adjPos);

--- a/engine/src/main/java/org/terasology/world/propagation/SunlightRegenBatchPropagator.java
+++ b/engine/src/main/java/org/terasology/world/propagation/SunlightRegenBatchPropagator.java
@@ -141,7 +141,7 @@ public class SunlightRegenBatchPropagator implements BatchPropagator {
         Block block = regenWorld.getBlockAt(pos);
         Vector3i position = new Vector3i(pos);
         while (regenRules.canSpreadOutOf(block, Side.BOTTOM)) {
-            regenValue = regenRules.propagateValue(regenValue, Side.BOTTOM, block);
+            regenValue = regenRules.propagateValue(regenValue, Side.BOTTOM, block, 1);
             position.y -= 1;
             byte adjValue = regenWorld.getValueAt(position);
             if (adjValue < regenValue && adjValue != PropagatorWorldView.UNAVAILABLE) {

--- a/engine/src/main/java/org/terasology/world/propagation/light/InternalLightProcessor.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/InternalLightProcessor.java
@@ -39,9 +39,13 @@ public final class InternalLightProcessor {
     }
 
     public static void generateInternalLighting(LitChunk chunk) {
-        populateSunlightRegen(chunk);
-        populateSunlight(chunk);
-        populateLight(chunk);
+        generateInternalLighting(chunk, 1);
+    }
+
+    public static void generateInternalLighting(LitChunk chunk, int scale) {
+        populateSunlightRegen(chunk, scale);
+        populateSunlight(chunk, scale);
+        populateLight(chunk, scale);
     }
 
     /**
@@ -49,8 +53,8 @@ public final class InternalLightProcessor {
      *
      * @param chunk The chunk to populate through
      */
-    private static void populateLight(LitChunk chunk) {
-        BatchPropagator lightPropagator = new StandardBatchPropagator(LIGHT_RULES, new SingleChunkView(LIGHT_RULES, chunk));
+    private static void populateLight(LitChunk chunk, int scale) {
+        BatchPropagator lightPropagator = new StandardBatchPropagator(LIGHT_RULES, new SingleChunkView(LIGHT_RULES, chunk), scale);
         Vector3i pos = new Vector3i();
         for (int x = 0; x < Chunks.SIZE_X; x++) {
             for (int z = 0; z < Chunks.SIZE_Z; z++) {
@@ -71,9 +75,9 @@ public final class InternalLightProcessor {
      *
      * @param chunk The chunk to set in
      */
-    private static void populateSunlight(LitChunk chunk) {
+    private static void populateSunlight(LitChunk chunk, int scale) {
         PropagationRules sunlightRules = new SunlightPropagationRules(chunk);
-        BatchPropagator lightPropagator = new StandardBatchPropagator(sunlightRules, new SingleChunkView(sunlightRules, chunk));
+        BatchPropagator lightPropagator = new StandardBatchPropagator(sunlightRules, new SingleChunkView(sunlightRules, chunk), scale);
 
         Vector3i pos = new Vector3i();
         for (int x = 0; x < Chunks.SIZE_X; x++) {
@@ -98,7 +102,7 @@ public final class InternalLightProcessor {
      *
      * @param chunk The chunk to populate the regeneration values through
      */
-    private static void populateSunlightRegen(LitChunk chunk) {
+    private static void populateSunlightRegen(LitChunk chunk, int scale) {
         int top = Chunks.SIZE_Y - 1;
         /* Scan through each column in the chunk & propagate light from the top down */
         for (int x = 0; x < Chunks.SIZE_X; x++) {
@@ -109,7 +113,7 @@ public final class InternalLightProcessor {
                     Block block = chunk.getBlock(x, y, z);
                     /* If the regeneration can propagate down into this block */
                     if (SUNLIGHT_REGEN_RULES.canSpreadOutOf(lastBlock, Side.BOTTOM) && SUNLIGHT_REGEN_RULES.canSpreadInto(block, Side.TOP)) {
-                        regen = SUNLIGHT_REGEN_RULES.propagateValue(regen, Side.BOTTOM, lastBlock);
+                        regen = SUNLIGHT_REGEN_RULES.propagateValue(regen, Side.BOTTOM, lastBlock, scale);
                         chunk.setSunlightRegen(x, y, z, regen);
                     } else {
                         regen = 0;

--- a/engine/src/main/java/org/terasology/world/propagation/light/InternalLightProcessor.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/InternalLightProcessor.java
@@ -79,7 +79,7 @@ public final class InternalLightProcessor {
         for (int x = 0; x < Chunks.SIZE_X; x++) {
             for (int z = 0; z < Chunks.SIZE_Z; z++) {
                 /* Start at the bottom of the chunk and then move up until the max sunlight level */
-                for (int y = 0; y < Chunks.MAX_SUNLIGHT; y++) {
+                for (int y = 0; y < Chunks.SIZE_Y; y++) {
                     pos.set(x, y, z);
                     Block block = chunk.getBlock(x, y, z);
                     byte light = sunlightRules.getFixedValue(block, pos);
@@ -103,7 +103,7 @@ public final class InternalLightProcessor {
         /* Scan through each column in the chunk & propagate light from the top down */
         for (int x = 0; x < Chunks.SIZE_X; x++) {
             for (int z = 0; z < Chunks.SIZE_Z; z++) {
-                byte regen = 0;
+                byte regen = chunk.getSunlightRegen(x, top, z);
                 Block lastBlock = chunk.getBlock(x, top, z);
                 for (int y = top - 1; y >= 0; y--) {
                     Block block = chunk.getBlock(x, y, z);

--- a/engine/src/main/java/org/terasology/world/propagation/light/LightPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/LightPropagationRules.java
@@ -44,8 +44,8 @@ public class LightPropagationRules extends CommonLightPropagationRules {
      * {@inheritDoc}
      */
     @Override
-    public byte propagateValue(byte existingValue, Side side, Block from) {
-        return (byte) (existingValue - 1);
+    public byte propagateValue(byte existingValue, Side side, Block from, int scale) {
+        return (byte) Math.max(existingValue - scale, 0);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightPropagationRules.java
@@ -56,8 +56,8 @@ public class SunlightPropagationRules extends CommonLightPropagationRules {
      * {@inheritDoc}
      */
     @Override
-    public byte propagateValue(byte existingValue, Side side, Block from) {
-        return (byte) Math.max(existingValue - 1, 0);
+    public byte propagateValue(byte existingValue, Side side, Block from, int scale) {
+        return (byte) Math.max(existingValue - scale, 0);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
+++ b/engine/src/main/java/org/terasology/world/propagation/light/SunlightRegenPropagationRules.java
@@ -45,9 +45,9 @@ public class SunlightRegenPropagationRules extends CommonLightPropagationRules {
      * {@inheritDoc}
      */
     @Override
-    public byte propagateValue(byte existingValue, Side side, Block from) {
+    public byte propagateValue(byte existingValue, Side side, Block from, int scale) {
         if (side == Side.BOTTOM) {
-            return (existingValue == Chunks.MAX_SUNLIGHT_REGEN) ? Chunks.MAX_SUNLIGHT_REGEN  : (byte) (existingValue + 1);
+            return (byte) Math.min(Chunks.MAX_SUNLIGHT_REGEN, existingValue + scale);
         }
         return 0;
     }

--- a/engine/src/main/resources/assets/i18n/menu.lang
+++ b/engine/src/main/resources/assets/i18n/menu.lang
@@ -80,6 +80,7 @@
     "category-nui": "category-nui",
     "change-keybind-popup-message": "change-keybind-popup-message",
     "change-keybind-popup-title": "change-keybind-popup-title",
+    "chunk-lods": "chunk-lods",
     "clamp-lighting": "clamp-lighting",
     "cloud-shadows": "cloud-shadows",
     "config": "config",

--- a/engine/src/main/resources/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/assets/i18n/menu_en.lang
@@ -81,6 +81,7 @@
     "category-nui": "NUI",
     "change-keybind-popup-message": "is already bound to an action. Rebind anyway?",
     "change-keybind-popup-title": "Key already bound",
+    "chunk-lods": "Chunk LODs",
     "clamp-lighting": "Clamp Lighting",
     "cloud-shadows": "Cloud Shadows",
     "config": "Configure",

--- a/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/assets/ui/menu/videoMenuScreen.ui
@@ -224,6 +224,14 @@
                                 },
                                 {
                                     "type": "UILabel",
+                                    "text": "${engine:menu#chunk-lods}: "
+                                },
+                                {
+                                    "type": "UISlider",
+                                    "id": "chunkLods"
+                                },
+                                {
+                                    "type": "UILabel",
                                     "text": "${engine:menu#framerate-limit}: "
                                 },
                                 {


### PR DESCRIPTION
Generate less detailed meshes of far away chunks without actually loading them. I have been able to test it with an effective view distance of around 8000 chunks in each direction just fine without using particularly much memory. In order for this feature to be enabled, the world generator needs to support scalable generation. This can be added for a subset of facet providers and rasterizers (the others will just be ignored), so it is backwards-compatible. This has been implemented for the default world generator in https://github.com/Terasology/CoreWorlds/pull/26 (although scaled trees have not been implemented yet).

There is room for improvement in the scheduling of loading and unloading LOD chunks (gaps appear while the game waits for replacements to be generated), and this PR also introduces some new occasional lighting bugs, but I thought I'd just get it merged and fix those later.

This resolves #319.