### PR TITLE
fix(PathManager): avoid calling Files method on paths that may not exist yet

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/paths/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/paths/PathManager.java
@@ -341,7 +341,7 @@ public final class PathManager {
         Path homeModPath = homePath.resolve(MODULE_DIR);
         Path modCachePath = homePath.resolve(MODULE_CACHE_DIR);
 
-        if (Files.isSameFile(homePath, installPath)) {
+        if (homePath == installPath) {
             return ImmutableList.of(modCachePath, homeModPath);
         } else {
             Path installModPath = installPath.resolve(MODULE_DIR);


### PR DESCRIPTION
Fixes #4587 

I've reached the point in the day when I'm wondering

_is it `==` or `.equals()`?_

_how does Java work?_

_what am I going to do about dinner?_