### PR TITLE
ModuleManager: ensure engine module is always present in environment

### DIFF
--- a/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/module/ModuleManager.java
@@ -67,6 +67,7 @@ public class ModuleManager {
     private ModuleEnvironment environment;
     private final ModuleMetadataJsonAdapter metadataReader;
     private final ModuleInstallManager installManager;
+    private Module engineModule;
 
     public ModuleManager(String masterServerAddress) {
         this(masterServerAddress, Collections.emptyList());
@@ -77,7 +78,7 @@ public class ModuleManager {
 
         metadataReader = newMetadataReader();
 
-        Module engineModule = loadEngineModule(classesOnClasspathsToAddToEngine);
+        engineModule = loadEngineModule(classesOnClasspathsToAddToEngine);
 
         registry = new TableModuleRegistry();
         registry.add(engineModule);
@@ -286,6 +287,7 @@ public class ModuleManager {
 
     public ModuleEnvironment loadEnvironment(Set<Module> modules, boolean asPrimary) {
         Set<Module> finalModules = Sets.newLinkedHashSet(modules);
+        finalModules.add(engineModule);
         ModuleEnvironment newEnvironment;
         boolean permissiveSecurityEnabled = Boolean.parseBoolean(System.getProperty(SystemConfig.PERMISSIVE_SECURITY_ENABLED_PROPERTY));
         if (permissiveSecurityEnabled) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

Should fix crash upon returning to menu from in-game state. I think the commit that initially caused this bug was 8ae06f0df3233422d397da23119b7bf97d8e99d4, but I have not tested the revision before.