### PR TITLE
fix: replicate mesh and material over network

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/logic/SkeletalMeshComponent.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/SkeletalMeshComponent.java
@@ -20,7 +20,10 @@ import java.util.Map;
 
 @ForceBlockActive
 public class SkeletalMeshComponent implements VisualComponent {
+    @Replicate
     public SkeletalMesh mesh;
+
+    @Replicate
     public Material material;
 
     /**


### PR DESCRIPTION

### Contains

Fix - Replicates mesh and material of Skeletal Mesh Component over the network.

### How to test

- Play Josharias Survival in multiplayer mode with the latest Manual Labor, with 2 players.
- Give yourself a crude shear using ```give crudeshears``` and spawn a sheep using ```spawnPrefab sheep```.
- Use shear on sheep and check if the model change is replicated for the second player 

