### PR TITLE
chore: upgrade reflections to 0.9.12-MB from 0.9.10

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     // Needed for caching reflected data during builds
-    implementation("org.reflections:reflections:0.9.10")
+    implementation("org.terasology:reflections:0.9.12-MB")
     implementation("dom4j:dom4j:1.6.1")
 
     // for inspecting modules

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 
     dependencies {
         // Needed for caching reflected data during builds
-        classpath 'org.reflections:reflections:0.9.10'
+        classpath 'org.terasology:reflections:0.9.12-MB'
         classpath 'dom4j:dom4j:1.6.1'
 
         //Spotbugs

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     runtimeOnly group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.21'
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
+    implementation "org.terasology:reflections:0.9.12-MB"
 
     // Test lib dependencies
     implementation(platform("org.junit:junit-bom:5.7.1")) {

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
     // Java magic
     implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.6.0'
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
+    implementation "org.terasology:reflections:0.9.12-MB"
     implementation group: 'org.javassist', name: 'javassist', version: '3.27.0-GA'
     implementation group: 'com.esotericsoftware', name: 'reflectasm', version: '1.11.1'
 

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -61,7 +61,7 @@ group = "org.terasology.facades"
 
 dependencies {
     implementation(project(":engine"))
-    implementation(group = "org.reflections", name = "reflections", version = "0.9.10")
+    implementation("org.terasology:reflections:0.9.12-MB")
     implementation(project(":subsystems:DiscordRPC"))
 
     // TODO: Consider whether we can move the CR dependency back here from the engine, where it is referenced from the main menu

--- a/facades/TeraEd/build.gradle
+++ b/facades/TeraEd/build.gradle
@@ -25,7 +25,7 @@ sourceSets {
 
 dependencies {
     implementation project(':engine')
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
+    implementation "org.terasology:reflections:0.9.12-MB"
 
     runtimeOnly(platform(project(":modules")))
     // For the "natives" configuration make it depend on the native files from LWJGL

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation("org.slf4j:slf4j-api:1.7.21")
     implementation("net.sf.trove4j:trove4j:3.0.3")
 
-    implementation("org.reflections:reflections:0.9.10")
+    implementation("org.terasology:reflections:0.9.12-MB")
     implementation("org.terasology.nui:nui-reflect:1.3.1")
     implementation("org.terasology:gestalt-module:5.1.5")
     implementation("org.terasology:gestalt-asset-core:5.1.5")


### PR DESCRIPTION
Using the org.terasology fork.

This is the version that gestalt-v7 uses. It might also work fine with our current one? Not too sure. Making a branch to see what CI thinks.

It's also possible that not all of these build files need the reflections dependency. e.g. do the facades make any direct use of it?
