### PR TITLE
chore: empty default implementation for RenderSystem interface

### DIFF
--- a/engine/src/main/java/org/terasology/engine/entitySystem/systems/RenderSystem.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/systems/RenderSystem.java
@@ -13,21 +13,21 @@ public interface RenderSystem extends ComponentSystem {
     /**
      * Called with an OpenGL state useful to the rendering of opaque objects. See OpaqueObjectsNode for more information.
      */
-    void renderOpaque();
+    default void renderOpaque() {};
 
     /**
      * Called with an OpenGL state useful to the rendering of alpha blended objects. See SimpleBlendMaterialsNode for more information.
      */
-    void renderAlphaBlend();
+    default void renderAlphaBlend() {};
 
     /**
      * Called with an OpenGL state useful to the rendering of overlays. See OverlaysNode for more information.
      */
-    void renderOverlay();
+    default void renderOverlay() {};
 
     /**
      * @deprecated Currently not used.
      */
     @Deprecated
-    void renderShadows();
+    default void renderShadows() {};
 }

--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
@@ -472,19 +472,6 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
         return (float) java.lang.Math.sin((double) bobFactor * frequency + phaseOffset) * amplitude;
     }
 
-    @Override
-    public void renderOpaque() {
-
-    }
-
-    @Override
-    public void renderAlphaBlend() {
-
-    }
-
-    @Override
-    public void renderShadows() {
-    }
 
     /**
      * Special getter that fetches the client entity via the NetworkSystem instead of the LocalPlayer. This can be

--- a/engine/src/main/java/org/terasology/engine/particles/rendering/SpriteParticleRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/particles/rendering/SpriteParticleRenderer.java
@@ -56,11 +56,6 @@ public class SpriteParticleRenderer implements RenderSystem {
     }
 
     @Override
-    public void renderOpaque() {
-
-    }
-
-    @Override
     public void renderAlphaBlend() {
         if (!opengl33) {
             return;
@@ -77,16 +72,6 @@ public class SpriteParticleRenderer implements RenderSystem {
 
         particleSystemManager.getParticleEmittersByDataComponent(ParticleDataSpriteComponent.class)
             .forEach(particleSystem -> drawParticles(material, particleSystem));
-    }
-
-    @Override
-    public void renderOverlay() {
-
-    }
-
-    @Override
-    public void renderShadows() {
-
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/FloatingTextRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/FloatingTextRenderer.java
@@ -18,16 +18,16 @@ import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.entitySystem.systems.RenderSystem;
 import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.assets.font.Font;
 import org.terasology.engine.rendering.assets.font.FontMeshBuilder;
 import org.terasology.engine.rendering.assets.material.Material;
+import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.cameras.Camera;
+import org.terasology.engine.world.WorldProvider;
 import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.nui.Color;
 import org.terasology.nui.HorizontalAlign;
-import org.terasology.engine.registry.In;
-import org.terasology.engine.rendering.assets.mesh.Mesh;
-import org.terasology.engine.world.WorldProvider;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -35,7 +35,6 @@ import java.util.Map;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
 import static org.lwjgl.opengl.GL11.glDisable;
 import static org.lwjgl.opengl.GL11.glEnable;
-
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class FloatingTextRenderer extends BaseComponentSystem implements RenderSystem {
@@ -155,27 +154,14 @@ public class FloatingTextRenderer extends BaseComponentSystem implements RenderS
     }
 
     @Override
-    public void renderOpaque() {
-    }
-
-    @Override
     public void renderAlphaBlend() {
         render(entityManager.getEntitiesWith(FloatingTextComponent.class, LocationComponent.class));
-    }
-
-    @Override
-    public void renderOverlay() {
-    }
-
-    @Override
-    public void renderShadows() {
     }
 
     @ReceiveEvent(components = FloatingTextComponent.class)
     public void onDisplayNameChange(OnChangedComponent event, EntityRef entity) {
         disposeCachedMeshOfEntity(entity);
     }
-
 
     @ReceiveEvent(components = FloatingTextComponent.class)
     public void onNameTagOwnerRemoved(BeforeDeactivateComponent event, EntityRef entity) {

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/MeshRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/MeshRenderer.java
@@ -130,6 +130,7 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
         }
     }
 
+    @Override
     public void renderOpaque() {
         if (config.getRendering().isRenderNearest()) {
             renderEntities(Arrays.asList(opaqueMeshSorter.getNearest(config.getRendering().getMeshLimit())));
@@ -231,14 +232,6 @@ public class MeshRenderer extends BaseComponentSystem implements RenderSystem {
      */
     private boolean isRelevant(EntityRef entity, Vector3fc position) {
         return worldProvider.isBlockRelevant(position) || entity.isAlwaysRelevant();
-    }
-
-    @Override
-    public void renderOverlay() {
-    }
-
-    @Override
-    public void renderShadows() {
     }
 
     public int getLastRendered() {

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/RegionOutlineRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/RegionOutlineRenderer.java
@@ -62,7 +62,6 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
         mesh = Assets.generateAsset(meshData, Mesh.class);
     }
 
