### PR TITLE
test: add unitTest target to TypeHandlerLibrary and facades

### DIFF
--- a/build-logic/src/main/kotlin/facade.gradle.kts
+++ b/build-logic/src/main/kotlin/facade.gradle.kts
@@ -34,3 +34,13 @@ dependencies {
     // Make sure all module dependencies are available to the game in cacheModules.
     "modules"(project(":modules"))
 }
+
+tasks.register<Test>("unitTest") {
+    group = "Verification"
+    description = "Runs unit tests (fast)"
+
+    useJUnitPlatform {
+        excludeTags("MteTest", "TteTest")
+    }
+    systemProperty("junit.jupiter.execution.timeout.default", "1m")
+}

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -26,3 +26,13 @@ dependencies {
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.2")
 }
+
+tasks.register<Test>("unitTest") {
+    group = "Verification"
+    description = "Runs unit tests (fast)"
+
+    useJUnitPlatform {
+        excludeTags("MteTest", "TteTest")
+    }
+    systemProperty("junit.jupiter.execution.timeout.default", "1m")
+}


### PR DESCRIPTION
I think we haven't been running the tests in TypeHandlerLibrary on CI ever since we did the unitTest / integrationTest split.

### How to test

Make sure the list of test results on Jenkins includes some tests from `org.terasology.persistence`.
