### PR TITLE
test: split and improve ObjectFieldMapTypeHandlerFactoryTests

### DIFF
--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
@@ -3,6 +3,7 @@
 package org.terasology.persistence.typeHandling.coreTypes.factories;
 
 import com.google.common.collect.Maps;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.terasology.persistence.typeHandling.TypeHandler;
 import org.terasology.persistence.typeHandling.TypeHandlerContext;
@@ -12,12 +13,16 @@ import org.terasology.persistence.typeHandling.reflection.SerializationSandbox;
 import org.terasology.reflection.TypeInfo;
 import org.terasology.reflection.reflect.ConstructorLibrary;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class ObjectFieldMapTypeHandlerFactoryTest {
@@ -30,22 +35,81 @@ public class ObjectFieldMapTypeHandlerFactoryTest {
     private final TypeHandlerContext context =
             new TypeHandlerContext(typeHandlerLibrary, mock(SerializationSandbox.class));
 
-    private static class SomeClass<T> {
-        private T t;
-        private List<T> list;
-    }
-
     @Test
-    public void testObject() {
-        Optional<TypeHandler<SomeClass<Integer>>> typeHandler =
-                typeHandlerFactory.create(new TypeInfo<SomeClass<Integer>>() { }, context);
+    @DisplayName("Test that type handler is correctly created via type handler factory")
+    public void testSingleTypeClassTypeHandlerCreationViaFactory() {
+        Optional<TypeHandler<SingleTypeClass<Integer>>> typeHandler =
+                typeHandlerFactory.create(new TypeInfo<SingleTypeClass<Integer>>() { }, context);
 
         assertTrue(typeHandler.isPresent());
         assertTrue(typeHandler.get() instanceof ObjectFieldMapTypeHandler);
+    }
 
-        // Verify that the Integer and List<Integer> TypeHandlers were loaded from the TypeHandlerLibrary
-        verify(typeHandlerLibrary).getTypeHandler(eq(TypeInfo.of(Integer.class).getType()));
+    @Test
+    @DisplayName("Test that type handler is correctly created via type handler factory")
+    public void testMultiTypeClassTypeHandlerCreationViaFactory() {
+        Optional<TypeHandler<MultiTypeClass<Integer, List<Integer>>>> typeHandler =
+                typeHandlerFactory.create(new TypeInfo<MultiTypeClass<Integer, List<Integer>>>() { }, context);
 
-        verify(typeHandlerLibrary).getTypeHandler(eq(new TypeInfo<List<Integer>>() { }.getType()));
+        assertTrue(typeHandler.isPresent());
+        assertTrue(typeHandler.get() instanceof ObjectFieldMapTypeHandler);
+    }
+
+    @Test
+    @DisplayName("Test implicit type handler loading for plain old java objects (pojo)")
+    public void testPojo() {
+        typeHandlerFactory.create(new TypeInfo<SingleTypeClass<Integer>>() { }, context);
+
+        // Verify that the Integer TypeHandler loading was called on the TypeHandlerLibrary
+        verify(typeHandlerLibrary, times(1)).getTypeHandler((Type) any());
+        verify(typeHandlerLibrary, times(1)).getTypeHandler(eq(TypeInfo.of(Integer.class).getType()));
+        verify(typeHandlerLibrary, never()).getTypeHandler((Class<Object>) any());
+        verify(typeHandlerLibrary, never()).getTypeHandler((TypeInfo<Object>) any());
+    }
+
+    @Test
+    @DisplayName("Test implicit type handler loading for list collection objects")
+    public void testListCollection() {
+        typeHandlerFactory.create(new TypeInfo<SingleTypeClass<List<Integer>>>() { }, context);
+
+        // Verify that the List<Integer> TypeHandler was loaded from the TypeHandlerLibrary
+        verify(typeHandlerLibrary, times(1)).getTypeHandler((Type) any());
+        verify(typeHandlerLibrary, times(1)).getTypeHandler(eq(new TypeInfo<List<Integer>>() { }.getType()));
+        verify(typeHandlerLibrary, never()).getTypeHandler((Class<Object>) any());
+        verify(typeHandlerLibrary, never()).getTypeHandler((TypeInfo<Object>) any());
+    }
+
+    @Test
+    @DisplayName("Test implicit type handler loading for multiple objects of same type")
+    public void testMultipleObjectsOfSameType() {
+        typeHandlerFactory.create(new TypeInfo<MultiTypeClass<Integer, Integer>>() { }, context);
+
+        // Verify that the Integer TypeHandler loading was called on the TypeHandlerLibrary
+        verify(typeHandlerLibrary, times(2)).getTypeHandler((Type) any());
+        verify(typeHandlerLibrary, times(2)).getTypeHandler(eq(TypeInfo.of(Integer.class).getType()));
+        verify(typeHandlerLibrary, never()).getTypeHandler((Class<Object>) any());
+        verify(typeHandlerLibrary, never()).getTypeHandler((TypeInfo<Object>) any());
+    }
+
+    @Test
+    @DisplayName("Test implicit type handler loading for multiple objects of different type")
+    public void testMultipleObjectsOfDifferentType() {
+        typeHandlerFactory.create(new TypeInfo<MultiTypeClass<Integer, List<Integer>>>() { }, context);
+
+        // Verify that the Integer TypeHandler loading was called on the TypeHandlerLibrary
+        verify(typeHandlerLibrary, times(2)).getTypeHandler((Type) any());
+        verify(typeHandlerLibrary, times(1)).getTypeHandler(eq(TypeInfo.of(Integer.class).getType()));
+        verify(typeHandlerLibrary, times(1)).getTypeHandler(eq(new TypeInfo<List<Integer>>() { }.getType()));
+        verify(typeHandlerLibrary, never()).getTypeHandler((Class<Object>) any());
+        verify(typeHandlerLibrary, never()).getTypeHandler((TypeInfo<Object>) any());
+    }
+
+    private static class SingleTypeClass<T> {
+        private T t;
+    }
+
+    private static class MultiTypeClass<T, U> {
+        private T t;
+        private U u;
     }
 }


### PR DESCRIPTION
- split into multiple tests to avoid testing different aspects in single test
- remove usage of implicit member type knowledge in assertion phase
- add negative assertions to ensure only expected calls are made
- improve test case documentation

Once #5154 is merged, we'll need to update the suppression of `UUF_UNUSED_FIELD` spotbugs findings for `SingleTypeClass` and `MultiTypeClass`.