### PR TITLE
perf(network): replace de-/inflate with lz4 for both directions

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     api group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.53.Final'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'
+    implementation 'org.lz4:lz4-java:1.8.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
     // Javax for protobuf due to @Generated - needed on Java 9 or newer Javas
     // TODO: Can likely replace with protobuf Gradle task and omit the generated source files instead

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -57,9 +57,9 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version: '30.1-jre'
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     api group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
-    implementation group: 'io.netty', name: 'netty-all', version: '4.1.53.Final'
+    implementation group: 'io.netty', name: 'netty-all', version: '4.1.65.Final'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '2.6.1'
-    implementation 'org.lz4:lz4-java:1.8.0'
+    implementation group: 'org.lz4', name: 'lz4-java', version: '1.8.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
     // Javax for protobuf due to @Generated - needed on Java 9 or newer Javas
     // TODO: Can likely replace with protobuf Gradle task and omit the generated source files instead

--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/InfoRequestPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/InfoRequestPipelineFactory.java
@@ -7,7 +7,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.compression.JdkZlibDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.compression.Lz4FrameDecoder;
+import io.netty.handler.codec.compression.Lz4FrameEncoder;
 import io.netty.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
@@ -22,7 +24,7 @@ import org.terasology.protobuf.NetData;
  * A pipeline that requests {@link org.terasology.engine.network.ServerInfoMessage} before it auto-disconnects. This is similar
  * to {@link TerasologyClientPipelineFactory}.
  */
-public class InfoRequestPipelineFactory extends ChannelInitializer {
+public class  InfoRequestPipelineFactory extends ChannelInitializer {
 
     @Override
     protected void initChannel(Channel ch) throws Exception {
@@ -31,12 +33,15 @@ public class InfoRequestPipelineFactory extends ChannelInitializer {
         p.addLast(MetricRecordingHandler.NAME, new MetricRecordingHandler());
 
         p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
-        p.addLast("inflateDecoder", new JdkZlibDecoder());
+        p.addLast("inflateDecoder", new Lz4FrameDecoder());
         p.addLast("frameDecoder", new ProtobufVarint32FrameDecoder());
         p.addLast("protobufDecoder", new ProtobufDecoder(NetData.NetMessage.getDefaultInstance()));
 
+        p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
+        p.addLast("deflateEncoder", new Lz4FrameEncoder());
         p.addLast("frameEncoder", new ProtobufVarint32LengthFieldPrepender());
         p.addLast("protobufEncoder", new ProtobufEncoder());
+
         p.addLast("authenticationHandler", new ClientHandshakeHandler(joinStatus));
         p.addLast("connectionHandler", new ServerInfoRequestHandler());
     }

--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/InfoRequestPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/InfoRequestPipelineFactory.java
@@ -24,7 +24,7 @@ import org.terasology.protobuf.NetData;
  * A pipeline that requests {@link org.terasology.engine.network.ServerInfoMessage} before it auto-disconnects. This is similar
  * to {@link TerasologyClientPipelineFactory}.
  */
-public class  InfoRequestPipelineFactory extends ChannelInitializer {
+public class InfoRequestPipelineFactory extends ChannelInitializer {
 
     @Override
     protected void initChannel(Channel ch) throws Exception {

--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyClientPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyClientPipelineFactory.java
@@ -7,7 +7,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.compression.JdkZlibDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.compression.Lz4FrameDecoder;
+import io.netty.handler.codec.compression.Lz4FrameEncoder;
 import io.netty.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
@@ -39,12 +41,15 @@ public class TerasologyClientPipelineFactory extends ChannelInitializer {
         p.addLast(MetricRecordingHandler.NAME, new MetricRecordingHandler());
 
         p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
-        p.addLast("inflateDecoder", new JdkZlibDecoder());
+        p.addLast("inflateDecoder", new Lz4FrameDecoder());
         p.addLast("frameDecoder", new ProtobufVarint32FrameDecoder());
         p.addLast("protobufDecoder", new ProtobufDecoder(NetData.NetMessage.getDefaultInstance()));
 
+        p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
+        p.addLast("deflateEncoder", new Lz4FrameEncoder(true));
         p.addLast("frameEncoder", new ProtobufVarint32LengthFieldPrepender());
         p.addLast("protobufEncoder", new ProtobufEncoder());
+
         p.addLast("authenticationHandler", new ClientHandshakeHandler(joinStatus));
         p.addLast("connectionHandler", new ClientConnectionHandler(joinStatus, networkSystem));
         p.addLast("handler", new ClientHandler(networkSystem));

--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyServerPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyServerPipelineFactory.java
@@ -6,8 +6,10 @@ package org.terasology.engine.network.internal.pipelineFactory;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.codec.compression.JdkZlibEncoder;
+import io.netty.handler.codec.compression.Lz4FrameDecoder;
+import io.netty.handler.codec.compression.Lz4FrameEncoder;
 import io.netty.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
@@ -35,11 +37,13 @@ public class TerasologyServerPipelineFactory extends ChannelInitializer {
         ChannelPipeline p = ch.pipeline();
         p.addLast(MetricRecordingHandler.NAME, new MetricRecordingHandler());
 
+        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
+        p.addLast("inflateDecoder", new Lz4FrameDecoder());
         p.addLast("frameDecoder", new ProtobufVarint32FrameDecoder());
         p.addLast("protobufDecoder", new ProtobufDecoder(NetData.NetMessage.getDefaultInstance()));
 
         p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
-        p.addLast("deflateEncoder", new JdkZlibEncoder());
+        p.addLast("deflateEncoder", new Lz4FrameEncoder(true));
         p.addLast("frameEncoder", new ProtobufVarint32LengthFieldPrepender());
         p.addLast("protobufEncoder", new ProtobufEncoder());
 


### PR DESCRIPTION
we would need to have a dry run test on a server to verify if this improves the actual network performance. Lz4 is a lot faster compression algorithm for both the consumer and reader. would it be possible to create a one off build to have this on a test server @Cervator. I also run the compress and deflation for both send and receiving packets.   

https://github.com/lz4/lz4