### PR TITLE
refactor: fix gradle warnings

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -4,7 +4,7 @@
 import java.net.URI
 
 plugins {
-    id("org.gradle.kotlin.kotlin-dsl") version "4.1.0"
+    id("org.gradle.kotlin.kotlin-dsl") version "4.0.14"
 }
 
 kotlin {
@@ -50,7 +50,7 @@ dependencies {
     implementation("org.terasology.gestalt:gestalt-module:7.1.0")
 
     // plugins we configure
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.3")  // TODO: upgrade with gradle 7.x
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
 
     api(kotlin("test"))

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation("org.terasology.gestalt:gestalt-module:7.1.0")
 
     // plugins we configure
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:4.8.0")  // TODO: upgrade with gradle 7.x
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.3")  // TODO: upgrade with gradle 7.x
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
 
     api(kotlin("test"))

--- a/build-logic/src/main/kotlin/org/terasology/gradology/module_deps.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/module_deps.kt
@@ -90,13 +90,10 @@ fun moduleDependencyOrdering(modulesConfig: Configuration): List<String> {
     // configurations.resolvedConfiguration is more straightforward if you just want all the artifacts,
     // but using `.incoming` lets us turn on lenient mode as well as do more accurate filtering of local modules
     val resolvable = modulesConfig.incoming
-    val artifactView = resolvable.artifactView {
-        lenient(true)
-    }
 
     val result = resolvable.resolutionResult
     val allDependencies = result.allDependencies
-    val resolvedDependencies = allDependencies.mapNotNull {
+    allDependencies.mapNotNull {
         if (it is ResolvedDependencyResult) {
             return@mapNotNull it
         }

--- a/build-logic/src/main/kotlin/reflections-manifest.gradle.kts
+++ b/build-logic/src/main/kotlin/reflections-manifest.gradle.kts
@@ -11,7 +11,7 @@ import java.net.URLClassLoader
 tasks.register("cacheReflections") {
     description = "Caches reflection output to make regular startup faster. May go stale and need cleanup at times."
 
-    val sourceSets = project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets
+    val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
     val mainSourceSet: SourceSet = sourceSets[SourceSet.MAIN_SOURCE_SET_NAME]
 
     inputs.files(mainSourceSet.output.classesDirs)

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -29,10 +29,10 @@ apply(from = "$rootDir/config/gradle/publish.gradle")
 // Handle some logic related to where what is
 configure<SourceSetContainer> {
     main {
-        java.destinationDirectory.set(buildDir.resolve("classes"))
+        java.destinationDirectory.set(layout.buildDirectory.dir("classes"))
     }
     test {
-        java.destinationDirectory.set(buildDir.resolve("testClasses"))
+        java.destinationDirectory.set(layout.buildDirectory.dir("testClasses"))
     }
 }
 
@@ -178,8 +178,8 @@ configure<IdeaModel> {
     module {
         // Change around the output a bit
         inheritOutputDirs = false
-        outputDir = buildDir.resolve("classes")
-        testOutputDir = buildDir.resolve("testClasses")
+        outputDir = layout.buildDirectory.dir("classes").get().asFile
+        testOutputDir = layout.buildDirectory.dir("testClasses").get().asFile
         isDownloadSources = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ plugins {
     // For the "Build and run using: Intellij IDEA | Gradle" switch
     id "org.jetbrains.gradle.plugin.idea-ext" version "1.0"
 
-    id("com.google.protobuf") version "0.8.16" apply false
+    id("com.google.protobuf") version "0.9.4" apply false
     id("terasology-repositories")
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -195,7 +195,7 @@ sourceSets {
 }
 
 task jmh(type: JavaExec, dependsOn: jmhClasses) {
-    main = 'org.openjdk.jmh.Main'
+    mainClass = 'org.openjdk.jmh.Main'
     classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -251,7 +251,7 @@ def createVersionInfoFile = tasks.register("createVersionInfoFile", WritePropert
         property("dateTime", startDateTimeString)
     }
 
-    outputFile = "$buildDir/createVersionInfoFile/versionInfo.properties"
+    destinationFile = layout.buildDirectory.dir("createrVersionInfoFile").get().file("versionInfo.properties")
 }
 
 tasks.named("processResources", Copy) {

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -168,7 +168,7 @@ val createVersionFile = tasks.register<Copy>("createVersionFile") {
 
     inputs.property("dateTime", startDateTimeString)
     from(templatesDir)
-    into("$buildDir/versionfile")
+    into(layout.buildDirectory.dir("versionfile").get().asFile)
     include(versionFileName)
     expand(mapOf(
         "buildNumber" to env["BUILD_NUMBER"],
@@ -205,7 +205,7 @@ val distForLauncher = tasks.register<Zip>("distForLauncher") {
             if (this.sourcePath == "Terasology" || this.sourcePath == "Terasology.bat") {
                 // I don't know how the "lib/" makes its way in to the classpath used by CreateStartScripts,
                 // so we're adjusting it after-the-fact.
-                filter(ScriptClasspathRewriter(this, defaultLibraryDirectory, launcherLibraryDirectory))
+                filter(ScriptClasspathRewriter(this, defaultLibraryDirectory, launcherLibraryDirectory) as Transformer<String?, String>)
             }
         }
     })
@@ -248,7 +248,7 @@ tasks.register<Task>("testDist") {
     dependsOn("testDistForLauncher", "testDistZip")
 }
 
-class ScriptClasspathRewriter(file: FileCopyDetails, val oldDirectory: String, val newDirectory: String) : Transformer<String, String> {
+class ScriptClasspathRewriter(file: FileCopyDetails, val oldDirectory: String, val newDirectory: String) : Transformer<String?, String> {
     private val isBatchFile = file.name.endsWith(".bat")
 
     override fun transform(line: String): String = if (isBatchFile) {

--- a/subsystems/DiscordRPC/build.gradle.kts
+++ b/subsystems/DiscordRPC/build.gradle.kts
@@ -11,8 +11,8 @@ apply(from = "$rootDir/config/gradle/common.gradle")
 
 configure<SourceSetContainer> {
     // Adjust output path (changed with the Gradle 6 upgrade, this puts it back)
-    main { java.destinationDirectory.set(File("$buildDir/classes")) }
-    test { java.destinationDirectory.set(File("$buildDir/testClasses")) }
+    main { java.destinationDirectory.set(layout.buildDirectory.dir("classes")) }
+    test { java.destinationDirectory.set(layout.buildDirectory.dir("testClasses")) }
 }
 
 dependencies {

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -14,8 +14,8 @@ version = project(":engine").version
 
 configure<SourceSetContainer> {
     // Adjust output path (changed with the Gradle 6 upgrade, this puts it back)
-    main { java.destinationDirectory.set(File("$buildDir/classes")) }
-    test { java.destinationDirectory.set(File("$buildDir/testClasses")) }
+    main { java.destinationDirectory.set(layout.buildDirectory.dir("classes")) }
+    test { java.destinationDirectory.set(layout.buildDirectory.dir("testClasses")) }
 }
 
 dependencies {

--- a/subsystems/build.gradle
+++ b/subsystems/build.gradle
@@ -6,8 +6,7 @@ subprojects {
     plugins.apply('java')
     plugins.apply('idea')
 
-    def sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).sourceSets
-
+    def sourceSets = project.getExtensions().getByType(SourceSetContainer.class)
 
     sourceSets.main.java.destinationDirectory = new File("$buildDir/classes")
     idea {


### PR DESCRIPTION
### Contains

Addresses #5127 

This should be added into #5109

### How to test

`./gradlew wrapper --warning-mode all`

### Outstanding before merging

I made some changes to the versions of some plugins due to the version being older, so they were using deprecated functions.

* `protobuf` -> `0.9.4`
* `spotbug` -> `5.1.3`