### PR TITLE
build: avoid transitive dependency on org.reflections

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -37,7 +37,14 @@ configure<SourceSetContainer> {
 
 configurations {
     all {
-        resolutionStrategy.preferProjectModules()
+        resolutionStrategy {
+            preferProjectModules()
+            // always pick reflections fork
+            dependencySubstitution {
+                @Suppress("UnstableApiUsage")
+                substitute(module("org.reflections:reflections")).using(module("org.terasology:reflections:0.9.12-MB"))
+            }
+        }
     }
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -51,6 +51,15 @@ configurations {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        // always pick reflections fork
+        dependencySubstitution {
+            substitute(module("org.reflections:reflections")).using(module("org.terasology:reflections:0.9.12-MB"))
+        }
+    }
+}
+
 // Primary dependencies definition
 dependencies {
     // Storage and networking


### PR DESCRIPTION
because we are using our org.terasology fork of reflections.

I noticed while running MTE tests that both `org.reflections:reflections:0.9.10` and `org.terasology:reflections:0.9.12-MB` are in the classpath.

I am not _sure_ if that was contributing to the things I was trying to troubleshoot, but it seems like a bad idea.

I think the root cause is that one of our libraries has a dependency on upstream, not the fork, and we don't have anything set up to declare that the two conflict.