### PR TITLE
fix: use system property instead of ENV to determine user home

### DIFF
--- a/engine/src/main/java/org/terasology/utilities/Jvm.java
+++ b/engine/src/main/java/org/terasology/utilities/Jvm.java
@@ -21,7 +21,7 @@ public final class Jvm {
     public static void logClasspath(Logger aLogger) {
         String interestingGroup = "org.terasology";
         String projectRoot = PathManager.getInstance().getInstallPath().toString();
-        String userHome = System.getenv("HOME");
+        String userHome = System.getProperty("user.home");
         String indent = "  ";
         int elidedCount = 0;
 


### PR DESCRIPTION
@Cervator reported on Discord that "it may not work in some cases on Windows". 

The problematic part is in the new `Jvm` class, where
```java
String userHome = System.getenv("HOME"); 
```
eventually leads to an NPE "as my Win10 simply doesn't have an env var by that name". 

@Cervator suggested that Windows uses a different ENV variable `HOMEPATH` for this, 
and I remembered that there is also a [system property] `user.home` we could use here.

[system property]: https://docs.oracle.com/javase/7/docs/api/java/lang/System.html#getProperties()