### PR TITLE
ci: configure jenkins to abort builds if new builds are triggered

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,9 @@ properties([
     // that can't simply be turned off
     copyArtifactPermission('*'),
     // Flag for Jenkins to discard attached artifacts after x builds
-    buildDiscarder(logRotator(artifactNumToKeepStr: artifactBuildsToKeep))
+    buildDiscarder(logRotator(artifactNumToKeepStr: artifactBuildsToKeep)),
+    // configure Jenkins to abort a build if a new one is triggered for the same branch
+    disableConcurrentBuilds(abortPrevious: true)
 ])
 
 /**


### PR DESCRIPTION
### Contains

Currently whenever we push new commits, a build is started. If another push comes in while that build is still running it will not be terminated. This can lead to multiple builds running for the same branch consuming resources and "blocking" build agents.
This PR configures Jenkins to abort a build if another build for the same branch is started, for instance through a new push.
This should reduce resource consumption and allow the build agents to be used for building other branches instead.

### How to test

Shortly after each other push two empty commits and verify that the build job started for the first one is terminated on starting a build job for the second one.
