### PR TITLE
chore(EntityPool): workaround "unchecked generics array creation" for getEntitiesWith

### DIFF
--- a/engine/src/main/java/org/terasology/engine/entitySystem/entity/EntityPool.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/entity/EntityPool.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.entitySystem.entity;
 
@@ -130,9 +130,31 @@ public interface EntityPool {
     Iterable<EntityRef> getAllEntities();
 
     /**
+     * All entities containing every one of the given components.
+     * <p>
+     * Implementation note:
+     * <a href="http://www.angelikalanger.com/GenericsFAQ/FAQSections/ProgrammingIdioms.html#Topic5"
+     *     title="Designing Generic Methods">Java generic types are a mess</a>, especially where
+     * varargs are involved. We can't use {@link SafeVarargs @SafeVarargs} on any interface methods
+     * because there is no way to know the <em>implementations</em> of the interface are safe.
+     * <p>
+     * In this case, in practice, there are few (if any) callers that pass more than two values.
+     * By adding methods that explicitly take one and two values, we can present an interface the
+     * compiler doesn't need to complain about at every call site.
+     *
      * @return An iterable over all entities with the provided component types.
      */
     Iterable<EntityRef> getEntitiesWith(Class<? extends Component>... componentClasses);
+
+    @SuppressWarnings("unchecked")
+    default Iterable<EntityRef> getEntitiesWith(Class<? extends Component> componentClass) {
+        return getEntitiesWith(new Class[] {componentClass});
+    }
+
+    @SuppressWarnings("unchecked")
+    default Iterable<EntityRef> getEntitiesWith(Class<? extends Component> componentClass, Class<? extends Component> componentClass2) {
+        return getEntitiesWith(new Class[] {componentClass, componentClass2});
+    }
 
     /**
      * @return A count of entities with the provided component types


### PR DESCRIPTION
[Java generic types are a mess][genericMethods], especially where varargs are involved. We can't use [`@SafeVarargs`][safeVarargs] on interface methods because there is no way to know the _implementations_ of the interface are safe.

In this case, in practice, there are few (if any) callers that pass more than two values.
By adding methods that explicitly take one and two values, we can present an interface the compiler doesn't need to complain about at every call site.

[genericMethods]: http://www.angelikalanger.com/GenericsFAQ/FAQSections/ProgrammingIdioms.html#Topic5 "Designing Generic Methods"
[safeVarargs]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/SafeVarargs.html

## How to Test

- find any caller of `entityManager.getEntitiesWith(SomeComponent.class)`
- notice unhappy compiler and IDE messages about "unchecked generics array creation for varargs parameter"
- apply PR
- notice lack of unhappy compiler and IDE messages