### PR TITLE
build: add Allure reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ blacklist.json
 terasology.jfr
 local.properties
 *.hprof
+
+# Allure error dumps
+ajcore.*.txt

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
@@ -36,6 +36,8 @@ plugins {
     id "idea"
     // For the "Build and run using: Intellij IDEA | Gradle" switch
     id "org.jetbrains.gradle.plugin.idea-ext" version "0.8.1"
+
+    id("io.qameta.allure") version "2.8.1"
 }
 
 
@@ -229,6 +231,19 @@ project(":modules").subprojects.forEach { proj ->
 tasks.named('wrapper') {
     // ALL distributionType because IntelliJ prefers having its sources for analysis and reference.
     distributionType = Wrapper.DistributionType.ALL
+}
+
+
+////////////////
+// Reporting
+//////////////
+
+allure {
+    version = "2.9.0"
+}
+
+tasks.register("allureMultiServe", io.qameta.allure.gradle.task.AllureServe) {
+    resultsDirs = rootProject.getSubprojects().collect {it.allure.resultsDir }
 }
 
 

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -15,6 +15,7 @@ apply plugin: 'pmd'
 apply plugin: 'com.github.spotbugs'
 apply plugin: 'jacoco'
 apply plugin: 'org.sonarqube'
+apply plugin: "io.qameta.allure"
 
 apply plugin: 'terasology-repositories'
 
@@ -82,6 +83,13 @@ jacocoTestReport {
         xml.enabled true
         csv.enabled false
         html.enabled true
+    }
+}
+
+allure {
+    version = rootProject.allure.version
+    useJUnit5 {
+        version = rootProject.allure.version
     }
 }
 

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -1,6 +1,9 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+plugins {
+    id("io.qameta.allure")
+}
 // Engine tests are split out due to otherwise quirky project dependency issues with module tests extending engine tests
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config
@@ -80,6 +83,18 @@ task copyResourcesToClasses(type:Copy) {
 //TODO: Remove it  when gestalt will can to handle ProtectionDomain without classes (Resources)
 test.dependsOn copyResourcesToClasses
 test.dependsOn rootProject.extractNatives
+
+
+allure {
+    version = "2.9.0"
+
+    autoconfigure = true
+
+    useJUnit5 {
+        version = "2.9.0"
+    }
+}
+
 
 idea {
     module {


### PR DESCRIPTION
This makes it so you can use [Allure](http://allure.qatools.ru/) to look at your local test results.

Just something to try out.

It reads the results of JUnit5 output generated by the `test` tasks.

Running `gradle :allureMultiServe` starts allure's web server and opens a browser window pointing to it.
