### PR TITLE
feature: migrate RegionOutlineRenderer and allow support to specify AllocationType

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/AABBRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/AABBRenderer.java
@@ -14,6 +14,7 @@ import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.mesh.MeshBuilder;
 import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
 import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.world.WorldRenderer;
@@ -178,7 +179,7 @@ public class AABBRenderer implements BlockOverlayRenderer, AutoCloseable {
     private void generateDisplayListWire() {
         float offset = 0.001f;
 
-        StandardMeshData meshData = new StandardMeshData(DrawingMode.LINES);
+        StandardMeshData meshData = new StandardMeshData(DrawingMode.LINES, AllocationType.DYNAMIC);
 
 
         Vector3f dimensions = aabb.extent(new Vector3f());

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/MeshData.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/MeshData.java
@@ -4,6 +4,7 @@ package org.terasology.engine.rendering.assets.mesh;
 
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
 import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.assets.mesh.resource.IndexResource;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
@@ -11,18 +12,32 @@ import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
 import org.terasology.gestalt.assets.AssetData;
 
 public abstract class MeshData implements AssetData {
-    private final DrawingMode mode;
+    private DrawingMode mode;
+    private AllocationType allocationType;
 
     public MeshData() {
-        this(DrawingMode.TRIANGLES);
+        this(DrawingMode.TRIANGLES, AllocationType.STATIC);
     }
 
-    public MeshData(DrawingMode mode) {
+    public MeshData(DrawingMode mode, AllocationType allocationType) {
         this.mode = mode;
+        this.allocationType = allocationType;
     }
 
     public DrawingMode getMode() {
         return mode;
+    }
+
+    public AllocationType allocationType() {
+        return allocationType;
+    }
+
+    public void setDrawMode(DrawingMode drawMode) {
+        this.mode = drawMode;
+    }
+
+    public void setAllocationType(AllocationType allocationType) {
+        this.allocationType = allocationType;
     }
 
     public abstract VertexAttributeBinding<Vector3fc, Vector3f> positions();

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/StandardMeshData.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/StandardMeshData.java
@@ -7,6 +7,7 @@ import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
 import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
 import org.terasology.engine.rendering.assets.mesh.resource.IndexResource;
@@ -69,11 +70,11 @@ public class StandardMeshData extends MeshData {
     }
 
     public StandardMeshData() {
-        this(DrawingMode.TRIANGLES);
+        this(DrawingMode.TRIANGLES, AllocationType.STATIC);
     }
 
-    public StandardMeshData(DrawingMode mode) {
-        super(mode);
+    public StandardMeshData(DrawingMode mode, AllocationType allocationType) {
+        super(mode, allocationType);
 
         VertexResourceBuilder builder = new VertexResourceBuilder();
         position = builder.add(VERTEX_INDEX, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/AllocationType.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/AllocationType.java
@@ -1,0 +1,18 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.assets.mesh.resource;
+
+import org.lwjgl.opengl.GL33;
+
+public enum AllocationType {
+    STATIC(GL33.GL_STATIC_DRAW),
+    DYNAMIC(GL33.GL_DYNAMIC_DRAW),
+    STREAM(GL33.GL_STREAM_DRAW);
+
+
+    public final int glCall;
+    AllocationType(int gl) {
+        this.glCall = gl;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/BufferedResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/BufferedResource.java
@@ -106,6 +106,7 @@ public abstract class BufferedResource {
         if (size > this.inSize) {
             this.inSize = size;
         }
+        buffer.limit(inSize);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/IndexResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/IndexResource.java
@@ -3,12 +3,17 @@
 
 package org.terasology.engine.rendering.assets.mesh.resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.config.flexible.ui.AutoConfigScreen;
+
 /**
  * defines the order of vertices to walk for rendering geometry
  *
  * refrence: https://www.khronos.org/opengl/wiki/Primitive
  */
 public class IndexResource extends BufferedResource {
+    public static final Logger logger = LoggerFactory.getLogger(IndexResource.class);
     private int inIndices = 0;
     private int posIndex = 0;
 
@@ -27,7 +32,6 @@ public class IndexResource extends BufferedResource {
         this.inIndices = resource.indices();
     }
 
-
     public void reserveElements(int elements) {
         reserve(elements * Integer.BYTES);
     }
@@ -37,12 +41,12 @@ public class IndexResource extends BufferedResource {
     }
 
     public void put(int value) {
-        if (posIndex >= inIndices) {
-            inIndices++;
-            allocateElements(inIndices);
-        }
+        ensureCapacity((posIndex + 1) * Integer.BYTES);
         buffer.putInt(posIndex * Integer.BYTES, value);
         posIndex++;
+        if (posIndex > inIndices) {
+            inIndices = posIndex;
+        }
     }
 
     public void putAll(int value, int ... values) {
@@ -60,8 +64,8 @@ public class IndexResource extends BufferedResource {
     }
 
     public void allocateElements(int indices) {
-        allocate(indices * Integer.BYTES);
-        inIndices = indices;
+        int size = indices * Integer.BYTES;
+        allocate(size);
     }
 
     public void position(int position) {

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/RegionOutlineRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/RegionOutlineRenderer.java
@@ -81,7 +81,7 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
         if (entityToRegionOutlineMap.isEmpty()) {
             return; // skip everything if there is nothing to do to avoid possibly costly draw mode changes
         }
-        GL33.glDisable(GL33.GL_DEPTH_TEST);
+        GL33.glDepthFunc(GL33.GL_ALWAYS);
         Vector3f cameraPosition = worldRenderer.getActiveCamera().getPosition();
 
         Vector3f worldPos = new Vector3f();
@@ -92,10 +92,10 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
         material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
         material.setMatrix4("modelViewMatrix", modelViewMatrix, true);
 
-        meshData.indices.allocateElements(0);
-        meshData.position.allocate(0);
+        meshData.reallocate(0,0);
         meshData.indices.rewind();
         meshData.position.rewind();
+        meshData.color0.rewind();
 
         int index = 0;
         Vector3f pos = new Vector3f();
@@ -107,15 +107,15 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
             BlockRegion region = new BlockRegion(regionOutline.corner1).union(regionOutline.corner2);
             AABBf bounds = region.getBounds(new AABBf());
 
+            meshData.position.put(pos.set(bounds.minX, bounds.minY, bounds.minZ));
             meshData.position.put(pos.set(bounds.maxX, bounds.minY, bounds.minZ));
             meshData.position.put(pos.set(bounds.maxX, bounds.minY, bounds.maxZ));
-            meshData.position.put(pos.set(bounds.minX, bounds.minY, bounds.minZ));
             meshData.position.put(pos.set(bounds.minX, bounds.minY, bounds.maxZ));
 
             meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
-            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
-            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
-            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.maxX, bounds.maxY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.maxX, bounds.maxY, bounds.maxZ));
+            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.maxZ));
 
             meshData.color0.put(regionOutline.color);
             meshData.color0.put(regionOutline.color);
@@ -150,8 +150,10 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
 
             index += 8;
         }
+        material.enable();
+        mesh.reload(meshData);
         mesh.render();
-        GL33.glEnable(GL33.GL_DEPTH_TEST);
+        GL33.glDepthFunc(GL33.GL_LEQUAL);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/RegionOutlineRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/RegionOutlineRenderer.java
@@ -5,12 +5,10 @@ package org.terasology.engine.rendering.logic;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
-import org.lwjgl.BufferUtils;
-import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL33;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.lifecycleEvents.BeforeDeactivateComponent;
@@ -20,22 +18,20 @@ import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.entitySystem.systems.RenderSystem;
+import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.assets.material.Material;
+import org.terasology.engine.rendering.assets.mesh.Mesh;
+import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
+import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.world.WorldRenderer;
+import org.terasology.engine.utilities.Assets;
+import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.joml.geom.AABBf;
-import org.terasology.engine.registry.In;
-import org.terasology.engine.world.block.BlockRegion;
 
-import java.nio.FloatBuffer;
 import java.util.Map;
 
-import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
-import static org.lwjgl.opengl.GL11.glBegin;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glEnd;
-import static org.lwjgl.opengl.GL11.glVertex3f;
 
 /**
  * Renderes region outlines for all entities with  {@link RegionOutlineComponent}s.
@@ -52,6 +48,8 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
     @In
     private EntityManager entityManager;
 
+    private StandardMeshData meshData = new StandardMeshData(DrawingMode.LINES, AllocationType.STREAM);
+    private Mesh mesh;
 
     private Material material;
 
@@ -61,6 +59,7 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
     public void initialise() {
         Preconditions.checkArgument(!Strings.isNullOrEmpty("engine:white"));
         this.material = assetManager.getAsset("engine:white", Material.class).get();
+        mesh = Assets.generateAsset(meshData, Mesh.class);
     }
 
 
@@ -82,109 +81,77 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
         if (entityToRegionOutlineMap.isEmpty()) {
             return; // skip everything if there is nothing to do to avoid possibly costly draw mode changes
         }
-        glDisable(GL_DEPTH_TEST);
+        GL33.glDisable(GL33.GL_DEPTH_TEST);
         Vector3f cameraPosition = worldRenderer.getActiveCamera().getPosition();
 
-        FloatBuffer tempMatrixBuffer44 = BufferUtils.createFloatBuffer(16);
-        FloatBuffer tempMatrixBuffer33 = BufferUtils.createFloatBuffer(12);
-
-        material.setFloat("sunlight", 1.0f, true);
-        material.setFloat("blockLight", 1.0f, true);
-        material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
         Vector3f worldPos = new Vector3f();
-
         Vector3f worldPositionCameraSpace = new Vector3f();
         worldPos.sub(cameraPosition, worldPositionCameraSpace);
-
         Matrix4f matrixCameraSpace = new Matrix4f().translationRotateScale(worldPositionCameraSpace, new Quaternionf(), 1.0f);
-
         Matrix4f modelViewMatrix = new Matrix4f(worldRenderer.getActiveCamera().getViewMatrix()).mul(matrixCameraSpace);
-        Matrix3f normalMatrix = new Matrix3f();
-        modelViewMatrix.get(tempMatrixBuffer44);
-        modelViewMatrix.normal(normalMatrix).get(tempMatrixBuffer33);
+        material.setMatrix4("projectionMatrix", worldRenderer.getActiveCamera().getProjectionMatrix());
+        material.setMatrix4("modelViewMatrix", modelViewMatrix, true);
 
-        material.setMatrix4("modelViewMatrix", tempMatrixBuffer44, true);
-        material.setMatrix3("normalMatrix", tempMatrixBuffer33, true);
+        meshData.indices.allocateElements(0);
+        meshData.position.allocate(0);
+        meshData.indices.rewind();
+        meshData.position.rewind();
 
+        int index = 0;
+        Vector3f pos = new Vector3f();
         for (RegionOutlineComponent regionOutline : entityToRegionOutlineMap.values()) {
-            material.setFloat3("colorOffset", regionOutline.color.rf(), regionOutline.color.gf(), regionOutline.color.bf(), true);
-            drawRegionOutline(regionOutline);
+            if (regionOutline.corner1 == null || regionOutline.corner2 == null) {
+                continue;
+            }
+
+            BlockRegion region = new BlockRegion(regionOutline.corner1).union(regionOutline.corner2);
+            AABBf bounds = region.getBounds(new AABBf());
+
+            meshData.position.put(pos.set(bounds.maxX, bounds.minY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.maxX, bounds.minY, bounds.maxZ));
+            meshData.position.put(pos.set(bounds.minX, bounds.minY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.minX, bounds.minY, bounds.maxZ));
+
+            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
+            meshData.position.put(pos.set(bounds.minX, bounds.maxY, bounds.minZ));
+
+            meshData.color0.put(regionOutline.color);
+            meshData.color0.put(regionOutline.color);
+            meshData.color0.put(regionOutline.color);
+            meshData.color0.put(regionOutline.color);
+
+            meshData.color0.put(regionOutline.color);
+            meshData.color0.put(regionOutline.color);
+            meshData.color0.put(regionOutline.color);
+            meshData.color0.put(regionOutline.color);
+
+            meshData.indices.putAll(new int[]{
+                    // top loop
+                    index, index + 1,
+                    index + 1, index + 2,
+                    index + 2, index + 3,
+                    index + 3, index,
+
+                    // connecting edges between top and bottom
+                    index, index + 4,
+                    index + 1, index + 5,
+                    index + 2, index + 6,
+                    index + 3, index + 7,
+
+                    // bottom loop
+                    index + 4, index + 5,
+                    index + 5, index + 6,
+                    index + 6, index + 7,
+                    index + 7, index + 4,
+
+            });
+
+            index += 8;
         }
-
-        glEnable(GL_DEPTH_TEST);
-    }
-
-    private void drawRegionOutline(RegionOutlineComponent regionComponent) {
-        if (regionComponent.corner1 == null || regionComponent.corner2 == null) {
-            return;
-        }
-
-        BlockRegion region = new BlockRegion(regionComponent.corner1).union(regionComponent.corner2);
-        AABBf bounds = region.getBounds(new AABBf());
-        // 4 lines along x axis:
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.minY, bounds.minZ);
-        glVertex3f(bounds.maxX, bounds.minY, bounds.minZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.maxY, bounds.minZ);
-        glVertex3f(bounds.maxX, bounds.maxY, bounds.minZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.minY, bounds.maxZ);
-        glVertex3f(bounds.maxX, bounds.minY, bounds.maxZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.maxY, bounds.maxZ);
-        glVertex3f(bounds.maxX, bounds.maxY, bounds.maxZ);
-        glEnd();
-
-
-        // 4 lines along y axis
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.minY, bounds.minZ);
-        glVertex3f(bounds.minX, bounds.maxY, bounds.minZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.maxX, bounds.minY, bounds.minZ);
-        glVertex3f(bounds.maxX, bounds.maxY, bounds.minZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.minY, bounds.maxZ);
-        glVertex3f(bounds.minX, bounds.maxY, bounds.maxZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.maxX, bounds.minY, bounds.maxZ);
-        glVertex3f(bounds.maxX, bounds.maxY, bounds.maxZ);
-        glEnd();
-
-        // 4 lines along z axis:
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.minY, bounds.minZ);
-        glVertex3f(bounds.minX, bounds.minY, bounds.maxZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.maxX, bounds.minY, bounds.minZ);
-        glVertex3f(bounds.maxX, bounds.minY, bounds.maxZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.minX, bounds.maxY, bounds.minZ);
-        glVertex3f(bounds.minX, bounds.maxY, bounds.maxZ);
-        glEnd();
-
-        glBegin(GL11.GL_LINES);
-        glVertex3f(bounds.maxX, bounds.maxY, bounds.minZ);
-        glVertex3f(bounds.maxX, bounds.maxY, bounds.maxZ);
-        glEnd();
-
+        mesh.render();
+        GL33.glEnable(GL33.GL_DEPTH_TEST);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMesh.java
@@ -81,7 +81,7 @@ public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
     @Override
     public void render() {
         if (!isDisposed()) {
-            updateState(state, allocationType);
+            updateState(state);
             GL30.glBindVertexArray(disposalAction.vao);
             GL30.glDrawElements(drawMode.glCall, this.indexCount, GL_UNSIGNED_INT, 0);
             GL30.glBindVertexArray(0);

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMesh.java
@@ -11,6 +11,8 @@ import org.terasology.engine.core.GameThread;
 import org.terasology.engine.core.subsystem.lwjgl.LwjglGraphicsProcessing;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.mesh.MeshData;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
+import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.assets.mesh.resource.IndexResource;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
@@ -28,9 +30,12 @@ import static org.lwjgl.opengl.GL11.GL_UNSIGNED_INT;
 public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
     private static final Logger logger = LoggerFactory.getLogger(OpenGLMesh.class);
     private AABBf aabb = new AABBf();
-    private MeshData data;
     private int indexCount;
     private DisposalAction disposalAction;
+    private DrawingMode drawMode;
+    private AllocationType allocationType;
+
+    private  VertexAttributeBinding<Vector3fc, Vector3f> positions;
 
     private VBOContext state = null;
 
@@ -64,21 +69,21 @@ public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
 
     @Override
     public VertexAttributeBinding<Vector3fc, Vector3f> vertices() {
-        return data.positions();
+        return positions;
     }
 
     @Override
     public int elementCount() {
-        return data.positions().getResource().elements();
+        return positions.elements();
     }
 
 
     @Override
     public void render() {
         if (!isDisposed()) {
-            updateState(state);
+            updateState(state, allocationType);
             GL30.glBindVertexArray(disposalAction.vao);
-            GL30.glDrawElements(data.getMode().glCall, this.indexCount, GL_UNSIGNED_INT, 0);
+            GL30.glDrawElements(drawMode.glCall, this.indexCount, GL_UNSIGNED_INT, 0);
             GL30.glBindVertexArray(0);
         } else {
             logger.error("Attempted to render disposed mesh: {}", getUrn());
@@ -87,25 +92,18 @@ public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
 
 
     private void buildMesh(MeshData newData) {
-        this.data = newData;
-
-        this.disposalAction.dispose();
-
-        this.disposalAction.vao = GL30.glGenVertexArrays();
-        this.disposalAction.vbo = GL30.glGenBuffers();
-        this.disposalAction.ebo = GL30.glGenBuffers();
-
-        GL30.glBindVertexArray(this.disposalAction.vao);
-
-        VertexResource[] resources = newData.vertexResources();
-        List<VertexResource> targets = new ArrayList<>();
-        for (VertexResource vertexResource : resources) {
-            if (vertexResource.inSize() > 0) {
-                targets.add(vertexResource);
-            }
+        if (this.disposalAction.vao == 0) {
+            this.disposalAction.vao = GL30.glGenVertexArrays();
+            this.disposalAction.vbo = GL30.glGenBuffers();
+            this.disposalAction.ebo = GL30.glGenBuffers();
         }
 
-        this.state = buildVBO(this.disposalAction.vbo, GL30.GL_STATIC_DRAW, targets);
+        allocationType = newData.allocationType();
+        drawMode = newData.getMode();
+
+        GL30.glBindVertexArray(this.disposalAction.vao);
+        positions = newData.positions();
+        this.state = buildVBO(this.disposalAction.vbo, allocationType, newData.vertexResources());
 
         IndexResource indexResource = newData.indexResource();
         this.indexCount = indexResource.indices();

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMeshBase.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMeshBase.java
@@ -20,7 +20,7 @@ public interface OpenGLMeshBase {
         }
     }
 
-    default boolean updateState(VBOContext state, AllocationType allocationType) {
+    default boolean updateState(VBOContext state) {
         GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, state.vbo);
         for (int x = 0; x < state.entries.length; x++) {
             if (state.entries[x].version != state.entries[x].resource.getVersion()) {

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMeshBase.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMeshBase.java
@@ -4,10 +4,8 @@
 package org.terasology.engine.rendering.opengl;
 
 import org.lwjgl.opengl.GL30;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
-
-import java.nio.ByteBuffer;
-import java.util.List;
 
 public interface OpenGLMeshBase {
     class VBOContext {
@@ -17,16 +15,19 @@ public interface OpenGLMeshBase {
         public static class VBOSubBuffer {
             int version;
             int offset;
+            int size;
             VertexResource resource;
         }
     }
 
-    default void updateState(VBOContext state) {
+    default boolean updateState(VBOContext state, AllocationType allocationType) {
         GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, state.vbo);
         for (int x = 0; x < state.entries.length; x++) {
             if (state.entries[x].version != state.entries[x].resource.getVersion()) {
+                if (state.entries[x].size != state.entries[x].resource.inSize()) {
+                    return false;
+                }
                 VertexResource resource = state.entries[x].resource;
-
                 int offset = state.entries[x].offset;
                 resource.writeBuffer((buffer) -> {
                     GL30.glBufferSubData(GL30.GL_ARRAY_BUFFER, offset, buffer);
@@ -34,27 +35,32 @@ public interface OpenGLMeshBase {
             }
         }
         GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, 0);
+        return true;
     }
 
-    default VBOContext buildVBO(int vbo, int drawType, List<VertexResource> resources) {
+    default VBOContext buildVBO(int vbo, AllocationType allocation, VertexResource[] resources) {
         GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, vbo);
         int bufferSize = 0;
         for (VertexResource vertexResource : resources) {
             bufferSize += vertexResource.inSize();
         }
-        GL30.glBufferData(GL30.GL_ARRAY_BUFFER, bufferSize, drawType);
+        GL30.glBufferData(GL30.GL_ARRAY_BUFFER, bufferSize, allocation.glCall);
 
         VBOContext state = new VBOContext();
-        state.entries = new VBOContext.VBOSubBuffer[resources.size()];
+        state.entries = new VBOContext.VBOSubBuffer[resources.length];
 
         int offset = 0;
-        for (int i = 0; i < resources.size(); i++) {
-            VertexResource resource = resources.get(i);
+        for (int i = 0; i < resources.length; i++) {
+            VertexResource resource = resources[i];
 
             state.entries[i] = new VBOContext.VBOSubBuffer();
             state.entries[i].resource = resource;
             state.entries[i].version = resource.getVersion();
             state.entries[i].offset = offset;
+            state.entries[i].size = resource.inSize();
+            if (state.entries[i].size == 0) {
+                continue;
+            }
 
             int currentOffset = offset;
             resource.writeBuffer((buffer) -> {

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/lightGeometryPass_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/lightGeometryPass_frag.glsl
@@ -38,13 +38,11 @@ uniform vec4 lightExtendedProperties;
     #endif
 
     uniform vec3 activeCameraToLightSpace;
-
-    uniform mat4 invProjMatrix;
     uniform mat4 lightMatrix;
-
     uniform mat4 invViewProjMatrix;
 #endif
 
+uniform mat4 invProjMatrix;
 
 void main() {
 


### PR DESCRIPTION
Allocation type allows openGL to work out how the data is going to managed/allocated.  for RegionOutlineRenderer I just batch all the lines together and process everything in a single draw call. should work similar to immediate mode but should be significantly faster since it allows all the the lines to be drawn in a single batched call. 

I realized I also don't upsize the limit on the buffer because some operations will break the buffer it its accessed outside of the limit. umm, maybe we might want to rethink the API a bit but this is working pretty well. I was testing this with structured resources using the wall replacement thingy. maybe we should use the limit of the buffer instead of tracking a separate property for the size of the buffer :?

```
- open terminal thing
- give toolbox
- select the wall replacement tool
- verify selection outline is rendered on the terrain. 
```