### PR TITLE
chore: init metrics only if monitoring enabled

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
@@ -13,7 +13,6 @@ import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.logic.players.LocalPlayer;
-import org.terasology.engine.logic.players.event.ResetCameraEvent;
 import org.terasology.engine.network.ClientComponent;
 import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.registry.In;

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
@@ -19,6 +19,7 @@ import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.BlockManager;
+import org.terasology.unittest.stubs.DummyEvent;
 
 import java.io.IOException;
 
@@ -75,7 +76,7 @@ public class ExampleTest {
         Context clientContext = helper.createClient();
 
         // send an event to a client's local player just for fun
-        clientContext.get(LocalPlayer.class).getClientEntity().send(new ResetCameraEvent());
+        clientContext.get(LocalPlayer.class).getClientEntity().send(new DummyEvent());
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
@@ -6,6 +6,8 @@ import com.google.common.collect.Lists;
 import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityManager;
@@ -22,6 +24,7 @@ import java.io.IOException;
 
 @IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
 public class ExampleTest {
+    private static final Logger logger = LoggerFactory.getLogger(ExampleTest.class);
 
     @In
     private WorldProvider worldProvider;
@@ -33,6 +36,13 @@ public class ExampleTest {
     private Time time;
     @In
     private ModuleTestingHelper helper;
+
+    @Test
+    public void testClientCreation() {
+        logger.info("Starting test 'testClientCreation'");
+        Assertions.assertDoesNotThrow(helper::createClient);
+        logger.info("Done with test 'testClientCreation'");
+    }
 
     @Test
     public void testClientConnection() throws IOException {

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/common/MonitoringSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/common/MonitoringSubsystem.java
@@ -38,9 +38,8 @@ public class MonitoringSubsystem implements EngineSubsystem {
         if (rootContext.get(SystemConfig.class).monitoringEnabled.get()) {
             advancedMonitor = new AdvancedMonitor();
             advancedMonitor.setVisible(true);
+            initMicrometerMetrics(rootContext.get(Time.class));
         }
-
-        initMicrometerMetrics(rootContext.get(Time.class));
     }
 
     /**


### PR DESCRIPTION
When looking into the integration test output, I noticed monitoring-related errors and thought that we don't need monitoring when running integration tests in the first place. On looking into the monitoring subsystem, I noticed that we do not create the `AdvancedMonitor` if monitoring is not enabled, but we still initialized metrics etc. I don't think this is necessary if monitoring is not enabled, so this PR changes that.

Also, the sporadically failing tests typically time out on creating a client (in particular, joining a client to the host). I added a new integration test that simply tests that client creation does not time out. Unfortunately, I was not able to reproduce the timeout situation locally. Still I think that this test might be helpful.

Finally, I noticed that in the example test `testSendEvent` we're sending a `ResetCameraEvent` which I thought to be weirdly specific and potentially introducing issues. If the goal of a test is to only test that sending an event doesn't fail, we should use a minimal dummy event and test specific events in a dedicated fashion. This is why, I changed the test to send `DummyEvent` instead.

TL;DR This PR contains
- initializing metrics only if monitoring is enabled
- adding client creation test to ensure clients can be created and connect to hosts without experiencing a timeout
- sending `DummyEvent` instead of `ResetCameraEvent` to avoid unintended side effects and delays that might falsify the intended test result

I'm not at all sure or convinced that these changes fix the sporadics, however they might add to making them more reliable.