### PR TITLE
build(distribution): re-enable SecurityManager in distributions running under Java 18 and above

### DIFF
--- a/facades/PC/src/main/startScripts/unixStartScript.gsp
+++ b/facades/PC/src/main/startScripts/unixStartScript.gsp
@@ -169,6 +169,13 @@ save () {
 }
 APP_ARGS=`save "\$@"`
 
+# Terasology-specific changes - Re-enable SecurityManager on Java 18+
+# According to https://openjdk.org/jeps/223, this string is intentionally parsable.
+JAVA_VERSION=`java -fullversion 2>&1 | sed 's/.* //;s/"//;s/\\([0-9]*\\)\\..*/\\1/'`
+if [ \$JAVA_VERSION -gt 17 ]; then
+    DEFAULT_JVM_OPTS="\$DEFAULT_JVM_OPTS -Djava.security.manager=allow"
+fi
+
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %> <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>-jar lib/Terasology.jar "\$APP_ARGS"
 

--- a/facades/PC/src/main/startScripts/windowsStartScript.bat.gsp
+++ b/facades/PC/src/main/startScripts/windowsStartScript.bat.gsp
@@ -62,6 +62,14 @@ goto fail
 
 <% if ( mainClassName.startsWith('--module ') ) { %>set MODULE_PATH=$modulePath<% } %>
 
+@rem Terasology-specific changes - Re-enable SecurityManager on Java 18+
+@rem According to https://openjdk.org/jeps/223, this string is intentionally parsable.
+for /f "tokens=4 delims= " %%a in ('"%JAVA_EXE%" -fullversion 2^>^&1 1^>nul') do ( for /f "delims=." %%b in ('echo %%a') do set JAVA_VERSION="%%b" )
+set JAVA_VERSION=%JAVA_VERSION:"=%
+if %JAVA_VERSION% gtr 17 (
+    set DEFAULT_JVM_OPTS=%DEFAULT_JVM_OPTS% -Djava.security.manager=allow
+)
+
 @rem Execute ${applicationName}
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "%MODULE_PATH%" <% } %>-jar lib\\Terasology.jar %*
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

When running under Java 18/19, the game crashes on start-up when attempting to set a `SecurityManager`. `SecurityManager` was deprecated in Java 17 and is disabled by-default from Java 18.

This fixes #5090 by re-enabling `SecurityManager` in the launch scripts. The changes should only affect users running Java 18 and later.

### How to test

- Build a distribution using `gradlew distZip`.
- Obtain a Java 19 runtime
  (I tested this with the one from https://adoptium.net)
- Temporaily set the `JAVA_HOME` environment variable to point at the Java 19 distribution.
- Run `./Terasology` (or `Terasology.bat`) from the built distribution folder.
- The game should reach the main menu.

### Notes
- I'm not certain that parsing the java version number in batch/sh files is going to be reliable but it seems to work. There is at least one JEP which suggests that the output format may be intentional. The parsing logic won't work with Java 8 but that's not supported for Terasology anymore, as far as I know.
- This will get you to the main menu but not much further (see https://github.com/MovingBlocks/Terasology/issues/3976#issuecomment-1432204132 for other issues).
