### PR TITLE
sonar upgrade to 5.0.0

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")
-    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
+    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:5.0.0.4638")
 
     api(kotlin("test"))
 }


### PR DESCRIPTION
the new default behavior of sonarscanner is to not compile any more, to permit easier re-run. it can be controlled by a flag. the default behavior changes from sonar 4.4.1 to sonar 5.0.0, as well the name of the flag is unlucky. see here for more explanation: https://community.sonarsource.com/t/sonarscanner-for-gradle-you-can-now-decide-when-to-compile

