### PR TITLE
build: Add Gradle task to assemble module build harness

### DIFF
--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -60,16 +60,28 @@ tasks.withType<Test> {
     }
 }
 
-tasks.withType<Checkstyle> {
-    dependsOn(tasks.getByPath(":extractConfig"))
-}
+ tasks.withType<Checkstyle> {
+    //FIXME: This is a workaround for module harness builds, where the config 
+    //       files are part of the harness but the task is not defined.
+    if (rootProject.name == "Terasology") {
+        dependsOn(tasks.getByPath(":extractConfig"))
+    }
+ }
 
 tasks.withType<Pmd> {
-    dependsOn(tasks.getByPath(":extractConfig"))
+    //FIXME: This is a workaround for module harness builds, where the config 
+    //       files are part of the harness but the task is not defined.
+    if (rootProject.name == "Terasology") {
+        dependsOn(tasks.getByPath(":extractConfig"))
+    }
 }
 
 tasks.withType<SpotBugsTask> {
-    dependsOn(tasks.getByPath(":extractConfig"))
+    //FIXME: This is a workaround for module harness builds, where the config 
+    //       files are part of the harness but the task is not defined.
+    if (rootProject.name == "Terasology") {
+        dependsOn(tasks.getByPath(":extractConfig"))
+    }
 }
 
 // The config files here work in both a multi-project workspace (IDEs, running from source) and for solo module builds

--- a/build.gradle
+++ b/build.gradle
@@ -332,4 +332,3 @@ task assembleBuildHarness(type: Zip) {
     // set the archive name
     archiveFileName.set('build-harness.zip')
 }
-    

--- a/build.gradle
+++ b/build.gradle
@@ -282,3 +282,54 @@ idea {
 cleanIdea.doLast {
     new File('Terasology.iws').delete()
 }
+
+// A task to assemble various files into a single zip for distribution as 'build-harness.zip' for module builds
+task assembleBuildHarness(type: Zip) {
+    description 'Assembles a zip of files useful for module development'
+
+    dependsOn extractNatives
+    from('natives'){
+        include '**/*'
+        // TODO: use output of extractNatives?
+        // TODO: which module needs natives to build?
+        into 'natives'
+    }
+
+    dependsOn extractConfig
+    from('config'){
+        //include 'gradle/**/*', 'metrics/**/*'
+        include '**/*'
+        // TODO: depend on output of extractConfig?
+        into 'config'
+    }
+
+    from('gradle'){
+        include '**/*' // include all files in 'gradle'
+        // TODO: exclude groovy jar?
+        into 'gradle'
+    }
+
+    from('build-logic'){
+        include 'src/**', '*.kts'
+        into 'build-logic'
+    }
+
+    from('templates') {
+        include 'build.gradle'        
+    }
+
+    from('.') {
+        include 'gradlew'
+    }
+
+    // include file 'templates/module.logback-test.xml' as 'src/test/resources/logback-test.xml'
+    from('templates'){
+        include 'module.logback-test.xml'
+        rename 'module.logback-test.xml', 'logback-test.xml'
+        into 'src/test/resources'
+    }
+
+    // set the archive name
+    archiveFileName.set('build-harness.zip')
+}
+    


### PR DESCRIPTION
### Contains

Trying to make some _Jenkins magic_ 🪄 more explicit in producing a build artifact for the _module build harness_ that we could publish somewhere and use it in module builds again.

### Context

Info is taken from

https://github.com/MovingBlocks/ModuleJteConfig/blob/b8599916257184f1258da5ff209e9fb55c26863f/Jenkinsfile#L62-L63

and 

https://github.com/MovingBlocks/Terasology/blob/43a7e053cca8e7c31a7bac6aa833316282586c36/Jenkinsfile#L55-L65

### How to Test

#### Module Build

For local testing, run the following in the engine repo, which should produce `build/distributions/build-harness.zip`.

```
./gradlew assembleBuildHarness
```

In a stand-alone checkout of a module (any module should work) extract the `build-harness.zip` file and try to run the Gradle build. For instance:

```sh
# in stand-alone module checkout
unzip ../Terasology/build/distributions/build-harness.zip 

# set project name and include plugin, see https://github.com/MovingBlocks/ModuleJteConfig/blob/b8599916257184f1258da5ff209e9fb55c26863f/Jenkinsfile#L62-L63
echo "rootProject.name = '$(basename "$PWD")'; includeBuild('build-logic');" > settings.gradle

./gradlew build
```

#### Engine Build

The config should be extracted as before in the engine. To test this, clean the `config/` directory, then run one of the affected tasks and observe that `:extractConfig` is part of the dependencies and the configs are extracted properly.

For instance, you can run

```sh
git clean -fdx -- config
./gradlew checkstyleMain
```

### Follow-up

- build the module build harness in CI and archive the ZIP file in the Jenkins job
- adjust the module build file to use the single build harness archive instead of copying files together
- version the build harness properly and publish to artifactory (and consume from there)
- (optional) implement a Github action to fetch the build harness from artifactory and build modules standalone
- (optional) address the FIXME by revisiting the gradle plugins, how they are structured, what they depend on, etc.