### PR TITLE
chore: replace map with switch for mapping direction

### DIFF
--- a/engine/src/main/java/org/terasology/engine/math/Direction.java
+++ b/engine/src/main/java/org/terasology/engine/math/Direction.java
@@ -3,6 +3,7 @@
 package org.terasology.engine.math;
 
 import com.google.common.collect.Maps;
+import net.logstash.logback.encoder.org.apache.commons.lang.UnhandledException;
 import org.joml.Math;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
@@ -23,28 +24,8 @@ public enum Direction {
     FORWARD(new Vector3i(0, 0, 1), new Vector3f(0, 0, 1)),
     DOWN(new Vector3i(0, -1, 0), new Vector3f(0, -1, 0));
 
-    private static final EnumMap<Direction, Direction> REVERSE_MAP;
-    private static final EnumMap<Direction, Side> CONVERSION_MAP;
-
     private final Vector3i vector3iDir;
     private final Vector3f vector3fDir;
-
-    static {
-        REVERSE_MAP = new EnumMap<>(Direction.class);
-        REVERSE_MAP.put(UP, DOWN);
-        REVERSE_MAP.put(LEFT, RIGHT);
-        REVERSE_MAP.put(RIGHT, LEFT);
-        REVERSE_MAP.put(FORWARD, BACKWARD);
-        REVERSE_MAP.put(BACKWARD, FORWARD);
-        REVERSE_MAP.put(DOWN, UP);
-        CONVERSION_MAP = Maps.newEnumMap(Direction.class);
-        CONVERSION_MAP.put(UP, Side.TOP);
-        CONVERSION_MAP.put(DOWN, Side.BOTTOM);
-        CONVERSION_MAP.put(FORWARD, Side.BACK);
-        CONVERSION_MAP.put(BACKWARD, Side.FRONT);
-        CONVERSION_MAP.put(LEFT, Side.RIGHT);
-        CONVERSION_MAP.put(RIGHT, Side.LEFT);
-    }
 
     Direction(Vector3i vector3i, Vector3f vector3f) {
         this.vector3iDir = vector3i;
@@ -67,7 +48,22 @@ public enum Direction {
     }
 
     public Side toSide() {
-        return CONVERSION_MAP.get(this);
+        switch (this) {
+            case UP:
+                return Side.TOP;
+            case DOWN:
+                return Side.BOTTOM;
+            case FORWARD:
+                return Side.BACK;
+            case BACKWARD:
+                return Side.FRONT;
+            case LEFT:
+                return Side.RIGHT;
+            case RIGHT:
+                return Side.LEFT;
+            default:
+                throw new IllegalStateException("Unexpected value: " + this);
+        }
     }
 
     /**
@@ -126,7 +122,22 @@ public enum Direction {
      * @return The opposite side to this side.
      */
     public Direction reverse() {
-        return REVERSE_MAP.get(this);
+        switch (this) {
+            case RIGHT:
+                return LEFT;
+            case LEFT:
+                return RIGHT;
+            case UP:
+                return DOWN;
+            case DOWN:
+                return UP;
+            case FORWARD:
+                return BACKWARD;
+            case BACKWARD:
+                return FORWARD;
+            default:
+                throw new IllegalStateException("Unexpected value: " + this);
+        }
     }
 
 }


### PR DESCRIPTION
The overhead of maintaining a map here is significantly more expensive then just using a simple switch case where the code is optimized with a jump table. I have the de-compiled bytecode to show how this ends up becoming an O(1) operation. The map in principle is also O(1) but you also incur the overhead of all the extra memory allocated on the heap + the additional fetching.  the code uses the ordinal value of the Direction and uses a jump table to jump to a statement and fetch the value. this is also O(1).


```
 0: getstatic     #20                 // Field org/terasology/engine/math/Direction$1.$SwitchMap$org$terasology$engine$math$Direction:[I
       3: aload_0
       4: invokevirtual #21                 // Method ordinal:()I
       7: iaload
       8: tableswitch   { // 1 to 6
                     1: 56
                     2: 60
                     3: 64
                     4: 68
                     5: 52
                     6: 48
               default: 72
          }
      48: getstatic     #10                 // Field LEFT:Lorg/terasology/engine/math/Direction;
      51: areturn
      52: getstatic     #11                 // Field RIGHT:Lorg/terasology/engine/math/Direction;
      55: areturn
      56: getstatic     #13                 // Field DOWN:Lorg/terasology/engine/math/Direction;
      59: areturn
      60: getstatic     #12                 // Field UP:Lorg/terasology/engine/math/Direction;
      63: areturn
      64: getstatic     #15                 // Field BACKWARD:Lorg/terasology/engine/math/Direction;
      67: areturn
      68: getstatic     #14                 // Field FORWARD:Lorg/terasology/engine/math/Direction;
      71: areturn
      72: new           #28                 // class java/lang/IllegalStateException
      75: dup
      76: new           #29                 // class java/lang/StringBuilder
      79: dup
      80: invokespecial #30                 // Method java/lang/StringBuilder."<init>":()V
      83: ldc           #31                 // String Unexpected value:
      85: invokevirtual #32                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
      88: aload_0
      89: invokevirtual #33                 // Method java/lang/StringBuilder.append:(Ljava/lang/Object;)Ljava/lang/StringBuilder;
      92: invokevirtual #34                 // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
      95: invokespecial #35                 // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V

```