### PR TITLE
fix: UI in game will get scaled with chaning "Resolution Scale" in world

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -59,6 +59,7 @@ import static org.lwjgl.opengl.GL11.glBlendFunc;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glDisable;
 import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glViewport;
 
 public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyChangeListener {
 
@@ -112,6 +113,9 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+        // TODO: figure out previous call to viewport scaling is handled
+        // changing resolution scaling affect viewport of LWJGLCanvas causing strange scaling artifact.
+        glViewport(0, 0, displayDevice.getWidth(), displayDevice.getHeight());
         projMatrix.setOrtho(0, displayDevice.getWidth(), displayDevice.getHeight(),0,0, 2048f);
         modelMatrixStack.pushMatrix();
         modelMatrixStack.set(new Matrix4f().setTranslation(0,0,-1024));


### PR DESCRIPTION
Changing viewport scaling while in a world will cause the game UI to also scale. glViewport is a bit un-manged so the state of the viewport can get dirty between draw calls.  the viewport is update in WorldRenderImpl.java and in a couple other places in the engine. for StateInGame worldRender is called followed by the UI so the viewport is changed somewhere within worldRender. This doesn't seem like necessarily the correct fix to the problem though. 

There is some strange non-determinism with this that I can't quite pin down. DAG pipeline seems to be pretty non-deterministic with how its initialized and the order of things changes. can't quite pin down the behavior. 

![image](https://user-images.githubusercontent.com/854359/118387000-66f3a280-b5d0-11eb-8389-50b12581c27d.png)

I also managed to run into this issue: https://github.com/MovingBlocks/Terasology/issues/4542 also fiddling with screen scale. some state is getting dirty and causing things to break down the line. 