### PR TITLE
feat: add convenience method  PhyiscEngine#recomputeCharacterCollider(entity)

### DIFF
--- a/engine/src/main/java/org/terasology/engine/physics/engine/PhysicsEngine.java
+++ b/engine/src/main/java/org/terasology/engine/physics/engine/PhysicsEngine.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.physics.engine;
@@ -238,4 +238,19 @@ public interface PhysicsEngine extends Physics {
      *                                  ShapeComponent.
      */
     boolean updateTrigger(EntityRef entity);
+
+
+    /**
+     * Recompute the character collider for the given entity.
+     *
+     * The entity must have a {@link org.terasology.engine.logic.location.LocationComponent LocationComponent}
+     * and a {@link org.terasology.engine.logic.characters.CharacterMovementComponent CharacterMovementComponent}.
+     *
+     * @param entity the entity to recompute the character collider for.
+     * @return the updated character collider of the entity
+     */
+    default CharacterCollider recomputeCharacterCollider(EntityRef entity) {
+        removeCharacterCollider(entity);
+        return getCharacterCollider(entity);
+    }
 }


### PR DESCRIPTION
We have code like this in some place, seemingly to make sure the character collider is recomputed to reflect changed values on the entity's components.

```java
physicsEngine.removeCharacterCollider(entity);
physicsEngine.getCharacterCollider(entity);
```

With the ability to simply add this as default method implementation in the interface we can provide a documented implementation for this, introducing a better alternative to cryptically calling `remove...` and `get...`.

