### PR TITLE
test: make parts of PathManagerProvider public for use by MTE

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -44,7 +44,7 @@ configurations {
 // Set dependencies. Note that the dependency information from module.txt is used for other Terasology modules
 dependencies {
     implementation(group = "org.terasology.engine", name = "engine", version = moduleMetadata.engineVersion())
-    implementation(group = "org.terasology.engine", name = "engine-tests", version = moduleMetadata.engineVersion())
+    testImplementation(group = "org.terasology.engine", name = "engine-tests", version = moduleMetadata.engineVersion())
 
     for ((gradleDep, optional) in moduleMetadata.moduleDependencies()) {
         if (optional) {
@@ -73,6 +73,7 @@ dependencies {
 if (project.name == "ModuleTestingEnvironment") {
     dependencies {
         // MTE is a special snowflake, it gets these things as non-test dependencies
+        implementation(group = "org.terasology.engine", name = "engine-tests", version = moduleMetadata.engineVersion())
         implementation("ch.qos.logback:logback-classic:1.2.3")
         runtimeOnly("org.codehaus.janino:janino:3.1.3") {
             because("logback filters")

--- a/engine-tests/src/main/java/org/terasology/engine/core/PathManagerProvider.java
+++ b/engine-tests/src/main/java/org/terasology/engine/core/PathManagerProvider.java
@@ -32,7 +32,7 @@ public final class PathManagerProvider implements ParameterResolver {
     private PathManagerProvider() { };
 
     /** Set a new global PathManager, returning the old one. */
-    static PathManager setPathManager(PathManager pathManager) {
+    public static PathManager setPathManager(PathManager pathManager) {
         return PathManager.setInstance(pathManager);
     }
 
@@ -54,11 +54,11 @@ public final class PathManagerProvider implements ParameterResolver {
     }
 
     /** Make sure the PathManager is reset to its original value at the end of the test. */
-    static class Cleaner implements ExtensionContext.Store.CloseableResource {
+    public static class Cleaner implements ExtensionContext.Store.CloseableResource {
         final PathManager originalPathManager;
         final PathManager tempPathManager;
 
-        Cleaner(PathManager originalPathManager, PathManager tempPathManager) {
+        public Cleaner(PathManager originalPathManager, PathManager tempPathManager) {
             this.originalPathManager = originalPathManager;
             this.tempPathManager = tempPathManager;
         }


### PR DESCRIPTION
We want to be able to run a module's MTE tests without it scanning `/modules/*` every test case, as explained in #4638. We made a `PathManagerProvider` extension to help with this, but when it comes to MTE, I haven't found a way for MTEExtension to declare a dependency on the PathManagerProvider extension.

As a work-around for not having a way to compose Jupiter extensions, MTEExtension wants to call some of these methods directly, which requires making them public.

To help guard against _non_-test code from using these, I've adjusted the dependencies in terasology-module so that a module's `implementation` does not have access to this code in `engine-tests`. That's only for use in `testImplementation`.

There is some risk of that change breaking existing module code, but modules really _shouldn't_ have been using `engine-tests` classes in non-test code in the first place.