### PR TITLE
feat: bgfx backend primatives for Mesh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ dependencies {
         natives "org.lwjgl:lwjgl-openal::$it"
         natives "org.lwjgl:lwjgl-opengl::$it"
         natives "org.lwjgl:lwjgl-stb::$it"
+        natives "org.lwjgl:lwjgl-bgfx::$it"
     }
 
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -98,13 +98,15 @@ dependencies {
     api "org.lwjgl:lwjgl-glfw"
     implementation "org.lwjgl:lwjgl-openal"
     api "org.lwjgl:lwjgl-opengl"
+    api "org.lwjgl:lwjgl-bgfx"
+
     implementation "org.lwjgl:lwjgl-stb"
 
     implementation 'io.micrometer:micrometer-core:1.8.0'
     implementation 'io.micrometer:micrometer-registry-jmx:1.8.0'
     api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.14'
     api group: 'io.projectreactor.addons', name: 'reactor-extra', version: '3.4.6'
-    
+
     api group: 'org.joml', name: 'joml', version: '1.10.0'
     api group: 'org.terasology.joml-ext', name: 'joml-geometry', version: '0.1.0'
 

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/StandardMeshData.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/StandardMeshData.java
@@ -7,6 +7,7 @@ import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
+import org.lwjgl.bgfx.BGFX;
 import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
 import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.assets.mesh.resource.GLAttributes;
@@ -18,12 +19,12 @@ import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 
 public class StandardMeshData extends MeshData {
-    public static final int VERTEX_INDEX = 0;
-    public static final int NORMAL_INDEX = 1;
-    public static final int UV0_INDEX = 2;
-    public static final int UV1_INDEX = 3;
-    public static final int COLOR0_INDEX = 4;
-    public static final int LIGHT0_INDEX = 5;
+    public static final VertexResource.VertexLocation VERTEX_INDEX = new VertexResource.VertexLocation(0, BGFX.BGFX_ATTRIB_POSITION);
+    public static final VertexResource.VertexLocation NORMAL_INDEX = new VertexResource.VertexLocation(1, BGFX.BGFX_ATTRIB_NORMAL);
+    public static final VertexResource.VertexLocation UV0_INDEX = new VertexResource.VertexLocation(2, BGFX.BGFX_ATTRIB_TEXCOORD0);
+    public static final VertexResource.VertexLocation UV1_INDEX = new VertexResource.VertexLocation(3, BGFX.BGFX_ATTRIB_TEXCOORD1);
+    public static final VertexResource.VertexLocation COLOR0_INDEX = new VertexResource.VertexLocation(4, BGFX.BGFX_ATTRIB_COLOR0);
+    public static final VertexResource.VertexLocation LIGHT0_INDEX = new VertexResource.VertexLocation(5, BGFX.BGFX_ATTRIB_TEXCOORD2);
 
     public final VertexResource positionBuffer;
     public final VertexAttributeBinding<Vector3fc, Vector3f> position;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/TypeMapping.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/TypeMapping.java
@@ -5,17 +5,23 @@ package org.terasology.engine.rendering.assets.mesh.resource;
 
 import org.lwjgl.opengl.GL30;
 
+import static org.lwjgl.bgfx.BGFX.BGFX_ATTRIB_TYPE_FLOAT;
+import static org.lwjgl.bgfx.BGFX.BGFX_ATTRIB_TYPE_INT16;
+import static org.lwjgl.bgfx.BGFX.BGFX_ATTRIB_TYPE_UINT8;
+
 public enum TypeMapping {
-    ATTR_FLOAT(Float.BYTES, GL30.GL_FLOAT),
-    ATTR_SHORT(Short.BYTES, GL30.GL_SHORT),
-    ATTR_BYTE(Byte.BYTES, GL30.GL_BYTE),
-    ATTR_INT(Integer.BYTES, GL30.GL_INT);
+    ATTR_FLOAT(Float.BYTES, GL30.GL_FLOAT, BGFX_ATTRIB_TYPE_FLOAT),
+    ATTR_SHORT(Short.BYTES, GL30.GL_SHORT, BGFX_ATTRIB_TYPE_INT16),
+    ATTR_BYTE(Byte.BYTES, GL30.GL_BYTE, BGFX_ATTRIB_TYPE_UINT8),
+    ATTR_INT(Integer.BYTES, GL30.GL_INT, BGFX_ATTRIB_TYPE_FLOAT);
 
     public final int size;
     public final int glType;
+    public final int bgfxType;
 
-    TypeMapping(int size, int glType) {
+    TypeMapping(int size, int glType, int bgfxType) {
         this.size = size;
         this.glType = glType;
+        this.bgfxType = bgfxType;
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexResource.java
@@ -98,15 +98,24 @@ public class VertexResource extends BufferedResource {
         return inSize == 0;
     }
 
+    public static class VertexLocation {
+        public final int glLocation;
+        public final int bgfxLocation;
+        public VertexLocation(int glLocation, int bgfxLocation) {
+            this.glLocation = glLocation;
+            this.bgfxLocation = bgfxLocation;
+        }
+    }
+
     /**
      * describes the metadata and placement into the buffer based off the stride.
      */
     public static class VertexDefinition {
-        public final int location;
+        public final VertexLocation location;
         public final BaseVertexAttribute attribute;
         public final int offset;
 
-        public VertexDefinition(int location, int offset, BaseVertexAttribute attribute) {
+        public VertexDefinition(VertexLocation location, int offset, BaseVertexAttribute attribute) {
             this.location = location;
             this.attribute = attribute;
             this.offset = offset;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexResourceBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/resource/VertexResourceBuilder.java
@@ -25,35 +25,35 @@ public class VertexResourceBuilder {
      * @param <T> the target object type
      * @param <I> a class implementing the target object type
      */
-    public <T, I extends T> VertexAttributeBinding<T, I> add(int location, VertexAttribute<T, I> attribute) {
+    public <T, I extends T> VertexAttributeBinding<T, I> add(VertexResource.VertexLocation location, VertexAttribute<T, I> attribute) {
         VertexAttributeBinding<T, I> result = new VertexAttributeBinding<T, I>(resource, inStride, attribute);
         this.definitions.add(new VertexResource.VertexDefinition(location, inStride, attribute));
         inStride += attribute.mapping.size * attribute.count;
         return result;
     }
 
-    public VertexIntegerAttributeBinding add(int location, VertexIntegerAttribute attribute) {
+    public VertexIntegerAttributeBinding add(VertexResource.VertexLocation location, VertexIntegerAttribute attribute) {
         VertexIntegerAttributeBinding result = new VertexIntegerAttributeBinding(resource, inStride, attribute);
         this.definitions.add(new VertexResource.VertexDefinition(location, inStride, attribute));
         inStride += attribute.mapping.size * attribute.count;
         return result;
     }
 
-    public VertexFloatAttributeBinding add(int location, VertexFloatAttribute attribute) {
+    public VertexFloatAttributeBinding add(VertexResource.VertexLocation location, VertexFloatAttribute attribute) {
         VertexFloatAttributeBinding result = new VertexFloatAttributeBinding(resource, inStride, attribute);
         this.definitions.add(new VertexResource.VertexDefinition(location, inStride, attribute));
         inStride += attribute.mapping.size * attribute.count;
         return result;
     }
 
-    public VertexByteAttributeBinding add(int location, VertexByteAttribute attribute) {
+    public VertexByteAttributeBinding add(VertexResource.VertexLocation location, VertexByteAttribute attribute) {
         VertexByteAttributeBinding result = new VertexByteAttributeBinding(resource, inStride, attribute);
         this.definitions.add(new VertexResource.VertexDefinition(location, inStride, attribute));
         inStride += attribute.mapping.size * attribute.count;
         return result;
     }
 
-    public VertexShortAttributeBinding add(int location, VertexShortAttribute attribute) {
+    public VertexShortAttributeBinding add(VertexResource.VertexLocation location, VertexShortAttribute attribute) {
         VertexShortAttributeBinding result = new VertexShortAttributeBinding(resource, inStride, attribute);
         this.definitions.add(new VertexResource.VertexDefinition(location, inStride, attribute));
         inStride += attribute.mapping.size * attribute.count;

--- a/engine/src/main/java/org/terasology/engine/rendering/bgfx/BGFXMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/bgfx/BGFXMesh.java
@@ -1,0 +1,93 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.bgfx;
+
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.lwjgl.bgfx.BGFX;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.rendering.assets.mesh.Mesh;
+import org.terasology.engine.rendering.assets.mesh.MeshData;
+import org.terasology.engine.rendering.assets.mesh.resource.AllocationType;
+import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexAttributeBinding;
+import org.terasology.gestalt.assets.AssetType;
+import org.terasology.gestalt.assets.DisposableResource;
+import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.joml.geom.AABBf;
+import org.terasology.joml.geom.AABBfc;
+
+import java.util.Optional;
+
+public class BGFXMesh extends Mesh implements BGFXMeshBase {
+    private static final Logger logger = LoggerFactory.getLogger(BGFXMesh.class);
+
+    private AABBf aabb = new AABBf();
+
+    private int indexCount;
+    private final DisposableAction disposalAction;
+
+    private DrawingMode drawMode;
+
+    private AllocationType allocationType;
+
+    private VertexAttributeBinding<Vector3fc, Vector3f> positions;
+
+
+    protected BGFXMesh(ResourceUrn urn, AssetType<?, MeshData> assetType, DisposableAction disposableAction) {
+        super(urn, assetType, disposableAction);
+        this.disposalAction = disposableAction;
+    }
+
+    @Override
+    public AABBfc getAABB() {
+        return aabb;
+    }
+
+    @Override
+    public VertexAttributeBinding<Vector3fc, Vector3f> vertices() {
+        return positions;
+    }
+
+    @Override
+    public int elementCount() {
+        return positions.elements();
+    }
+
+    @Override
+    public void render() {
+        disposalAction.resource.ifPresent((data) -> {
+            for (int i = 0; i < data.vertex.length; i++) {
+                BGFX.bgfx_set_vertex_buffer(i, data.vertex[i].bufferId, 0, 0);
+            }
+        });
+    }
+
+
+    @Override
+    protected void doReload(MeshData data) {
+        positions = data.positions();
+        disposalAction.setVertexResource(buildBGFXResource(data.vertexResources()));
+    }
+
+    private static class DisposableAction implements DisposableResource {
+        public Optional<BGFXResource> resource = Optional.empty();
+
+        DisposableAction() {
+
+        }
+
+        public void setVertexResource(BGFXResource data) {
+            resource.ifPresent(BGFXResource::free);
+            resource = Optional.of(data);
+        }
+
+        @Override
+        public void close() {
+            resource.ifPresent(BGFXResource::free);
+            resource = Optional.empty();
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/bgfx/BGFXMeshBase.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/bgfx/BGFXMeshBase.java
@@ -1,0 +1,66 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.bgfx;
+
+import org.lwjgl.bgfx.BGFX;
+import org.lwjgl.bgfx.BGFXMemory;
+import org.lwjgl.bgfx.BGFXVertexLayout;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
+
+import java.nio.ByteBuffer;
+
+
+
+public interface BGFXMeshBase {
+
+    default BGFXResource buildBGFXResource(VertexResource[] resources) {
+        BGFXResource state = new BGFXResource();
+        state.vertex = new BGFXResource.BGFXVertexItem[resources.length];
+        for (int i = 0; i < resources.length; i++) {
+            if (resources[i].inSize() == 0) {
+                continue;
+            }
+            var bgfxResource = new BGFXResource.BGFXVertexItem();
+            resources[i].writeBuffer((buffer) -> {
+                bgfxResource.buffer = buffer;
+                bgfxResource.memory = BGFX.bgfx_make_ref(buffer);
+            });
+            BGFXVertexLayout layout = BGFXVertexLayout.calloc();
+            BGFX.bgfx_vertex_layout_begin(layout, -1);
+            for (VertexResource.VertexDefinition attribute : resources[i].definitions()) {
+                BGFX.bgfx_vertex_layout_add(layout, attribute.location.bgfxLocation,
+                        attribute.attribute.count,
+                        attribute.attribute.mapping.size, false, false);
+            }
+            BGFX.bgfx_vertex_layout_end(layout);
+            bgfxResource.bufferId = BGFX.bgfx_create_vertex_buffer(bgfxResource.memory, layout, BGFX.BGFX_BUFFER_NONE);
+            bgfxResource.layout = layout;
+            bgfxResource.resource = resources[i];
+            state.vertex[i] = bgfxResource;
+        }
+        return state;
+    }
+
+    class BGFXResource {
+        public BGFXVertexItem[] vertex;
+
+        public static class BGFXVertexItem {
+            public ByteBuffer buffer = null;
+            public BGFXMemory memory = null;
+            public BGFXVertexLayout layout = null;
+            public VertexResource resource = null;
+            public short bufferId = -1;
+        }
+
+        public void free() {
+            for (var en : vertex) {
+                if (en != null) {
+                    en.layout.free();
+                    en.memory.free();
+                    en.layout.free();
+                }
+            }
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/bgfx/BGFXResource.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/bgfx/BGFXResource.java
@@ -1,0 +1,39 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.rendering.bgfx;
+
+import org.lwjgl.bgfx.BGFXMemory;
+import org.lwjgl.bgfx.BGFXVertexLayout;
+import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
+import org.terasology.gestalt.assets.DisposableResource;
+
+import java.nio.ByteBuffer;
+
+public class BGFXResource implements DisposableResource {
+
+    public BGFXVertexItem[] vertex;
+
+    @Override
+    public void close() {
+
+    }
+
+    public static class BGFXVertexItem {
+        public ByteBuffer buffer = null;
+        public BGFXMemory memory = null;
+        public BGFXVertexLayout layout = null;
+        public VertexResource resource = null;
+        public short bufferId = -1;
+    }
+
+    public void free() {
+        for (var en : vertex) {
+            if (en != null) {
+                en.layout.free();
+                en.memory.free();
+                en.layout.free();
+            }
+        }
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMeshBase.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLMeshBase.java
@@ -56,8 +56,8 @@ public interface OpenGLMeshBase {
                 GL30.glBufferSubData(GL30.GL_ARRAY_BUFFER, currentOffset, buffer);
             });
             for (VertexResource.VertexDefinition attribute : resource.definitions()) {
-                GL30.glEnableVertexAttribArray(attribute.location);
-                GL30.glVertexAttribPointer(attribute.location, attribute.attribute.count,
+                GL30.glEnableVertexAttribArray(attribute.location.glLocation);
+                GL30.glVertexAttribPointer(attribute.location.glLocation, attribute.attribute.count,
                         attribute.attribute.mapping.glType, false, resource.inStride(), offset + attribute.offset);
             }
             offset += resource.inSize();

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLSkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/OpenGLSkeletalMesh.java
@@ -79,16 +79,16 @@ public class OpenGLSkeletalMesh extends SkeletalMesh {
                 GL30.glBindVertexArray(this.disposalAction.vao);
                 GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, this.disposalAction.vbo);
 
-                GL30.glEnableVertexAttribArray(StandardMeshData.VERTEX_INDEX);
-                GL30.glVertexAttribPointer(StandardMeshData.VERTEX_INDEX, 3, GL30.GL_FLOAT, false,
+                GL30.glEnableVertexAttribArray(StandardMeshData.VERTEX_INDEX.glLocation);
+                GL30.glVertexAttribPointer(StandardMeshData.VERTEX_INDEX.glLocation, 3, GL30.GL_FLOAT, false,
                         VERTEX_NORMAL_SIZE, 0);
 
-                GL30.glEnableVertexAttribArray(StandardMeshData.NORMAL_INDEX);
-                GL30.glVertexAttribPointer(StandardMeshData.NORMAL_INDEX, 3, GL30.GL_FLOAT, false,
+                GL30.glEnableVertexAttribArray(StandardMeshData.NORMAL_INDEX.glLocation);
+                GL30.glVertexAttribPointer(StandardMeshData.NORMAL_INDEX.glLocation, 3, GL30.GL_FLOAT, false,
                         VERTEX_NORMAL_SIZE, VERTEX_SIZE);
 
-                GL30.glEnableVertexAttribArray(StandardMeshData.UV0_INDEX);
-                GL30.glVertexAttribPointer(StandardMeshData.UV0_INDEX, 2, GL30.GL_FLOAT, false,
+                GL30.glEnableVertexAttribArray(StandardMeshData.UV0_INDEX.glLocation);
+                GL30.glVertexAttribPointer(StandardMeshData.UV0_INDEX.glLocation, 2, GL30.GL_FLOAT, false,
                         UV_SIZE, (long) VERTEX_NORMAL_SIZE * newData.getVertexCount());
 
                 int payloadSize = (UV_SIZE + VERTEX_SIZE + NORMAL_SIZE) * newData.getVertexCount();


### PR DESCRIPTION
I think it makes a lot of sense to take advantage of bgfx. a lot of the complex interactions for the graphics api can be simplified going this way. the vertex abstraction is table driven so its not too much to add more entries to the table to support another backend. probably a significantly harder problem to do the same for a lot of the other abstractions since they are highly coupled. 

This can be a gradual process of supporting more of these primitives and keeping everything going without significantly impacting the current gameplay. just means revisiting these older systems and building a cleaner interface.  

https://github.com/bkaradzic/bgfx
