### PR TITLE
ci: buildSrc moved to build-logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node ("heavy-java") {
     stage('Build') {
         // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
         sh './gradlew --console=plain clean extractConfig extractNatives distForLauncher testDist'
-        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/version/versionInfo.properties, natives/**, buildSrc/src/**, buildSrc/*.kts'
+        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/version/versionInfo.properties, natives/**, build-logic/src/**, build-logic/*.kts'
     }
     stage('Publish') {
         if (specialBranch) {


### PR DESCRIPTION
adjust for #4553

hopefully fixes http://jenkins.terasology.io/teraorg/job/Terasology/job/Modules/job/H/job/Health/job/develop/31/console

> * What went wrong:
> Included build '/home/jenkins/agent/workspace/asology_Modules_H_Health_develop/build-logic' does not exist.
