### PR TITLE
chore: simplify logic for getShapeFor

### DIFF
--- a/engine/src/main/java/org/terasology/engine/physics/bullet/BulletPhysics.java
+++ b/engine/src/main/java/org/terasology/engine/physics/bullet/BulletPhysics.java
@@ -14,6 +14,7 @@ import com.badlogic.gdx.physics.bullet.collision.btCollisionConfiguration;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionDispatcher;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionObject;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionShape;
+import com.badlogic.gdx.physics.bullet.collision.btConvexHullShape;
 import com.badlogic.gdx.physics.bullet.collision.btConvexShape;
 import com.badlogic.gdx.physics.bullet.collision.btCylinderShape;
 import com.badlogic.gdx.physics.bullet.collision.btDbvtBroadphase;
@@ -50,9 +51,6 @@ import org.terasology.engine.monitoring.PerformanceMonitor;
 import org.terasology.engine.physics.CollisionGroup;
 import org.terasology.engine.physics.HitResult;
 import org.terasology.engine.physics.StandardCollisionGroup;
-import org.terasology.engine.physics.bullet.shapes.BulletBoxShape;
-import org.terasology.engine.physics.bullet.shapes.BulletConvexHullShape;
-import org.terasology.engine.physics.bullet.shapes.BulletSphereShape;
 import org.terasology.engine.physics.components.RigidBodyComponent;
 import org.terasology.engine.physics.components.TriggerComponent;
 import org.terasology.engine.physics.components.shapes.BoxShapeComponent;
@@ -677,11 +675,11 @@ public class BulletPhysics implements PhysicsEngine {
         BoxShapeComponent box = entityRef.getComponent(BoxShapeComponent.class);
         if (box != null) {
             Vector3f halfExtents = new Vector3f(box.extents);
-            return new BulletBoxShape(halfExtents.mul(.5f)).underlyingShape;
+            return new btBoxShape(halfExtents.mul(.5f));
         }
         SphereShapeComponent sphere = entityRef.getComponent(SphereShapeComponent.class);
         if (sphere != null) {
-            return new BulletSphereShape(sphere.radius).underlyingShape;
+            return new btSphereShape(sphere.radius);
         }
         CapsuleShapeComponent capsule = entityRef.getComponent(CapsuleShapeComponent.class);
         if (capsule != null) {
@@ -702,7 +700,7 @@ public class BulletPhysics implements PhysicsEngine {
                 buffer.put(iterator.next());
                 buffer.put(iterator.next());
             }
-            return new BulletConvexHullShape(buffer, numPoints, 3 * Float.BYTES).underlyingShape;
+            return new btConvexHullShape(buffer, numPoints, 3 * Float.BYTES);
         }
         CharacterMovementComponent characterMovementComponent =
             entityRef.getComponent(CharacterMovementComponent.class);


### PR DESCRIPTION
The bulletBoxShape logic is a wrapper that provides the object and passes it back out but the implementation is already self contained within BulletPhyiscs. just easier to instantiate the objects as is then then introduce this extra level of indirection into the code. 