### PR TITLE
use kotlin-1.9, force java-11 target.

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -4,7 +4,11 @@
 import java.net.URI
 
 plugins {
-    `kotlin-dsl`
+    id("org.gradle.kotlin.kotlin-dsl") version "4.1.0"
+}
+
+kotlin {
+    jvmToolchain(11)
 }
 
 repositories {

--- a/config/gradle/common.gradle
+++ b/config/gradle/common.gradle
@@ -10,14 +10,11 @@ apply plugin: 'idea'
 
 apply plugin: 'terasology-repositories'
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-}
-
 javadoc.options.encoding = 'UTF-8'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+    options.release.set(11)
 }
 
 task sourceJar(type: Jar) {


### PR DESCRIPTION
kotlin-1.9 knows java-20. setting java-11 as target a little more harsh than currently,  source version 11 does weak checks. target 11 is important for the current codebase to work. 

