### PR TITLE
feat(InjectionHelper): inject() returns the object for chaining

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/registry/InjectionHelperTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/registry/InjectionHelperTest.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.registry;
 
@@ -44,6 +44,7 @@ public class InjectionHelperTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testDefaultFieldInjection() {
         InjectionHelper.share(serviceA);
         InjectionHelper.share(serviceB);
@@ -57,6 +58,7 @@ public class InjectionHelperTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testInjectUnavailableObject() {
         InjectionHelper.share(serviceA);
         //  InjectionHelper.share(serviceB);

--- a/engine/src/main/java/org/terasology/engine/context/Context.java
+++ b/engine/src/main/java/org/terasology/engine/context/Context.java
@@ -37,7 +37,8 @@ public interface Context {
     default <T> T getValue(Class<T> type) {
         T value = get(type);
         if (value == null) {
-            throw new NoSuchElementException(type.toString());
+            throw new NoSuchElementException(
+                    String.format("%s has no %s", this, type.getName()));
         }
         return value;
     }

--- a/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
+++ b/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.context.internal;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 import org.terasology.engine.context.Context;
 
@@ -49,4 +50,11 @@ public class ContextImpl implements Context {
         map.put(type, object);
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("#", Integer.toHexString(hashCode()))
+                .add("parent", parent)
+                .toString();
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/registry/InjectionHelper.java
+++ b/engine/src/main/java/org/terasology/engine/registry/InjectionHelper.java
@@ -23,6 +23,17 @@ public final class InjectionHelper {
     private InjectionHelper() {
     }
 
+    /**
+     * Inject values from this context to annotated fields.
+     * <p>
+     * The injector looks for fields annotated with {@link In @In} and tries to set them by
+     * getting a value by looking up the field's type in the {@code context}.
+     * <p>
+     * If there is no matching value in the context, the field is silently skipped and left
+     * with its previous value.
+     *
+     * @return the input {@code object}, now with fields set
+     */
     public static <T> T inject(final T object, Context context) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             for (Field field : ReflectionUtils.getAllFields(object.getClass(), ReflectionUtils.withAnnotation(In.class))) {
@@ -42,6 +53,14 @@ public final class InjectionHelper {
         return object;
     }
 
+    /**
+     * Inject values from CoreRegistry to annotated fields.
+     *
+     * @deprecated CoreRegistry-based methods are deprecated in favor of the more thread-safe Context.
+     *
+     * @see #inject(Object, Context)
+     */
+    @Deprecated(since = "5.3.0", forRemoval = true)
     public static void inject(final Object object) {
         AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             for (Field field : ReflectionUtils.getAllFields(object.getClass(), ReflectionUtils.withAnnotation(In.class))) {

--- a/engine/src/main/java/org/terasology/engine/registry/InjectionHelper.java
+++ b/engine/src/main/java/org/terasology/engine/registry/InjectionHelper.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.registry;
 
@@ -23,8 +23,8 @@ public final class InjectionHelper {
     private InjectionHelper() {
     }
 
-    public static void inject(final Object object, Context context) {
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+    public static <T> T inject(final T object, Context context) {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             for (Field field : ReflectionUtils.getAllFields(object.getClass(), ReflectionUtils.withAnnotation(In.class))) {
                 Object value = context.get(field.getType());
                 if (value != null) {
@@ -39,6 +39,7 @@ public final class InjectionHelper {
 
             return null;
         });
+        return object;
     }
 
     public static void inject(final Object object) {


### PR DESCRIPTION
Allows doing things like 
```java
Foo x = inject(new Foo(), context);
```
compared to previously, when inject() was void:
```java
Foo x = new Foo();
inject(x, context);
```

Won't break any existing code.

Also includes some minor changes to ContextImpl error messages.
