### PR TITLE
CI: fix path to versionInfo.properties

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node ("heavy-java") {
     stage('Build') {
         // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
         sh './gradlew --console=plain clean extractConfig extractNatives distForLauncher testDist'
-        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, build/resources/main/org/terasology/version/versionInfo.properties, natives/**, buildSrc/src/**, buildSrc/*.kts'
+        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/version/versionInfo.properties, natives/**, buildSrc/src/**, buildSrc/*.kts'
     }
     stage('Publish') {
         if (specialBranch) {


### PR DESCRIPTION
part of what we need to fix the lack of a versionInfo.properties artifact in the place Launcher looks.

this might be only half of it and we need to do a similar thing with Index/Jenkinsfile: https://github.com/Terasology/Index/pull/12