### PR TITLE
test: mockito inline for modules

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -66,7 +66,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-    testImplementation("org.mockito:mockito-junit-jupiter:3.7.7")
+    testImplementation("org.mockito:mockito-inline:3.11.2")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.11.2")
 }
 
 

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -80,7 +80,7 @@ if (project.name == "ModuleTestingEnvironment") {
         }
         add("implementation", platform("org.junit:junit-bom:5.7.1"))
         implementation("org.junit.jupiter:junit-jupiter-api")
-        implementation("org.mockito:mockito-junit-jupiter:3.7.7")
+        implementation("org.mockito:mockito-junit-jupiter:3.11.2")
     }
 }
 

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -68,9 +68,9 @@ dependencies {
     implementation("org.junit.jupiter:junit-jupiter-api")
     implementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.mockito:mockito-inline:3.7.7")
+    testImplementation("org.mockito:mockito-inline:3.11.2")
 
-    implementation("org.mockito:mockito-junit-jupiter:3.7.7")
+    implementation("org.mockito:mockito-junit-jupiter:3.11.2")
 
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
 

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.5.2")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.2.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.11.2")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.2")
 }


### PR DESCRIPTION
This [enables mockito to work on final types, enums, and final methods](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#39). We already had this in engine-tests, this PR makes it available to module tests.

Also includes a minor upgrade to the version of mockito while we're at it.

PathManagerProvider does use Mockito to stub PathManager, a final class, which means this will be a requirement to use #4807 in practice.