### PR TITLE
fix(rendering): correct order of initilization for GLSLShader

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLShader.java
@@ -55,6 +55,11 @@ public class GLSLShader extends Shader {
 
     private static final Logger logger = LoggerFactory.getLogger(GLSLShader.class);
 
+    private static String includedFunctionsVertex = "";
+    private static String includedFunctionsFragment = "";
+    private static String includedDefines = "";
+    private static String includedUniforms = "";
+
     static {
         try (
                 InputStreamReader vertStream = getInputStreamReaderFromResource("org/terasology/engine/include/globalFunctionsVertIncl.glsl");
@@ -70,11 +75,6 @@ public class GLSLShader extends Shader {
             logger.error("Failed to load Include shader resources");
         }
     }
-
-    private static String includedFunctionsVertex = "";
-    private static String includedFunctionsFragment = "";
-    private static String includedDefines = "";
-    private static String includedUniforms = "";
 
     // TODO this should be handled another way, we need to get ssao parameters here
     public int ssaoKernelElements = 32;


### PR DESCRIPTION
I've run into this a few times when testing shaders. so these properties end up with empty strings and the shader end up in a misconfigured state so it fails when some property is called but missing from the shader. why does changing this order resolve the problem? 