### PR TITLE
build: update TeraConfig to 1.6.3 and adjust IntelliJ settings

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,6 +14,7 @@
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="140" />
       <option name="WRAP_COMMENTS" value="true" />
       <option name="WRAP_LONG_LINES" value="true" />
     </codeStyleSettings>

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 
 
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
-    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.6.2', ext: 'zip'
+    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.6.3', ext: 'zip'
 
     // Natives for JNLua (Kallisti, KComputers)
     natives group: 'org.terasology.jnlua', name: 'jnlua_natives', version: '0.1.0-SNAPSHOT', ext: 'zip'


### PR DESCRIPTION
- build(idea): align IntelliJ line length with Checkstyle config
- build(codemetrics): use release v1.6.3 of TeraConfig

Consume changes from https://github.com/MovingBlocks/TeraConfig/pull/17
