### PR TITLE
build(ci): add quality guards for static code analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node ("ts-engine && heavy && java8") {
         'checkstyle': {
             stage('CheckStyle'){
                 sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
-                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
+                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml') qualityGates: [[threshold: 1, type: 'TOTAL_HIGH', unstable: false]]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,15 +30,19 @@ node ("ts-engine && heavy && java8") {
 
     stage('Validation') {
         parallel 'unit test': {
-            try {
-                sh './gradlew --console=plain unitTest'
-            } finally {
-                junit testResults: '**/build/test-results/unitTest/*.xml'
-            }
+            stage('Unit Test') {
+                try {
+                    sh './gradlew --console=plain unitTest'
+                } finally {
+                    junit testResults: '**/build/test-results/unitTest/*.xml'
+                }
+            }            
         },
         'checkstyle': {
-            sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
-            recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
+            stage('CheckStyle'){
+                sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
+                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
+            }
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node ("ts-engine && heavy && java8") {
         'checkstyle': {
             stage('CheckStyle'){
                 sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
-                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml') qualityGates: [[threshold: 1, type: 'TOTAL_HIGH', unstable: false]]
+                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), qualityGates: [[threshold: 1, type: 'TOTAL_HIGH', unstable: false]]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,13 +36,6 @@ node ("ts-engine && heavy && java8") {
         }
     }            
 
-    stage('CheckStyle'){
-        sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
-        recordIssues skipBlames: true, 
-            tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), 
-            qualityGates: [[threshold: 1, type: 'TOTAL_ERROR', unstable: false], [threshold: 1, type: 'TOTAL_HIGH', unstable: true]]
-    }
-
     stage('Publish') {
         if (specialBranch) {
             withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
@@ -66,9 +59,9 @@ node ("ts-engine && heavy && java8") {
 
     stage('Analytics') {
         sh './gradlew --console=plain check -x test'
-        recordIssues skipBlames: true, tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
-        recordIssues skipBlames: true, tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true)
-        recordIssues skipBlames: true, tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
+        recordIssues skipBlames: true, tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), qualityGates: [[threshold: 1, type: 'NEW', unstable: false]]
+        recordIssues skipBlames: true, tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true), qualityGates: [[threshold: 1, type: 'NEW', unstable: false]]
+        recordIssues skipBlames: true, tool: pmdParser(pattern: '**/build/reports/pmd/*.xml'), qualityGates: [[threshold: 1, type: 'NEW', unstable: false]]
         recordIssues skipBlames: true, tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,22 +28,17 @@ node ("ts-engine && heavy && java8") {
         archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/engine/version/versionInfo.properties, natives/**, build-logic/src/**, build-logic/*.kts'
     }
 
-    stage('Validation') {
-        parallel 'unit test': {
-            stage('Unit Test') {
-                try {
-                    sh './gradlew --console=plain unitTest'
-                } finally {
-                    junit testResults: '**/build/test-results/unitTest/*.xml'
-                }
-            }            
-        },
-        'checkstyle': {
-            stage('CheckStyle'){
-                sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
-                recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), qualityGates: [[threshold: 1, type: 'TOTAL_HIGH', unstable: false]]
-            }
+    stage('Unit Test') {
+        try {
+            sh './gradlew --console=plain unitTest'
+        } finally {
+            junit testResults: '**/build/test-results/unitTest/*.xml'
         }
+    }            
+
+    stage('CheckStyle'){
+        sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
+        recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), qualityGates: [[threshold: 1, type: 'TOTAL_ERROR', unstable: false], [threshold: 1, type: 'TOTAL_HIGH', unstable: true]], skipBlames: true
     }
 
     stage('Publish') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,11 +31,10 @@ node ("ts-engine && heavy && java8") {
     stage('Validation') {
         parallel 'unit test': {
             try {
-            sh './gradlew --console=plain unitTest'
-        } finally {
-            junit testResults: '**/build/test-results/unitTest/*.xml'
-        }
-
+                sh './gradlew --console=plain unitTest'
+            } finally {
+                junit testResults: '**/build/test-results/unitTest/*.xml'
+            }
         },
         'checkstyle': {
             sh './gradlew --console=plain checkstyleMain checkstyleTest checkstyleJmh'
@@ -71,7 +70,7 @@ node ("ts-engine && heavy && java8") {
             } finally {
                 junit testResults: '**/build/test-results/integrationTest/*.xml', allowEmptyResults: true
             }
-        }
+        },
         'spotbugs': {
             sh './gradlew --console=plain spotbugsMain spotbugsTest spotbugsJmh'
             recordIssues tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,46 +22,46 @@ node ("ts-engine && heavy && java8") {
         sh 'chmod +x gradlew'
     }
 
-    stage('Build') {
-        // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
-        sh './gradlew --console=plain clean extractConfig extractNatives distForLauncher testDist'
-        archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/engine/version/versionInfo.properties, natives/**, build-logic/src/**, build-logic/*.kts'
-    }
+    // stage('Build') {
+    //     // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
+    //     sh './gradlew --console=plain clean extractConfig extractNatives distForLauncher testDist'
+    //     archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, facades/PC/build/distributions/Terasology.zip, engine/build/resources/main/org/terasology/engine/version/versionInfo.properties, natives/**, build-logic/src/**, build-logic/*.kts'
+    // }
 
-    stage('Unit Test') {
-        try {
-            sh './gradlew --console=plain unitTest'
-        } finally {
-            junit testResults: '**/build/test-results/unitTest/*.xml'
-        }
-    }            
+    // stage('Unit Test') {
+    //     try {
+    //         sh './gradlew --console=plain unitTest'
+    //     } finally {
+    //         junit testResults: '**/build/test-results/unitTest/*.xml'
+    //     }
+    // }            
 
-    stage('Publish') {
-        if (specialBranch) {
-            withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
-                sh './gradlew --console=plain -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}'
-            }
-        } else {
-            println "Running on a branch other than 'master' or 'develop' bypassing publishing"
-        }
+    // stage('Publish') {
+    //     if (specialBranch) {
+    //         withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
+    //             sh './gradlew --console=plain -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}'
+    //         }
+    //     } else {
+    //         println "Running on a branch other than 'master' or 'develop' bypassing publishing"
+    //     }
 
-        // Trigger the Omega dist job to repackage a game zip with modules
-        if (env.JOB_NAME.equals("Terasology/engine/develop")) {
-            build job: 'Terasology/Omega/develop', wait: false
-        } else if (env.JOB_NAME.equals("Terasology/engine/master")) {
-            build job: 'Terasology/Omega/master', wait: false
-        } else if (env.JOB_NAME.equals("Nanoware/Terasology/develop")) {
-            build job: 'Nanoware/Omega/develop', wait: false
-        } else if (env.JOB_NAME.equals("Nanoware/Terasology/master")) {
-            build job: 'Nanoware/Omega/master', wait: false
-        }
-    }
+    //     // Trigger the Omega dist job to repackage a game zip with modules
+    //     if (env.JOB_NAME.equals("Terasology/engine/develop")) {
+    //         build job: 'Terasology/Omega/develop', wait: false
+    //     } else if (env.JOB_NAME.equals("Terasology/engine/master")) {
+    //         build job: 'Terasology/Omega/master', wait: false
+    //     } else if (env.JOB_NAME.equals("Nanoware/Terasology/develop")) {
+    //         build job: 'Nanoware/Omega/develop', wait: false
+    //     } else if (env.JOB_NAME.equals("Nanoware/Terasology/master")) {
+    //         build job: 'Nanoware/Omega/master', wait: false
+    //     }
+    // }
 
     stage('Analytics') {
         sh './gradlew --console=plain check -x test'
-        recordIssues skipBlames: true, tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), qualityGates: [[threshold: 1, type: 'NEW', unstable: false]]
-        recordIssues skipBlames: true, tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true), qualityGates: [[threshold: 1, type: 'NEW', unstable: false]]
-        recordIssues skipBlames: true, tool: pmdParser(pattern: '**/build/reports/pmd/*.xml'), qualityGates: [[threshold: 1, type: 'NEW', unstable: false]]
+        recordIssues skipBlames: true, tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'), qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]
+        recordIssues skipBlames: true, tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true), qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]
+        recordIssues skipBlames: true, tool: pmdParser(pattern: '**/build/reports/pmd/*.xml'), qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]
         recordIssues skipBlames: true, tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
     }
 

--- a/engine/src/main/java/org/terasology/engine/audio/events/PlaySoundEvent.java
+++ b/engine/src/main/java/org/terasology/engine/audio/events/PlaySoundEvent.java
@@ -4,6 +4,7 @@
 package org.terasology.engine.audio.events;
 
 import org.terasology.engine.audio.StaticSound;
+import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.network.BroadcastEvent;
 
@@ -13,8 +14,7 @@ import org.terasology.engine.network.BroadcastEvent;
  */
 @BroadcastEvent(skipInstigator = true)
 public class PlaySoundEvent extends AbstractPlaySoundEvent {
-    protected PlaySoundEvent() {
-    }
+    protected PlaySoundEvent(){}
 
 
     public PlaySoundEvent(StaticSound sound, float volume) {


### PR DESCRIPTION
Experiment with parallel stages and warnings next generation plugin (https://github.com/jenkinsci/warnings-ng-plugin) to make some of the static code checks mandatory in the future.
