### PR TITLE
refactor: move DiscordRPC to org.terasology.subsystem

### DIFF
--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -18,7 +18,6 @@ import org.terasology.engine.subsystem.common.ConfigurationSubsystem;
 import org.terasology.engine.subsystem.common.ThreadManager;
 import org.terasology.engine.subsystem.common.hibernation.HibernationSubsystem;
 import org.terasology.engine.subsystem.config.BindsSubsystem;
-import org.terasology.engine.subsystem.discordrpc.DiscordRPCSubSystem;
 import org.terasology.engine.subsystem.headless.HeadlessAudio;
 import org.terasology.engine.subsystem.headless.HeadlessGraphics;
 import org.terasology.engine.subsystem.headless.HeadlessInput;
@@ -36,6 +35,7 @@ import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
 import org.terasology.splash.SplashScreen;
 import org.terasology.splash.SplashScreenBuilder;
+import org.terasology.subsystem.discordrpc.DiscordRPCSubSystem;
 
 import java.awt.GraphicsEnvironment;
 import java.io.IOException;

--- a/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCBuffer.java
+++ b/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCBuffer.java
@@ -1,7 +1,7 @@
 // Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-package org.terasology.engine.subsystem.discordrpc;
+package org.terasology.subsystem.discordrpc;
 
 import java.time.OffsetDateTime;
 

--- a/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSubSystem.java
+++ b/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSubSystem.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.engine.subsystem.discordrpc;
+package org.terasology.subsystem.discordrpc;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSystem.java
+++ b/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSystem.java
@@ -1,6 +1,6 @@
 // Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-package org.terasology.engine.subsystem.discordrpc;
+package org.terasology.subsystem.discordrpc;
 
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;

--- a/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCThread.java
+++ b/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCThread.java
@@ -1,7 +1,7 @@
 // Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-package org.terasology.engine.subsystem.discordrpc;
+package org.terasology.subsystem.discordrpc;
 
 import com.jagrosh.discordipc.IPCClient;
 import com.jagrosh.discordipc.IPCListener;


### PR DESCRIPTION
to indicate it is not in engine itself.

following notes about package namespaces on #4560.