### PR TITLE
bugfix: migrate deprecated texture2D

### DIFF
--- a/facades/PC/src/main/resources/splash/shader/frag.glsl
+++ b/facades/PC/src/main/resources/splash/shader/frag.glsl
@@ -6,6 +6,6 @@ varying vec2 textureCoord;
 uniform sampler2D texImage;
 
 void main() {
-    vec4 textureColor = texture2D(texImage, textureCoord);
+    vec4 textureColor = texture(texImage, textureCoord);
     gl_FragColor = vertexColor * textureColor;
 }

--- a/facades/PC/src/main/resources/splash/shader/frag.glsl
+++ b/facades/PC/src/main/resources/splash/shader/frag.glsl
@@ -1,4 +1,4 @@
-#version 120
+#version 330 core
 
 varying vec4 vertexColor;
 varying vec2 textureCoord;

--- a/facades/PC/src/main/resources/splash/shader/vert.glsl
+++ b/facades/PC/src/main/resources/splash/shader/vert.glsl
@@ -1,4 +1,4 @@
-#version 120
+#version 330 core
 
 attribute vec2 position;
 attribute vec4 color;


### PR DESCRIPTION
found we have some old references for texture2D
```
13:14:24.593 [main] WARN  o.t.e.rendering.opengl.GLSLShader - Shader 'CoreRendering:chunk' failed to compile for features '[]'.
Game output: 
Game output: Shader Info: 
Game output: ERROR: 0:506: Invalid call of undeclared identifier 'texture2D'
Game output: ERROR: 0:509: Use of undeclared identifier 'maskColor'
```

ref: https://github.com/Terasology/CoreRendering/pull/72