### PR TITLE
logistics: use new pre-cached builder image in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ properties([
 ])
 
 // Main pipeline definition
-node ("heavy-java") {
+node ("ts-engine && heavy && java8") {
     stage('Checkout') {
         echo "Going to check out the things !"
         checkout scm

--- a/templates/gradle.properties
+++ b/templates/gradle.properties
@@ -2,8 +2,7 @@
 # In Jenkins builds will default to "plain" and rich/verbose logging doesn't print right at all
 org.gradle.console=verbose
 
-# These settings can speed up the execution of Gradle (and some may be set this way by default anyway)
-org.gradle.daemon=true
+# These settings may speed up the execution of Gradle or otherwise affect performance (daemon is on by default)
 org.gradle.parallel=false
 org.gradle.configureondemand=false
 org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
## Contains

Changes the label for the engine build to a new one, defined presently using https://github.com/Cervator/pre-cached-jenkins-agent (that repo will likely move and might itself get a build in our Jenkins but - one step at a time) - see its repo readme for more technical details.

In short the goal is to use a Docker build of a custom Jenkins agent to pre-cache our main dependencies (at the moment for the TS engine, joml-ext, and modules), as well as pre-download the files needed for each Gradle wrapper version.

This PR also removes the already-default setting for the Gradle Daemon in case any attempts to experiment are desired elsewhere (has no effect normally). Loooong time since that actually mattered, the setting was changed to true by default years ago.

Label reasoning goes with a potential later change to make light/medium/heavy agents (again), easily vary the version of Java (plus make it more explicit/visible), easily vary / diversify agents later for different archetypes (Terasology engine build vs Destination Sol engine build including Android, for instance)

## How to test

Logistics change - tested in Jenkins already. No particular way to test this separately, can just look at the job execution on the Nanoware forks

Performance stats are hard to narrow down since builds may differ in duration based on what else is going on in the cluster. I tried to closely watch a few of them to make sure the system was otherwise idle to guesstimate "best case" improvements

* [Nanoware/Terasology:develop build](http://jenkins.terasology.io/teraorg/job/Nanoware/job/Terasology/job/develop/) & [Nanoware/Terasology:customAgent build](http://jenkins.terasology.io/teraorg/job/Nanoware/job/Terasology/job/customAgent/ ) vs [Existing MovingBlocks/Terasology:develop build](http://jenkins.terasology.io/teraorg/job/Terasology/job/engine/job/develop/) - Build (compile) step is faster, from 1-3 minutes (up to 50%), but analytics still take way longer so overall impact isn't huge.
* [Nanoware/joml-ext build](http://jenkins.terasology.io/teraorg/job/Nanoware/job/joml-ext/job/main/) vs [MovingBlocks/joml-ext build](http://jenkins.terasology.io/teraorg/job/Libraries/job/joml-ext/job/main/) - 20s improvement, about 33% faster overall than before
* [Nanoware/Sample build](http://jenkins.terasology.io/teraorg/job/Nanoware/job/TerasologyModules/job/H/job/Sample/job/develop/) vs [Terasology/Sample build](http://jenkins.terasology.io/teraorg/job/Terasology/job/Modules/job/S/job/Sample/job/develop/) - nearly 66% reduction in average compile time leads to an overall 50% faster build - just from pre-caching dependencies, including the engine jar in this case 🚀 


## Outstanding before merging

- [ ] This PR goes along with one in the module Jenkinsfile repo - https://github.com/MovingBlocks/ModuleJteConfig/pull/8
- [ ] Doubt: What happens if a module build starts with a snapshot jar of the engine in its Gradle cache, but a newer snapshot is available in Artifactory? We could skip the optimization for module builds until more experimentation can occur.
- [ ] Haven't applied it to joml-ext as that was just a handy test candidate for a tiny lib build. More to come on how to apply this more broadly, but have some more ideas to explore first - could push it over there too tho