### PR TITLE
feat: move vignette to seperate shader

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
+++ b/engine/src/main/java/org/terasology/rendering/ShaderManagerLwjgl.java
@@ -56,6 +56,7 @@ public class ShaderManagerLwjgl implements ShaderManager {
         addShaderProgram("prePostComposite");
         addShaderProgram("highPass");
         addShaderProgram("blur");
+        addShaderProgram("vignette");
         addShaderProgram("downSampler");
         addShaderProgram("toneMapping");
         addShaderProgram("sky");

--- a/engine/src/main/resources/assets/shaders/initialPost_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/initialPost_frag.glsl
@@ -29,11 +29,6 @@ uniform vec2 aberrationOffset = vec2(0.0, 0.0);
 
 uniform sampler2D texScene;
 
-#ifdef VIGNETTE
-uniform sampler2D texVignette;
-uniform vec3 inLiquidTint;
-#endif
-
 #ifdef LIGHT_SHAFTS
 uniform sampler2D texLightShafts;
 #endif
@@ -58,17 +53,6 @@ void main() {
 #ifdef BLOOM
     vec4 colorBloom = texture2D(texBloom, gl_TexCoord[0].xy);
     color += colorBloom * bloomFactor;
-#endif
-
-#ifdef VIGNETTE
-    float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
-
-    if (!swimming) {
-        color.rgb *= vig;
-    } else {
-        color.rgb *= vig * vig * vig;
-        color.rgb *= inLiquidTint;
-    }
 #endif
 
     gl_FragData[0].rgba = color.rgba;

--- a/engine/src/main/resources/assets/shaders/vignette_frag.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_frag.glsl
@@ -1,0 +1,22 @@
+uniform sampler2D texScene;
+
+#ifdef VIGNETTE
+uniform sampler2D texVignette;
+uniform vec3 inLiquidTint;
+uniform vec3 tint = vec3(1.0,1.0,1.0);
+#endif
+
+void main(){
+    vec4 color = texture2D(texScene, gl_TexCoord[0].xy);
+
+    #ifdef VIGNETTE
+        float vig = texture2D(texVignette, gl_TexCoord[0].xy).x;
+        if (!swimming) {
+            color.rgb *= vec3(vig)+(1-vig)*tint.rgb;
+        } else {
+            color.rgb *= vig * vig * vig;
+            color.rgb *= inLiquidTint;
+        }
+    #endif
+    gl_FragData[0].rgba = color.rgba;
+}

--- a/engine/src/main/resources/assets/shaders/vignette_vert.glsl
+++ b/engine/src/main/resources/assets/shaders/vignette_vert.glsl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void main() {
+    gl_Position = ftransform();
+    gl_TexCoord[0] = gl_MultiTexCoord0;
+    gl_FrontColor = gl_Color;
+}


### PR DESCRIPTION
This adds the vignette shader from this PR https://github.com/MovingBlocks/Terasology/pull/3604 and introduces the changes into CoreRendering: https://github.com/Terasology/CoreRendering/pull/32. I omitted the changes for VR and I think this will have to be revisited at a later point to resolve these changes. 