### PR TITLE
fix: resolve Advance World Settings issue

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -487,6 +487,7 @@ public class TerasologyEngine implements GameEngine {
         }
 
         Iterator<Float> updateCycles = timeSubsystem.getEngineTime().tick();
+        CoreRegistry.setContext(currentState.getContext());
         rootContext.get(NetworkSystem.class).setContext(currentState.getContext());
 
         for (EngineSubsystem subsystem : allSubsystems) {


### PR DESCRIPTION
I reverted a part of the change introduce in this PR: https://github.com/MovingBlocks/Terasology/pull/4829

something is strange about how the context is configured. 