### PR TITLE
ci: fix project-autoadd github action

### DIFF
--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, labeled]
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -13,20 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to inbox board
-        id: add-to-inbox-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/26'
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
-      - name: Set board item fields
-        uses: github/update-project-action@v2
-        with:
-          organization: MovingBlocks
-          project_number: 26
-          content_id: ${{ steps.add-to-inbox-project.outputs.itemId }}
-          field: Status
-          value: New (Inbox)
-          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_bug_labeled_to_bug_board:
     name: Assign bug report issues and pull requests to bug board backlog
     if: |
@@ -35,20 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to bug board
-        id: add-to-bug-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/29'
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
-      - name: Set board item fields
-        uses: github/update-project-action@v2
-        with:
-          organization: MovingBlocks
-          project_number: 29
-          content_id: ${{ steps.add-to-bug-project.outputs.itemId }}
-          field: Status
-          value: Backlog
-          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_maintenance_to_stabilization_board:
     name: Assign stabilization / refactoring / chore issues and pull requests to stabilization board backlog
     if: |
@@ -62,20 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to stabilization board
-        id: add-to-stabilization-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/25'
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
-      - name: Set board item fields
-        uses: github/update-project-action@v2
-        with:
-          organization: MovingBlocks
-          project_number: 25
-          content_id: ${{ steps.add-to-stabilization-project.outputs.itemId }}
-          field: Status
-          value: Backlog
-          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_features_to_feature_board:
     name: Assign improvement issues and pull requests to feature board backlog
     if: |
@@ -85,17 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to feature board
-        id: add-to-feature-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/27'
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
-      - name: Set board item fields
-        uses: github/update-project-action@v2
-        with:
-          organization: MovingBlocks
-          project_number: 27
-          content_id: ${{ steps.add-to-feature-project.outputs.itemId }}
-          field: Status
-          value: Backlog
-          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to inbox board
-        uses: actions/add-to-project@0.3.0
+        uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/26'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to bug board
-        uses: actions/add-to-project@0.3.0
+        uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/29'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to stabilization board
-        uses: actions/add-to-project@0.3.0
+        uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/25'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to feature board
-        uses: actions/add-to-project@0.3.0
+        uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/27'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -9,47 +9,91 @@ env:
   MY_GITHUB_TOKEN: ${{ secrets.PROJECT_GITHUB_TOKEN }}
 
 jobs:
-  assign_one_project:
+  add_opened_to_inbox_board:
+    name: Add New Issue/PR to Terasology Inbox Board
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
-    name: Assign to One Project
     steps:
