### PR TITLE
upgrade slf4j-2.0, permit passing suppliers to loggers, and thus lazy…

### DIFF
--- a/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-metrics.gradle.kts
@@ -17,13 +17,13 @@ dependencies {
     pmd("net.sourceforge.pmd:pmd-core:6.55.0")
     pmd("net.sourceforge.pmd:pmd-java:6.55.0")
 
-    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.11") {
+    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.12") {
         because("runtime: to configure logging during tests with logback.xml")
     }
     testRuntimeOnly("org.codehaus.janino:janino:3.1.7") {
         because("allows use of EvaluatorFilter in logback.xml")
     }
-    testRuntimeOnly("org.slf4j:jul-to-slf4j:1.7.36") {
+    testRuntimeOnly("org.slf4j:jul-to-slf4j:2.0.9") {
         because("redirects java.util.logging (from e.g. junit) through slf4j")
     }
 

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -75,7 +75,7 @@ if (project.name == "ModuleTestingEnvironment") {
     dependencies {
         // MTE is a special snowflake, it gets these things as non-test dependencies
         implementation(group = "org.terasology.engine", name = "engine-tests", version = moduleMetadata.engineVersion())
-        implementation("ch.qos.logback:logback-classic:1.2.3")
+        implementation("ch.qos.logback:logback-classic:1.2.12")
         runtimeOnly("org.codehaus.janino:janino:3.1.3") {
             because("logback filters")
         }

--- a/engine-tests/build.gradle
+++ b/engine-tests/build.gradle
@@ -62,11 +62,11 @@ dependencies {
 
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
 
-    implementation('org.slf4j:slf4j-api:1.7.36') {
+    implementation('org.slf4j:slf4j-api:2.0.9') {
         because('a backend-independent Logger')
     }
 
-    testImplementation("ch.qos.logback:logback-classic:1.2.11") {
+    testImplementation("ch.qos.logback:logback-classic:1.4.11") {
         because("implementation: a test directly uses logback.classic classes")
     }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -115,10 +115,10 @@ dependencies {
     implementation group: 'de.matthiasmann.twl', name: 'PNGDecoder', version: '1111'
 
     // Logging
-    implementation('org.slf4j:slf4j-api:1.7.36') {
+    implementation('org.slf4j:slf4j-api:2.0.9') {
         because('a backend-independent Logger')
     }
-    implementation("ch.qos.logback:logback-classic:1.2.11") {
+    implementation("ch.qos.logback:logback-classic:1.2.12") {
         because("telemetry implementation uses logback to send to logstash " +
                 "and we bundle org.terasology.logback for the regex filter")
     }
@@ -133,7 +133,7 @@ dependencies {
     implementation(group: 'com.snowplowanalytics', name: 'snowplow-java-tracker', version: '0.12.1') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
-    implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.2'
+    implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
 
     // Our developed libs
     api group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.2.0-SNAPSHOT'

--- a/engine/src/main/resources/org/terasology/engine/logback/setup.xml
+++ b/engine/src/main/resources/org/terasology/engine/logback/setup.xml
@@ -14,6 +14,6 @@
     <newRule pattern="*/appender/denyRegex" actionClass="org.terasology.logback.RegexFilterAction" />
     <newRule pattern="*/appender/requireRegex" actionClass="org.terasology.logback.RegexFilterAction" />
 
-    <!-- allow include inside appenders (logback 1.2.11 only enabled Include on the root config by default.) -->
+    <!-- allow include inside appenders (logback 1.2 only enabled Include on the root config by default.) -->
     <newRule pattern="*/appender/include" actionClass="ch.qos.logback.core.joran.action.IncludeAction" />
 </included>

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     // TODO: Consider whether we can move the CR dependency back here from the engine, where it is referenced from the main menu
     implementation(group = "org.terasology.crashreporter", name = "cr-terasology", version = "5.0.0")
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.11") {
+    runtimeOnly("ch.qos.logback:logback-classic:1.2.12") {
         because("to configure logging with logback.xml")
     }
     runtimeOnly("org.codehaus.janino:janino:3.1.7") {


### PR DESCRIPTION
… evaluation.

permit use of slf4j fluent api:
https://www.slf4j.org/manual.html#fluent

tried to upgrade to logback 1.3.x or logback 1.4.x, but code contains code depending on ch.qos.logback.core.joran.spi.InterpretationContext: engine/src/main/java/org/terasology/logback/RegexFilterAction.java

