### PR TITLE
fix(test): set jacoco excludes for engine-test's unitTest and integrationTest tasks

### DIFF
--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -66,6 +66,7 @@ test {
         dependsOn rootProject.extractNatives
     }
 
+    // Keep in sync with other exclude-lists for Jacoco, e.g., in 'engine-tests/build.gradle' 
     jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -66,14 +66,11 @@ test {
         dependsOn rootProject.extractNatives
     }
 
-    jacoco {
-        excludes = ["org.terasology.protobuf.*",
-                    "*MethodAccess","*FieldAccess"]
-    }
+    jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.8"
 }
 
 jacocoTestReport {

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -108,6 +108,7 @@ task unitTest(type: Test) {
     }
     systemProperty("junit.jupiter.execution.timeout.default", "1m")
 
+    // Keep in sync with other exclude-lists for Jacoco, e.g., in 'common.gradle' 
     jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -107,6 +107,8 @@ task unitTest(type: Test) {
         excludeTags "MteTest", "TteTest"
     }
     systemProperty("junit.jupiter.execution.timeout.default", "1m")
+
+    jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 
 task integrationTest(type: Test) {
@@ -121,6 +123,8 @@ task integrationTest(type: Test) {
         includeTags "MteTest", "TteTest"
     }
     systemProperty("junit.jupiter.execution.timeout.default", "5m")
+
+    jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 
 idea {


### PR DESCRIPTION
upgrade to jacoco 0.8.8 (from 0.8.5)

relates to #4985

### How to test

Run integrationTest and unitTest

Run jacocoTestReport

check to see if test output contains loads of messages about IllegalClassFormat

### It Would Be Nice If

It would be good to have less configuration duplication. The excludes-list is set in several places,
and there are probably places that need it but don't have it yet. (module tests? subsystem tests?)