### PR TITLE
feat(RelevanceSystem): addRelevanceEntity returns the relevant region

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -5,6 +5,7 @@ package org.terasology.engine.world.chunks.localChunkProvider;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.ListenableFuture;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.TShortObjectMap;
@@ -55,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 /**
@@ -115,7 +115,7 @@ public class LocalChunkProvider implements ChunkProvider {
     }
 
 
-    protected Future<Chunk> createOrLoadChunk(Vector3ic chunkPos) {
+    protected ListenableFuture<Chunk> createOrLoadChunk(Vector3ic chunkPos) {
         Vector3i pos = new Vector3i(chunkPos);
         return loadingPipeline.invokeGeneratorTask(
             pos,

--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/RelevanceSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/RelevanceSystem.java
@@ -17,6 +17,7 @@ import org.terasology.engine.monitoring.PerformanceMonitor;
 import org.terasology.engine.world.RelevanceRegionComponent;
 import org.terasology.engine.world.WorldComponent;
 import org.terasology.engine.world.block.BlockRegion;
+import org.terasology.engine.world.block.BlockRegionc;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.ChunkRegionListener;
 import org.terasology.engine.world.chunks.event.BeforeChunkUnload;
@@ -144,20 +145,22 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
      * Add entity to relevance system. create region for it. Update distance if region exists already. Create/Load
      * chunks for region.
      *
-     * @param entity entity to add.
-     * @param distance region's distance.
-     * @param listener chunk relevance listener.
+     * @param entity the region will be centered around the LocationComponent of this entity
+     * @param distance the dimensions of the region, in chunks
+     * @param listener notified when relevant chunks become available
+     *
+     * @return the region of chunks deemed relevant
      */
-    public void addRelevanceEntity(EntityRef entity, Vector3ic distance, ChunkRegionListener listener) {
+    public BlockRegionc addRelevanceEntity(EntityRef entity, Vector3ic distance, ChunkRegionListener listener) {
         if (!entity.exists()) {
-            return;
+            return null;  // Futures.immediateFailedFuture(new IllegalArgumentException("Entity does not exist."));
         }
         regionLock.readLock().lock();
         try {
             ChunkRelevanceRegion region = regions.get(entity);
             if (region != null) {
                 region.setRelevanceDistance(distance);
-                return;
+                return new BlockRegion(region.getCurrentRegion());  // Future of “when region.currentRegion is no longer dirty”?
             }
         } finally {
             regionLock.readLock().unlock();
@@ -175,16 +178,17 @@ public class RelevanceSystem implements UpdateSubscriberSystem {
 
         StreamSupport.stream(region.getCurrentRegion().spliterator(), false)
                 .sorted(new PositionRelevanceComparator()) //<-- this is n^2 cost. not sure why this needs to be sorted like this.
-                .forEach(
-                        pos -> {
+                .forEach(pos -> {
                             Chunk chunk = chunkProvider.getChunk(pos);
                             if (chunk != null) {
                                 region.checkIfChunkIsRelevant(chunk);
+                                // return Futures.immediateFuture(chunk);
                             } else {
-                                chunkProvider.createOrLoadChunk(pos);
+                                chunkProvider.createOrLoadChunk(pos); // return this
                             }
                         }
                 );
+        return new BlockRegion(region.getCurrentRegion());  // whenAllComplete
     }
 
     /**

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -6,6 +6,7 @@ package org.terasology.engine.world.chunks.pipeline;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
@@ -221,7 +222,7 @@ public class ChunkProcessingPipeline {
      * @param generatorTask ChunkTask which provides new chunk to pipeline
      * @return Future of chunk processing.
      */
-    public Future<Chunk> invokeGeneratorTask(Vector3ic position, Supplier<Chunk> generatorTask) {
+    public ListenableFuture<Chunk> invokeGeneratorTask(Vector3ic position, Supplier<Chunk> generatorTask) {
         Preconditions.checkState(!stages.isEmpty(), "ChunkProcessingPipeline must to have at least one stage");
         ChunkProcessingInfo chunkProcessingInfo = chunkProcessingInfoMap.get(position);
         if (chunkProcessingInfo != null) {


### PR DESCRIPTION
This is used by the code I'm adding so MTE knows when a region is ready.

No user-visible changes, as this method only returned `void` before.

One wrinkle is that the return value only tells you the region's _initial_ position. That's something that could change as the entity moves or resizes the region.