### PR TITLE
fix(player): target box not disappearing when target is removed

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
@@ -120,6 +120,7 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     private int inputSequenceNumber = 1;
 
     private AABBf aabb = new AABBf();
+    private boolean hasTarget = false;
 
     public void setPlayerCamera(Camera camera) {
         playerCamera = camera;
@@ -356,7 +357,8 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     @ReceiveEvent
     public void onTargetChanged(PlayerTargetChangedEvent event, EntityRef entity) {
         EntityRef target = event.getNewTarget();
-        if (target.exists()) {
+        hasTarget = target.exists();
+        if (hasTarget) {
             LocationComponent location = target.getComponent(LocationComponent.class);
             if (location != null) {
                 BlockComponent blockComp = target.getComponent(BlockComponent.class);
@@ -379,11 +381,9 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     @Override
     public void renderOverlay() {
         // Display the block the player is aiming at
-        if (config.getRendering().isRenderPlacingBox()) {
-            if (aabb != null) {
-                aabbRenderer.setAABB(aabb);
-                aabbRenderer.render();
-            }
+        if (config.getRendering().isRenderPlacingBox() && hasTarget) {
+            aabbRenderer.setAABB(aabb);
+            aabbRenderer.render();
         }
     }
 


### PR DESCRIPTION
### Contains
Fixes a bug where the target indication box does not disappear when the player points at a block that is not within range.

### How to test
- Open a world, hover over a block and rotate the camera upwards so no block is in range. The target indication box for the most recently targeted block should still be present.
- Apply the PR and repeat. The indication box should instead disappear.
