### PR TITLE
test(MTE)! set default NetworkMode to NONE

### DIFF
--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -33,6 +33,7 @@ import org.terasology.engine.core.subsystem.lwjgl.LwjglGraphics;
 import org.terasology.engine.core.subsystem.lwjgl.LwjglInput;
 import org.terasology.engine.core.subsystem.lwjgl.LwjglTimer;
 import org.terasology.engine.core.subsystem.openvr.OpenVRInput;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.network.JoinStatus;
 import org.terasology.engine.network.NetworkMode;
@@ -131,6 +132,11 @@ public class Engines {
 
     /**
      * Creates a new client and connects it to the host.
+     * <p>
+     * Requires the host to have a {@link NetworkMode} that accepts connections.
+     * Configure the host's network mode using
+     * {@link IntegrationEnvironment#networkMode @IntegrationEnvironment#networkmode}
+     * on your test class.
      *
      * @return the created client's context object
      */

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/jupiter/IntegrationEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/jupiter/IntegrationEnvironment.java
@@ -13,5 +13,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface IntegrationEnvironment {
-    NetworkMode networkMode() default NetworkMode.LISTEN_SERVER;
+    NetworkMode networkMode() default NetworkMode.NONE;
 }

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -11,13 +11,16 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.TerasologyEngine;
 import org.terasology.engine.core.modes.StateIngame;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
+import org.terasology.engine.network.NetworkMode;
 
 import java.io.IOException;
 import java.util.List;
 
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
+@IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
 public class ClientConnectionTest {
     private static final Logger logger = LoggerFactory.getLogger(ClientConnectionTest.class);
 

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.players.LocalPlayer;
 import org.terasology.engine.logic.players.event.ResetCameraEvent;
 import org.terasology.engine.network.ClientComponent;
+import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.BlockManager;
@@ -23,6 +25,7 @@ import java.io.IOException;
 
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
+@IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
 public class ExampleTest {
 
     @In

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/delay/DelayManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/delay/DelayManagerTest.java
@@ -15,16 +15,19 @@ import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.TestEventReceiver;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.delay.DelayManager;
 import org.terasology.engine.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.engine.network.ClientComponent;
+import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.registry.In;
 
 import java.io.IOException;
 
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
+@IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
 public class DelayManagerTest {
     private static final Logger logger = LoggerFactory.getLogger(DelayManagerTest.class);
 


### PR DESCRIPTION
This changes MTE's default network mode from LISTEN_SERVER to NONE.

I expect this to provide in increased reliability and speed for most MTE tests, as it removes the question of whether the server port is available and the delay on network shutdown.

Those few [tests that _do_ use `createClient`](https://github.com/search?q=org%3ATerasology+createClient+-repo%3ATerasology%2FModuleTestingEnvironment&type=code) will need to adjust by setting their NetworkMode to LISTEN_SERVER or DEDICATED_SERVER.

The other potential incompatibility is that NONE does start with a Player; LISTEN_SERVER did not. That may be a problem if the environment does not provide a place for the player to spawn.

(Currently, we do not have any way of starting without either a network server _or_ a player.)

Related:
- [ ] Terasology/BlockDetector#14 fixes the test that was using `createClient`.

### How to test

Run `integrationTest` in modules. Note only modules that import MTE from `engine.integrationtest` will be affected; check for module pull requests linked to #5010.