### PR TITLE
refactor(rendering): factor out MutableChunkMesh

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/rendering/world/ChunkMeshWorkerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/rendering/world/ChunkMeshWorkerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.terasology.engine.rendering.primitives.ChunkMesh;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.RenderableChunk;
 import reactor.core.publisher.Mono;
@@ -35,9 +35,9 @@ public class ChunkMeshWorkerTest {
     Comparator<RenderableChunk> comparator;
     StepVerifier.FirstStep<Chunk> verifier;
 
-    static Mono<Tuple2<Chunk, ChunkMesh>> alwaysCreateMesh(Chunk chunk) {
+    static Mono<Tuple2<Chunk, MutableChunkMesh>> alwaysCreateMesh(Chunk chunk) {
         chunk.setDirty(false);
-        return Mono.just(Tuples.of(chunk, mock(ChunkMesh.class)));
+        return Mono.just(Tuples.of(chunk, mock(MutableChunkMesh.class)));
     }
 
     @BeforeEach

--- a/engine/src/main/java/org/terasology/engine/monitoring/chunk/ChunkMeshInfo.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/chunk/ChunkMeshInfo.java
@@ -1,8 +1,9 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.monitoring.chunk;
 
 import org.terasology.engine.rendering.primitives.ChunkMesh;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -14,7 +15,7 @@ public class ChunkMeshInfo {
     public final int totalTimeToGenerateBlockVertices;
     public final int totalTimeToGenerateOptimizedBuffers;
 
-    public ChunkMeshInfo(ChunkMesh mesh) {
+    public ChunkMeshInfo(MutableChunkMesh mesh) {
         checkNotNull(mesh, "The parameter 'mesh' must not be null");
 
         int vertices = 0;
@@ -22,7 +23,7 @@ public class ChunkMeshInfo {
 
         if (mesh.hasVertexElements()) {
             for (ChunkMesh.RenderType type : ChunkMesh.RenderType.values()) {
-                final ChunkMesh.VertexElements element = mesh.getVertexElements(type);
+                final MutableChunkMesh.VertexElements element = mesh.getVertexElements(type);
                 vertices += element.buffer.elements();
                 indices += element.indices.indices();
             }

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.persistence.typeHandling;
@@ -53,7 +53,7 @@ import org.terasology.engine.persistence.typeHandling.mathTypes.Vector4iTypeHand
 import org.terasology.engine.persistence.typeHandling.mathTypes.Vector4icTypeHandler;
 import org.terasology.engine.persistence.typeHandling.reflection.ModuleEnvironmentSandbox;
 import org.terasology.engine.rendering.assets.texture.TextureRegion;
-import org.terasology.engine.rendering.primitives.ChunkMesh;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.engine.world.block.BlockArea;
 import org.terasology.engine.world.block.BlockAreac;
 import org.terasology.engine.world.block.BlockRegion;
@@ -115,7 +115,7 @@ public class TypeHandlerLibraryImpl extends TypeHandlerLibrary {
         serializationLibrary.addTypeHandler(Name.class, new NameTypeHandler());
         serializationLibrary.addTypeHandler(TextureRegion.class, new TextureRegionTypeHandler());
         serializationLibrary.addTypeHandler(UITextureRegion.class, new UITextureRegionTypeHandler());
-        serializationLibrary.addTypeHandler(ChunkMesh.class, new ChunkMeshTypeHandler());
+        serializationLibrary.addTypeHandler(MutableChunkMesh.class, new ChunkMeshTypeHandler());
 
         serializationLibrary.addTypeHandlerFactory(new TextureRegionAssetTypeHandlerFactory());
 

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/ChunkMeshTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/ChunkMeshTypeHandler.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.persistence.typeHandling.extensionTypes;
@@ -6,6 +6,7 @@ package org.terasology.engine.persistence.typeHandling.extensionTypes;
 import org.lwjgl.BufferUtils;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.rendering.primitives.ChunkMeshImpl;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
 import org.terasology.persistence.typeHandling.TypeHandler;
@@ -15,9 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class ChunkMeshTypeHandler extends TypeHandler<ChunkMesh> {
+public class ChunkMeshTypeHandler extends TypeHandler<MutableChunkMesh> {
     @Override
-    protected PersistedData serializeNonNull(ChunkMesh value, PersistedDataSerializer serializer) {
+    protected PersistedData serializeNonNull(MutableChunkMesh value, PersistedDataSerializer serializer) {
         if (!value.hasVertexElements()) {
             throw new IllegalStateException("Attempting to serialize a ChunkMesh whose data has already been discarded.");
         }
@@ -35,7 +36,7 @@ public class ChunkMeshTypeHandler extends TypeHandler<ChunkMesh> {
     }
 
     @Override
-    public Optional<ChunkMesh> deserialize(PersistedData data) {
+    public Optional<MutableChunkMesh> deserialize(PersistedData data) {
         List<ByteBuffer> asBuffers = new ArrayList<>();
         for (PersistedData datum : data.getAsArray()) {
             ByteBuffer buffer = datum.getAsByteBuffer();
@@ -44,7 +45,7 @@ public class ChunkMeshTypeHandler extends TypeHandler<ChunkMesh> {
             directBuffer.rewind();
             asBuffers.add(directBuffer);
         }
-        ChunkMesh result = new ChunkMeshImpl();
+        MutableChunkMesh result = new ChunkMeshImpl();
         for (ChunkMesh.RenderType renderType : ChunkMesh.RenderType.values()) {
             result.getVertexElements(renderType).buffer.replace(asBuffers.remove(0));
             result.getVertexElements(renderType).indices.replace(asBuffers.remove(0));

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/ChunkMeshComponent.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/ChunkMeshComponent.java
@@ -4,7 +4,7 @@
 package org.terasology.engine.rendering.logic;
 
 import org.terasology.engine.network.Replicate;
-import org.terasology.engine.rendering.primitives.ChunkMesh;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.joml.geom.AABBf;
 
 /**
@@ -13,7 +13,7 @@ import org.terasology.joml.geom.AABBf;
  */
 public class ChunkMeshComponent implements VisualComponent<ChunkMeshComponent> {
     @Replicate
-    public ChunkMesh mesh;
+    public MutableChunkMesh mesh;
     @Replicate
     public AABBf aabb;
     @Replicate
@@ -21,12 +21,12 @@ public class ChunkMeshComponent implements VisualComponent<ChunkMeshComponent> {
 
     public ChunkMeshComponent() { }
 
-    public ChunkMeshComponent(ChunkMesh mesh, AABBf aabb) {
+    public ChunkMeshComponent(MutableChunkMesh mesh, AABBf aabb) {
         this.mesh = mesh;
         this.aabb = aabb;
     }
 
-    public synchronized void setMesh(ChunkMesh mesh) {
+    public synchronized void setMesh(MutableChunkMesh mesh) {
         if (this.mesh != null) {
             this.mesh.dispose();
         }

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGenerator.java
@@ -1,10 +1,10 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.primitives;
 
-import org.terasology.gestalt.module.sandbox.API;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.world.ChunkView;
+import org.terasology.gestalt.module.sandbox.API;
 
 /**
  * This is used to generate Mesh data from a block in a chunk to a ChunkMesh output.
@@ -21,7 +21,7 @@ public interface BlockMeshGenerator {
      * @param y     Input position Y.
      * @param z     Input position Z.
      */
-    void generateChunkMesh(ChunkView view, ChunkMesh mesh, int x, int y, int z);
+    void generateChunkMesh(ChunkView view, MutableChunkMesh mesh, int x, int y, int z);
 
     /**
      * @return A standalone mesh used for items, inventory, etc...

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGeneratorSingleShape.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.primitives;
 
@@ -34,7 +34,7 @@ public class BlockMeshGeneratorSingleShape extends BlockMeshShapeGenerator {
 
 
     @Override
-    public void generateChunkMesh(ChunkView view, ChunkMesh chunkMesh, int x, int y, int z) {
+    public void generateChunkMesh(ChunkView view, MutableChunkMesh chunkMesh, int x, int y, int z) {
         final BlockAppearance blockAppearance = block.getPrimaryAppearance();
         if (!blockAppearance.hasAppearance()) {
             // perf: Skip mesh generation for blocks without appearance, e.g., air blocks.

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkMesh.java
@@ -1,49 +1,17 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.engine.rendering.primitives;
 
-import org.joml.Vector2f;
-import org.joml.Vector2fc;
-import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.terasology.engine.rendering.assets.material.Material;
-import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
-import org.terasology.engine.rendering.assets.mesh.resource.IndexResource;
-import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
-import org.terasology.engine.rendering.assets.mesh.resource.VertexByteAttributeBinding;
-import org.terasology.engine.rendering.assets.mesh.resource.VertexFloatAttributeBinding;
-import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
-import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
 import org.terasology.gestalt.module.sandbox.API;
-import org.terasology.nui.Color;
-import org.terasology.nui.Colorc;
 
-/**
- * Chunk meshes store, manipulate and render the vertex data of tessellated chunks.
- */
 public interface ChunkMesh {
-
-    VertexElements getVertexElements(ChunkMesh.RenderType renderType);
-
-    /**
-     * has any vertex elements for is cleared from {@link #discardData()}
-     *
-     * @return if the vertex data is cleared
-     */
-    boolean hasVertexElements();
-
-    /**
-     * update the mesh data
-     *
-     * @return true if the data has been updated
-     */
-    boolean updateMesh();
-
-    void discardData();
 
     void updateMaterial(Material chunkMaterial, Vector3fc chunkPosition, boolean chunkIsAnimated);
 
-    int triangleCount(ChunkMesh.RenderPhase phase);
+    int triangleCount(RenderPhase phase);
 
     int getTimeToGenerateBlockVertices();
 
@@ -51,7 +19,7 @@ public interface ChunkMesh {
 
     void dispose();
 
-    int render(ChunkMesh.RenderPhase type);
+    int render(RenderPhase type);
 
     /**
      * Possible rendering types.
@@ -79,57 +47,5 @@ public interface ChunkMesh {
         ALPHA_REJECT,
         REFRACTIVE,
         Z_PRE_PASS
-    }
-
-    class VertexElements {
-
-        public static final int VERTEX_INDEX = 0; // vec3
-        public static final int NORMAL_INDEX = 1;  // vec3
-        public static final int UV0_INDEX = 2;  // vec3
-
-        public static final int FLAGS_INDEX = 3;  // int
-        public static final int FRAME_INDEX = 4; // float
-
-        public static final int SUNLIGHT_INDEX = 5; // float
-        public static final int BLOCK_INDEX = 6; // float
-        public static final int AMBIENT_OCCLUSION_INDEX = 7; // float
-
-        public static final int COLOR_INDEX = 8; // vec4
-
-        public final VertexResource buffer;
-        public final IndexResource indices = new IndexResource();
-
-        public final VertexAttributeBinding<Vector3fc, Vector3f> position;
-        public final VertexAttributeBinding<Vector3fc, Vector3f> normals;
-        public final VertexAttributeBinding<Vector2fc, Vector2f> uv0;
-
-        public final VertexAttributeBinding<Colorc, Color> color;
-
-        public final VertexByteAttributeBinding flags;
-        public final VertexByteAttributeBinding frames;
-
-        public final VertexFloatAttributeBinding sunlight;         // this could be changed to a single byte
-        public final VertexFloatAttributeBinding blockLight;       // this could be changed to a single byte
-        public final VertexFloatAttributeBinding ambientOcclusion; // this could be changed to a single byte
-        public int vertexCount;
-
-
-        VertexElements() {
-            VertexResourceBuilder builder = new VertexResourceBuilder();
-            position = builder.add(VERTEX_INDEX, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
-            normals = builder.add(NORMAL_INDEX, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
-            uv0 = builder.add(UV0_INDEX, GLAttributes.VECTOR_2_F_VERTEX_ATTRIBUTE);
-
-            flags = builder.add(FLAGS_INDEX, GLAttributes.BYTE_1_VERTEX_ATTRIBUTE);
-            frames = builder.add(FRAME_INDEX, GLAttributes.BYTE_1_VERTEX_ATTRIBUTE);
-
-            sunlight = builder.add(SUNLIGHT_INDEX, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
-            blockLight = builder.add(BLOCK_INDEX, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
-            ambientOcclusion = builder.add(AMBIENT_OCCLUSION_INDEX, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
-
-            color = builder.add(COLOR_INDEX, GLAttributes.COLOR_4_F_VERTEX_ATTRIBUTE);
-
-            buffer = builder.build();
-        }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkMeshImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkMeshImpl.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.rendering.primitives;
@@ -8,7 +8,7 @@ import org.lwjgl.opengl.GL30;
 import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
 
-public class ChunkMeshImpl implements ChunkMesh {
+public class ChunkMeshImpl implements MutableChunkMesh {
 
     /* VERTEX DATA */
     private final int[] vertexBuffers = new int[4];

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkTessellator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkTessellator.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.primitives;
 
@@ -23,11 +23,11 @@ public final class ChunkTessellator {
 
     }
 
-    public ChunkMesh generateMesh(ChunkView chunkView) {
+    public MutableChunkMesh generateMesh(ChunkView chunkView) {
         return generateMesh(chunkView, 1, 0);
     }
 
-    public ChunkMesh generateMesh(ChunkView chunkView, float scale, int border) {
+    public MutableChunkMesh generateMesh(ChunkView chunkView, float scale, int border) {
         PerformanceMonitor.startActivity("GenerateMesh");
         ChunkMeshImpl mesh = new ChunkMeshImpl();
 
@@ -47,7 +47,7 @@ public final class ChunkTessellator {
         if (border != 0) {
             float totalScale = scale * Chunks.SIZE_X / (Chunks.SIZE_X - 2 * border);
             for (ChunkMesh.RenderType type : ChunkMesh.RenderType.values()) {
-                ChunkMesh.VertexElements elements = mesh.getVertexElements(type);
+                MutableChunkMesh.VertexElements elements = mesh.getVertexElements(type);
                 Vector3f pos = new Vector3f();
                 for (int x = 0; x < elements.position.elements(); x++) {
                     elements.position.get(x, pos);

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/MutableChunkMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/MutableChunkMesh.java
@@ -1,0 +1,93 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.rendering.primitives;
+
+import org.joml.Vector2f;
+import org.joml.Vector2fc;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
+import org.terasology.engine.rendering.assets.mesh.resource.IndexResource;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexByteAttributeBinding;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexFloatAttributeBinding;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
+import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
+
+/**
+ * Chunk meshes store, manipulate and render the vertex data of tessellated chunks.
+ */
+public interface MutableChunkMesh extends ChunkMesh {
+
+    VertexElements getVertexElements(MutableChunkMesh.RenderType renderType);
+
+    /**
+     * has any vertex elements for is cleared from {@link #discardData()}
+     *
+     * @return if the vertex data is cleared
+     */
+    boolean hasVertexElements();
+
+    /**
+     * update the mesh data
+     *
+     * @return true if the data has been updated
+     */
+    boolean updateMesh();
+
+    void discardData();
+
+    class VertexElements {
+
+        public static final int VERTEX_INDEX = 0; // vec3
+        public static final int NORMAL_INDEX = 1;  // vec3
+        public static final int UV0_INDEX = 2;  // vec3
+
+        public static final int FLAGS_INDEX = 3;  // int
+        public static final int FRAME_INDEX = 4; // float
+
+        public static final int SUNLIGHT_INDEX = 5; // float
+        public static final int BLOCK_INDEX = 6; // float
+        public static final int AMBIENT_OCCLUSION_INDEX = 7; // float
+
+        public static final int COLOR_INDEX = 8; // vec4
+
+        public final VertexResource buffer;
+        public final IndexResource indices = new IndexResource();
+
+        public final VertexAttributeBinding<Vector3fc, Vector3f> position;
+        public final VertexAttributeBinding<Vector3fc, Vector3f> normals;
+        public final VertexAttributeBinding<Vector2fc, Vector2f> uv0;
+
+        public final VertexAttributeBinding<Colorc, Color> color;
+
+        public final VertexByteAttributeBinding flags;
+        public final VertexByteAttributeBinding frames;
+
+        public final VertexFloatAttributeBinding sunlight;         // this could be changed to a single byte
+        public final VertexFloatAttributeBinding blockLight;       // this could be changed to a single byte
+        public final VertexFloatAttributeBinding ambientOcclusion; // this could be changed to a single byte
+        public int vertexCount;
+
+
+        VertexElements() {
+            VertexResourceBuilder builder = new VertexResourceBuilder();
+            position = builder.add(VERTEX_INDEX, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+            normals = builder.add(NORMAL_INDEX, GLAttributes.VECTOR_3_F_VERTEX_ATTRIBUTE);
+            uv0 = builder.add(UV0_INDEX, GLAttributes.VECTOR_2_F_VERTEX_ATTRIBUTE);
+
+            flags = builder.add(FLAGS_INDEX, GLAttributes.BYTE_1_VERTEX_ATTRIBUTE);
+            frames = builder.add(FRAME_INDEX, GLAttributes.BYTE_1_VERTEX_ATTRIBUTE);
+
+            sunlight = builder.add(SUNLIGHT_INDEX, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
+            blockLight = builder.add(BLOCK_INDEX, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
+            ambientOcclusion = builder.add(AMBIENT_OCCLUSION_INDEX, GLAttributes.FLOAT_1_VERTEX_ATTRIBUTE);
+
+            color = builder.add(COLOR_INDEX, GLAttributes.COLOR_4_F_VERTEX_ATTRIBUTE);
+
+            buffer = builder.build();
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/world/RenderableWorldImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/RenderableWorldImpl.java
@@ -18,6 +18,7 @@ import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.logic.ChunkMeshRenderer;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.rendering.primitives.ChunkTessellator;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
 import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.WorldProvider;
@@ -136,7 +137,7 @@ class RenderableWorldImpl implements RenderableWorld {
         chunkProvider.update();
 
         Chunk chunk;
-        ChunkMesh newMesh;
+        MutableChunkMesh newMesh;
         ChunkView localView;
         for (Vector3ic chunkCoordinates : calculateRenderableRegion(renderingConfig.getViewDistance())) {
             chunk = chunkProvider.getChunk(chunkCoordinates);

--- a/engine/src/main/java/org/terasology/engine/world/block/shapes/BlockMeshPart.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/shapes/BlockMeshPart.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.block.shapes;
 
@@ -9,6 +9,7 @@ import org.terasology.engine.math.Direction;
 import org.terasology.engine.monitoring.PerformanceMonitor;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.rendering.primitives.ChunkVertexFlag;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.block.Block;
 import org.terasology.math.TeraMath;
@@ -80,9 +81,9 @@ public class BlockMeshPart {
         return new BlockMeshPart(vertices, normals, newTexCoords, indices, frames);
     }
 
-    public void appendTo(ChunkMesh chunk, ChunkView chunkView, int offsetX, int offsetY, int offsetZ,
+    public void appendTo(MutableChunkMesh chunk, ChunkView chunkView, int offsetX, int offsetY, int offsetZ,
                          ChunkMesh.RenderType renderType, Colorc colorOffset, ChunkVertexFlag flags) {
-        ChunkMesh.VertexElements elements = chunk.getVertexElements(renderType);
+        MutableChunkMesh.VertexElements elements = chunk.getVertexElements(renderType);
         for (Vector2f texCoord : texCoords) {
             elements.uv0.put(texCoord);
         }

--- a/engine/src/main/java/org/terasology/engine/world/chunks/LodChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/LodChunkProvider.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.world.chunks;
@@ -8,6 +8,7 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.rendering.primitives.ChunkTessellator;
+import org.terasology.engine.rendering.primitives.MutableChunkMesh;
 import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
 import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.block.Block;
@@ -106,8 +107,9 @@ public class LodChunkProvider {
             int scale = chunk.scale;
             if (requiredScale != null && requiredScale <= scale) { // The relevant region may have been updated since
                 // this chunk was requested.
-                chunk.getMesh().updateMesh();
-                chunk.getMesh().discardData();
+                MutableChunkMesh mesh = (MutableChunkMesh) chunk.getMesh(); // FIXME ASAP
+                mesh.updateMesh();
+                mesh.discardData();
                 Vector3i subPos = new Vector3i();
                 if (scale > 0) {
                     int subScale = 1 << (scale - 1);

--- a/engine/src/main/java/org/terasology/engine/world/chunks/RenderableChunk.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/RenderableChunk.java
@@ -1,11 +1,11 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.chunks;
 
 import org.joml.Vector3f;
-import org.terasology.joml.geom.AABBfc;
-import org.terasology.gestalt.module.sandbox.API;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
+import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.joml.geom.AABBfc;
 
 /**
  * Anything that acts like a chunk for rendering purposes


### PR DESCRIPTION
One of the things that made working on ChunkMeshWorker for #4987 scary was the concern that a ChunkMesh's data might be updated while it was in the middle of updating the mesh for OpenGL.

Upon closer examination, it looks like in practice that a _new instance_ of ChunkMesh is created each time the chunk is dirtied. That means `Chunk.mesh` could be a reference to a safer, non-mutable interface.

I experimented with this (see attached 269f8231e34ba5231d4f52e614c9cc0d40475a15), moving the methods `vertexElements`, `updateMesh` and `disposeData` to a new `MutableMesh` interface.

### Outstanding before merging

There are a few things that need to be addressed:

* [ ] LodChunkProvider does _not_ follow the same approach of generating new instances, and instead calls `updateMesh` and `discardData` on its RenderableChunk. Should that change? Or is the LodChunkProvider code redundant with the ChunkMeshWorker code?
* [ ] ChunkMesh.updateMaterial sounds like it might mutate the chunk (it starts with `update`), but it really only updates the _material._ In fact, I see only one implementation of this, and it looks like it could be a static method.
* [ ] ChunkMeshTypeHandler operates directly on vertexElements that an immutable ChunkMesh does not provide access to.
  - that type handler looks like it is for EntityBasedRenderableChunk #4614 for FallingBlocks kinds of things. I think we can provide for this, introduce some private methods for serialization, if we decide that's the way to go.
