### PR TITLE
chore!: limit API for BlockComponent (2/2)

### DIFF
--- a/engine/src/main/java/org/terasology/world/block/BlockComponent.java
+++ b/engine/src/main/java/org/terasology/world/block/BlockComponent.java
@@ -14,7 +14,7 @@ public final class BlockComponent implements Component {
     @Replicate
     protected Vector3i position = new Vector3i();
     @Replicate
-    public Block block;
+    protected Block block;
 
     public BlockComponent() {
     }


### PR DESCRIPTION
Restrict visibility of field `block` on `BlockComponent` to `protected`. All access in Omega was already migrated to use the accessor instead.

Follow-up to #4528