### PR TITLE
chore!: remove JUnit 4 from module dependencies

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -72,11 +72,6 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     testImplementation("org.mockito:mockito-junit-jupiter:3.7.7")
-
-    //backwards compatibility with modules tests
-    testImplementation("junit:junit:4.13.1")
-    testImplementation("org.junit.jupiter:junit-jupiter-migrationsupport")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 
@@ -90,7 +85,6 @@ if (project.name == "ModuleTestingEnvironment") {
         add("implementation", platform("org.junit:junit-bom:5.7.1"))
         implementation("org.junit.jupiter:junit-jupiter-api")
         implementation("org.mockito:mockito-junit-jupiter:3.7.7")
-        implementation("junit:junit:4.13.1")
     }
 }
 


### PR DESCRIPTION
Just some housekeeping.

I have not yet confirmed that we've removed the JUnit 4 imports from all the modules.

### Missing Module Migrations

- [x] ModuleTestingEnvironment
- [x] FlexiblePathfinding
- [x] Genome 
- [x] HumanoidCharacters 
- [x] Inventory 
- [x] MarkovChains 
- [x] WeatherManager 