### PR TITLE
build(IntelliJ): update annotation paths and other configurations

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -35,6 +35,7 @@ workspace.xml
 /modules
 /inspectionProfiles
 /libraries-with-intellij-classes.xml
+/*.local.xml
 
 # Ignore Sonar linting, if set up locally
 /sonarlint/

--- a/.idea/dictionaries/kevint.xml
+++ b/.idea/dictionaries/kevint.xml
@@ -6,6 +6,7 @@
       <w>minecraft</w>
       <w>reddit</w>
       <w>terasology</w>
+      <w>terasology's</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,5 +10,5 @@
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,8 +10,8 @@
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-</project>
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="4">
-      <item index="0" class="java.lang.String" itemvalue="org.terasology.entitySystem.event.ReceiveEvent" />
-      <item index="1" class="java.lang.String" itemvalue="org.terasology.entitySystem.systems.RegisterSystem" />
-      <item index="2" class="java.lang.String" itemvalue="org.terasology.logic.console.commandSystem.annotations.Command" />
-      <item index="3" class="java.lang.String" itemvalue="org.terasology.registry.In" />
+    <list size="2">
+      <item index="0" class="java.lang.String" itemvalue="org.terasology.engine.entitySystem.event.ReceiveEvent" />
+      <item index="1" class="java.lang.String" itemvalue="org.terasology.engine.logic.console.commandSystem.annotations.Command" />
     </list>
     <writeAnnotations>
-      <writeAnnotation name="org.terasology.registry.In" />
+      <writeAnnotation name="org.terasology.engine.registry.In" />
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,4 +11,7 @@
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
 </project>
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />


### PR DESCRIPTION
Updates IntelliJ's configuration with the newer location of Terasology annotations. Assorted other updates to `/.idea/` while we're here. See individual commit messages for details.

If you squash-merge this, please be sure the contents of those commit messages are included!

### How to test

I wrote this on IntelliJ 2021 Ultimate edition under Linux. It would be good to have someone test

- [ ] under Windows
- [x] using IntelliJ Community Edition

The primary thing to look out for is diff thrashing. The intention behind checking this in is to provide a configuration that _matches_ what we use in practice. If your IDE makes changes to these files every time you start it (leaving your working directory "dirty") it may defeat the purpose.

**However,** it might be confusing for IntelliJ if git makes changes to these files _while you have IntelliJ open._ Before reporting problems with this PR, try

1. Closing IntelliJ
2. pulling this branch (or resetting local changes if you already have this branch checked out)
3. Start IntelliJ
    + look for changes with git status or git diff
    + [anything else you need to do to make sure the project is not broken in IntelliJ]
4. Close IntelliJ
    + look for changes with git status or git diff
