### PR TITLE
fix pmd warnings, codemetrics-2.1.0, gradle-8.4

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     implementation("org.terasology.gestalt:gestalt-module:7.1.0")
 
     // plugins we configure
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.3")
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.0")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3")
 
     api(kotlin("test"))

--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -14,8 +14,8 @@ plugins {
 }
 
 dependencies {
-    "pmd"("net.sourceforge.pmd:pmd-core:6.15.0")
-    "pmd"("net.sourceforge.pmd:pmd-java:6.15.0")
+    pmd("net.sourceforge.pmd:pmd-core:6.55.0")
+    pmd("net.sourceforge.pmd:pmd-java:6.55.0")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.2.11") {
         because("runtime: to configure logging during tests with logback.xml")
@@ -27,7 +27,7 @@ dependencies {
         because("redirects java.util.logging (from e.g. junit) through slf4j")
     }
 
-    add("testImplementation", platform("org.junit:junit-bom:5.8.1"))
+    add("testImplementation", platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
 
 
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
-    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '1.6.3', ext: 'zip'
+    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '2.1.0', ext: 'zip'
 
     // Natives for JNLua (Kallisti, KComputers)
     natives group: 'org.terasology.jnlua', name: 'jnlua_natives', version: '0.1.0-SNAPSHOT', ext: 'zip'

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -247,7 +247,7 @@ def createVersionInfoFile = tasks.register("createVersionInfoFile", WritePropert
         // It is a value we can always get (on Jenkins or otherwise) but we don't want local builds
         // to invalidate their cache whenever the time changes.
         // TODO: after upgrading to Gradle 6.8, see if we can have it ignore this property specifically:
-        //     https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:property_file_normalization
+        //     https://docs.gradle.org/current/userguide/incremental_build.html#sec:property_file_normalization
         property("dateTime", startDateTimeString)
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
gradle-8.4 released, fully supports java-21. codemetrics-2.1.0 has the pmd rules inlined, so warnings are gone now. see https://github.com/MovingBlocks/TeraConfig/pull/19 . remove a couple of outdated TODOs. adjust a link in a comment to new gradle versions.