-
-    - name: Assign NEW issues and issues to bug/inbox board's inbox
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/MovingBlocks/projects/26'
-        column_name: 'New (Inbox)'
-
-    - name: Assign bug report issues and pull requests to bug board backlog
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: |
-        contains(github.event.issue.labels.*.name, 'Type: Bug') ||
-        contains(github.event.pull_request.labels.*.name, 'Type: Bug')
-      with:
-        project: 'https://github.com/orgs/MovingBlocks/projects/26'
-        column_name: 'Backlog'
-
-    - name: Assign stabilization / refactoring / maintenance issues and pull requests to stabilization board backlog
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: |
-        github.event.action != 'opened' && 
-        ( contains(github.event.issue.labels.*.name, 'Type: Refactoring') ||
-        contains(github.event.pull_request.labels.*.name, 'Type: Refactoring') ||
-        contains(github.event.issue.labels.*.name, 'Type: Chore') ||
-        contains(github.event.pull_request.labels.*.name, 'Type: Chore') ||
-        contains(github.event.issue.labels.*.name, 'Topic: Stabilization') && !contains(github.event.issue.labels.*.name, 'Type: Bug') ||
-        contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization') && !contains(github.event.pull_request.labels.*.name, 'Type: Bug') )
-      with:
-        project: 'https://github.com/orgs/MovingBlocks/projects/25'
-        column_name: 'Backlog'
-
-    - name: Assign improvement issues and pull requests to feature board backlog
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: |
-        github.event.action != 'opened' && 
-        contains(github.event.issue.labels.*.name, 'Type: Improvement') && !contains(github.event.issue.labels.*.name, 'Topic: Stabilization') ||
-        contains(github.event.pull_request.labels.*.name, 'Type: Improvement') && !contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization')
-      with:
-        project: 'https://github.com/orgs/MovingBlocks/projects/27'
-        column_name: 'Backlog'
+      - name: Add to inbox board
+        uses: actions/add-to-project@0.3.0
+        with:
+          project-url: 'https://github.com/orgs/MovingBlocks/projects/26'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set board item fields
+        uses: github/update-project-action@v2
+        with:
+          organization: MovingBlocks
+          project_number: 26
+          content_id: ${{ steps.add-project.outputs.itemId }}
+          field: Status
+          value: New (Inbox)
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  add_bug_labeled_to_bug_board:
+    name: Assign bug report issues and pull requests to bug board backlog
+    if: |
+      contains(github.event.issue.labels.*.name, 'Type: Bug') ||
+      contains(github.event.pull_request.labels.*.name, 'Type: Bug')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to bug board
+        uses: actions/add-to-project@0.3.0
+        with:
+          project-url: 'https://github.com/orgs/MovingBlocks/projects/29'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set board item fields
+        uses: github/update-project-action@v2
+        with:
+          organization: MovingBlocks
+          project_number: 29
+          content_id: ${{ steps.add-project.outputs.itemId }}
+          field: Status
+          value: Backlog
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  add_maintenance_to_stabilization_board:
+    name: Assign stabilization / refactoring / chore issues and pull requests to stabilization board backlog
+    if: |
+      github.event.action != 'opened' && 
+      ( contains(github.event.issue.labels.*.name, 'Type: Refactoring') ||
+      contains(github.event.pull_request.labels.*.name, 'Type: Refactoring') ||
+      contains(github.event.issue.labels.*.name, 'Type: Chore') ||
+      contains(github.event.pull_request.labels.*.name, 'Type: Chore') ||
+      contains(github.event.issue.labels.*.name, 'Topic: Stabilization') && !contains(github.event.issue.labels.*.name, 'Type: Bug') ||
+      contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization') && !contains(github.event.pull_request.labels.*.name, 'Type: Bug') )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to stabilization board
+        uses: actions/add-to-project@0.3.0
+        with:
+          project-url: 'https://github.com/orgs/MovingBlocks/projects/25'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set board item fields
+        uses: github/update-project-action@v2
+        with:
+          organization: MovingBlocks
+          project_number: 25
+          content_id: ${{ steps.add-project.outputs.itemId }}
+          field: Status
+          value: Backlog
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  add_features_to_feature_board:
+    name: Assign improvement issues and pull requests to feature board backlog
+    if: |
+      github.event.action != 'opened' && 
+      contains(github.event.issue.labels.*.name, 'Type: Improvement') && !contains(github.event.issue.labels.*.name, 'Topic: Stabilization') ||
+      contains(github.event.pull_request.labels.*.name, 'Type: Improvement') && !contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to feature board
+        uses: actions/add-to-project@0.3.0
+        with:
+          project-url: 'https://github.com/orgs/MovingBlocks/projects/27'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set board item fields
+        uses: github/update-project-action@v2
+        with:
+          organization: MovingBlocks
+          project_number: 27
+          content_id: ${{ steps.add-project.outputs.itemId }}
+          field: Status
+          value: Backlog
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -18,7 +18,7 @@ jobs:
       uses: srggrs/assign-one-project-github-action@1.2.1
       if: github.event.action == 'opened'
       with:
-        project: 'https://github.com/srggrs/assign-one-project-github-action/projects/26'
+        project: 'https://github.com/orgs/MovingBlocks/projects/26'
         column_name: 'New (Inbox)'
 
     - name: Assign bug report issues and pull requests to bug board backlog
@@ -27,7 +27,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'Type: Bug') ||
         contains(github.event.pull_request.labels.*.name, 'Type: Bug')
       with:
-        project: 'https://github.com/srggrs/assign-one-project-github-action/projects/26'
+        project: 'https://github.com/orgs/MovingBlocks/projects/26'
         column_name: 'Backlog'
 
     - name: Assign stabilization / refactoring / maintenance issues and pull requests to stabilization board backlog
@@ -41,7 +41,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'Topic: Stabilization') && !contains(github.event.issue.labels.*.name, 'Type: Bug') ||
         contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization') && !contains(github.event.pull_request.labels.*.name, 'Type: Bug') )
       with:
