### PR TITLE
test: add info logs to help track down sporadic

### DIFF
--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -139,6 +139,9 @@ public class Engines {
         connectToHost(terasologyEngine, mainLoop);
         Context context = terasologyEngine.getState().getContext();
         context.put(ScreenGrabber.class, hostContext.get(ScreenGrabber.class));
+
+        logger.info("Created client: {}", terasologyEngine);
+
         return terasologyEngine.getState().getContext();
     }
 
@@ -282,6 +285,9 @@ public class Engines {
                 ));
             }
         }
+
+        logger.info("Created host: {}", terasologyEngine);
+
         return terasologyEngine;
     }
 

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.TerasologyEngine;
 import org.terasology.engine.core.modes.StateIngame;
@@ -17,15 +19,18 @@ import java.util.List;
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
 public class ClientConnectionTest {
+    private static final Logger logger = LoggerFactory.getLogger(ClientConnectionTest.class);
 
     @Test
     public void testClientConnection(ModuleTestingHelper helper) throws IOException {
         Context clientContext = helper.createClient();
         List<TerasologyEngine> engines = helper.getEngines();
         Assertions.assertEquals(2, engines.size());
+        logger.info("Engine 0 is {}", engines.get(0));
+        logger.info("Engine 1 is {}", engines.get(1));
         Assertions.assertAll(engines
                 .stream()
                 .map((engine) ->
-                        () -> Assertions.assertEquals(StateIngame.class, engine.getState().getClass())));
+                        () -> Assertions.assertEquals(StateIngame.class, engine.getState().getClass(), "Unexpected engine state: " + engine + " is in state " + engine.getState().toString())));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.integrationenvironment;
 
-import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.integrationenvironment;
 
+import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,8 +24,9 @@ public class ClientConnectionTest {
 
     @Test
     public void testClientConnection(ModuleTestingHelper helper) throws IOException {
-        Context clientContext = helper.createClient();
         List<TerasologyEngine> engines = helper.getEngines();
+        Context clientContext = helper.createClient();
+        engines = helper.getEngines();
         Assertions.assertEquals(2, engines.size());
         logger.info("Engine 0 is {}", engines.get(0));
         logger.info("Engine 1 is {}", engines.get(1));

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -31,6 +31,7 @@ public class ClientConnectionTest {
         Assertions.assertAll(engines
                 .stream()
                 .map((engine) ->
-                        () -> Assertions.assertEquals(StateIngame.class, engine.getState().getClass(), "Unexpected engine state: " + engine + " is in state " + engine.getState().toString())));
+                        () -> Assertions.assertEquals(StateIngame.class, engine.getState().getClass(),
+                                "Unexpected engine state: " + engine + " is in state " + engine.getState().toString())));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -24,9 +24,8 @@ public class ClientConnectionTest {
 
     @Test
     public void testClientConnection(ModuleTestingHelper helper) throws IOException {
-        List<TerasologyEngine> engines = helper.getEngines();
         Context clientContext = helper.createClient();
-        engines = helper.getEngines();
+        List<TerasologyEngine> engines = helper.getEngines();
         Assertions.assertEquals(2, engines.size());
         logger.info("Engine 0 is {}", engines.get(0));
         logger.info("Engine 1 is {}", engines.get(1));


### PR DESCRIPTION
We saw a sporadic test failure on `develop` builds recently (e.g., [develop/709](https://jenkins.terasology.io/teraorg/blue/organizations/jenkins/Terasology%2Fengine/detail/develop/709/tests/) a0c6606).

```
org.opentest4j.MultipleFailuresError: Multiple Failures (1 failure)
    org.opentest4j.AssertionFailedError: expected: <org.terasology.engine.core.modes.StateIngame> but was: <org.terasology.engine.core.modes.StateLoading>
```

To help understand which of the "engines" is actually in the wrong state, we add some logging information about the instances. 

This should help to figure out whether the `createClient()` method is errorneous (as it should be blocking until the client is in state _in-game_) or the failure lies with the host's engine.

Furthermore, this PR changes `Engines::connectToHost` to return whether waiting for the engine to enter `StateIngame` succeeded or timed out. This allows to fail early and intentionally if the engine did not make it into the expected state.