### PR TITLE
Fix: Gitignore some more files that Intellij automatically generates.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -10,13 +10,8 @@ workspace.xml
 # Shelf is where it put changes you're not ready to share. (it's like git stash)
 /shelf
 
-# Dictionaries: do not ignore!
-#  /dictionaries
-# Yes, it makes a new file for each user, but JetBrains product manager Dmitry Jemerov explains:
-#
-# >    The dictionary is not in fact per-user; the spellchecker uses words from all users'
-# >    dictionaries for checking the spelling.
-#          — https://youtrack.jetbrains.com/issue/WI-45679#focus=streamItem-27-3457290.0-0
+# Dictionaries: automatically generated per user
+/dictionaries
 
 # managed by gradle sync
 /gradle.xml
@@ -33,6 +28,8 @@ workspace.xml
 /uiDesigner.xml
 /modules.xml
 /modules
+/inspectionProfiles
+/libraries-with-intellij-classes.xml
 
 # Ignore Sonar linting, if set up locally
 /sonarlint/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -10,8 +10,13 @@ workspace.xml
 # Shelf is where it put changes you're not ready to share. (it's like git stash)
 /shelf
 
-# Dictionaries: automatically generated per user
-/dictionaries
+# Dictionaries: do not ignore!
+#  /dictionaries
+# Yes, it makes a new file for each user, but JetBrains product manager Dmitry Jemerov explains:
+#
+# >    The dictionary is not in fact per-user; the spellchecker uses words from all users'
+# >    dictionaries for checking the spelling.
+#          — https://youtrack.jetbrains.com/issue/WI-45679#focus=streamItem-27-3457290.0-0
 
 # managed by gradle sync
 /gradle.xml


### PR DESCRIPTION
IntelliJ automatically generated these files in my workspace, but they are just empty or relate to local display preferences or something. I assume other people have been running into the same issue. Anyway, they aren't actually part of any changes I've made to the project and they don't need to be shared, but they show up as changed in git, which is annoying, so this should fix that.

There was an explicit comment previously about why dictionaries were not gitignored, even though it generates one per user, that the dictionaries are actually meant to be shared. There's some discussion about it at https://youtrack.jetbrains.com/issue/IDEA-208431, which seems to mostly be the Jetbrains staff arguing with their users that it's working as intended, and the users arguing that they don't want it to work this way. Sharing dictionaries doesn't sound like that useful a feature, and I haven't even got any entries in my dictionary but it still generated a file with an empty list, which I then have to ignore manually every time I'm staging changes.