### PR TITLE
feature(WorkspaceValidationTests): add possible to create workspace-wide tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ extensions
 /facades/*
 !/facades/PC
 !/facades/TeraEd
+!/facades/WorkspaceValidation
 !/facades/subprojects.gradle
 /modules/*
 !/modules/subprojects.gradle

--- a/facades/WorkspaceValidation/.gitignore
+++ b/facades/WorkspaceValidation/.gitignore
@@ -1,0 +1,11 @@
+# Boo eclipse! - every eclipse project needs its own .gitignore file
+
+# Ignore Eclipse
+/.checkstyle
+/.project
+/.classpath
+/.settings/
+/bin/
+
+# Ignore gradle
+/build/

--- a/facades/WorkspaceValidation/build.gradle
+++ b/facades/WorkspaceValidation/build.gradle
@@ -1,0 +1,76 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// The Editor facade is responsible for the (shader) editor - a plain Java application runnable on PCs
+
+// Grab all the common stuff like plugins to use, artifact repositories, code analysis config
+apply from: "$rootDir/config/gradle/publish.gradle"
+
+// Base the engine tests on the same version number as the engine
+version = project(':engine').version
+println "TeraEd VERSION: $version"
+
+// Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
+group = 'org.terasology.facades'
+
+sourceSets {
+    // Adjust output path (changed with the Gradle 6 upgrade, this puts it back)
+    main.java.outputDir = new File("$buildDir/classes")
+    test.java.outputDir = new File("$buildDir/testClasses")
+}
+
+dependencies {
+    implementation project(':engine')
+    implementation "org.terasology:reflections:0.9.12-MB"
+
+    implementation(platform(project(":modules")))
+//    // For the "natives" configuration make it depend on the native files from LWJGL
+//    implementation platform("org.lwjgl:lwjgl-bom:$LwjglVersion")
+//    ["natives-linux", "natives-windows", "natives-macos"].forEach {
+//        implementation "org.lwjgl:lwjgl::$it"
+//        implementation "org.lwjgl:lwjgl-assimp::$it"
+//        implementation "org.lwjgl:lwjgl-glfw::$it"
+//        implementation "org.lwjgl:lwjgl-openal::$it"
+//        implementation "org.lwjgl:lwjgl-opengl::$it"
+//        implementation "org.lwjgl:lwjgl-stb::$it"
+//    }
+
+    implementation(group: 'com.google.guava', name: 'guava', version: '30.1-jre')
+
+    implementation(project(":subsystems:DiscordRPC"))
+    implementation(project(":subsystems:TypeHandlerLibrary"))
+
+    implementation(group: 'org.lwjglx', name: 'lwjgl3-awt', version: '0.1.7') {
+        exclude group: 'org.lwjgl', module: ''
+    }
+
+    // Test lib dependencies
+    implementation(platform("org.junit:junit-bom:5.8.1")) {
+        // junit-bom will set version numbers for the other org.junit dependencies.
+    }
+    implementation("org.junit.jupiter:junit-jupiter-api")
+    implementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation('org.mockito:mockito-inline:3.12.4')
+}
+
+test {
+//    dependsOn copyResourcesToClasses
+    dependsOn rootProject.extractNatives
+
+    description("Runs all tests (slow)")
+
+    systemProperty("junit.jupiter.execution.timeout.default", "4m")
+}
+
+
+
+// Prep an IntelliJ module for the facade
+idea {
+    module {
+        // Change around the output a bit
+        inheritOutputDirs = false
+        outputDir = file('build/classes')
+        testOutputDir = file('build/testClasses')
+    }
+}

--- a/facades/WorkspaceValidation/src/test/java/org/terasology/workspace/validation/BehaviorsLoadingTest.java
+++ b/facades/WorkspaceValidation/src/test/java/org/terasology/workspace/validation/BehaviorsLoadingTest.java
@@ -1,0 +1,67 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.workspace.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.prefab.Prefab;
+import org.terasology.engine.logic.behavior.BehaviorComponent;
+import org.terasology.engine.logic.behavior.asset.BehaviorTree;
+import org.terasology.engine.registry.In;
+import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.gestalt.assets.management.AssetManager;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+
+import java.util.stream.Stream;
+
+@Tag("Mte")
+@ExtendWith(MTEExtension.class)
+@Dependencies("JoshariasSurvival")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BehaviorsLoadingTest {
+
+    @In
+    AssetManager assetManager;
+    @In
+    EntityManager entityManager;
+
+    public Stream<Arguments> behaviors() {
+        return assetManager.getAvailableAssets(BehaviorTree.class)
+                .stream()
+                .map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("behaviors")
+    void behaviorsTest(ResourceUrn urn) {
+        Assertions.assertDoesNotThrow(() ->
+                assetManager.getAsset(urn, BehaviorTree.class));
+    }
+
+
+    public Stream<Arguments> prefabs() {
+        return assetManager.getAvailableAssets(Prefab.class)
+                .stream()
+                .map((p) -> assetManager.getAsset(p, Prefab.class).get())
+                .filter((p) -> p.hasComponent(BehaviorComponent.class))
+                .map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("prefabs")
+    void prefabsTest(Prefab prefab, ModuleTestingHelper helper) {
+        EntityRef ref = entityManager.create(prefab);
+        Assertions.assertNotNull(ref.getComponent(BehaviorComponent.class).tree);
+    }
+
+}


### PR DESCRIPTION
### Contains

Proof-of-concept Workspace-wide tests(a.k.a mega test)

Currently using MTE as module. will not works without it.

Currently use JS as target module to test. just for demonstration purposes.

### How to test

1. `gradlew :facades:WorkspaceValidation:test`

### Outstanding before merging

- [ ] MTE as Subsystem? 
      It should be fine: will grants more possibles, remove `optional module`
- [ ] provide mechanism for using modules as test's parameter for loading (like runs `tryToLoadBehavior` test across all modules)
