### PR TITLE
perf: remove extra length prepend

### DIFF
--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/InfoRequestPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/InfoRequestPipelineFactory.java
@@ -12,8 +12,6 @@ import io.netty.handler.codec.compression.Lz4FrameDecoder;
 import io.netty.handler.codec.compression.Lz4FrameEncoder;
 import io.netty.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.handler.codec.protobuf.ProtobufEncoder;
-import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
-import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import org.terasology.engine.network.internal.ClientHandshakeHandler;
 import org.terasology.engine.network.internal.JoinStatusImpl;
 import org.terasology.engine.network.internal.MetricRecordingHandler;
@@ -32,14 +30,12 @@ public class InfoRequestPipelineFactory extends ChannelInitializer {
         ChannelPipeline p = ch.pipeline();
         p.addLast(MetricRecordingHandler.NAME, new MetricRecordingHandler());
 
-        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
         p.addLast("inflateDecoder", new Lz4FrameDecoder());
-        p.addLast("frameDecoder", new ProtobufVarint32FrameDecoder());
+        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
         p.addLast("protobufDecoder", new ProtobufDecoder(NetData.NetMessage.getDefaultInstance()));
 
+        p.addLast("deflateEncoder", new Lz4FrameEncoder(true));
         p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
-        p.addLast("deflateEncoder", new Lz4FrameEncoder());
-        p.addLast("frameEncoder", new ProtobufVarint32LengthFieldPrepender());
         p.addLast("protobufEncoder", new ProtobufEncoder());
 
         p.addLast("authenticationHandler", new ClientHandshakeHandler(joinStatus));

--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyClientPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyClientPipelineFactory.java
@@ -12,8 +12,6 @@ import io.netty.handler.codec.compression.Lz4FrameDecoder;
 import io.netty.handler.codec.compression.Lz4FrameEncoder;
 import io.netty.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.handler.codec.protobuf.ProtobufEncoder;
-import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
-import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import org.terasology.engine.network.internal.ClientConnectionHandler;
 import org.terasology.engine.network.internal.ClientHandler;
 import org.terasology.engine.network.internal.ClientHandshakeHandler;
@@ -40,14 +38,12 @@ public class TerasologyClientPipelineFactory extends ChannelInitializer {
         ChannelPipeline p = ch.pipeline();
         p.addLast(MetricRecordingHandler.NAME, new MetricRecordingHandler());
 
-        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
         p.addLast("inflateDecoder", new Lz4FrameDecoder());
-        p.addLast("frameDecoder", new ProtobufVarint32FrameDecoder());
+        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
         p.addLast("protobufDecoder", new ProtobufDecoder(NetData.NetMessage.getDefaultInstance()));
 
-        p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
         p.addLast("deflateEncoder", new Lz4FrameEncoder(true));
-        p.addLast("frameEncoder", new ProtobufVarint32LengthFieldPrepender());
+        p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
         p.addLast("protobufEncoder", new ProtobufEncoder());
 
         p.addLast("authenticationHandler", new ClientHandshakeHandler(joinStatus));

--- a/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyServerPipelineFactory.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/pipelineFactory/TerasologyServerPipelineFactory.java
@@ -12,8 +12,6 @@ import io.netty.handler.codec.compression.Lz4FrameDecoder;
 import io.netty.handler.codec.compression.Lz4FrameEncoder;
 import io.netty.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.handler.codec.protobuf.ProtobufEncoder;
-import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
-import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import org.terasology.engine.network.internal.MetricRecordingHandler;
 import org.terasology.engine.network.internal.NetworkSystemImpl;
 import org.terasology.engine.network.internal.ServerConnectionHandler;
@@ -37,14 +35,12 @@ public class TerasologyServerPipelineFactory extends ChannelInitializer {
         ChannelPipeline p = ch.pipeline();
         p.addLast(MetricRecordingHandler.NAME, new MetricRecordingHandler());
 
-        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
         p.addLast("inflateDecoder", new Lz4FrameDecoder());
-        p.addLast("frameDecoder", new ProtobufVarint32FrameDecoder());
+        p.addLast("lengthFrameDecoder", new LengthFieldBasedFrameDecoder(8388608, 0, 3, 0, 3));
         p.addLast("protobufDecoder", new ProtobufDecoder(NetData.NetMessage.getDefaultInstance()));
 
-        p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
         p.addLast("deflateEncoder", new Lz4FrameEncoder(true));
-        p.addLast("frameEncoder", new ProtobufVarint32LengthFieldPrepender());
+        p.addLast("frameLengthEncoder", new LengthFieldPrepender(3));
         p.addLast("protobufEncoder", new ProtobufEncoder());
 
         p.addLast("authenticationHandler", new ServerHandshakeHandler());


### PR DESCRIPTION
here are some small tweaks the stream. looks like we've encoded the length of the packet like 3 times. prepend a size before the compressed frame, lz4frame prepends a length to the compressed packet, followed by another length encoding for the protobuf message. l

![rework](https://user-images.githubusercontent.com/854359/125181522-70f1e600-e1ba-11eb-8ab0-51ed5961a799.png)


this is what this change does. lz4frame will split the payload into multiple frames that are sent over the wire. we need the length to be prepend to the protobuf message so we can decode individual protobuf message. 

[frame_rework.zip](https://github.com/MovingBlocks/Terasology/files/6796293/frame_rework.zip)