### PR TITLE
test: provide a subsystem to register the unittest module

### DIFF
--- a/engine-tests/src/main/java/org/terasology/engine/testUtil/WithUnittestModule.java
+++ b/engine-tests/src/main/java/org/terasology/engine/testUtil/WithUnittestModule.java
@@ -1,0 +1,25 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.testUtil;
+
+import org.terasology.engine.context.Context;
+import org.terasology.engine.core.GameEngine;
+import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.EngineSubsystem;
+import org.terasology.gestalt.module.Module;
+
+public class WithUnittestModule implements EngineSubsystem {
+    @Override
+    public String getName() {
+        return "Unittest";
+    }
+
+    @Override
+    public void initialise(GameEngine engine, Context rootContext) {
+        EngineSubsystem.super.initialise(engine, rootContext);
+        ModuleManager manager = rootContext.get(ModuleManager.class);
+        Module unittestModule = manager.registerPackageModule("org.terasology.unittest");
+        manager.resolveAndLoadEnvironment(unittestModule.getId());
+    }
+}

--- a/engine-tests/src/main/java/org/terasology/engine/testUtil/WithUnittestModule.java
+++ b/engine-tests/src/main/java/org/terasology/engine/testUtil/WithUnittestModule.java
@@ -9,6 +9,17 @@ import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.subsystem.EngineSubsystem;
 import org.terasology.gestalt.module.Module;
 
+/**
+ * This subsystem registers the {@code unittest} module containing stub component classes with the {@link ModuleManager} before the engine
+ * is initialized.
+ * <p>
+ * It is indended to be used on the MTE side by adding it to the list of subsystems given to the builder.
+ * <p>
+ * NOTE: The usage of this subsystem for MTE is potentially fragile as it depends on specific assumptions on when subsystems are initialized.
+ * This makes things work because {@code Subsystem.initialize} is called at a useful place in the engine's boot
+ * sequence, but it's very possible that something else will call {@code ModuleManager.loadEnvironment} later — without including "unittest"
+ * in the environment — and then things might break with an unclear error again.
+ */
 public class WithUnittestModule implements EngineSubsystem {
     @Override
     public String getName() {


### PR DESCRIPTION
Many current ModuleTestingEnvironment errors (#4757) come from a failure to find a module associated with some stub Components included with engine-tests.

This subsystem registers the `unittest` module containing those classes with the ModuleManager before the engine is initialized.

It's used on the MTE side by adding it to the list of subsystems given to the builder: https://github.com/Terasology/ModuleTestingEnvironment/pull/55

## Pros

- Looks like we're on the right track. With this, MTE's own test suite goes from almost-all-failing to 19 pass, 3 failing.
- Very little code to implement and use.


## Cons

- 💄🐷. I still feel this is a kludge that isn't exactly making things simpler. At least it using an existing extension point (subsystems), but it adds a new thing to the mix that isn't usually considered in the module-loading process.
- I worry it's fragile. This makes things work because Subsystem.initialize is called at a useful place in the engine's boot sequence, but it's very possible that something else will call `ModuleManager.loadEnvironment` later—_without_ including `"unittest"` in the environment—and then things will break with an unclear error again. (At least, I think so. Might not. Should test.)
- It leaves the question of "why are we trying to register all components before loading modules?" unanswered.


## Outstanding but maybe not critical?
- Question: If we register the module _without_ entering it in the current module environment, is that sufficient to avoid the error?
- Are there other places in engine-test that should prefer this over their current use of ModuleManagerFactory?