### PR TITLE
fix(Context)!: correct signature of Context.get

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/registry/CoreRegistryTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/registry/CoreRegistryTest.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.registry;
@@ -82,7 +82,7 @@ public class CoreRegistryTest {
         private final Map<Class<?>, Object> map = Maps.newConcurrentMap();
 
         @Override
-        public <T> T get(Class<? extends T> type) {
+        public <T> T get(Class<T> type) {
             T result = type.cast(map.get(type));
             if (result != null) {
                 return result;

--- a/engine/src/main/java/org/terasology/engine/context/Context.java
+++ b/engine/src/main/java/org/terasology/engine/context/Context.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.context;
 
@@ -23,7 +23,7 @@ public interface Context {
     /**
      * @return the object that is known in this context for this type.
      */
-    <T> T get(Class<? extends T> type);
+    <T> T get(Class<T> type);
 
     /**
      * Makes the object known in this context to be the object to work with for the given type.

--- a/engine/src/main/java/org/terasology/engine/context/Context.java
+++ b/engine/src/main/java/org/terasology/engine/context/Context.java
@@ -4,6 +4,9 @@ package org.terasology.engine.context;
 
 import org.terasology.gestalt.module.sandbox.API;
 
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
 /**
  * Provides classes with the utility objects that belong to the context they are running in.
  *
@@ -21,9 +24,31 @@ import org.terasology.gestalt.module.sandbox.API;
 public interface Context {
 
     /**
-     * @return the object that is known in this context for this type.
+     * Get the object that is known in this context for this type.
      */
     <T> T get(Class<T> type);
+
+    /**
+     * Get the object that is known in this context for this type. Never null.
+     *
+     * @throws NoSuchElementException No instance was registered with that type.
+     */
+    @SuppressWarnings("unused")
+    default <T> T getValue(Class<T> type) {
+        T value = get(type);
+        if (value == null) {
+            throw new NoSuchElementException(type.toString());
+        }
+        return value;
+    }
+
+    /**
+     * Get the object that is known in this context for this type.
+     */
+    @SuppressWarnings("unused")
+    default <T> Optional<T> getMaybe(Class<T> type) {
+        return Optional.ofNullable(get(type));
+    }
 
     /**
      * Makes the object known in this context to be the object to work with for the given type.

--- a/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
+++ b/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.context.internal;
 
@@ -30,7 +30,7 @@ public class ContextImpl implements Context {
     }
 
     @Override
-    public <T> T get(Class<? extends T> type) {
+    public <T> T get(Class<T> type) {
         if (type == Context.class) {
             return type.cast(this);
         }

--- a/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
+++ b/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class ContextImpl implements Context {
     private final Context parent;
 
-    private final Map<Class<? extends Object>, Object> map = Maps.newConcurrentMap();
+    private final Map<Class<?>, Object> map = Maps.newConcurrentMap();
 
 
     /**
@@ -41,7 +41,7 @@ public class ContextImpl implements Context {
         if (parent != null) {
             return parent.get(type);
         }
-        return result;
+        return null;
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/context/internal/MockContext.java
+++ b/engine/src/main/java/org/terasology/engine/context/internal/MockContext.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.context.internal;
 
@@ -6,7 +6,7 @@ import org.terasology.engine.context.Context;
 
 public class MockContext implements Context {
     @Override
-    public <T> T get(Class<? extends T> type) {
+    public <T> T get(Class<T> type) {
         return null;
     }
 


### PR DESCRIPTION
T get(Class<? extends T> type) would mean that `type` could be a subclass of the return value.
e.g. returning a Number when asked for a Float.

That's the opposite of what we wanted!

Might break binary compatibility and trigger a lot of recompiling. I don't expect it to break source compatibility with any current code.

**Also:** 
feat(Context): add non-null and Optional get methods