### PR TITLE
fix: avoid writing window size of 0 to the config Re: #4601

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphics.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphics.java
@@ -44,6 +44,12 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
     private Context context;
     private RenderingConfig config;
 
+    private int defaultHeight;
+    private int defaultWidth;
+
+    private int defaultX;
+    private int defaultY;
+
     private GameEngine engine;
     private LwjglDisplayDevice lwjglDisplay;
 
@@ -60,6 +66,10 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
         this.engine = gameEngine;
         this.context = rootContext;
         this.config = context.get(Config.class).getRendering();
+        defaultHeight = config.getWindowHeight();
+        defaultWidth = config.getWindowWidth();
+        defaultX = config.getWindowPosX();
+        defaultY = config.getWindowPosY();
         lwjglDisplay = new LwjglDisplayDevice(context);
         context.put(DisplayDevice.class, lwjglDisplay);
         logger.info("Initial initialization complete");
@@ -108,14 +118,22 @@ public class LwjglGraphics extends BaseLwjglSubsystem {
                 int[] xBuffer = new int[1];
                 int[] yBuffer = new int[1];
                 GLFW.glfwGetWindowPos(window, xBuffer, yBuffer);
-                config.setWindowPosX(xBuffer[0]);
-                config.setWindowPosY(yBuffer[0]);
 
                 int[] widthBuffer = new int[1];
                 int[] heightBuffer = new int[1];
                 GLFW.glfwGetWindowSize(window, widthBuffer, heightBuffer);
-                config.setWindowWidth(widthBuffer[0]);
-                config.setWindowHeight(heightBuffer[0]);
+                if (widthBuffer[0]<= 0 && heightBuffer[0]<=0){
+                    config.setWindowPosX(defaultX);
+                    config.setWindowPosY(defaultY);
+                    config.setWindowWidth(defaultWidth);
+                    config.setWindowHeight(defaultHeight);
+                }else{
+                    config.setWindowPosX(xBuffer[0]);
+                    config.setWindowPosY(yBuffer[0]);
+                    config.setWindowWidth(widthBuffer[0]);
+                    config.setWindowHeight(heightBuffer[0]);
+                }
+
             }
         }
     }


### PR DESCRIPTION
### Contains

This PR will fix the Bug mentioned here #4596.  


Approach - As in the suggestions in #4601, Now the config file doesn't end up writing zeros to the config.

### How to test

Close the game when it is minimized and open the game again. Game window resolution will set to default values.

