### PR TITLE
feat(reactor): make separate graphic scheduler/thread

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/ThreadCaptureScheduler.java
+++ b/engine/src/main/java/org/terasology/engine/core/ThreadCaptureScheduler.java
@@ -1,0 +1,86 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.core;
+
+import com.google.common.collect.Queues;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.scheduler.Scheduler;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ThreadCaptureScheduler implements Scheduler {
+
+    private static Logger logger = LoggerFactory.getLogger(ThreadCaptureScheduler.class);
+
+    private Thread capturedThread;
+    private AtomicBoolean requestToDispose = new AtomicBoolean(false);
+    private BlockingQueue<Runnable> tasks = Queues.newArrayBlockingQueue(200);
+
+    @Override
+    public Disposable schedule(Runnable task) {
+        Disposable dis = Disposables.single();
+        tasks.offer(task);
+        return dis;
+    }
+
+
+    @Override
+    public Worker createWorker() {
+        return new ThreadCapturedWorker(capturedThread);
+    }
+
+    @Override
+    public void start() {
+        while (!capturedThread.isInterrupted() || !requestToDispose.get()) {
+            try {
+                tasks.take().run();
+            } catch (InterruptedException e) {
+                if (!requestToDispose.get()) {
+                    logger.error("Interrupting captured thread", e);
+                }
+                return;
+            }
+        }
+    }
+
+
+    public Thread getCapturedThread() {
+        return capturedThread;
+    }
+
+    public ThreadCaptureScheduler setCapturedThread(Thread capturedThread) {
+        this.capturedThread = capturedThread;
+        return this;
+    }
+
+    @Override
+    public void dispose() {
+        requestToDispose.set(true);
+    }
+
+    public class ThreadCapturedWorker implements Worker {
+
+        private final Thread capturedThread;
+
+        public ThreadCapturedWorker(Thread capturedThread) {
+            this.capturedThread = capturedThread;
+        }
+
+        @Override
+        public Disposable schedule(Runnable task) {
+            return ThreadCaptureScheduler.this.schedule(task);
+        }
+
+        @Override
+        public void dispose() {
+            // Ignore worker disposing. we have only one thread. it is very important for macos rendering thread.
+        }
+    }
+
+
+}

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphicsManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphicsManager.java
@@ -7,7 +7,7 @@ import com.google.common.collect.Queues;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.terasology.engine.context.Context;
-import org.terasology.engine.core.GameThread;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.subsystem.DisplayDeviceInfo;
 import org.terasology.engine.core.subsystem.RenderingSubsystemFactory;
 import org.terasology.engine.rendering.assets.animation.MeshAnimation;
