### PR TITLE
chore(engine-test): use a temp directory instead of a Shrinkwrap archive

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -91,8 +91,6 @@ if (project.name == "ModuleTestingEnvironment") {
         implementation("org.junit.jupiter:junit-jupiter-api")
         implementation("org.mockito:mockito-junit-jupiter:3.7.7")
         implementation("junit:junit:4.13.1")
-        //TODO: Remove shrinkwrap from code, you have FileSystem in java 8
-        implementation("org.jboss.shrinkwrap:shrinkwrap-depchain-java7:1.2.1")
     }
 }
 

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -68,9 +68,6 @@ dependencies {
     implementation("org.mockito:mockito-junit-jupiter:3.7.7")
 
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
-
-    //TODO: Remove shrinkwrap from code, you have FileSystem in java 8
-    implementation group: 'org.jboss.shrinkwrap', name: 'shrinkwrap-depchain-java7', version: '1.2.1'
 }
 
 task copyResourcesToClasses(type:Copy) {

--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -1,23 +1,7 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.management.AssetManager;
@@ -104,8 +88,9 @@ import org.terasology.world.time.WorldTime;
 import org.terasology.world.time.WorldTimeImpl;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -291,14 +276,11 @@ public class HeadlessEnvironment extends Environment {
         EntitySystemSetupUtil.addReflectionBasedLibraries(context);
     }
 
-    /**
-     * @throws IOException ShrinkWrap errors
-     */
     @Override
     protected void setupPathManager() throws IOException {
-        final JavaArchive homeArchive = ShrinkWrap.create(JavaArchive.class);
-        final FileSystem vfs = ShrinkWrapFileSystems.newFileSystem(homeArchive);
-        PathManager.getInstance().useOverrideHomePath(vfs.getPath(""));
+        Path tempHome = Files.createTempDirectory("terasology-env", (FileAttribute<?>[]) null);
+        tempHome.toFile().deleteOnExit();
+        PathManager.getInstance().useOverrideHomePath(tempHome);
     }
 
     @Override

--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -90,7 +90,6 @@ import org.terasology.world.time.WorldTimeImpl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -278,7 +277,7 @@ public class HeadlessEnvironment extends Environment {
 
     @Override
     protected void setupPathManager() throws IOException {
-        Path tempHome = Files.createTempDirectory("terasology-env", (FileAttribute<?>[]) null);
+        Path tempHome = Files.createTempDirectory("terasology-env");
         tempHome.toFile().deleteOnExit();
         PathManager.getInstance().useOverrideHomePath(tempHome);
     }

--- a/engine-tests/src/main/java/org/terasology/ModuleEnvironmentTest.java
+++ b/engine-tests/src/main/java/org/terasology/ModuleEnvironmentTest.java
@@ -1,23 +1,7 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeEach;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
@@ -27,7 +11,9 @@ import org.terasology.module.ResolutionResult;
 import org.terasology.reflection.TypeRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
-import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -37,9 +23,9 @@ public abstract class ModuleEnvironmentTest {
 
     @BeforeEach
     public void before() throws Exception {
-        final JavaArchive homeArchive = ShrinkWrap.create(JavaArchive.class);
-        final FileSystem vfs = ShrinkWrapFileSystems.newFileSystem(homeArchive);
-        PathManager.getInstance().useOverrideHomePath(vfs.getPath(""));
+        Path tempHome = Files.createTempDirectory("terasology-met", (FileAttribute<?>[]) null);
+        tempHome.toFile().deleteOnExit();
+        PathManager.getInstance().useOverrideHomePath(tempHome);
 
         moduleManager = ModuleManagerFactory.create();
 

--- a/engine-tests/src/main/java/org/terasology/ModuleEnvironmentTest.java
+++ b/engine-tests/src/main/java/org/terasology/ModuleEnvironmentTest.java
@@ -3,6 +3,7 @@
 package org.terasology;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.module.DependencyResolver;
@@ -11,9 +12,7 @@ import org.terasology.module.ResolutionResult;
 import org.terasology.reflection.TypeRegistry;
 import org.terasology.testUtil.ModuleManagerFactory;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -22,9 +21,7 @@ public abstract class ModuleEnvironmentTest {
     protected TypeRegistry typeRegistry;
 
     @BeforeEach
-    public void before() throws Exception {
-        Path tempHome = Files.createTempDirectory("terasology-met", (FileAttribute<?>[]) null);
-        tempHome.toFile().deleteOnExit();
+    public void before(@TempDir Path tempHome) throws Exception {
         PathManager.getInstance().useOverrideHomePath(tempHome);
 
         moduleManager = ModuleManagerFactory.create();

--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -1,25 +1,9 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology;
 
 import com.badlogic.gdx.physics.bullet.Bullet;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,8 +34,9 @@ import org.terasology.reflection.TypeRegistry;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 
-import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 
 import static org.mockito.Mockito.mock;
 
@@ -71,9 +56,9 @@ public abstract class TerasologyTestingEnvironment {
 
     @BeforeAll
     public static void setupEnvironment() throws Exception {
-        final JavaArchive homeArchive = ShrinkWrap.create(JavaArchive.class);
-        final FileSystem vfs = ShrinkWrapFileSystems.newFileSystem(homeArchive);
-        PathManager.getInstance().useOverrideHomePath(vfs.getPath(""));
+        Path tempHome = Files.createTempDirectory("terasology-tte", (FileAttribute<?>[]) null);
+        tempHome.toFile().deleteOnExit();
+        PathManager.getInstance().useOverrideHomePath(tempHome);
         Bullet.init(true,false);
 
         /*

--- a/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.physics.bullet.Bullet;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.terasology.context.Context;
 import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.EngineTime;
@@ -34,9 +35,7 @@ import org.terasology.reflection.TypeRegistry;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.blockdata.ExtraBlockDataManager;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 
 import static org.mockito.Mockito.mock;
 
@@ -55,9 +54,7 @@ public abstract class TerasologyTestingEnvironment {
     private EngineEntityManager engineEntityManager;
 
     @BeforeAll
-    public static void setupEnvironment() throws Exception {
-        Path tempHome = Files.createTempDirectory("terasology-tte", (FileAttribute<?>[]) null);
-        tempHome.toFile().deleteOnExit();
+    public static void setupEnvironment(@TempDir Path tempHome) throws Exception {
         PathManager.getInstance().useOverrideHomePath(tempHome);
         Bullet.init(true,false);
 

--- a/engine-tests/src/test/java/org/terasology/config/flexible/AutoConfigManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/config/flexible/AutoConfigManagerTest.java
@@ -1,23 +1,7 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.config.flexible;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -29,7 +13,9 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
 
-import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,9 +37,9 @@ public class AutoConfigManagerTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        final JavaArchive homeArchive = ShrinkWrap.create(JavaArchive.class);
-        final FileSystem vfs = ShrinkWrapFileSystems.newFileSystem(homeArchive);
-        PathManager.getInstance().useOverrideHomePath(vfs.getPath(""));
+        Path tempHome = Files.createTempDirectory("terasology-env", (FileAttribute<?>[]) null);
+        tempHome.toFile().deleteOnExit();
+        PathManager.getInstance().useOverrideHomePath(tempHome);
 
         when(environment.getModuleProviding(any())).thenReturn(PROVIDING_MODULE);
         when(environment.getSubtypesOf(eq(AutoConfig.class))).thenReturn(Collections.singleton(TestAutoConfig.class));

--- a/engine-tests/src/test/java/org/terasology/config/flexible/AutoConfigManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/config/flexible/AutoConfigManagerTest.java
@@ -4,6 +4,7 @@ package org.terasology.config.flexible;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
@@ -13,9 +14,7 @@ import org.terasology.module.ModuleEnvironment;
 import org.terasology.naming.Name;
 import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,9 +35,7 @@ public class AutoConfigManagerTest {
     private final ModuleEnvironment environment = mock(ModuleEnvironment.class);
 
     @BeforeEach
-    public void setUp() throws Exception {
-        Path tempHome = Files.createTempDirectory("terasology-env", (FileAttribute<?>[]) null);
-        tempHome.toFile().deleteOnExit();
+    public void setUp(@TempDir Path tempHome) throws Exception {
         PathManager.getInstance().useOverrideHomePath(tempHome);
 
         when(environment.getModuleProviding(any())).thenReturn(PROVIDING_MODULE);

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatchers;
 import org.terasology.TerasologyTestingEnvironment;
 import org.terasology.assets.ResourceUrn;
@@ -57,7 +58,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.util.Arrays;
 import java.util.List;
 
@@ -98,10 +98,8 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup(@TempDir Path tempHome) throws Exception {
         super.setup();
-        Path tempHome = Files.createTempDirectory("terasology-smt", (FileAttribute<?>[]) null);
-        tempHome.toFile().deleteOnExit();
         PathManager.getInstance().useOverrideHomePath(tempHome);
         savePath = PathManager.getInstance().getSavePath("testSave");
 

--- a/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/persistence/internal/StorageManagerTest.java
@@ -1,24 +1,8 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.persistence.internal;
 
 import com.google.common.collect.Lists;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
@@ -71,9 +55,9 @@ import org.terasology.world.internal.WorldInfo;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Arrays;
 import java.util.List;
 
@@ -116,12 +100,12 @@ public class StorageManagerTest extends TerasologyTestingEnvironment {
     @BeforeEach
     public void setup() throws Exception {
         super.setup();
-        JavaArchive homeArchive = ShrinkWrap.create(JavaArchive.class);
-        FileSystem vfs = ShrinkWrapFileSystems.newFileSystem(homeArchive);
-        PathManager.getInstance().useOverrideHomePath(temporaryFolder.toPath());
+        Path tempHome = Files.createTempDirectory("terasology-smt", (FileAttribute<?>[]) null);
+        tempHome.toFile().deleteOnExit();
+        PathManager.getInstance().useOverrideHomePath(tempHome);
         savePath = PathManager.getInstance().getSavePath("testSave");
 
-        assert !Files.isRegularFile(vfs.getPath("global.dat"));
+        assert !Files.isRegularFile(tempHome.resolve("global.dat"));
 
         entityManager = context.get(EngineEntityManager.class);
         moduleEnvironment = mock(ModuleEnvironment.class);


### PR DESCRIPTION
allows removing the dependency on Shrinkwrap.

How are there so many of these???