### PR TITLE
build: move more implementation details about gestalt out of terasology-module

### DIFF
--- a/buildSrc/src/main/kotlin/org/terasology/gradology/constants.kt
+++ b/buildSrc/src/main/kotlin/org/terasology/gradology/constants.kt
@@ -5,3 +5,5 @@ package org.terasology.gradology
 
 const val TERASOLOGY_MODULES_GROUP = "org.terasology.modules"
 const val ENGINE_MODULE_NAME = "engine"
+
+const val MODULE_INFO_FILENAME = "module.txt"

--- a/buildSrc/src/main/kotlin/terasology-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/terasology-module.gradle.kts
@@ -14,8 +14,8 @@ import org.terasology.gradology.ModuleMetadataForGradle
 
 plugins {
     `java-library`
-    id("idea")
-    id("eclipse")
+    idea
+    eclipse
 }
 
 val moduleMetadata = ModuleMetadataForGradle.forProject(project)
@@ -32,15 +32,13 @@ apply(from = "$rootDir/config/gradle/publish.gradle")
 
 // Handle some logic related to where what is
 configure<SourceSetContainer> {
-    named("main") {
-        java.outputDir = File("$buildDir/classes")
+    main {
+        java.outputDir = buildDir.resolve("classes")
     }
-    named("test") {
-        java.outputDir = File("$buildDir/testClasses")
+    test {
+        java.outputDir = buildDir.resolve("testClasses")
     }
 }
-val convention = project.getConvention().getPlugin(JavaPluginConvention::class)
-val mainSourceSet = convention.getSourceSets().getByName("main")
 
 configurations {
     all {
@@ -127,6 +125,10 @@ tasks.register("createSkeleton") {
     mkdir("src/test/java")
 }
 
+
+val mainSourceSet: SourceSet = sourceSets[SourceSet.MAIN_SOURCE_SET_NAME]
+
+
 tasks.register("cacheReflections") {
     description = "Caches reflection output to make regular startup faster. May go stale and need cleanup at times."
     inputs.files(mainSourceSet.output.classesDirs)
@@ -193,8 +195,8 @@ configure<IdeaModel> {
     module {
         // Change around the output a bit
         inheritOutputDirs = false
-        outputDir = file("build/classes")
-        testOutputDir = file("build/testClasses")
+        outputDir = buildDir.resolve("classes")
+        testOutputDir = buildDir.resolve("testClasses")
         isDownloadSources = true
     }
 }


### PR DESCRIPTION
Another in this series of clean-up work for terasology-module.kts. No change in functionality expected, these changes are made in hopes that putting things in named methods makes the code less tangled and more readable.