### PR TITLE
build(module_build): use same DependencyInfo -> String logic for modules and engine

### DIFF
--- a/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
@@ -77,15 +77,6 @@ class ModuleMetadataForGradle(private val moduleConfig: ModuleMetadata) {
     }
 
     private fun gradleModule(gestaltDependency: DependencyInfo): Pair<GradleDependencyInfo, Boolean> {
-        if (!gestaltDependency.minVersion.isSnapshot) {
-            // gestalt considers snapshots to satisfy a minimum requirement:
-            // https://github.com/MovingBlocks/gestalt/blob/fe1893821127/gestalt-module/src/main/java/org/terasology/naming/VersionRange.java#L58-L59
-            gestaltDependency.minVersion = gestaltDependency.minVersion.snapshot
-            // (maybe there's some way to do that with a custom gradle resolver?
-            // but making a resolver that only works that way on gestalt modules specifically
-            // sounds complicated.)
-        }
-
         val version = versionStringFromGestaltDependency(gestaltDependency)
 
         val gradleDep = GradleDependencyInfo(TERASOLOGY_MODULES_GROUP, gestaltDependency.id.toString(), version)


### PR DESCRIPTION
**Problem:** In https://github.com/MovingBlocks/gestalt/pull/115 we changed the semantics of module version resolution to no longer include the SNAPSHOT to satisfy a non-snapshot `minVersion`. We also removed the `DependencyInfo::versionRange` accessor as it seemed to be no longer in use.

However, we missed that it's actually used in Terasology's module builds.

**Solution:** This PR unifies the way a String representation of the version range is derived from `DependencyInfo`, no longer accessing the now missing `versionRange()` method. 

In addition, it cleans up some of the build file (one corner-case handling became obsolete).

- build(module_build): use same DependencyInfo -> String logic for modules and engine
- build(module_build): remove corner case handling for min SNAPHSOT
