### PR TITLE
fix(rendering): clipping plane on LoD 0

### DIFF
--- a/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
+++ b/engine/src/main/java/org/terasology/rendering/cameras/PerspectiveCamera.java
@@ -187,7 +187,7 @@ public class PerspectiveCamera extends SubmersibleCamera implements PropertyChan
 
     private void updateFarClippingDistance() {
         float distance = renderingConfig.getViewDistance().getChunkDistance().x() * Chunks.SIZE_X * (1 << (int) renderingConfig.getChunkLods());
-        zFar = Math.max(distance, 500) * 2;
+        zFar = Math.max(distance, 600) * 2;
         // distance is an estimate of how far away the farthest chunks are, and the minimum bound is to ensure that the sky is visible.
     }
 


### PR DESCRIPTION
Noticed a black something in the center of my screen after setting LoD from 10 to 0. Seemed to be on the "back plane" as it disappeared behind loaded chunks. When setting LoD to 1, it didn't show anymore.

@PS-Soundwave assumed that the far clipping plane might be pulled in too far on lowest LoD and suggested this quickfix. Turned out fine, although there seems to be a larger issue, that @PS-Soundwave plans to write up (please also link it here) and investigate :+1: 

Co-authored-by: Soundwave <PS-Soundwave@users.noreply.github.com>