### PR TITLE
refactor(GameState): extract common code from MainMenu and HeadlessSetup

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/AbstractState.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/AbstractState.java
@@ -1,0 +1,84 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.core.modes;
+
+import org.terasology.engine.context.Context;
+import org.terasology.engine.core.ComponentSystemManager;
+import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
+import org.terasology.engine.entitySystem.event.internal.EventSystem;
+import org.terasology.engine.logic.console.Console;
+import org.terasology.engine.logic.console.ConsoleImpl;
+import org.terasology.engine.logic.console.ConsoleSystem;
+import org.terasology.engine.logic.console.commands.CoreCommands;
+import org.terasology.engine.logic.players.LocalPlayer;
+import org.terasology.engine.network.ClientComponent;
+import org.terasology.engine.recording.DirectionAndOriginPosRecorderList;
+import org.terasology.engine.recording.RecordAndReplayCurrentStatus;
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.rendering.nui.NUIManager;
+import org.terasology.engine.rendering.nui.internal.NUIManagerInternal;
+import org.terasology.engine.rendering.nui.internal.TerasologyCanvasRenderer;
+import org.terasology.nui.canvas.CanvasRenderer;
+
+import static com.google.common.base.Verify.verifyNotNull;
+
+public abstract class AbstractState implements GameState {
+    protected Context context;
+    protected EngineEntityManager entityManager;
+    protected EventSystem eventSystem;
+    protected ComponentSystemManager componentSystemManager;
+
+    protected void initEntityAndComponentManagers() {
+        verifyNotNull(context);
+        CoreRegistry.setContext(context);
+
+        // let's get the entity event system running
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
+        entityManager = context.get(EngineEntityManager.class);
+
+        eventSystem = context.get(EventSystem.class);
+        context.put(Console.class, new ConsoleImpl(context));
+
+        NUIManager nuiManager = new NUIManagerInternal((TerasologyCanvasRenderer) context.get(CanvasRenderer.class), context);
+        context.put(NUIManager.class, nuiManager);
+
+        componentSystemManager = new ComponentSystemManager(context);
+        context.put(ComponentSystemManager.class, componentSystemManager);
+
+        componentSystemManager.register(new ConsoleSystem(), "engine:ConsoleSystem");
+        componentSystemManager.register(new CoreCommands(), "engine:CoreCommands");
+    }
+
+    protected static void createLocalPlayer(Context context) {
+        EngineEntityManager entityManager = context.get(EngineEntityManager.class);
+        EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
+        LocalPlayer localPlayer = new LocalPlayer();
+        localPlayer.setRecordAndReplayClasses(context.get(DirectionAndOriginPosRecorderList.class),
+                context.get(RecordAndReplayCurrentStatus.class));
+        context.put(LocalPlayer.class, localPlayer);
+        localPlayer.setClientEntity(localPlayerEntity);
+    }
+
+    @Override
+    public void dispose(boolean shuttingDown) {
+        // Apparently this can be disposed of before it is completely initialized? Probably only during
+        // crashes, but crashing again during shutdown complicates the diagnosis.
+        if (eventSystem != null) {
+            eventSystem.process();
+        }
+        if (componentSystemManager != null) {
+            componentSystemManager.shutdown();
+        }
+        if (entityManager != null) {
+            entityManager.clear();
+        }
+    }
+
+    @Override
+    public Context getContext() {
+        return context;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Queues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.crashreporter.CrashReporter;
-import org.terasology.engine.config.Config;
 import org.terasology.engine.config.SystemConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.EngineTime;
@@ -66,9 +65,9 @@ public class StateLoading implements GameState {
     private static final Logger logger = LoggerFactory.getLogger(StateLoading.class);
 
     private Context context;
-    private GameManifest gameManifest;
-    private NetworkMode netMode;
-    private Queue<LoadProcess> loadProcesses = Queues.newArrayDeque();
+    private final GameManifest gameManifest;
+    private final NetworkMode netMode;
+    private final Queue<LoadProcess> loadProcesses = Queues.newArrayDeque();
     private LoadProcess current;
     private JoinStatus joinStatus;
 
@@ -76,7 +75,6 @@ public class StateLoading implements GameState {
 
     private LoadingScreen loadingScreen;
 
-    private Config config;
     private SystemConfig systemConfig;
 
     private int progress;
@@ -109,7 +107,6 @@ public class StateLoading implements GameState {
         this.context = engine.createChildContext();
         CoreRegistry.setContext(context);
 
-        config = context.get(Config.class);
         systemConfig = context.get(SystemConfig.class);
 
         this.nuiManager = new NUIManagerInternal((TerasologyCanvasRenderer) context.get(CanvasRenderer.class), context);

--- a/engine/src/main/java/org/terasology/engine/core/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateMainMenu.java
@@ -5,52 +5,27 @@ package org.terasology.engine.core.modes;
 import org.terasology.engine.audio.AudioManager;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.TelemetryConfig;
-import org.terasology.engine.context.Context;
-import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.GameEngine;
 import org.terasology.engine.core.LoggingContext;
-import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.modes.loadProcesses.RegisterInputSystem;
-import org.terasology.engine.entitySystem.entity.EntityRef;
-import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
-import org.terasology.engine.entitySystem.event.internal.EventSystem;
 import org.terasology.engine.i18n.TranslationSystem;
 import org.terasology.engine.identity.storageServiceClient.StorageServiceWorker;
 import org.terasology.engine.input.InputSystem;
-import org.terasology.engine.input.cameraTarget.CameraTargetSystem;
 import org.terasology.engine.logic.console.Console;
-import org.terasology.engine.logic.console.ConsoleImpl;
-import org.terasology.engine.logic.console.ConsoleSystem;
-import org.terasology.engine.logic.console.commands.CoreCommands;
-import org.terasology.engine.logic.players.LocalPlayer;
-import org.terasology.engine.network.ClientComponent;
-import org.terasology.engine.recording.DirectionAndOriginPosRecorderList;
-import org.terasology.engine.recording.RecordAndReplayCurrentStatus;
-import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.rendering.nui.NUIManager;
 import org.terasology.engine.rendering.nui.editor.systems.NUIEditorSystem;
 import org.terasology.engine.rendering.nui.editor.systems.NUISkinEditorSystem;
-import org.terasology.engine.rendering.nui.internal.NUIManagerInternal;
-import org.terasology.engine.rendering.nui.internal.TerasologyCanvasRenderer;
 import org.terasology.engine.rendering.nui.layers.mainMenu.LaunchPopup;
 import org.terasology.engine.rendering.nui.layers.mainMenu.MessagePopup;
 import org.terasology.engine.telemetry.TelemetryScreen;
 import org.terasology.engine.telemetry.TelemetryUtils;
 import org.terasology.engine.telemetry.logstash.TelemetryLogstashAppender;
 import org.terasology.engine.utilities.Assets;
-import org.terasology.nui.canvas.CanvasRenderer;
 
 /**
  * The class implements the main game menu.
- * <br><br>
- *
- * @version 0.3
  */
-public class StateMainMenu implements GameState {
-    private Context context;
-    private EngineEntityManager entityManager;
-    private EventSystem eventSystem;
-    private ComponentSystemManager componentSystemManager;
+public class StateMainMenu extends AbstractState {
     private NUIManager nuiManager;
     private InputSystem inputSystem;
     private Console console;
@@ -69,33 +44,15 @@ public class StateMainMenu implements GameState {
     @Override
     public void init(GameEngine gameEngine) {
         context = gameEngine.createChildContext();
-        CoreRegistry.setContext(context);
+        initEntityAndComponentManagers();
 
-        //let's get the entity event system running
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
-        entityManager = context.get(EngineEntityManager.class);
+        createLocalPlayer(context);
 
-        eventSystem = context.get(EventSystem.class);
-        console = new ConsoleImpl(context);
-        context.put(Console.class, console);
+        // TODO: REMOVE this and handle refreshing of core game state at the engine level - see Issue #1127
+        new RegisterInputSystem(context).step();
 
-        nuiManager = new NUIManagerInternal((TerasologyCanvasRenderer) context.get(CanvasRenderer.class), context);
-        context.put(NUIManager.class, nuiManager);
-
+        nuiManager = context.get(NUIManager.class);
         eventSystem.registerEventHandler(nuiManager);
-
-        componentSystemManager = new ComponentSystemManager(context);
-        context.put(ComponentSystemManager.class, componentSystemManager);
-
-        // TODO: Reduce coupling between Input system and CameraTargetSystem,
-        // TODO: potentially eliminating the following lines. See Issue #1126
-        CameraTargetSystem cameraTargetSystem = new CameraTargetSystem();
-        context.put(CameraTargetSystem.class, cameraTargetSystem);
-
-        componentSystemManager.register(cameraTargetSystem, "engine:CameraTargetSystem");
-        componentSystemManager.register(new ConsoleSystem(), "engine:ConsoleSystem");
-        componentSystemManager.register(new CoreCommands(), "engine:CoreCommands");
-
         NUIEditorSystem nuiEditorSystem = new NUIEditorSystem();
         context.put(NUIEditorSystem.class, nuiEditorSystem);
         componentSystemManager.register(nuiEditorSystem, "engine:NUIEditorSystem");
@@ -106,17 +63,9 @@ public class StateMainMenu implements GameState {
 
         inputSystem = context.get(InputSystem.class);
 
-        // TODO: REMOVE this and handle refreshing of core game state at the engine level - see Issue #1127
-        new RegisterInputSystem(context).step();
-
-        EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
-        LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setRecordAndReplayClasses(context.get(DirectionAndOriginPosRecorderList.class), context.get(RecordAndReplayCurrentStatus.class));
-        context.put(LocalPlayer.class, localPlayer);
-        localPlayer.setClientEntity(localPlayerEntity);
-
         componentSystemManager.initialise();
 
+        console = context.get(Console.class);
         storageServiceWorker = context.get(StorageServiceWorker.class);
 
         playBackgroundMusic();
@@ -164,22 +113,11 @@ public class StateMainMenu implements GameState {
 
     @Override
     public void dispose(boolean shuttingDown) {
-        // Apparently this can be disposed of before it is completely initialized? Probably only during
-        // crashes, but crashing again during shutdown complicates the diagnosis.
-        if (eventSystem != null) {
-            eventSystem.process();
-        }
-        if (componentSystemManager != null) {
-            componentSystemManager.shutdown();
-        }
         stopBackgroundMusic();
-
         if (nuiManager != null) {
             nuiManager.clear();
         }
-        if (entityManager != null) {
-            entityManager.clear();
-        }
+        super.dispose(shuttingDown);
     }
 
     private void playBackgroundMusic() {
@@ -212,11 +150,6 @@ public class StateMainMenu implements GameState {
     @Override
     public String getLoggingPhase() {
         return LoggingContext.MENU;
-    }
-
-    @Override
-    public Context getContext() {
-        return context;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/headless/mode/StateHeadlessSetup.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/headless/mode/StateHeadlessSetup.java
@@ -6,42 +6,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.WorldGenerationConfig;
-import org.terasology.engine.context.Context;
-import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.GameEngine;
 import org.terasology.engine.core.LoggingContext;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.TerasologyConstants;
-import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
-import org.terasology.engine.core.modes.GameState;
+import org.terasology.engine.core.modes.AbstractState;
 import org.terasology.engine.core.modes.StateLoading;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.module.StandardModuleExtension;
-import org.terasology.engine.entitySystem.entity.EntityRef;
-import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
-import org.terasology.engine.entitySystem.event.internal.EventSystem;
 import org.terasology.engine.game.GameManifest;
 import org.terasology.engine.input.InputSystem;
-import org.terasology.engine.logic.console.Console;
-import org.terasology.engine.logic.console.ConsoleImpl;
-import org.terasology.engine.logic.console.ConsoleSystem;
-import org.terasology.engine.logic.console.commands.CoreCommands;
-import org.terasology.engine.logic.players.LocalPlayer;
-import org.terasology.engine.network.ClientComponent;
 import org.terasology.engine.network.NetworkMode;
-import org.terasology.engine.recording.DirectionAndOriginPosRecorderList;
-import org.terasology.engine.recording.RecordAndReplayCurrentStatus;
-import org.terasology.engine.registry.CoreRegistry;
-import org.terasology.engine.rendering.nui.NUIManager;
-import org.terasology.engine.rendering.nui.internal.NUIManagerInternal;
-import org.terasology.engine.rendering.nui.internal.TerasologyCanvasRenderer;
 import org.terasology.engine.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.engine.rendering.nui.layers.mainMenu.savedGames.GameProvider;
 import org.terasology.engine.world.internal.WorldInfo;
 import org.terasology.engine.world.time.WorldTime;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.naming.Name;
-import org.terasology.nui.canvas.CanvasRenderer;
 
 import java.util.List;
 
@@ -49,14 +30,9 @@ import java.util.List;
  * The class is game selection menu replacement for the headless server.
  *
  */
-public class StateHeadlessSetup implements GameState {
+public class StateHeadlessSetup extends AbstractState {
 
     private static final Logger logger = LoggerFactory.getLogger(StateHeadlessSetup.class);
-
-    private EngineEntityManager entityManager;
-    private EventSystem eventSystem;
-    private ComponentSystemManager componentSystemManager;
-    private Context context;
 
     public StateHeadlessSetup() {
     }
@@ -64,31 +40,10 @@ public class StateHeadlessSetup implements GameState {
     @Override
     public void init(GameEngine gameEngine) {
         context = gameEngine.createChildContext();
-        CoreRegistry.setContext(context);
+        initEntityAndComponentManagers();
+        createLocalPlayer(context);
 
-        // let's get the entity event system running
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context);
-        entityManager = context.get(EngineEntityManager.class);
-
-        eventSystem = context.get(EventSystem.class);
-        context.put(Console.class, new ConsoleImpl(context));
-
-        NUIManager nuiManager = new NUIManagerInternal((TerasologyCanvasRenderer) context.get(CanvasRenderer.class), context);
-        context.put(NUIManager.class, nuiManager);
-
-        componentSystemManager = new ComponentSystemManager(context);
-        context.put(ComponentSystemManager.class, componentSystemManager);
-
-        componentSystemManager.register(new ConsoleSystem(), "engine:ConsoleSystem");
-        componentSystemManager.register(new CoreCommands(), "engine:CoreCommands");
         componentSystemManager.register(context.get(InputSystem.class), "engine:InputSystem");
-
-        EntityRef localPlayerEntity = entityManager.create(new ClientComponent());
-        LocalPlayer localPlayer = new LocalPlayer();
-        localPlayer.setRecordAndReplayClasses(context.get(DirectionAndOriginPosRecorderList.class), context.get(RecordAndReplayCurrentStatus.class));
-        context.put(LocalPlayer.class, localPlayer);
-        localPlayer.setClientEntity(localPlayerEntity);
-
         componentSystemManager.initialise();
 
         GameManifest gameManifest;
@@ -148,15 +103,6 @@ public class StateHeadlessSetup implements GameState {
     }
 
     @Override
-    public void dispose(boolean shuttingDown) {
-        eventSystem.process();
-
-        componentSystemManager.shutdown();
-
-        entityManager.clear();
-    }
-
-    @Override
     public void handleInput(float delta) {
     }
 
@@ -177,10 +123,5 @@ public class StateHeadlessSetup implements GameState {
     @Override
     public String getLoggingPhase() {
         return LoggingContext.INIT_PHASE;
-    }
-
-    @Override
-    public Context getContext() {
-        return context;
     }
 }


### PR DESCRIPTION
I was working with the StateHeadlessSetup class and noticing it has a lot of code duplicated from another class. To make it easier to see what the differences between the various classes are, I extracted the common code to some methods.

No change in functionality is intended by this PR, but I did re-order the execution of some of these components, which has the potential to break something.

## Notes to Reviewers

I'm not thrilled about the state of things here, but it's a refactor, so please try to limit the scope of your requests to the refactoring. I'd also like to avoid getting pulled down the rabbit hole of putting _all_ the potentially related refactors we can think of into this PR.

Things it would be useful to have feedback on:

* Should this code really **not** be common between these two classes? If you think some of it was copied from one to the other by mistake and it really shouldn't be in both, this change could be counterproductive.
* _Create a superclass_ is not a great pattern, but since we need to initialize four fields on the instance, I haven't thought of another pattern that would fit without more extensive changes.
* Names of things. `AbstractState` is a particularly unhelpful name.