### PR TITLE
fix: ensure absolute path in PathManager

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/PathManager.java
@@ -160,7 +160,7 @@ public final class PathManager {
      * @throws IOException Thrown when required directories cannot be accessed.
      */
     public void useOverrideHomePath(Path rootPath) throws IOException {
-        this.homePath = rootPath;
+        this.homePath = rootPath.toAbsolutePath();
         updateDirs();
     }
 
@@ -355,7 +355,7 @@ public final class PathManager {
         Path homeModPath = homePath.resolve(MODULE_DIR);
         Path modCachePath = homePath.resolve(MODULE_CACHE_DIR);
 
-        if (homePath == installPath) {
+        if (homePath.equals(installPath)) {
             return ImmutableList.of(modCachePath, homeModPath);
         } else {
             Path installModPath = installPath.resolve(MODULE_DIR);

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -125,7 +125,9 @@ public class ModuleManager {
 
     private void loadModulesFromApplicationPath(PathManager pathManager) {
         ModulePathScanner scanner = new ModulePathScanner(moduleFactory);
-        List<File> paths = pathManager.getModulePaths().stream().map(Path::toFile).collect(Collectors.toList());
+        List<File> paths = pathManager.getModulePaths().stream()
+                .map(Path::toFile)
+                .collect(Collectors.toList());
         scanner.scan(registry, paths);
     }
 


### PR DESCRIPTION
This fixes the discovery of duplicate modules, such as
```
22:16:12.763 [main] ERROR o.t.g.module.TableModuleRegistry - Duplicate module CoreAdvancedAssets-1.3.0-SNAPSHOT discovered
22:16:12.763 [main] INFO  o.t.gestalt.module.ModulePathScanner - Discovered duplicate module: CoreAdvancedAssets-1.3.0-SNAPSHOT, skipping
```

This also makes sure to compare the paths with `.equals` instead of checking for reference equality with `==`.

Plus, small style change to make stream operations more readable in `ModuleManager`.

