### PR TITLE
fix: auto-correct window resolution if set to (0,0)

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphics.java
@@ -60,6 +60,12 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         this.engine = gameEngine;
         this.context = rootContext;
         this.config = context.get(Config.class).getRendering();
+        if (config.getWindowHeight()<=0 && config.getWindowWidth()<=0){
+            config.setWindowPosX(379);
+            config.setWindowPosY(235);
+            config.setWindowWidth(1280);
+            config.setWindowHeight(800);
+        }
         lwjglDisplay = new LwjglDisplayDevice(context);
         context.put(DisplayDevice.class, lwjglDisplay);
         logger.info("Initial initialization complete");


### PR DESCRIPTION
### Contains

This PR will fix the Bug mentioned here #4596

### How to test

Close the game when it is minimized and open the game again. Game window resolution will set to default values.


