### PR TITLE
fix(SelectionScreen): be more robust in the face of save files with incomplete manifests

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.core.modes.loadProcesses;
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
 
 public class InitialiseWorld extends SingleStepLoadProcess {
 
@@ -84,7 +85,8 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         context.put(WorldGeneratorPluginLibrary.class, new DefaultWorldGeneratorPluginLibrary(environment, context));
 
-        WorldInfo worldInfo = gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD);
+        WorldInfo worldInfo = verifyNotNull(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD),
+                "Game manifest does not contain a MAIN_WORLD");
         verify(worldInfo.getWorldGenerator().isValid(), "Game manifest did not specify world type.");
         if (worldInfo.getSeed() == null || worldInfo.getSeed().isEmpty()) {
             FastRandom random = new FastRandom();

--- a/engine/src/main/java/org/terasology/engine/game/GameManifest.java
+++ b/engine/src/main/java/org/terasology/engine/game/GameManifest.java
@@ -1,7 +1,8 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.game;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -174,4 +175,10 @@ public class GameManifest {
         modules.add(new NameVersion(id, version));
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("title", title)
+                .toString();
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/game/GameManifest.java
+++ b/engine/src/main/java/org/terasology/engine/game/GameManifest.java
@@ -9,10 +9,13 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.utilities.gson.CaseInsensitiveEnumTypeAdapterFactory;
 import org.terasology.engine.utilities.gson.UriTypeAdapterFactory;
+import org.terasology.engine.world.generator.internal.WorldGeneratorManager;
 import org.terasology.engine.world.internal.WorldInfo;
 import org.terasology.gestalt.entitysystem.component.Component;
 import org.terasology.gestalt.naming.Name;
@@ -30,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 public class GameManifest {
+    private static final Logger logger = LoggerFactory.getLogger(GameManifest.class);
+
     public static final String DEFAULT_FILE_NAME = "manifest.json";
 
     private String title = "";
@@ -173,6 +178,26 @@ public class GameManifest {
 
     public void addModule(Name id, Version version) {
         modules.add(new NameVersion(id, version));
+    }
+
+    /**
+     * The name of the generator used for the main world.
+     * <p>
+     * Always returns a String, but may be an "ERROR:" string.
+     */
+    public String mainWorldDisplayName(WorldGeneratorManager manager) {
+        var world = getWorldInfo(TerasologyConstants.MAIN_WORLD);
+        if (world == null) {
+            logger.warn("{} has no MAIN_WORLD", this);
+            return "ERROR: No main world";
+        }
+        SimpleUri generatorUri = world.getWorldGenerator();
+        var generator = manager.getWorldGeneratorInfo(generatorUri);
+        if (generator == null) {
+            logger.warn("{}: {} has no generator for {}", this, manager, generatorUri);
+            return "ERROR: No generator found for " + generatorUri;
+        }
+        return generator.getDisplayName();
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/game/GameManifest.java
+++ b/engine/src/main/java/org/terasology/engine/game/GameManifest.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 
 public class GameManifest {
-    private static final Logger logger = LoggerFactory.getLogger(GameManifest.class);
-
     public static final String DEFAULT_FILE_NAME = "manifest.json";
+
+    private static final Logger logger = LoggerFactory.getLogger(GameManifest.class);
 
     private String title = "";
     private String seed = "";

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectionScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectionScreen.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.PlayerConfig;
-import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.game.GameManifest;
 import org.terasology.engine.i18n.TranslationSystem;
 import org.terasology.engine.persistence.internal.GamePreviewImageProvider;
@@ -18,9 +17,7 @@ import org.terasology.engine.rendering.nui.CoreScreenLayer;
 import org.terasology.engine.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.engine.utilities.Assets;
 import org.terasology.engine.utilities.FilesUtil;
-import org.terasology.engine.world.generator.internal.WorldGeneratorInfo;
 import org.terasology.engine.world.generator.internal.WorldGeneratorManager;
-import org.terasology.engine.world.internal.WorldInfo;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.NameVersion;
@@ -81,25 +78,7 @@ public abstract class SelectionScreen extends CoreScreenLayer {
         }
 
         GameManifest manifest = gameInfo.getManifest();
-        WorldInfo worldInfo = manifest.getWorldInfo(TerasologyConstants.MAIN_WORLD);
-
-        String mainWorldGenerator = "ERROR: world generator ";
-        if (worldInfo == null) {
-            logger.warn("Could not get MAIN_WORLD for {} with worlds {}",
-                    manifest, manifest.getWorldInfoMap().keySet());
-            mainWorldGenerator = "ERROR: no main world";
-        } else {
-            final WorldGeneratorInfo wgi = worldGeneratorManager.getWorldGeneratorInfo(
-                    worldInfo.getWorldGenerator());
-
-            if (wgi != null) {
-                mainWorldGenerator = wgi.getDisplayName();
-            } else {
-                mainWorldGenerator = mainWorldGenerator + worldInfo
-                        .getWorldGenerator()
-                        .toString() + " not found";
-            }
-        }
+        String mainWorldGenerator = manifest.mainWorldDisplayName(worldGeneratorManager);
 
         final String commaSeparatedModules = manifest
                 .getModules()

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.nui.layers.mainMenu.gameDetailsScreen;
 
@@ -392,11 +392,17 @@ public class GameDetailsScreen extends CoreScreenLayer {
     }
 
     private String getGeneralInfo(final GameInfo theGameInfo) {
-        SimpleUri name = theGameInfo.getManifest().getWorldInfo(TerasologyConstants.MAIN_WORLD).getWorldGenerator();
-        WorldGeneratorInfo wgi = worldGeneratorManager.getWorldGeneratorInfo(name);
-        String display = "ERROR: generator " + name + " not found.";
-        if (wgi != null) {
-            display = wgi.getDisplayName();
+        WorldInfo mainWorld = theGameInfo.getManifest().getWorldInfo(TerasologyConstants.MAIN_WORLD);
+        String display;
+        if (mainWorld == null) {
+            display = "ERROR: no main world";
+        } else {
+            SimpleUri name = mainWorld.getWorldGenerator();
+            display = "ERROR: generator " + name + " not found";
+            WorldGeneratorInfo wgi = worldGeneratorManager.getWorldGeneratorInfo(name);
+            if (wgi != null) {
+                display = wgi.getDisplayName();
+            }
         }
         return translationSystem.translate("${engine:menu#game-details-game-title} ")
                 + theGameInfo.getManifest().getTitle() + '\n' + '\n' +

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/gameDetailsScreen/GameDetailsScreen.java
@@ -9,9 +9,8 @@ import org.joml.Vector2i;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.game.GameManifest;
 import org.terasology.engine.i18n.TranslationSystem;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.CoreScreenLayer;
@@ -21,7 +20,6 @@ import org.terasology.engine.rendering.nui.layers.mainMenu.SelectGameScreen;
 import org.terasology.engine.rendering.nui.layers.mainMenu.moduleDetailsScreen.ModuleDetailsScreen;
 import org.terasology.engine.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.engine.utilities.time.DateTimeHelper;
-import org.terasology.engine.world.generator.internal.WorldGeneratorInfo;
 import org.terasology.engine.world.generator.internal.WorldGeneratorManager;
 import org.terasology.engine.world.internal.WorldInfo;
 import org.terasology.gestalt.assets.ResourceUrn;
@@ -392,28 +390,18 @@ public class GameDetailsScreen extends CoreScreenLayer {
     }
 
     private String getGeneralInfo(final GameInfo theGameInfo) {
-        WorldInfo mainWorld = theGameInfo.getManifest().getWorldInfo(TerasologyConstants.MAIN_WORLD);
-        String display;
-        if (mainWorld == null) {
-            display = "ERROR: no main world";
-        } else {
-            SimpleUri name = mainWorld.getWorldGenerator();
-            display = "ERROR: generator " + name + " not found";
-            WorldGeneratorInfo wgi = worldGeneratorManager.getWorldGeneratorInfo(name);
-            if (wgi != null) {
-                display = wgi.getDisplayName();
-            }
-        }
+        GameManifest manifest = theGameInfo.getManifest();
+
         return translationSystem.translate("${engine:menu#game-details-game-title} ")
-                + theGameInfo.getManifest().getTitle() + '\n' + '\n' +
+                + manifest.getTitle() + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-last-play}: ")
                 + DATE_FORMAT.format(theGameInfo.getTimestamp()) + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-game-duration} ")
-                + DateTimeHelper.getDeltaBetweenTimestamps(new Date(0).getTime(), theGameInfo.getManifest().getTime()) + '\n' + '\n' +
+                + DateTimeHelper.getDeltaBetweenTimestamps(new Date(0).getTime(), manifest.getTime()) + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-game-seed} ")
-                + theGameInfo.getManifest().getSeed() + '\n' + '\n' +
+                + manifest.getSeed() + '\n' + '\n' +
                 translationSystem.translate("${engine:menu#game-details-world-generator}: ") + '\t'
-                + display;
+                + manifest.mainWorldDisplayName(worldGeneratorManager);
     }
 
     private void loadGameWorlds() {

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/savedGames/GameInfo.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/savedGames/GameInfo.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.nui.layers.mainMenu.savedGames;
 
@@ -9,6 +9,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Contains information about saved game.
  */
@@ -17,11 +19,11 @@ public class GameInfo {
     private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     private Date timestamp;
-    private GameManifest manifest;
+    private final GameManifest manifest;
     private Path savePath;
 
     public GameInfo(GameManifest manifest, Date timestamp, Path savePath) {
-        this.manifest = manifest;
+        this.manifest = checkNotNull(manifest, "manifest");
         this.timestamp = timestamp;
         this.savePath = savePath;
     }


### PR DESCRIPTION
Fixes #4912

### Notes for Reviewers

The `mainWorldDisplayName` method I factored out to `GameManifest` is very much a "view" type of method, given the way it returns error strings. I'd accept suggestions of other places to put it. Especially if that place had dependency injection support so the caller doesn't have to explicitly pass WorldGeneratorManager.

### How to test

Edit the `manifest.json` of one of your save files so the `worlds` entry is the empty set: `"worlds": {},`

Start Terasology and go to the game loading screen, make sure that doesn't crash.
Hit the "Details" button, make sure that doesn't crash.

If you proceed to try to actually load the game, _that_ will crash (we can only do so much with a broken save!). Hopefully with a relevant error message.