### PR TITLE
fix: replace gl_TexCoord with v_uv0 for post_frag

### DIFF
--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/post_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/post_frag.glsl
@@ -100,7 +100,7 @@ void main() {
 #endif
 
 #ifdef FILM_GRAIN
-    vec3 noise = texture(texNoise, renderTargetSize * (gl_TexCoord[0].xy + noiseOffset) / noiseSize).xyz * 2.0 - 1.0;
+    vec3 noise = texture(texNoise, renderTargetSize * (v_uv0.xy + noiseOffset) / noiseSize).xyz * 2.0 - 1.0;
     finalColor.rgb += clamp(noise.xxx * grainIntensity, 0.0, 1.0);
 #endif
 


### PR DESCRIPTION
looks like I missed this when migrating post_frag. this can be verified by enabling film grain and verifying that the shader does not crash and the film grain shows up correctly in game. 