### PR TITLE
fix: Avoid a couple cases where no NUIManager would cause trouble.

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/StartServer.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/StartServer.java
@@ -3,15 +3,19 @@
 
 package org.terasology.engine.core.modes.loadProcesses;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.modes.SingleStepLoadProcess;
+import org.terasology.engine.core.modes.StateLoading;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.network.exceptions.HostingFailedException;
 import org.terasology.engine.rendering.nui.NUIManager;
 import org.terasology.engine.rendering.nui.layers.mainMenu.MessagePopup;
 
 public class StartServer extends SingleStepLoadProcess {
+    private static final Logger logger = LoggerFactory.getLogger(StartServer.class);
 
     private final Context context;
     private final boolean dedicated;
@@ -36,8 +40,14 @@ public class StartServer extends SingleStepLoadProcess {
             int port = config.getNetwork().getServerPort();
             context.get(NetworkSystem.class).host(port, dedicated);
         } catch (HostingFailedException e) {
-            context.get(NUIManager.class).pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Failed to Host",
-                    e.getMessage() + " - Reverting to single player");
+            NUIManager nui = context.get(NUIManager.class);
+            if (nui != null) {
+                nui.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Failed to Host",
+                        e.getMessage() + " - Reverting to single player");
+            } else {
+                logger.error("Failed to Host. NUI was also unavailable for warning popup (headless?)", e);
+                throw new RuntimeException("Cannot host game successfully from likely headless start, terminating");
+            }
         }
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/StartServer.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/StartServer.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.modes.SingleStepLoadProcess;
-import org.terasology.engine.core.modes.StateLoading;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.network.exceptions.HostingFailedException;
 import org.terasology.engine.rendering.nui.NUIManager;

--- a/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
@@ -179,13 +179,20 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
 
                 // enumerate all network interfaces that listen
                 Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+
                 while (interfaces.hasMoreElements()) {
                     NetworkInterface ifc = interfaces.nextElement();
                     if (!ifc.isLoopback()) {
                         for (InterfaceAddress ifadr : ifc.getInterfaceAddresses()) {
-                            InetAddress adr = ifadr.getAddress();
-                            logger.info("Listening on network interface \"{}\", hostname \"{}\" ({})",
-                                    ifc.getDisplayName(), adr.getCanonicalHostName(), adr.getHostAddress());
+                            // Exclude interfaces with the following key words to avoid common virtual and otherwise unlikely useful nics
+                            // TODO: Make this configurable via config.cfg?
+                            if (ifc.getDisplayName().contains("VirtualBox") || ifc.getDisplayName().contains("ISATAP")) {
+                                logger.info("Skipping filtered interface name {}", ifc.getDisplayName());
+                            } else {
+                                InetAddress adr = ifadr.getAddress();
+                                logger.info("Listening on network interface \"{}\", hostname \"{}\" ({})",
+                                        ifc.getDisplayName(), adr.getCanonicalHostName(), adr.getHostAddress());
+                            }
                         }
                     }
                 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinFormat.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinFormat.java
@@ -129,6 +129,14 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
 
         public void apply(UISkinBuilder builder) {
             super.apply(builder);
+
+            // Check if we actually have the NUI Manager available, this would for instance not be the case if starting a headless game server
+            NUIManager nui = CoreRegistry.get(NUIManager.class);
+            if (nui == null) {
+                logger.warn("NUIManager was unavailable, skipping UISkinFormat as not needed. This may or may not be a problem");
+                return;
+            }
+
             if (elements != null) {
                 for (Map.Entry<String, ElementInfo> entry : elements.entrySet()) {
                     WidgetLibrary library = CoreRegistry.get(NUIManager.class).getWidgetMetadataLibrary();


### PR DESCRIPTION
This seemingly fixes a case where you can't host the game headlessly _if you have modules active with `UISkinFormat` assets_ ! Which is probably a bit quirky. Since there's no longer a `NUIManager` available in the `Context` when you're running headlessly we really shouldn't attempt to use it during initialization. There may still be other cases where this could factor in.

Additionally I caught an exception being swallowed and a weird game state being entered in the case where you fail to establish the game host due to for instance already having the port in use. Previously that would freak out and fail to create a NUI popup informing the user which isn't very helpful when trying to start a headless server. Now it logs an error and promptly terminates the game - if headed it'll still fall back to single player, although I'm not sure if that's actually sensible.

With that fixed you now get a good error in the logs. You _still_ get the CrashReporter starting, which is kinda weird. Maybe we lack that flag when starting from Gradle, but what if you're running from a game binary on a server? CR should be disabled if headless, period. Haven't looked into fixing that, I had to juggle this tricky fix alongside toddler, baby feeding, and angry neighbors showing up to complain about our plants dripping water onto their balcony stairs below us. Yup.

Bonus: filters out typical virtual NICs from listening - this may be more controversial but I'd like to leave it as a GFI exercise to turn it configurable via `config.cfg` - I *suspect* it is _hugely unlikely_ to cause trouble in the meantime. Even if somebody tries to host a game server inside VirtualBox I figure that would end up reachable via some bridged network like the host OS? Dunno. But this speeds up "listening to all the NICs!" from more than 30 seconds for me to just a few. Could ignore a couple more still. This is how my startup ends up looking:

```
17:22:21.464 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #4
17:22:21.464 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #4
17:22:21.471 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter #7
17:22:21.474 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #2
17:22:21.474 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #2
17:22:22.298 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Listening on network interface "Intel(R) Dual Band Wireless-AC 8260 #2", hostname "fe80:0:0:0:1d39:3ebe:32df:2a55%wlan0" (fe80:0:0:0:1d39:3ebe:32df:2a55%wlan0)
17:22:23.124 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Listening on network interface "Microsoft Wi-Fi Direct Virtual Adapter #2", hostname "fe80:0:0:0:1910:f4c:9c83:8718%wlan1" (fe80:0:0:0:1910:f4c:9c83:8718%wlan1)
17:22:23.129 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter #5
17:22:23.954 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Listening on network interface "Microsoft Teredo Tunneling Adapter", hostname "fe80:0:0:0:0:100:7f:fffe%net3" (fe80:0:0:0:0:100:7f:fffe%net3)
17:22:23.957 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter #2
17:22:24.785 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Listening on network interface "TAP Adapter OAS NDIS 6.0", hostname "fe80:0:0:0:44bf:7d8c:94f3:b1d4%eth4" (fe80:0:0:0:44bf:7d8c:94f3:b1d4%eth4)
17:22:24.789 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Listening on network interface "Intel(R) Ethernet Connection (2) I218-V", hostname "192.168.86.36" (192.168.86.36)
17:22:24.789 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Listening on network interface "Intel(R) Ethernet Connection (2) I218-V", hostname "fe80:0:0:0:3552:69f2:d9ed:6a3b%eth5" (fe80:0:0:0:3552:69f2:d9ed:6a3b%eth5)
17:22:24.792 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter
17:22:24.792 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter
17:22:24.794 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter #6
17:22:24.797 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #5
17:22:24.797 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #5
17:22:24.800 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #3
17:22:24.800 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #3
17:22:24.803 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter
17:22:24.806 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter #8
17:22:24.809 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #6
17:22:24.809 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name VirtualBox Host-Only Ethernet Adapter #6
17:22:24.812 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Skipping filtered interface name Microsoft ISATAP Adapter #9
17:22:24.934 [main] INFO  o.t.e.n.internal.NetworkSystemImpl - Server started
```