-
     @ReceiveEvent
     public void onRegionOutlineComponentActivation(OnActivatedComponent event, EntityRef entity,
                                                    RegionOutlineComponent component) {
@@ -74,7 +73,6 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
                                                      RegionOutlineComponent component) {
         entityToRegionOutlineMap.remove(entity);
     }
-
 
     @Override
     public void renderOverlay() {
@@ -154,17 +152,5 @@ public class RegionOutlineRenderer extends BaseComponentSystem implements Render
         mesh.reload(meshData);
         mesh.render();
         GL33.glDepthFunc(GL33.GL_LEQUAL);
-    }
-
-    @Override
-    public void renderOpaque() {
-    }
-
-    @Override
-    public void renderAlphaBlend() {
-    }
-
-    @Override
-    public void renderShadows() {
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/SkeletonRenderer.java
@@ -23,17 +23,17 @@ import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.entitySystem.systems.RenderSystem;
 import org.terasology.engine.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.engine.logic.location.Location;
+import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.assets.animation.MeshAnimation;
 import org.terasology.engine.rendering.assets.animation.MeshAnimationFrame;
 import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.assets.skeletalmesh.Bone;
 import org.terasology.engine.rendering.opengl.OpenGLSkeletalMesh;
 import org.terasology.engine.rendering.world.WorldRenderer;
-import org.terasology.joml.geom.AABBf;
-import org.terasology.engine.logic.location.Location;
-import org.terasology.engine.logic.location.LocationComponent;
-import org.terasology.engine.registry.In;
 import org.terasology.engine.utilities.Assets;
+import org.terasology.joml.geom.AABBf;
 
 import java.nio.FloatBuffer;
 import java.util.Arrays;
@@ -168,11 +168,9 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
         entity.saveComponent(skeletalMeshComp);
     }
 
-
     private float getDurationOfAnimation(SkeletalMeshComponent skeletalMeshComp) {
         return skeletalMeshComp.animation.getTimePerFrame() * (skeletalMeshComp.animation.getFrameCount() - 1);
     }
-
 
     private static MeshAnimation randomAnimationData(SkeletalMeshComponent skeletalMeshComp, Random random) {
         List<MeshAnimation> animationPool = skeletalMeshComp.animationPool;
@@ -303,10 +301,6 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
     }
 
     @Override
-    public void renderAlphaBlend() {
-    }
-
-    @Override
     public void renderOverlay() {
         if (config.getRendering().getDebug().isRenderSkeletons()) {
             glDisable(GL_DEPTH_TEST);
@@ -348,10 +342,6 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             }
             glEnable(GL_DEPTH_TEST);
         }
-    }
-
-    @Override
-    public void renderShadows() {
     }
 
     private void renderBoneOrientation(EntityRef boneEntity) {

--- a/engine/src/main/java/org/terasology/engine/rendering/world/selection/BlockSelectionRenderSystem.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/selection/BlockSelectionRenderSystem.java
@@ -75,16 +75,4 @@ public class BlockSelectionRenderSystem extends BaseComponentSystem implements R
         selectionRenderer.endRenderOverlay();
 
     }
-
-    @Override
-    public void renderShadows() {
-    }
-
-    @Override
-    public void renderOpaque() {
-    }
-
-    @Override
-    public void renderAlphaBlend() {
-    }
 }


### PR DESCRIPTION
### Contains

I noticed a bit of clutter boilerplate code in a system implementing `RenderSystem` because of empty implementations of the method hooks for different rendering passes. With Java's default implementations for methods in interfaces we get rid of this boilerplate code by providing the empty implementation directly in the interface.

### How to test

Start the game, everything should look and work the same as before.

### Outstanding before merging

Nothing.