-        project: 'https://github.com/srggrs/assign-one-project-github-action/projects/25'
+        project: 'https://github.com/orgs/MovingBlocks/projects/25'
         column_name: 'Backlog'
 
     - name: Assign improvement issues and pull requests to feature board backlog
@@ -51,5 +51,5 @@ jobs:
         contains(github.event.issue.labels.*.name, 'Type: Improvement') && !contains(github.event.issue.labels.*.name, 'Topic: Stabilization') ||
         contains(github.event.pull_request.labels.*.name, 'Type: Improvement') && !contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization')
       with:
-        project: 'https://github.com/srggrs/assign-one-project-github-action/projects/27'
+        project: 'https://github.com/orgs/MovingBlocks/projects/27'
         column_name: 'Backlog'

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, labeled]
 env:
-  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.PROJECT_GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/26'
-          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -26,7 +26,7 @@ jobs:
           content_id: ${{ steps.add-to-inbox-project.outputs.itemId }}
           field: Status
           value: New (Inbox)
-          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_bug_labeled_to_bug_board:
     name: Assign bug report issues and pull requests to bug board backlog
     if: |
@@ -39,7 +39,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/29'
-          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -48,7 +48,7 @@ jobs:
           content_id: ${{ steps.add-to-bug-project.outputs.itemId }}
           field: Status
           value: Backlog
-          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_maintenance_to_stabilization_board:
     name: Assign stabilization / refactoring / chore issues and pull requests to stabilization board backlog
     if: |
@@ -66,7 +66,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/25'
-          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -75,7 +75,7 @@ jobs:
           content_id: ${{ steps.add-to-stabilization-project.outputs.itemId }}
           field: Status
           value: Backlog
-          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_features_to_feature_board:
     name: Assign improvement issues and pull requests to feature board backlog
     if: |
@@ -89,7 +89,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/27'
-          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -98,4 +98,4 @@ jobs:
           content_id: ${{ steps.add-to-feature-project.outputs.itemId }}
           field: Status
           value: Backlog
