### PR TITLE
feat: micrometer metrics over JMX

### DIFF
--- a/build-logic/src/main/kotlin/org/terasology/gradology/exec.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/exec.kt
@@ -10,10 +10,10 @@ import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.the
 
 const val DEFAULT_MAX_HEAP_SIZE = "3G"
@@ -46,10 +46,11 @@ fun isMacOS() : Boolean {
 }
 
 
-open class RunTerasology : JavaExec() {
+abstract class RunTerasology : JavaExec() {
 
+    @get:Optional
     @get:Input
-    val jmxPort: Property<Int> = objectFactory.property()
+    abstract val jmxPort: Property<Int>
 
     @Option(option="jmx-port", description="Enable JMX connections on this port (jmxremote.port)")
     fun parseJmxPort(value: String?) {

--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,26 @@ task copyInMissingTemplates {
     }
 }
 
+tasks.register("jmxPassword", Copy) {
+    description = "Create config/jmxremote.password from a template."
+
+    setFileMode(0600)  // passwords must be accessible only by owner
+
+    // there is a template file in $JAVA_HOME/conf/management
+    from(java.nio.file.Path.of(System.getProperty("java.home"), "conf", "management"))
+    include("jmxremote.password.template")
+    rename("(.*).template", '$1')
+    into("config")
+
+    onlyIf {
+        // Do not overwrite an existing password file.
+        !it.destinationDir.toPath().resolve("jmxremote.password").toFile().exists()
+    }
+    doLast {
+        logger.warn("${it.outputs.files.singleFile}/jmxremote.password:100: Edit this to set your password.")
+    }
+}
+
 // Make sure the IDE prep includes extraction of natives
 ideaModule.dependsOn extractNatives
 ideaModule.dependsOn copyInMissingTemplates

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+*.password

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     api "org.lwjgl:lwjgl-opengl"
     implementation "org.lwjgl:lwjgl-stb"
 
+    implementation 'io.micrometer:micrometer-core:1.8.0'
+    implementation 'io.micrometer:micrometer-registry-jmx:1.8.0'
     api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.11'
     api group: 'io.projectreactor.addons', name: 'reactor-extra', version: '3.4.5'
     api group: 'org.joml', name: 'joml', version: '1.10.0'

--- a/engine/src/main/java/org/terasology/engine/core/GameScheduler.java
+++ b/engine/src/main/java/org/terasology/engine/core/GameScheduler.java
@@ -22,11 +22,16 @@ public final class GameScheduler {
     private static final Scheduler MAIN;
 
     static {
-        MAIN = Schedulers.fromExecutor(GameThread::asynch);
-
-        // Calling Reactor scheduler once to make sure it's initialized.
         // doPriviledged in case this class isn't initialized before the security policy is installed.
-        AccessController.doPrivileged((PrivilegedAction<Scheduler>) Schedulers::parallel);
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            // Enable Reactor metrics. Must be done before creating schedulers.
+            Schedulers.enableMetrics();
+            // Calling Reactor scheduler once to make sure it's initialized.
+            Schedulers.parallel();
+            return null;
+        });
+
+        MAIN = Schedulers.fromExecutor(GameThread::asynch);
     }
 
     private GameScheduler() {

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/common/MonitoringSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/common/MonitoringSubsystem.java
@@ -2,13 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core.subsystem.common;
 
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.jmx.JmxConfig;
+import io.micrometer.jmx.JmxMeterRegistry;
 import org.terasology.engine.config.SystemConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.GameEngine;
+import org.terasology.engine.core.Time;
 import org.terasology.engine.core.subsystem.EngineSubsystem;
 import org.terasology.engine.monitoring.gui.AdvancedMonitor;
 
+import java.time.Duration;
+
 public class MonitoringSubsystem implements EngineSubsystem {
+
+    public static final Duration JMX_INTERVAL = Duration.ofSeconds(5);
 
     private AdvancedMonitor advancedMonitor;
 
@@ -23,6 +39,68 @@ public class MonitoringSubsystem implements EngineSubsystem {
             advancedMonitor = new AdvancedMonitor();
             advancedMonitor.setVisible(true);
         }
+
+        initMicrometerMetrics(rootContext.get(Time.class));
+    }
+
+    /**
+     * Initialize Micrometer metrics and publishers.
+     *
+     * @see org.terasology.engine.core.GameScheduler GameScheduler for global Reactor metrics
+     * @param time provides statistics
+     *     <p>
+     *     Note {@link org.terasology.engine.core.EngineTime EngineTime}
+     *     does not serve the same role as a {@link Clock micrometer Clock}.
+     *     (Not yet. Maybe it should?)
+     */
+    private void initMicrometerMetrics(Time time) {
+        // Register metrics with the built-in global composite registry.
+        // This makes them available to any agent(s) we add to it.
+        MeterRegistry meterRegistry = Metrics.globalRegistry;
+
+        Gauge.builder("terasology.fps", time::getFps)
+                .description("framerate")
+                .baseUnit("Hz")
+                .register(meterRegistry);
+
+        // Publish the global metrics registry on a JMX server.
+        MeterRegistry jmxMeterRegistry = new JmxMeterRegistry(new JmxConfig() {
+            @Override
+            public String get(String key) {
+                return null;  // only needed if we have runtime configuration changes
+            }
+
+            @Override
+            public Duration step() {
+                return JMX_INTERVAL;  // default was 1 minute
+            }
+        }, Clock.SYSTEM);
+        Metrics.addRegistry(jmxMeterRegistry);
+
+        // If we want to make global metrics available to our custom view,
+        // we add our custom registry to the global composite:
+        //
+        // Metrics.addRegistry(DebugOverlay.meterRegistry);
+        //
+        // If we want to see JVM metrics there as well:
+        //
+        // initAllJvmMetrics(DebugOverlay.meterRegistry);
+    }
+
+    /**
+     * Installs all the micrometer built-in metrics.
+     * <p>
+     * Don't add these if you only intend to view them through a JMX registry, because they are
+     * already available from the default JMX server even without micrometer. Add them if you
+     * have a different agent you want them published through.
+     */
+    @SuppressWarnings("unused")
+    void initAllJvmMetrics(MeterRegistry registry) {
+        new ClassLoaderMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
     }
 
     @Override


### PR DESCRIPTION
This adds an option to the `gradlew game` task that configures it to accept remote JMX connections. JMX is _Java Management Extensions_, see the [Java Monitoring and Management Guide][JMnMG] for details. It gives us as Terasology developers a way to see some system stats in near real-time without figuring out how to fit them on a F3 debug overlay, and it works equally well for headless servers.

[JMnMG]: https://docs.oracle.com/en/java/javase/11/management/preface.html#GUID-416153CD-A661-4F46-ACC3-CDA94E4A8CDA

It depends on [Micrometer](https://micrometer.io/) to facilitate this, which you may recall from previous conversations around #4799.

As a demonstration for how we can use this to view Terasology-specific things, it publishes the game's current framerate as `terasology.fps`.

Demo clip:

https://user-images.githubusercontent.com/83819/142078723-d1d52394-5f13-4b2d-a7b2-120bbc01013f.mp4


## To Do

These documentation sources live outside the repo, so action on these won't show up in the PR.
- [x] document `--jmx-port` gradle option somewhere. Maybe https://github.com/MovingBlocks/Terasology/wiki/Troubleshooting-Developer ? Or a developer version of https://github.com/MovingBlocks/Terasology/wiki/Advanced-Options ?
- [ ] document how to do the equivalent thing on the playtest server. Or incorporate it in to the server management scripts? Where do we keep those?
