### PR TITLE
build(IntelliJ): turn on checkstyle.scan-before-checkin

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -4,13 +4,13 @@
     <option name="configuration">
       <map>
         <entry key="active-configuration" value="PROJECT_RELATIVE:$PROJECT_DIR$/config/metrics/checkstyle/checkstyle.xml:Terasology" />
-        <entry key="checkstyle-version" value="8.32" />
+        <entry key="checkstyle-version" value="8.45" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="PROJECT_RELATIVE:$PROJECT_DIR$/config/metrics/checkstyle/checkstyle.xml:Terasology" />
-        <entry key="property-2.samedir" value="config/metrics/checkstyle" />
-        <entry key="scan-before-checkin" value="false" />
+        <entry key="property-2.samedir" value="$PROJECT_DIR$/config/metrics/checkstyle" />
+        <entry key="scan-before-checkin" value="true" />
         <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />
       </map>

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -90,8 +90,10 @@ jacocoTestReport {
 // TODO: Maybe update other projects like modules to pull the zipped dependency so fewer quirks are needed in Jenkins
 checkstyle {
     ignoreFailures = false
-    configFile = new File(rootDir, 'config/metrics/checkstyle/checkstyle.xml')
-    configProperties.samedir = checkstyle.configFile.parentFile
+
+    def checkstyleDir = rootProject.file('config/metrics/checkstyle')
+    configDirectory = checkstyleDir
+    configProperties.samedir = checkstyleDir
 }
 
 pmd {


### PR DESCRIPTION
Small tweaks to how CheckStyle is setup in gradle and IntelliJ.

The most impactful one is that `scan-before-checkin`.

I was tempted to see if we could get rid of the `samedir` property, but that princess is in another castle.