### PR TITLE
test: HeadlessEnvironment loads modules from classpath

### DIFF
--- a/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java
@@ -256,7 +256,7 @@ public class HeadlessEnvironment extends Environment {
         TypeRegistry.WHITELISTED_CLASSES = ExternalApiWhitelist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
         context.put(TypeRegistry.class, typeRegistry);
 
-        ModuleManager moduleManager = ModuleManagerFactory.create();
+        ModuleManager moduleManager = ModuleManagerFactory.create(true);
         ModuleRegistry registry = moduleManager.getRegistry();
 
         DependencyResolver resolver = new DependencyResolver(registry);

--- a/engine-tests/src/main/java/org/terasology/testUtil/ModuleManagerFactory.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/ModuleManagerFactory.java
@@ -4,16 +4,14 @@ package org.terasology.engine.testUtil;
 
 import com.google.common.collect.Sets;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.entitySystem.stubs.StringComponent;
 import org.terasology.module.Module;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static com.google.common.base.Verify.verify;
 import static org.terasology.engine.core.TerasologyConstants.ENGINE_MODULE;
-import static org.terasology.engine.core.TerasologyConstants.MODULE_INFO_FILENAME;
 
 public final class ModuleManagerFactory {
 
@@ -26,8 +24,8 @@ public final class ModuleManagerFactory {
     }
 
     public static void loadUnitTestModule(ModuleManager manager) throws IOException, URISyntaxException {
-        Path myPath = Paths.get(ModuleManagerFactory.class.getResource("/" + MODULE_INFO_FILENAME).toURI()).getParent();
-        Module testModule = manager.loadClasspathModule(myPath);
+        // using the StringComponent stub class as representative example of classes in the unittest module
+        Module testModule = manager.loadClasspathModule(StringComponent.class);
         verify(testModule.getMetadata().getId().toString().equals("unittest"),
                 "Intended to load the unittest module but ended up with this instead: %s", testModule);
         manager.loadEnvironment(

--- a/engine-tests/src/main/java/org/terasology/testUtil/ModuleManagerFactory.java
+++ b/engine-tests/src/main/java/org/terasology/testUtil/ModuleManagerFactory.java
@@ -9,6 +9,7 @@ import org.terasology.module.Module;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 
 import static com.google.common.base.Verify.verify;
 import static org.terasology.engine.core.TerasologyConstants.ENGINE_MODULE;
@@ -18,7 +19,11 @@ public final class ModuleManagerFactory {
     private ModuleManagerFactory() { }
 
     public static ModuleManager create() throws Exception {
-        ModuleManager moduleManager = new ModuleManager("");
+        return create(false);
+    }
+
+    public static ModuleManager create(boolean loadModulesFromClasspath) throws Exception {
+        ModuleManager moduleManager = new ModuleManager("", Collections.emptyList(), loadModulesFromClasspath);
         loadUnitTestModule(moduleManager);
         return moduleManager;
     }

--- a/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
@@ -13,6 +13,7 @@ import org.terasology.engine.config.Config;
 import org.terasology.engine.config.SystemConfig;
 import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.core.paths.PathManager;
+import org.terasology.engine.utilities.Jvm;
 import org.terasology.input.device.KeyboardDevice;
 import org.terasology.module.ClasspathModule;
 import org.terasology.module.DependencyInfo;
@@ -33,7 +34,6 @@ import org.terasology.module.sandbox.StandardPermissionProviderFactory;
 import org.terasology.module.sandbox.WarnOnlyProviderFactory;
 import org.terasology.nui.UIWidget;
 import org.terasology.reflection.TypeRegistry;
-import org.terasology.engine.utilities.Jvm;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -229,29 +229,28 @@ public class ModuleManager {
     }
 
     /**
-     * Load a module from the given path.
+     * Load a module from the location containing a class.
      *
-     * Assumes that the path <em>should</em> contain a Terasology module. Will add the module to
+     * Assumes that the location <em>should</em> contain a Terasology module. Will add the module to
      * {@link #registry} and return the resulting module if successful.
      *
      * May throw IOException or RuntimeExceptions on failure.
      *
      * For troubleshooting failure cases, check for log messages from this package and from {@link ModuleLoader}.
      *
-     * @param path the path to the jar or directory
+     * @param clazz a class in the module, see {@link ClasspathModule#create}
      */
-    public Module loadClasspathModule(Path path) throws IOException {
-        ModuleLoader loader = new ClasspathSupportingModuleLoader(metadataReader, true, false);
+    public Module loadClasspathModule(Class<?> clazz) throws IOException {
+        ClasspathSupportingModuleLoader loader = new ClasspathSupportingModuleLoader(metadataReader, true, false);
         loader.setModuleInfoPath(TerasologyConstants.MODULE_INFO_FILENAME);
 
-        //noinspection UnstableApiUsage
-        Module module = verifyNotNull(loader.load(path), "Failed to load module from %s", path);
+        Module module = verifyNotNull(loader.load(clazz), "Failed to load module from %s", clazz);
         boolean isNew = registry.add(module);
         if (isNew) {
-            logger.info("Added new module: {} from {} on classpath", module, path.getFileName());
+            logger.info("Added new module: {} from {} on classpath", module, module.getClasspaths());
         } else {
             logger.warn("Skipped duplicate module: {}-{} from {} on classpath",
-                    module.getId(), module.getVersion(), path.getFileName());
+                    module.getId(), module.getVersion(), module.getClasspaths());
         }
         return module;
     }

--- a/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
@@ -73,6 +73,10 @@ public class ModuleManager {
     }
 
     public ModuleManager(String masterServerAddress, List<Class<?>> classesOnClasspathsToAddToEngine) {
+        this(masterServerAddress, classesOnClasspathsToAddToEngine, null);
+    }
+
+    public ModuleManager(String masterServerAddress, List<Class<?>> classesOnClasspathsToAddToEngine, Boolean loadModulesFromClasspath) {
         PathManager pathManager = PathManager.getInstance();  // get early so if it needs to initialize, it does it now
 
         metadataReader = newMetadataReader();
@@ -82,7 +86,7 @@ public class ModuleManager {
         registry = new TableModuleRegistry();
         registry.add(engineModule);
 
-        if (doLoadModulesFromClasspath()) {
+        if (doLoadModulesFromClasspath(loadModulesFromClasspath)) {
             loadModulesFromClassPath();
         } else {
             logger.info("Not loading classpath modules.");
@@ -162,14 +166,21 @@ public class ModuleManager {
         return metadataJsonAdapter;
     }
 
-    boolean doLoadModulesFromClasspath() {
+    boolean doLoadModulesFromClasspath(Boolean loadModulesFromClasspath) {
         boolean env = Boolean.parseBoolean(System.getenv(LOAD_CLASSPATH_MODULES_ENV));
         boolean prop = Boolean.getBoolean(LOAD_CLASSPATH_MODULES_PROPERTY);
-        logger.debug("Load modules from classpath? {} [env: {}, property: {}]",
-                env || prop,
+        boolean useClasspath;
+        if (loadModulesFromClasspath != null) {
+            useClasspath = loadModulesFromClasspath;
+        } else {
+            useClasspath = env || prop;
+        }
+        logger.debug("Load modules from classpath? {} [arg: {}, env: {}, property: {}]",
+                useClasspath,
+                loadModulesFromClasspath,
                 System.getenv(LOAD_CLASSPATH_MODULES_ENV),
                 System.getProperty(LOAD_CLASSPATH_MODULES_PROPERTY));
-        return env || prop;
+        return useClasspath;
     }
 
     /**


### PR DESCRIPTION
Tests using engine-test's [HeadlessEnvironment](https://github.com/MovingBlocks/Terasology/blob/ecb5c56a3b2c3e80caef64524b01f5c76fc4b2ed/engine-tests/src/main/java/org/terasology/HeadlessEnvironment.java#L104) have a lot in common with the issues in https://github.com/Terasology/ModuleTestingEnvironment/pull/41, so they could use the same sort of treatment, which is "turn on classpath module loading until we have a better idea."

This change to HeadlessEnvironment is a more general solution than that in https://github.com/Terasology/Pathfinding/pull/57, possible because HeadlessEnvironment directly creates its own ModuleManager so we don't need to try to indirectly influence ModuleManager creation by something in the global environment.

This PR is built on #4573 because they both modify ModuleManagerFactory. 


### How to test

Run tests involving HeadlessEnvironment or WorldProvidingHeadlessEnvironment. Check the [Unhealthy Modules](http://jenkins.terasology.io/teraorg/job/Terasology/job/Modules/view/Unhealthy/) list on Jenkins, try running those tests under gradle locally, and see if this branch makes the number of failures go down or change in useful ways.