### PR TITLE
test(modules): set default test case timeout to four minutes

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -182,6 +182,11 @@ tasks.named("jar") {
     finalizedBy("cleanReflections")
 }
 
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+    systemProperty("junit.jupiter.execution.timeout.default", "4m")
+}
+
 // Prep an IntelliJ module for the Terasology module - yes, might want to read that twice :D
 configure<IdeaModel> {
     module {


### PR DESCRIPTION
This should cause Jupiter to interrupt if any test case or setup method takes longer than four minutes to run.