### PR TITLE
feat: fix ExecutorCompletionService workaround in ChunkProcessingPipeline

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkExecutorCompletionService.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkExecutorCompletionService.java
@@ -1,0 +1,126 @@
+// Copyright 2023 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.world.chunks.pipeline;
+
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.terasology.engine.world.chunks.Chunk;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A specialised alternative to {@link java.util.concurrent.ExecutorCompletionService},
+ * used for submitting chunk tasks and queuing their results.
+ *
+ * Whilst this class adheres to the {@link CompletionService} interface, use of the class's
+ * {@link #submit(Callable, Vector3ic)} overload is preferred over those inherited from the interface.
+ */
+public class ChunkExecutorCompletionService implements CompletionService<Chunk> {
+    private static final Vector3ic EMPTY_VECTOR3I = new Vector3i();
+    private final ThreadPoolExecutor threadPoolExecutor;
+    private final BlockingQueue<Future<Chunk>> completionQueue;
+
+    private final class ChunkFutureWithCompletion extends PositionFuture<Chunk> {
+        ChunkFutureWithCompletion(Callable callable, Vector3ic position) {
+            super(callable, position);
+        }
+
+        ChunkFutureWithCompletion(Runnable runnable, Chunk result, Vector3ic position) {
+            super(runnable, result, position);
+        }
+
+        @Override
+        protected void done() {
+            super.done();
+            try {
+                completionQueue.put(this);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public ChunkExecutorCompletionService(ThreadPoolExecutor threadPoolExecutor, BlockingQueue<Future<Chunk>> completionQueue) {
+        this.threadPoolExecutor = threadPoolExecutor;
+        this.completionQueue = completionQueue;
+    }
+
+    /**
+     * Submits a task to be executed.
+     * @param callable the task to submit
+     *
+     * @deprecated Use {@link #submit(Callable, Vector3ic)} instead
+     */
+    @Override
+    @Deprecated
+    public Future<Chunk> submit(Callable<Chunk> callable) {
+        RunnableFuture<Chunk> task = new ChunkFutureWithCompletion(callable, EMPTY_VECTOR3I);
+        threadPoolExecutor.execute(task);
+        return task;
+    }
+
+    /**
+     * Submits a chunk task to be executed.
+     * @param callable the chunk task to execute.
+     * @param position the position of the chunk.
+     * @return the submitted task.
+     */
+    public Future<Chunk> submit(Callable<Chunk> callable, Vector3ic position) {
+        RunnableFuture<Chunk> task = new ChunkFutureWithCompletion(callable, position);
+        threadPoolExecutor.execute(task);
+        return task;
+    }
+
+    /**
+     * Submits a task to be executed.
+     * @param runnable the task to run.
+     * @param value the value to return upon task completion.
+     *
+     * @deprecated Use {@link #submit(Callable, Vector3ic)} instead
+     */
+    @Override
+    @Deprecated
+    public Future<Chunk> submit(Runnable runnable, Chunk value) {
+        RunnableFuture<Chunk> task = new ChunkFutureWithCompletion(runnable, value, EMPTY_VECTOR3I);
+        threadPoolExecutor.execute(task);
+        return task;
+    }
+
+    /**
+     * Retrieves a completed task from the queue.
+     * @return a completed task.
+     * @throws InterruptedException if interrupted whilst waiting on the queue.
+     */
+    @Override
+    public Future<Chunk> take() throws InterruptedException {
+        return completionQueue.take();
+    }
+
+    /**
+     * Retrieves a completed task from the queue if not empty.
+     * @return a completed task, or null if there are no tasks in the queue.
+     */
+    @Override
+    public Future<Chunk> poll() {
+        return completionQueue.poll();
+    }
+
+    /**
+     * Retrieves a completed task from the queue if not empty.
+     * @param l the timeout duration before returning null.
+     * @param timeUnit the time units of the timeout duration.
+     *
+     * @return a completed task, or null if there are no tasks in the queue.
+     */
+    @Override
+    public Future<Chunk> poll(long l, TimeUnit timeUnit) throws InterruptedException {
+        return completionQueue.poll(l, timeUnit);
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.monitoring.ThreadActivity;
 import org.terasology.engine.monitoring.ThreadMonitor;
-import org.terasology.engine.utilities.ReflectionUtil;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTask;
 import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
@@ -21,14 +20,10 @@ import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -50,7 +45,7 @@ public class ChunkProcessingPipeline {
 
     private final List<ChunkTaskProvider> stages = Lists.newArrayList();
     private final Thread reactor;
-    private final CompletionService<Chunk> chunkProcessor;
+    private final ChunkExecutorCompletionService chunkProcessor;
     private final ThreadPoolExecutor executor;
     private final Function<Vector3ic, Chunk> chunkProvider;
     private final Map<Vector3ic, ChunkProcessingInfo> chunkProcessingInfoMap = Maps.newConcurrentMap();
@@ -66,34 +61,16 @@ public class ChunkProcessingPipeline {
                 NUM_TASK_THREADS,
                 NUM_TASK_THREADS, 0L,
                 TimeUnit.MILLISECONDS,
-                new PriorityBlockingQueue(800, unwrappingComporator(comparable)),
+                new PriorityBlockingQueue(800, comparable),
                 this::threadFactory,
-                this::rejectQueueHandler) {
-            @Override
-            protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
-                RunnableFuture<T> newTaskFor = super.newTaskFor(callable);
-                return new PositionFuture<>(newTaskFor, ((PositionalCallable) callable).getPosition());
-            }
-        };
+                this::rejectQueueHandler);
         logger.debug("allocated {} threads", NUM_TASK_THREADS);
-        chunkProcessor = new ExecutorCompletionService<>(executor,
+        chunkProcessor = new ChunkExecutorCompletionService(executor,
                 new PriorityBlockingQueue<>(800, comparable));
         reactor = new Thread(this::chunkTaskHandler);
         reactor.setDaemon(true);
         reactor.setName("Chunk-Processing-Reactor");
         reactor.start();
-    }
-
-    /**
-     * BlackMagic method: {@link ExecutorCompletionService} wraps task with QueueingFuture (private access)
-     * there takes wrapped task for comparing in {@link ThreadPoolExecutor}
-     */
-    private Comparator unwrappingComporator(Comparator<Future<Chunk>> comparable) {
-        return (o1, o2) -> {
-                Object unwrapped1 = ReflectionUtil.readField(o1, "task");
-                Object unwrapped2 = ReflectionUtil.readField(o2, "task");
-                return comparable.compare((Future<Chunk>) unwrapped1, (Future<Chunk>) unwrapped2);
-        };
     }
 
     /**
@@ -190,11 +167,11 @@ public class ChunkProcessingPipeline {
     }
 
     private Future<Chunk> runTask(ChunkTask task, List<Chunk> chunks) {
-        return chunkProcessor.submit(new PositionalCallable(() -> {
+        return chunkProcessor.submit(() -> {
             try (ThreadActivity ignored = ThreadMonitor.startThreadActivity(task.getName())) {
                 return task.apply(chunks);
             }
-        }, task.getPosition()));
+        }, task.getPosition());
     }
 
     private Thread threadFactory(Runnable runnable) {
@@ -236,8 +213,7 @@ public class ChunkProcessingPipeline {
             SettableFuture<Chunk> exitFuture = SettableFuture.create();
             chunkProcessingInfo = new ChunkProcessingInfo(position, exitFuture);
             chunkProcessingInfoMap.put(position, chunkProcessingInfo);
-            chunkProcessingInfo.setCurrentFuture(chunkProcessor.submit(new PositionalCallable(generatorTask::get,
-                    position)));
+            chunkProcessingInfo.setCurrentFuture(chunkProcessor.submit(generatorTask::get, position));
             return exitFuture;
         }
     }
@@ -316,27 +292,5 @@ public class ChunkProcessingPipeline {
      */
     public Iterable<Vector3ic> getProcessingPosition() {
         return chunkProcessingInfoMap.keySet();
-    }
-
-    /**
-     * Dummy callable for passthru position for {@link java.util.concurrent.ThreadPoolExecutor}#newTaskFor
-     */
-    private static final class PositionalCallable implements Callable<Chunk> {
-        private final Callable<Chunk> callable;
-        private final Vector3ic position;
-
-        private PositionalCallable(Callable<Chunk> callable, Vector3ic position) {
-            this.callable = callable;
-            this.position = position;
-        }
-
-        public Vector3ic getPosition() {
-            return position;
-        }
-
-        @Override
-        public Chunk call() throws Exception {
-            return callable.call();
-        }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/PositionFuture.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/PositionFuture.java
@@ -5,53 +5,23 @@ package org.terasology.engine.world.chunks.pipeline;
 
 import org.joml.Vector3ic;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
 
-public class PositionFuture<T> implements RunnableFuture<T> {
-
-    private final RunnableFuture<T> delegate;
+public class PositionFuture<T> extends FutureTask<T> {
     private final Vector3ic position;
 
-    public PositionFuture(RunnableFuture<T> delegate, Vector3ic position) {
-        this.delegate = delegate;
+    public PositionFuture(Callable callable, Vector3ic position) {
+        super(callable);
+        this.position = position;
+    }
+
+    public PositionFuture(Runnable runnable, T result, Vector3ic position) {
+        super(runnable, result);
         this.position = position;
     }
 
     public Vector3ic getPosition() {
         return position;
-    }
-
-    @Override
-    public void run() {
-        delegate.run();
-    }
-
-    @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
-        return delegate.cancel(mayInterruptIfRunning);
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return delegate.isCancelled();
-    }
-
-    @Override
-    public boolean isDone() {
-        return delegate.isDone();
-    }
-
-    @Override
-    public T get() throws InterruptedException, ExecutionException {
-        return delegate.get();
-    }
-
-    @Override
-    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
-            TimeoutException {
-        return delegate.get(timeout, unit);
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains
This pull request removes the work-around in `ChunkProcessingPipeline` where it reflects into the internals of the built-in `ExecutorCompletionService` class. This is no longer possible with newer Java versions and was never guarenteed to work in the first place.

Instead of making assumptions about `ExecutorCompletionService`, this pull request replaces the usage of the class with a new one specialised for dealing with chunks. Essentially, this makes sure that the submitted tasks are always of type `PositionFuture`, as several other classes in the codebase depend on the task future being an instance of that type. I believe that `PositionFuture` is used for certain optimisations related to the chunk load order.

This contributes to #3976.

### How to test
- Run the game
- Create a new world
- Run the newly created world
- The world generation process should complete successfully
- Chunks should load around the player in-game
