### PR TITLE
feat(octree): Octo tree as chunk's data structure.

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/world/TeraArrayTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/TeraArrayTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.world;
+
+import com.google.common.collect.Streams;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.terasology.engine.world.chunks.blockdata.TeraArray;
+import org.terasology.engine.world.chunks.blockdata.TeraDenseArray16Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraDenseArray4Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraDenseArray8Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraOcTree;
+import org.terasology.engine.world.chunks.blockdata.TeraSparseArray16Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraSparseArray4Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraSparseArray8Bit;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.stream.Stream;
+
+public class TeraArrayTest {
+
+    public static Stream<Arguments> arrays() {
+        return Stream.of(
+                new TeraOcTree((byte) 32),
+                new TeraDenseArray4Bit(32, 32, 32),
+                new TeraDenseArray8Bit(32, 32, 32),
+                new TeraDenseArray16Bit(32, 32, 32),
+                new TeraSparseArray4Bit(32, 32, 32),
+                new TeraSparseArray8Bit(32, 32, 32),
+                new TeraSparseArray16Bit(32, 32, 32)
+        ).map(Arguments::of);
+    }
+
+    public static Stream<Arguments> serializers() {
+        return Stream.of(
+                new TeraOcTree.SerializationHandler(),
+                new TeraDenseArray4Bit.SerializationHandler(),
+                new TeraDenseArray8Bit.SerializationHandler(),
+                new TeraDenseArray16Bit.SerializationHandler(),
+                new TeraSparseArray4Bit.SerializationHandler(),
+                new TeraSparseArray8Bit.SerializationHandler(),
+                new TeraSparseArray16Bit.SerializationHandler()
+        ).map(Arguments::of);
+    }
+
+    public static Stream<Arguments> arrayAndSerializers() {
+        return Streams.zip(arrays(), serializers(), (a, s) -> Arguments.arguments(a.get()[0], s.get()[0]));
+    }
+
+    @MethodSource("arrays")
+    @ParameterizedTest
+    public void writeRead(TeraArray array) {
+
+        Assertions.assertEquals(0, array.set(5, 31, 1, 1));
+        int i = array.get(5, 31, 1);
+        Assertions.assertEquals(1, i);
+    }
+
+    @MethodSource("arrayAndSerializers")
+    @ParameterizedTest
+    public void buffer(TeraArray array, TeraArray.SerializationHandler serializationHandler) {
+        Random random = new Random();
+        for (int i = 0; i < random.nextInt(40); i++) {
+            array.set(random.nextInt(32),
+                    random.nextInt(32),
+                    random.nextInt(32),
+                    random.nextInt(32)
+            );
+        }
+        ByteBuffer buffer = serializationHandler.serialize(array);
+        buffer.rewind();
+        TeraArray deserializedArray = serializationHandler.deserialize(buffer);
+        // At least this code is not fall.
+    }
+
+}

--- a/engine/src/main/java/org/terasology/engine/world/chunks/Chunks.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/Chunks.java
@@ -8,14 +8,14 @@ import org.joml.RoundingMode;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
-import org.terasology.gestalt.module.sandbox.API;
 import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.engine.world.block.BlockRegionc;
