### PR TITLE
perf(rendering): use MONO rendering stage

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
@@ -219,8 +219,7 @@ public class StateIngame implements GameState {
         display.prepareToRender();
 
         if (worldRenderer != null) {
-            worldRenderer.render(RenderingStage.LEFT_EYE);
-            worldRenderer.render(RenderingStage.RIGHT_EYE);
+            worldRenderer.render(RenderingStage.MONO);
         }
 
         /* UI */


### PR DESCRIPTION
### Contains

Use the `MONO` rendering stage in a single rendering pass instead of two rendering passes for the `LEFT_EYE` and `RIGHT_EYE`.

I believe this is a left-over/bug from removing VR support. In previous revisions, the `MONO` stage was used when **not** supporting VR.

https://github.com/MovingBlocks/Terasology/blob/602ef46a5bf81a175c4667560d8c2e802d4259be/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java#L213-L218

### How to test

Run the game and check for any rendering quirks. 

The game should run a bit smoother (some rough profiling suggests that the second rendering pass accounted for 25% of the total rendering time).

### Outstanding before merging

n/a
