### PR TITLE
build(modules): improve matching of compatible versions in module deps

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation("dom4j:dom4j:1.6.1")
 
     // for inspecting modules
-    implementation("org.terasology.gestalt:gestalt-module:7.0.6-SNAPSHOT")
+    implementation("org.terasology.gestalt:gestalt-module:7.1.0-SNAPSHOT")
 
     api(kotlin("test"))
 }

--- a/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
@@ -8,6 +8,7 @@ import org.terasology.gestalt.module.ModuleMetadata
 import org.terasology.gestalt.module.ModuleMetadataJsonAdapter
 import org.terasology.gestalt.module.dependencyresolution.DependencyInfo
 import org.terasology.gestalt.naming.Version
+import org.terasology.gestalt.naming.VersionRange
 import java.io.File
 
 
@@ -72,7 +73,15 @@ class ModuleMetadataForGradle(private val moduleConfig: ModuleMetadata) {
             // sounds complicated.)
         }
 
-        val gradleDep = GradleDependencyInfo(TERASOLOGY_MODULES_GROUP, gestaltDependency.id.toString(), gestaltDependency.versionRange().toString())
+        val version = if (gestaltDependency.versionPredicate() is VersionRange) {
+            gestaltDependency.versionPredicate().toString()
+        } else {
+            // TODO: gradle-compatible version expressions for gestalt dependencies
+            //     https://github.com/MovingBlocks/gestalt/issues/114
+            gestaltDependency.minVersion.toString();
+        }
+
+        val gradleDep = GradleDependencyInfo(TERASOLOGY_MODULES_GROUP, gestaltDependency.id.toString(), version)
         return Pair(gradleDep, gestaltDependency.isOptional)
     }
 }

--- a/engine-tests/src/main/java/org/terasology/unittest/stubs/package-info.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/stubs/package-info.java
@@ -1,0 +1,7 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+@API
+package org.terasology.unittest.stubs;
+
+import org.terasology.gestalt.module.sandbox.API;


### PR DESCRIPTION
by avoiding use of gestalt.VersionRange

I'm not too worried about this PR needing review, but having build-related things seen by another set of eyes is always good.

the package-info in engine-test isn't really related, it's a stowaway