### PR TITLE
chore: cache hashcode for uniform id

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLMaterial.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLMaterial.java
@@ -602,11 +602,13 @@ public class GLSLMaterial extends BaseMaterial {
     private static final class UniformId {
         private int shaderProgramId;
         private String name;
+        private int hashCode;
 
         // made package-private after Jenkins' suggestion
         UniformId(int shaderProgramId, String name) {
             this.shaderProgramId = shaderProgramId;
             this.name = name;
+            this.hashCode = Objects.hashCode(shaderProgramId, name);
         }
 
         @Override
@@ -623,7 +625,7 @@ public class GLSLMaterial extends BaseMaterial {
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(shaderProgramId, name);
+            return this.hashCode;
         }
     }
 


### PR DESCRIPTION
the hash code is used quite a bit in some pretty tight draw loops hashing a string plus the id is not a trivial cost. 