### PR TITLE
chore: update vertex attribute with put(T[] data)

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
@@ -8,22 +8,26 @@ import org.joml.Vector3fc;
 import org.junit.Test;
 import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexFloatAttributeBinding;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexIntegerAttributeBinding;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
 import org.terasology.joml.test.VectorAssert;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class VertexAttributeBindingTest {
     @Test
-    public void testPutAllBinding() {
+    public void testPutAllBindingVector() {
         VertexResourceBuilder builder = new VertexResourceBuilder();
         VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
         builder.build();
 
-        a1.putAll(new Vector3f[]{
+        a1.putAll(
                 new Vector3f(10, 5, 2),
                 new Vector3f(2, 15, 2),
                 new Vector3f(1, 5, 13),
                 new Vector3f(1, 1, 1)
-        });
+        );
 
         VectorAssert.assertEquals(new Vector3f(10, 5, 2), a1.get(0, new Vector3f()), 0.001f);
         VectorAssert.assertEquals(new Vector3f(2, 15, 2), a1.get(1, new Vector3f()), 0.001f);
@@ -31,4 +35,31 @@ public class VertexAttributeBindingTest {
         VectorAssert.assertEquals(new Vector3f(1, 1, 1), a1.get(3, new Vector3f()), 0.001f);
     }
 
+    @Test
+    public void testPutAllBindingFloat() {
+        VertexResourceBuilder builder = new VertexResourceBuilder();
+        VertexFloatAttributeBinding a1 = builder.add(0, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
+        builder.build();
+
+        a1.putAll(10f, .5f, 12.5f, 13.5f);
+
+        assertEquals(10f, a1.get(0), 0.001f);
+        assertEquals(.5f, a1.get(1), 0.001f);
+        assertEquals(12.5f, a1.get(2), 0.001f);
+        assertEquals(13.5f, a1.get(3), 0.001f);
+    }
+
+    @Test
+    public void testPutAllBindingInt() {
+        VertexResourceBuilder builder = new VertexResourceBuilder();
+        VertexIntegerAttributeBinding a1 = builder.add(0, GLAttributes.INT_1_VERTEX_ATTRIBUTE);
+        builder.build();
+
+        a1.putAll(10, 2, 1, 1);
+
+        assertEquals(10, a1.get(0));
+        assertEquals(2, a1.get(1));
+        assertEquals(1, a1.get(2));
+        assertEquals(1, a1.get(3));
+    }
 }

--- a/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
@@ -22,12 +22,12 @@ public class VertexAttributeBindingTest {
         VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
         builder.build();
 
-        a1.putAll(
+        a1.put(new Vector3fc[]{
                 new Vector3f(10, 5, 2),
                 new Vector3f(2, 15, 2),
                 new Vector3f(1, 5, 13),
                 new Vector3f(1, 1, 1)
-        );
+        });
 
         VectorAssert.assertEquals(new Vector3f(10, 5, 2), a1.get(0, new Vector3f()), 0.001f);
         VectorAssert.assertEquals(new Vector3f(2, 15, 2), a1.get(1, new Vector3f()), 0.001f);
@@ -41,7 +41,7 @@ public class VertexAttributeBindingTest {
         VertexFloatAttributeBinding a1 = builder.add(0, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
         builder.build();
 
-        a1.putAll(10f, .5f, 12.5f, 13.5f);
+        a1.put(new float[]{10f, .5f, 12.5f, 13.5f});
 
         assertEquals(10f, a1.get(0), 0.001f);
         assertEquals(.5f, a1.get(1), 0.001f);
@@ -55,7 +55,7 @@ public class VertexAttributeBindingTest {
         VertexIntegerAttributeBinding a1 = builder.add(0, GLAttributes.INT_1_VERTEX_ATTRIBUTE);
         builder.build();
 
-        a1.putAll(10, 2, 1, 1);
+        a1.put(new int[]{10, 2, 1, 1});
 
         assertEquals(10, a1.get(0));
         assertEquals(2, a1.get(1));

--- a/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
@@ -8,7 +8,6 @@ import org.joml.Vector3fc;
 import org.junit.Test;
 import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
-import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
 import org.terasology.joml.test.VectorAssert;
 
@@ -17,7 +16,7 @@ public class VertexAttributeBindingTest {
     public void testPutAllBinding() {
         VertexResourceBuilder builder = new VertexResourceBuilder();
         VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
-        VertexResource resource = builder.build();
+        builder.build();
 
         a1.putAll(new Vector3f[]{
                 new Vector3f(10, 5, 2),

--- a/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexAttributeBindingTest.java
@@ -1,0 +1,35 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.assets.mesh;
+
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.junit.Test;
+import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
+import org.terasology.joml.test.VectorAssert;
+
+public class VertexAttributeBindingTest {
+    @Test
+    public void testPutAllBinding() {
+        VertexResourceBuilder builder = new VertexResourceBuilder();
+        VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+        VertexResource resource = builder.build();
+
+        a1.putAll(new Vector3f[]{
+                new Vector3f(10, 5, 2),
+                new Vector3f(2, 15, 2),
+                new Vector3f(1, 5, 13),
+                new Vector3f(1, 1, 1)
+        });
+
+        VectorAssert.assertEquals(new Vector3f(10, 5, 2), a1.get(0, new Vector3f()), 0.001f);
+        VectorAssert.assertEquals(new Vector3f(2, 15, 2), a1.get(1, new Vector3f()), 0.001f);
+        VectorAssert.assertEquals(new Vector3f(1, 5, 13), a1.get(2, new Vector3f()), 0.001f);
+        VectorAssert.assertEquals(new Vector3f(1, 1, 1), a1.get(3, new Vector3f()), 0.001f);
+    }
+
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexAttributeBinding.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexAttributeBinding.java
@@ -49,7 +49,7 @@ public class VertexAttributeBinding<T, I extends T> extends VertexBinding {
      *
      * @param values the values to commit
      */
-    public void putAll(T... values) {
+    public void put(T[] values) {
         resource.ensureElements(this.vertexIndex + values.length);
         for (T value : values) {
             attribute.configuration.write(value, this.vertexIndex, this.offset, resource);

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexAttributeBinding.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexAttributeBinding.java
@@ -44,6 +44,21 @@ public class VertexAttributeBinding<T, I extends T> extends VertexBinding {
         this.resource.mark();
     }
 
+    /**
+     * write all value by the index.
+     *
+     * @param values the values to commit
+     */
+    public void putAll(T... values) {
+        resource.ensureElements(this.vertexIndex + values.length);
+        for (T value : values) {
+            attribute.configuration.write(value, this.vertexIndex, this.offset, resource);
+            this.vertexIndex++;
+            this.resource.mark();
+        }
+    }
+
+
     public void set(int index, T value) {
         attribute.configuration.write(value, index, this.offset, resource);
         this.resource.mark();

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexFloatAttributeBinding.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexFloatAttributeBinding.java
@@ -29,6 +29,21 @@ public class VertexFloatAttributeBinding extends VertexBinding {
         this.resource.mark();
     }
 
+    /**
+     * write all value by the index.
+     *
+     * @param values the values to commit
+     */
+    public void putAll(float... values) {
+        resource.ensureElements(this.vertexIndex + values.length);
+        for (float value : values) {
+            attribute.configuration.write(value, this.vertexIndex, this.offset, resource);
+            this.vertexIndex++;
+            this.resource.mark();
+        }
+    }
+
+
     public void set(int index, float value) {
         attribute.configuration.write(value, index, this.offset, resource);
         this.resource.mark();

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexFloatAttributeBinding.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexFloatAttributeBinding.java
@@ -34,7 +34,7 @@ public class VertexFloatAttributeBinding extends VertexBinding {
      *
      * @param values the values to commit
      */
-    public void putAll(float... values) {
+    public void put(float[] values) {
         resource.ensureElements(this.vertexIndex + values.length);
         for (float value : values) {
             attribute.configuration.write(value, this.vertexIndex, this.offset, resource);

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexIntegerAttributeBinding.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexIntegerAttributeBinding.java
@@ -32,6 +32,22 @@ public class VertexIntegerAttributeBinding extends VertexBinding {
         this.resource.mark();
     }
 
+
+    /**
+     * write all value by the index.
+     *
+     * @param values the values to commit
+     */
+    public void putAll(int... values) {
+        resource.ensureElements(this.vertexIndex + values.length);
+        for (int value : values) {
+            attribute.configuration.write(value, this.vertexIndex, this.offset, resource);
+            this.vertexIndex++;
+            this.resource.mark();
+        }
+    }
+
+
     public void set(int index, int value) {
         attribute.configuration.write(value, index, this.offset, resource);
         this.resource.mark();

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexIntegerAttributeBinding.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexIntegerAttributeBinding.java
@@ -38,7 +38,7 @@ public class VertexIntegerAttributeBinding extends VertexBinding {
      *
      * @param values the values to commit
      */
-    public void putAll(int... values) {
+    public void put(int[] values) {
         resource.ensureElements(this.vertexIndex + values.length);
         for (int value : values) {
             attribute.configuration.write(value, this.vertexIndex, this.offset, resource);


### PR DESCRIPTION
I added a way to pass in multiple vertices in one pass. should make the API easier to use. 