### PR TITLE
refactor(PathManager): do all the `createDirectories` at once

### DIFF
--- a/engine/src/main/java/org/terasology/engine/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/paths/PathManager.java
@@ -327,13 +327,13 @@ public final class PathManager {
         final Path path;
         switch (OS.get()) {
             case WINDOWS:
-                path = PathManager.getInstance().getNativesPath().resolve("windows");
+                path = nativesPath.resolve("windows");
                 break;
             case MACOSX:
-                path = PathManager.getInstance().getNativesPath().resolve("macosx");
+                path = nativesPath.resolve("macosx");
                 break;
             case LINUX:
-                path = PathManager.getInstance().getNativesPath().resolve("linux");
+                path = nativesPath.resolve("linux");
                 break;
             default:
                 throw new UnsupportedOperationException("Unsupported operating system: " + System.getProperty("os" +

--- a/engine/src/main/java/org/terasology/engine/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/paths/PathManager.java
@@ -308,15 +308,7 @@ public final class PathManager {
         }
         sandboxPath = homePath.resolve(SANDBOX_DIR);
 
-        Path homeModPath = homePath.resolve(MODULE_DIR);
-        Path modCachePath = homePath.resolve(MODULE_CACHE_DIR);
-
-        if (Files.isSameFile(homePath, installPath)) {
-            modPaths = ImmutableList.of(modCachePath, homeModPath);
-        } else {
-            Path installModPath = installPath.resolve(MODULE_DIR);
-            modPaths = ImmutableList.of(installModPath, modCachePath, homeModPath);
-        }
+        modPaths = defaultModPaths();
 
         for (Path path : getAllPaths()) {
             Files.createDirectories(path);
@@ -343,6 +335,18 @@ public final class PathManager {
         System.setProperty("net.java.games.input.librarypath", natives);  // libjinput
         System.setProperty("org.terasology.librarypath", natives); // JNBullet
 
+    }
+
+    protected ImmutableList<Path> defaultModPaths() throws IOException {
+        Path homeModPath = homePath.resolve(MODULE_DIR);
+        Path modCachePath = homePath.resolve(MODULE_CACHE_DIR);
+
+        if (Files.isSameFile(homePath, installPath)) {
+            return ImmutableList.of(modCachePath, homeModPath);
+        } else {
+            Path installModPath = installPath.resolve(MODULE_DIR);
+            return ImmutableList.of(installModPath, modCachePath, homeModPath);
+        }
     }
 
     public Path getHomeModPath() {


### PR DESCRIPTION
I've always found PathManager.updateDirs hard to read with it doing `createDirectories` every-other-line. I think applying `createDirectories` to a collection of all of them helps.

Not a strict-Refactor in that `getDeclaredFields` wasn't part of the logic previously.

This came out of #4543 when I thought I was going to be doing more PathManager manipulation, but it went in another direction.


### How to test

Make sure all the various paths (for configs, saves, screenshots, etc) are created when you start the game.