### PR TITLE
perf: replace creating streams by arrays in stream

### DIFF
--- a/engine/src/main/java/org/terasology/engine/entitySystem/entity/internal/PojoEntityPool.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/entity/internal/PojoEntityPool.java
@@ -287,8 +287,14 @@ public class PojoEntityPool implements EngineEntityPool {
     public final Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses) {
         return () -> entityStore.keySet().stream()
                 //Keep entities which have all of the required components
-                .filter(id -> Arrays.stream(componentClasses)
-                        .allMatch(component -> componentStore.get(id, component) != null))
+                .filter(id -> {
+                    for (Class<? extends Component> component : componentClasses) {
+                        if (componentStore.get(id, component) == null) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
                 .map(id -> getEntity(id))
                 .iterator();
     }


### PR DESCRIPTION
### Contains

Just reduce many stream's object creation.
See #performance channel at discord

### How to test

VisualVM:
1. start CoreGamplay empty server
2. attach visualvm
3. set memory sampler and per thread allocation. (there reduce 100MB -> 30MB per second at my system)

Game:
1. start CoreGameplay(or another gameplay)
2. check that all works as previous ( any process with selecting entity with several components enough)