### PR TITLE
fix(templates): replace perlin with simplex as the default override.cfg

### DIFF
--- a/templates/override.cfg
+++ b/templates/override.cfg
@@ -6,6 +6,6 @@
     "defaultGameplayModuleName": "CoreSampleGameplay"
   },
   "worldGeneration": {
-    "defaultGenerator": "CoreWorlds:facetedperlin"
+    "defaultGenerator": "CoreWorlds:facetedsimplex"
   }
 }


### PR DESCRIPTION
Follow-up from the removal of the perlin world type in https://github.com/Terasology/CoreWorlds/pull/44
