### PR TITLE
bugfix(rendering): rework glsl for osx

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/assets/font/FontMaterialProducer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/font/FontMaterialProducer.java
@@ -59,7 +59,7 @@ public class FontMaterialProducer implements AssetDataProducer<MaterialData> {
             Optional<Texture> texture = assetManager.getAsset(new ResourceUrn(urn.getModuleName(), urn.getFragmentName()), Texture.class);
             if (texture.isPresent()) {
                 MaterialData materialData = new MaterialData(fontShader.get());
-                materialData.setParam("texture", texture.get());
+                materialData.setParam("tex", texture.get());
                 return Optional.of(materialData);
             }
         }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -320,7 +320,7 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
             }
         }
 
-        textureMat.setTexture("texture", ((TextureRegion) texture).getTexture());
+        textureMat.setTexture("tex", ((TextureRegion) texture).getTexture());
         textureMat.setFloat4("color", color.rf(), color.gf(), color.bf(), color.af() * alpha);
 
         textureMat.setMatrix4("projectionMatrix", projMatrix);
@@ -488,7 +488,7 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
                 textureArea.minY + uy * textureArea.lengthY());
         textureMat.setFloat2("texSize", uw * textureArea.lengthX(), uh * textureArea.lengthY());
 
-        textureMat.setTexture("texture", ((TextureRegion) texture).getTexture());
+        textureMat.setTexture("tex", ((TextureRegion) texture).getTexture());
         textureMat.setFloat4("color", 1, 1, 1, alpha);
         textureMat.bindTextures();
         mesh.render();

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/TerasologyCanvasImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/TerasologyCanvasImpl.java
@@ -111,7 +111,7 @@ public class TerasologyCanvasImpl extends CanvasImpl implements PropertyChangeLi
     }
 
     public void drawMesh(Mesh mesh, UITextureRegion texture, Rectanglei region, Quaternionfc rotation, Vector3fc offset, float scale) {
-        meshMat.setTexture("texture", ((TextureRegion) texture).getTexture());
+        meshMat.setTexture("tex", ((TextureRegion) texture).getTexture());
         drawMesh(mesh, meshMat, region, rotation, offset, scale);
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/world/selection/BlockSelectionRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/selection/BlockSelectionRenderer.java
@@ -90,7 +90,7 @@ public class BlockSelectionRenderer {
         blockSelectionMat.enable();
         blockSelectionMat.activateFeature(ShaderProgramFeature.FEATURE_ALPHA_REJECT);
         blockSelectionMat.setMatrix4("projectionMatrix", camera.getProjectionMatrix());
-        blockSelectionMat.setTexture("texture", effectsTexture);
+        blockSelectionMat.setTexture("tex", effectsTexture);
         blockSelectionMat.bindTextures();
 
         glEnable(GL11.GL_BLEND);

--- a/engine/src/main/resources/org/terasology/engine/assets/materials/ui/UIUnderline.mat
+++ b/engine/src/main/resources/org/terasology/engine/assets/materials/ui/UIUnderline.mat
@@ -1,7 +1,7 @@
 {
     "shader": "engine:font",
     "params": {
-        "texture": "engine:white",
+        "tex": "engine:white",
         "offset": [0.0, 0.0]
     }
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/blockSelection.info
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/blockSelection.info
@@ -1,7 +1,7 @@
 {
     "params": [
         {
-            "name": "texture",
+            "name": "tex",
             "type": "sampler2D"
         }
     ]

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/blockSelection_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/blockSelection_frag.glsl
@@ -2,21 +2,24 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 in vec2 v_uv0;
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+layout(location = 1) out vec4 outNormal;
+layout(location = 2) out vec4 outLight;
+
 void main(){
-    vec4 diffColor = texture2D(texture, v_uv0);
+    vec4 diffColor = texture(tex, v_uv0);
 
     #if defined (FEATURE_ALPHA_REJECT)
     if (diffColor.a < 0.1) {
         discard;
     }
     #endif
-
-    gl_FragData[0].rgba = diffColor * v_color0;
-    gl_FragData[1].rgba = vec4(0.5, 1.0, 0.5, 1.0);
-    gl_FragData[2].rgba = vec4(0.0, 0.0, 0.0, 0.0);
+    outColor = diffColor * v_color0;
+    outNormal = vec4(0.5, 1.0, 0.5, 1.0);
+    outLight = vec4(0.0, 0.0, 0.0, 0.0);
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/block_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/block_frag.glsl
@@ -17,10 +17,14 @@ in vec3 v_normal;
 in vec2 v_uv0;
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+layout(location = 1) out vec4 outNormal;
+layout(location = 2) out vec4 outLight;
+
 void main() {
     vec4 color;
     if (textured) {
-        color = v_color0 * texture2D(textureAtlas, v_uv0);
+        color = v_color0 * texture(textureAtlas, v_uv0);
     } else {
         color = v_color0;
     }
@@ -32,7 +36,7 @@ void main() {
 
     color.rgb *= colorOffset.rgb;
 
-    gl_FragData[0].rgba = color;
-    gl_FragData[1].rgba = vec4(v_normal.x / 2.0 + 0.5, v_normal.y / 2.0 + 0.5, v_normal.z / 2.0 + 0.5, 0.0);
-    gl_FragData[2].rgba = vec4(blockLight, sunlight, 0.0, 0.0);
+    outColor = color;
+    outNormal = vec4(v_normal.x / 2.0 + 0.5, v_normal.y / 2.0 + 0.5, v_normal.z / 2.0 + 0.5, 0.0);
+    outLight = vec4(blockLight, sunlight, 0.0, 0.0);
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/debug_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/debug_frag.glsl
@@ -1,18 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 uniform sampler2D texDebug;
 
@@ -20,62 +8,60 @@ uniform int debugRenderingStage;
 
 uniform mat4 invProjMatrix;
 
+
+layout(location = 0) out vec4 outColor;
+
 void main(){
-    vec4 color;
     vec4 texColor;
 
     if (debugRenderingStage == DEBUG_STAGE_OPAQUE_DEPTH) {
 
-        texColor = texture2D(texDebug, gl_TexCoord[0].xy);
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
         float linDepth = linDepth(texColor.x);
-        color.xyz = vec3(linDepth);
-        color.a = 1.0;
+        outColor.xyz = vec3(linDepth);
+        outColor.a = 1.0;
 
     } else if (debugRenderingStage == DEBUG_STAGE_OPAQUE_COLOR) {
 
-        texColor = texture2D(texDebug, gl_TexCoord[0].xy);
-        color.xyz = texColor.xyz;
-        color.a = 1.0;
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
+        outColor.xyz = texColor.xyz;
+        outColor.a = 1.0;
 
     } else if (debugRenderingStage == DEBUG_STAGE_OPAQUE_NORMALS) {
 
-        texColor = texture2D(texDebug, gl_TexCoord[0].xy);
-        color.xyz = texColor.xyz * 2.0 - 1.0;
-        color.a = 1.0;
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
+        outColor.xyz = texColor.xyz * 2.0 - 1.0;
+        outColor.a = 1.0;
 
     } else if (debugRenderingStage == DEBUG_STAGE_OPAQUE_LIGHT_BUFFER) {
 
-        texColor = texture2D(texDebug, gl_TexCoord[0].xy);
-        color.rgb = texColor.rgb;
-        color.rgb += texColor.aaa;
-        color.a = 1.0;
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
+        outColor.rgb = texColor.rgb;
+        outColor.rgb += texColor.aaa;
+        outColor.a = 1.0;
 
     } else if (debugRenderingStage == DEBUG_STAGE_OPAQUE_SUNLIGHT) {
 
-        texColor = texture2D(texDebug, gl_TexCoord[0].xy);
-        color.rgb = texColor.aaa;
-        color.a = 1.0;
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
+        outColor.rgb = texColor.aaa;
+        outColor.a = 1.0;
 
     } else if (debugRenderingStage == DEBUG_STAGE_BAKED_OCCLUSION) {
 
-        texColor = texture2D(texDebug, gl_TexCoord[0].xy);
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
         color.rgb = texColor.aaa;
         color.a = 1.0;
 
-   }  else if (debugRenderingStage == DEBUG_STAGE_RECONSTRUCTED_POSITION) {
+    } else if (debugRenderingStage == DEBUG_STAGE_RECONSTRUCTED_POSITION) {
 
-       float depth = texture2D(texDebug, gl_TexCoord[0].xy).r;
-       vec3 viewSpacePos = reconstructViewPos(depth, gl_TexCoord[0].xy, invProjMatrix);
+        float depth = texture(texDebug, gl_TexCoord[0].xy).r;
+        vec3 viewSpacePos = reconstructViewPos(depth, gl_TexCoord[0].xy, invProjMatrix);
 
-       color.rgb = viewSpacePos.rgb;
-       color.a = 1.0;
+        outColor.rgb = viewSpacePos.rgb;
+        outColor.a = 1.0;
 
-   }  else {
-
-       texColor = texture2D(texDebug, gl_TexCoord[0].xy);
-       color = texColor;
-
-   }
-
-   gl_FragData[0] = color;
+    } else {
+        texColor = texture(texDebug, gl_TexCoord[0].xy);
+        outColor = texColor;
+    }
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/debug_vert.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/debug_vert.glsl
@@ -1,18 +1,6 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 void main()
 {

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/defaultTextured.info
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/defaultTextured.info
@@ -1,7 +1,7 @@
 {
     "params": [
         {
-            "name": "texture",
+            "name": "tex",
             "type": "sampler2D"
         }
     ]

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/default_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/default_frag.glsl
@@ -4,8 +4,12 @@
 
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+layout(location = 1) out vec4 outNormal;
+layout(location = 2) out vec4 outLight;
+
 void main() {
-    gl_FragData[0].rgba = v_color0;
-    gl_FragData[1].rgba = vec4(0.5, 1.0, 0.5, 1.0);
-    gl_FragData[2].rgba = vec4(0.0, 0.0, 0.0, 0.0);
+    outColor = v_color0;
+    outNormal = vec4(0.5, 1.0, 0.5, 1.0);
+    outLight = vec4(0.0, 0.0, 0.0, 0.0);
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/genericMeshMaterial_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/genericMeshMaterial_frag.glsl
@@ -17,19 +17,22 @@ in vec3 v_normal;
 in vec2 v_uv0;
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+layout(location = 1) out vec4 outNormal;
+layout(location = 2) out vec4 outLight;
 
 void main(){
     vec4 color;
 
     if (textured) {
-        color = texture2D(diffuse, v_uv0);
+        color = texture(diffuse, v_uv0);
         color.rgb *= colorOffset.rgb;
-        gl_FragData[0].rgba = color;
+        outColor.rgba = color;
     } else {
         color = vec4(colorOffset.rgb, 1.0);
-        gl_FragData[0].rgba = color;
+        outColor.rgba = color;
     }
 
-    gl_FragData[1].rgba = vec4(v_normal.x / 2.0 + 0.5, v_normal.y / 2.0 + 0.5, v_normal.z / 2.0 + 0.5, 0.0);
-    gl_FragData[2].rgba = vec4(blockLight, sunlight, 0.0, 0.0);
+    outNormal.rgba = vec4(v_normal.x / 2.0 + 0.5, v_normal.y / 2.0 + 0.5, v_normal.z / 2.0 + 0.5, 0.0);
+    outLight.rgba = vec4(blockLight, sunlight, 0.0, 0.0);
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/particle_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/particle_frag.glsl
@@ -6,19 +6,19 @@
 in vec4 color_gs;
 in vec2 uv;
 
-out vec4 out_color;
-
 uniform bool use_texture = false;
 uniform sampler2D texture_sampler;
 
+layout(location = 0) out vec4 outColor;
+
 void main() {
     if (use_texture) {
-        out_color = texture(texture_sampler, uv);
+        outColor = texture(texture_sampler, uv);
     } else {
-        out_color = color_gs;
+        outColor = color_gs;
     }
 
-    if (out_color.a < 0.01) {
+    if (outColor.a < 0.01) {
         discard;
     }
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/particle_geom.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/particle_geom.glsl
@@ -1,20 +1,7 @@
 #version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 layout (points) in;
 layout (triangle_strip) out;

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/particle_vert.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/particle_vert.glsl
@@ -1,20 +1,7 @@
 #version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 layout (location = 0) in vec3 position_ws;
 layout (location = 1) in vec3 scale;

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/simple_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/simple_frag.glsl
@@ -1,20 +1,9 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
+layout(location = 0) out vec4 outColor;
 
 void main() {
-    gl_FragData[0].rgba = vec4(1.0, 0.0, 0.0, 0.0);
+    outColor = vec4(1.0, 0.0, 0.0, 0.0);
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/simple_vert.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/simple_vert.glsl
@@ -1,25 +1,15 @@
-/*
- * Copyright 2012 Benjamin Glatzel <benjamin.glatzel@me.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 uniform mat4 modelMatrix;
 uniform mat4 viewMatrix;
 uniform mat4 projMatrix;
 uniform mat4 viewProjMatrix;
 
+layout (location = 0) in vec3 in_vert;
+
 void main()
 {
-	gl_Position = (viewProjMatrix * modelMatrix) * gl_Vertex;
+	gl_Position = (viewProjMatrix * modelMatrix) * vec4(in_vert, 1.0);
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/font.info
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/font.info
@@ -1,7 +1,7 @@
 {
     "params": [
         {
-            "name": "texture",
+            "name": "tex",
             "type": "sampler2D"
         }
     ]

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/font_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/font_frag.glsl
@@ -1,31 +1,20 @@
 #version 330 core
-/*
- * Copyright 2013 Moving Blocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 uniform vec4 croppingBoundaries;
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 in vec2 v_relPos;
 in vec2 v_uv0;
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+
 void main(){
     if (v_relPos.x < croppingBoundaries.x || v_relPos.x > croppingBoundaries.y || v_relPos.y < croppingBoundaries.z || v_relPos.y > croppingBoundaries.w) {
         discard;
     }
-    vec4 diffColor = texture2D(texture, v_uv0);
-    gl_FragData[0].rgba = diffColor * v_color0;
+    vec4 diffColor = texture(tex, v_uv0);
+    outColor = diffColor * v_color0;
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uiLitMesh.info
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uiLitMesh.info
@@ -1,7 +1,7 @@
 {
     "params": [
         {
-            "name": "texture",
+            "name": "tex",
             "type": "sampler2D"
         }
     ]

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uiLitMesh_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uiLitMesh_frag.glsl
@@ -3,20 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 uniform vec4 croppingBoundaries;
-uniform sampler2D texture;
+uniform sampler2D tex;
 
 in vec3 v_normal;
 in vec2 v_relPos;
 in vec2 v_uv0;
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+
 void main(){
     if (v_relPos.x < croppingBoundaries.x || v_relPos.x > croppingBoundaries.y || v_relPos.y < croppingBoundaries.z || v_relPos.y > croppingBoundaries.w) {
         discard;
     }
-    vec4 color = texture2D(texture, v_uv0);
+    vec4 color = texture(tex, v_uv0);
     float light = min(1.0, 0.3 * max(0.0, dot(v_normal, vec3(0, -1, 0))) + 1.0 * max(0.0, dot(v_normal, vec3(0,0,1))));
     color.rgb = color.rgb * light;
 
-    gl_FragData[0].rgba = color * v_color0;
+    outColor = color * v_color0;
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uitexture.info
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uitexture.info
@@ -1,7 +1,7 @@
 {
     "params": [
         {
-            "name": "texture",
+            "name": "tex",
             "type": "sampler2D"
         }
     ]

--- a/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uitexture_frag.glsl
+++ b/engine/src/main/resources/org/terasology/engine/assets/shaders/ui/uitexture_frag.glsl
@@ -3,18 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 uniform vec4 croppingBoundaries;
-uniform sampler2D texture;
-
-varying vec2 relPos;
+uniform sampler2D tex;
 
 in vec2 v_relPos;
 in vec2 v_uv0;
 in vec4 v_color0;
 
+layout(location = 0) out vec4 outColor;
+
 void main(){
     if (v_relPos.x < croppingBoundaries.x || v_relPos.x > croppingBoundaries.y || v_relPos.y < croppingBoundaries.z || v_relPos.y > croppingBoundaries.w) {
         discard;
     }
-    vec4 diffColor = texture2D(texture, v_uv0);
-    gl_FragData[0].rgba = diffColor * v_color0;
+    vec4 diffColor = texture(tex, v_uv0);
+    outColor = diffColor * v_color0;
 }


### PR DESCRIPTION
with some notes from this PR: https://github.com/MovingBlocks/Terasology/pull/4766. I made some adjustments that should hopefully get this to work on osx. 

- varying is removed from the standard
- texture2d is deprecated but I expected a warning but its been removed when compiling for osx
- gl_FragData is something I know was deprecated but threw warnings for NVIDIA and AMD but seems to be removed for osx. I use the correct api's which use layout.  