### PR TITLE
fixup! test(MTE)! set default NetworkMode to NONE (#5041)

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ChunkRegionFutureTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ChunkRegionFutureTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
+import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.Block;
@@ -25,6 +27,7 @@ import static org.terasology.engine.world.block.BlockManager.UNLOADED_ID;
 
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
+@IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
 class ChunkRegionFutureTest {
 
     Vector3fc center = new Vector3f(2021, DummyWorldGenerator.SURFACE_HEIGHT, 1117);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

PR #5041 introdcued a failing test due to a missing network mode setting on the `ChunkRegionFutureTest`.

This PR adds the `networkMode = NetworkMode.LISTEN_SERVER` setting for the integration environment to fix it.

### How to test

Run the integration tests for the engine and ensure no failures:

```
gradlew :engine-tests:integrationTest
```

