### PR TITLE
fix: texture3d is deprecated after 120 for nvidia cards

### DIFF
--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/post_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/post_frag.glsl
@@ -31,10 +31,10 @@ uniform mat4 prevViewProjMatrix;
 
 void main() {
 #if !defined (NO_BLUR)
-    vec4 colorBlur = texture2D(texBlur, v_uv0.xy);
+    vec4 colorBlur = texture(texBlur, v_uv0.xy);
 #endif
 
-    float currentDepth = texture2D(texDepth, v_uv0.xy).x * 2.0 - 1.0;
+    float currentDepth = texture(texDepth, v_uv0.xy).x * 2.0 - 1.0;
 //TODO: Separate the underwater shader effect from the depth of field effect - Amrit 'Who'
 /**
  * Calculate blur for depth of field effect and underwater.
@@ -58,7 +58,7 @@ void main() {
     }
 #endif
 
-    vec4 color = texture2D(texScene, v_uv0.xy);
+    vec4 color = texture(texScene, v_uv0.xy);
 
 #if defined (MOTION_BLUR)
     vec4 screenSpaceNorm = vec4(v_uv0.x, v_uv0.y, currentDepth, 1.0);
@@ -76,9 +76,9 @@ void main() {
     blurTexCoord += velocity;
     for(int i = 1; i < MOTION_BLUR_SAMPLES; ++i, blurTexCoord += velocity)
     {
-      vec4 currentColor = texture2D(texScene, blurTexCoord);
+      vec4 currentColor = texture(texScene, blurTexCoord);
 #ifndef NO_BLUR
-      vec4 currentColorBlur = texture2D(texBlur, blurTexCoord);
+      vec4 currentColorBlur = texture(texBlur, blurTexCoord);
 #endif
 
       color += currentColor;
@@ -100,7 +100,7 @@ void main() {
 #endif
 
 #ifdef FILM_GRAIN
-    vec3 noise = texture2D(texNoise, renderTargetSize * (gl_TexCoord[0].xy + noiseOffset) / noiseSize).xyz * 2.0 - 1.0;
+    vec3 noise = texture(texNoise, renderTargetSize * (gl_TexCoord[0].xy + noiseOffset) / noiseSize).xyz * 2.0 - 1.0;
     finalColor.rgb += clamp(noise.xxx * grainIntensity, 0.0, 1.0);
 #endif
 
@@ -110,7 +110,7 @@ void main() {
 
     // Color grading
     vec3 lutOffset = vec3(1.0 / 32.0);
-    finalColor.rgb = texture3D(texColorGradingLut, lutScale * finalColor.rgb + lutOffset).rgb;
+    finalColor.rgb = texture(texColorGradingLut, lutScale * finalColor.rgb + lutOffset).rgb;
 
     gl_FragData[0].rgba = finalColor;
 }


### PR DESCRIPTION
Tereasology won't run on certain nvidia cards because texture3d is deprecated.

ref: https://github.com/MovingBlocks/Terasology/pull/4636
```
13:20:41.276 [main] INFO  o.t.e.rendering.opengl.GLSLShader - Dumped Shader Path: logs/shaders/fragment_engine-post_0.glsl
13:20:41.277 [main] WARN  o.t.e.rendering.opengl.GLSLShader - Shader 'engine:post' failed to compile for features '[]'.

Shader Info: 
0(466) : error C7616: global function texture3D is removed after version 140
0(468) : warning C7533: global variable gl_FragData is deprecated after version 120


13:20:41.280 [main] INFO  o.t.e.rendering.opengl.GLSLShader - Dumped Shader Path: logs/shaders/fragment_engine-post_0.glsl
13:20:41.282 [main] ERROR o.t.engine.core.modes.StateLoading - Error while loading org.terasology.engine.core.modes.loadProcesses.InitialiseWorld@6238b10a
java.lang.RuntimeException: Shader 'engine:post' failed to compile for features '[]'.

Shader Info: 
0(466) : error C7616: global function texture3D is removed after version 140
0(468) : warning C7533: global variable gl_FragData is deprecated after version 120


	at org.terasology.engine.rendering.opengl.GLSLShader.compileShader(GLSLShader.java:350)
	at org.terasology.engine.rendering.opengl.GLSLShader.registerAllShaderPermutations(GLSLShader.java:267)
	at org.terasology.engine.rendering.opengl.GLSLShader.lambda$recompile$1(GLSLShader.java:133)
	at org.terasology.engine.core.subsystem.lwjgl.LwjglGraphicsManager.asynchToDisplayThread(LwjglGraphicsManager.java:130)
	at org.terasology.engine.rendering.opengl.GLSLShader.recompile(GLSLShader.java:132)
	at org.terasology.engine.rendering.ShaderManagerLwjgl.addShaderProgram(ShaderManagerLwjgl.java:155)
	at org.terasology.engine.rendering.ShaderManagerLwjgl.addShaderProgram(ShaderManagerLwjgl.java:147)
	at org.terasology.engine.rendering.ShaderManagerLwjgl.initShaders(ShaderManagerLwjgl.java:51)
	at org.terasology.engine.rendering.world.WorldRendererImpl.initRenderingSupport(WorldRendererImpl.java:178)
	at org.terasology.engine.rendering.world.WorldRendererImpl.<init>(WorldRendererImpl.java:161)
	at org.terasology.engine.core.subsystem.lwjgl.LwjglRenderingSubsystemFactory.createWorldRenderer(LwjglRenderingSubsystemFactory.java:32)
	at org.terasology.engine.core.modes.loadProcesses.InitialiseWorld.step(InitialiseWorld.java:158)
	at org.terasology.engine.core.modes.StateLoading.update(StateLoading.java:240)
	at org.terasology.engine.core.TerasologyEngine.tick(TerasologyEngine.java:495)
	at org.terasology.engine.core.TerasologyEngine.mainLoop(TerasologyEngine.java:456)
	at org.terasology.engine.core.TerasologyEngine.runMain(TerasologyEngine.java:432)
	at org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:398)
	at org.terasology.engine.Terasology.main(Terasology.java:179)
```


replaced texture3d/2d with texture since texture2d/3d appears to be deprecated from the standard: 

https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/texture.xhtml