### PR TITLE
fix: path quirk on an M1 Mac using Azul JDK 11

### DIFF
--- a/build-logic/src/main/kotlin/org/terasology/gradology/file_operations.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/file_operations.kt
@@ -1,0 +1,28 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.gradology
+
+import org.gradle.api.internal.file.copy.CopySpecInternal
+import org.gradle.api.tasks.Copy
+
+
+/**
+ * Copy, but never overwrite any existing file.
+ *
+ * Preserves existing files regardless of how up-to-date they are.
+ *
+ * Useful for providing boilerplate or defaults.
+ */
+abstract class CopyButNeverOverwrite : Copy() {
+
+    override fun createRootSpec(): CopySpecInternal {
+        val copySpec = super.createRootSpec()
+        copySpec.eachFile {
+            if (this.relativePath.getFile(destinationDir).exists()) {
+                this.exclude()
+            }
+        }
+        return copySpec;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -235,10 +235,10 @@ task copyInMissingTemplates {
     File gradlePropsFile = new File(rootDir, 'gradle.properties')
     File OverrideCfgFile = new File(rootDir, 'override.cfg')
     if (!gradlePropsFile.exists()) {
-        new File(rootDir, 'gradle.properties') << new File(templatesDir, 'gradle.properties').text
+        new File(rootDir, 'gradle.properties') << new File(rootDir, "$templatesDir/gradle.properties").text
     }
     if (!OverrideCfgFile.exists()) {
-        new File(rootDir, 'override.cfg') << new File(templatesDir, 'override.cfg').text
+        new File(rootDir, 'override.cfg') << new File(rootDir, "$templatesDir/override.cfg").text
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ plugins {
 
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.jetbrains.gradle.ext.ActionDelegationConfig
+import org.terasology.gradology.CopyButNeverOverwrite
 
 import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
@@ -80,7 +81,7 @@ located at ${System.getProperty("java.home")}
 ext {
     dirNatives = 'natives'
     dirConfigMetrics = 'config/metrics'
-    templatesDir = 'templates'
+    templatesDir = file('templates')
 
     // Lib dir for use in manifest entries etc (like in :engine). A separate "libsDir" exists, auto-created by Gradle
     subDirLibs = 'libs'
@@ -230,19 +231,14 @@ tasks.named('wrapper') {
 // General IDE customization                                                                                         //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-task copyInMissingTemplates {
+tasks.register("copyInMissingTemplates", CopyButNeverOverwrite) {
     description = "Copies in placeholders from the /templates dir to project root if not present yet"
-    File gradlePropsFile = new File(rootDir, 'gradle.properties')
-    File OverrideCfgFile = new File(rootDir, 'override.cfg')
-    if (!gradlePropsFile.exists()) {
-        new File(rootDir, 'gradle.properties') << new File(rootDir, "$templatesDir/gradle.properties").text
-    }
-    if (!OverrideCfgFile.exists()) {
-        new File(rootDir, 'override.cfg') << new File(rootDir, "$templatesDir/override.cfg").text
-    }
+    from(templatesDir)
+    into(rootDir)
+    include('gradle.properties', 'override.cfg')
 }
 
-tasks.register("jmxPassword", Copy) {
+tasks.register("jmxPassword", CopyButNeverOverwrite) {
     description = "Create config/jmxremote.password from a template."
 
     setFileMode(0600)  // passwords must be accessible only by owner
@@ -253,10 +249,6 @@ tasks.register("jmxPassword", Copy) {
     rename("(.*).template", '$1')
     into("config")
 
-    onlyIf {
-        // Do not overwrite an existing password file.
-        !it.destinationDir.toPath().resolve("jmxremote.password").toFile().exists()
-    }
     doLast {
         logger.warn("${it.outputs.files.singleFile}/jmxremote.password:100: Edit this to set your password.")
     }


### PR DESCRIPTION
Without this fix Gradle fails to find the templates directory for some reason. Exact same setup (although different JDK 11 I think) on my non-M1 Mac worked fine. Not sure if it is a base issue with M1 Macs or the JDK, but in either case this fixed it.

More issues are piled up beyond this for where there are no arm64 lib variants for the new Apple Silicon chip setup, first one is protobuf, but that's a problem for another day.