### PR TITLE
build(IntelliJ): add inspections allowing IntelliJ to correct "modifier out of order" infractions

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -33,7 +33,6 @@ workspace.xml
 /uiDesigner.xml
 /modules.xml
 /modules
-/inspectionProfiles
 /libraries-with-intellij-classes.xml
 /*.local.xml
 

--- a/.idea/inspectionProfiles/Terasology.xml
+++ b/.idea/inspectionProfiles/Terasology.xml
@@ -1,0 +1,16 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <description>Used in Terasology, compatible with TeraConfig Checkstyle</description>
+    <option name="myName" value="Terasology" />
+    <inspection_tool class="AssertEqualsCalledOnArray" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="AssertEqualsMayBeAssertSame" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="JUnit5Converter" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="LongLine" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="MalformedSetUpTearDown" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MisorderedAssertEqualsArguments" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MissortedModifiers" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_requireAnnotationsFirst" value="true" />
+    </inspection_tool>
+    <inspection_tool class="SimplifiableAnnotation" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Terasology" />
+    <version value="1.0" />
+  </settings>
+</component>


### PR DESCRIPTION
Be aware this does partly revert #4630—people might have differing opinions on how to approach this.

### How to test

put some code in a class like
```java
   final static private Logger logger;
```
assert you can apply an inspection fix (usually _Alt-Enter_) "Sort Modifiers" to correct it to 
```java
   private static final Logger logger;
```