### PR TITLE
Fix for version file for launcher + increment to next major release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node ("ts-engine && heavy && java8") {
     stage('Build') {
         // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
         sh './gradlew --console=plain clean extractConfig extractNatives distForLauncher testDist'
-        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/version/versionInfo.properties, natives/**, build-logic/src/**, build-logic/*.kts'
+        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/engine/version/versionInfo.properties, natives/**, build-logic/src/**, build-logic/*.kts'
     }
     stage('Publish') {
         if (specialBranch) {

--- a/engine-tests/src/main/resources/org/terasology/unittest/module.txt
+++ b/engine-tests/src/main/resources/org/terasology/unittest/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "unittest",
-    "version" : "4.4.1-SNAPSHOT",
+    "version" : "5.0.0-SNAPSHOT",
     "displayName" : "Terasology Engine Test",
     "description" : "Engine unit test content"
 }

--- a/engine/src/main/resources/org/terasology/engine/engine-module.txt
+++ b/engine/src/main/resources/org/terasology/engine/engine-module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "engine",
-    "version" : "4.4.1-SNAPSHOT",
+    "version" : "5.0.0-SNAPSHOT",
     "displayName" : "Terasology Engine",
     "description" : "Core engine content"
 }


### PR DESCRIPTION
This quick-fixes https://github.com/Terasology/Index/issues/16 and should let the launcher identify newer Omega zips from Jenkins, as the `versionInfo.properties` is again attached from a slightly updated path then retrieved during the Omega zip making.

Goes with https://github.com/Terasology/Index/pull/17

Additionally I think we're overdue for bumping the engine version to the next major, considering the next release will include the _major_ upgrade to Gestalt v7, that definitely deserves a bump.

If no objections we should also adjust the current milestone accordingly: https://github.com/MovingBlocks/Terasology/milestones/45/edit

And I think #4509 should probably be closed as complete as part of that? I know there are still leftovers floating around, but that core issue seems to deserve its finished status 👍 

Omega fix confirmed with https://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/34/