### PR TITLE
doc: update minimal system requirements for OpenGL 3.3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,15 +50,15 @@ We encourage contributions from anybody and try to keep a warm and friendly comm
     <tr>
         <td>Graphics (GPU)</td>
         <td style="vertical-align:top">
-            Intel HD Graphics (Gen 5)<br/>
-            GeForce 6xxx series or<br/>
-            Radeon HD 2000 series <br/>
-            with OpenGL 2.1*
+            Intel HD Graphics (Gen 7)<br/>
+            GeForce 8xxx series (or higher) or<br/>
+            Radeon HD 2000 series (or higher)<br/>
+            with OpenGL 3.3
         </td>
         <td  style="vertical-align:top">
             GeForce 8xxx series (or higher) or<br/>
             Radeon HD 2000 series (or higher)<br/>
-            with OpenGL 3.x
+            with OpenGL 3.3
         </td>
     </tr>
     <tr>

--- a/README.markdown
+++ b/README.markdown
@@ -31,21 +31,18 @@ We encourage contributions from anybody and try to keep a warm and friendly comm
     <tr>
         <td></td>
         <th>Minimum Requirements</th>
-        <th>Recommended Requirements</th>
     </tr>
     <tr>
         <td>System (OS)</td>
-        <td colspan="2" align="center">Windows, MacOS, Linux (64 bit)</td>
+        <td>Windows, MacOS, Linux (64 bit)</td>
     </tr>
     <tr>
         <td>Processor (CPU)</td>
         <td>dual-core CPU</td>
-        <td>quad-core CPU</td>
     </tr>
     <tr>
         <td>Memory (RAM)</td>
         <td>2 GB</td>
-        <td>8 GB</td>
     </tr>
     <tr>
         <td>Graphics (GPU)</td>
@@ -55,15 +52,10 @@ We encourage contributions from anybody and try to keep a warm and friendly comm
             Radeon HD 2000 series (or higher)<br/>
             with OpenGL 3.3
         </td>
-        <td  style="vertical-align:top">
-            GeForce 8xxx series (or higher) or<br/>
-            Radeon HD 2000 series (or higher)<br/>
-            with OpenGL 3.3
-        </td>
     </tr>
     <tr>
         <td>Storage (HDD)</td>
-        <td colspan="2" align="center">1 GB</td>
+        <td>1 GB</td>
     </tr>
 </table>
 


### PR DESCRIPTION
If I understand this correctly, with the latest changes to rendering we now have a **minimum requirement** for a GPU supporting OpenGL 3.3. 
According to Wikipedia, the listed GPUs (both dedicated and integrated) should match that requirement.
