### PR TITLE
build: factor out ModuleInfoException from terasology-module

### DIFF
--- a/buildSrc/src/main/kotlin/org/terasology/gradology/ModuleInfoException.kt
+++ b/buildSrc/src/main/kotlin/org/terasology/gradology/ModuleInfoException.kt
@@ -1,0 +1,36 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.gradology
+
+import org.gradle.api.Project
+import java.io.File
+
+class ModuleInfoException(
+    cause: Throwable,
+    @Suppress("MemberVisibilityCanBePrivate") val file: File? = null,
+    private val project: Project? = null
+) : RuntimeException(cause) {
+    override val message: String
+        get() {
+            // trying to get the fully-qualified-class-name-mess off the front and just show
+            // the useful part.
+            val detail = cause?.cause?.localizedMessage ?: cause?.localizedMessage
+            return "Error while reading module info from ${describeFile()}:\n  ${detail}"
+        }
+
+    private fun describeFile(): String {
+        return if (project != null && file != null) {
+            project.rootProject.relativePath(file)
+        } else if (file != null) {
+            file.toString()
+        } else {
+            "[unnamed file]"
+        }
+    }
+
+    override fun toString(): String {
+        val causeType = cause?.let { it::class.simpleName }
+        return "ModuleInfoException(file=${describeFile()}, cause=${causeType})"
+    }
+}

--- a/buildSrc/src/main/kotlin/terasology-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/terasology-module.gradle.kts
@@ -10,6 +10,7 @@ import org.reflections.scanners.SubTypesScanner
 import org.reflections.scanners.TypeAnnotationsScanner
 import org.reflections.util.ConfigurationBuilder
 import org.reflections.util.FilterBuilder
+import org.terasology.gradology.ModuleInfoException
 import org.terasology.gradology.ModuleMetadataForGradle
 import org.terasology.module.ModuleMetadataJsonAdapter
 
@@ -25,35 +26,6 @@ val moduleFile = file("module.txt")
 if (!moduleFile.exists()) {
     println("Y U NO EXIST MODULE.TXT!")
     throw GradleException("Failed to find module.txt for " + project.name)
-}
-
-class ModuleInfoException(
-    cause: Throwable,
-    @Suppress("MemberVisibilityCanBePrivate") val file: File? = null,
-    private val project: Project? = null
-) : RuntimeException(cause) {
-    override val message: String
-        get() {
-            // trying to get the fully-qualified-class-name-mess off the front and just show
-            // the useful part.
-            val detail = cause?.cause?.localizedMessage ?: cause?.localizedMessage
-            return "Error while reading module info from ${describeFile()}:\n  ${detail}"
-        }
-
-    private fun describeFile(): String {
-        return if (project != null && file != null) {
-            project.rootProject.relativePath(file)
-        } else if (file != null) {
-            file.toString()
-        } else {
-            "[unnamed file]"
-        }
-    }
-
-    override fun toString(): String {
-        val causeType = cause?.let { it::class.simpleName }
-        return "ModuleInfoException(file=${describeFile()}, cause=${causeType})"
-    }
 }
 
 val moduleConfig = try {


### PR DESCRIPTION
Straightforward refactor. If you want to test, change a `module.txt` to have a syntax error and see how it's reported when gradle next tries to configure it.

e.g. `gradlew jar` but almost any gradle command will do, including `gradlew tasks`.