@@ -51,11 +51,6 @@ public class LwjglGraphicsManager implements LwjglGraphicsProcessing {
     private final BlockingDeque<Runnable> displayThreadActions = Queues.newLinkedBlockingDeque();
 
     private DisplayDeviceInfo displayDeviceInfo = new DisplayDeviceInfo("unknown");
-    private ThreadMode threadMode = ThreadMode.GAME_THREAD;
-
-    public void setThreadMode(ThreadMode threadMode) {
-        this.threadMode = threadMode;
-    }
 
     public void registerCoreAssetTypes(ModuleAwareAssetTypeManager assetTypeManager) {
         // cast lambdas explicitly to avoid inconsistent compiler behavior wrt. type inference
@@ -113,11 +108,7 @@ public class LwjglGraphicsManager implements LwjglGraphicsProcessing {
     }
 
     public void asynchToDisplayThread(Runnable action) {
-        if (threadMode == ThreadMode.GAME_THREAD && GameThread.isCurrentThread()) {
-            action.run();
-        } else {
-            displayThreadActions.add(action);
-        }
+        GameScheduler.runBlockingGraphics("Run somethingTODO rename", action); //TODO remove?
     }
 
     public void createTexture3D(ByteBuffer alignedBuffer, Texture.WrapMode wrapMode, Texture.FilterMode filterMode,
@@ -153,37 +144,35 @@ public class LwjglGraphicsManager implements LwjglGraphicsProcessing {
 
     public void createTexture2D(ByteBuffer[] buffers, Texture.WrapMode wrapMode, Texture.FilterMode filterMode,
                                 int width, int height, Consumer<Integer> idConsumer) {
-        asynchToDisplayThread(() -> {
-            int id = glGenTextures();
-            reloadTexture2D(id, buffers, wrapMode, filterMode, width, height);
-            idConsumer.accept(id);
-        });
+        int id = glGenTextures();
+        reloadTexture2D(id, buffers, wrapMode, filterMode, width, height);
+        idConsumer.accept(id);
     }
 
     public void reloadTexture2D(int id, ByteBuffer[] buffers, Texture.WrapMode wrapMode,
                                 Texture.FilterMode filterMode, int width, int height) {
-        asynchToDisplayThread(() -> {
-            glBindTexture(GL11.GL_TEXTURE_2D, id);
 
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, LwjglGraphicsUtil.getGLMode(wrapMode));
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, LwjglGraphicsUtil.getGLMode(wrapMode));
-            GL11.glTexParameteri(GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER,
-                    LwjglGraphicsUtil.getGlMinFilter(filterMode));
-            GL11.glTexParameteri(GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER,
-                    LwjglGraphicsUtil.getGlMagFilter(filterMode));
-            GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 4);
-            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL12.GL_TEXTURE_MAX_LEVEL, buffers.length - 1);
+        glBindTexture(GL11.GL_TEXTURE_2D, id);
 
-            if (buffers.length > 0) {
-                for (int i = 0; i < buffers.length; i++) {
-                    GL11.glTexImage2D(GL11.GL_TEXTURE_2D, i, GL11.GL_RGBA, width >> i, height >> i, 0, GL11.GL_RGBA,
-                            GL11.GL_UNSIGNED_BYTE, buffers[i]);
-                }
-            } else {
-                GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA, width, height, 0, GL11.GL_RGBA,
-                        GL11.GL_UNSIGNED_BYTE, (ByteBuffer) null);
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, LwjglGraphicsUtil.getGLMode(wrapMode));
+        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, LwjglGraphicsUtil.getGLMode(wrapMode));
+        GL11.glTexParameteri(GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER,
+                LwjglGraphicsUtil.getGlMinFilter(filterMode));
+        GL11.glTexParameteri(GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER,
+                LwjglGraphicsUtil.getGlMagFilter(filterMode));
+        GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 4);
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL12.GL_TEXTURE_MAX_LEVEL, buffers.length - 1);
+
+        if (buffers.length > 0) {
+            for (int i = 0; i < buffers.length; i++) {
+                GL11.glTexImage2D(GL11.GL_TEXTURE_2D, i, GL11.GL_RGBA, width >> i, height >> i, 0, GL11.GL_RGBA,
+                        GL11.GL_UNSIGNED_BYTE, buffers[i]);
             }
-        });
+        } else {
+            GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA, width, height, 0, GL11.GL_RGBA,
+                    GL11.GL_UNSIGNED_BYTE, (ByteBuffer) null);
+        }
+
     }
 
     public void disposeTexture(int id) {
@@ -192,10 +181,5 @@ public class LwjglGraphicsManager implements LwjglGraphicsProcessing {
 
     public DisplayDeviceInfo getDisplayDeviceInfo() {
         return displayDeviceInfo;
-    }
-
-    public enum ThreadMode {
-        GAME_THREAD,
-        DISPLAY_THREAD
     }
 }

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglInput.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglInput.java
@@ -6,6 +6,7 @@ import org.lwjgl.glfw.GLFW;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.ControllerConfig;
 import org.terasology.engine.context.Context;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.modes.GameState;
 import org.terasology.engine.core.subsystem.config.BindsManager;
 import org.terasology.engine.input.InputSystem;
@@ -51,9 +52,12 @@ public class LwjglInput extends BaseLwjglSubsystem {
         LwjglControllerDevice controllerDevice = new LwjglControllerDevice(controllerConfig);
         inputSystem.setControllerDevice(controllerDevice);
 
-        long window = GLFW.glfwGetCurrentContext();
-        ((LwjglKeyboardDevice) inputSystem.getKeyboard()).registerToLwjglWindow(window);
-        ((LwjglMouseDevice) inputSystem.getMouseDevice()).registerToLwjglWindow(window);
+
+        GameScheduler.runOnGraphics("register input callbacks", () -> {
+            long window = GLFW.glfwGetCurrentContext();
+            ((LwjglKeyboardDevice) inputSystem.getKeyboard()).registerToLwjglWindow(window);
+            ((LwjglMouseDevice) inputSystem.getMouseDevice()).registerToLwjglWindow(window);
+        });
     }
 
     private void updateInputConfig() {

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglRenderingSubsystemFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglRenderingSubsystemFactory.java
@@ -3,6 +3,7 @@
 package org.terasology.engine.core.subsystem.lwjgl;
 
 import org.terasology.engine.context.Context;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.subsystem.RenderingSubsystemFactory;
 import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.rendering.world.WorldRendererImpl;
@@ -16,6 +17,6 @@ public class LwjglRenderingSubsystemFactory implements RenderingSubsystemFactory
 
     @Override
     public WorldRenderer createWorldRenderer(Context context) {
-        return new WorldRendererImpl(context);
+        return GameScheduler.runBlockingGraphics("createWorldRenderer", ()->new WorldRendererImpl(context));
     }
 }

--- a/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
+++ b/engine/src/main/java/org/terasology/engine/input/lwjgl/LwjglMouseDevice.java
@@ -11,6 +11,7 @@ import org.joml.Vector2i;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.glfw.GLFW;
 import org.terasology.engine.config.RenderingConfig;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.input.ButtonState;
 import org.terasology.input.InputType;
 import org.terasology.input.MouseInput;
@@ -55,11 +56,12 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
 
     @Override
     public void update() {
-        long window = GLFW.glfwGetCurrentContext();
         DoubleBuffer mouseX = BufferUtils.createDoubleBuffer(1);
         DoubleBuffer mouseY = BufferUtils.createDoubleBuffer(1);
-
-        GLFW.glfwGetCursorPos(window, mouseX, mouseY);
+        GameScheduler.runBlockingGraphics("Lwjgl get mouse position", () -> {
+            long window = GLFW.glfwGetCurrentContext();
+            GLFW.glfwGetCursorPos(window, mouseX, mouseY);
+        });
 
         double x = mouseX.get(0);
         double y = mouseY.get(0);
@@ -95,8 +97,10 @@ public class LwjglMouseDevice implements MouseDevice, PropertyChangeListener {
     public void setGrabbed(boolean newGrabbed) {
         if (newGrabbed != mouseGrabbed) {
             mouseGrabbed = newGrabbed;
-            GLFW.glfwSetInputMode(GLFW.glfwGetCurrentContext(), GLFW.GLFW_CURSOR,
-                    newGrabbed ? GLFW.GLFW_CURSOR_DISABLED : GLFW.GLFW_CURSOR_NORMAL);
+            GameScheduler.runBlockingGraphics("",()-> {
+                GLFW.glfwSetInputMode(GLFW.glfwGetCurrentContext(), GLFW.GLFW_CURSOR,
+                        newGrabbed ? GLFW.GLFW_CURSOR_DISABLED : GLFW.GLFW_CURSOR_NORMAL);
+            });
         }
     }
 

--- a/engine/src/main/java/org/terasology/engine/particles/ParticlePool.java
+++ b/engine/src/main/java/org/terasology/engine/particles/ParticlePool.java
@@ -8,6 +8,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
+import org.terasology.engine.core.GameScheduler;
 
 import java.nio.FloatBuffer;
 
@@ -231,55 +232,61 @@ public final class ParticlePool {
      * The method should be called right after object creation.
      */
     public void initRendering() {
-        vao = GL30.glGenVertexArrays();
-        positionVbo = GL15.glGenBuffers();
-        scaleVbo = GL15.glGenBuffers();
-        colorVbo = GL15.glGenBuffers();
-        textureOffsetVbo = GL15.glGenBuffers();
+        GameScheduler.runBlockingGraphics("init particles rendering", ()-> {
+            vao = GL30.glGenVertexArrays();
+            positionVbo = GL15.glGenBuffers();
+            scaleVbo = GL15.glGenBuffers();
+            colorVbo = GL15.glGenBuffers();
+            textureOffsetVbo = GL15.glGenBuffers();
 
-        GL30.glBindVertexArray(vao);
+            GL30.glBindVertexArray(vao);
 
-        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, positionVbo);
-        GL20.glEnableVertexAttribArray(0);
-        GL20.glVertexAttribPointer(0, 3, GL11.GL_FLOAT, false, 0, 0);
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, positionVbo);
+            GL20.glEnableVertexAttribArray(0);
+            GL20.glVertexAttribPointer(0, 3, GL11.GL_FLOAT, false, 0, 0);
 
-        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, scaleVbo);
-        GL20.glEnableVertexAttribArray(1);
-        GL20.glVertexAttribPointer(1, 3, GL11.GL_FLOAT, false, 0, 0);
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, scaleVbo);
+            GL20.glEnableVertexAttribArray(1);
+            GL20.glVertexAttribPointer(1, 3, GL11.GL_FLOAT, false, 0, 0);
 
-        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, colorVbo);
-        GL20.glEnableVertexAttribArray(2);
-        GL20.glVertexAttribPointer(2, 4, GL11.GL_FLOAT, false, 0, 0);
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, colorVbo);
+            GL20.glEnableVertexAttribArray(2);
+            GL20.glVertexAttribPointer(2, 4, GL11.GL_FLOAT, false, 0, 0);
 
-        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, textureOffsetVbo);
-        GL20.glEnableVertexAttribArray(3);
-        GL20.glVertexAttribPointer(3, 2, GL11.GL_FLOAT, false, 0, 0);
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, textureOffsetVbo);
+            GL20.glEnableVertexAttribArray(3);
+            GL20.glVertexAttribPointer(3, 2, GL11.GL_FLOAT, false, 0, 0);
 