+import org.terasology.gestalt.module.sandbox.API;
 
 @API
 public final class Chunks {
     public static final int SIZE_X = 32;
-    public static final int SIZE_Y = 64;
+    public static final int SIZE_Y = 32;
     public static final int SIZE_Z = 32;
 
     public static final int INNER_CHUNK_POS_FILTER_X = Integer.highestOneBit(SIZE_X) - 1;

--- a/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/ExtraBlockDataManager.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/ExtraBlockDataManager.java
@@ -7,10 +7,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.module.ModuleManager;
-import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;
+import org.terasology.gestalt.module.ModuleEnvironment;
+import org.terasology.gestalt.module.sandbox.API;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -220,7 +220,7 @@ public class ExtraBlockDataManager {
     public TeraArray[] makeDataArrays(int sizeX, int sizeY, int sizeZ) {
         TeraArray[] extraData = new TeraArray[slotFactories.length];
         for (int i = 0; i < extraData.length; i++) {
-            extraData[i] = slotFactories[i].create(sizeX, sizeY, sizeZ);
+            extraData[i] = new TeraOcTree((byte) sizeX);
         }
         return extraData;
     }

--- a/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/TeraOcTree.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/TeraOcTree.java
@@ -1,0 +1,268 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.world.chunks.blockdata;
+
+import com.google.common.base.Preconditions;
+import org.terasology.engine.world.chunks.deflate.TeraVisitingDeflator;
+
+import java.nio.ByteBuffer;
+
+/**
+ * <p>Dumb simple Octo tree implementation for TeraArray</p>
+ * <p>Theoretical complexity</p>
+ * <p>read: O(1) - O(log(n))</p>
+ * <p>write: O(1) - O(log(n))+ (?)</p>
+ * <p/>
+ * Max size 64x64x64 (or 256x256x256 if you made ubyte ;) )
+ */
+public class TeraOcTree extends TeraArray {
+
+    private byte size;
+    private Node root;
+
+    public TeraOcTree(byte size) {
+        super(size, size, size, false);
+        this.size = size;
+        root = new Node(size);
+    }
+
+    @Override
+    protected void initialize() {
+    }
+
+    @Override
+    public boolean isSparse() {
+        return true;
+    }
+
+    @Override
+    public TeraArray copy() {
+        return this;
+    }
+
+    @Override
+    public TeraArray deflate(TeraVisitingDeflator deflator) {
+        return null;
+    }
+
+    @Override
+    public int getEstimatedMemoryConsumptionInBytes() {
+        return 0;
+    }
+
+    @Override
+    public int getElementSizeInBits() {
+        return 32;
+    }
+
+    @Override
+    public int get(int x, int y, int z) {
+        Preconditions.checkArgument(x < size, "X should be less then {}", size);
+        Preconditions.checkArgument(y < size, "Y should be less then {}", size);
+        Preconditions.checkArgument(z < size, "Z should be less then {}", size);
+        return root.get((byte) x, (byte) y, (byte) z);
+    }
+
+    @Override
+    public int set(int x, int y, int z, int value) {
+        Preconditions.checkArgument(x < size, "X should be less then {}", size);
+        Preconditions.checkArgument(y < size, "Y should be less then {}", size);
+        Preconditions.checkArgument(z < size, "Z should be less then {}", size);
+        return root.set((byte) x, (byte) y, (byte) z, value);
+    }
+
+    @Override
+    public boolean set(int x, int y, int z, int value, int expected) {
+        Preconditions.checkArgument(x < size, "X should be less then {}", size);
+        Preconditions.checkArgument(y < size, "Y should be less then {}", size);
+        Preconditions.checkArgument(z < size, "Z should be less then {}", size);
+        return set(x, y, z, value) == expected;
+    }
+
+
+    static final class Node {
+        private final byte size;
+        private final byte half;
+
+        private Node[] children;
+        private int value = 0;
+
+        public Node(byte size) {
+            this.size = size;
+            this.half = (byte) (size / 2);
+        }
+
+        int get(byte x, byte y, byte z) {
+            if (children == null) {
+                return value;
+            }
+            int pos = pos(x, y, z);
+            if (children[pos] == null) {
+                return value;
+            }
+            return children[pos].get((byte) (x % half), (byte) (y % half), (byte) (z % half));
+        }
+
+        int set(byte x, byte y, byte z, int value) {
+            if (size == 1) {
+                int oldVal = this.value;
+                this.value = value;
+                return oldVal;
+            }
+
+            if (children == null) {
+                if (value == this.value) {
+                    return value;
+                } else {
+                    children = new Node[8];
+                    int pos = pos(x, y, z);
+                    children[pos] = new Node(half);
+                    return children[pos].set((byte) (x % half), (byte) (y % half), (byte) (z % half), value);
+                }
+            } else {
+                int pos = pos(x, y, z);
+                Node child = children[pos];
+                if (child == null) {
+                    if (value == this.value) {
+                        return value;
+                    } else {
+                        child = new Node(half);
+                        children[pos] = child;
+                        int oldValue = children[pos].set((byte) (x % half), (byte) (y % half), (byte) (z % half), value);
+                        tryToDeflate(value, pos, child);
+                        return oldValue;
+                    }
+                } else {
+                    int oldVal = child.set((byte) (x % half), (byte) (y % half), (byte) (z % half), value);
+                    tryToDeflate(value, pos, child);
+                    return oldVal;
+                }
+            }
+        }
+
+        private void tryToDeflate(int value, int pos, Node child) {
+            if (child.children == null) {
+                if (child.value == this.value) {
+                    children[pos] = null;
+                    boolean empty = true;
+                    for (int i = 0; i < 8; i++) {
+                        if (children[i] != null) {
+                            empty = false;
+                            break;
+                        }
+                    }
+                    if (empty) {
+                        children = null;
+                    }
+                } else {
+                    boolean same = true;
+                    for (int i = 0; i < 8; i++) {
+                        if (children[i] == null || children[i].children == null && children[i].value != value) {
+                            same = false;
+                            break;
+                        }
+                    }
+                    if (same) {
+                        this.value = value;
+                        this.children = null;
+                    }
+                }
+            }
+        }
+
+        private int pos(byte x, byte y, byte z) {
+            int pos = 0;
+            if (x >= half) {
+                pos |= 1 << 2;
+            }
+            if (y >= half) {
+                pos |= 1 << 1;
+            }
+            if (z >= half) {
+                pos |= 1;
+            }
+            return pos;
+        }
+    }
+
+    public static class SerializationHandler implements TeraArray.SerializationHandler<TeraOcTree> {
+
+        @Override
+        public int computeMinimumBufferSize(TeraOcTree array) {
+            int size = 1; // first byte - size
+            return computeNodeBufferSize(array.root) + size;
+        }
+
+        public int computeNodeBufferSize(Node node) {
+            int nodeSize = 0;
+            nodeSize += 4; // value
+            nodeSize += 1; // mask
+            if (node.children != null) {
+                for (Node childNode : node.children) {
+                    if (childNode != null) {
+                        nodeSize += computeNodeBufferSize(childNode);
+                    }
+                }
+            }
+            return nodeSize;
+        }
+
+        @Override
+        public ByteBuffer serialize(TeraOcTree array) {
+            return serialize(array, ByteBuffer.allocateDirect(computeMinimumBufferSize(array)));
+        }
+
+        @Override
+        public ByteBuffer serialize(TeraOcTree array, ByteBuffer toBuffer) {
+            toBuffer.put(array.size);
+            serializeNode(array.root, toBuffer);
+            return toBuffer;
+        }
+
+        private void serializeNode(Node node, ByteBuffer toBuffer) {
+            toBuffer.putInt(node.value);
+            byte mask = 0;
+            if (node.children != null) {
+                for (int i = 0; i < 8; i++) {
+                    mask |= (node.children[i] != null ? 1 : 0) << i;
+                }
+            }
+            toBuffer.put(mask);
+            if (node.children != null) {
+                for (int i = 0; i < 8; i++) {
+                    if (node.children[i] != null) {
+                        serializeNode(node.children[i], toBuffer);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public TeraOcTree deserialize(ByteBuffer buffer) {
+            byte size = buffer.get();
+            TeraOcTree tree = new TeraOcTree(size);
+            deserializeNode(buffer, tree.root);
+            return tree;
+        }
+
+        public void deserializeNode(ByteBuffer buffer, Node node) {
+            node.value = buffer.getInt();
+            byte mask = buffer.get();
+            if (mask != 0) {
+                node.children = new Node[8];
+                for (int i = 0; i < 8; i++) {
+                    if (((mask >> i) & 1) == 1) {
+                        Node childNode = new Node(node.half);
+                        deserializeNode(buffer, childNode);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean canHandle(Class<?> clazz) {
+            return TeraOcTree.class.equals(clazz);
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/world/chunks/internal/ChunkImpl.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/internal/ChunkImpl.java
@@ -8,15 +8,7 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
-import org.terasology.engine.world.chunks.blockdata.TeraArray;
-import org.terasology.engine.world.chunks.blockdata.TeraDenseArray16Bit;
-import org.terasology.engine.world.chunks.blockdata.TeraDenseArray8Bit;
-import org.terasology.engine.world.chunks.blockdata.TeraSparseArray8Bit;
-import org.terasology.joml.geom.AABBf;
-import org.terasology.joml.geom.AABBfc;
 import org.terasology.engine.monitoring.chunk.ChunkMonitor;
-import org.terasology.protobuf.EntityData;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;
@@ -24,8 +16,16 @@ import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.ChunkBlockIterator;
 import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
+import org.terasology.engine.world.chunks.blockdata.TeraArray;
+import org.terasology.engine.world.chunks.blockdata.TeraDenseArray16Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraDenseArray8Bit;
+import org.terasology.engine.world.chunks.blockdata.TeraOcTree;
 import org.terasology.engine.world.chunks.deflate.TeraDeflator;
 import org.terasology.engine.world.chunks.deflate.TeraStandardDeflator;
+import org.terasology.joml.geom.AABBf;
+import org.terasology.joml.geom.AABBfc;
+import org.terasology.protobuf.EntityData;
 
 import java.text.DecimalFormat;
 
@@ -83,9 +83,9 @@ public class ChunkImpl implements Chunk {
         this.chunkPos.set(Preconditions.checkNotNull(chunkPos));
         this.blockData = Preconditions.checkNotNull(blocks);
         this.extraData = Preconditions.checkNotNull(extra);
-        sunlightData = new TeraSparseArray8Bit(getChunkSizeX(), getChunkSizeY(), getChunkSizeZ());
-        sunlightRegenData = new TeraSparseArray8Bit(getChunkSizeX(), getChunkSizeY(), getChunkSizeZ());
-        lightData = new TeraSparseArray8Bit(getChunkSizeX(), getChunkSizeY(), getChunkSizeZ());
+        sunlightData = new TeraOcTree((byte)getChunkSizeX());
+        sunlightRegenData = new TeraOcTree((byte)getChunkSizeX());
+        lightData = new TeraOcTree((byte)getChunkSizeX());
         dirty = true;
         this.blockManager = blockManager;
         region = new BlockRegion(


### PR DESCRIPTION
### Contains

Octo tree implementation should save your ram memory.

We can modificate it further  for partial loaded chunks(as layers) for lod or low res maps.
 
Benchmarks:
```

Benchmark                            (arrayType)  Mode  Cnt       Score   Error  Units
TeraArrayBenchmark.fromByteBuffer     DENCE_4BIT  avgt         1550.774          ns/op
TeraArrayBenchmark.fromByteBuffer     DENCE_8BIT  avgt         2777.533          ns/op
TeraArrayBenchmark.fromByteBuffer    DENCE_16BIT  avgt         6499.177          ns/op
TeraArrayBenchmark.fromByteBuffer    SPARCE_4BIT  avgt          147.327          ns/op
TeraArrayBenchmark.fromByteBuffer    SPARCE_8BIT  avgt          126.852          ns/op
TeraArrayBenchmark.fromByteBuffer        OC_TREE  avgt          248.897          ns/op
TeraArrayBenchmark.fullyRead          DENCE_4BIT  avgt        38172.746          ns/op
TeraArrayBenchmark.fullyRead          DENCE_8BIT  avgt        10844.992          ns/op
TeraArrayBenchmark.fullyRead         DENCE_16BIT  avgt        10806.451          ns/op
TeraArrayBenchmark.fullyRead         SPARCE_4BIT  avgt        16872.861          ns/op
TeraArrayBenchmark.fullyRead         SPARCE_8BIT  avgt         8682.106          ns/op
TeraArrayBenchmark.fullyRead             OC_TREE  avgt         4627.718          ns/op
TeraArrayBenchmark.fullyWrite         DENCE_4BIT  avgt        45813.764          ns/op
TeraArrayBenchmark.fullyWrite         DENCE_8BIT  avgt         8871.264          ns/op
TeraArrayBenchmark.fullyWrite        DENCE_16BIT  avgt        11910.677          ns/op
TeraArrayBenchmark.fullyWrite        SPARCE_4BIT  avgt        90514.489          ns/op
TeraArrayBenchmark.fullyWrite        SPARCE_8BIT  avgt        90936.131          ns/op
TeraArrayBenchmark.fullyWrite            OC_TREE  avgt       145118.936          ns/op
TeraArrayBenchmark.singleRead         DENCE_4BIT  avgt           26.075          ns/op
TeraArrayBenchmark.singleRead         DENCE_8BIT  avgt           21.288          ns/op
TeraArrayBenchmark.singleRead        DENCE_16BIT  avgt           21.198          ns/op
TeraArrayBenchmark.singleRead        SPARCE_4BIT  avgt           24.925          ns/op
TeraArrayBenchmark.singleRead        SPARCE_8BIT  avgt           20.574          ns/op
TeraArrayBenchmark.singleRead            OC_TREE  avgt           19.800          ns/op
TeraArrayBenchmark.singleReadEmpty    DENCE_4BIT  avgt            3.412          ns/op
TeraArrayBenchmark.singleReadEmpty    DENCE_8BIT  avgt            3.174          ns/op
TeraArrayBenchmark.singleReadEmpty   DENCE_16BIT  avgt            3.149          ns/op
TeraArrayBenchmark.singleReadEmpty   SPARCE_4BIT  avgt            3.295          ns/op
TeraArrayBenchmark.singleReadEmpty   SPARCE_8BIT  avgt            3.058          ns/op
TeraArrayBenchmark.singleReadEmpty       OC_TREE  avgt            3.552          ns/op
TeraArrayBenchmark.singleWrite        DENCE_4BIT  avgt           26.064          ns/op
TeraArrayBenchmark.singleWrite        DENCE_8BIT  avgt           23.100          ns/op
TeraArrayBenchmark.singleWrite       DENCE_16BIT  avgt           21.988          ns/op
TeraArrayBenchmark.singleWrite       SPARCE_4BIT  avgt           28.518          ns/op
TeraArrayBenchmark.singleWrite       SPARCE_8BIT  avgt           25.641          ns/op
TeraArrayBenchmark.singleWrite           OC_TREE  avgt           90.758          ns/op
TeraArrayBenchmark.singleWriteEmpty   DENCE_4BIT  avgt            4.230          ns/op
TeraArrayBenchmark.singleWriteEmpty   DENCE_8BIT  avgt            4.010          ns/op
TeraArrayBenchmark.singleWriteEmpty  DENCE_16BIT  avgt            3.378          ns/op
TeraArrayBenchmark.singleWriteEmpty  SPARCE_4BIT  avgt            4.465          ns/op
TeraArrayBenchmark.singleWriteEmpty  SPARCE_8BIT  avgt            3.788          ns/op
TeraArrayBenchmark.singleWriteEmpty      OC_TREE  avgt           39.300          ns/op
TeraArrayBenchmark.toByteBuffer       DENCE_4BIT  avgt          567.699          ns/op
TeraArrayBenchmark.toByteBuffer       DENCE_8BIT  avgt         1274.120          ns/op
TeraArrayBenchmark.toByteBuffer      DENCE_16BIT  avgt        10954.144          ns/op
TeraArrayBenchmark.toByteBuffer      SPARCE_4BIT  avgt           97.438          ns/op
TeraArrayBenchmark.toByteBuffer      SPARCE_8BIT  avgt           94.817          ns/op
TeraArrayBenchmark.toByteBuffer          OC_TREE  avgt           23.923          ns/op

```

### How to test

VisualVM. check memory usage in gameplays
Then Check this at:
- Start singleplayer. a dig, a run around.

- Start multiplayer. a dig, a run around.

### Outstanding before merging

- [ ] Split OcTree (32Bit) to 8,16 bit versions.
- [ ] Investigate and replace TeraArray at another places is needed.
