### PR TITLE
New Artifactory URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
 
         stage('Analytics') {
             steps {
-                sh './gradlew --console=plain check -x test'
+                sh './gradlew --console=plain check -x test -x pmdMain -x pmdTest' // TODO: Probably more cleanly remove PMD overall if no use?
             }
             post {
                 always {
@@ -140,8 +140,7 @@ pipeline {
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tools: [
-                            spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true),
-                            pmdParser(pattern: '**/build/reports/pmd/*.xml')
+                            spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true)
                         ])
 
                     recordIssues(skipBlames: true, enabledForFailure: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
 
         stage('Analytics') {
             steps {
-                sh './gradlew --console=plain check -x test -x pmdMain -x pmdTest' // TODO: Probably more cleanly remove PMD overall if no use?
+                sh './gradlew --console=plain check -x test -x pmdMain -x pmdTest -x pmdJmh' // TODO: Probably more cleanly remove PMD overall if no use?
             }
             post {
                 always {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -18,18 +18,14 @@ repositories {
 
     maven {
         name = "Terasology Artifactory"
-        url = URI("http://artifactory.terasology.org/artifactory/virtual-repo-live")
-        @Suppress("UnstableApiUsage")
-        isAllowInsecureProtocol = true  // 😱
+        url = URI("https://artifactory.terasology.io/artifactory/virtual-repo-live")
     }
 
-    // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
+    // TODO MYSTERY: As of November 7th 2021 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
     // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
     maven {
         name = "Terasology snapshot locals"
-        url = URI("http://artifactory.terasology.org/artifactory/terasology-snapshot-local")
-        @Suppress("UnstableApiUsage")
-        isAllowInsecureProtocol = true  // 😱
+        url = URI("https://artifactory.terasology.io/artifactory/terasology-snapshot-local")
     }
 }
 

--- a/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-repositories.gradle.kts
@@ -44,8 +44,7 @@ repositories {
         } else {
             // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
             name = "Terasology Artifactory"
-            url = URI("http://artifactory.terasology.org/artifactory/virtual-repo-live")
-            isAllowInsecureProtocol = true  // 😱
+            url = URI("https://artifactory.terasology.io/artifactory/virtual-repo-live")
         }
     }
 
@@ -53,7 +52,6 @@ repositories {
     // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
     maven {
         name = "Terasology snapshot locals"
-        url = URI("http://artifactory.terasology.org/artifactory/terasology-snapshot-local")
-        isAllowInsecureProtocol = true  // 😱
+        url = URI("https://artifactory.terasology.io/artifactory/terasology-snapshot-local")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,16 +11,14 @@ buildscript {
         maven {
             // required to provide runtime dependencies to build-logic.
             name = "Terasology Artifactory"
-            url = "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-            allowInsecureProtocol = true  // 😱
+            url = "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         }
 
         // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
         // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
         maven {
             name = "Terasology snapshot locals"
-            url = "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
-            allowInsecureProtocol = true  // 😱
+            url = "https://artifactory.terasology.io/artifactory/terasology-snapshot-local"
         }
     }
 
@@ -64,7 +62,7 @@ safe to use, any newer than 11 may cause issues.
 If you encounter oddities try Java 11.
 See https://github.com/MovingBlocks/Terasology/issues/3976.
 Current detected Java version is ${JavaVersion.current()}
- from vendor ${System.getProperty("java.vendor")} 
+ from vendor ${System.getProperty("java.vendor")}
 located at ${System.getProperty("java.home")}
 """)
 }
@@ -315,7 +313,7 @@ task assembleBuildHarness(type: Zip) {
     }
 
     from('templates') {
-        include 'build.gradle'        
+        include 'build.gradle'
     }
 
     from('.') {

--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -14,8 +14,7 @@ publishing {
 
             if (rootProject.hasProperty("publishRepo")) {
                 // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                url = "http://artifactory.terasology.org/artifactory/$publishRepo"
-                allowInsecureProtocol true // 😱
+                url = "https://artifactory.terasology.io/artifactory/$publishRepo"
                 logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
             } else {
                 // Support override from the environment to use a different target publish org
@@ -38,8 +37,7 @@ publishing {
                     }
 
                     logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                    url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
-                    allowInsecureProtocol true
+                    url = "https://artifactory.terasology.io/artifactory/$deducedPublishRepo"
                 }
             }
 

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -7,16 +7,14 @@ buildscript {
         maven {
             // required to provide runtime dependencies to build-logic.
             name = "Terasology Artifactory"
-            url = "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-            allowInsecureProtocol = true  // 😱
+            url = "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         }
 
         // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?
         // We've been using it that way for *years* and nothing likewise changed in the area for years as well. This seems to work ....
         maven {
             name = "Terasology snapshot locals"
-            url = "http://artifactory.terasology.org/artifactory/terasology-snapshot-local"
-            allowInsecureProtocol = true  // 😱
+            url = "https://artifactory.terasology.io/artifactory/terasology-snapshot-local"
         }
     }
 }

--- a/templates/facades.gradle
+++ b/templates/facades.gradle
@@ -12,7 +12,7 @@ repositories {
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
     maven {
         name "Terasology Artifactory"
-        url "http://artifactory.terasology.org/artifactory/repo"
+        url "https://artifactory.terasology.io/artifactory/repo"
     }
 }
 

--- a/templates/gradle.properties
+++ b/templates/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1024m
 # To pass via CLI use: -Dorg.gradle.internal.publish.checksums.insecure=true
 
 # Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
-# alternativeResolutionRepo=http://artifactory.terasology.org/artifactory/virtual-nanoware-and-remote
+# alternativeResolutionRepo=https://artifactory.terasology.io/artifactory/virtual-nanoware-and-remote
 
 # Credentials for publishing to Artifactory. Good for local testing
 # mavenUser=


### PR DESCRIPTION
Finally puts the new Artifactory to use. Plus skips PMD for now but in a simple way as my head isn't quite deep enough in the Gradle magic to clean it out more properly right now (focused on Artifactory, just was annoyed by overly long builds)