### PR TITLE
fix: failing publish stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,13 +89,13 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', \
                                                     usernameVariable: 'artifactoryUser', \
                                                     passwordVariable: 'artifactoryPass')]) {
-                    sh '''./gradlew
-                        --console=plain
-                        -Dorg.gradle.internal.publish.checksums.insecure=true
-                        publish
-                        -PmavenUser=${artifactoryUser}
+                    sh """./gradlew \
+                        --console=plain \
+                        -Dorg.gradle.internal.publish.checksums.insecure=true \
+                        publish \
+                        -PmavenUser=${artifactoryUser} \
                         -PmavenPass=${artifactoryPass}
-                    '''
+                    """
                 }
                 script {
                     // Trigger the Omega dist job to repackage a game zip with modules


### PR DESCRIPTION
- use double-quotes instead of single-quotes to allow variable substitution
- add backslashes to continue command instead of having multiple in the multiline sh block