### PR TITLE
fix: trigger update for location component for physics update

### DIFF
--- a/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/physics/bullet/BulletPhysics.java
@@ -890,11 +890,13 @@ public class BulletPhysics implements PhysicsEngine {
 
         @Override
         public void setLinearVelocity(Vector3f value) {
+            rb.activate();
             rb.setLinearVelocity(value);
         }
 
         @Override
         public void setAngularVelocity(Vector3f value) {
+            rb.activate();
             rb.setAngularVelocity(value);
         }
 
@@ -908,9 +910,6 @@ public class BulletPhysics implements PhysicsEngine {
         public void setLocation(Vector3f location) {
             Matrix4f translation = rb.getWorldTransform();
             Quaternionf quaternion = new Quaternionf().setFromUnnormalized(translation);
-
-//            Quat4f quaternion = new Quat4f();
-//            quaternion.set(translation);
 
             rb.setWorldTransform(new Matrix4f().translationRotateScale(location, quaternion, 1.0f));
 

--- a/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
+++ b/engine/src/main/java/org/terasology/physics/engine/PhysicsSystem.java
@@ -190,6 +190,11 @@ public class PhysicsSystem extends BaseComponentSystem implements UpdateSubscrib
             RigidBodyComponent comp = entity.getComponent(RigidBodyComponent.class);
             RigidBody body = physics.getRigidBody(entity);
 
+            // force location component to update and sync trigger state
+            if(entity.hasComponent(TriggerComponent.class)) {
+                physics.updateTrigger(entity);
+            }
+
             if (body.isActive()) {
                 body.getLinearVelocity(comp.velocity);
                 body.getAngularVelocity(comp.angularVelocity);


### PR DESCRIPTION
rigidbody triggers can get out of sync with rigid-bodies so its possible to push an object and have it change location while the trigger stays in a fixed location. 