### PR TITLE
refactor: component field visibility public

### DIFF
--- a/engine-tests/src/main/java/org/terasology/unittest/stubs/GetterSetterComponent.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/stubs/GetterSetterComponent.java
@@ -9,7 +9,7 @@ public class GetterSetterComponent implements Component<GetterSetterComponent> {
     public transient boolean getterUsed;
     public transient boolean setterUsed;
 
-    private Vector3f value = new Vector3f(0, 0, 0);
+    public Vector3f value = new Vector3f(0, 0, 0);
 
     public Vector3f getValue() {
         getterUsed = true;

--- a/engine/src/jmh/java/org/terasology/benchmark/reflectFactory/GetterSetterComponent.java
+++ b/engine/src/jmh/java/org/terasology/benchmark/reflectFactory/GetterSetterComponent.java
@@ -5,7 +5,7 @@ package org.terasology.benchmark.reflectFactory;
 import org.terasology.gestalt.entitysystem.component.Component;
 
 public class GetterSetterComponent implements Component<GetterSetterComponent> {
-    private int value;
+    public int value;
 
     public void setValue(int value) {
         this.value = value;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorSimulationComponent.java
@@ -46,7 +46,7 @@ public class SectorSimulationComponent implements Component<SectorSimulationComp
      * This is used to calculate the delta between simulation events, and should not be changed outside of this class
      * or the {@link SectorSimulationSystem}.
      */
-    protected long lastSimulationTime;
+    public long lastSimulationTime;
 
     /**
      * Create a new {@link SectorSimulationComponent} with the default max delta.

--- a/engine/src/main/java/org/terasology/engine/logic/delay/DelayedActionComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/delay/DelayedActionComponent.java
@@ -17,8 +17,8 @@ import java.util.Set;
  */
 @ForceBlockActive
 public final class DelayedActionComponent implements Component<DelayedActionComponent> {
-    private Map<String, Long> actionIdsWakeUp = new HashMap<>();
-    private long lowestWakeUp = Long.MAX_VALUE;
+    public Map<String, Long> actionIdsWakeUp = new HashMap<>();
+    public long lowestWakeUp = Long.MAX_VALUE;
 
     public DelayedActionComponent() {
     }

--- a/engine/src/main/java/org/terasology/engine/logic/delay/PeriodicActionComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/delay/PeriodicActionComponent.java
@@ -17,9 +17,9 @@ import java.util.Set;
  */
 @ForceBlockActive
 public final class PeriodicActionComponent implements Component<PeriodicActionComponent> {
-    private Map<String, Long> actionIdsWakeUp = new HashMap<>();
-    private Map<String, Long> actionIdsPeriod = new HashMap<>();
-    private long lowestWakeUp = Long.MAX_VALUE;
+    public Map<String, Long> actionIdsWakeUp = new HashMap<>();
+    public Map<String, Long> actionIdsPeriod = new HashMap<>();
+    public long lowestWakeUp = Long.MAX_VALUE;
 
     public PeriodicActionComponent() {
     }

--- a/engine/src/main/java/org/terasology/engine/logic/location/LocationComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/location/LocationComponent.java
@@ -30,22 +30,22 @@ public final class LocationComponent implements Component<LocationComponent>, Re
 
     // Relative to
     @Replicate
-    EntityRef parent = EntityRef.NULL;
+    public EntityRef parent = EntityRef.NULL;
     @Replicate
-    List<EntityRef> children = Lists.newArrayList();
+    public List<EntityRef> children = Lists.newArrayList();
     // Standard position/rotation
     @Replicate
     @TextField
-    final Vector3f position = new Vector3f();
+    public final Vector3f position = new Vector3f();
     @Replicate
-    Quaternionf rotation = new Quaternionf();
+    public Quaternionf rotation = new Quaternionf();
     @Replicate
-    float scale = 1.0f;
+    public float scale = 1.0f;
     @Replicate
-    Vector3f lastPosition = new Vector3f();
+    public Vector3f lastPosition = new Vector3f();
     @Replicate
-    Quaternionf lastRotation = new Quaternionf();
-    private boolean isDirty = false;
+    public Quaternionf lastRotation = new Quaternionf();
+    public boolean isDirty = false;
 
     public LocationComponent() {
     }

--- a/engine/src/main/java/org/terasology/engine/logic/players/FirstPersonHeldItemMountPointComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/FirstPersonHeldItemMountPointComponent.java
@@ -22,12 +22,12 @@ public class FirstPersonHeldItemMountPointComponent implements Component<FirstPe
     public Quaternionf rotationQuaternion;
     public float scale = 1f;
 
-    private boolean trackingDataReceived;
+    public boolean trackingDataReceived;
 
 
     // The hand/tool models seem to have an origin other than the pivot point. This is a best-effort correction,
     // in the form of a 4x4 homogeneous transformation matrix
-    private Matrix4f toolAdjustmentMatrix = new Matrix4f(
+    public Matrix4f toolAdjustmentMatrix = new Matrix4f(
             1.0f, 0.0f, 0.0f, 0.0f,
             0.0f, (float) Math.cos(230. * TeraMath.DEG_TO_RAD), (float) Math.sin(230. * TeraMath.DEG_TO_RAD), 0.0f,
             0.0f, (float) -Math.sin(230. * TeraMath.DEG_TO_RAD), (float) Math.cos(230. * TeraMath.DEG_TO_RAD), 0.0f,

--- a/engine/src/main/java/org/terasology/engine/network/NetworkComponent.java
+++ b/engine/src/main/java/org/terasology/engine/network/NetworkComponent.java
@@ -10,7 +10,7 @@ public class NetworkComponent implements Component<NetworkComponent> {
 
     // Network identifier for the entity
     @Replicate
-    private int networkId;
+    public int networkId;
 
     @Override
     public void copyFrom(NetworkComponent other) {

--- a/engine/src/main/java/org/terasology/engine/network/PingComponent.java
+++ b/engine/src/main/java/org/terasology/engine/network/PingComponent.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public final class PingComponent implements Component<PingComponent> {
 
     @Replicate
-    private Map<EntityRef, Long> pings = new HashMap<>();
+    public Map<EntityRef, Long> pings = new HashMap<>();
 
     public void setValues(Map<EntityRef, Long> values) {
         pings.clear();

--- a/engine/src/main/java/org/terasology/engine/world/block/BlockComponent.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/BlockComponent.java
@@ -12,9 +12,9 @@ import org.terasology.gestalt.entitysystem.component.Component;
  */
 public final class BlockComponent implements Component<BlockComponent> {
     @Replicate
-    protected Vector3i position = new Vector3i();
+    public Vector3i position = new Vector3i();
     @Replicate
-    protected Block block;
+    public Block block;
 
     public BlockComponent() {
     }


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.