### PR TITLE
feat(ModuleManager): do not depend on PathManager to load modules from the classpath

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
@@ -57,6 +57,8 @@ import org.terasology.gestalt.module.ModuleEnvironment;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static com.google.common.base.Verify.verify;
+
 public class InitialiseWorld extends SingleStepLoadProcess {
 
     private static final Logger logger = LoggerFactory.getLogger(InitialiseWorld.class);
@@ -83,6 +85,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         context.put(WorldGeneratorPluginLibrary.class, new DefaultWorldGeneratorPluginLibrary(environment, context));
 
         WorldInfo worldInfo = gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD);
+        verify(worldInfo.getWorldGenerator().isValid(), "Game manifest did not specify world type.");
         if (worldInfo.getSeed() == null || worldInfo.getSeed().isEmpty()) {
             FastRandom random = new FastRandom();
             worldInfo.setSeed(random.nextString(16));

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -94,17 +94,18 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
         return findModuleRoot(relativePathFromModuleRoot, path).orElse(path);
     }
 
-    private Path modulePathFromMetadataJarUrl(URL url) {
-        checkArgument(url.getProtocol().equals("jar"), "Not a jar URL: %s", url);
+    private Path modulePathFromMetadataJarUrl(URL jarUrl) {
+        checkArgument(jarUrl.getProtocol().equals("jar"), "Not a jar URL: %s", jarUrl);
+        URL fileUrl;
         try {
-            JarURLConnection connection = (JarURLConnection) url.openConnection();
-            url = connection.getJarFileURL();
+            JarURLConnection connection = (JarURLConnection) jarUrl.openConnection();
+            fileUrl = connection.getJarFileURL();
             // despite the method name, openConnection doesn't open anything unless we
             // call connect(), so we needn't clean up anything here.
         } catch (IOException e) {
-            throw new RuntimeException("Failed to get file from " + url, e);
+            throw new RuntimeException("Failed to get file from " + jarUrl, e);
         }
-        Path path = fromUrl(url);
+        Path path = fromUrl(fileUrl);
         // We are considering the location of a jar file, so compare it to the libs path.
         Path relativePathFromModuleRoot = Paths.get(getDefaultLibsSubpath());
         // Assume jars would be directly in the libs path (not in a subdirectory).

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -86,11 +86,11 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
         }
     }
 
-    private Path modulePathFromMetadataFileUrl(String metadata_name, URL url) {
+    private Path modulePathFromMetadataFileUrl(String metadataName, URL url) {
         Path path = fromUrl(url);
         // We are considering the location of a resource file, so compare it to the code path.
-        // Include the metadata_name in case it has path components of its own.
-        Path relativePathFromModuleRoot = Paths.get(getDefaultCodeSubpath(), metadata_name);
+        // Include the metadata name in case it has path components of its own.
+        Path relativePathFromModuleRoot = Paths.get(getDefaultCodeSubpath(), metadataName);
         return findModuleRoot(relativePathFromModuleRoot, path).orElse(path);
     }
 

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -135,7 +135,7 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
             }
             return Optional.of(parentPath);
         } else {
-            logger.warn(" +- does not seem to be in a build directory {}", path);
+            logger.warn("does not seem to be in a build directory {}", path);
             return Optional.empty();
         }
     }

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -13,6 +13,7 @@ import org.terasology.engine.config.Config;
 import org.terasology.engine.config.SystemConfig;
 import org.terasology.engine.core.PathManager;
 import org.terasology.engine.core.TerasologyConstants;
