### PR TITLE
build(javadoc): disable doclint messages about missing tags

### DIFF
--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -118,7 +118,16 @@ spotbugsMain {
     }
 }
 
-// TODO: Temporary until javadoc has been fixed for Java 8 everywhere
-javadoc {
+tasks.javadoc {
+    // Disable doclint messages about missing "@param" or "@return" tags.
+    options.addBooleanOption("Xdoclint:all,-missing", true)
+
+    // Omit package qualifiers for some of the most common types.
+    options.noQualifiers(
+            "java.lang", "java.util.*", "org.joml",
+            "org.terasology.engine.entitySystem.entity"
+    )
+
+    // TODO: Temporary until javadoc has been fixed for Java 8 everywhere
     failOnError = false
 }


### PR DESCRIPTION
Removes the messages that say things like `no @return` when building javadoc.

Because there is no way to suppress those on a case-by-case basis before [Java 18](https://bugs.openjdk.java.net/browse/JDK-8274926).