### PR TITLE
chore(StateMainMenu): include message in toString representation for debugging

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/StateMainMenu.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateMainMenu.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core.modes;
 
+import com.google.common.base.MoreObjects;
 import org.terasology.engine.audio.AudioManager;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.TelemetryConfig;
@@ -159,5 +160,12 @@ public class StateMainMenu extends AbstractState {
 
     private void updateUserInterface(float delta) {
         nuiManager.update(delta);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("messageOnLoad", messageOnLoad)
+                .toString();
     }
 }


### PR DESCRIPTION
How to test: There are places in MTE where it logs the game state. Not sure if the headless server does by itself.