### PR TITLE
fix: do not run behavior simulation while paused

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/behavior/BehaviorSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/BehaviorSystem.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.logic.behavior;
 
@@ -83,6 +83,9 @@ public class BehaviorSystem extends BaseComponentSystem implements UpdateSubscri
 
     @Override
     public void update(float delta) {
+        if (delta == 0) {
+            return;  // paused
+        }
         Iterable<EntityRef> entities = entityManager.getEntitiesWith(BehaviorComponent.class);
         for (EntityRef entity : entities) {
             BehaviorComponent behaviorComponent = entity.getComponent(BehaviorComponent.class);


### PR DESCRIPTION
Fixes some of the messages about entities not having finite position or rotation.

### Contains

Skips all `BehaviorSystem.update` when the time delta is zero.

The issue was coming up specifically as a result of movement actions running during this update, since they were coming up with absurd results trying to calculate changes in position over zero time.

But I figured that skipping the entire system is probably a sensible thing to do. Unless you can think of anything Behavior-related that should still be ticking during the pause menu?

Or perhaps we should have a separate variant of [UpdateSubscriberSystem](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/engine/entitySystem/systems/UpdateSubscriberSystem.java) that only updates when engine-time is advancing.

### How to test

- play single player (no network) with WildAnimals
- find some deer (or some other animal with a functioning movement behavior)
- hit Escape for pause menu
- note whether log is being spammed with messages about entities with a non-finite position or location