-        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
-        GL30.glBindVertexArray(0);
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+            GL30.glBindVertexArray(0);
+        });
     }
 
     /**
      * Renders the particles in the pool by doing an OpenGL draw call.
      */
     public void draw() {
-        GL30.glBindVertexArray(vao);
-        GL11.glDrawArrays(GL11.GL_POINTS, 0, livingParticles());
-        GL30.glBindVertexArray(0);
+        GameScheduler.runBlockingGraphics("draw particles", ()-> {
+            GL30.glBindVertexArray(vao);
+            GL11.glDrawArrays(GL11.GL_POINTS, 0, livingParticles());
+            GL30.glBindVertexArray(0);
+        });
     }
 
     public void prepareRendering() {
-        refreshBuffer(positionBuffer, position, 3);
-        refreshBuffer(scaleBuffer, scale, 3);
-        refreshBuffer(colorBuffer, color, 4);
-        refreshBuffer(textureOffsetBuffer, textureOffset, 2);
+        GameScheduler.runBlockingGraphics("prepare particle rendering", ()-> {
+            refreshBuffer(positionBuffer, position, 3);
+            refreshBuffer(scaleBuffer, scale, 3);
+            refreshBuffer(colorBuffer, color, 4);
+            refreshBuffer(textureOffsetBuffer, textureOffset, 2);
 
-        bufferData(positionBuffer, positionVbo);
-        bufferData(scaleBuffer, scaleVbo);
-        bufferData(colorBuffer, colorVbo);
-        bufferData(textureOffsetBuffer, textureOffsetVbo);
+            bufferData(positionBuffer, positionVbo);
+            bufferData(scaleBuffer, scaleVbo);
+            bufferData(colorBuffer, colorVbo);
+            bufferData(textureOffsetBuffer, textureOffsetVbo);
 
-        GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+            GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+        });
     }
 
     private void refreshBuffer(FloatBuffer buffer, float[] data, int typeSize) {

--- a/engine/src/main/java/org/terasology/engine/particles/rendering/SpriteParticleRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/particles/rendering/SpriteParticleRenderer.java
@@ -8,6 +8,7 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.entitySystem.systems.RenderSystem;
@@ -76,7 +77,7 @@ public class SpriteParticleRenderer implements RenderSystem {
 
     @Override
     public void initialise() {
-        opengl33 = GL.createCapabilities().OpenGL33;
+        opengl33 = GameScheduler.runBlockingGraphics("get opengl33 cap",  ()-> GL.createCapabilities().OpenGL33);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/FBO.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/FBO.java
@@ -10,6 +10,7 @@ import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.SimpleUri;
 
 import java.nio.ByteBuffer;
@@ -522,10 +523,11 @@ public final class FBO {
     public ByteBuffer getColorBufferRawData() {
         ByteBuffer buffer = BufferUtils.createByteBuffer(this.width() * this.height() * 4);
 
-        this.bindTexture();
-        GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
-        FBO.unbindTexture();
-
+        GameScheduler.runBlockingGraphics("getColorBuffer by FBO", ()-> {
+            this.bindTexture();
+            GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, buffer);
+            FBO.unbindTexture();
+        });
         return buffer;
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMesh.java
@@ -7,7 +7,7 @@ import org.joml.Vector3fc;
 import org.lwjgl.opengl.GL30;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.core.GameThread;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.subsystem.lwjgl.LwjglGraphicsProcessing;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.mesh.MeshData;
@@ -39,9 +39,7 @@ public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
                       DisposalAction disposalAction, LwjglGraphicsProcessing graphicsProcessing) {
         super(urn, assetType, disposalAction);
         this.disposalAction = disposalAction;
-        graphicsProcessing.asynchToDisplayThread(() -> {
-            reload(data);
-        });
+        reload(data);
     }
 
     public static OpenGLMesh create(ResourceUrn urn, AssetType<?, MeshData> assetType, MeshData data,
@@ -51,11 +49,9 @@ public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
 
     @Override
     protected void doReload(MeshData newData) {
-        try {
-            GameThread.synch(() -> buildMesh(newData));
-        } catch (InterruptedException e) {
-            logger.error("Failed to reload {}", getUrn(), e);
-        }
+        GameScheduler.runBlockingGraphics("build meshes", () -> {
+            buildMesh(newData);
+        });
     }
 
     @Override
@@ -143,13 +139,7 @@ public class OpenGLMesh extends Mesh implements OpenGLMeshBase {
 
         @Override
         public void close() {
-            try {
-                GameThread.synch(() -> {
-                    dispose();
-                });
-            } catch (InterruptedException e) {
-                logger.error("Failed to dispose {}", urn, e);
-            }
+            GameScheduler.runBlockingGraphics("dispose mesh", this::dispose);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLSkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLSkeletalMesh.java
@@ -9,6 +9,7 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL30;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.GameThread;
 import org.terasology.engine.core.subsystem.lwjgl.LwjglGraphicsProcessing;
 import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
@@ -48,9 +49,7 @@ public class OpenGLSkeletalMesh extends SkeletalMesh {
                               OpenGLSkeletalMesh.DisposalAction disposalAction) {
         super(urn, assetType, disposalAction);
         this.disposalAction = disposalAction;
-        graphicsProcessing.asynchToDisplayThread(() -> {
-            reload(data);
-        });
+        reload(data);
     }
 
     public static OpenGLSkeletalMesh create(ResourceUrn urn, AssetType<?, SkeletalMeshData> assetType,
@@ -66,54 +65,52 @@ public class OpenGLSkeletalMesh extends SkeletalMesh {
 
     @Override
     protected void doReload(SkeletalMeshData newData) {
-        try {
-            GameThread.synch(() -> {
-                this.data = newData;
+        GameScheduler.runBlockingGraphics("opengl skeletal mesh reload", () -> {
 
-                if (this.disposalAction.vao == 0) {
-                    this.disposalAction.vao = GL30.glGenVertexArrays();
-                    this.disposalAction.vbo = GL30.glGenBuffers();
-                    this.disposalAction.ebo = GL30.glGenBuffers();
-                }
-                // bind vertex array and buffer
-                GL30.glBindVertexArray(this.disposalAction.vao);
-                GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, this.disposalAction.vbo);
+            this.data = newData;
 
-                GL30.glEnableVertexAttribArray(StandardMeshData.VERTEX_INDEX);
-                GL30.glVertexAttribPointer(StandardMeshData.VERTEX_INDEX, 3, GL30.GL_FLOAT, false,
-                        VERTEX_NORMAL_SIZE, 0);
+            if (this.disposalAction.vao == 0) {
+                this.disposalAction.vao = GL30.glGenVertexArrays();
+                this.disposalAction.vbo = GL30.glGenBuffers();
+                this.disposalAction.ebo = GL30.glGenBuffers();
+            }
+            // bind vertex array and buffer
+            GL30.glBindVertexArray(this.disposalAction.vao);
+            GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, this.disposalAction.vbo);
 
-                GL30.glEnableVertexAttribArray(StandardMeshData.NORMAL_INDEX);
-                GL30.glVertexAttribPointer(StandardMeshData.NORMAL_INDEX, 3, GL30.GL_FLOAT, false,
-                        VERTEX_NORMAL_SIZE, VERTEX_SIZE);
+            GL30.glEnableVertexAttribArray(StandardMeshData.VERTEX_INDEX);
+            GL30.glVertexAttribPointer(StandardMeshData.VERTEX_INDEX, 3, GL30.GL_FLOAT, false,
+                    VERTEX_NORMAL_SIZE, 0);
 
-                GL30.glEnableVertexAttribArray(StandardMeshData.UV0_INDEX);
-                GL30.glVertexAttribPointer(StandardMeshData.UV0_INDEX, 2, GL30.GL_FLOAT, false,
-                        UV_SIZE, (long) VERTEX_NORMAL_SIZE * newData.getVertexCount());
+            GL30.glEnableVertexAttribArray(StandardMeshData.NORMAL_INDEX);
+            GL30.glVertexAttribPointer(StandardMeshData.NORMAL_INDEX, 3, GL30.GL_FLOAT, false,
+                    VERTEX_NORMAL_SIZE, VERTEX_SIZE);
 
-                int payloadSize = (UV_SIZE + VERTEX_SIZE + NORMAL_SIZE) * newData.getVertexCount();
-                ByteBuffer buffer = BufferUtils.createByteBuffer(payloadSize);
+            GL30.glEnableVertexAttribArray(StandardMeshData.UV0_INDEX);
+            GL30.glVertexAttribPointer(StandardMeshData.UV0_INDEX, 2, GL30.GL_FLOAT, false,
+                    UV_SIZE, (long) VERTEX_NORMAL_SIZE * newData.getVertexCount());
 
-                buffer.position(newData.getVertexCount() * VERTEX_NORMAL_SIZE);
+            int payloadSize = (UV_SIZE + VERTEX_SIZE + NORMAL_SIZE) * newData.getVertexCount();
+            ByteBuffer buffer = BufferUtils.createByteBuffer(payloadSize);
 
-                for (Vector2f uv : newData.getUVs()) {
-                    buffer.putFloat(uv.x);
-                    buffer.putFloat(uv.y);
-                }
-                buffer.flip();
-                GL30.glBufferData(GL30.GL_ARRAY_BUFFER, buffer, GL30.GL_DYNAMIC_DRAW);
+            buffer.position(newData.getVertexCount() * VERTEX_NORMAL_SIZE);
 
-                IntBuffer indexBuffer = BufferUtils.createIntBuffer(newData.getIndices().size());
-                indexBuffer.put(newData.getIndices().toArray());
-                indexBuffer.flip();
-                GL30.glBindBuffer(GL30.GL_ELEMENT_ARRAY_BUFFER, this.disposalAction.ebo);
-                GL30.glBufferData(GL30.GL_ELEMENT_ARRAY_BUFFER, indexBuffer, GL30.GL_STATIC_DRAW);
+            for (Vector2f uv : newData.getUVs()) {
+                buffer.putFloat(uv.x);
+                buffer.putFloat(uv.y);
+            }
+            buffer.flip();
+            GL30.glBufferData(GL30.GL_ARRAY_BUFFER, buffer, GL30.GL_DYNAMIC_DRAW);
 
-                GL30.glBindVertexArray(0);
-            });
-        } catch (InterruptedException e) {
-            logger.error("Failed to reload {}", getUrn(), e);
-        }
+            IntBuffer indexBuffer = BufferUtils.createIntBuffer(newData.getIndices().size());
+            indexBuffer.put(newData.getIndices().toArray());
+            indexBuffer.flip();
+            GL30.glBindBuffer(GL30.GL_ELEMENT_ARRAY_BUFFER, this.disposalAction.ebo);
+            GL30.glBufferData(GL30.GL_ELEMENT_ARRAY_BUFFER, indexBuffer, GL30.GL_STATIC_DRAW);
+
+            GL30.glBindVertexArray(0);
+        });
+
     }
 
 

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLTexture.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLTexture.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import org.joml.Vector2i;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.DisposableResource;
 import org.terasology.gestalt.assets.ResourceUrn;
@@ -41,78 +42,80 @@ public class OpenGLTexture extends Texture {
 
     @Override
     protected void doReload(TextureData data) {
-        switch (data.getType()) {
-            // TODO: reconsider how 3D textures handled (probably separate asset implementation with common interface?
-            case TEXTURE3D:
-                if (data.getWidth() % data.getHeight() != 0 || data.getWidth() / data.getHeight() != data.getHeight()) {
-                    throw new RuntimeException("3D texture must be cubic (height^3) - width must thus be a multiple of height");
-                }
-                int size = data.getHeight();
+        GameScheduler.runBlockingGraphics("reload texture",()-> {
+            switch (data.getType()) {
+                // TODO: reconsider how 3D textures handled (probably separate asset implementation with common interface?
+                case TEXTURE3D:
+                    if (data.getWidth() % data.getHeight() != 0 || data.getWidth() / data.getHeight() != data.getHeight()) {
+                        throw new RuntimeException("3D texture must be cubic (height^3) - width must thus be a multiple of height");
+                    }
+                    int size = data.getHeight();
 
-                final int byteLength = 4 * 16 * 16 * 16;
-                final int strideX = 16 * 4;
-                final int strideY = 16 * 16 * 4;
-                final int strideZ = 4;
+                    final int byteLength = 4 * 16 * 16 * 16;
+                    final int strideX = 16 * 4;
+                    final int strideY = 16 * 16 * 4;
+                    final int strideZ = 4;
 
-                ByteBuffer alignedBuffer = ByteBuffer.allocateDirect(byteLength);
-                for (int x = 0; x < size; x++) {
-                    for (int y = 0; y < size; y++) {
-                        for (int z = 0; z < size; z++) {
-                            final int index = x * strideX + z * strideZ + strideY * y;
+                    ByteBuffer alignedBuffer = ByteBuffer.allocateDirect(byteLength);
+                    for (int x = 0; x < size; x++) {
+                        for (int y = 0; y < size; y++) {
+                            for (int z = 0; z < size; z++) {
+                                final int index = x * strideX + z * strideZ + strideY * y;
 
-                            alignedBuffer.put(data.getBuffers()[0].get(index));
-                            alignedBuffer.put(data.getBuffers()[0].get(index + 1));
-                            alignedBuffer.put(data.getBuffers()[0].get(index + 2));
-                            alignedBuffer.put(data.getBuffers()[0].get(index + 3));
+                                alignedBuffer.put(data.getBuffers()[0].get(index));
+                                alignedBuffer.put(data.getBuffers()[0].get(index + 1));
+                                alignedBuffer.put(data.getBuffers()[0].get(index + 2));
+                                alignedBuffer.put(data.getBuffers()[0].get(index + 3));
+                            }
                         }
                     }
-                }
-                alignedBuffer.flip();
+                    alignedBuffer.flip();
 
-                resources.loadedTextureInfo = new LoadedTextureInfo(size, size, size, data);
+                    resources.loadedTextureInfo = new LoadedTextureInfo(size, size, size, data);
 
-                if (resources.id == 0) {
-                    resources.graphicsManager.createTexture3D(alignedBuffer, getWrapMode(), getFilterMode(),
-                            size, (newId) -> {
-                                synchronized (this) {
-                                    if (resources.id != 0) {
-                                        resources.graphicsManager.disposeTexture(resources.id);
-                                    }
-                                    if (isDisposed()) {
-                                        resources.graphicsManager.disposeTexture(newId);
-                                    } else {
-                                        resources.id = newId;
-                                        logger.debug("Bound texture '{}' - {}", getUrn(), resources.id);
-                                    }
+                    if (resources.id == 0) {
+                        resources.graphicsManager.createTexture3D(alignedBuffer, getWrapMode(), getFilterMode(),
+                                size, (newId) -> {
+
+                                        if (resources.id != 0) {
+                                            resources.graphicsManager.disposeTexture(resources.id);
+                                        }
+                                        if (isDisposed()) {
+                                            resources.graphicsManager.disposeTexture(newId);
+                                        } else {
+                                            resources.id = newId;
+                                            logger.debug("Bound texture '{}' - {}", getUrn(), resources.id);
+                                        }
+
+                                });
+                    } else {
+                        resources.graphicsManager.reloadTexture3D(resources.id, alignedBuffer, getWrapMode(), getFilterMode(), size);
+                    }
+                    break;
+                default:
+                    int width = data.getWidth();
+                    int height = data.getHeight();
+                    resources.loadedTextureInfo = new LoadedTextureInfo(width, height, 1, data);
+                    if (resources.id == 0) {
+                        resources.graphicsManager.createTexture2D(data.getBuffers(), getWrapMode(), getFilterMode(), width, height, (newId) -> {
+
+                                if (resources.id != 0) {
+                                    resources.graphicsManager.disposeTexture(resources.id);
                                 }
-                            });
-                } else {
-                    resources.graphicsManager.reloadTexture3D(resources.id, alignedBuffer, getWrapMode(), getFilterMode(), size);
-                }
-                break;
-            default:
-                int width = data.getWidth();
-                int height = data.getHeight();
-                resources.loadedTextureInfo = new LoadedTextureInfo(width, height, 1, data);
-                if (resources.id == 0) {
-                    resources.graphicsManager.createTexture2D(data.getBuffers(), getWrapMode(), getFilterMode(), width, height, (newId) -> {
-                        synchronized (this) {
-                            if (resources.id != 0) {
-                                resources.graphicsManager.disposeTexture(resources.id);
-                            }
-                            if (isDisposed()) {
-                                resources.graphicsManager.disposeTexture(newId);
-                            } else {
-                                resources.id = newId;
-                                logger.debug("Bound texture '{}' - {}", getUrn(), resources.id);
-                            }
-                        }
-                    });
-                } else {
-                    resources.graphicsManager.reloadTexture2D(resources.id, data.getBuffers(), getWrapMode(), getFilterMode(), width, height);
-                }
-                break;
-        }
+                                if (isDisposed()) {
+                                    resources.graphicsManager.disposeTexture(newId);
+                                } else {
+                                    resources.id = newId;
+                                    logger.debug("Bound texture '{}' - {}", getUrn(), resources.id);
+                                }
+
+                        });
+                    } else {
+                        resources.graphicsManager.reloadTexture2D(resources.id, data.getBuffers(), getWrapMode(), getFilterMode(), width, height);
+                    }
+                    break;
+            }
+        });
     }
 
     @Override
@@ -252,10 +255,12 @@ public class OpenGLTexture extends Texture {
         @Override
         public void close() {
             if (loadedTextureInfo != null) {
-                disposalSubscribers.forEach(DisposableResource::close);
-                graphicsManager.disposeTexture(id);
-                loadedTextureInfo = null;
-                id = 0;
+                GameScheduler.runBlockingGraphics("dispose texture", ()-> {
+                    disposalSubscribers.forEach(DisposableResource::close);
+                    graphicsManager.disposeTexture(id);
+                    loadedTextureInfo = null;
+                    id = 0;
+                });
             }
         }
     }

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -11,6 +11,7 @@ import org.terasology.engine.config.PlayerConfig;
 import org.terasology.engine.config.RenderingConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.GameEngine;
+import org.terasology.engine.core.GameScheduler;
 import org.terasology.engine.core.modes.StateMainMenu;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.module.rendering.RenderingModuleRegistry;
@@ -370,9 +371,11 @@ public final class WorldRendererImpl implements WorldRenderer {
      */
     @Override
     public void dispose() {
-        renderableWorld.dispose();
-        worldProvider.dispose();
-        renderGraph.dispose();
+        GameScheduler.runBlockingGraphics("dispose world renderer", ()-> {
+            renderableWorld.dispose();
+            worldProvider.dispose();
+            renderGraph.dispose();
+        });
         // TODO: Shift this to a better place, after a RenderGraph class has been implemented.
         SetViewportToSizeOf.disposeDefaultInstance();
     }

--- a/facades/TeraEd/src/main/java/org/terasology/editor/subsystem/LwjglPortlet.java
+++ b/facades/TeraEd/src/main/java/org/terasology/editor/subsystem/LwjglPortlet.java
@@ -70,7 +70,6 @@ public class LwjglPortlet extends BaseLwjglSubsystem {
         this.context = rootContext;
         this.config = context.get(Config.class).getRendering();
 
-        graphics.setThreadMode(LwjglGraphicsManager.ThreadMode.DISPLAY_THREAD);
         display = new LwjglPortletDisplayDevice(canvas, graphics);
         context.put(DisplayDevice.class, display);
         logger.info("Initial initialization complete");
@@ -111,7 +110,6 @@ public class LwjglPortlet extends BaseLwjglSubsystem {
     public void setupThreads() {
         GameThread.reset();
         GameThread.setToCurrentThread();
-        graphics.setThreadMode(LwjglGraphicsManager.ThreadMode.GAME_THREAD);
 
         EventSystem eventSystem = CoreRegistry.get(EventSystem.class);
         if (eventSystem != null) {


### PR DESCRIPTION

### Contains

* Introducing GRAPHICS Scheduler
* wraps calls to GL/GLFW to runBlocking at graphics scheduler ( hopping flow to another thread)
* Splash screen should  works at MacOS now. (ref: https://github.com/MovingBlocks/Terasology/issues/4206)
* splitting opengl context between splashscreen and game
* wrapped calls to runBlocking should tracking by ActivityMonitor

### How to test

1. runs Terasology with splash screen (especial  at MacOs)
2. start any gameplay
3. try to call maximum rendering stuffs
3.1.  block digging particles 
3.2. different Overlay renderer. 


### Outstanding before merging

- [ ] docs
- [ ] refactor
- [ ] cleanup

### After merge:

- rethink/refactor reactor usage with LWJGL subsystem, lwjgl's assets and opengl rendering.
