### PR TITLE
refactor: construct block mesh generator single shape with standard mesh data

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -28,7 +28,7 @@ public class BlockMeshGeneratorSingleShape extends BlockMeshShapeGenerator {
     }
 
     @Override
-    public ResourceUrn baseUrn() {
+    public ResourceUrn getBaseUrn() {
         return this.baseUrn;
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -4,26 +4,25 @@ package org.terasology.engine.rendering.primitives;
 
 import org.joml.Vector3ic;
 import org.terasology.engine.math.Side;
-import org.terasology.engine.rendering.assets.mesh.Mesh;
-import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
-import org.terasology.engine.utilities.Assets;
 import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockAppearance;
 import org.terasology.engine.world.block.BlockManager;
 import org.terasology.engine.world.block.BlockPart;
 import org.terasology.engine.world.block.shapes.BlockMeshPart;
-import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 
-public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
-
+public class BlockMeshGeneratorSingleShape extends BlockMeshShapeGenerator {
     private Block block;
-    private Mesh mesh;
 
     public BlockMeshGeneratorSingleShape(Block block) {
         this.block = block;
+    }
+
+    @Override
+    public Block getBlock() {
+        return block;
     }
 
     @Override
@@ -169,40 +168,4 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
 
     }
 
-    @Override
-    public Mesh getStandaloneMesh() {
-        if (mesh == null || mesh.isDisposed()) {
-            mesh = generateMesh();
-        }
-        return mesh;
-    }
-
-    private Mesh generateMesh() {
-        StandardMeshData meshData = new StandardMeshData();
-        int nextIndex = 0;
-        for (BlockPart dir : BlockPart.allParts()) {
-            BlockMeshPart part = block.getPrimaryAppearance().getPart(dir);
-            if (part != null) {
-                for (int i = 0; i < part.size(); i++) {
-                    meshData.position.put(part.getVertex(i));
-                    meshData.color0.put(Color.white);
-                    meshData.normal.put(part.getNormal(i));
-                    meshData.uv0.put(part.getTexCoord(i));
-                }
-                for (int i = 0; i < part.indicesSize(); ++i) {
-                    meshData.indices.put(nextIndex + part.getIndex(i));
-                }
-                if (block.isDoubleSided()) {
-                    for (int i = 0; i < part.indicesSize(); i += 3) {
-                        meshData.indices.put(nextIndex + part.getIndex(i + 1));
-                        meshData.indices.put(nextIndex + part.getIndex(i));
-                        meshData.indices.put(nextIndex + part.getIndex(i + 2));
-                    }
-                }
-                nextIndex += part.size();
-
-            }
-        }
-        return Assets.generateAsset(new ResourceUrn("engine", "blockmesh", block.getURI().toString()), meshData, Mesh.class);
-    }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -185,8 +185,11 @@ public class BlockMeshGeneratorSingleShape implements BlockMeshGenerator {
             if (part != null) {
                 for (int i = 0; i < part.size(); i++) {
                     meshData.position.put(part.getVertex(i));
+                    meshData.color0.put(Color.white);
                     meshData.normal.put(part.getNormal(i));
                     meshData.uv0.put(part.getTexCoord(i));
+                }
+                for (int i = 0; i < part.indicesSize(); ++i) {
                     meshData.indices.put(nextIndex + part.getIndex(i));
                 }
                 if (block.isDoubleSided()) {

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -10,11 +10,13 @@ import org.terasology.engine.world.block.BlockAppearance;
 import org.terasology.engine.world.block.BlockManager;
 import org.terasology.engine.world.block.BlockPart;
 import org.terasology.engine.world.block.shapes.BlockMeshPart;
+import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 
 public class BlockMeshGeneratorSingleShape extends BlockMeshShapeGenerator {
-    private Block block;
+    private final Block block;
+    private final ResourceUrn baseUrn = new ResourceUrn("engine", "blockmesh");
 
     public BlockMeshGeneratorSingleShape(Block block) {
         this.block = block;
@@ -24,6 +26,12 @@ public class BlockMeshGeneratorSingleShape extends BlockMeshShapeGenerator {
     public Block getBlock() {
         return block;
     }
+
+    @Override
+    public ResourceUrn baseUrn() {
+        return this.baseUrn;
+    }
+
 
     @Override
     public void generateChunkMesh(ChunkView view, ChunkMesh chunkMesh, int x, int y, int z) {

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
@@ -18,7 +18,7 @@ public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
 
     public abstract Block getBlock();
 
-    public abstract ResourceUrn baseUrn();
+    public abstract ResourceUrn getBaseUrn();
 
     @Override
     public Mesh getStandaloneMesh() {
@@ -51,7 +51,7 @@ public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
                 }
             }
             mesh = Assets.generateAsset(
-                    new ResourceUrn(baseUrn(), block.getURI().toString()), meshData,
+                    new ResourceUrn(getBaseUrn(), block.getURI().toString()), meshData,
                     Mesh.class);
         }
         return mesh;

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
@@ -1,0 +1,55 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.primitives;
+
+import org.terasology.engine.rendering.assets.mesh.Mesh;
+import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
+import org.terasology.engine.utilities.Assets;
+import org.terasology.engine.world.block.Block;
+import org.terasology.engine.world.block.BlockPart;
+import org.terasology.engine.world.block.shapes.BlockMeshPart;
+import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.nui.Color;
+
+import java.util.Optional;
+
+public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
+    protected Optional<Mesh> mesh = Optional.empty();
+
+    public abstract Block getBlock();
+
+    @Override
+    public Mesh getStandaloneMesh() {
+        if (!mesh.isPresent()) {
+            Block block = getBlock();
+            StandardMeshData meshData = new StandardMeshData();
+            int nextIndex = 0;
+            for (BlockPart dir : BlockPart.allParts()) {
+                BlockMeshPart part = block.getPrimaryAppearance().getPart(dir);
+                if (part != null) {
+                    for (int i = 0; i < part.size(); i++) {
+                        meshData.position.put(part.getVertex(i));
+                        meshData.color0.put(Color.white);
+                        meshData.normal.put(part.getNormal(i));
+                        meshData.uv0.put(part.getTexCoord(i));
+                    }
+                    for (int i = 0; i < part.indicesSize(); ++i) {
+                        meshData.indices.put(nextIndex + part.getIndex(i));
+                    }
+                    if (block.isDoubleSided()) {
+                        for (int i = 0; i < part.indicesSize(); i += 3) {
+                            meshData.indices.put(nextIndex + part.getIndex(i + 1));
+                            meshData.indices.put(nextIndex + part.getIndex(i));
+                            meshData.indices.put(nextIndex + part.getIndex(i + 2));
+                        }
+                    }
+                    nextIndex += part.size();
+                }
+            }
+            mesh = Optional.of(Assets.generateAsset(new ResourceUrn("engine", "blockmesh", block.getURI().toString()), meshData,
+                    Mesh.class));
+        }
+        return mesh.get();
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.rendering.primitives;
 
+import org.joml.Vector3f;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
 import org.terasology.engine.utilities.Assets;
@@ -25,6 +26,7 @@ public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
             Block block = getBlock();
             StandardMeshData meshData = new StandardMeshData();
             int nextIndex = 0;
+            Vector3f light0 = new Vector3f(1,1,1);
             for (BlockPart dir : BlockPart.allParts()) {
                 BlockMeshPart part = block.getPrimaryAppearance().getPart(dir);
                 if (part != null) {
@@ -33,6 +35,7 @@ public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
                         meshData.color0.put(Color.white);
                         meshData.normal.put(part.getNormal(i));
                         meshData.uv0.put(part.getTexCoord(i));
+                        meshData.light0.put(light0);
                     }
                     for (int i = 0; i < part.indicesSize(); ++i) {
                         meshData.indices.put(nextIndex + part.getIndex(i));

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
@@ -12,16 +12,16 @@ import org.terasology.engine.world.block.shapes.BlockMeshPart;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.nui.Color;
 
-import java.util.Optional;
-
 public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
-    protected Optional<Mesh> mesh = Optional.empty();
+    protected Mesh mesh = null;
 
     public abstract Block getBlock();
 
+    public abstract ResourceUrn baseUrn();
+
     @Override
     public Mesh getStandaloneMesh() {
-        if (!mesh.isPresent()) {
+        if (mesh == null || mesh.isDisposed()) {
             Block block = getBlock();
             StandardMeshData meshData = new StandardMeshData();
             int nextIndex = 0;
@@ -47,9 +47,10 @@ public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
                     nextIndex += part.size();
                 }
             }
-            mesh = Optional.of(Assets.generateAsset(new ResourceUrn("engine", "blockmesh", block.getURI().toString()), meshData,
-                    Mesh.class));
+            mesh = Assets.generateAsset(
+                    new ResourceUrn(baseUrn(), block.getURI().toString()), meshData,
+                    Mesh.class);
         }
-        return mesh.get();
+        return mesh;
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshShapeGenerator.java
@@ -26,7 +26,7 @@ public abstract class BlockMeshShapeGenerator implements BlockMeshGenerator {
             Block block = getBlock();
             StandardMeshData meshData = new StandardMeshData();
             int nextIndex = 0;
-            Vector3f light0 = new Vector3f(1,1,1);
+            Vector3f light0 = new Vector3f(1, 1, 1);
             for (BlockPart dir : BlockPart.allParts()) {
                 BlockMeshPart part = block.getPrimaryAppearance().getPart(dir);
                 if (part != null) {


### PR DESCRIPTION
After reviewing what the tesselator used to look like before the attribute changes I think its a pretty straightforward change to drop the use of the Tesselator and submit the mesh data directly. The code is already to a degree simpler so Tesselator does not seem appropriate anymore. The only other place this is referenced is within flowing liquids so I could just move this up into the interface as a default maybe?


https://github.com/MovingBlocks/Terasology/blob/c725b454517bcaec881c343d5045eb76d722868b/engine/src/main/java/org/terasology/engine/rendering/primitives/Tessellator.java