### PR TITLE
chore: adding some null checks

### DIFF
--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.bootstrap;
@@ -27,6 +27,7 @@ import org.terasology.input.cameraTarget.CameraTargetChangedEvent;
 import org.terasology.input.events.InputEvent;
 import org.terasology.logic.characters.CharacterMoveInputEvent;
 import org.terasology.module.ModuleEnvironment;
+import org.terasology.naming.Name;
 import org.terasology.network.NetworkSystem;
 import org.terasology.nui.properties.OneOfProviderFactory;
 import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
@@ -48,6 +49,8 @@ import org.terasology.reflection.reflect.ReflectionReflectFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.google.common.base.Verify.verifyNotNull;
 
 /**
  * Provides static methods that can be used to put entity system related objects into a {@link Context} instance.
@@ -160,7 +163,9 @@ public final class EntitySystemSetupUtil {
         for (Class<? extends Component> componentType : environment.getSubtypesOf(Component.class)) {
             if (componentType.getAnnotation(DoNotAutoRegister.class) == null) {
                 String componentName = MetadataUtil.getComponentClassName(componentType);
-                library.register(new ResourceUrn(environment.getModuleProviding(componentType).toString(), componentName), componentType);
+                //noinspection UnstableApiUsage
+                Name componentModuleName = verifyNotNull(environment.getModuleProviding(componentType), "Could not find module for %s %s", componentName, componentType);
+                library.register(new ResourceUrn(componentModuleName.toString(), componentName), componentType);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.bootstrap;
 
@@ -19,6 +19,7 @@ import org.terasology.entitySystem.prefab.internal.PrefabDeltaFormat;
 import org.terasology.entitySystem.prefab.internal.PrefabFormat;
 import org.terasology.entitySystem.systems.internal.DoNotAutoRegister;
 import org.terasology.module.ModuleEnvironment;
+import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.RegisterTypeHandler;
 import org.terasology.persistence.typeHandling.RegisterTypeHandlerFactory;
 import org.terasology.persistence.typeHandling.TypeHandler;
@@ -40,6 +41,8 @@ import org.terasology.utilities.ReflectionUtil;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+
+import static com.google.common.base.Verify.verifyNotNull;
 
 /**
  * Handles an environment switch by updating the asset manager, component library, and other context objects.
@@ -177,7 +180,9 @@ public final class EnvironmentSwitchHandler {
         for (Class<? extends Component> componentType : environment.getSubtypesOf(Component.class)) {
             if (componentType.getAnnotation(DoNotAutoRegister.class) == null) {
                 String componentName = MetadataUtil.getComponentClassName(componentType);
-                library.register(new ResourceUrn(environment.getModuleProviding(componentType).toString(), componentName), componentType);
+                //noinspection UnstableApiUsage
+                Name componentModuleName = verifyNotNull(environment.getModuleProviding(componentType), "Could not find module for %s %s", componentName, componentType);
+                library.register(new ResourceUrn(componentModuleName.toString(), componentName), componentType);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
+++ b/engine/src/main/java/org/terasology/world/generator/internal/WorldGeneratorManager.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.world.generator.internal;
 
 import com.google.common.collect.ImmutableList;
@@ -132,7 +119,11 @@ public class WorldGeneratorManager {
     public static WorldGenerator createWorldGenerator(SimpleUri uri, Context context, ModuleEnvironment environment) throws UnresolvedWorldGeneratorException {
         for (Class<?> generatorClass : environment.getTypesAnnotatedWith(RegisterWorldGenerator.class)) {
             RegisterWorldGenerator annotation = generatorClass.getAnnotation(RegisterWorldGenerator.class);
-            SimpleUri generatorUri = new SimpleUri(environment.getModuleProviding(generatorClass), annotation.id());
+            Name moduleName = environment.getModuleProviding(generatorClass);
+            if (moduleName == null) {
+                throw new UnresolvedWorldGeneratorException("Cannot find module for world generator " + generatorClass);
+            }
+            SimpleUri generatorUri = new SimpleUri(moduleName, annotation.id());
             if (generatorUri.equals(uri)) {
                 WorldGenerator worldGenerator = loadGenerator(generatorClass, generatorUri);
                 InjectionHelper.inject(worldGenerator, context);


### PR DESCRIPTION
Adds errors more informative that NullPointerException to some places I ran in to when `environment.getModuleProviding` fails.

Seeing that it was the same method three times, now I wonder: do we ever use this method in a way where a null result is expected, or should the method throw a thing-not-found exception?

(cherry-picked from #4543)