### PR TITLE
chore: add maven repo that contains jpastebin

### DIFF
--- a/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
@@ -22,6 +22,11 @@ repositories {
         }
     }
 
+    maven {
+        name = "JBoss Public Maven Repository Group"
+        url = URI("https://repository.jboss.org/nexus/content/repositories/public/")
+    }
+
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
     maven {
         val repoViaEnv = System.getenv()["RESOLUTION_REPO"]

--- a/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
@@ -22,9 +22,13 @@ repositories {
         }
     }
 
+    // JBoss Maven Repository requried to fetch `org.jpastebin` dependency for CrashReporter
     maven {
         name = "JBoss Public Maven Repository Group"
         url = URI("https://repository.jboss.org/nexus/content/repositories/public/")
+        content {
+            includeModule("org", "jpastebin")
+        }
     }
 
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs


### PR DESCRIPTION
This change is required to allow the CrashReporter to import the [`org.jpastebin`](https://mvnrepository.com/artifact/org/jpastebin/1.0.1) dependency which is required to fix the broken CrashReporter integration with PasteBin.

See issue #4699 
See fix https://github.com/MovingBlocks/CrashReporter/pull/44