### PR TITLE
build(idea): fix parameters in run configurations

### DIFF
--- a/.idea/runConfigurations/TerasologyPC__2nd_client_for_mac.xml
+++ b/.idea/runConfigurations/TerasologyPC__2nd_client_for_mac.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="TerasologyPC (2nd client) for Mac" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology" />
     <module name="Terasology.facades.PC.main" />
-    <option name="PROGRAM_PARAMETERS" value="-homedir=terasology-2ndclient -noCrashReport -noSplash" />
+    <option name="PROGRAM_PARAMETERS" value="--homedir=terasology-2ndclient --no-crash-report --no-splash" />
     <shortenClasspath name="MANIFEST" />
     <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m -XstartOnFirstThread -Djava.awt.headless=true" />
     <extension name="coverage">

--- a/.idea/runConfigurations/TerasologyPC_for_mac.xml
+++ b/.idea/runConfigurations/TerasologyPC_for_mac.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="TerasologyPC for Mac" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.terasology.engine.Terasology" />
     <module name="Terasology.facades.PC.main" />
-    <option name="PROGRAM_PARAMETERS" value="-homedir -noCrashReport -noSplash" />
+    <option name="PROGRAM_PARAMETERS" value="--homedir=. --no-crash-report --no-splash" />
     <shortenClasspath name="MANIFEST" />
     <option name="VM_PARAMETERS" value="-Xms256m -Xmx1536m -XstartOnFirstThread -Djava.awt.headless=true" />
     <extension name="coverage">


### PR DESCRIPTION
We must have missed these run configurations when we changed the way we do our
command line argument parsing. Only changes are correcting the way the 
confiugration passes parameters to the game:

- ~~`-homedir`~~ becomes `--homedir`
- ~~`-noCrashReport`~~ becomes `--no-crash-report`
- ~~`-noSpalsh`~~ becomes `--no-splash`
