### PR TITLE
chore: add reactor-extra to dependencies

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -99,8 +99,9 @@ dependencies {
     implementation "org.lwjgl:lwjgl-openal"
     api "org.lwjgl:lwjgl-opengl"
     implementation "org.lwjgl:lwjgl-stb"
-    
-    api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.7'
+
+    api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.11'
+    api group: 'io.projectreactor.addons', name: 'reactor-extra', version: '3.4.5'
     api group: 'org.joml', name: 'joml', version: '1.10.0'
     api group: 'org.terasology.joml-ext', name: 'joml-geometry', version: '0.1.0'
 


### PR DESCRIPTION
being able to use functions with multiple arguments as subscribers is very nice.

There's a bit of a question here whether we use the BOM they publish to specify which versions of the reactor stuff we use, or track versions of reactor-core and reactor-extra ourselves: https://projectreactor.io/docs/core/release/reference/#getting

I'm fine either way with that one.