### PR TITLE
build(idea): update dictionary and gitignores

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -47,6 +47,3 @@ workspace.xml
 
 # Automatically created when the checkout directy name is different from git origin?
 /.name
-
-# Discord files. It's user-specific and not-for-sharing
-discord.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -47,3 +47,11 @@ workspace.xml
 
 # Automatically created when the checkout directy name is different from git origin?
 /.name
+
+# Git Toolbox https://plugins.jetbrains.com/plugin/7499-gittoolbox
+# Settings appear to be user-specific.
+/git_toolbox_prj.xml
+
+# Grep Console https://plugins.jetbrains.com/plugin/7125-grep-console
+# Settings appear to be workspace-specific.
+/GrepConsole.xml

--- a/.idea/dictionaries/kevint.xml
+++ b/.idea/dictionaries/kevint.xml
@@ -3,10 +3,14 @@
     <words>
       <w>SPDX-License-Identifier</w>
       <w>artifactory</w>
+      <w>biome</w>
       <w>classpaths</w>
+      <w>coord</w>
       <w>deserialized</w>
       <w>deserializing</w>
       <w>gameplay</w>
+      <w>lootable</w>
+      <w>lootables</w>
       <w>minecraft</w>
       <w>reddit</w>
       <w>renderable</w>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="2">
+    <list size="3">
       <item index="0" class="java.lang.String" itemvalue="org.terasology.engine.entitySystem.event.ReceiveEvent" />
-      <item index="1" class="java.lang.String" itemvalue="org.terasology.engine.logic.console.commandSystem.annotations.Command" />
+      <item index="1" class="java.lang.String" itemvalue="org.terasology.engine.logic.behavior.BehaviorAction" />
+      <item index="2" class="java.lang.String" itemvalue="org.terasology.engine.logic.console.commandSystem.annotations.Command" />
     </list>
     <writeAnnotations>
       <writeAnnotation name="org.terasology.engine.registry.In" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -15,5 +15,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>


### PR DESCRIPTION
Some updates to `.idea`. Currently using IntelliJ IDEA 2022.1 (Ultimate Edition)
Build #IU-221.5080.210, built on April 11, 2022

Test plan:
- pull
- restart IntelliJ
- `git diff`: are there any changes to `.idea/misc.xml`?

I did leave out a `SwUserDefinedSpecifications` component from `misc.xml`, as that's new and I'm not sure if everyone got it or it's something peculiar to my instance.

If it turns out that's something auto-generated for everyone when upgrading to IntelliJ 2022.1, we can go ahead and add that too.