### PR TITLE
ci: update spotbugs version for gradle 7+, java-17, java-20

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation("org.terasology.gestalt:gestalt-module:7.1.0")
 
     // plugins we configure
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:4.8.0")  // TODO: upgrade with gradle 7.x
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
 
     api(kotlin("test"))

--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -93,9 +93,6 @@ configure<PmdExtension> {
 }
 
 configure<SpotBugsExtension> {
-    // The version of the spotbugs tool https://github.com/spotbugs/spotbugs
-    // not necessarily the same as the version of spotbugs-gradle-plugin
-    toolVersion.set("4.7.0")
     ignoreFailures.set(true)
     excludeFilter.set(file(rootDir.resolve("config/metrics/findbugs/findbugs-exclude.xml")))
 }


### PR DESCRIPTION
spotbugs needs to be able to read new class format.