### PR TITLE
feat: rework chunk ordering using Reactor

### DIFF
--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     runtimeOnly group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.21'
     implementation "org.terasology:reflections:0.9.12-MB"
+    implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.4.7'
 
     // Test lib dependencies
     implementation(platform("org.junit:junit-bom:5.7.1")) {

--- a/engine-tests/src/test/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -3,6 +3,7 @@
 package org.terasology.engine.world.chunks.localChunkProvider;
 
 import com.google.common.collect.Maps;
+import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.AfterEach;
@@ -13,11 +14,11 @@ import org.mockito.ArgumentCaptor;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.event.Event;
+import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.world.BlockEntityRegistry;
 import org.terasology.engine.world.block.BeforeDeactivateBlocks;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;
-import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.engine.world.block.OnActivatedBlocks;
 import org.terasology.engine.world.block.OnAddedBlocks;
 import org.terasology.engine.world.chunks.Chunk;
@@ -35,18 +36,15 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class LocalChunkProviderTest {
 
-    private static final int WAIT_CHUNK_IS_READY_IN_SECONDS = 30;
+    private static final int WAIT_CHUNK_IS_READY_IN_SECONDS = 5;
 
     private LocalChunkProvider chunkProvider;
     private EntityManager entityManager;
@@ -58,6 +56,8 @@ class LocalChunkProviderTest {
     private Block blockAtBlockManager;
     private TestStorageManager storageManager;
     private TestWorldGenerator generator;
+    private RelevanceSystem relevanceSystem;
+    private EntityRef playerEntity;
 
     @BeforeEach
     public void setUp() {
@@ -81,7 +81,8 @@ class LocalChunkProviderTest {
                 chunkCache);
         chunkProvider.setBlockEntityRegistry(blockEntityRegistry);
         chunkProvider.setWorldEntity(worldEntity);
-        chunkProvider.setRelevanceSystem(new RelevanceSystem(chunkProvider)); // workaround. initialize loading pipeline
+        relevanceSystem = new RelevanceSystem(chunkProvider);
+        chunkProvider.setRelevanceSystem(relevanceSystem); // workaround. initialize loading pipeline
     }
 
     @AfterEach
@@ -89,77 +90,66 @@ class LocalChunkProviderTest {
         chunkProvider.shutdown();
     }
 
-    private Future<Chunk> requestCreatingOrLoadingArea(Vector3ic chunkPosition, int radius) {
-        Future<Chunk> chunkFuture = chunkProvider.createOrLoadChunk(chunkPosition);
-        BlockRegion extentsRegion = new BlockRegion(
-                chunkPosition.x() - radius, chunkPosition.y() - radius, chunkPosition.z() - radius,
-                chunkPosition.x() + radius, chunkPosition.y() + radius, chunkPosition.z() + radius);
-
-        extentsRegion.iterator().forEachRemaining(pos -> {
-            if (!pos.equals(chunkPosition)) { // remove center. we takes future for it already.
-                chunkProvider.createOrLoadChunk(pos);
-            }
-        });
-        return chunkFuture;
+    private void requestCreatingOrLoadingArea(Vector3ic chunkPosition, int radius) {
+        playerEntity = mock(EntityRef.class);
+        when(playerEntity.exists()).thenReturn(true);
+        when(playerEntity.getComponent(LocationComponent.class)).thenReturn(new LocationComponent(new Vector3f(chunkPosition)));
+        Vector3i distance = new Vector3i(radius * 2, radius * 2, radius * 2);
+        relevanceSystem.addRelevanceEntity(playerEntity, distance, null);
+        chunkProvider.notifyRelevanceChanged();
     }
 
-    private Future<Chunk> requestCreatingOrLoadingArea(Vector3ic chunkPosition) {
-        return requestCreatingOrLoadingArea(chunkPosition, 1);
+    private void requestCreatingOrLoadingArea(Vector3ic chunkPosition) {
+        requestCreatingOrLoadingArea(chunkPosition, 2);
+    }
+
+    private void waitForChunks() throws InterruptedException {
+        chunkProvider.testMarkCompleteAndWait(WAIT_CHUNK_IS_READY_IN_SECONDS * 1000);
     }
 
     @Test
-    void testGenerateSingleChunk() throws InterruptedException, ExecutionException, TimeoutException {
+    void testGenerateSingleChunk() throws InterruptedException {
         Vector3i chunkPosition = new Vector3i(0, 0, 0);
-        requestCreatingOrLoadingArea(chunkPosition).get(WAIT_CHUNK_IS_READY_IN_SECONDS, TimeUnit.SECONDS);
+        requestCreatingOrLoadingArea(chunkPosition);
+        waitForChunks();
         chunkProvider.update();
 
         final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(worldEntity, atLeast(2)).send(eventArgumentCaptor.capture());
-        Assertions.assertAll("WorldEvents not valid",
+        Assertions.assertAll("World Events not valid",
                 () -> {
-                    Event mustBeOnGeneratedEvent = eventArgumentCaptor.getAllValues().get(0);
-                    Assertions.assertTrue(mustBeOnGeneratedEvent instanceof OnChunkGenerated,
-                            "First world event must be OnChunkGenerated");
-                    Assertions.assertEquals(((OnChunkGenerated) mustBeOnGeneratedEvent).getChunkPos(),
-                            chunkPosition,
-                            "Chunk position at event not expected");
+                    Assertions.assertTrue(eventArgumentCaptor.getAllValues().stream().anyMatch(x ->
+                        x instanceof OnChunkGenerated && ((OnChunkGenerated) x).getChunkPos().equals(chunkPosition)
+                    ), "Must be OnChunkGenerated event for chunk");
                 },
                 () -> {
-                    Event mustBeOnLoadedEvent = eventArgumentCaptor.getAllValues().get(1);
-                    Assertions.assertTrue(mustBeOnLoadedEvent instanceof OnChunkLoaded,
-                            "Second world event must be OnChunkLoaded");
-                    Assertions.assertEquals(chunkPosition,
-                            ((OnChunkLoaded) mustBeOnLoadedEvent).getChunkPos(),
-                            "Chunk position at event not expected");
+                    Assertions.assertTrue(eventArgumentCaptor.getAllValues().stream().anyMatch(x ->
+                            x instanceof OnChunkLoaded && ((OnChunkLoaded) x).getChunkPos().equals(chunkPosition)
+                    ), "Must be OnChunkLoaded event for chunk");
                 });
     }
 
     @Test
-    void testGenerateSingleChunkWithBlockLifeCycle() throws InterruptedException, ExecutionException, TimeoutException {
+    void testGenerateSingleChunkWithBlockLifeCycle() throws InterruptedException {
         Vector3i chunkPosition = new Vector3i(0, 0, 0);
         blockAtBlockManager.setLifecycleEventsRequired(true);
         blockAtBlockManager.setEntity(mock(EntityRef.class));
-        requestCreatingOrLoadingArea(chunkPosition).get(WAIT_CHUNK_IS_READY_IN_SECONDS, TimeUnit.SECONDS);
+        requestCreatingOrLoadingArea(chunkPosition);
+        waitForChunks();
         chunkProvider.update();
 
         final ArgumentCaptor<Event> worldEventCaptor = ArgumentCaptor.forClass(Event.class);
         verify(worldEntity, atLeast(2)).send(worldEventCaptor.capture());
         Assertions.assertAll("World Events not valid",
                 () -> {
-                    Event mustBeOnGeneratedEvent = worldEventCaptor.getAllValues().get(0);
-                    Assertions.assertTrue(mustBeOnGeneratedEvent instanceof OnChunkGenerated,
-                            "First world event must be OnChunkGenerated");
-                    Assertions.assertEquals(((OnChunkGenerated) mustBeOnGeneratedEvent).getChunkPos(),
-                            chunkPosition,
-                            "Chunk position at event not expected");
+                    Assertions.assertTrue(worldEventCaptor.getAllValues().stream().anyMatch(x ->
+                        x instanceof OnChunkGenerated && ((OnChunkGenerated) x).getChunkPos().equals(chunkPosition)
+                    ), "Must be OnChunkGenerated event for chunk");
                 },
                 () -> {
-                    Event mustBeOnLoadedEvent = worldEventCaptor.getAllValues().get(1);
-                    Assertions.assertTrue(mustBeOnLoadedEvent instanceof OnChunkLoaded,
-                            "Second world event must be OnChunkLoaded");
-                    Assertions.assertEquals(chunkPosition,
-                            ((OnChunkLoaded) mustBeOnLoadedEvent).getChunkPos(),
-                            "Chunk position at event not expected");
+                    Assertions.assertTrue(worldEventCaptor.getAllValues().stream().anyMatch(x ->
+                            x instanceof OnChunkLoaded && ((OnChunkLoaded) x).getChunkPos().equals(chunkPosition)
+                    ), "Must be OnChunkLoaded event for chunk");
                 });
 
         //TODO, it is not clear if the activate/addedBlocks event logic is correct.
@@ -175,13 +165,14 @@ class LocalChunkProviderTest {
     }
 
     @Test
-    void testLoadSingleChunk() throws InterruptedException, ExecutionException, TimeoutException {
+    void testLoadSingleChunk() throws InterruptedException {
         Vector3i chunkPosition = new Vector3i(0, 0, 0);
         Chunk chunk = new ChunkImpl(chunkPosition, blockManager, extraDataManager);
         generator.createChunk(chunk, null);
         storageManager.add(chunk);
 
-        requestCreatingOrLoadingArea(chunkPosition).get(WAIT_CHUNK_IS_READY_IN_SECONDS, TimeUnit.SECONDS);
+        requestCreatingOrLoadingArea(chunkPosition);
+        waitForChunks();
         chunkProvider.update();
 
         Assertions.assertTrue(((TestChunkStore) storageManager.loadChunkStore(chunkPosition)).isEntityRestored(),
@@ -189,16 +180,13 @@ class LocalChunkProviderTest {
 
         final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(worldEntity, atLeast(1)).send(eventArgumentCaptor.capture());
-        Event mustBeOnLoadedEvent = eventArgumentCaptor.getAllValues().get(0);
-        Assertions.assertTrue(mustBeOnLoadedEvent instanceof OnChunkLoaded,
-                "Second world event must be OnChunkLoaded");
-        Assertions.assertEquals(chunkPosition,
-                ((OnChunkLoaded) mustBeOnLoadedEvent).getChunkPos(),
-                "Chunk position at event not expected");
+        Assertions.assertTrue(eventArgumentCaptor.getAllValues().stream().anyMatch(x ->
+                x instanceof OnChunkLoaded && ((OnChunkLoaded) x).getChunkPos().equals(chunkPosition)
+        ), "Must be OnChunkLoaded event for chunk");
     }
 
     @Test
-    void testLoadSingleChunkWithBlockLifecycle() throws InterruptedException, ExecutionException, TimeoutException {
+    void testLoadSingleChunkWithBlockLifecycle() throws InterruptedException {
         Vector3i chunkPosition = new Vector3i(0, 0, 0);
         Chunk chunk = new ChunkImpl(chunkPosition, blockManager, extraDataManager);
         generator.createChunk(chunk, null);
@@ -206,7 +194,8 @@ class LocalChunkProviderTest {
         blockAtBlockManager.setLifecycleEventsRequired(true);
         blockAtBlockManager.setEntity(mock(EntityRef.class));
 
-        requestCreatingOrLoadingArea(chunkPosition).get(WAIT_CHUNK_IS_READY_IN_SECONDS, TimeUnit.SECONDS);
+        requestCreatingOrLoadingArea(chunkPosition);
+        waitForChunks();
         chunkProvider.update();
 
         Assertions.assertTrue(((TestChunkStore) storageManager.loadChunkStore(chunkPosition)).isEntityRestored(),
@@ -215,12 +204,9 @@ class LocalChunkProviderTest {
 
         final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(worldEntity, atLeast(1)).send(eventArgumentCaptor.capture());
-        Event mustBeOnLoadedEvent = eventArgumentCaptor.getAllValues().get(0);
-        Assertions.assertTrue(mustBeOnLoadedEvent instanceof OnChunkLoaded,
-                "Second world event must be OnChunkLoaded");
-        Assertions.assertEquals(chunkPosition,
-                ((OnChunkLoaded) mustBeOnLoadedEvent).getChunkPos(),
-                "Chunk position at event not expected");
+        Assertions.assertTrue(eventArgumentCaptor.getAllValues().stream().anyMatch(x ->
+                x instanceof OnChunkLoaded && ((OnChunkLoaded) x).getChunkPos().equals(chunkPosition)
+        ), "Must be OnChunkLoaded event for chunk");
 
         //TODO, it is not clear if the activate/addedBlocks event logic is correct.
         //See https://github.com/MovingBlocks/Terasology/issues/3244
@@ -228,30 +214,29 @@ class LocalChunkProviderTest {
         verify(blockAtBlockManager.getEntity(), atLeast(2)).send(blockEventCaptor.capture());
         Assertions.assertAll("Block events not valid",
                 () -> {
-                    Event mustBeOnAddedBlocks = blockEventCaptor.getAllValues().get(0);
-                    Assertions.assertTrue(mustBeOnAddedBlocks instanceof OnAddedBlocks,
-                            "First block event must be OnAddedBlocks");
-                    Assertions.assertTrue(((OnAddedBlocks) mustBeOnAddedBlocks).blockCount() > 0,
-                            "Block count on activate must be non zero");
+                    Assertions.assertTrue(blockEventCaptor.getAllValues().stream().anyMatch(x ->
+                        x instanceof OnAddedBlocks && ((OnAddedBlocks) x).blockCount() > 0
+                    ), "Must be OnAddedBlocks event for chunk");
                 },
                 () -> {
-                    Event mustBeOnActivatedBlocks = blockEventCaptor.getAllValues().get(1);
-                    Assertions.assertTrue(mustBeOnActivatedBlocks instanceof OnActivatedBlocks,
-                            "First block event must be OnActivatedBlocks");
-                    Assertions.assertTrue(((OnActivatedBlocks) mustBeOnActivatedBlocks).blockCount() > 0,
-                            "Block count on activate must be non zero");
+                    Assertions.assertTrue(blockEventCaptor.getAllValues().stream().anyMatch(x ->
+                            x instanceof OnActivatedBlocks && ((OnActivatedBlocks) x).blockCount() > 0
+                    ), "Must be OnActivatedBlocks event for chunk");
                 });
     }
 
     @Test
-    void testUnloadChunkAndDeactivationBlock() throws InterruptedException, TimeoutException, ExecutionException {
+    void testUnloadChunkAndDeactivationBlock() throws InterruptedException {
         Vector3i chunkPosition = new Vector3i(0, 0, 0);
         blockAtBlockManager.setLifecycleEventsRequired(true);
         blockAtBlockManager.setEntity(mock(EntityRef.class));
 
-        requestCreatingOrLoadingArea(chunkPosition).get(WAIT_CHUNK_IS_READY_IN_SECONDS, TimeUnit.SECONDS);
+        requestCreatingOrLoadingArea(chunkPosition);
+        waitForChunks();
+        relevanceSystem.removeRelevanceEntity(playerEntity);
+        chunkProvider.notifyRelevanceChanged();
 
-        //Wait BeforeDeactivateBlocks event
+        // Wait for BeforeDeactivateBlocks event
         Assertions.assertTimeoutPreemptively(Duration.of(WAIT_CHUNK_IS_READY_IN_SECONDS, ChronoUnit.SECONDS),
                 () -> {
                     ArgumentCaptor<Event> blockEventCaptor = ArgumentCaptor.forClass(Event.class);
@@ -270,17 +255,11 @@ class LocalChunkProviderTest {
 
         final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(worldEntity, atLeast(1)).send(eventArgumentCaptor.capture());
-        Optional<BeforeChunkUnload> beforeChunkUnload = eventArgumentCaptor.getAllValues()
+        Assertions.assertTrue(eventArgumentCaptor.getAllValues()
                 .stream()
                 .filter((e) -> e instanceof BeforeChunkUnload)
                 .map((e) -> (BeforeChunkUnload) e)
-                .findFirst();
-
-        Assertions.assertTrue(beforeChunkUnload.isPresent(),
-                "World events must have BeforeChunkUnload event when chunk was unload");
-        Assertions.assertEquals(chunkPosition,
-                beforeChunkUnload.get().getChunkPos(),
-                "Chunk position at event not expected");
+                .anyMatch(x -> x.getChunkPos().equals(chunkPosition)), "World events must have BeforeChunkUnload event when chunk was unload");
 
         //TODO, it is not clear if the activate/addedBlocks event logic is correct.
         //See https://github.com/MovingBlocks/Terasology/issues/3244

--- a/engine-tests/src/test/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipelineTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipelineTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.engine.TerasologyTestingEnvironment;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.block.BlockManager;
@@ -22,22 +21,22 @@ import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.engine.world.chunks.internal.ChunkImpl;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
+import org.terasology.gestalt.assets.management.AssetManager;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Tag("TteTest")
@@ -47,30 +46,39 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
             CoreRegistry.get(AssetManager.class));
     private final ExtraBlockDataManager extraDataManager = new ExtraBlockDataManager();
     private ChunkProcessingPipeline pipeline;
+    private FluxSink<Chunk> chunkSink;
 
     @Test
-    void simpleProcessingSuccess() throws ExecutionException, InterruptedException, TimeoutException {
-        pipeline = new ChunkProcessingPipeline((p) -> null, (o1, o2) -> 0);
+    void simpleProcessingSuccess() throws InterruptedException {
+        pipeline = new ChunkProcessingPipeline((p) -> null, Flux.create(sink -> {
+            chunkSink = sink;
+        }));
 
         Vector3i chunkPos = new Vector3i(0, 0, 0);
         Chunk chunk = createChunkAt(chunkPos);
+        List<Chunk> result = new ArrayList<>();
 
         pipeline.addStage(ChunkTaskProvider.create("dummy task", (c) -> c));
+        pipeline.addStage(ChunkTaskProvider.create("Chunk ready", (Consumer<Chunk>) result::add));
 
-        Future<Chunk> chunkFuture = pipeline.invokeGeneratorTask(new Vector3i(0, 0, 0), () -> chunk);
-        Chunk chunkAfterProcessing = chunkFuture.get(1, TimeUnit.SECONDS);
+        chunkSink.next(chunk);
+        chunkSink.complete();
+        pipeline.waitUntilComplete(500);
 
-        Assertions.assertEquals(chunkAfterProcessing.getPosition(new Vector3i()), chunk.getPosition(new Vector3i()),
-                "Chunk after processing must have equals position, probably pipeline lost you chunk");
+        Chunk chunkAfterProcessing = result.get(0);
+
+        Assertions.assertEquals(chunkAfterProcessing.getPosition(), chunk.getPosition(),
+                "Chunk after processing must have the same position, the pipeline probably lost your chunk");
     }
 
     @Test
     void simpleStopProcessingSuccess() {
-        pipeline = new ChunkProcessingPipeline((p) -> null, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline((p) -> null, Flux.create(sink -> {
+            chunkSink = sink;
+        }));
 
         Vector3i position = new Vector3i(0, 0, 0);
         Chunk chunk = createChunkAt(position);
-
 
         pipeline.addStage(ChunkTaskProvider.create("dummy long executing task", (c) -> {
             try {
@@ -80,20 +88,18 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
             return c;
         }));
 
-        Future<Chunk> chunkFuture = pipeline.invokeGeneratorTask(position, () -> chunk);
+        chunkSink.next(chunk);
+        chunkSink.complete();
+
         pipeline.stopProcessingAt(position);
-        Assertions.assertThrows(
-                CancellationException.class,
-                () -> chunkFuture.get(1, TimeUnit.SECONDS),
-                "chunkFuture must be cancelled, when processing stopped"
-        );
+        Assertions.assertFalse(pipeline.isPositionProcessing(position));
     }
 
     /**
      * Imagine that we have task, which requires neighbors with same Z level. neighbors chunk already in chunk cache.
      */
     @Test
-    void multiRequirementsChunksExistsSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    void multiRequirementsChunksExistsSuccess() throws InterruptedException {
         Vector3i positionToGenerate = new Vector3i(0, 0, 0);
         Map<Vector3ic, Chunk> chunkCache =
                 getNearChunkPositions(positionToGenerate)
@@ -105,7 +111,9 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
                                 Function.identity()
                         ));
 
-        pipeline = new ChunkProcessingPipeline(chunkCache::get, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline(chunkCache::get, Flux.create(sink -> {
+            chunkSink = sink;
+        }));
         pipeline.addStage(ChunkTaskProvider.createMulti(
                 "flat merging task",
                 (chunks) -> chunks.stream()
@@ -113,69 +121,72 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
                         .findFirst() // return central chunk.
                         .get(),
                 this::getNearChunkPositions));
+        List<Chunk> result = new ArrayList<>();
+        pipeline.addStage(ChunkTaskProvider.create("Chunk ready", (Consumer<Chunk>) result::add));
 
         Chunk chunk = createChunkAt(positionToGenerate);
-        Future<Chunk> chunkFuture = pipeline.invokeGeneratorTask(new Vector3i(0, 0, 0), () -> chunk);
-        Chunk chunkAfterProcessing = chunkFuture.get(1, TimeUnit.SECONDS);
 
-        Assertions.assertEquals(chunkAfterProcessing.getPosition(new Vector3i()), chunk.getPosition(new Vector3i()),
-                "Chunk after processing must have equals position, probably pipeline lost you chunk");
+        chunkSink.next(chunk);
+        chunkSink.complete();
+
+        pipeline.waitUntilComplete(500);
+        Chunk chunkAfterProcessing = result.get(0);
+
+        Assertions.assertEquals(chunkAfterProcessing.getPosition(), chunk.getPosition(),
+                "Chunk after processing must have the same position, the pipeline probably lost your chunk");
     }
 
     /**
      * Imagine that we have task, which requires neighbors with same Z level. neighbor will generated.
      */
     @Test
-    void multiRequirementsChunksWillGeneratedSuccess() throws ExecutionException, InterruptedException,
-            TimeoutException {
+    void multiRequirementsChunksWillGeneratedSuccess() throws InterruptedException {
         Vector3i positionToGenerate = new Vector3i(0, 0, 0);
-        Map<Vector3i, Chunk> chunkToGenerate =
+        List<Chunk> chunkToGenerate =
                 getNearChunkPositions(positionToGenerate)
                         .stream()
                         .filter((p) -> !p.equals(positionToGenerate)) //remove central chunk.
                         .map(this::createChunkAt)
-                        .collect(Collectors.toMap(
-                                (chunk) -> chunk.getPosition(new Vector3i()),
-                                Function.identity()
-                        ));
+                        .collect(Collectors.toList());
 
-        pipeline = new ChunkProcessingPipeline((p) -> null, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline((p) -> null, Flux.create(sink -> {
+            chunkSink = sink;
+        }));
         pipeline.addStage(ChunkTaskProvider.createMulti(
                 "flat merging task",
                 (chunks) -> chunks.stream()
                         .filter((c) -> c.getPosition().equals(positionToGenerate)).findFirst() // return central chunk.
                         .get(),
                 this::getNearChunkPositions));
+        List<Chunk> result = new ArrayList<>();
+        pipeline.addStage(ChunkTaskProvider.create("Chunk ready", (Consumer<Chunk>) result::add));
 
         Chunk chunk = createChunkAt(positionToGenerate);
-        Future<Chunk> chunkFuture = pipeline.invokeGeneratorTask(new Vector3i(0, 0, 0), () -> chunk);
+
+        chunkSink.next(chunk);
+
 
         Thread.sleep(1_000); // sleep 1 second. and check future.
-        Assertions.assertFalse(chunkFuture.isDone(), "Chunk must be not generated, because ChunkTask have not exists " +
-                "neighbors in requirements");
+        Assertions.assertTrue(result.isEmpty(), "Chunk must be not generated, because the ChunkTask have doesn't have " +
+                "its neighbors in requirements");
 
-        chunkToGenerate.forEach((position, neighborChunk) -> pipeline.invokeGeneratorTask(position,
-                () -> neighborChunk));
+        chunkToGenerate.forEach(chunkSink::next);
+        chunkSink.complete();
 
-        Chunk chunkAfterProcessing = chunkFuture.get(1, TimeUnit.SECONDS);
+        pipeline.waitUntilComplete(500);
+        Chunk chunkAfterProcessing = result.get(0);
 
-        Assertions.assertEquals(chunkAfterProcessing.getPosition(new Vector3i()), chunk.getPosition(new Vector3i()),
-                "Chunk after processing must have equals position, probably pipeline lost you chunk");
+        Assertions.assertEquals(chunkAfterProcessing.getPosition(), chunk.getPosition(),
+                "Chunk after processing must have the same position, the pipeline probably lost your chunk");
     }
 
     @Test
     void emulateEntityMoving() throws InterruptedException {
         final AtomicReference<Vector3ic> position = new AtomicReference<>();
-        Map<Vector3ic, Future<Chunk>> futures = Maps.newHashMap();
         Map<Vector3ic, Chunk> chunkCache = Maps.newConcurrentMap();
-        pipeline = new ChunkProcessingPipeline(chunkCache::get, (o1, o2) -> {
-            if (position.get() != null) {
-                Vector3ic entityPos = position.get();
-                return (int) (entityPos.distance(((PositionFuture<?>) o1).getPosition())
-                            - entityPos.distance(((PositionFuture<?>) o2).getPosition()));
-            }
-            return 0;
-        });
+        pipeline = new ChunkProcessingPipeline(chunkCache::get, Flux.create(sink -> {
+            chunkSink = sink;
+        }));
         pipeline.addStage(ChunkTaskProvider.createMulti(
                 "flat merging task",
                 (chunks) -> chunks.stream()
@@ -189,7 +200,7 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
                 this::getNearChunkPositions));
         pipeline.addStage(ChunkTaskProvider.create("finish chunk", (c) -> {
             c.markReady();
-            chunkCache.put(c.getPosition(new Vector3i()), c);
+            chunkCache.put(c.getPosition(), c);
         }));
 
 
@@ -197,13 +208,8 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
         for (int i = 0; i < 10; i++) {
             position.set(new Vector3i(i, 0, 0));
             Set<Vector3ic> newRegion = getNearChunkPositions(position.get(), 10);
-            Sets.difference(newRegion, relativeRegion).forEach(// load new chunks.
-                    (pos) -> {
-                        Future<Chunk> future = pipeline.invokeGeneratorTask(new Vector3i(pos),
-                                () -> createChunkAt(pos));
-                        futures.put(pos, future);
-                    }
-            );
+            // load new chunks.
+            Sets.difference(newRegion, relativeRegion).forEach((pos) -> chunkSink.next(createChunkAt(pos)));
 
             Sets.difference(relativeRegion, newRegion).forEach(// remove old chunks
                     (pos) -> {
@@ -217,19 +223,11 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
 
             Assertions.assertTrue(Sets.difference(chunkCache.keySet(), relativeRegion).isEmpty(), "We must haven't " +
                     "chunks not related to relativeRegion");
-            Assertions.assertTrue(Sets.difference(Sets.newHashSet(pipeline.getProcessingPosition()), relativeRegion).isEmpty(),
+            Assertions.assertTrue(Sets.difference(pipeline.getProcessingPositions(), relativeRegion).isEmpty(),
                     "We must haven't chunks in processing not related to relativeRegion");
 
-            Stream<Future<Chunk>> relativeFutures = relativeRegion.stream().map(futures::get);
-            Assertions.assertTrue(
-                    relativeFutures.noneMatch(Future::isCancelled),
-                    "Relative futures must be not cancelled");
-
-            Stream<Future<Chunk>> nonRelativeFutures =
-                    Sets.difference(futures.keySet(), relativeRegion).stream().map(futures::get);
-            Assertions.assertTrue(
-                    nonRelativeFutures.allMatch((f) -> f.isCancelled() || f.isDone()),
-                    "Non relative futures must be cancelled or done");
+            Assertions.assertTrue(relativeRegion.containsAll(pipeline.getProcessingPositions()),
+                    "No non-relative chunks should be processing");
 
             Thread.sleep(new Random().nextInt(500)); //think time
         }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     implementation "org.terasology:reflections:0.9.12-MB"
     implementation group: 'org.javassist', name: 'javassist', version: '3.27.0-GA'
     implementation group: 'com.esotericsoftware', name: 'reflectasm', version: '1.11.9'
+    implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.4.7'
 
     // Graphics, 3D, UI, etc
     api platform("org.lwjgl:lwjgl-bom:$LwjglVersion")

--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/RelevanceSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/RelevanceSystem.java
@@ -22,14 +22,13 @@ import org.terasology.engine.world.chunks.ChunkRegionListener;
 import org.terasology.engine.world.chunks.event.BeforeChunkUnload;
 import org.terasology.engine.world.chunks.event.OnChunkLoaded;
 import org.terasology.engine.world.chunks.internal.ChunkRelevanceRegion;
-import org.terasology.engine.world.chunks.pipeline.PositionFuture;
 
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
@@ -118,6 +117,12 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
         }
     }
 
+    public Stream<Vector3i> neededChunks() {
+        return regions.values()
+                .stream()
+                .flatMap(x -> StreamSupport.stream(x.getNeededChunks().spliterator(), false));
+    }
+
     /**
      * Synchronize region center to entity's position and create/load chunks in that region.
      */
@@ -130,10 +135,9 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
                         Chunk chunk = chunkProvider.getChunk(pos);
                         if (chunk != null) {
                             chunkRelevanceRegion.checkIfChunkIsRelevant(chunk);
-                        } else {
-                            chunkProvider.createOrLoadChunk(pos);
                         }
                     }
+                    chunkProvider.notifyRelevanceChanged();
                     chunkRelevanceRegion.setUpToDate();
                 }
             }
@@ -174,14 +178,11 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
         }
 
         StreamSupport.stream(region.getCurrentRegion().spliterator(), false)
-                .sorted(new PositionRelevanceComparator()) //<-- this is n^2 cost. not sure why this needs to be sorted like this.
                 .forEach(
                         pos -> {
                             Chunk chunk = chunkProvider.getChunk(pos);
                             if (chunk != null) {
                                 region.checkIfChunkIsRelevant(chunk);
-                            } else {
-                                chunkProvider.createOrLoadChunk(pos);
                             }
                         }
                 );
@@ -203,12 +204,12 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
     }
 
     /**
-     * Create comporator for ChunkTasks, which compare by distance from region centers
+     * Create comparator for chunk positions, which compare by distance from region centers
      *
-     * @return Comporator.
+     * @return Comparator.
      */
-    public Comparator<Future<Chunk>> createChunkTaskComporator() {
-        return new ChunkTaskRelevanceComparator();
+    public Comparator<Vector3ic> createChunkPosComparator() {
+        return new PositionRelevanceComparator();
     }
 
     /**
@@ -269,22 +270,6 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
             regionLock.readLock().unlock();
         }
     }
-
-    /**
-     * Compare ChunkTasks by distance from region's centers.
-     */
-    private class ChunkTaskRelevanceComparator implements Comparator<Future<Chunk>> {
-
-        @Override
-        public int compare(Future<Chunk> o1, Future<Chunk> o2) {
-            return score((PositionFuture<?>) o1) - score((PositionFuture<?>) o2);
-        }
-
-        private int score(PositionFuture<?> task) {
-            return RelevanceSystem.this.regionsDistanceScore(task.getPosition());
-        }
-    }
-
 
     /**
      * Compare ChunkTasks by distance from region's centers.

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingInfo.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingInfo.java
@@ -3,36 +3,30 @@
 
 package org.terasology.engine.world.chunks.pipeline;
 
-import com.google.common.util.concurrent.SettableFuture;
 import org.joml.Vector3ic;
+import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTask;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
-import org.terasology.engine.world.chunks.Chunk;
 
 import java.util.List;
-import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantLock;
 
 public final class ChunkProcessingInfo {
+    public final ReentrantLock lock = new ReentrantLock();
+
     private final Vector3ic position;
-    private final SettableFuture<Chunk> externalFuture;
 
     private Chunk chunk;
     private ChunkTaskProvider chunkTaskProvider;
 
-    private Future<Chunk> currentFuture;
     private org.terasology.engine.world.chunks.pipeline.stages.ChunkTask chunkTask;
 
-    public ChunkProcessingInfo(Vector3ic position, SettableFuture<Chunk> externalFuture) {
+    public ChunkProcessingInfo(Vector3ic position) {
         this.position = position;
-        this.externalFuture = externalFuture;
     }
 
     public Vector3ic getPosition() {
         return position;
-    }
-
-    public SettableFuture<Chunk> getExternalFuture() {
-        return externalFuture;
     }
 
     public Chunk getChunk() {
@@ -47,24 +41,8 @@ public final class ChunkProcessingInfo {
         return chunkTaskProvider;
     }
 
-    public void setChunkTaskProvider(ChunkTaskProvider chunkTaskProvider) {
-        this.chunkTaskProvider = chunkTaskProvider;
-    }
-
-    public Future<Chunk> getCurrentFuture() {
-        return currentFuture;
-    }
-
-    public void setCurrentFuture(Future<Chunk> currentFuture) {
-        this.currentFuture = currentFuture;
-    }
-
     public org.terasology.engine.world.chunks.pipeline.stages.ChunkTask getChunkTask() {
         return chunkTask;
-    }
-
-    public void setChunkTask(org.terasology.engine.world.chunks.pipeline.stages.ChunkTask chunkTask) {
-        this.chunkTask = chunkTask;
     }
 
     boolean hasNextStage(List<ChunkTaskProvider> stages) {
@@ -83,10 +61,6 @@ public final class ChunkProcessingInfo {
         chunkTaskProvider = stages.get(nextStageIndex);
     }
 
-    void endProcessing() {
-        externalFuture.set(chunk);
-    }
-
     ChunkTask makeChunkTask() {
         if (chunkTask == null) {
             chunkTask = chunkTaskProvider.createChunkTask(position);
@@ -95,7 +69,6 @@ public final class ChunkProcessingInfo {
     }
 
     void resetTaskState() {
-        currentFuture = null;
         chunkTask = null;
     }
 }

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -3,39 +3,27 @@
 
 package org.terasology.engine.world.chunks.pipeline;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.SettableFuture;
-import org.joml.Vector3i;
 import org.joml.Vector3ic;
+import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.monitoring.ThreadActivity;
 import org.terasology.engine.monitoring.ThreadMonitor;
-import org.terasology.engine.utilities.ReflectionUtil;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTask;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.Future;
-import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Manages execution of chunk processing.
@@ -44,120 +32,162 @@ import java.util.stream.Collectors;
  */
 public class ChunkProcessingPipeline {
 
-    private static final int NUM_TASK_THREADS = 4;
+    private static final int NUM_TASK_THREADS = 2;
+    private static final int CHUNKS_AT_ONCE = 8;
     private static final Logger logger = LoggerFactory.getLogger(ChunkProcessingPipeline.class);
 
     private final List<ChunkTaskProvider> stages = Lists.newArrayList();
-    private final Thread reactor;
-    private final CompletionService<Chunk> chunkProcessor;
-    private final ThreadPoolExecutor executor;
+
     private final Function<Vector3ic, Chunk> chunkProvider;
     private final Map<Vector3ic, ChunkProcessingInfo> chunkProcessingInfoMap = Maps.newConcurrentMap();
-    private int threadIndex;
+    private final List<Subscription> subs = new ArrayList<>();
+    private final Scheduler scheduler;
+
+    private final Object completeSignal = new Object();
 
     /**
      * Create ChunkProcessingPipeline.
      */
-    public ChunkProcessingPipeline(Function<Vector3ic, Chunk> chunkProvider, Comparator<Future<Chunk>> comparable) {
+    public ChunkProcessingPipeline(Function<Vector3ic, Chunk> chunkProvider, Flux<Chunk> chunkStream) {
         this.chunkProvider = chunkProvider;
 
-        executor = new ThreadPoolExecutor(
-                NUM_TASK_THREADS,
-                NUM_TASK_THREADS, 0L,
-                TimeUnit.MILLISECONDS,
-                new PriorityBlockingQueue(800, unwrappingComporator(comparable)),
-                this::threadFactory,
-                this::rejectQueueHandler) {
-            @Override
-            protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
-                RunnableFuture<T> newTaskFor = super.newTaskFor(callable);
-                return new PositionFuture<>(newTaskFor, ((PositionalCallable) callable).getPosition());
-            }
-        };
-        chunkProcessor = new ExecutorCompletionService<>(executor,
-                new PriorityBlockingQueue<>(800, comparable));
-        reactor = new Thread(this::chunkTaskHandler);
-        reactor.setDaemon(true);
-        reactor.setName("Chunk-Processing-Reactor");
-        reactor.start();
-    }
+        scheduler = Schedulers.newParallel("chunk processing", NUM_TASK_THREADS);
+        Flux<Chunk> stream = chunkStream.subscribeOn(scheduler);
+        for (int i = 0; i < NUM_TASK_THREADS; i++) {
+            stream.subscribe(new BaseSubscriber<Chunk>() {
+                private final List<Chunk> buffer = new ArrayList<>();
+                private Subscription sub;
 
-    /**
-     * BlackMagic method: {@link ExecutorCompletionService} wraps task with QueueingFuture (private access)
-     * there takes wrapped task for comparing in {@link ThreadPoolExecutor}
-     */
-    private Comparator unwrappingComporator(Comparator<Future<Chunk>> comparable) {
-        return (o1, o2) -> {
-                Object unwrapped1 = ReflectionUtil.readField(o1, "task");
-                Object unwrapped2 = ReflectionUtil.readField(o2, "task");
-                return comparable.compare((Future<Chunk>) unwrapped1, (Future<Chunk>) unwrapped2);
-        };
-    }
-
-    /**
-     * Reactor thread. Handles all ChunkTask dependency logic and running.
-     */
-    private void chunkTaskHandler() {
-        try {
-            while (!executor.isTerminated()) {
-                PositionFuture<Chunk> future = (PositionFuture<Chunk>) chunkProcessor.take();
-                ChunkProcessingInfo chunkProcessingInfo = chunkProcessingInfoMap.get(future.getPosition());
-                if (chunkProcessingInfo == null) {
-                    continue; // chunk processing was cancelled.
+                @Override
+                public void hookOnSubscribe(Subscription sub) {
+                    this.sub = sub;
+                    subs.add(sub);
                 }
-                onStageDone(future, chunkProcessingInfo);
-            }
-        } catch (InterruptedException e) {
-            if (!executor.isTerminated()) {
-                logger.error("Reactor thread was interrupted", e);
-            }
-            reactor.interrupt();
-        }
-    }
 
-    private void onStageDone(PositionFuture<Chunk> future, ChunkProcessingInfo chunkProcessingInfo) throws InterruptedException {
-        try {
-            chunkProcessingInfo.resetTaskState();
-            chunkProcessingInfo.setChunk(future.get());
-
-            //Move by stage.
-            if (chunkProcessingInfo.hasNextStage(stages)) {
-                chunkProcessingInfo.nextStage(stages);
-                chunkProcessingInfo.makeChunkTask();
-            } else {
-                // haven't next stage
-                chunkProcessingInfo.endProcessing();
-                cleanup(chunkProcessingInfo);
-            }
-            processChunkTasks();
-
-        } catch (ExecutionException e) {
-            String stageName =
-                    chunkProcessingInfo.getChunkTaskProvider() == null
-                            ? "Generation or Loading"
-                            : chunkProcessingInfo.getChunkTaskProvider().getName();
-            logger.error(
-                    String.format("ChunkTask at position %s and stage [%s] catch error: ",
-                            chunkProcessingInfo.getPosition(), stageName),
-                    e);
-            chunkProcessingInfo.getExternalFuture().setException(e);
-        } catch (CancellationException ignored) {
-        }
-    }
-
-    private void processChunkTasks() {
-        chunkProcessingInfoMap.values().stream()
-                .filter(chunkProcessingInfo -> chunkProcessingInfo.getChunkTask() != null && chunkProcessingInfo.getCurrentFuture() == null)
-                .forEach(chunkProcessingInfo -> {
-                    org.terasology.engine.world.chunks.pipeline.stages.ChunkTask chunkTask = chunkProcessingInfo.getChunkTask();
-                    Set<Chunk> providedChunks = chunkTask.getRequirements().stream()
-                            .map(pos -> getChunkBy(chunkProcessingInfo.getChunkTaskProvider(), pos))
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toSet());
-                    if (providedChunks.size() == chunkTask.getRequirements().size()) {
-                        chunkProcessingInfo.setCurrentFuture(runTask(chunkTask, providedChunks));
+                @Override
+                public void hookOnNext(Chunk chunk) {
+                    buffer.add(chunk);
+                    if (buffer.size() >= CHUNKS_AT_ONCE) {
+                        processNewChunks(buffer);
+                        buffer.clear();
+                        sub.request(CHUNKS_AT_ONCE);
                     }
-                });
+                }
+
+                @Override
+                public void hookOnComplete() {
+                    processNewChunks(buffer);
+                    synchronized (completeSignal) {
+                        completeSignal.notifyAll();
+                    }
+                }
+            });
+        }
+    }
+
+    public void waitUntilComplete(long timeoutMillis) throws InterruptedException {
+        notifyUpdate();
+        synchronized (completeSignal) {
+            completeSignal.wait(timeoutMillis);
+        }
+    }
+
+    /**
+     * Notify the pipeline that new chunks are available, so if any worker threads were suspended, they should be resumed.
+     */
+    public void notifyUpdate() {
+        for (Subscription s : subs) {
+            s.request(CHUNKS_AT_ONCE);
+        }
+    }
+
+    private void processNewChunks(List<Chunk> chunks) {
+        for (Chunk chunk : chunks) {
+            Vector3ic position = chunk.getPosition();
+            if (chunkProcessingInfoMap.containsKey(position)) {
+                logger.error("DUPLICATE CHUNK!!!!");
+            }
+
+            ChunkProcessingInfo chunkProcessingInfo = new ChunkProcessingInfo(position);
+            chunkProcessingInfo.setChunk(chunk);
+            chunkProcessingInfo.nextStage(stages);
+            chunkProcessingInfo.makeChunkTask();
+            chunkProcessingInfoMap.put(position, chunkProcessingInfo);
+        }
+
+        while (processChunkTasks()) {
+            continue;
+        }
+    }
+
+    /**
+     * @return whether any progress was made.
+     */
+    private boolean processChunkTasks() {
+        boolean anyChanged = false;
+        for (ChunkProcessingInfo chunkProcessingInfo : chunkProcessingInfoMap.values()) {
+            ChunkTask chunkTask = chunkProcessingInfo.getChunkTask();
+            if (chunkTask != null) {
+
+                List<Chunk> providedChunks = new ArrayList<>();
+                boolean satisfied = true;
+                for (Vector3ic pos : chunkTask.getRequirements()) {
+                    Chunk chunk = getChunkBy(chunkProcessingInfo.getChunkTaskProvider(), pos);
+                    // If we don't have all the requirements generated yet, skip it
+                    if (chunk == null) {
+                        satisfied = false;
+                        break;
+                    }
+                    providedChunks.add(chunk);
+                }
+
+                // If another thread is running the task, just skip it
+                if (satisfied && chunkProcessingInfo.lock.tryLock()) {
+                    try {
+                        try (ThreadActivity ignored = ThreadMonitor.startThreadActivity(chunkTask.getName())) {
+                            chunkProcessingInfo.setChunk(chunkTask.apply(providedChunks));
+                        }
+                        chunkProcessingInfo.resetTaskState();
+
+                        if (chunkProcessingInfo.hasNextStage(stages)) {
+                            chunkProcessingInfo.nextStage(stages);
+                            chunkProcessingInfo.makeChunkTask();
+                            anyChanged = true;
+                        } else {
+                            cleanup(chunkProcessingInfo);
+                        }
+                    } catch (Exception e) {
+                        String stageName =
+                                chunkProcessingInfo.getChunkTaskProvider() == null
+                                        ? "Generation or Loading"
+                                        : chunkProcessingInfo.getChunkTaskProvider().getName();
+                        logger.error(
+                                String.format("ChunkTask at position %s and stage [%s] catch error: ",
+                                        chunkProcessingInfo.getPosition(), stageName),
+                                e);
+                    } finally {
+                        chunkProcessingInfo.lock.unlock();
+                    }
+                }
+            } else {
+                // It doesn't have a task, so either it needs to be advanced a stage, or it's done and needs to be removed
+                if (chunkProcessingInfo.lock.tryLock()) {
+                    try {
+                        if (chunkProcessingInfo.hasNextStage(stages)) {
+                            chunkProcessingInfo.nextStage(stages);
+                            chunkProcessingInfo.makeChunkTask();
+                            anyChanged = true;
+                        } else {
+                            cleanup(chunkProcessingInfo);
+                        }
+                    } finally {
+                        chunkProcessingInfo.lock.unlock();
+                    }
+                }
+
+            }
+        }
+        return anyChanged;
     }
 
     private Chunk getChunkBy(ChunkTaskProvider requiredStage, Vector3ic position) {
@@ -175,25 +205,6 @@ public class ChunkProcessingPipeline {
         return chunk;
     }
 
-    private Future<Chunk> runTask(ChunkTask task, Set<Chunk> chunks) {
-        return chunkProcessor.submit(new PositionalCallable(() -> {
-            try (ThreadActivity ignored = ThreadMonitor.startThreadActivity(task.getName())) {
-                return task.apply(chunks);
-            }
-        }, task.getPosition()));
-    }
-
-    private Thread threadFactory(Runnable runnable) {
-        Thread thread = new Thread(runnable);
-        thread.setDaemon(true);
-        thread.setName("Chunk-Processing-" + threadIndex++);
-        return thread;
-    }
-
-    private void rejectQueueHandler(Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {
-        logger.error("Cannot run {}  because queue is full", runnable);
-    }
-
     /**
      * Add stage to pipeline.
      *
@@ -205,51 +216,18 @@ public class ChunkProcessingPipeline {
         return this;
     }
 
-    /**
-     * Run generator task and then run pipeline processing with it.
-     * <p>
-     * Additionally add technical stages for cleaning pipeline after chunk processing and handles errors in stages.
-     *
-     * @param generatorTask ChunkTask which provides new chunk to pipeline
-     * @return Future of chunk processing.
-     */
-    public Future<Chunk> invokeGeneratorTask(Vector3i position, Supplier<Chunk> generatorTask) {
-        Preconditions.checkState(!stages.isEmpty(), "ChunkProcessingPipeline must to have at least one stage");
-        ChunkProcessingInfo chunkProcessingInfo = chunkProcessingInfoMap.get(position);
-        if (chunkProcessingInfo != null) {
-            return chunkProcessingInfo.getExternalFuture();
-        } else {
-            SettableFuture<Chunk> exitFuture = SettableFuture.create();
-            chunkProcessingInfo = new ChunkProcessingInfo(position, exitFuture);
-            chunkProcessingInfoMap.put(position, chunkProcessingInfo);
-            chunkProcessingInfo.setCurrentFuture(chunkProcessor.submit(new PositionalCallable(generatorTask::get,
-                    position)));
-            return exitFuture;
-        }
-    }
-
-    /**
-     * Send chunk to processing pipeline. If chunk not processing yet then pipeline will be setted. If chunk processed
-     * then chunk will be processing in next stage;
-     *
-     * @param chunk chunk to process.
-     */
-    public Future<Chunk> invokePipeline(Chunk chunk) {
-        return invokeGeneratorTask(chunk.getPosition(new Vector3i()), () -> chunk);
-    }
-
     public void shutdown() {
-        executor.shutdown();
+        for (Subscription s : subs) {
+            s.cancel();
+        }
+        scheduler.dispose();
         chunkProcessingInfoMap.keySet().forEach(this::stopProcessingAt);
         chunkProcessingInfoMap.clear();
-        executor.getQueue().clear();
-        reactor.interrupt();
     }
 
     public void restart() {
-        chunkProcessingInfoMap.clear();
-        executor.getQueue().clear();
         chunkProcessingInfoMap.keySet().forEach(this::stopProcessingAt);
+        chunkProcessingInfoMap.clear();
     }
 
     /**
@@ -261,13 +239,6 @@ public class ChunkProcessingPipeline {
         ChunkProcessingInfo removed = chunkProcessingInfoMap.remove(pos);
         if (removed == null) {
             return;
-        }
-
-        removed.getExternalFuture().cancel(true);
-
-        Future<Chunk> currentFuture = removed.getCurrentFuture();
-        if (currentFuture != null) {
-            currentFuture.cancel(true);
         }
 
         Chunk chunk = removed.getChunk();
@@ -300,29 +271,7 @@ public class ChunkProcessingPipeline {
      *
      * @return copy of processing positions
      */
-    public Iterable<Vector3ic> getProcessingPosition() {
+    public Set<Vector3ic> getProcessingPositions() {
         return chunkProcessingInfoMap.keySet();
-    }
-
-    /**
-     * Dummy callable for passthru position for {@link java.util.concurrent.ThreadPoolExecutor}#newTaskFor
-     */
-    private static final class PositionalCallable implements Callable<Chunk> {
-        private final Callable<Chunk> callable;
-        private final Vector3ic position;
-
-        private PositionalCallable(Callable<Chunk> callable, Vector3ic position) {
-            this.callable = callable;
-            this.position = position;
-        }
-
-        public Vector3ic getPosition() {
-            return position;
-        }
-
-        @Override
-        public Chunk call() throws Exception {
-            return callable.call();
-        }
     }
 }


### PR DESCRIPTION
### Contains

This is a rewrite of https://github.com/MovingBlocks/Terasology/pull/4773 to use Reactor for concurrency (see https://github.com/MovingBlocks/Terasology/issues/4798 and https://github.com/MovingBlocks/Terasology/pull/4786). It does the same thing as the old PR, but is a lot simpler and has more reliable concurrency. Performace should be about the same.

### How to test

Try flying around the world with this PR - it should be the same as https://github.com/MovingBlocks/Terasology/pull/4773 and much better than normal.

### Outstanding before merging

Unlike https://github.com/MovingBlocks/Terasology/pull/4773, in clients connected to a remote server, this PR currently doesn't bother reordering chunks recieved from the server to load the closest ones first. I don't think there's much reason to do that, since the bottleneck will almost always be the server and network, but if it's a problem we can switch back to a PriorityBlockingQueue.