+import org.terasology.engine.utilities.Jvm;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
@@ -40,10 +41,12 @@ import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Policy;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +77,9 @@ public class ModuleManager {
         engineModule = loadAndConfigureEngineModule(moduleFactory, classesOnClasspathsToAddToEngine);
         registry.add(engineModule);
 
+        if (isLoadingClasspathModules()) {
+            loadModulesFromClassPath();
+        }
         loadModulesFromApplicationPath(PathManager.getInstance());
 
         ensureModulesDependOnEngine();
@@ -91,11 +97,16 @@ public class ModuleManager {
         this(config.getNetwork().getMasterServer(), classesOnClasspathsToAddToEngine);
     }
 
+    protected static boolean isLoadingClasspathModules() {
+        return Boolean.getBoolean(LOAD_CLASSPATH_MODULES_PROPERTY);
+    };
+
     /** Create a ModuleFactory configured for Terasology modules. */
     private static ModuleFactory newModuleFactory(ModuleMetadataJsonAdapter metadataReader) {
         final ModuleFactory moduleFactory;
-        if (Boolean.getBoolean(LOAD_CLASSPATH_MODULES_PROPERTY)) {
+        if (isLoadingClasspathModules()) {
             moduleFactory = new ClasspathCompromisingModuleFactory();
+            Jvm.logClasspath(logger);
         } else {
             moduleFactory = new ModuleFactory();
         }
@@ -134,6 +145,56 @@ public class ModuleManager {
                 .map(Path::toFile)
                 .collect(Collectors.toList());
         scanner.scan(registry, paths);
+    }
+
+    private void loadModulesFromClassPath() {
+        for (String metadata_name : moduleFactory.getModuleMetadataLoaderMap().keySet()) {
+            Enumeration<URL> urls;
+            try {
+                urls = ClassLoader.getSystemResources(metadata_name);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            Path relativePathFromModuleRoot = Paths.get(moduleFactory.getDefaultCodeSubpath(), metadata_name);
+            int relativeDepth = relativePathFromModuleRoot.getNameCount();
+            while (urls.hasMoreElements()) {
+                URL url = urls.nextElement();
+                Path path;
+                try {
+                    path = Paths.get(url.toURI());
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+                logger.warn(" 🌷 Might be a module in U:{} P:{}", url, path);
+                // TODO: test case for metadata file in code subpath
+                if (path.endsWith(relativePathFromModuleRoot)) {
+                    Path parentPath = path.subpath(0, path.getNameCount() - relativeDepth);
+                    if (path.getRoot() != null) {
+                        parentPath = path.getRoot().resolve(parentPath);
+                    }
+                    if (parentPath.toFile().exists()) {
+                        logger.warn(" +-🌷 Could be built from here {}", parentPath);
+                        path = parentPath;
+                    } else {
+                        logger.warn(" +-🥀 Does this not exist? P:{} F:{}", parentPath, parentPath.toFile());
+                    }
+                } else {
+                    logger.warn(" +-🌷 does not seem to be in a build directory");
+                }
+                Module module;
+                try {
+                    module = moduleFactory.createModule(path.toFile());
+                } catch (IOException e) {
+                    logger.warn("Failed to create module from {}", path, e);
+                    continue;
+                }
+                if (registry.add(module)) {
+                    logger.info("Loaded {} from {}", module.getId(), path);
+                } else {
+                    logger.info("Module {} from {} was a duplicate; not registering this copy.", module.getId(), path);
+                }
+            }
+        }
     }
 
     /**

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -148,17 +148,17 @@ public class ModuleManager {
 
     private void loadModulesFromClassPath() {
         ClasspathCompromisingModuleFactory moduleFactory = (ClasspathCompromisingModuleFactory) this.moduleFactory;
-        for (String metadata_name : moduleFactory.getModuleMetadataLoaderMap().keySet()) {
+        for (String metadataName : moduleFactory.getModuleMetadataLoaderMap().keySet()) {
             Enumeration<URL> urls;
             try {
-                urls = ClassLoader.getSystemResources(metadata_name);
+                urls = ClassLoader.getSystemResources(metadataName);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
             while (urls.hasMoreElements()) {
                 URL url = urls.nextElement();
                 logger.debug("Probably a module in U:{}", url);
-                Path path = moduleFactory.canonicalModuleLocation(metadata_name, url);
+                Path path = moduleFactory.canonicalModuleLocation(metadataName, url);
                 Module module;
                 try {
                     module = moduleFactory.createModule(path.toFile());


### PR DESCRIPTION
When modules run tests, the module and its dependencies are in the classpath. The test runner is unlikely to put unrelated modules in the classpath. This PR enables us to load those modules without registering everything in a `modules/` directory.

Required for some MTE improvements (PR pending).

No expected impact in normal execution, this only takes effect when the system property telling ModuleManager to use classpath modules is turned on.

### How to test

I think to thing to check is that module tests that are currently passing are still passing with this branch.

I _expect_ that works; if it doesn't, this may have to wait for merge until the accompanying MTE PR is ready.

### Outstanding before merging

- [x] unit tests
- [ ] try with module-tests that have dependencies; source-present and otherwise