### PR TITLE
TeraNUI 3.0 update: Implemented `UISkinTypeHandler.getAsString`

### DIFF
--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/UISkinTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/UISkinTypeHandler.java
@@ -4,6 +4,9 @@
 package org.terasology.engine.persistence.typeHandling.extensionTypes;
 
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.rendering.nui.skin.UISkinWithUrn;
 import org.terasology.engine.utilities.Assets;
 import org.terasology.nui.skin.UISkin;
 import org.terasology.nui.skin.UISkinAsset;
@@ -12,13 +15,19 @@ import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 import java.util.Optional;
 
 public class UISkinTypeHandler extends StringRepresentationTypeHandler<UISkin> {
+    private static final Logger logger = LoggerFactory.getLogger(UISkinTypeHandler.class);
+
     @Override
     public String getAsString(UISkin item) {
         if (item == null) {
             return "";
+        } else if (item instanceof UISkinWithUrn) {
+            return ((UISkinWithUrn) item).getUrn().toString();
+        } else {
+            // Can't associate UISkin with urn.
+            logger.warn("Couldn't associate UISkin with urn. Unable to serialize.");
+            return "";
         }
-        // TODO
-        return item.toString();
     }
 
     @Override
@@ -28,7 +37,7 @@ public class UISkinTypeHandler extends StringRepresentationTypeHandler<UISkin> {
         }
         Optional<UISkinAsset> asset = Assets.get(representation, UISkinAsset.class);
         if (asset.isPresent()) {
-            return asset.get().getSkin();
+            return UISkinWithUrn.createFromSkin(asset.get().getSkin(), asset.get().getUrn());
         }
         return null;
     }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinWithUrn.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinWithUrn.java
@@ -1,0 +1,33 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.nui.skin;
+
+import org.terasology.assets.ResourceUrn;
+import org.terasology.nui.skin.UISkin;
+import org.terasology.nui.skin.UIStyleFamily;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UISkinWithUrn extends UISkin {
+    private final ResourceUrn urn;
+
+    public UISkinWithUrn(Map<String, UIStyleFamily> skinFamilies, ResourceUrn urn) {
+        super(skinFamilies);
+        this.urn = urn;
+    }
+
+    public static UISkinWithUrn createFromSkin(UISkin skin, ResourceUrn urn) {
+        Map<String, UIStyleFamily> skinFamilies = new HashMap<>();
+        for (String family : skin.getFamilies()) {
+            skinFamilies.put(family, skin.getFamily(family));
+        }
+
+        return new UISkinWithUrn(skinFamilies, urn);
+    }
+
+    public ResourceUrn getUrn() {
+        return urn;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinWithUrn.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinWithUrn.java
@@ -10,6 +10,12 @@ import org.terasology.nui.skin.UIStyleFamily;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * [NOTE] Sub-classing UISkin into UISkinWithUrn is a work-around in order to associate a ResourceUrn with a UISkin.
+ * When a UISkin is deserialised (via UISkinTypeHandler), then it is copied into a new UISkinWithUrn instance to associate it with the urn it was deserialised with.
+ *
+ * (2021-03-31) It is not clear whether this feature is used anywhere (in the Omega module space) right now.
+ */
 public class UISkinWithUrn extends UISkin {
     private final ResourceUrn urn;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Description
This pull request attempts to resolve https://github.com/MovingBlocks/Terasology/pull/4598#discussion_r600276900 through a work-around involving sub-classing `UISkin` into `UISkinWithUrn` in order to associate a `ResourceUrn` with it. When a `UISkin` is deserialised, then it is copied into a new `UISkinWithUrn` instance to associate it with the urn it was deserialised with.
### How to test
I haven't found anywhere where the serialisation part of this code is used yet whilst debugging, so I am not sure how to test this.
### Notes
This is based off #4598 and, if merged, should be merged into it.
