### PR TITLE
fix: do not crash on unexpected map format in GenericMapTypeHandler

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.6.21" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.6.21" />
-  </component>
-</project>

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandler.java
@@ -74,6 +74,7 @@ public class GenericMapTypeHandler<K, V> extends TypeHandler<Map<K, V>> {
             PersistedData rawValue = kvEntry.get(VALUE);
             if (rawKey == null || rawValue == null) {
                 logger.warn("Incorrect map format detected: missing map entry with \"key\" or \"value\" key.\n" + getUsageInfo(data));
+                return Optional.empty();
             }
 
             final Optional<K> key = keyHandler.deserialize(rawKey);

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandler.java
@@ -62,12 +62,7 @@ public class GenericMapTypeHandler<K, V> extends TypeHandler<Map<K, V>> {
     @Override
     public Optional<Map<K, V>> deserialize(PersistedData data) {
         if (!data.isArray() || data.isValueMap()) {
-            logger.warn("Incorrect map format detected: object instead of array.\n" +
-                    "Expected\n" +
-                    "  \"mapName\": [\n" +
-                    "    { \"key\": \"...\", \"value\": \"...\" }\n" +
-                    "  ]\n" +
-                    "but found \n'{}'", data);
+            logger.warn("Incorrect map format detected: object instead of array.\n" + getUsageInfo(data));
             return Optional.empty();
         }
 
@@ -78,13 +73,7 @@ public class GenericMapTypeHandler<K, V> extends TypeHandler<Map<K, V>> {
             PersistedData rawKey = kvEntry.get(KEY);
             PersistedData rawValue = kvEntry.get(VALUE);
             if (rawKey == null || rawValue == null) {
-                logger.warn("Incorrect map format detected: missing map entry with \"key\" or \"value\" key.\n" +
-                        "Expected\n" +
-                        "  \"mapName\": [\n" +
-                        "    { \"key\": \"...\", \"value\": \"...\" }\n" +
-                        "  ]\n" +
-                        "but found \n'{}'", data);
-                return Optional.empty();
+                logger.warn("Incorrect map format detected: missing map entry with \"key\" or \"value\" key.\n" + getUsageInfo(data));
             }
 
             final Optional<K> key = keyHandler.deserialize(rawKey);
@@ -103,5 +92,13 @@ public class GenericMapTypeHandler<K, V> extends TypeHandler<Map<K, V>> {
         }
 
         return Optional.of(result);
+    }
+
+    private String getUsageInfo(PersistedData data) {
+        return "Expected\n" +
+                "  \"mapName\": [\n" +
+                "    { \"key\": \"...\", \"value\": \"...\" }\n" +
+                "  ]\n" +
+                "but found \n'{}'" + data + "'";
     }
 }

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandler.java
@@ -3,6 +3,7 @@
 
 package org.terasology.persistence.typeHandling.coreTypes;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
@@ -101,5 +102,13 @@ public class GenericMapTypeHandler<K, V> extends TypeHandler<Map<K, V>> {
                 "    { \"key\": \"...\", \"value\": \"...\" }\n" +
                 "  ]\n" +
                 "but found \n'{}'" + data + "'";
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("key", keyHandler)
+                .add("value", valueHandler)
+                .toString();
     }
 }

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
@@ -47,7 +47,7 @@ class GenericMapTypeHandlerTest {
      * JSON equivalent:
      * <pre><code>
      * {
-     *   "health:baseRegen": -1"
+     *   "health:baseRegen": -1
      * }
      * </code></pre>
      */

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
@@ -3,6 +3,7 @@
 
 package org.terasology.persistence.typeHandling.coreTypes;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.PersistedDataSerializer;
@@ -24,6 +25,17 @@ class GenericMapTypeHandlerTest {
     private static final String TEST_KEY = "health:baseRegen";
     private static final long TEST_VALUE = -1;
 
+    /**
+     * JSON equivalent:
+     * ```json5
+     * [
+     *   {
+     *       "key": "health:baseRegen",
+     *       "value": -1
+     *   }
+     * ]
+     * ```
+     */
     private final PersistedData testData = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
                     GenericMapTypeHandler.KEY, new PersistedString(TEST_KEY),
@@ -31,14 +43,31 @@ class GenericMapTypeHandlerTest {
             ))
     ));
 
+    /**
+     * JSON equivalent:
+     * ```json5
+     * {
+     *   "health:baseRegen": -1"
+     * }
+     * ```
+     */
     private final PersistedData testDataMalformatted = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
-                    "testmap", new PersistedMap(Map.of(
-                            TEST_KEY, new PersistedLong(TEST_VALUE)
-                    ))
+                    TEST_KEY, new PersistedLong(TEST_VALUE)
             ))
     ));
 
+    /**
+     * JSON equivalent:
+     * ```json5
+     * [
+     *   {
+     *       "not key": "health:baseRegen",
+     *       "value": -1
+     *   }
+     * ]
+     * ```
+     */
     private final PersistedData testDataMissingKeyEntry = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
                     "not key", new PersistedString(TEST_KEY),
