### PR TITLE
Revert "build(ci): build using a java 11 toolchain"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ properties([
 
 pipeline {
     agent {
-        label 'ts-engine && heavy && java11'
+        label 'ts-engine && heavy && java8'
     }
     stages {
         // declarative pipeline does `checkout scm` automatically when hitting first stage
@@ -42,7 +42,6 @@ pipeline {
             steps {
                 echo 'Automatically checked out the things!'
                 sh 'chmod +x gradlew'
-                sh './gradlew --version'
             }
         }
 


### PR DESCRIPTION
Reverts MovingBlocks/Terasology#4927 due to failing TypeHandlerLibrary test