-          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          github_token: ${{ secrets.PROJECT_GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to inbox board
+        id: add-to-inbox-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/26'
@@ -22,7 +23,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 26
-          content_id: ${{ steps.add-project.outputs.itemId }}
+          content_id: ${{ steps.add-to-inbox-project.outputs.itemId }}
           field: Status
           value: New (Inbox)
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -34,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to bug board
+        id: add-to-bug-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/29'
@@ -43,7 +45,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 29
-          content_id: ${{ steps.add-project.outputs.itemId }}
+          content_id: ${{ steps.add-to-bug-project.outputs.itemId }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -60,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to stabilization board
+        id: add-to-stabilization-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/25'
@@ -69,7 +72,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 25
-          content_id: ${{ steps.add-project.outputs.itemId }}
+          content_id: ${{ steps.add-to-stabilization-project.outputs.itemId }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -82,6 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to feature board
+        id: add-to-feature-project
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/27'
@@ -91,7 +95,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 27
-          content_id: ${{ steps.add-project.outputs.itemId }}
+          content_id: ${{ steps.add-to-feature-project.outputs.itemId }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, labeled]
   pull_request:
     types: [opened, labeled]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.PROJECT_GITHUB_TOKEN }}
 
 jobs:
   add_opened_to_inbox_board:
@@ -18,7 +16,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/26'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -27,7 +25,7 @@ jobs:
           content_id: ${{ steps.add-project.outputs.itemId }}
           field: Status
           value: New (Inbox)
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
   add_bug_labeled_to_bug_board:
     name: Assign bug report issues and pull requests to bug board backlog
     if: |
@@ -39,7 +37,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/29'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -48,7 +46,7 @@ jobs:
           content_id: ${{ steps.add-project.outputs.itemId }}
           field: Status
           value: Backlog
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
   add_maintenance_to_stabilization_board:
     name: Assign stabilization / refactoring / chore issues and pull requests to stabilization board backlog
     if: |
@@ -65,7 +63,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/25'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -74,7 +72,7 @@ jobs:
           content_id: ${{ steps.add-project.outputs.itemId }}
           field: Status
           value: Backlog
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
   add_features_to_feature_board:
     name: Assign improvement issues and pull requests to feature board backlog
     if: |
@@ -87,7 +85,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         with:
           project-url: 'https://github.com/orgs/MovingBlocks/projects/27'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Set board item fields
         uses: github/update-project-action@v2
         with:
@@ -96,4 +94,4 @@ jobs:
           content_id: ${{ steps.add-project.outputs.itemId }}
           field: Status
           value: Backlog
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ORG_GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 26
-          content_id: ${{ github.event.client_payload.command.resource.id }}
+          content_id: ${{ steps.add-to-inbox-project.outputs.itemId }}
           field: Status
           value: New (Inbox)
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 29
-          content_id: ${{ github.event.client_payload.command.resource.id }}
+          content_id: ${{ steps.add-to-bug-project.outputs.itemId }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 25
-          content_id: ${{ github.event.client_payload.command.resource.id }}
+          content_id: ${{ steps.add-to-stabilization-project.outputs.itemId }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -95,7 +95,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 27
-          content_id: ${{ github.event.client_payload.command.resource.id }}
+          content_id: ${{ steps.add-to-feature-project.outputs.itemId }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 26
-          content_id: ${{ steps.add-to-inbox-project.outputs.itemId }}
+          content_id: ${{ github.event.client_payload.command.resource.id }}
           field: Status
           value: New (Inbox)
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 29
-          content_id: ${{ steps.add-to-bug-project.outputs.itemId }}
+          content_id: ${{ github.event.client_payload.command.resource.id }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 25
-          content_id: ${{ steps.add-to-stabilization-project.outputs.itemId }}
+          content_id: ${{ github.event.client_payload.command.resource.id }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}
@@ -95,7 +95,7 @@ jobs:
         with:
           organization: MovingBlocks
           project_number: 27
-          content_id: ${{ steps.add-to-feature-project.outputs.itemId }}
+          content_id: ${{ github.event.client_payload.command.resource.id }}
           field: Status
           value: Backlog
           github_token: ${{ secrets.ORG_GITHUB_TOKEN }}


### PR DESCRIPTION
### Contains

A fix for the [`project-autoadd` github action](https://github.com/MovingBlocks/Terasology/blob/develop/.github/workflows/project-autoadd.yml) which failed because the utilized underlying action only supports classic projects but we're using v2 (beta) projects. The replacement action not only works but is a base action provided by GitHub which hopefully means better maintenance and higher security awareness.

The action requires a token with control privileges for projects. I added such a token to the organization secrets and wrote a [maintainer guide](https://github.com/MovingBlocks/Terasology/wiki/Maintenance#how-to-fix-an-expired-github-action-token) on what to do in case the action starts failing because this token expired.

### How to test

Add a new label to the PR (ideally remove it again afterwards so we don't clutter the PR with arbitrary / not applicable labels).
The action should run automatically in the PR checks. If not, a new run should be accessible at https://github.com/MovingBlocks/Terasology/actions

### Outstanding before merging

- [x] verify that the action no longer crashes
- [x] optional: play around with the labels in this PR and verify that the issue is added to boards accordingly
