### PR TITLE
gradle 8.3, supporting java-21 via its kotlin dependency

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -4,7 +4,7 @@
 import java.net.URI
 
 plugins {
-    id("org.gradle.kotlin.kotlin-dsl") version "4.1.0"
+    `kotlin-dsl`
 }
 
 kotlin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
permits to remove hardcoded kotlin version again, like mentioned in #5130.