### PR TITLE
refactor: split out chunk work as a seperate helper class

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/world/ChunkMeshWorker.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/ChunkMeshWorker.java
@@ -5,8 +5,6 @@ package org.terasology.engine.rendering.world;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
@@ -19,32 +17,33 @@ import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
 import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.chunks.Chunk;
-import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.world.chunks.RenderableChunk;
 import reactor.core.publisher.Sinks;
 import reactor.function.TupleUtils;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public class ChunkWorker {
-    private static final Logger logger = LoggerFactory.getLogger(ChunkWorker.class);
+public final class ChunkMeshWorker {
+    private static final Logger logger = LoggerFactory.getLogger(ChunkMeshWorker.class);
 
     private static final int MAX_LOADABLE_CHUNKS =
             ViewDistance.MEGA.getChunkDistance().x() * ViewDistance.MEGA.getChunkDistance().y() * ViewDistance.MEGA.getChunkDistance().z();
 
-    private final RenderableWorldImpl.ChunkFrontToBackComparator frontToBackComparator;
+    private final Comparator<RenderableChunk>  frontToBackComparator;
     private final Set<Vector3ic> chunkMeshProcessing = Sets.newConcurrentHashSet();
     private final Sinks.Many<Chunk> chunkMeshPublisher = Sinks.many().unicast().onBackpressureBuffer();
     private final List<Chunk> chunksInProximityOfCamera = Lists.newArrayListWithCapacity(MAX_LOADABLE_CHUNKS);
 
-    public ChunkWorker(ChunkTessellator chunkTessellator,
-                       WorldProvider worldProvider,
-                       RenderableWorldImpl.ChunkFrontToBackComparator frontToBackComparator) {
+    public ChunkMeshWorker(ChunkTessellator chunkTessellator,
+                           WorldProvider worldProvider,
+                           Comparator<RenderableChunk> frontToBackComparator) {
         this.frontToBackComparator = frontToBackComparator;
 
         chunkMeshPublisher.asFlux()
@@ -101,7 +100,6 @@ public class ChunkWorker {
             }
         }
     }
-
 
     public int update() {
         int statDirtyChunks = 0;

--- a/engine/src/main/java/org/terasology/engine/rendering/world/ChunkWorker.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/ChunkWorker.java
@@ -1,0 +1,128 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.world;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.GameScheduler;
+import org.terasology.engine.monitoring.chunk.ChunkMonitor;
+import org.terasology.engine.rendering.primitives.ChunkMesh;
+import org.terasology.engine.rendering.primitives.ChunkTessellator;
+import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
+import org.terasology.engine.world.ChunkView;
+import org.terasology.engine.world.WorldProvider;
+import org.terasology.engine.world.chunks.Chunk;
+import org.terasology.engine.world.chunks.Chunks;
+import reactor.core.publisher.Sinks;
+import reactor.function.TupleUtils;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class ChunkWorker {
+    private static final Logger logger = LoggerFactory.getLogger(ChunkWorker.class);
+
+    private static final int MAX_LOADABLE_CHUNKS =
+            ViewDistance.MEGA.getChunkDistance().x() * ViewDistance.MEGA.getChunkDistance().y() * ViewDistance.MEGA.getChunkDistance().z();
+
+    private final RenderableWorldImpl.ChunkFrontToBackComparator frontToBackComparator;
+    private final Set<Vector3ic> chunkMeshProcessing = Sets.newConcurrentHashSet();
+    private final Sinks.Many<Chunk> chunkMeshPublisher = Sinks.many().unicast().onBackpressureBuffer();
+    private final List<Chunk> chunksInProximityOfCamera = Lists.newArrayListWithCapacity(MAX_LOADABLE_CHUNKS);
+
+    public ChunkWorker(ChunkTessellator chunkTessellator,
+                       WorldProvider worldProvider,
+                       RenderableWorldImpl.ChunkFrontToBackComparator frontToBackComparator) {
+        this.frontToBackComparator = frontToBackComparator;
+
+        chunkMeshPublisher.asFlux()
+                .distinct(Chunk::getPosition, () -> chunkMeshProcessing)
+                .doOnNext(k -> k.setDirty(false))
+                .parallel(5).runOn(GameScheduler.parallel())
+                .<Optional<Tuple2<Chunk, ChunkMesh>>>map(c -> {
+                    ChunkView chunkView = worldProvider.getLocalView(c.getPosition());
+                    if (chunkView != null && chunkView.isValidView() && chunkMeshProcessing.remove(c.getPosition())) {
+                        ChunkMesh newMesh = chunkTessellator.generateMesh(chunkView);
+                        ChunkMonitor.fireChunkTessellated(new Vector3i(c.getPosition()), newMesh);
+                        return Optional.of(Tuples.of(c, newMesh));
+                    }
+                    return Optional.empty();
+                }).filter(Optional::isPresent).sequential()
+                .publishOn(GameScheduler.gameMain())
+                .subscribe(result -> result.ifPresent(TupleUtils.consumer((chunk, chunkMesh) -> {
+                    if (chunksInProximityOfCamera.contains(chunk)) {
+                        chunkMesh.updateMesh();
+                        chunkMesh.discardData();
+                        if (chunk.hasMesh()) {
+                            chunk.getMesh().dispose();
+                        }
+                        chunk.setMesh(chunkMesh);
+                    }
+
+                })), throwable -> logger.error("Failed to build mesh {}", throwable));
+    }
+
+
+    public void add(Chunk chunk) {
+        if (chunk != null) {
+            chunksInProximityOfCamera.add(chunk);
+        }
+    }
+
+    public void remove(Chunk chunk) {
+        chunkMeshProcessing.remove(chunk.getPosition());
+
+        chunksInProximityOfCamera.remove(chunk);
+        chunk.disposeMesh();
+    }
+
+    public void remove(Vector3ic coord) {
+        chunkMeshProcessing.remove(coord);
+
+        Iterator<Chunk> iterator = chunksInProximityOfCamera.iterator();
+        while (iterator.hasNext()) {
+            Chunk chunk = iterator.next();
+            if (chunk.getPosition().equals(coord)) {
+                chunk.disposeMesh();
+                iterator.remove();
+                break;
+            }
+        }
+    }
+
+
+    public int update() {
+        int statDirtyChunks = 0;
+        chunksInProximityOfCamera.sort(frontToBackComparator);
+        for (Chunk chunk : chunksInProximityOfCamera) {
+            if (chunk.isReady() && chunk.isDirty()) {
+                statDirtyChunks++;
+                Sinks.EmitResult result = chunkMeshPublisher.tryEmitNext(chunk);
+                if (result.isFailure()) {
+                    logger.error("failed to process chunk {} : {}", chunk, result);
+                }
+            }
+        }
+        return statDirtyChunks;
+    }
+
+    public int numberChunkMeshProcessing() {
+        return chunkMeshProcessing.size();
+    }
+
+    public Collection<Chunk> chunks() {
+        return chunksInProximityOfCamera;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/RenderableWorldImpl.java
@@ -71,7 +71,8 @@ class RenderableWorldImpl implements RenderableWorld {
 
     private final ChunkMeshWorker chunkWorker;
 
-    RenderableWorldImpl(WorldRenderer worldRenderer, LodChunkProvider lodChunkProvider, ChunkProvider chunkProvider, ChunkTessellator chunkTessellator, WorldProvider worldProvider, Config config, Camera playerCamera) {
+    RenderableWorldImpl(WorldRenderer worldRenderer, LodChunkProvider lodChunkProvider, ChunkProvider chunkProvider,
+                        ChunkTessellator chunkTessellator, WorldProvider worldProvider, Config config, Camera playerCamera) {
         frontToBackComparator = new RenderableWorldImpl.ChunkFrontToBackComparator(worldRenderer);
         backToFrontComparator = new RenderableWorldImpl.ChunkBackToFrontComparator(worldRenderer);
 
@@ -418,7 +419,7 @@ class RenderableWorldImpl implements RenderableWorld {
     public static class ChunkFrontToBackComparator implements Comparator<RenderableChunk> {
 
         private final WorldRenderer worldRenderer;
-        public ChunkFrontToBackComparator(WorldRenderer worldRenderer) {
+        ChunkFrontToBackComparator(WorldRenderer worldRenderer) {
             this.worldRenderer = worldRenderer;
         }
 
@@ -439,7 +440,7 @@ class RenderableWorldImpl implements RenderableWorld {
 
     public static class ChunkBackToFrontComparator implements Comparator<RenderableChunk> {
         private final WorldRenderer worldRenderer;
-        public ChunkBackToFrontComparator(WorldRenderer worldRenderer) {
+        ChunkBackToFrontComparator(WorldRenderer worldRenderer) {
             this.worldRenderer = worldRenderer;
         }
         @Override

--- a/engine/src/main/java/org/terasology/engine/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/RenderableWorldImpl.java
@@ -3,7 +3,6 @@
 package org.terasology.engine.rendering.world;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import org.joml.Math;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
@@ -70,7 +69,7 @@ class RenderableWorldImpl implements RenderableWorld {
     private final RenderableWorldImpl.ChunkFrontToBackComparator frontToBackComparator;
     private final RenderableWorldImpl.ChunkBackToFrontComparator backToFrontComparator;
 
-    private final ChunkWorker chunkWorker;
+    private final ChunkMeshWorker chunkWorker;
 
     RenderableWorldImpl(WorldRenderer worldRenderer, LodChunkProvider lodChunkProvider, ChunkProvider chunkProvider, ChunkTessellator chunkTessellator, WorldProvider worldProvider, Config config, Camera playerCamera) {
         frontToBackComparator = new RenderableWorldImpl.ChunkFrontToBackComparator(worldRenderer);
@@ -84,7 +83,7 @@ class RenderableWorldImpl implements RenderableWorld {
         this.renderingConfig = config.getRendering();
         this.maxChunksForShadows = Math.clamp(config.getRendering().getMaxChunksUsedForShadowMapping(), 64, 1024);
 
-        this.chunkWorker = new ChunkWorker(chunkTessellator, worldProvider, frontToBackComparator);
+        this.chunkWorker = new ChunkMeshWorker(chunkTessellator, worldProvider, frontToBackComparator);
         renderQueues = new RenderQueuesHelper(new PriorityQueue<>(MAX_LOADABLE_CHUNKS,
                 frontToBackComparator),
                 new PriorityQueue<>(MAX_LOADABLE_CHUNKS, frontToBackComparator),

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -1,9 +1,8 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.world;
 
 import org.joml.Vector3f;
-import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,7 +162,6 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         context.put(ChunkTessellator.class, new ChunkTessellator());
 
-        WorldProvider worldProvider = context.get(WorldProvider.class);
         ChunkProvider chunkProvider = context.get(ChunkProvider.class);
         ChunkTessellator chunkTessellator = context.get(ChunkTessellator.class);
         BlockManager blockManager = context.get(BlockManager.class);

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -3,6 +3,7 @@
 package org.terasology.engine.rendering.world;
 
 import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,12 @@ import org.terasology.engine.rendering.primitives.ChunkTessellator;
 import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
 import org.terasology.engine.utilities.Assets;
 import org.terasology.engine.world.WorldProvider;
+import org.terasology.engine.world.block.BlockManager;
+import org.terasology.engine.world.chunks.ChunkProvider;
+import org.terasology.engine.world.chunks.LodChunkProvider;
+import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
+import org.terasology.engine.world.generator.ScalableWorldGenerator;
+import org.terasology.engine.world.generator.WorldGenerator;
 import org.terasology.math.TeraMath;
 
 import java.util.List;
@@ -156,7 +163,21 @@ public final class WorldRendererImpl implements WorldRenderer {
 
         context.put(ChunkTessellator.class, new ChunkTessellator());
 
-        renderableWorld = new RenderableWorldImpl(context, playerCamera);
+        WorldProvider worldProvider = context.get(WorldProvider.class);
+        ChunkProvider chunkProvider = context.get(ChunkProvider.class);
+        ChunkTessellator chunkTessellator = context.get(ChunkTessellator.class);
+        BlockManager blockManager = context.get(BlockManager.class);
+        ExtraBlockDataManager extraDataManager = context.get(ExtraBlockDataManager.class);
+        Config config = context.get(Config.class);
+
+
+        WorldGenerator worldGenerator = context.get(WorldGenerator.class);
+        LodChunkProvider lodChunkProvider = null;
+        if (worldGenerator instanceof ScalableWorldGenerator) {
+            lodChunkProvider = new LodChunkProvider(chunkProvider, blockManager, extraDataManager,
+                    (ScalableWorldGenerator) worldGenerator, chunkTessellator);
+        }
+        this.renderableWorld = new RenderableWorldImpl(this, lodChunkProvider, chunkProvider, chunkTessellator, worldProvider, config, playerCamera);
         renderQueues = renderableWorld.getRenderQueues();
 
         initRenderingSupport();

--- a/engine/src/main/java/org/terasology/engine/world/chunks/LodChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/LodChunkProvider.java
@@ -6,8 +6,6 @@ package org.terasology.engine.world.chunks;
 import com.google.common.collect.Queues;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.rendering.primitives.ChunkTessellator;
 import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
@@ -33,8 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.PriorityBlockingQueue;
 
 public class LodChunkProvider {
-    private static final Logger logger = LoggerFactory.getLogger(LodChunkProvider.class);
-
     private final ChunkProvider chunkProvider;
     private final BlockManager blockManager;
     private final ExtraBlockDataManager extraDataManager;
@@ -61,7 +57,8 @@ public class LodChunkProvider {
     private final BlockingQueue<LodChunk> readyChunks = Queues.newLinkedBlockingQueue();
     private final List<Thread> generationThreads = new ArrayList<>();
 
-    public LodChunkProvider(ChunkProvider chunkProvider, BlockManager blockManager, ExtraBlockDataManager extraDataManager, ScalableWorldGenerator generator, ChunkTessellator tessellator) {
+    public LodChunkProvider(ChunkProvider chunkProvider, BlockManager blockManager, ExtraBlockDataManager extraDataManager,
+                            ScalableWorldGenerator generator, ChunkTessellator tessellator) {
         this.chunkProvider = chunkProvider;
         this.blockManager = blockManager;
         this.extraDataManager = extraDataManager;


### PR DESCRIPTION
so I have a separate object just for managing the chunk meshiness and I moved a lot of stuff out so we don't couple the implementation directly to the context. constructor is looking a lot worse but I rather do that then use the context in its current form. 

RenderableWorldImpl at the moment is gluing a lot of systems together not sure how this could be better organized. The way that LOD's are processed in a separate system introduces a lot of complications with control flow. 

this is just a continuation of these changes: https://github.com/MovingBlocks/Terasology/pull/4786