### PR TITLE
test(modules): make com.google.truth assertion library available

### DIFF
--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -68,13 +68,16 @@ dependencies {
 
     testRuntimeOnly("org.slf4j:jul-to-slf4j:1.7.21")
 
-    add("testImplementation", platform("org.junit:junit-bom:5.7.1"))
+    add("testImplementation", platform("org.junit:junit-bom:5.8.1"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-    testImplementation("org.mockito:mockito-inline:3.11.2")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.11.2")
+    testImplementation("org.mockito:mockito-inline:3.12.4")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
+
+    testImplementation("com.google.truth:truth:1.1.3")
+    testImplementation("com.google.truth.extensions:truth-java8-extension:1.1.3")
 }
 
 
@@ -86,9 +89,9 @@ if (project.name == "ModuleTestingEnvironment") {
         runtimeOnly("org.codehaus.janino:janino:3.1.3") {
             because("logback filters")
         }
-        add("implementation", platform("org.junit:junit-bom:5.7.1"))
+        add("implementation", platform("org.junit:junit-bom:5.8.1"))
         implementation("org.junit.jupiter:junit-jupiter-api")
-        implementation("org.mockito:mockito-junit-jupiter:3.11.2")
+        implementation("org.mockito:mockito-junit-jupiter:3.12.4")
     }
 }
 

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -62,20 +62,20 @@ dependencies {
     implementation "org.terasology:reflections:0.9.12-MB"
 
     // Test lib dependencies
-    implementation(platform("org.junit:junit-bom:5.7.1")) {
+    implementation(platform("org.junit:junit-bom:5.8.1")) {
         // junit-bom will set version numbers for the other org.junit dependencies.
     }
     implementation("org.junit.jupiter:junit-jupiter-api")
     implementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.mockito:mockito-inline:3.11.2")
+    testImplementation('org.mockito:mockito-inline:3.12.4')
 
-    implementation("org.mockito:mockito-junit-jupiter:3.11.2")
+    implementation('org.mockito:mockito-junit-jupiter:3.12.4')
 
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
 
-    testImplementation("com.google.truth:truth:1.1.2")
-    testImplementation("com.google.truth.extensions:truth-java8-extension:1.1.2")
+    testImplementation('com.google.truth:truth:1.1.3')
+    testImplementation('com.google.truth.extensions:truth-java8-extension:1.1.3')
 }
 
 task copyResourcesToClasses(type:Copy) {

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -71,7 +71,7 @@ configurations.all {
 // Primary dependencies definition
 dependencies {
     // Storage and networking
-    api group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+    api group: 'com.google.guava', name: 'guava', version: '31.0-jre'
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     api group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.65.Final'


### PR DESCRIPTION
test: upgrade to junit 5.8.1 from 5.7, mockito 3.12.4 from 3.11

### How to test

The minor upgrades to junit and mockito upgrades are _unlikely_ to break, but you could run module tests if you're feeling extra cautious.