### PR TITLE
chore: remove url check when updating repositories

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -222,8 +222,8 @@ class common {
             def targetUrl = remotes.find {
                 it.name == defaultRemote
             }?.url
-            if (targetUrl == null || !isUrlValid(targetUrl)) {
-                println color("While updating $itemName found its '$defaultRemote' remote invalid or its URL unresponsive: $targetUrl", Ansi.RED)
+            if (targetUrl == null) {
+                println color("While updating $itemName remote `$defaultRemote` is not found.", Ansi.RED)
                 return
             }
 

--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -124,18 +124,19 @@ class common {
         } else {
             itemsRetrieved << itemName
             def targetUrl = "https://github.com/${githubTargetHome}/${itemName}"
-            if (!isUrlValid(targetUrl)) {
-                println "Can't retrieve $itemType from $targetUrl - URL appears invalid. Typo? Not created yet?"
+            try {
+                println "Retrieving $itemType $itemName from $targetUrl"
+                if (githubTargetHome != githubDefaultHome) {
+                    println "Doing a retrieve from a custom remote: $githubTargetHome - will name it as such plus add the $githubDefaultHome remote as '$defaultRemote'"
+                    Grgit.clone dir: targetDir, uri: targetUrl, remote: githubTargetHome
+                    println "Primary clone operation complete, about to add the '$defaultRemote' remote for the $githubDefaultHome org address"
+                    addRemote(itemName, defaultRemote, "https://github.com/${githubDefaultHome}/${itemName}")
+                } else {
+                    Grgit.clone dir: targetDir, uri: targetUrl
+                }
+            } catch (GrgitException exception) {
+                println color("Unable to clone $itemName, Skipping: ${exception.getMessage()}", Ansi.RED)
                 return
-            }
-            println "Retrieving $itemType $itemName from $targetUrl"
-            if (githubTargetHome != githubDefaultHome) {
-                println "Doing a retrieve from a custom remote: $githubTargetHome - will name it as such plus add the $githubDefaultHome remote as '$defaultRemote'"
-                Grgit.clone dir: targetDir, uri: targetUrl, remote: githubTargetHome
-                println "Primary clone operation complete, about to add the '$defaultRemote' remote for the $githubDefaultHome org address"
-                addRemote(itemName, defaultRemote, "https://github.com/${githubDefaultHome}/${itemName}")
-            } else {
-                Grgit.clone dir: targetDir, uri: targetUrl
             }
 
             // This step allows the item type to check the newly cloned item and add in extra template stuff


### PR DESCRIPTION
I found grgit works perfectly well with updating ssh remotes. this just drop the validity check here and if the remote does not exist then it will fail when it tries to pull. I moved the check to when the repository is either pulled or cloned. 

- validate by setting up an omega repository `./groovyw module init omega`
- update all the modules `./groovyw module update-all` 