### PR TITLE
chore: consume CrashReporter v5.0.0

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     api fileTree(dir: 'libs', include: '*.jar')
 
     // TODO: Consider moving this back to the PC Facade instead of having the engine rely on it?
-    implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '4.2.0'
+    implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '5.0.0'
 
     api(project(":subsystems:TypeHandlerLibrary"))
 }

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("io.projectreactor:reactor-core:3.4.7")
 
     // TODO: Consider whether we can move the CR dependency back here from the engine, where it is referenced from the main menu
-    implementation(group = "org.terasology.crashreporter", name = "cr-terasology", version = "4.2.0")
+    implementation(group = "org.terasology.crashreporter", name = "cr-terasology", version = "5.0.0")
 
     runtimeOnly("ch.qos.logback:logback-classic:1.2.11") {
         because("to configure logging with logback.xml")


### PR DESCRIPTION
- GDrive support was removed with CrashReporter v5

### How to test

1. Checkout this PR
2. Start Terasology
3. Observe in the logs that v5.0.0 can be properly fetched from artifactory
4. Optional: provoke a crash and see that crash reporter comes up properly
  (I already tested that locally both when introducing the latest changes in crash reporter and for this PR, but feel free to reproduce)
