### PR TITLE
feat(F3): show process data size and limit

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/DebugOverlay.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/DebugOverlay.java
@@ -79,29 +79,30 @@ public class DebugOverlay extends CoreScreenLayer {
                 ? OperatingSystemMemory.dataAndStackSizeLimit() : -1;
 
         if (debugLine1 != null) {
-            debugLine1.bindText(new ReadOnlyBinding<String>() {
+            debugLine1.bindText(new ReadOnlyBinding<>() {
                 @Override
                 public String get() {
-                    long runtimeTotalMemory = Runtime.getRuntime().totalMemory();
-                    float memoryUsage = ((float) runtimeTotalMemory - (float) Runtime.getRuntime().freeMemory()) / MB_SIZE;
+                    Runtime runtime = Runtime.getRuntime();
+                    long totalHeapSize = runtime.totalMemory();
+                    float usedHeapMemory = ((float) totalHeapSize - (float) runtime.freeMemory()) / MB_SIZE;
                     String s = String.format(
-                            "FPS: %.1f, Memory Usage: %.1f MB, Total Memory: %.1f MB, Max Memory: %.1f MB",
+                            "FPS: %.1f, Heap Usage: %.1f MB, Total Heap: %.1f MB, Max Heap: %.1f MB",
                             time.getFps(),
-                            memoryUsage,
-                            runtimeTotalMemory / MB_SIZE,
-                            Runtime.getRuntime().maxMemory() / MB_SIZE
+                            usedHeapMemory,
+                            totalHeapSize / MB_SIZE,
+                            runtime.maxMemory() / MB_SIZE
                     );
                     if (OperatingSystemMemory.isAvailable()) {
                         // Check data size, because that's the one comparable to Terasology#setMemoryLimit
                         long dataSize = OperatingSystemMemory.dataAndStackSize();
                         // How much bigger is that than the number reported by the Java runtime?
-                        long nonJava = dataSize - runtimeTotalMemory;
+                        long nonJavaHeapDataSize = dataSize - totalHeapSize;
                         String limitString = (dataLimit > 0)
                             ? String.format(" / %.1f MB (%02d%%)", dataLimit / MB_SIZE, 100 * dataSize / dataLimit)
                             : "";
                         return String.format(
                                 "%s, Data: %.1f MB%s, Extra: %.1f MB",
-                                s, dataSize / MB_SIZE, limitString, nonJava / MB_SIZE
+                                s, dataSize / MB_SIZE, limitString, nonJavaHeapDataSize / MB_SIZE
                         );
                     } else {
                         return s;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/MetricsMode.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/MetricsMode.java
@@ -45,7 +45,9 @@ public abstract class MetricsMode {
      */
     public abstract boolean isAvailable();
 
-    public abstract boolean isPerformanceManagerMode();
+    public boolean isPerformanceManagerMode() {
+        return false;
+    }
 
     /**
      * A (human readable) name for the metrics mode.

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/NetworkStatsMode.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/NetworkStatsMode.java
@@ -50,9 +50,4 @@ final class NetworkStatsMode extends MetricsMode {
     public boolean isAvailable() {
         return networkSystem.getMode() != NetworkMode.NONE;
     }
-
-    @Override
-    public boolean isPerformanceManagerMode() {
-        return false;
-    }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/NullMetricsMode.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/NullMetricsMode.java
@@ -17,9 +17,4 @@ public class NullMetricsMode extends MetricsMode {
     public boolean isAvailable() {
         return true;
     }
-
-    @Override
-    public boolean isPerformanceManagerMode() {
-        return false;
-    }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/RunningThreadsMode.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/RunningThreadsMode.java
@@ -30,9 +30,4 @@ final class RunningThreadsMode extends MetricsMode {
     public boolean isAvailable() {
         return true;
     }
-
-    @Override
-    public boolean isPerformanceManagerMode() {
-        return false;
-    }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/WorldRendererMode.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/WorldRendererMode.java
@@ -20,9 +20,4 @@ public class WorldRendererMode extends MetricsMode {
     public boolean isAvailable() {
         return CoreRegistry.get(WorldRenderer.class) != null;
     }
-
-    @Override
-    public boolean isPerformanceManagerMode() {
-        return false;
-    }
 }

--- a/engine/src/main/java/org/terasology/engine/utilities/OperatingSystemMemory.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/OperatingSystemMemory.java
@@ -1,0 +1,92 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.utilities;
+
+import com.sun.jna.platform.unix.LibC;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Monitor process memory usage.
+ * <p>
+ * This checks process's total memory usage as seen by the operating system.
+ * This includes memory not managed by the JVM.
+ */
+public final class OperatingSystemMemory {
+    public static final int PAGE_SIZE = 1 << 12;  // 4 kB on x86 platforms
+
+    private static final Path PROC_STATM = Path.of("/proc/self/statm");
+
+    private OperatingSystemMemory() { }
+
+    public static boolean isAvailable() {
+        return OS.IS_LINUX;
+    }
+
+    public static long residentSetSize() {
+        try {
+            return STATM.RESIDENT.inBytes(Files.readString(PROC_STATM));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static long dataAndStackSize() {
+        try {
+            return STATM.DATA.inBytes(Files.readString(PROC_STATM));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static long dataAndStackSizeLimit() {
+        final LibC.Rlimit dataLimit = new LibC.Rlimit();
+        LibC.INSTANCE.getrlimit(LibC.RLIMIT_DATA, dataLimit);
+        return dataLimit.rlim_cur;
+    }
+
+    /**
+     * The fields of /proc/[pid]/statm
+     * <p>
+     * Note from proc(5):
+     * <blockquote><p>
+     * Some of these values are inaccurate because of a kernel-internal scalability optimization.
+     * If accurate values are required, use /proc/[pid]/smaps or /proc/[pid]/smaps_rollup instead,
+     * which are much slower but provide accurate, detailed information.
+     * </p></blockquote>
+     */
+    enum STATM {
+        /** total program size */
+        SIZE(0),
+        /** resident set size */
+        RESIDENT(1),
+        /** number of resident shared pages */
+        SHARED(2),
+        /** text (code) */
+        TEXT(3),
+        /** unused since Linux 2.6 */
+        LIB(4),
+        /** data + stack */
+        DATA(5),
+        /** unused since Linux 2.6 */
+        DT(6);
+
+        private final short index;
+
+        STATM(int i) {
+            index = (short) i;
+        }
+
+        public long rawValue(String line) {
+            return Long.parseLong(line.split(" ")[index]);
+        }
+
+        public long inBytes(String line) {
+            return rawValue(line) * PAGE_SIZE;
+        }
+    }
+}


### PR DESCRIPTION
Adds the data size of the process to the F3 debug overlay. This is a value from the operating system, not the JVM.

![f3-data-size](https://user-images.githubusercontent.com/83819/140842305-7a0a1c06-24fb-40fe-967e-9b01a87ce4ed.png)

The new values are:
- **Data:** 5850.3 / 6144.0 MB (95%)
  - 5850.3 MB is the size of this process's data segment and stack
  - 6144.0 MB is the maximum data size allowed by the `--max-data-size=6G` option I launched the game with
  - 95% is how close it is to that limit
- **Extra:** 2778.3 MB is how much larger this data size is than the _Total Memory_ number shown by the JVM

Only implemented for Linux.

## How to Test

Push `F3` to bring up the debug overlay while in game.

Try it with and without the [`--max-data-size`](https://github.com/MovingBlocks/Terasology/wiki/Advanced-Options#memory-usage) option on Linux.