### PR TITLE
feat: allow for ranged item activation

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
@@ -357,7 +357,7 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
             //      player's character component and the used item's range component...
             float interactionRange;
             if (event.isOwnedEntityUsage() && event.getUsedOwnedEntity().hasComponent(RangeComponent.class)) {
-                interactionRange = Math.max(event.getUsedOwnedEntity().getComponent(RangeComponent.class).value,
+                interactionRange = Math.max(event.getUsedOwnedEntity().getComponent(RangeComponent.class).range,
                         characterComponent.interactionRange);
             } else {
                 interactionRange = characterComponent.interactionRange;

--- a/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
@@ -30,6 +30,7 @@ import org.terasology.engine.logic.characters.events.PlayerDeathEvent;
 import org.terasology.engine.logic.characters.interactions.InteractionUtil;
 import org.terasology.engine.logic.common.ActivateEvent;
 import org.terasology.engine.logic.common.DisplayNameComponent;
+import org.terasology.engine.logic.common.RangeComponent;
 import org.terasology.engine.logic.health.BeforeDestroyEvent;
 import org.terasology.engine.logic.health.DestroyEvent;
 import org.terasology.engine.logic.health.EngineDamageTypes;
@@ -352,7 +353,17 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
                 return false; // can happen if target existed on client
             }
 
-            HitResult result = physics.rayTrace(originPos, direction, characterComponent.interactionRange, Sets.newHashSet(character),
+            //FIXME This is the same code as in LocalPlayer#activateTargetOrOwnedEntity to derive the actual interaction range from the
+            //      player's character component and the used item's range component...
+            float interactionRange;
+            if (event.isOwnedEntityUsage() && event.getUsedOwnedEntity().hasComponent(RangeComponent.class)) {
+                interactionRange = Math.max(event.getUsedOwnedEntity().getComponent(RangeComponent.class).value,
+                        characterComponent.interactionRange);
+            } else {
+                interactionRange = characterComponent.interactionRange;
+            }
+
+            HitResult result = physics.rayTrace(originPos, direction, interactionRange, Sets.newHashSet(character),
                     DEFAULTPHYSICSFILTER);
             if (!result.isHit()) {
                 String msg = "Denied activation attempt by {} since at the authority there was nothing to activate at that place";
@@ -383,8 +394,13 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
                 logger.info(msg, getPlayerNameFromCharacter(character));
                 return false;
             }
-            if (!(event.getHitPosition().equals(originPos, 0.0001f))) {
-                String msg = "Denied activation attempt by {} since the event was not properly labeled as having a hit postion";
+            if (event.getHitPosition() != null) {
+                String msg = "Denied activation attempt by {} since the event was not properly labeled as having a hit position";
+                logger.info(msg, getPlayerNameFromCharacter(character));
+                return false;
+            }
+            if (event.getHitNormal() != null) {
+                String msg = "Denied activation attempt by {} since the event was not properly labeled as having a hit delta";
                 logger.info(msg, getPlayerNameFromCharacter(character));
                 return false;
             }

--- a/engine/src/main/java/org/terasology/engine/logic/characters/events/ActivationPredicted.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/events/ActivationPredicted.java
@@ -17,7 +17,10 @@ public class ActivationPredicted extends AbstractConsumableEvent {
     private Vector3f hitNormal;
     private int activationId;
 
-    public ActivationPredicted() {
+    /**
+     * INTERNAL: required for serialization.
+     */
+    protected ActivationPredicted() {
     }
 
     public ActivationPredicted(EntityRef instigator, EntityRef target, Vector3f origin, Vector3f direction,
@@ -35,6 +38,9 @@ public class ActivationPredicted extends AbstractConsumableEvent {
         return instigator;
     }
 
+    /**
+     * @return the entity that is hit, or {@link EntityRef#NULL} if the activation has no target
+     */
     public EntityRef getTarget() {
         return target;
     }
@@ -47,10 +53,16 @@ public class ActivationPredicted extends AbstractConsumableEvent {
         return direction;
     }
 
+    /**
+     * @return the hit position if {@link #getTarget()} exists, {@code null} otherwise
+     */
     public Vector3f getHitPosition() {
         return hitPosition;
     }
 
+    /**
+     * @return the hit normal if {@link #getTarget()} exists, {@code null} otherwise
+     */
     public Vector3f getHitNormal() {
         return hitNormal;
     }
@@ -59,6 +71,9 @@ public class ActivationPredicted extends AbstractConsumableEvent {
         return activationId;
     }
 
+    /**
+     * @return the target location if {@link #getTarget()} exists and has a location, {@code null} otherwise
+     */
     public Vector3f getTargetLocation() {
         LocationComponent loc = target.getComponent(LocationComponent.class);
         if (loc != null) {

--- a/engine/src/main/java/org/terasology/engine/logic/characters/events/ActivationRequest.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/events/ActivationRequest.java
@@ -27,7 +27,10 @@ public class ActivationRequest extends NetworkEvent {
     private Vector3f hitNormal;
     private int activationId;
 
-    public ActivationRequest() {
+    /**
+     * INTERNAL: required for serialization.
+     */
+    protected ActivationRequest() {
     }
 
     public ActivationRequest(EntityRef instigator, boolean ownedEntityUsage, EntityRef usedOwnedEntity,
@@ -57,6 +60,9 @@ public class ActivationRequest extends NetworkEvent {
         return eventWithTarget;
     }
 
+    /**
+     * @return the entity that is hit, or {@link EntityRef#NULL} if the activation has no target
+     */
     public EntityRef getTarget() {
         return target;
     }
@@ -69,10 +75,16 @@ public class ActivationRequest extends NetworkEvent {
         return direction;
     }
 
+    /**
+     * @return the hit position if {@link #isEventWithTarget()} is true, {@code null} otherwise
+     */
     public Vector3f getHitPosition() {
         return hitPosition;
     }
 
+    /**
+     * @return the hit normal if {@link #isEventWithTarget()} is true, {@code null} otherwise
+     */
     public Vector3f getHitNormal() {
         return hitNormal;
     }

--- a/engine/src/main/java/org/terasology/engine/logic/common/ActivateEvent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/common/ActivateEvent.java
@@ -43,6 +43,9 @@ public class ActivateEvent extends AbstractConsumableEvent {
         return instigator;
     }
 
+    /**
+     * @return the entity that is targeted, or {@link EntityRef#NULL} if the activation has no target
+     */
     public EntityRef getTarget() {
         return target;
     }
@@ -55,10 +58,16 @@ public class ActivateEvent extends AbstractConsumableEvent {
         return direction;
     }
 
+    /**
+     * @return the hit position if {@link #getTarget()} exists, {@code null} otherwise
+     */
     public Vector3f getHitPosition() {
         return hitPosition;
     }
 
+    /**
+     * @return the hit normal if {@link #getTarget()} exists, {@code null} otherwise
+     */
     public Vector3f getHitNormal() {
         return hitNormal;
     }
@@ -67,6 +76,9 @@ public class ActivateEvent extends AbstractConsumableEvent {
         return activationId;
     }
 
+    /**
+     * @return the target location if {@link #getTarget()} exists and has a location, {@code null} otherwise
+     */
     public Vector3f getTargetLocation() {
         LocationComponent loc = target.getComponent(LocationComponent.class);
         if (loc != null) {
@@ -89,5 +101,18 @@ public class ActivateEvent extends AbstractConsumableEvent {
             return result;
         }
         return new Vector3f();
+    }
+
+    @Override
+    public String toString() {
+        return "ActivateEvent{" +
+                "instigator=" + instigator +
+                ", target=" + target +
+                ", origin=" + origin +
+                ", direction=" + direction +
+                ", hitPosition=" + hitPosition +
+                ", hitNormal=" + hitNormal +
+                ", activationId=" + activationId +
+                '}';
     }
 }

--- a/engine/src/main/java/org/terasology/engine/logic/common/RangeComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/common/RangeComponent.java
@@ -14,5 +14,5 @@ public class RangeComponent implements Component {
     /**
      * The range measured in in-game blocks.
      */
-    public float value;
+    public float range;
 }

--- a/engine/src/main/java/org/terasology/engine/logic/common/RangeComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/common/RangeComponent.java
@@ -1,0 +1,18 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.logic.common;
+
+import org.terasology.engine.entitySystem.Component;
+
+/**
+ * Indicate that an entity has a <i>range</i>.
+ * <p>
+ * This can be used to give items an extended range for activation, but may also be used to indicate any other ranged ability of an entity.
+ */
+public class RangeComponent implements Component {
+    /**
+     * The range measured in in-game blocks.
+     */
+    public float value;
+}

--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayer.java
@@ -238,6 +238,8 @@ public class LocalPlayer {
         int activationId = nextActivationId++;
         Physics physics = CoreRegistry.get(Physics.class);
 
+        //FIXME This is the same code as in CharacterSystem#isPredictionOfEventCorrect to derive the actual interaction range from the
+        //      player's character component and the used item's range component...
         float interactionRange;
         if (ownedEntityUsage && usedOwnedEntity.hasComponent(RangeComponent.class)) {
             interactionRange = Math.max(usedOwnedEntity.getComponent(RangeComponent.class).range, characterComponent.interactionRange);

--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayer.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayer.java
@@ -240,7 +240,7 @@ public class LocalPlayer {
 
         float interactionRange;
         if (ownedEntityUsage && usedOwnedEntity.hasComponent(RangeComponent.class)) {
-            interactionRange = Math.max(usedOwnedEntity.getComponent(RangeComponent.class).value, characterComponent.interactionRange);
+            interactionRange = Math.max(usedOwnedEntity.getComponent(RangeComponent.class).range, characterComponent.interactionRange);
         } else {
             interactionRange = characterComponent.interactionRange;
         }


### PR DESCRIPTION
This originates from a discussion with @ahv15 and @jdrueckert on allowing ranged activation of items, e.g., to activate the magic staff in LigthAndShadow targeting a player a couple blocks away. We noticed that `ActivateEvent` fits the use case, but the computation of the `target` is bound to the interaction range as defined in the character component.

As a mitigation, this PR adds a generic `RangeComponent` to indicate some kind of ranged property, e.g., the interaction range of an item, an activation range of a tower or trap, ...

Eventually, we probably want to decouple the interaction range from the character component, and instead just use the `RangeComponent` on the player entity itself.

- feat: allow for ranged item activation
- feat: add simple RangeComponent
- feat: allow owned entities to increase interaction range
- doc: add API contracts as docstring to activation-related events

### Follow-Up Questions

These questions may be discussed now, but are not blocking merging this PR.

- [ ] the activation-related events look very similar to each other - maybe we can share code (or at least an interface) between them?
- [x] this does change the semantics of hit normal and hit position on those events. I documented this to state the method contracts, but we should keep an eye open whether this breaks anything.
- [ ] there's a tight coupling between `LocalPlayer` and the `CharacterSystem` for prediction. How can we test this? Can/should they share code?