### PR TITLE
chore: upgrade guava to 30.1 from 23.0

### DIFF
--- a/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/rendering/nui/layers/mainMenu/savedGames/GameProviderTest.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.rendering.nui.layers.mainMenu.savedGames;
 
 import com.google.common.base.Charsets;
@@ -78,7 +65,6 @@ public class GameProviderTest {
 
         final File file = new File(GameProviderTest.class.getClassLoader().getResource(GAME_MANIFEST_JSON).getFile());
         try {
-            //noinspection UnstableApiUsage
             MANIFEST_EXAMPLE = com.google.common.io.Files.asCharSource(file, Charsets.UTF_8).read();
         } catch (IOException e) {
             fail("Could not load input file");

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -55,7 +55,7 @@ configurations {
 // Primary dependencies definition
 dependencies {
     // Storage and networking
-    api group: 'com.google.guava', name: 'guava', version: '23.0'
+    api group: 'com.google.guava', name: 'guava', version: '30.1-jre'
     api group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     api group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.53.Final'

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EntitySystemSetupUtil.java
@@ -163,7 +163,6 @@ public final class EntitySystemSetupUtil {
         for (Class<? extends Component> componentType : environment.getSubtypesOf(Component.class)) {
             if (componentType.getAnnotation(DoNotAutoRegister.class) == null) {
                 String componentName = MetadataUtil.getComponentClassName(componentType);
-                //noinspection UnstableApiUsage
                 Name componentModuleName = verifyNotNull(environment.getModuleProviding(componentType), "Could not find module for %s %s", componentName, componentType);
                 library.register(new ResourceUrn(componentModuleName.toString(), componentName), componentType);
             }

--- a/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
+++ b/engine/src/main/java/org/terasology/engine/bootstrap/EnvironmentSwitchHandler.java
@@ -180,7 +180,6 @@ public final class EnvironmentSwitchHandler {
         for (Class<? extends Component> componentType : environment.getSubtypesOf(Component.class)) {
             if (componentType.getAnnotation(DoNotAutoRegister.class) == null) {
                 String componentName = MetadataUtil.getComponentClassName(componentType);
-                //noinspection UnstableApiUsage
                 Name componentModuleName = verifyNotNull(environment.getModuleProviding(componentType), "Could not find module for %s %s", componentName, componentType);
                 library.register(new ResourceUrn(componentModuleName.toString(), componentName), componentType);
             }

--- a/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
+++ b/engine/src/main/java/org/terasology/entitySystem/entity/EntityBuilder.java
@@ -79,7 +79,6 @@ public class EntityBuilder implements MutableComponentContainer {
         if (prefab != null) {
             for (Component component : prefab.iterateComponents()) {
                 Component componentCopy = entityManager.getComponentLibrary().copy(component);
-                //noinspection UnstableApiUsage
                 addComponent(verifyNotNull(componentCopy, "Component %s not registered (in prefab %s)", component, prefab));
             }
             addComponent(new EntityInfoComponent(prefab, prefab.isPersisted(), prefab.isAlwaysRelevant()));

--- a/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
+++ b/engine/src/main/java/org/terasology/entitySystem/event/internal/EventSystemImpl.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.entitySystem.event.internal;
 
 import com.esotericsoftware.reflectasm.MethodAccess;
@@ -117,7 +104,7 @@ public class EventSystemImpl implements EventSystem {
     public void registerEvent(SimpleUri uri, Class<? extends Event> eventType) {
         eventIdMap.put(uri, eventType);
         logger.debug("Registering event {}", eventType.getSimpleName());
-        for (Class parent : ReflectionUtils.getAllSuperTypes(eventType, Predicates.assignableFrom(Event.class))) {
+        for (Class parent : ReflectionUtils.getAllSuperTypes(eventType, Predicates.subtypeOf(Event.class))) {
             if (!AbstractConsumableEvent.class.equals(parent) && !Event.class.equals(parent)) {
                 childEvents.put(parent, eventType);
             }

--- a/engine/src/main/java/org/terasology/recording/EventSystemReplayImpl.java
+++ b/engine/src/main/java/org/terasology/recording/EventSystemReplayImpl.java
@@ -1,25 +1,7 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.recording;
 
-import org.terasology.assets.ResourceUrn;
-import org.terasology.engine.paths.PathManager;
-import org.terasology.entitySystem.entity.internal.EngineEntityManager;
-import org.terasology.entitySystem.event.internal.EventReceiver;
-import org.terasology.entitySystem.event.internal.EventSystem;
 import com.esotericsoftware.reflectasm.MethodAccess;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicates;
@@ -35,15 +17,20 @@ import com.google.common.collect.Sets;
 import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.assets.ResourceUrn;
 import org.terasology.engine.SimpleUri;
+import org.terasology.engine.paths.PathManager;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.event.AbstractConsumableEvent;
 import org.terasology.entitySystem.event.ConsumableEvent;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.event.EventPriority;
-import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.event.PendingEvent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.event.internal.EventReceiver;
+import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.entitySystem.metadata.EventLibrary;
 import org.terasology.entitySystem.metadata.EventMetadata;
 import org.terasology.entitySystem.systems.ComponentSystem;
@@ -284,7 +271,7 @@ public class EventSystemReplayImpl implements EventSystem {
     public void registerEvent(SimpleUri uri, Class<? extends Event> eventType) {
         eventIdMap.put(uri, eventType);
         logger.debug("Registering event {}", eventType.getSimpleName());
-        for (Class parent : ReflectionUtils.getAllSuperTypes(eventType, Predicates.assignableFrom(Event.class))) {
+        for (Class parent : ReflectionUtils.getAllSuperTypes(eventType, Predicates.subtypeOf(Event.class))) {
             if (!AbstractConsumableEvent.class.equals(parent) && !Event.class.equals(parent)) {
                 childEvents.put(parent, eventType);
             }

--- a/facades/TeraEd/build.gradle
+++ b/facades/TeraEd/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // The Editor facade is responsible for the (shader) editor - a plain Java application runnable on PCs
@@ -40,7 +40,7 @@ dependencies {
     }
     implementation "org.lwjgl:lwjgl-jawt"
 
-    implementation(group: 'com.google.guava', name: 'guava', version: '23.0')
+    implementation(group: 'com.google.guava', name: 'guava', version: '30.1-jre')
 
     implementation(project(":subsystems:DiscordRPC"))
     implementation(project(":subsystems:TypeHandlerLibrary"))


### PR DESCRIPTION
There was one function that had been deprecated long enough that it was no longer available and we had to switch to its new name.

A few other functions are no longer `@Beta` and we got to remove some "unstable api" tags from their call sites.

Seems to be working fine.

You can see info about how it resolved dependencies for guava in a [build scan](https://scans.gradle.com/s/gmljvt3zrah2i/dependencies?focusedDependency=WzIsMSw0MjEsWzIsMSxbNDIxXV1d&focusedDependencyView=versions&toggled=W1syXSxbMiwxXV0).