### PR TITLE
doc: document restrictions for BindButtonEvent

### DIFF
--- a/engine/src/main/java/org/terasology/engine/input/BindButtonEvent.java
+++ b/engine/src/main/java/org/terasology/engine/input/BindButtonEvent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.engine.input;
@@ -7,6 +7,15 @@ import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.input.events.ButtonEvent;
 import org.terasology.input.ButtonState;
 
+/**
+ * An event triggered by auto-registered (physical) buttons when they are pressed.
+ * <p>
+ * To be used in combination with {@link RegisterBindButton} and {@link DefaultBinding}.
+ * <p>
+ * Classes extending this usually follow the naming pattern {@code &#60;Name&#62;Button}.
+ * <p>
+ * <b>NOTE:</b> DO NOT USE DIRECTLY!
+ */
 public class BindButtonEvent extends ButtonEvent {
 
     private SimpleUri id;


### PR DESCRIPTION
### Contains

While working on https://github.com/Terasology/FlexiblePathfinding/pull/8 we noticed that there seem to be issues with sending events extending from `BindButtonEvent` programmatically (without the physical button press).

To avoid any future confusion (or at least find the issue sooner) I'm adding a brief docstring to the class stating it's intended use and that one should NOT use it directly.

### How to test

n/a

### Outstanding before merging

n/a
