### PR TITLE
chore: upgrade gson to 2.8.6 from 2.6

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation project(':engine')
 
     // Dependency not provided for modules, but required for module-tests
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     implementation group: 'org.codehaus.plexus', name: 'plexus-utils', version: '1.5.6'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -56,7 +56,7 @@ configurations {
 dependencies {
     // Storage and networking
     api group: 'com.google.guava', name: 'guava', version: '23.0'
-    api group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
+    api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     api group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.53.Final'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'


### PR DESCRIPTION
Changelog available here: https://github.com/google/gson/blob/master/CHANGELOG.md

I don't see any red flags there.
