### PR TITLE
build: extract project metrics/analytics to terasology-metrics gradle plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ pipeline {
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tools: [
-                            spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true),
+                            spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true),
                             pmdParser(pattern: '**/build/reports/pmd/*.xml')
                         ])
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 import java.net.URI
@@ -10,6 +10,7 @@ plugins {
 repositories {
     mavenCentral()
     google()  // gestalt uses an annotation package by Google
+    gradlePluginPortal()
 
     maven {
         name = "Terasology Artifactory"
@@ -39,6 +40,10 @@ dependencies {
 
     // for inspecting modules
     implementation("org.terasology.gestalt:gestalt-module:7.1.0")
+
+    // plugins we configure
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:4.8.0")  // TODO: upgrade with gradle 7.x
+    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
 
     api(kotlin("test"))
 }

--- a/build-logic/src/main/kotlin/facade.gradle.kts
+++ b/build-logic/src/main/kotlin/facade.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 import org.terasology.gradology.JAR_COLLECTION
@@ -6,6 +6,7 @@ import org.terasology.gradology.namedAttribute
 
 plugins {
     application
+    id("terasology-common")
 }
 
 val dirNatives: String by rootProject.extra

--- a/build-logic/src/main/kotlin/terasology-common.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-common.gradle.kts
@@ -1,0 +1,7 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+plugins {
+    id("terasology-repositories")
+    id("terasology-metrics")
+}

--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -7,7 +7,6 @@ import com.github.spotbugs.snom.SpotBugsTask
 plugins {
     java
     checkstyle
-    jacoco
     pmd
     `project-report`
     id("com.github.spotbugs")
@@ -17,17 +16,6 @@ plugins {
 dependencies {
     "pmd"("net.sourceforge.pmd:pmd-core:6.15.0")
     "pmd"("net.sourceforge.pmd:pmd-java:6.15.0")
-}
-
-the<JacocoPluginExtension>().toolVersion = "0.8.8"
-
-tasks.withType<JacocoReport> {
-    // TODO: does this need explicit `dependsOn`?
-    reports {
-        csv.isEnabled = false
-        html.isEnabled = true
-        xml.isEnabled = true
-    }
 }
 
 tasks.withType<Test> {
@@ -45,10 +33,6 @@ tasks.withType<Test> {
     // Make sure the natives have been extracted, but only for multi-workspace setups (not for solo module builds)
     if (project.name != project(":").name) {
         dependsOn(tasks.getByPath(":extractNatives"))
-    }
-
-    configure<JacocoTaskExtension> {
-        excludes = listOf("org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess")
     }
 }
 

--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -1,0 +1,85 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import com.github.spotbugs.snom.SpotBugsExtension
+import com.github.spotbugs.snom.SpotBugsTask
+
+plugins {
+    java
+    checkstyle
+    jacoco
+    pmd
+    `project-report`
+    id("com.github.spotbugs")
+    id("org.sonarqube")
+}
+
+dependencies {
+    "pmd"("net.sourceforge.pmd:pmd-core:6.15.0")
+    "pmd"("net.sourceforge.pmd:pmd-java:6.15.0")
+}
+
+the<JacocoPluginExtension>().toolVersion = "0.8.8"
+
+tasks.withType<JacocoReport> {
+    // TODO: does this need explicit `dependsOn`?
+    reports {
+        csv.isEnabled = false
+        html.isEnabled = true
+        xml.isEnabled = true
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+
+    // ignoreFailures: Specifies whether the build should break when the verifications performed by this task fail.
+    ignoreFailures = true
+    // showStandardStreams: makes the standard streams (err and out) visible at console when running tests
+    testLogging.showStandardStreams = true
+    reports {
+        junitXml.isEnabled = true
+    }
+    jvmArgs("-Xms512m", "-Xmx1024m")
+
+    // Make sure the natives have been extracted, but only for multi-workspace setups (not for solo module builds)
+    if (project.name != project(":").name) {
+        dependsOn(tasks.getByPath(":extractNatives"))
+    }
+
+    configure<JacocoTaskExtension> {
+        excludes = listOf("org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess")
+    }
+}
+
+// The config files here work in both a multi-project workspace (IDEs, running from source) and for solo module builds
+// Solo module builds in Jenkins get a copy of the config dir from the engine harness so it still lives at root/config
+// TODO: Maybe update other projects like modules to pull the zipped dependency so fewer quirks are needed in Jenkins
+configure<CheckstyleExtension> {
+    isIgnoreFailures = false
+
+    val checkstyleDir = rootDir.resolve("config/metrics/checkstyle")
+    configDirectory.set(checkstyleDir)
+    setConfigProperties("samedir" to checkstyleDir)
+}
+
+configure<PmdExtension> {
+    isIgnoreFailures = true
+    ruleSetFiles = files(rootDir.resolve("config/metrics/pmd/pmd.xml"))
+    // By default, gradle uses both ruleset file AND the rulesets. Override the ruleSets to use only those from the file
+    ruleSets = listOf()
+}
+
+configure<SpotBugsExtension> {
+    // The version of the spotbugs tool https://github.com/spotbugs/spotbugs
+    // not necessarily the same as the version of spotbugs-gradle-plugin
+    toolVersion.set("4.7.0")
+    ignoreFailures.set(true)
+    excludeFilter.set(file(rootDir.resolve("config/metrics/findbugs/findbugs-exclude.xml")))
+}
+
+tasks.named<SpotBugsTask>("spotbugsMain") {
+    reports.register("xml") {
+        enabled = true
+    }
+}

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     `java-library`
     idea
     eclipse
+    id("terasology-metrics")
 }
 
 val moduleMetadata = ModuleMetadataForGradle.forProject(project)

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // Simple build file for modules - the one under the Core module is the template, will be copied as needed to modules
@@ -11,7 +11,7 @@ plugins {
     `java-library`
     idea
     eclipse
-    id("terasology-metrics")
+    id("terasology-common")
 }
 
 val moduleMetadata = ModuleMetadataForGradle.forProject(project)

--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,6 @@ buildscript {
     }
 
     dependencies {
-        //Spotbugs
-        classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.0"
-
-        // SonarQube / Cloud scanning
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8"
-
         // Protobuf plugin
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.16'
 
@@ -51,6 +45,10 @@ plugins {
     id "idea"
     // For the "Build and run using: Intellij IDEA | Gradle" switch
     id "org.jetbrains.gradle.plugin.idea-ext" version "1.0"
+
+    // Things applied by terasology-metrics
+    id("com.github.spotbugs") version "4.8.0" apply false // TODO: upgrade with gradle 7.x
+    id("org.sonarqube") version "3.3" apply false
 
     id("terasology-repositories")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,6 @@ buildscript {
     }
 
     dependencies {
-        // Protobuf plugin
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.16'
-
         // Our locally included /build-logic
         classpath("org.terasology.gradology:build-logic")
     }
@@ -46,10 +43,7 @@ plugins {
     // For the "Build and run using: Intellij IDEA | Gradle" switch
     id "org.jetbrains.gradle.plugin.idea-ext" version "1.0"
 
-    // Things applied by terasology-metrics
-    id("com.github.spotbugs") version "4.8.0" apply false // TODO: upgrade with gradle 7.x
-    id("org.sonarqube") version "3.3" apply false
-
+    id("com.google.protobuf") version "0.8.16" apply false
     id("terasology-repositories")
 }
 

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -8,14 +8,6 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 
-// Analytics
-apply plugin: 'project-report'
-apply plugin: 'checkstyle'
-apply plugin: 'pmd'
-apply plugin: 'com.github.spotbugs'
-apply plugin: 'jacoco'
-apply plugin: 'org.sonarqube'
-
 apply plugin: 'terasology-repositories'
 
 java {
@@ -26,12 +18,6 @@ javadoc.options.encoding = 'UTF-8'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
-}
-
-dependencies {
-    pmd('net.sourceforge.pmd:pmd-core:6.15.0')
-    pmd('net.sourceforge.pmd:pmd-java:6.15.0')
-    // the FindBugs version is set in the configuration
 }
 
 task sourceJar(type: Jar) {
@@ -45,76 +31,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     description = "Create a JAR with the JavaDoc for the java sources"
     from javadoc.destinationDir
     archiveClassifier = 'javadoc'
-}
-
-// Extra details provided for unit tests
-test {
-    useJUnitPlatform()
-
-    // ignoreFailures: Specifies whether the build should break when the verifications performed by this task fail.
-    ignoreFailures = true
-    // showStandardStreams: makes the standard streams (err and out) visible at console when running tests
-    testLogging.showStandardStreams = true
-    reports {
-        junitXml.enabled = true
-    }
-    // Arguments to include while running tests
-    jvmArgs '-Xms512m', '-Xmx1024m'
-
-    // Make sure the natives have been extracted, but only for multi-workspace setups (not for solo module builds)
-    if (project.name != project(':').name) {
-        dependsOn rootProject.extractNatives
-    }
-
-    // Keep in sync with other exclude-lists for Jacoco, e.g., in 'engine-tests/build.gradle' 
-    jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
-}
-
-jacoco {
-    toolVersion = "0.8.8"
-}
-
-jacocoTestReport {
-    dependsOn test // Despite doc saying this should be automatic we need to explicitly add it anyway :-(
-    reports {
-        // Used to be exec, but that had a binary incompatibility between JaCoCo 0.7.4 and 0.7.5 and issues with some plugins
-        xml.enabled true
-        csv.enabled false
-        html.enabled true
-    }
-}
-
-// The config files here work in both a multi-project workspace (IDEs, running from source) and for solo module builds
-// Solo module builds in Jenkins get a copy of the config dir from the engine harness so it still lives at root/config
-// TODO: Maybe update other projects like modules to pull the zipped dependency so fewer quirks are needed in Jenkins
-checkstyle {
-    ignoreFailures = false
-
-    def checkstyleDir = rootProject.file('config/metrics/checkstyle')
-    configDirectory = checkstyleDir
-    configProperties.samedir = checkstyleDir
-}
-
-pmd {
-    ignoreFailures = true
-    ruleSetFiles = files("$rootDir/config/metrics/pmd/pmd.xml")
-    // By default, gradle uses both ruleset file AND the rulesets. Override the ruleSets to use only those from the file
-    ruleSets = []
-}
-
-spotbugs {
-    toolVersion = '4.0.0'
-    ignoreFailures = true
-    excludeFilter = new File(rootDir, "config/metrics/findbugs/findbugs-exclude.xml")
-}
-
-spotbugsMain {
-    reports {
-        xml {
-            enabled = true
-            destination = file("$buildDir/reports/spotbugs/main/spotbugs.xml")
-        }
-    }
 }
 
 tasks.javadoc {

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -6,7 +6,7 @@
 plugins {
     id "java-library"
     id "org.jetbrains.gradle.plugin.idea-ext"
-    id "terasology-metrics"
+    id "terasology-common"
 }
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -6,6 +6,7 @@
 plugins {
     id "java-library"
     id "org.jetbrains.gradle.plugin.idea-ext"
+    id "terasology-metrics"
 }
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -108,9 +108,6 @@ task unitTest(type: Test) {
         excludeTags "MteTest", "TteTest"
     }
     systemProperty("junit.jupiter.execution.timeout.default", "1m")
-
-    // Keep in sync with other exclude-lists for Jacoco, e.g., in 'common.gradle' 
-    jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 
 task integrationTest(type: Test) {
@@ -125,8 +122,6 @@ task integrationTest(type: Test) {
         includeTags "MteTest", "TteTest"
     }
     systemProperty("junit.jupiter.execution.timeout.default", "5m")
-
-    jacoco.excludes = ["org.terasology.protobuf.*", "*MethodAccess", "*FieldAccess"]
 }
 
 idea {

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id "java-library"
     id "org.jetbrains.gradle.plugin.idea-ext"
     id "com.google.protobuf"
-    id "terasology-metrics"
+    id "terasology-common"
 }
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config, etc

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -6,9 +6,10 @@
 plugins {
     id "java-library"
     id "org.jetbrains.gradle.plugin.idea-ext"
+    id "com.google.protobuf"
+    id "terasology-metrics"
 }
 
-apply plugin: 'com.google.protobuf'
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config, etc
 apply from: "$rootDir/config/gradle/publish.gradle"
 

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -15,7 +15,6 @@ import kotlin.test.fail
 plugins {
     application
     id("terasology-dist")
-    id("terasology-metrics")
     id("facade")
 }
 

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // The PC facade is responsible for the primary distribution - a plain Java application runnable on PCs
@@ -15,6 +15,7 @@ import kotlin.test.fail
 plugins {
     application
     id("terasology-dist")
+    id("terasology-metrics")
     id("facade")
 }
 

--- a/subsystems/DiscordRPC/build.gradle.kts
+++ b/subsystems/DiscordRPC/build.gradle.kts
@@ -1,9 +1,10 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 plugins {
     java
     `java-library`
+    id("terasology-common")
 }
 
 apply(from = "$rootDir/config/gradle/common.gradle")

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -1,9 +1,10 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 plugins {
     java
     `java-library`
+    id("terasology-common")
 }
 
 apply(from = "$rootDir/config/gradle/publish.gradle")

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -1,14 +1,9 @@
 // Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-// Since SpotBugs and SonarQube in the legacy style have external dependencies we have to have this block here.
-// Alternatively we untangle and update the common.gradle / Kotlin Gradle plugin stuff or just remove these two
 buildscript {
     repositories {
         mavenCentral()
         google()
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
-        }
         maven {
             // required to provide runtime dependencies to build-logic.
             name = "Terasology Artifactory"
@@ -23,14 +18,6 @@ buildscript {
             url = "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
             allowInsecureProtocol = true  // 😱
         }
-    }
-
-    dependencies {
-        //Spotbugs
-        classpath("gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.0")
-
-        // SonarQube / Cloud scanning
-        classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8")
     }
 }
 


### PR DESCRIPTION
It didn't take long to run in to other parts of #4985; #5013 didn't include configuration for module builds.

That was happening in `common.gradle`, so it seemed like a good time to extract a chunk of that stuff to `build-logic`, in line with the other gradle plans of #4015.

Removes jacoco, because it wasn't even used by CI.

### For Reviewers

Most of the stuff from `common.gradle` went to `terasology-metrics.gradle.kts`. Except the jacoco parts, they were dropped.

It does look a little weird to have moved 80% of common.gradle, but some of the last things needed more investigation, so I decided to keep scope to the various checks.

### How to test

- run engine-tests locally: unitTest, integrationTest, test
- run subsystem tests locally: unitTest, test
- run module tests locally: unitTest, integrationTest, test
- run `check` locally for checkstyle and whatnot
- ~~run `clean jacocoReport`, make sure jacoco task depends on (and runs) the tests~~
- make sure CI has all expected reports for checkstyle, spotbugs, pmd, ~~jacoco~~

### Post-Merge
- Update ModuleJteConfig spotbugs path, as in https://github.com/MovingBlocks/ModuleJteConfig/commit/23a3cb61d79f4b99e907f2f8277a7b7636271e1b