### PR TITLE
fix(DiscordRPC): NPE on shutdown

### DIFF
--- a/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSystem.java
+++ b/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSystem.java
@@ -71,10 +71,12 @@ public final class DiscordRPCSystem extends BaseComponentSystem {
 
     @Override
     public void shutdown() {
-        if (delayManager.hasPeriodicAction(player.getClientEntity(), UPDATE_PARTY_SIZE_ID)) {
-            delayManager.cancelPeriodicAction(player.getClientEntity(), UPDATE_PARTY_SIZE_ID);
+        if (player != null) {
+            EntityRef client = player.getClientEntity();
+            if (delayManager != null && delayManager.hasPeriodicAction(client, UPDATE_PARTY_SIZE_ID)) {
+                delayManager.cancelPeriodicAction(client, UPDATE_PARTY_SIZE_ID);
+            }
         }
-
         DiscordRPCSubSystem.reset();
         DiscordRPCSubSystem.setState("In Main Menu");
         DiscordRPCSubSystem.setStartTimestamp(null);

--- a/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSystem.java
+++ b/subsystems/DiscordRPC/src/main/java/org/terasology/subsystem/discordrpc/DiscordRPCSystem.java
@@ -83,10 +83,10 @@ public final class DiscordRPCSystem extends BaseComponentSystem {
     }
 
     @ReceiveEvent
-    public void onPlayerInitialized(LocalPlayerInitializedEvent event, EntityRef player) {
+    public void onPlayerInitialized(LocalPlayerInitializedEvent event, EntityRef localPlayer) {
         /* Adds the periodic action when the player is hosting or playing online to update party size */
         if (networkSystem.getMode() != NetworkMode.NONE) {
-            delayManager.addPeriodicAction(player, UPDATE_PARTY_SIZE_ID, 0, UPDATE_PARTY_SIZE_PERIOD);
+            delayManager.addPeriodicAction(localPlayer, UPDATE_PARTY_SIZE_ID, 0, UPDATE_PARTY_SIZE_PERIOD);
         }
     }
 


### PR DESCRIPTION
This was causing a NPE exception (not sure whether on `player` or `delayManager`) on shutdown, causing the game process to stall and the game did not exit properly.
    
If either of `player` or `delayManager` are no longer present we just don't do anything about it and continue with the other shutdown actions.

## How to test

Start the game a couple of times and close it via the (pause) menu. It should exit properly (at least it should not throw a NPE here).

