### PR TITLE
Don't move the camera when window is refocused

### DIFF
--- a/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
@@ -60,8 +60,6 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
         DoubleBuffer mouseY = BufferUtils.createDoubleBuffer(1);
 
         GLFW.glfwGetCursorPos(window, mouseX, mouseY);
-        mouseX.rewind();
-        mouseY.rewind();
 
         double x = mouseX.get(0);
         double y = mouseY.get(0);
@@ -128,8 +126,6 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
             DoubleBuffer mouseY = BufferUtils.createDoubleBuffer(1);
 
             GLFW.glfwGetCursorPos(window, mouseX, mouseY);
-            mouseX.rewind();
-            mouseY.rewind();
 
             xpos = mouseX.get(0);
             ypos = mouseY.get(0);

--- a/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
@@ -50,6 +50,7 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
     public void registerToLwjglWindow(long window) {
         GLFW.glfwSetMouseButtonCallback(window, this::mouseButtonCallback);
         GLFW.glfwSetScrollCallback(window, this::scrollCallback);
+        GLFW.glfwSetWindowFocusCallback(window, this::focusCallback);
     }
 
     @Override
@@ -120,6 +121,26 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(RenderingConfig.UI_SCALE)) {
             this.uiScale = this.renderingConfig.getUiScale() / 100f;
+        }
+    }
+
+    private void focusCallback(long window, boolean isFocused) {
+        // When the window is unfocused and focused again, the mouse coordinates
+        // reported by GLFW change even if the mouse hasn't moved.
+        // So when the window regains focus, we set the new position as the reference without generating deltas.
+        if (isFocused) {
+            DoubleBuffer mouseX = BufferUtils.createDoubleBuffer(1);
+            DoubleBuffer mouseY = BufferUtils.createDoubleBuffer(1);
+
+            GLFW.glfwGetCursorPos(window, mouseX, mouseY);
+            mouseX.rewind();
+            mouseY.rewind();
+
+            double x = mouseX.get(0);
+            double y = mouseY.get(0);
+    
+            this.xpos = x;
+            this.ypos = y;
         }
     }
 

--- a/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
@@ -63,10 +63,6 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
         mouseX.rewind();
         mouseY.rewind();
 
-        GLFW.glfwGetCursorPos(window, mouseX, mouseY);
-        mouseX.rewind();
-        mouseY.rewind();
-
         double x = mouseX.get(0);
         double y = mouseY.get(0);
 
@@ -83,7 +79,6 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
 
     @Override
     public Vector2d getDelta() {
-
         Vector2d result = new Vector2d(xposDelta, yposDelta);
         return result;
     }

--- a/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
@@ -136,11 +136,8 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
             mouseX.rewind();
             mouseY.rewind();
 
-            double x = mouseX.get(0);
-            double y = mouseY.get(0);
-    
-            this.xpos = x;
-            this.ypos = y;
+            xpos = mouseX.get(0);
+            ypos = mouseY.get(0);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Fix the camera position resetting to look at the sky when the window is unfocused and then focused again. It just resets the mouse position whenever the window is focused, which also means that if you unfocus, move the mouse, and focus again, the camera doesn't move.

### How to test

Start the game, move the camera, alt-tab to another window, then alt-tab back. The camera shouldn't move.