### PR TITLE
feat: send BeforeDisconnectEvent before disconnecting clients

### DIFF
--- a/engine/src/main/java/org/terasology/engine/network/events/BeforeDisconnectEvent.java
+++ b/engine/src/main/java/org/terasology/engine/network/events/BeforeDisconnectEvent.java
@@ -1,0 +1,15 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.network.events;
+
+import org.terasology.gestalt.entitysystem.event.Event;
+
+/**
+ * Event notifying of a client scheduled for disconnect.
+ */
+public class BeforeDisconnectEvent implements Event {
+
+    public BeforeDisconnectEvent() {
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
@@ -53,6 +53,7 @@ import org.terasology.engine.network.NetworkComponent;
 import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.network.Server;
+import org.terasology.engine.network.events.BeforeDisconnectEvent;
 import org.terasology.engine.network.events.ConnectedEvent;
 import org.terasology.engine.network.events.DisconnectedEvent;
 import org.terasology.engine.network.exceptions.HostingFailedException;
@@ -354,7 +355,10 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
         if (!disconnectedClients.isEmpty()) {
             List<NetClient> removedPlayers = Lists.newArrayListWithExpectedSize(disconnectedClients.size());
             disconnectedClients.drainTo(removedPlayers);
-            removedPlayers.forEach(this::processRemovedClient);
+            for (NetClient client : removedPlayers) {
+                client.getEntity().send(new BeforeDisconnectEvent());
+                processRemovedClient(client);
+            }
         }
     }
 

--- a/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
@@ -53,6 +53,7 @@ import org.terasology.engine.network.NetworkComponent;
 import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.network.Server;
+import org.terasology.engine.network.events.BeforeDisconnectEvent;
 import org.terasology.engine.network.events.ConnectedEvent;
 import org.terasology.engine.network.events.DisconnectedEvent;
 import org.terasology.engine.network.exceptions.HostingFailedException;
@@ -353,7 +354,10 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
         if (!disconnectedClients.isEmpty()) {
             List<NetClient> removedPlayers = Lists.newArrayListWithExpectedSize(disconnectedClients.size());
             disconnectedClients.drainTo(removedPlayers);
-            removedPlayers.forEach(this::processRemovedClient);
+            for (NetClient client : removedPlayers) {
+                client.getEntity().send(new BeforeDisconnectEvent());
+                processRemovedClient(client);
+            }
         }
     }
 


### PR DESCRIPTION
### Contains

A new `BeforeDisconnectEvent` event that is sent before disconnecting clients to allow, e.g. component clean-ups on the disconnecting player's entity.

Required by https://github.com/Terasology/LightAndShadow/pull/256