### PR TITLE
fix(audio): skip update when player is invalid

### DIFF
--- a/engine/src/main/java/org/terasology/engine/audio/system/AudioSystem.java
+++ b/engine/src/main/java/org/terasology/engine/audio/system/AudioSystem.java
@@ -112,9 +112,13 @@ public class AudioSystem extends BaseComponentSystem implements UpdateSubscriber
 
     @Override
     public void update(float delta) {
+        if (!localPlayer.isValid()) {
+            // localplayer is invalid so no audio
+            return;
+        }
         audioManager.updateListener(
-            localPlayer.getPosition(playerPosition),
-            localPlayer.getViewRotation(playerViewRotation),
-            localPlayer.getVelocity(playerVelocity));
+                localPlayer.getPosition(playerPosition),
+                localPlayer.getViewRotation(playerViewRotation),
+                localPlayer.getVelocity(playerVelocity));
     }
 }


### PR DESCRIPTION
looks like when the player is invalid the game now crashes in audioSystem. for the initial frames I skip updating the Listener while the player is in an invalid state. 

https://github.com/MovingBlocks/Terasology/pull/4662