### PR TITLE
fix: make entity dump filename windows compatible

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/console/commands/CoreCommands.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/commands/CoreCommands.java
@@ -479,7 +479,7 @@ public class CoreCommands extends BaseComponentSystem {
         PrefabSerializer prefabSerializer =
                 new PrefabSerializer(engineEntityManager.getComponentLibrary(), engineEntityManager.getTypeSerializerLibrary());
         WorldDumper worldDumper = new WorldDumper(engineEntityManager, prefabSerializer);
-        Path outFile = PathManager.getInstance().getHomePath().resolve(Instant.now() + "-entityDump.json");
+        Path outFile = PathManager.getInstance().getHomePath().resolve(Instant.now().toString().replaceAll(":", "-") + "-entityDump.json");
         if (componentNames.length == 0) {
             savedEntityCount = worldDumper.save(outFile);
         } else {


### PR DESCRIPTION
### Contains

- windows doesn't allow colons (':') in filenames
- so far the filename included the timestamp in format YYYY-MM-DDTHH:MM:SS.MSZ, e.g. 2023-09-28T17:01:31.685172Z-entityDump.json
- now colons will be replaced by dashes ('-')

### How to test

1. Start any Terasology world on Windows with this branch checked out
2. Open the in-game console (F1) and execute `dumpEntities`
3. Verify that Terasology does not crash and that an entity dump file without colons in its name is created

### Outstanding before merging

- [ ] confirming the fix

Fixes #5144 