### PR TITLE
logistics: Replace usage of jcenter (shutting down)

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 
     maven {
         name = "Terasology Artifactory"

--- a/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
@@ -5,13 +5,11 @@ import java.net.URI
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    // External libs - jcenter is Bintray and a superset of Maven Central
-    jcenter {
+    mavenCentral {
         content {
             // This is first choice for most java dependencies, but assume we'll need to check our
             // own repository for things from our own organization.
-            // (This is an optimization so gradle doesn't try to find our hundreds of modules
-            // in jcenter.)
+            // (This is an optimization so gradle doesn't try to find our hundreds of modules in 3rd party repos)
             excludeGroupByRegex("""org\.terasology(\..+)?""")
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,6 @@
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
-        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
 
@@ -75,8 +73,6 @@ ext {
 
 // Declare remote repositories we're interested in - library files will be fetched from here
 repositories {
-    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-    jcenter()
     mavenCentral()
 
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -3,7 +3,8 @@ import groovy.json.JsonSlurper
 @Grab(group = 'org.slf4j', module = 'slf4j-api', version = '1.6.1')
 @Grab(group = 'org.slf4j', module = 'slf4j-nop', version = '1.6.1')
 
-@GrabResolver(name = 'jcenter', root = 'http://jcenter.bintray.com/')
+// TODO: Temp replacement for jcenter, grgit is not in MavenCentral yet
+@GrabResolver(name = 'ajoberstar-backup', root = 'https://ajoberstar.github.io/bintray-backup/')
 @Grab(group = 'org.ajoberstar', module = 'grgit', version = '1.9.3')
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.exception.GrgitException

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -4,8 +4,6 @@
 // Alternatively we untangle and update the common.gradle / Kotlin Gradle plugin stuff or just remove these two
 buildscript {
     repositories {
-        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-        jcenter()
         mavenCentral()
         maven {
             url = uri("https://plugins.gradle.org/m2/")

--- a/templates/facades.gradle
+++ b/templates/facades.gradle
@@ -6,8 +6,6 @@ apply plugin: 'pmd'
 
 // Same repository configuration as root project
 repositories {
-    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-    jcenter()
     mavenCentral()
 
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs


### PR DESCRIPTION
### Contains

Replaces/removes `jcenter` usage. Fixes #4582, for the engine repo at least, both regular Gradle bits and a Groovy hit.

There are / will be a few more PRs for other repos, that's tracked decently in Trello even if the engine issue auto-closes with this PR getting merged.

Seems to work after local testing and http://jenkins.terasology.io/teraorg/job/Nanoware/job/Terasology/job/jCenter/

Also tested it in that develop branch to get a build harness to try with the Sample module, just in case: http://jenkins.terasology.io/teraorg/job/Nanoware/job/TerasologyModules/job/H/job/Sample/job/develop/6/

### How to test

* Make sure the project can still be built from scratch using Gradle, with `--refresh-dependencies` thrown in or the local Gradle cache deleted
* Probably also try a super duper clean build of some sort in IntelliJ? Not sure how to make it force-refresh dependencies tho
* Make sure `groovyw` utility commands using Git actions still work

You can also confirm that Gradle can still fetch all the dependency things by adding this little snippet to, say, the `build.gradle` in the engine dir:

```
task getDeps(type: Copy) {
    from sourceSets.main.runtimeClasspath
    into 'pullRuntimeClasspathDeps/'
}
```

`engine/pullRuntimeClasspathDeps` should end up containing a bunch of things if you run `gradlew engine:getDeps` - including the `trove4j-3.0.3.jar` that had been brought up at some point as possibly causing trouble. It seemed to fetch no problem and does exist at the right version in Maven Central, so I dunno what the problem was there.