### PR TITLE
fix: resolve lightgeometry pass problems with nonfunctional point lights

### DIFF
--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/lightGeometryPass_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/lightGeometryPass_frag.glsl
@@ -39,7 +39,7 @@ uniform sampler2D texSceneClouds;
 uniform sampler2D texSceneShadowMap;
 #endif
 
-uniform mat4 lightViewProjMatrix;
+uniform mat4 viewProjMatrix;
 
 uniform vec3 activeCameraToLightSpace;
 
@@ -67,7 +67,7 @@ void main() {
     vec3 worldPosition = reconstructViewPos(depth, v_uv0.xy, invViewProjMatrix);
     vec3 lightWorldPosition = worldPosition.xyz + activeCameraToLightSpace;
 
-    vec4 lightProjVertPos = lightViewProjMatrix * vec4(lightWorldPosition.x, lightWorldPosition.y, lightWorldPosition.z, 1.0);
+    vec4 lightProjVertPos = viewProjMatrix * vec4(lightWorldPosition.x, lightWorldPosition.y, lightWorldPosition.z, 1.0);
 
     lightProjVertPos.xyz /= lightProjVertPos.w;
     vec2 shadowMapTexPos = lightProjVertPos.xy * vec2(0.5) + vec2(0.5);

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/lightGeometryPass_vert.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/lightGeometryPass_vert.glsl
@@ -8,18 +8,18 @@ layout (location = 2) in vec2 in_uv0;
 layout (location = 4) in vec4 in_color0;
 
 out vec2 v_uv0;
-out vec4 vertexProjPos;
+out vec4 v_vertexProjPos;
 
 uniform mat4 modelMatrix;
 uniform mat4 viewProjMatrix;
 
 void main() {
 #if defined (FEATURE_LIGHT_POINT)
-    vertexProjPos = (viewProjMatrix * modelMatrix) * vec4(in_vert, 1.0);
+    v_vertexProjPos = (viewProjMatrix * modelMatrix) * vec4(in_vert, 1.0);
 #elif defined (FEATURE_LIGHT_DIRECTIONAL)
-    vertexProjPos = vec4(in_vert, 1.0);
+    v_vertexProjPos = vec4(in_vert, 1.0);
 #endif
 
-    gl_Position = vertexProjPos;
+    gl_Position = v_vertexProjPos;
     v_uv0 = in_uv0;
 }


### PR DESCRIPTION
the sphere problem is resolved with this pr: https://github.com/MovingBlocks/Terasology/pull/4744

when I made the changes for lightgeometry I forgot to pass the vertex information correctly over to the fragment shader.

https://github.com/MovingBlocks/Terasology/pull/4730