### PR TITLE
perf: remove extra locking in pipeline to avoid thread contention

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingInfo.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingInfo.java
@@ -9,10 +9,8 @@ import org.terasology.engine.world.chunks.pipeline.stages.ChunkTask;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
 
 import java.util.List;
-import java.util.concurrent.locks.ReentrantLock;
 
 public final class ChunkProcessingInfo {
-    public final ReentrantLock lock = new ReentrantLock();
 
     private final Vector3ic position;
 

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -122,13 +122,13 @@ public class ChunkProcessingPipeline {
     }
 
     private void processingInfoReactor() {
-        Queue<ChunkProcessingInfo> defer = Queues.newArrayDeque();
+        List<ChunkProcessingInfo> defer = Lists.newArrayList();
         ChunkProcessingInfo info;
         while ((info = processing.poll()) != null) {
             ChunkTask task = info.getChunkTask();
             if (task != null) {
-                List<Chunk> providedChunks = new ArrayList<>();
                 boolean satisfied = true;
+                List<Chunk> providedChunks = new ArrayList<>(10);
                 for (Vector3ic pos : task.getRequirements()) {
                     Chunk chunk = getChunkBy(info.getChunkTaskProvider(), pos);
                     // If we don't have all the requirements generated yet, skip it

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -105,7 +105,6 @@ public class ChunkProcessingPipeline {
     }
 
     private void processNewChunks(List<Chunk> chunks) {
-//        Queue<ChunkProcessingInfo> processing = Queues.newArrayDeque();
         for (Chunk chunk : chunks) {
             Vector3ic position = chunk.getPosition();
             if (chunkProcessingInfoMap.containsKey(position)) {
@@ -124,8 +123,8 @@ public class ChunkProcessingPipeline {
 
     private void processingInfoReactor() {
         Queue<ChunkProcessingInfo> defer = Queues.newArrayDeque();
-        while (processing.size() > 0) {
-            ChunkProcessingInfo info = processing.remove();
+        ChunkProcessingInfo info;
+        while ((info = processing.poll()) != null) {
             ChunkTask task = info.getChunkTask();
             if (task != null) {
                 List<Chunk> providedChunks = new ArrayList<>();


### PR DESCRIPTION
I removed the lock on ChunkProcessInfo and replaced it with a concurrent queue along with the locking on the individual processing objects. the problem is this can introduce a lot of contention where the two reactor threads will have contention over locking both the concurrent map and also locking the individual processing objects. I still see a problem of thrashing where we schedule a chunk processor on one thread and then schedule it again on a different thread.