### PR TITLE
fix(ChunkProcessingPipeline): base thread pool size on available processors

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.google.common.primitives.Ints.constrainToRange;
+
 /**
  * Manages execution of chunk processing.
  * <p>
@@ -41,8 +43,9 @@ import java.util.function.Supplier;
  */
 public class ChunkProcessingPipeline {
 
-    private static final int NUM_TASK_THREADS = Math.min(
-            Math.max(1, Runtime.getRuntime().availableProcessors() - 1), 8);
+    @SuppressWarnings("UnstableApiUsage")
+    private static final int NUM_TASK_THREADS = constrainToRange(
+            Runtime.getRuntime().availableProcessors() - 1, 1, 8);
     private static final Logger logger = LoggerFactory.getLogger(ChunkProcessingPipeline.class);
 
     private final List<ChunkTaskProvider> stages = Lists.newArrayList();

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.world.chunks.pipeline;
@@ -41,7 +41,8 @@ import java.util.function.Supplier;
  */
 public class ChunkProcessingPipeline {
 
-    private static final int NUM_TASK_THREADS = 4;
+    private static final int NUM_TASK_THREADS = Math.min(
+            Math.max(1, Runtime.getRuntime().availableProcessors() - 1), 8);
     private static final Logger logger = LoggerFactory.getLogger(ChunkProcessingPipeline.class);
 
     private final List<ChunkTaskProvider> stages = Lists.newArrayList();
@@ -71,6 +72,7 @@ public class ChunkProcessingPipeline {
                 return new PositionFuture<>(newTaskFor, ((PositionalCallable) callable).getPosition());
             }
         };
+        logger.debug("allocated {} threads", NUM_TASK_THREADS);
         chunkProcessor = new ExecutorCompletionService<>(executor,
                 new PriorityBlockingQueue<>(800, comparable));
         reactor = new Thread(this::chunkTaskHandler);


### PR DESCRIPTION
This is the sort of thing I wanted to fix by moving everything to consistent use of a reactor Scheduler. But it's causing test failures now: the test runner with 1.9 CPUs can't handle running 4 chunk generation threads plus the main loop and the overhead of having them all report to the jacoco monitor.

(it was managing about 2 chunks/second, blocking #5010)

### How to test

Play game, see if chunk generation is at least as fast as it was.