### PR TITLE
fix: don't restrict world generators to a certain type of module source

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     implementation("org.mockito:mockito-junit-jupiter:3.7.7")
 
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
+
+    testImplementation("com.google.truth:truth:1.1.2")
+    testImplementation("com.google.truth.extensions:truth-java8-extension:1.1.2")
 }
 
 task copyResourcesToClasses(type:Copy) {

--- a/engine-tests/src/main/java/org/terasology/unittest/stubs/StubWorldGenerator.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/stubs/StubWorldGenerator.java
@@ -1,0 +1,62 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.unittest.stubs;
+
+import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.world.chunks.Chunk;
+import org.terasology.engine.world.generation.EntityBuffer;
+import org.terasology.engine.world.generation.World;
+import org.terasology.engine.world.generator.RegisterWorldGenerator;
+import org.terasology.engine.world.generator.WorldConfigurator;
+import org.terasology.engine.world.generator.WorldGenerator;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@RegisterWorldGenerator(id = "stub", displayName = "Stub")
+public class StubWorldGenerator implements WorldGenerator {
+    private final SimpleUri uri;
+
+    public StubWorldGenerator() {
+        this(new SimpleUri("unittest", "stub"));
+    }
+
+    public StubWorldGenerator(SimpleUri uri) {
+        this.uri = checkNotNull(uri);
+    }
+
+    @Override
+    public SimpleUri getUri() {
+        return uri;
+    }
+
+    @Override
+    public String getWorldSeed() {
+        return null;
+    }
+
+    @Override
+    public void setWorldSeed(String seed) {
+
+    }
+
+    @Override
+    public void createChunk(Chunk chunk, EntityBuffer buffer) {
+
+    }
+
+    @Override
+    public void initialize() {
+
+    }
+
+    @Override
+    public WorldConfigurator getConfigurator() {
+        return null;
+    }
+
+    @Override
+    public World getWorld() {
+        return null;
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/world/generator/internal/WorldGeneratorManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generator/internal/WorldGeneratorManagerTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.world.generator.internal;
+
+import com.google.common.truth.Correspondence;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.context.Context;
+import org.terasology.engine.context.internal.ContextImpl;
+import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.testUtil.ModuleManagerFactory;
+
+import static com.google.common.truth.Truth.assertThat;
+
+class WorldGeneratorManagerTest {
+
+    Context context;
+    WorldGeneratorManager manager;
+
+    @BeforeEach
+    void provideContext() throws Exception {
+        context = new ContextImpl();
+        context.put(ModuleManager.class, ModuleManagerFactory.create());
+    }
+
+    @Test
+    void hasUnittestWorldGenerator() {
+        manager = new WorldGeneratorManager(context);
+        assertThat(manager.getWorldGenerators())
+                .comparingElementsUsing(
+                        Correspondence.transforming(WorldGeneratorInfo::getUri, "info"))
+                .contains(new SimpleUri("unittest:stub"));
+    }
+}

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.6.0'
     implementation "org.terasology:reflections:0.9.12-MB"
     implementation group: 'org.javassist', name: 'javassist', version: '3.27.0-GA'
-    implementation group: 'com.esotericsoftware', name: 'reflectasm', version: '1.11.1'
+    implementation group: 'com.esotericsoftware', name: 'reflectasm', version: '1.11.9'
 
     // Graphics, 3D, UI, etc
     api platform("org.lwjgl:lwjgl-bom:$LwjglVersion")


### PR DESCRIPTION
Fixes #4673.

This seems to have been not as wide in scope as I'd feared. The changes are specific to the UI in Advanced Game Setup.

Instead of changing the conditional to something other than `instanceof DirectoryFileSource`, I removed the conditional entirely. Not sure if the thing that led to the conditional is no longer relevant in gestalt-module v7. Letting it iterate over all modules instead of only some does not seem to have caused immediate problems.

### How to test

Use a workspace that does have gameplay modes (e.g. CoreSampleGameplay) but does **not** have the world generators as source in `modules/`. (If you've checked them out, either remove them or temporary move them someplace else to hide them. gradle will fetch jars for dependent modules and put them in `cachedModules/`)

Start a new game with Advanced Game Setup.

Assert that all the expected types of worlds are listed in the world creation screen. If the only entry in the dropdown is `dummy`, something is wrong.
