### PR TITLE
fix: attempt to fix the Rendering Module Configuration screen

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseRendering.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseRendering.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.core.modes.loadProcesses;
@@ -23,7 +23,6 @@ public class InitialiseRendering extends SingleStepLoadProcess {
         this.context = context;
     }
 
-
     @Override
     public String getMessage() {
         return "Initialising Rendering System...";
@@ -31,7 +30,11 @@ public class InitialiseRendering extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        context.put(RenderingModuleRegistry.class, new RenderingModuleRegistry());
+        // NOTE: a {@link RenderingModuleRegistry} is also required during game setup to configure rendering.
+        // Thus, the rendering module registry might already be added to the context beforehand.
+        if (context.get(RenderingModuleRegistry.class) != null) {
+            context.put(RenderingModuleRegistry.class, new RenderingModuleRegistry());
+        }
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/videoSettings/RenderingModuleSettingScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/videoSettings/RenderingModuleSettingScreen.java
@@ -1,16 +1,20 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.nui.layers.mainMenu.videoSettings;
 
 import org.joml.Vector2i;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.GameEngine;
 import org.terasology.engine.core.modes.StateMainMenu;
 import org.terasology.engine.core.module.rendering.RenderingModuleRegistry;
 import org.terasology.engine.i18n.TranslationSystem;
+import org.terasology.engine.registry.In;
+import org.terasology.engine.rendering.dag.ModuleRendering;
+import org.terasology.engine.rendering.nui.CoreScreenLayer;
+import org.terasology.engine.rendering.nui.layers.mainMenu.StartPlayingScreen;
+import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.nui.Canvas;
 import org.terasology.nui.WidgetUtil;
@@ -22,10 +26,6 @@ import org.terasology.nui.widgets.UIDropdownScrollable;
 import org.terasology.nui.widgets.UISlider;
 import org.terasology.nui.widgets.UISliderOnChangeTriggeredListener;
 import org.terasology.nui.widgets.UIText;
-import org.terasology.engine.registry.In;
-import org.terasology.engine.rendering.dag.ModuleRendering;
-import org.terasology.engine.rendering.nui.CoreScreenLayer;
-import org.terasology.engine.rendering.nui.layers.mainMenu.StartPlayingScreen;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +62,11 @@ public class RenderingModuleSettingScreen extends CoreScreenLayer implements UIS
         moduleEnvironment = subContext.get(ModuleEnvironment.class);
 
         renderingModuleRegistry = context.get(RenderingModuleRegistry.class);
+        if (renderingModuleRegistry == null) {
+            //FIXME: Ideally, we want to do 'InitialiseRendering' earlier than usual here to ensure the rendering module registry is present
+            renderingModuleRegistry = new RenderingModuleRegistry();
+            context.put(RenderingModuleRegistry.class, renderingModuleRegistry);
+        }
 
         orderedModuleRenderingInstances = renderingModuleRegistry.updateRenderingModulesOrder(moduleEnvironment, subContext);
 


### PR DESCRIPTION
### Contains

Attempts to find a solution for #5075. I'm not sure whether the hacky approach I took here is a good step, or whether it will just bite us later...

See also [thread on Discord](https://discord.com/channels/270264625419911192/696830442065625118/1038912894097694781).

Contributes to #5075.

### How to test

Go through the advanced game setup and click on the "Module Rendering Configuration".

A screen should show up where one can adjust the priority of rendering modules (CoreRendering and AdvancedRendering).

Changing the priority or disabling a module should have an effect when starting the game, e.g., the game crashes when CoreRendering is disabled.

### Outstanding before merging

Decide whether we want to merge a hacky quick-fix like this. Alternative, disable the button for now.