@@ -46,6 +75,17 @@ class GenericMapTypeHandlerTest {
             ))
     ));
 
+    /**
+     * JSON equivalent:
+     * ```json5
+     * [
+     *   {
+     *       "key": "health:baseRegen",
+     *       "not value": -1
+     *   }
+     * ]
+     * ```
+     */
     private final PersistedData testDataMissingValueEntry = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
                     GenericMapTypeHandler.KEY, new PersistedString(TEST_KEY),
@@ -53,6 +93,21 @@ class GenericMapTypeHandlerTest {
             ))
     ));
 
+    /**
+     * JSON equivalent:
+     * ```json5
+     * [
+     *   {
+     *       "key": "health:baseRegen",
+     *       "value": -1
+     *   },
+     *   {
+     *       "not key": "health:baseRegen",
+     *       "not value": -1
+     *   },
+     * ]
+     * ```
+     */
     private final PersistedData testDataValidAndInvalidMix = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
                     GenericMapTypeHandler.KEY, new PersistedString(TEST_KEY),
@@ -65,6 +120,7 @@ class GenericMapTypeHandlerTest {
     ));
 
     @Test
+    @DisplayName("Data with valid formatting can be deserialized successfully.")
     void testDeserialize() {
         var th = new GenericMapTypeHandler<>(
                 new StringTypeHandler(),
@@ -76,6 +132,7 @@ class GenericMapTypeHandlerTest {
     }
 
     @Test
+    @DisplayName("Deserializing valid data with a mismatching value type handler fails deserialization (returns empty `Optional`)")
     void testDeserializeWithMismatchedValueHandler() {
         var th = new GenericMapTypeHandler<>(
                 new StringTypeHandler(),
@@ -86,6 +143,7 @@ class GenericMapTypeHandlerTest {
     }
 
     @Test
+    @DisplayName("Deserializing valid data with a mismatching key type handler fails deserialization (returns empty `Optional`)")
     void testDeserializeWithMismatchedKeyHandler() {
         var th = new GenericMapTypeHandler<>(
                 new UselessTypeHandler<>(),
@@ -96,6 +154,7 @@ class GenericMapTypeHandlerTest {
     }
     
     @Test
+    @DisplayName("Incorrectly formatted data (without an outer array) fails deserialization (returns empty `Optional`)")
     void testDeserializeWithObjectInsteadOfArray() {
         var th = new GenericMapTypeHandler<>(
                 new StringTypeHandler(),
@@ -106,6 +165,7 @@ class GenericMapTypeHandlerTest {
     }
 
     @Test
+    @DisplayName("Incorrectly formatted data (without a map entry with key \"key\") fails deserialization (returns empty `Optional`)")
     void testDeserializeWithMissingKeyEntry() {
         var th = new GenericMapTypeHandler<>(
                 new StringTypeHandler(),
@@ -116,6 +176,7 @@ class GenericMapTypeHandlerTest {
     }
 
     @Test
+    @DisplayName("Incorrectly formatted data (without a map entry with key \"value\") fails deserialization (returns empty `Optional`)")
     void testDeserializeWithMissingValueEntry() {
         var th = new GenericMapTypeHandler<>(
                 new StringTypeHandler(),
@@ -126,6 +187,7 @@ class GenericMapTypeHandlerTest {
     }
 
     @Test
+    @DisplayName("A map containing both, correctly and incorrectly formatted data, fails deserialization (returns empty `Optional`)")
     void testDeserializeWithValidAndInvalidEntries() {
         var th = new GenericMapTypeHandler<>(
                 new StringTypeHandler(),

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
@@ -32,6 +32,39 @@ class GenericMapTypeHandlerTest {
             ))
     ));
 
+    private final PersistedData testDataMalformatted = new PersistedValueArray(List.of(
+            new PersistedMap(Map.of(
+                    "testmap", new PersistedMap(Map.of(
+                            TEST_KEY, new PersistedLong(TEST_VALUE)
+                    ))
+            ))
+    ));
+
+    private final PersistedData testDataMissingKeyEntry = new PersistedValueArray(List.of(
+            new PersistedMap(Map.of(
+                    "not key", new PersistedString(TEST_KEY),
+                    GenericMapTypeHandler.VALUE, new PersistedLong(TEST_VALUE)
+            ))
+    ));
+
+    private final PersistedData testDataMissingValueEntry = new PersistedValueArray(List.of(
+            new PersistedMap(Map.of(
+                    GenericMapTypeHandler.KEY, new PersistedString(TEST_KEY),
+                    "not value", new PersistedLong(TEST_VALUE)
+            ))
+    ));
+
+    private final PersistedData testDataValidAndInvalidMix = new PersistedValueArray(List.of(
+            new PersistedMap(Map.of(
+                    GenericMapTypeHandler.KEY, new PersistedString(TEST_KEY),
+                    GenericMapTypeHandler.VALUE, new PersistedLong(TEST_VALUE)
+            )),
+            new PersistedMap(Map.of(
+                    "not key", new PersistedString(TEST_KEY),
+                    "not value", new PersistedLong(TEST_VALUE)
+            ))
+    ));
+
     @Test
     void testDeserialize() {
         var th = new GenericMapTypeHandler<>(
@@ -50,7 +83,7 @@ class GenericMapTypeHandlerTest {
                 new UselessTypeHandler<>()
         );
 
-        assertThat(th.deserialize(testData)).hasValue(Collections.emptyMap());
+        assertThat(th.deserialize(testData)).isEmpty();
     }
 
     @Test
@@ -60,7 +93,47 @@ class GenericMapTypeHandlerTest {
                 new LongTypeHandler()
         );
 
-        assertThat(th.deserialize(testData)).hasValue(Collections.emptyMap());
+        assertThat(th.deserialize(testData)).isEmpty();
+    }
+    
+    @Test
+    void testDeserializeWithObjectInsteadOfArray() {
+        var th = new GenericMapTypeHandler<>(
+                new StringTypeHandler(),
+                new LongTypeHandler()
+        );
+
+        assertThat(th.deserialize(testDataMalformatted)).isEmpty();
+    }
+
+    @Test
+    void testDeserializeWithMissingKeyEntry() {
+        var th = new GenericMapTypeHandler<>(
+                new StringTypeHandler(),
+                new LongTypeHandler()
+        );
+
+        assertThat(th.deserialize(testDataMissingKeyEntry)).isEmpty();
+    }
+
+    @Test
+    void testDeserializeWithMissingValueEntry() {
+        var th = new GenericMapTypeHandler<>(
+                new StringTypeHandler(),
+                new LongTypeHandler()
+        );
+
+        assertThat(th.deserialize(testDataMissingValueEntry)).isEmpty();
+    }
+
+    @Test
+    void testDeserializeWithValidAndInvalidEntries() {
+        var th = new GenericMapTypeHandler<>(
+                new StringTypeHandler(),
+                new LongTypeHandler()
+        );
+
+        assertThat(th.deserialize(testDataValidAndInvalidMix)).isEmpty();
     }
 
     /** Never returns a value. */

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
@@ -27,14 +27,14 @@ class GenericMapTypeHandlerTest {
 
     /**
      * JSON equivalent:
-     * ```json5
+     * <pre><code>
      * [
      *   {
      *       "key": "health:baseRegen",
      *       "value": -1
      *   }
      * ]
-     * ```
+     * </code></pre>
      */
     private final PersistedData testData = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
@@ -45,11 +45,11 @@ class GenericMapTypeHandlerTest {
 
     /**
      * JSON equivalent:
-     * ```json5
+     * <pre><code>
      * {
      *   "health:baseRegen": -1"
      * }
-     * ```
+     * </code></pre>
      */
     private final PersistedData testDataMalformatted = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
@@ -59,14 +59,14 @@ class GenericMapTypeHandlerTest {
 
     /**
      * JSON equivalent:
-     * ```json5
+     * <pre><code>
      * [
      *   {
      *       "not key": "health:baseRegen",
      *       "value": -1
      *   }
      * ]
-     * ```
+     * </code></pre>
      */
     private final PersistedData testDataMissingKeyEntry = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
@@ -77,14 +77,14 @@ class GenericMapTypeHandlerTest {
 
     /**
      * JSON equivalent:
-     * ```json5
+     * <pre><code>
      * [
      *   {
      *       "key": "health:baseRegen",
      *       "not value": -1
      *   }
      * ]
-     * ```
+     * </code></pre>
      */
     private final PersistedData testDataMissingValueEntry = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(
@@ -95,7 +95,7 @@ class GenericMapTypeHandlerTest {
 
     /**
      * JSON equivalent:
-     * ```json5
+     * <pre><code>
      * [
      *   {
      *       "key": "health:baseRegen",
@@ -106,7 +106,7 @@ class GenericMapTypeHandlerTest {
      *       "not value": -1
      *   },
      * ]
-     * ```
+     * </code></pre>
      */
     private final PersistedData testDataValidAndInvalidMix = new PersistedValueArray(List.of(
             new PersistedMap(Map.of(

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/GenericMapTypeHandlerTest.java
@@ -12,7 +12,6 @@ import org.terasology.persistence.typeHandling.inMemory.PersistedMap;
 import org.terasology.persistence.typeHandling.inMemory.PersistedString;
 import org.terasology.persistence.typeHandling.inMemory.arrays.PersistedValueArray;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;


### PR DESCRIPTION
### Contains

- detect incorrect map format (object instead of array) early, log expected format
  ```
  "mapName": [
    { "key": "...", "value": "..." }
  ]
  ```
- add null check to avoid crashing if key "key" not found in case of incorrect map format (no map entry for "key")
- add null check to avoid crashing if key "value" not found in case of incorrect map format (no map entry for "value")

### How to test

Can be tested in combination with https://github.com/Terasology/PlantPack/pull/20

### Outstanding before merging

- [ ] judge whether refactoring actually improves readability
- [x] check that refactoring doesn't break anything 
  - [x] discuss the return value in case of mismatched key / value handler
