### PR TITLE
build: fix mystery Artifactory issue

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -17,6 +17,15 @@ repositories {
         @Suppress("UnstableApiUsage")
         isAllowInsecureProtocol = true  // 😱
     }
+
+    // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
+    // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
+    maven {
+        name = "Terasology snapshot locals"
+        url = URI("http://artifactory.terasology.org/artifactory/terasology-snapshot-local")
+        @Suppress("UnstableApiUsage")
+        isAllowInsecureProtocol = true  // 😱
+    }
 }
 
 dependencies {

--- a/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
@@ -48,4 +48,12 @@ repositories {
             isAllowInsecureProtocol = true  // 😱
         }
     }
+
+    // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
+    // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
+    maven {
+        name = "Terasology snapshot locals"
+        url = URI("http://artifactory.terasology.org/artifactory/terasology-snapshot-local")
+        isAllowInsecureProtocol = true  // 😱
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,14 @@ buildscript {
             url = "http://artifactory.terasology.org/artifactory/virtual-repo-live"
             allowInsecureProtocol = true  // 😱
         }
+
+        // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
+        // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
+        maven {
+            name = "Terasology snapshot locals"
+            url = "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
+            allowInsecureProtocol = true  // 😱
+        }
     }
 
     dependencies {

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         maven {
             name = "Terasology snapshot locals"
             url = "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
-            isAllowInsecureProtocol = true  // 😱
+            allowInsecureProtocol = true  // 😱
         }
     }
 

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -15,6 +15,14 @@ buildscript {
             url = "http://artifactory.terasology.org/artifactory/virtual-repo-live"
             allowInsecureProtocol = true  // 😱
         }
+
+        // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
+        // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
+        maven {
+            name = "Terasology snapshot locals"
+            url = URI("http://artifactory.terasology.org/artifactory/terasology-snapshot-local")
+            isAllowInsecureProtocol = true  // 😱
+        }
     }
 
     dependencies {

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
         maven {
             name = "Terasology snapshot locals"
-            url = URI("http://artifactory.terasology.org/artifactory/terasology-snapshot-local")
+            url = "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
             isAllowInsecureProtocol = true  // 😱
         }
     }


### PR DESCRIPTION
So today Nov 7th for no discernable reason Gradle stopped being able to resolve snapshot dependencies from our Artifactory instance. I was able to replicate it locally in a handy workspace I hadn't touched since June, so it wasn't anything we changed anywhere, including Artifactory really - it is rarely ever touched and hasn't been upgraded for years (doing so is on a todo list somewhere).

Closest guess I can make is that it is an Artifactory OSS vs Pro feature: https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-RetrieveLatestArtifact - supposedly automatically fetching the latest incremental version of a snapshot is a Pro feature. Who knew? We've been using it in the OSS version since day 1! No idea how that has worked so far if the docs are accurate.

Ultimately it turned out to be "blocked" (if saying so is really accurate, I dunno) in the _virtual_ repository definition in Artifactory (the "virtual-repo-live" thing that is a proxy collection of a bunch of repos, internal and external) yet if you explicitly call out the snapshot repo path itself (terasology-snapshot-local) then somehow it works fine. So this adds that to our Gradle. I've adjusted it in the Index repo already, after testing it with a Nanoware Omega build. It _may_ be needed elsewhere - say if we rely on a snapshot _library_ dependency somewhere. But at least this gets the game building again.

Lost in the shuffle is the dynamic nature of swapping between the "live" virtual repo and the Nanoware variant that specifically excludes the terasology local repos in favor of nanoware local repos so you can do Artifactory testing in isolation. That'd TODO to make conditional, or maybe there's some more clever way to overhaul that if we just go to Nexus already?

It has been a day so I'm going to leave it at that. I've tested the change and am confident in it, note that no module builds (with dependencies) will work until this PR is merged.

Also, don't forget to squash merge this - the _first_ commit is titled correctly, the rest not so much ;-)

Edit: I should mention that while troubleshooting I noticed that the remote repos configured in Artifactory (so proxy repos, essentially, so we could request things from say Maven Central _through_ our virtual repos) are probably all broken at this point, being that they were configured 5+ years ago. Most URLs are no longer good, the Maven central one was, but the log had complaints about lacking HTTPS (in our definition of the Maven Central repo, not actually about our poor HTTPS-less Artifactory). I tweaked that one address to https and am not sure if that helped the logs. We directly configure Maven Central etc within Gradle so we don't need to rely on pulling it through Artifactory (typically more of an enterprise thing)

Also, a bit of testing proof: https://jenkins.terasology.io/teraorg/job/Nanoware/job/Omega/job/develop/43/console