### PR TITLE
chore(rendering): cleanup and remove deprecated glDisabled

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphicsUtil.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphicsUtil.java
@@ -101,7 +101,6 @@ public final class LwjglGraphicsUtil {
     public static void initOpenGLParams() {
         glEnable(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
-        glEnable(GL_NORMALIZE);
         glDepthFunc(GL_LEQUAL);
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -334,10 +334,6 @@ public final class WorldRendererImpl implements WorldRenderer {
      */
     @Override
     public void render(RenderingStage renderingStage) {
-        // If no rendering module populated renderGraph, throw an exception.
-        /* if (renderGraph.getNodeMapSize() < 1) {
-            throw new RuntimeException("Render graph is not ready to render. Did you use a rendering module?");
-        } */
 
         preRenderUpdate(renderingStage);
 
@@ -350,9 +346,6 @@ public final class WorldRendererImpl implements WorldRenderer {
         glDisable(GL_CULL_FACE);
         FBO lastUpdatedGBuffer = displayResolutionDependentFbo.getGBufferPair().getLastUpdatedFbo();
         glViewport(0, 0, lastUpdatedGBuffer.width(), lastUpdatedGBuffer.height());
-        // glDisable(GL_DEPTH_TEST);
-        // glDisable(GL_NORMALIZE); // currently keeping these as they are, until we find where they are used.
-        // glDepthFunc(GL_LESS);
 
         renderPipelineTaskList.forEach(RenderPipelineTask::process);
 


### PR DESCRIPTION
here is some minor cleanup of this logic and I also remove GL_NORMALIZED. this is not available in the standard for opengl 30: http://docs.gl/gl3/glEnable

- GL_NORMALIZE is deprecated
- cleanup unused code in WorldRenderImpl