### PR TITLE
Fixing spelling.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,5 +12,5 @@
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/engine/src/main/java/org/terasology/engine/utilities/procedural/SimplexNoise.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/procedural/SimplexNoise.java
@@ -70,7 +70,7 @@ public class SimplexNoise extends AbstractNoise implements Noise2D, Noise3D {
     /**
      * Initialize permutations with a given seed and grid dimension.
      * Supports 1D tileable noise
-     * @see SimplexNoise#tileable1DMagicNumber
+     * @see SimplexNoise#TILEABLE1DMAGICNUMBER
      *
      * @param seed a seed value used for permutation shuffling
      * @param gridDim gridDim x gridDim will be the number of squares in the square grid formed after skewing the simplices belonging to once "tile"


### PR DESCRIPTION
File - https://github.com/mahela97/Terasology/blob/2aa5cbbf6b08bdf8826acc3b3f8517815df9eb5c/engine/src/main/java/org/terasology/engine/utilities/procedural/SimplexNoise.java

Line -73

### Contains

Fix spelling errors in the documentation. The correct name of the variable is TILEABLE1DMAGICNUMBER.

- Before it was  ->
@see SimplexNoise#tileable1DMagicNumber

- Now ->
@see SimplexNoise#TILEABLE1DMAGICNUMBER
