### PR TITLE
feat: add type handlers for SimpleUri and BlockUri

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandlerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandlerTest.java
@@ -1,0 +1,52 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.persistence.typeHandling.extensionTypes;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.world.block.BlockUri;
+import org.terasology.engine.world.block.BlockUriParseException;
+import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.gestalt.naming.Name;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.inMemory.PersistedString;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockUriTypeHandlerTest {
+
+    private final BlockUriTypeHandler handler = new BlockUriTypeHandler();
+
+    @Test
+    public void testDeserializeValidShortUri() {
+        PersistedData data = new PersistedString("foo:bar");
+        Optional<BlockUri> uri = handler.deserialize(data);
+        assertTrue(uri.isPresent());
+        assertEquals(new BlockUri(new ResourceUrn("foo", "bar")), uri.get());
+    }
+
+    @Test
+    public void testDeserializeValidFullUri() {
+        PersistedData data = new PersistedString("package:family:shapePackage:shapeName.identifier");
+        Optional<BlockUri> uri = handler.deserialize(data);
+        assertTrue(uri.isPresent());
+        assertEquals(new BlockUri(
+                new ResourceUrn("package", "family"), new ResourceUrn("shapePackage", "shapeName"), new Name("identifier")), uri.get());
+    }
+
+    @Test
+    public void testDeserializeInvalidUri() {
+        PersistedData data = new PersistedString("baz");
+        BlockUriParseException thrown = Assertions.assertThrows(BlockUriParseException.class, () -> {
+            handler.deserialize(data);
+        });
+
+        Assertions.assertEquals("Could not parse block uri: 'baz'", thrown.getMessage());
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandlerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandlerTest.java
@@ -5,7 +5,6 @@ package org.terasology.engine.persistence.typeHandling.extensionTypes;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.world.block.BlockUri;
 import org.terasology.engine.world.block.BlockUriParseException;
 import org.terasology.gestalt.assets.ResourceUrn;
@@ -16,7 +15,6 @@ import org.terasology.persistence.typeHandling.inMemory.PersistedString;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockUriTypeHandlerTest {

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandlerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandlerTest.java
@@ -1,0 +1,34 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.persistence.typeHandling.extensionTypes;
+
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.core.SimpleUri;
+import org.terasology.persistence.typeHandling.PersistedData;
+import org.terasology.persistence.typeHandling.inMemory.PersistedString;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleUriTypeHandlerTest {
+
+    private final SimpleUriTypeHandler handler = new SimpleUriTypeHandler();
+
+    @Test
+    public void testDeserializeValidUri() {
+        PersistedData data = new PersistedString("foo:bar");
+        Optional<SimpleUri> uri = handler.deserialize(data);
+        assertTrue(uri.isPresent());
+        assertEquals(new SimpleUri("foo", "bar"), uri.get());
+    }
+
+    @Test
+    public void testDeserializeInvalidUri() {
+        PersistedData data = new PersistedString("baz");
+        Optional<SimpleUri> uri = handler.deserialize(data);
+        assertTrue(uri.isEmpty());
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
@@ -18,12 +18,14 @@ import org.joml.Vector4fc;
 import org.joml.Vector4i;
 import org.joml.Vector4ic;
 import org.reflections.Reflections;
+import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.math.IntegerRange;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.ChunkMeshTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.ColorTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.ColorcTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.NameTypeHandler;
+import org.terasology.engine.persistence.typeHandling.extensionTypes.SimpleUriTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.TextureRegionTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.UITextureRegionTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.factories.AssetTypeHandlerFactory;
@@ -113,6 +115,7 @@ public class TypeHandlerLibraryImpl extends TypeHandlerLibrary {
         serializationLibrary.addTypeHandlerFactory(new AssetTypeHandlerFactory());
 
         serializationLibrary.addTypeHandler(Name.class, new NameTypeHandler());
+        serializationLibrary.addTypeHandler(SimpleUri.class, new SimpleUriTypeHandler());
         serializationLibrary.addTypeHandler(TextureRegion.class, new TextureRegionTypeHandler());
         serializationLibrary.addTypeHandler(UITextureRegion.class, new UITextureRegionTypeHandler());
         serializationLibrary.addTypeHandler(ChunkMesh.class, new ChunkMeshTypeHandler());

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
@@ -21,6 +21,7 @@ import org.reflections.Reflections;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.math.IntegerRange;
+import org.terasology.engine.persistence.typeHandling.extensionTypes.BlockUriTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.ChunkMeshTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.ColorTypeHandler;
 import org.terasology.engine.persistence.typeHandling.extensionTypes.ColorcTypeHandler;
@@ -59,6 +60,7 @@ import org.terasology.engine.rendering.primitives.ChunkMesh;
 import org.terasology.engine.world.block.BlockArea;
 import org.terasology.engine.world.block.BlockAreac;
 import org.terasology.engine.world.block.BlockRegion;
+import org.terasology.engine.world.block.BlockUri;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.joml.geom.AABBf;
 import org.terasology.joml.geom.AABBi;
@@ -116,6 +118,7 @@ public class TypeHandlerLibraryImpl extends TypeHandlerLibrary {
 
         serializationLibrary.addTypeHandler(Name.class, new NameTypeHandler());
         serializationLibrary.addTypeHandler(SimpleUri.class, new SimpleUriTypeHandler());
+        serializationLibrary.addTypeHandler(BlockUri.class, new BlockUriTypeHandler());
         serializationLibrary.addTypeHandler(TextureRegion.class, new TextureRegionTypeHandler());
         serializationLibrary.addTypeHandler(UITextureRegion.class, new UITextureRegionTypeHandler());
         serializationLibrary.addTypeHandler(ChunkMesh.class, new ChunkMeshTypeHandler());

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandler.java
@@ -1,0 +1,35 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.persistence.typeHandling.extensionTypes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.world.block.BlockUri;
+import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
+
+public class BlockUriTypeHandler extends StringRepresentationTypeHandler<BlockUri> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BlockUriTypeHandler.class);
+
+    @Override
+    public String getAsString(BlockUri uri) {
+        if (uri == null) {
+            return "";
+        }
+        return uri.toString();
+    }
+
+    @Override
+    public BlockUri getFromString(String representation) {
+        BlockUri uri = new BlockUri(representation);
+        if (!uri.isValid()) {
+            logger.error("Failed to create valid BlockUri from string '{}'", representation);
+            // StringRepresentationTypeHandler will turn this 'null' value into an empty Optional
+            return null;
+        }
+
+        return uri;
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/BlockUriTypeHandler.java
@@ -5,7 +5,6 @@ package org.terasology.engine.persistence.typeHandling.extensionTypes;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.world.block.BlockUri;
 import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandler.java
@@ -3,10 +3,14 @@
 
 package org.terasology.engine.persistence.typeHandling.extensionTypes;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
 
 public class SimpleUriTypeHandler extends StringRepresentationTypeHandler<SimpleUri> {
+
+    private static final Logger logger = LoggerFactory.getLogger(SimpleUriTypeHandler.class);
 
     @Override
     public String getAsString(SimpleUri uri) {
@@ -18,6 +22,11 @@ public class SimpleUriTypeHandler extends StringRepresentationTypeHandler<Simple
 
     @Override
     public SimpleUri getFromString(String representation) {
-        return new SimpleUri(representation);
+        SimpleUri uri = new SimpleUri(representation);
+        if (!uri.isValid()) {
+            logger.error("Failed to create valid SimpleURI from string '{}'", representation);
+        }
+
+        return uri;
     }
 }

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandler.java
@@ -1,0 +1,23 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.persistence.typeHandling.extensionTypes;
+
+import org.terasology.engine.core.SimpleUri;
+import org.terasology.persistence.typeHandling.StringRepresentationTypeHandler;
+
+public class SimpleUriTypeHandler extends StringRepresentationTypeHandler<SimpleUri> {
+
+    @Override
+    public String getAsString(SimpleUri uri) {
+        if (uri == null) {
+            return "";
+        }
+        return uri.toString();
+    }
+
+    @Override
+    public SimpleUri getFromString(String representation) {
+        return new SimpleUri(representation);
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/SimpleUriTypeHandler.java
@@ -25,6 +25,8 @@ public class SimpleUriTypeHandler extends StringRepresentationTypeHandler<Simple
         SimpleUri uri = new SimpleUri(representation);
         if (!uri.isValid()) {
             logger.error("Failed to create valid SimpleURI from string '{}'", representation);
+            // StringRepresentationTypeHandler will turn this 'null' value into an empty Optional
+            return null;
         }
 
         return uri;


### PR DESCRIPTION
### Contains

New type handlers to support de-/serializing to/from [`SimpleUri`](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/engine/core/SimpleUri.java) and [`BlockUri`](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/engine/world/block/BlockUri.java).

### How to test

Can be tested in combination with https://github.com/Terasology/ChangingBlocks/pull/15.
