### PR TITLE
fix: correct index for world view

### DIFF
--- a/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -208,8 +208,7 @@ public class RemoteChunkProvider implements ChunkProvider {
         Chunk[] chunks = new Chunk[region.getSizeX() * region.getSizeY() * region.getSizeZ()];
         for (Vector3ic chunkPos : region) {
             Chunk chunk = chunkCache.get(chunkPos);
-            chunkPos.sub(region.minX(), region.minY(), region.minZ(), new Vector3i());
-            int index = chunkPos.x() + region.getSizeX() * (chunkPos.z() + region.getSizeZ() * (chunkPos.y()));
+            int index = (chunkPos.x() - region.minX()) + region.getSizeX() * ((chunkPos.z() - region.minZ()) + region.getSizeZ()  * (chunkPos.y() - region.minY()));
             chunks[index] = chunk;
         }
         return new ChunkViewCoreImpl(chunks, region, offset, blockManager.getBlock(BlockManager.AIR_ID));


### PR DESCRIPTION
The remote chunk provider was calculating a negative index. 

Fixes https://github.com/MovingBlocks/Terasology/issues/4505