### PR TITLE
chore: Update lwjgl version to 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ ext {
     // Lib dir for use in manifest entries etc (like in :engine). A separate "libsDir" exists, auto-created by Gradle
     subDirLibs = 'libs'
 
-    LwjglVersion = '3.2.3'
+    LwjglVersion = '3.3.1'
 }
 
 


### PR DESCRIPTION
### Contains

Update lwjgl version to 3.3.
this version  of lwjgl provide:
1. wayland support (needs code changes at current moment)
2. arm64 versions of windows/macOs/linux

### How to test

Run Terasology and create/load game.
