### PR TITLE
fix: could place blocks inside the player

### DIFF
--- a/engine/src/main/java/org/terasology/engine/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/engine/physics/bullet/BulletPhysics.java
@@ -183,7 +183,7 @@ public class BulletPhysics implements PhysicsEngine {
         List<EntityRef> result = Lists.newArrayList();
         for (int i = 0; i < scanObject.getNumOverlappingObjects(); ++i) {
             btCollisionObject other = scanObject.getOverlappingObject(i);
-            Object userObj = other.getUserPointer();
+            Object userObj = other.userData;
             if (userObj instanceof EntityRef) {
                 result.add((EntityRef) userObj);
             }

--- a/engine/src/main/java/org/terasology/engine/world/block/items/BlockItemSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/items/BlockItemSystem.java
@@ -42,7 +42,7 @@ public class BlockItemSystem extends BaseComponentSystem {
      * Margin and other allowed penetration is also 0.03 or 0.04. Since precision is only float it needs to be that
      * high.
      */
-    private static final float ADDITIONAL_ALLOWED_PENETRATION = 0.4f;
+    private static final float ADDITIONAL_ALLOWED_PENETRATION = 0.04f;
 
     @In
     private WorldProvider worldProvider;
@@ -193,13 +193,13 @@ public class BlockItemSystem extends BaseComponentSystem {
             /*
              * Calculations aren't exact and in the corner cases it is better to let the user place the block.
              */
-            blockBounds.minX -= ADDITIONAL_ALLOWED_PENETRATION;
-            blockBounds.minY -= ADDITIONAL_ALLOWED_PENETRATION;
-            blockBounds.minZ -= ADDITIONAL_ALLOWED_PENETRATION;
+            blockBounds.minX += ADDITIONAL_ALLOWED_PENETRATION;
+            blockBounds.minY += ADDITIONAL_ALLOWED_PENETRATION;
+            blockBounds.minZ += ADDITIONAL_ALLOWED_PENETRATION;
 
-            blockBounds.maxX += ADDITIONAL_ALLOWED_PENETRATION;
-            blockBounds.maxY += ADDITIONAL_ALLOWED_PENETRATION;
-            blockBounds.maxZ += ADDITIONAL_ALLOWED_PENETRATION;
+            blockBounds.maxX -= ADDITIONAL_ALLOWED_PENETRATION;
+            blockBounds.maxY -= ADDITIONAL_ALLOWED_PENETRATION;
+            blockBounds.maxZ -= ADDITIONAL_ALLOWED_PENETRATION;
 
 
             return physics.scanArea(blockBounds, StandardCollisionGroup.DEFAULT, StandardCollisionGroup.CHARACTER).isEmpty();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Disallows placing blocks inside the player. The restriction on placing blocks inside colliders was broken, so you could place blocks inside of yourself. This was mentioned briefly in the org meeting as a problem with jumping and placing blocks below you.

It turns out it was due to calling `btCollisionObject.getUserPointer()` to get a collider's attached entity, which returns a `long` which casts implicitly into an `Object` through `Long`, instead of getting `.userData`. The entity data is set with `.userData`, so it should be accessed the same way.

The margins of the bounding box had been messed up at some point as well, making it so you couldn't place blocks near the player, so I put them back to a reasonable position.

### How to test

Try looking down and placing blocks inside your feet - it shouldn't work. You should still be able to place blocks near you: try walking up to a block at waist height and placing one on top of it, or placing a block next to the one you're standing on.
