### PR TITLE
refactor: add test cases for vertex resource and update api with put and replace

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexResourceTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexResourceTest.java
@@ -38,7 +38,7 @@ public class VertexResourceTest {
 
         resource.put(buffer);
         resource.put(buffer);
-        
+
         assertEquals(4, a1.elements());
 
         VectorAssert.assertEquals(new Vector3f(12.0f, 20.0f, 50.0f), a1.get(0, new Vector3f()), .0001f);

--- a/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexResourceTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/assets/mesh/VertexResourceTest.java
@@ -6,16 +6,96 @@ package org.terasology.engine.rendering.assets.mesh;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.junit.Test;
+import org.lwjgl.BufferUtils;
 import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexIntegerAttributeBinding;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
+import org.terasology.joml.test.VectorAssert;
+
+import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class VertexResourceTest {
+
+    @Test
+    public void testPutWithByteBuffer() {
+        VertexResourceBuilder builder = new VertexResourceBuilder();
+        VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+        VertexResource resource = builder.build();
+
+        ByteBuffer buffer = BufferUtils.createByteBuffer(Float.BYTES * 6);
+        buffer.putFloat(0 * Float.BYTES, 12.0f);
+        buffer.putFloat(1 * Float.BYTES, 20.0f);
+        buffer.putFloat(2 * Float.BYTES, 50.0f);
+
+        buffer.putFloat(3 * Float.BYTES, 25.0f);
+        buffer.putFloat(4 * Float.BYTES, 15.0f);
+        buffer.putFloat(5 * Float.BYTES, 1.5f);
+
+        resource.put(buffer);
+        resource.put(buffer);
+        
+        assertEquals(4, a1.elements());
+
+        VectorAssert.assertEquals(new Vector3f(12.0f, 20.0f, 50.0f), a1.get(0, new Vector3f()), .0001f);
+        VectorAssert.assertEquals(new Vector3f(25.0f, 15.0f, 1.5f), a1.get(1, new Vector3f()), .0001f);
+
+        VectorAssert.assertEquals(new Vector3f(12.0f, 20.0f, 50.0f), a1.get(2, new Vector3f()), .0001f);
+        VectorAssert.assertEquals(new Vector3f(25.0f, 15.0f, 1.5f), a1.get(3, new Vector3f()), .0001f);
+
+    }
+
+    @Test
+    public void testPutWithBufferedResource() {
+        VertexResourceBuilder builder = new VertexResourceBuilder();
+        VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+        VertexResource firstResource = builder.build();
+
+        a1.put(new Vector3f(12.0f, 0.0f, 13.0f));
+        a1.put(new Vector3f(12.5f, 13f, 1.5f));
+
+        builder = new VertexResourceBuilder();
+        VertexAttributeBinding<Vector3fc, Vector3f> b2 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+        VertexResource secondResource = builder.build();
+
+        b2.put(new Vector3f(13.0f, 0.0f, 1.5f));
+
+        firstResource.put(secondResource);
+
+        assertEquals(3, a1.elements());
+
+        VectorAssert.assertEquals(new Vector3f(12.0f, 0.0f, 13.0f), a1.get(0, new Vector3f()), .0001f);
+        VectorAssert.assertEquals(new Vector3f(12.5f, 13f, 1.5f), a1.get(1, new Vector3f()), .0001f);
+        VectorAssert.assertEquals(new Vector3f(13.0f, 0.0f, 1.5f), a1.get(2, new Vector3f()), .0001f);
+    }
+
+
+    @Test
+    public void testReplaceBufferedResource() {
+        VertexResourceBuilder builder = new VertexResourceBuilder();
+        VertexAttributeBinding<Vector3fc, Vector3f> a1 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+        VertexResource firstResource = builder.build();
+
+        a1.put(new Vector3f(12.0f, 0.0f, 13.0f));
+        a1.put(new Vector3f(12.5f, 13f, 1.5f));
+
+        builder = new VertexResourceBuilder();
+        VertexAttributeBinding<Vector3fc, Vector3f> b2 = builder.add(0, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+        VertexResource secondResource = builder.build();
+
+        b2.put(new Vector3f(13.0f, 0.0f, 1.5f));
+
+        firstResource.replace(secondResource);
+
+        assertEquals(1, a1.elements());
+        VectorAssert.assertEquals(new Vector3f(13.0f, 0.0f, 1.5f), a1.get(0, new Vector3f()), .0001f);
+    }
+
+
     @Test
     public void testReserveVertexResource() {
         VertexResourceBuilder builder = new VertexResourceBuilder();
@@ -27,7 +107,7 @@ public class VertexResourceTest {
         a1.put(new Vector3f(5, 10, 10));
         a1.put(new Vector3f(15, 10, 10));
 
-        assertEquals(1, a1.getPosition());
+        assertEquals(3, a1.getPosition());
 
         resource.writeBuffer(buffer -> {
             assertNotNull(buffer);

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/ChunkMeshTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/ChunkMeshTypeHandler.java
@@ -46,8 +46,8 @@ public class ChunkMeshTypeHandler extends TypeHandler<ChunkMesh> {
         }
         ChunkMesh result = new ChunkMesh();
         for (ChunkMesh.RenderType renderType : ChunkMesh.RenderType.values()) {
-            result.getVertexElements(renderType).buffer.copyBuffer(asBuffers.remove(0));
-            result.getVertexElements(renderType).indices.copyBuffer(asBuffers.remove(0));
+            result.getVertexElements(renderType).buffer.replace(asBuffers.remove(0));
+            result.getVertexElements(renderType).indices.replace(asBuffers.remove(0));
         }
         result.generateVBOs();
         return Optional.of(result);

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/StandardMeshData.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/StandardMeshData.java
@@ -53,13 +53,13 @@ public class StandardMeshData extends MeshData {
      */
     public StandardMeshData(StandardMeshData data) {
         this();
-        positionBuffer.copy(data.positionBuffer);
-        normalBuffer.copy(data.normalBuffer);
-        uv0Buffer.copy(data.uv0Buffer);
-        uv1Buffer.copy(data.uv1Buffer);
-        lightBuffer.copy(data.lightBuffer);
-        colorBuffer.copy(data.colorBuffer);
-        indices.copy(data.indices);
+        positionBuffer.replace(data.positionBuffer);
+        normalBuffer.replace(data.normalBuffer);
+        uv0Buffer.replace(data.uv0Buffer);
+        uv1Buffer.replace(data.uv1Buffer);
+        lightBuffer.replace(data.lightBuffer);
+        colorBuffer.replace(data.colorBuffer);
+        indices.replace(data.indices);
 
         position.setPosition(data.position.getPosition());
         normal.setPosition(data.normal.getPosition());

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/BufferedResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/BufferedResource.java
@@ -64,6 +64,9 @@ public abstract class BufferedResource {
      * <p>
      * make sure the data is structured in a way that the buffer expects.
      *
+     * All {@link BufferedResource} are all in native order. data will
+     * be garbage if the order of the buffer is different from the endianness system.
+     *
      * @param copyBuffer the buffer to replace the contents with
      */
     public void put(ByteBuffer copyBuffer) {
@@ -82,6 +85,7 @@ public abstract class BufferedResource {
 
     /**
      * append the buffer to the current BufferedResource
+     *
      * <p>
      * make sure the data is structured in a way that the buffer expects.
      *
@@ -106,6 +110,9 @@ public abstract class BufferedResource {
      * replace this resource directory with the contents from another buffer
      * <p>
      * make sure the data is structured in a way that the buffer expects.
+     *
+     * All {@link BufferedResource} are all in native order. data will
+     * be garbage if the order of the buffer is different from the endianness system.
      *
      * @param copyBuffer the buffer to replace the contents with
      */
@@ -201,7 +208,7 @@ public abstract class BufferedResource {
     }
 
     /**
-     * shrink the buffer capacity to match the {@link #inSize()}
+     * shrink the buffer capacity to match {@link #inSize()}
      */
     public void squeeze() {
         if (this.inSize != buffer.capacity()) {

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/IndexResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/IndexResource.java
@@ -23,11 +23,6 @@ public class IndexResource extends BufferedResource {
         return this.inSize / Integer.BYTES;
     }
 
-    public void copy(IndexResource resource) {
-        copyBuffer(resource);
-        this.inSize = resource.inSize;
-    }
-
     public void reserveElements(int elements) {
         reserve(elements * Integer.BYTES);
     }

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexResource.java
@@ -8,7 +8,6 @@ package org.terasology.engine.rendering.assets.mesh.resource;
  */
 public class VertexResource extends BufferedResource {
     private int inStride = 0;
-    private int version = 0;
     private VertexDefinition[] attributes;
 
     public VertexResource() {
@@ -30,7 +29,7 @@ public class VertexResource extends BufferedResource {
     }
 
     /**
-     * definition information that the end consumer uses to determin the layout of the vertex data
+     * definition information that the end consumer uses to determine the layout of the vertex data
      * @return the definition
      */
     public VertexDefinition[] definitions() {
@@ -43,20 +42,6 @@ public class VertexResource extends BufferedResource {
      */
     public void setDefinitions(VertexDefinition[] attr) {
         this.attributes = attr;
-    }
-
-    /**
-     * copy the contents of a vertex resource over.
-     *
-     * @param resource
-     */
-    public void copy(VertexResource resource) {
-        if (resource.isEmpty()) {
-            return;
-        }
-        copyBuffer(resource);
-        this.inStride = resource.inStride;
-        this.mark();
     }
 
     /**
@@ -106,22 +91,6 @@ public class VertexResource extends BufferedResource {
     public void allocate(int size, int stride) {
         this.allocate(size);
         this.inStride = stride;
-    }
-
-    /**
-     * the version of the buffer is used to determine if the contents has changed.
-     * this should notify the end user of the buffer to sync the data back to the driver
-     * @return the version flag
-     */
-    public int getVersion() {
-        return version;
-    }
-
-    /**
-     * increase version flag for change
-     */
-    public void mark() {
-        version++;
     }
 
     @Override


### PR DESCRIPTION
refactored vertex resource with updated javadocs, more tests and tried to make test cases more consistent

- replaced `copyBuffer` with `replace`
  - this will replace the contents of a buffer with the target one 
- introduced put commend
  - will take a bytebuffer or buffered resource and append it to the existing.  
