### PR TITLE
prepare switch over to kotlin, "new" java date formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,14 +67,14 @@ located at ${System.getProperty("java.home")}
 
 // Declare "extra properties" (variables) for the project (and subs) - a Gradle thing that makes them special.
 ext {
-    dirNatives = 'natives'
-    dirConfigMetrics = 'config/metrics'
-    templatesDir = file('templates')
+    dirNatives = "natives"
+    dirConfigMetrics = "config/metrics"
+    templatesDir = file("templates")
 
     // Lib dir for use in manifest entries etc (like in :engine). A separate "libsDir" exists, auto-created by Gradle
-    subDirLibs = 'libs'
+    subDirLibs = "libs"
 
-    LwjglVersion = '3.3.3'
+    LwjglVersion = "3.3.3"
 }
 
 
@@ -112,7 +112,7 @@ dependencies {
 
 }
 
-task extractWindowsNatives(type: Copy) {
+tasks.register("extractWindowsNatives", Copy) {
     description = "Extracts the Windows natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains("natives-windows") ? zipTree(it) : [] }
@@ -121,7 +121,7 @@ task extractWindowsNatives(type: Copy) {
     exclude("META-INF/**")
 }
 
-task extractMacOSXNatives(type: Copy) {
+tasks.register("extractMacOSXNatives", Copy) {
     description = "Extracts the OSX natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains("natives-macos") ? zipTree(it) : [] }
@@ -130,16 +130,16 @@ task extractMacOSXNatives(type: Copy) {
     exclude("META-INF/**")
 }
 
-task extractLinuxNatives(type: Copy) {
+tasks.register("extractLinuxNatives", Copy) {
     description = "Extracts the Linux natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains("natives-linux") ? zipTree(it) : [] }
     }
     into("$dirNatives/linux")
-    exclude('META-INF/**')
+    exclude("META-INF/**")
 }
 
-task extractJNLuaNatives(type: Copy) {
+tasks.register("extractJNLuaNatives", Copy) {
     description = "Extracts the JNLua natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains("jnlua") ? zipTree(it) : [] }
@@ -147,7 +147,7 @@ task extractJNLuaNatives(type: Copy) {
     into("$dirNatives")
 }
 
-task extractNativeBulletNatives(type: Copy) {
+tasks.register("extractNativeBulletNatives", Copy) {
     description = "Extracts the JNBullet natives from the downloaded zip"
     from {
         configurations.natives.collect { it.getName().contains("JNBullet") ? zipTree(it) : [] }
@@ -156,7 +156,7 @@ task extractNativeBulletNatives(type: Copy) {
 }
 
 
-task extractNatives {
+tasks.register("extractNatives") {
     description = "Extracts all the native lwjgl libraries from the downloaded zip"
     dependsOn extractWindowsNatives
     dependsOn extractLinuxNatives
@@ -169,7 +169,7 @@ task extractNatives {
 // Helper tasks                                                                                                      //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-task extractConfig(type: Copy) {
+tasks.register("extractConfig", Copy) {
     description = "Extracts our configuration files from the zip we fetched as a dependency"
     from {
         configurations.codeMetrics.collect {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
     id "java-platform"
 
     // The root project should not be an eclipse project. It keeps eclipse (4.2) from finding the sub-projects.
-    //apply plugin: 'eclipse'
+    //apply plugin: "eclipse"
     id "idea"
     // For the "Build and run using: Intellij IDEA | Gradle" switch
     id "org.jetbrains.gradle.plugin.idea-ext" version "1.1.7"
@@ -103,38 +103,38 @@ dependencies {
 
 
     // Config for our code analytics lives in a centralized repo: https://github.com/MovingBlocks/TeraConfig
-    codeMetrics group: 'org.terasology.config', name: 'codemetrics', version: '2.2.0', ext: 'zip'
+    codeMetrics(group: "org.terasology.config", name: "codemetrics", version: "2.2.0", ext: "zip")
 
     // Natives for JNLua (Kallisti, KComputers)
-    natives group: 'org.terasology.jnlua', name: 'jnlua_natives', version: '0.1.0-SNAPSHOT', ext: 'zip'
+    natives(group: "org.terasology.jnlua", name: "jnlua_natives", version: "0.1.0-SNAPSHOT", ext: "zip")
 
     // Natives for JNBullet
-    natives group: 'org.terasology.jnbullet', name: 'JNBullet', version: '1.0.2', ext: 'zip'
+    natives(group: "org.terasology.jnbullet", name: "JNBullet", version: "1.0.2", ext: "zip")
 
 }
 
 task extractWindowsNatives(type: Copy) {
     description = "Extracts the Windows natives from the downloaded zip"
     from {
-        configurations.natives.collect { it.getName().contains('natives-windows') ? zipTree(it) : [] }
+        configurations.natives.collect { it.getName().contains("natives-windows") ? zipTree(it) : [] }
     }
     into("$dirNatives/windows")
-    exclude('META-INF/**')
+    exclude("META-INF/**")
 }
 
 task extractMacOSXNatives(type: Copy) {
     description = "Extracts the OSX natives from the downloaded zip"
     from {
-        configurations.natives.collect { it.getName().contains('natives-macos') ? zipTree(it) : [] }
+        configurations.natives.collect { it.getName().contains("natives-macos") ? zipTree(it) : [] }
     }
     into("$dirNatives/macosx")
-    exclude('META-INF/**')
+    exclude("META-INF/**")
 }
 
 task extractLinuxNatives(type: Copy) {
     description = "Extracts the Linux natives from the downloaded zip"
     from {
-        configurations.natives.collect { it.getName().contains('natives-linux') ? zipTree(it) : [] }
+        configurations.natives.collect { it.getName().contains("natives-linux") ? zipTree(it) : [] }
     }
     into("$dirNatives/linux")
     exclude('META-INF/**')
@@ -143,7 +143,7 @@ task extractLinuxNatives(type: Copy) {
 task extractJNLuaNatives(type: Copy) {
     description = "Extracts the JNLua natives from the downloaded zip"
     from {
-        configurations.natives.collect { it.getName().contains('jnlua') ? zipTree(it) : [] }
+        configurations.natives.collect { it.getName().contains("jnlua") ? zipTree(it) : [] }
     }
     into("$dirNatives")
 }
@@ -151,7 +151,7 @@ task extractJNLuaNatives(type: Copy) {
 task extractNativeBulletNatives(type: Copy) {
     description = "Extracts the JNBullet natives from the downloaded zip"
     from {
-        configurations.natives.collect { it.getName().contains('JNBullet') ? zipTree(it) : [] }
+        configurations.natives.collect { it.getName().contains("JNBullet") ? zipTree(it) : [] }
     }
     into("$dirNatives")
 }
@@ -210,7 +210,7 @@ project(":modules").subprojects.forEach { proj ->
     }
 }
 
-tasks.named('wrapper') {
+tasks.named("wrapper") {
     // ALL distributionType because IntelliJ prefers having its sources for analysis and reference.
     distributionType = Wrapper.DistributionType.ALL
 }
@@ -224,7 +224,7 @@ tasks.register("copyInMissingTemplates", CopyButNeverOverwrite) {
     description = "Copies in placeholders from the /templates dir to project root if not present yet"
     from(templatesDir)
     into(rootDir)
-    include('gradle.properties', 'override.cfg')
+    include("gradle.properties", "override.cfg")
 }
 
 tasks.register("jmxPassword", CopyButNeverOverwrite) {
@@ -252,21 +252,21 @@ idea {
 
     // Exclude Eclipse dirs
     // TODO: Update this as Eclipse bin dirs now generate in several deeper spots rather than at top-level
-    module.excludeDirs += file('bin')
-    module.excludeDirs += file('.settings')
+    module.excludeDirs += file("bin")
+    module.excludeDirs += file(".settings")
     // TODO: Add a single file exclude for facades/PC/Terasology.launch ?
 
     // Exclude special dirs
-    module.excludeDirs += file('natives')
-    module.excludeDirs += file('protobuf')
+    module.excludeDirs += file("natives")
+    module.excludeDirs += file("protobuf")
 
     // Exclude output dirs
-    module.excludeDirs += file('configs')
-    module.excludeDirs += file('logs')
-    module.excludeDirs += file('saves')
-    module.excludeDirs += file('screenshots')
-    module.excludeDirs += file('terasology-server')
-    module.excludeDirs += file('terasology-2ndclient')
+    module.excludeDirs += file("configs")
+    module.excludeDirs += file("logs")
+    module.excludeDirs += file("saves")
+    module.excludeDirs += file("screenshots")
+    module.excludeDirs += file("terasology-server")
+    module.excludeDirs += file("terasology-2ndclient")
 
     module.downloadSources = true
 
@@ -277,55 +277,55 @@ idea {
 }
 
 cleanIdea.doLast {
-    new File('Terasology.iws').delete()
+    new File("Terasology.iws").delete()
 }
 
-// A task to assemble various files into a single zip for distribution as 'build-harness.zip' for module builds
+// A task to assemble various files into a single zip for distribution as "build-harness.zip" for module builds
 task assembleBuildHarness(type: Zip) {
-    description 'Assembles a zip of files useful for module development'
+    description "Assembles a zip of files useful for module development"
 
     dependsOn extractNatives
-    from('natives'){
-        include '**/*'
+    from("natives"){
+        include "**/*"
         // TODO: use output of extractNatives?
         // TODO: which module needs natives to build?
-        into 'natives'
+        into "natives"
     }
 
     dependsOn extractConfig
-    from('config'){
-        //include 'gradle/**/*', 'metrics/**/*'
-        include '**/*'
+    from("config"){
+        //include "gradle/**/*", "metrics/**/*"
+        include "**/*"
         // TODO: depend on output of extractConfig?
-        into 'config'
+        into "config"
     }
 
-    from('gradle'){
-        include '**/*' // include all files in 'gradle'
+    from("gradle"){
+        include "**/*" // include all files in "gradle"
         // TODO: exclude groovy jar?
-        into 'gradle'
+        into "gradle"
     }
 
-    from('build-logic'){
-        include 'src/**', '*.kts'
-        into 'build-logic'
+    from("build-logic"){
+        include "src/**", "*.kts"
+        into "build-logic"
     }
 
-    from('templates') {
-        include 'build.gradle'
+    from("templates") {
+        include "build.gradle"
     }
 
-    from('.') {
-        include 'gradlew'
+    from(".") {
+        include "gradlew"
     }
 
-    // include file 'templates/module.logback-test.xml' as 'src/test/resources/logback-test.xml'
-    from('templates'){
-        include 'module.logback-test.xml'
-        rename 'module.logback-test.xml', 'logback-test.xml'
-        into 'src/test/resources'
+    // include file "templates/module.logback-test.xml" as "src/test/resources/logback-test.xml"
+    from("templates"){
+        include "module.logback-test.xml"
+        rename "module.logback-test.xml", "logback-test.xml"
+        into "src/test/resources"
     }
 
     // set the archive name
-    archiveFileName.set('build-harness.zip')
+    archiveFileName.set("build-harness.zip")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,12 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import org.jetbrains.gradle.ext.ActionDelegationConfig
+import org.terasology.gradology.CopyButNeverOverwrite
+
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
 // Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
 buildscript {
     repositories {
@@ -30,27 +36,20 @@ buildscript {
 
 plugins {
     // Needed for extending the "clean" task to also delete custom stuff defined here like natives
-    id "base"
+    id("base")
 
     // needs for native platform("org.lwjgl") handling.
-    id "java-platform"
+    id("java-platform")
 
     // The root project should not be an eclipse project. It keeps eclipse (4.2) from finding the sub-projects.
     //apply plugin: "eclipse"
-    id "idea"
+    id("idea")
     // For the "Build and run using: Intellij IDEA | Gradle" switch
-    id "org.jetbrains.gradle.plugin.idea-ext" version "1.1.7"
+    id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.7"
 
     id("com.google.protobuf") version "0.9.4" apply false
     id("terasology-repositories")
 }
-
-
-import org.gradle.internal.logging.text.StyledTextOutputFactory
-import org.jetbrains.gradle.ext.ActionDelegationConfig
-import org.terasology.gradology.CopyButNeverOverwrite
-
-import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
 // Test for right version of Java in use for running this script
 assert org.gradle.api.JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -3,6 +3,11 @@
 
 // The engine build is the primary Java project and has the primary list of dependencies
 
+import groovy.json.JsonSlurper
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
 plugins {
     id "java-library"
     id "org.jetbrains.gradle.plugin.idea-ext"
@@ -13,14 +18,6 @@ plugins {
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config, etc
 apply from: "$rootDir/config/gradle/publish.gradle"
 
-
-import groovy.json.JsonSlurper
-
-import java.text.SimpleDateFormat
-
-def dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
-dateTimeFormat.timeZone = TimeZone.getTimeZone("UTC")
-
 // Declare "extra properties" (variables) for the project - a Gradle thing that makes them special.
 ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
@@ -29,7 +26,7 @@ ext {
     templatesDir = new File(rootDir, "templates")
 
     // Stuff for our automatic version file setup
-    startDateTimeString = dateTimeFormat.format(new Date())
+    startDateTimeString = OffsetDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"))
     versionBase = new File(templatesDir, "version.txt").text.trim()
     displayVersion = versionBase
 }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -61,7 +61,7 @@ configurations {
     }
 }
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         // always pick reflections fork
         dependencySubstitution {
@@ -194,7 +194,8 @@ sourceSets {
     }
 }
 
-task jmh(type: JavaExec, dependsOn: jmhClasses) {
+tasks.register("jmh", JavaExec) {
+    dependsOn jmhClasses
     mainClass = "org.openjdk.jmh.Main"
     classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
 }
@@ -264,7 +265,7 @@ tasks.named("processResources", Copy) {
 }
 
 //TODO: Remove this when gestalt can handle ProtectionDomain without classes (Resources)
-task copyResourcesToClasses(type: Copy) {
+tasks.register("copyResourcesToClasses", Copy) {
     from processResources
     into sourceSets.main.output.classesDirs.first()
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -51,7 +51,7 @@ sourceSets {
 // Customizations for the main compilation configuration
 configurations {
 
-    // Exclude a couple JWJGL modules that aren"t needed during compilation (OS specific stuff in these two perhaps)
+    // Exclude a couple JWJGL modules that aren't needed during compilation (OS specific stuff in these two perhaps)
     implementation {
         exclude module: "lwjgl-platform"
         exclude module: "jinput-platform"
@@ -70,46 +70,46 @@ configurations.configureEach {
 // Primary dependencies definition
 dependencies {
     // Storage and networking
-    api "com.google.guava:guava:31.0-jre"
-    api "com.google.code.gson:gson:2.8.6"
-    api "net.sf.trove4j:trove4j:3.0.3"
-    implementation "io.netty:netty-all:4.1.77.Final"
-    implementation "com.google.protobuf:protobuf-java:3.16.1"
-    implementation "org.lz4:lz4-java:1.8.0"
-    implementation "org.apache.httpcomponents:httpclient:4.5.13"
+    api("com.google.guava:guava:31.0-jre")
+    api("com.google.code.gson:gson:2.8.6")
+    api("net.sf.trove4j:trove4j:3.0.3")
+    implementation("io.netty:netty-all:4.1.77.Final")
+    implementation("com.google.protobuf:protobuf-java:3.16.1")
+    implementation("org.lz4:lz4-java:1.8.0")
+    implementation("org.apache.httpcomponents:httpclient:4.5.13")
     // Javax for protobuf due to @Generated - needed on Java 9 or newer Javas
     // TODO: Can likely replace with protobuf Gradle task and omit the generated source files instead
-    implementation "javax.annotation:javax.annotation-api:1.3.2"
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
 
     //Utilities
-    api "org.codehaus.plexus:plexus-utils:3.0.16"
+    api("org.codehaus.plexus:plexus-utils:3.0.16")
 
     // Java magic
-    implementation "net.java.dev.jna:jna-platform:5.6.0"
-    implementation "org.terasology:reflections:0.9.12-MB"
-    implementation "com.esotericsoftware:reflectasm:1.11.9"
+    implementation("net.java.dev.jna:jna-platform:5.6.0")
+    implementation("org.terasology:reflections:0.9.12-MB")
+    implementation("com.esotericsoftware:reflectasm:1.11.9")
 
     // Graphics, 3D, UI, etc
-    api platform("org.lwjgl:lwjgl-bom:$LwjglVersion")
-    api "org.lwjgl:lwjgl"
-    implementation "org.lwjgl:lwjgl-assimp"
-    api "org.lwjgl:lwjgl-glfw"
-    implementation "org.lwjgl:lwjgl-openal"
-    api "org.lwjgl:lwjgl-opengl"
-    implementation "org.lwjgl:lwjgl-stb"
+    api(platform("org.lwjgl:lwjgl-bom:$LwjglVersion"))
+    api("org.lwjgl:lwjgl")
+    implementation("org.lwjgl:lwjgl-assimp")
+    api("org.lwjgl:lwjgl-glfw")
+    implementation("org.lwjgl:lwjgl-openal")
+    api("org.lwjgl:lwjgl-opengl")
+    implementation("org.lwjgl:lwjgl-stb")
 
-    implementation "io.micrometer:micrometer-core:1.9.12"
-    implementation "io.micrometer:micrometer-registry-jmx:1.9.12"
-    api "io.projectreactor:reactor-core:3.4.18"
-    api "io.projectreactor.addons:reactor-extra:3.4.8"
-    implementation "io.projectreactor.netty:reactor-netty-core:1.0.19"
+    implementation("io.micrometer:micrometer-core:1.9.12")
+    implementation("io.micrometer:micrometer-registry-jmx:1.9.12")
+    api("io.projectreactor:reactor-core:3.4.18")
+    api("io.projectreactor.addons:reactor-extra:3.4.8")
+    implementation("io.projectreactor.netty:reactor-netty-core:1.0.19")
 
-    api "org.joml:joml:1.10.0"
-    api "org.terasology.joml-ext:joml-geometry:0.1.0"
+    api("org.joml:joml:1.10.0")
+    api("org.terasology.joml-ext:joml-geometry:0.1.0")
 
-    implementation "org.abego.treelayout:org.abego.treelayout.core:1.0.3"
-    api "com.miglayout:miglayout-core:5.0"
-    implementation "de.matthiasmann.twl:PNGDecoder:1111"
+    implementation("org.abego.treelayout:org.abego.treelayout.core:1.0.3")
+    api("com.miglayout:miglayout-core:5.0")
+    implementation("de.matthiasmann.twl:PNGDecoder:1111")
 
     // Logging
     implementation("org.slf4j:slf4j-api:1.7.36") {
@@ -121,38 +121,38 @@ dependencies {
     }
 
     // audio
-    implementation "com.projectdarkstar.ext.jorbis:jorbis:0.0.17"
+    implementation("com.projectdarkstar.ext.jorbis:jorbis:0.0.17")
 
     // Small-time 3rd party libs we"ve stored in our Artifactory for access
-    implementation "ec.util:MersenneTwister:20"
+    implementation("ec.util:MersenneTwister:20")
 
     // telemetry
     implementation("com.snowplowanalytics:snowplow-java-tracker:0.12.1") {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
-    implementation "net.logstash.logback:logstash-logback-encoder:7.4"
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
     // Our developed libs
-    api "org.terasology.gestalt:gestalt-asset-core:7.2.0-SNAPSHOT"
-    api "org.terasology.gestalt:gestalt-module:7.2.0-SNAPSHOT"
-    api "org.terasology.gestalt:gestalt-entity-system:7.2.0-SNAPSHOT"
-    api "org.terasology.gestalt:gestalt-util:7.2.0-SNAPSHOT"
-    api "com.github.zafarkhaja:java-semver:0.10.0"  // ASAP: Remove after https://github.com/MovingBlocks/gestalt/pull/110
+    api("org.terasology.gestalt:gestalt-asset-core:7.2.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-module:7.2.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-entity-system:7.2.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-util:7.2.0-SNAPSHOT")
+    api("com.github.zafarkhaja:java-semver:0.10.0")  // ASAP: Remove after https://github.com/MovingBlocks/gestalt/pull/110
 
-    api "org.terasology:TeraMath:1.5.0"
-    api "org.terasology:splash-screen:1.1.1"
-    api "org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT"
-    api "org.terasology.jnbullet:JNBullet:1.0.2"
-    api "org.terasology.nui:nui:3.0.0"
-    api "org.terasology.nui:nui-reflect:3.0.0"
-    api "org.terasology.nui:nui-gestalt7:3.0.0"
+    api("org.terasology:TeraMath:1.5.0")
+    api("org.terasology:splash-screen:1.1.1")
+    api("org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT")
+    api("org.terasology.jnbullet:JNBullet:1.0.2")
+    api("org.terasology.nui:nui:3.0.0")
+    api("org.terasology.nui:nui-reflect:3.0.0")
+    api("org.terasology.nui:nui-gestalt7:3.0.0")
 
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
     api fileTree(dir: "libs", include: "*.jar")
 
     // TODO: Consider moving this back to the PC Facade instead of having the engine rely on it?
-    implementation "org.terasology.crashreporter:cr-terasology:5.0.0"
+    implementation("org.terasology.crashreporter:cr-terasology:5.0.0")
 
     api(project(":subsystems:TypeHandlerLibrary"))
 }
@@ -198,9 +198,9 @@ tasks.register("jmh", JavaExec) {
 }
 
 dependencies {
-    jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.27"
-    jmhImplementation "org.openjdk.jmh:jmh-core:1.27"
-    jmhImplementation "org.openjdk.jmh:jmh-generator-annprocess:1.27"
+    jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.27")
+    jmhImplementation("org.openjdk.jmh:jmh-core:1.27")
+    jmhImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.27")
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -9,10 +9,10 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 plugins {
-    id "java-library"
-    id "org.jetbrains.gradle.plugin.idea-ext"
-    id "com.google.protobuf"
-    id "terasology-common"
+    id("java-library")
+    id("org.jetbrains.gradle.plugin.idea-ext")
+    id("com.google.protobuf")
+    id("terasology-common")
 }
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config, etc

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -26,7 +26,7 @@ ext {
     // Read environment variables, including variables passed by jenkins continuous integration server
     env = System.getenv()
 
-    templatesDir = new File(rootDir, 'templates')
+    templatesDir = new File(rootDir, "templates")
 
     // Stuff for our automatic version file setup
     startDateTimeString = dateTimeFormat.format(new Date())
@@ -41,7 +41,7 @@ ext {
 sourceSets {
     main {
         proto {
-            srcDir 'src/main/protobuf'
+            srcDir "src/main/protobuf"
         }
         java {
             // Adjust output path (changed with the Gradle 6 upgrade, this puts it back)
@@ -54,10 +54,10 @@ sourceSets {
 // Customizations for the main compilation configuration
 configurations {
 
-    // Exclude a couple JWJGL modules that aren't needed during compilation (OS specific stuff in these two perhaps)
+    // Exclude a couple JWJGL modules that aren"t needed during compilation (OS specific stuff in these two perhaps)
     implementation {
-        exclude module: 'lwjgl-platform'
-        exclude module: 'jinput-platform'
+        exclude module: "lwjgl-platform"
+        exclude module: "jinput-platform"
     }
 }
 
@@ -73,24 +73,24 @@ configurations.all {
 // Primary dependencies definition
 dependencies {
     // Storage and networking
-    api group: 'com.google.guava', name: 'guava', version: '31.0-jre'
-    api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
-    api group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
-    implementation group: 'io.netty', name: 'netty-all', version: '4.1.77.Final'
-    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.16.1'
-    implementation group: 'org.lz4', name: 'lz4-java', version: '1.8.0'
-    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+    api "com.google.guava:guava:31.0-jre"
+    api "com.google.code.gson:gson:2.8.6"
+    api "net.sf.trove4j:trove4j:3.0.3"
+    implementation "io.netty:netty-all:4.1.77.Final"
+    implementation "com.google.protobuf:protobuf-java:3.16.1"
+    implementation "org.lz4:lz4-java:1.8.0"
+    implementation "org.apache.httpcomponents:httpclient:4.5.13"
     // Javax for protobuf due to @Generated - needed on Java 9 or newer Javas
     // TODO: Can likely replace with protobuf Gradle task and omit the generated source files instead
-    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+    implementation "javax.annotation:javax.annotation-api:1.3.2"
 
     //Utilities
-    api group: 'org.codehaus.plexus', name: 'plexus-utils', version: '3.0.16'
+    api "org.codehaus.plexus:plexus-utils:3.0.16"
 
     // Java magic
-    implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.6.0'
+    implementation "net.java.dev.jna:jna-platform:5.6.0"
     implementation "org.terasology:reflections:0.9.12-MB"
-    implementation group: 'com.esotericsoftware', name: 'reflectasm', version: '1.11.9'
+    implementation "com.esotericsoftware:reflectasm:1.11.9"
 
     // Graphics, 3D, UI, etc
     api platform("org.lwjgl:lwjgl-bom:$LwjglVersion")
@@ -101,22 +101,22 @@ dependencies {
     api "org.lwjgl:lwjgl-opengl"
     implementation "org.lwjgl:lwjgl-stb"
 
-    implementation 'io.micrometer:micrometer-core:1.9.12'
-    implementation 'io.micrometer:micrometer-registry-jmx:1.9.12'
-    api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.18'
-    api group: 'io.projectreactor.addons', name: 'reactor-extra', version: '3.4.8'
-    implementation 'io.projectreactor.netty:reactor-netty-core:1.0.19'
+    implementation "io.micrometer:micrometer-core:1.9.12"
+    implementation "io.micrometer:micrometer-registry-jmx:1.9.12"
+    api "io.projectreactor:reactor-core:3.4.18"
+    api "io.projectreactor.addons:reactor-extra:3.4.8"
+    implementation "io.projectreactor.netty:reactor-netty-core:1.0.19"
 
-    api group: 'org.joml', name: 'joml', version: '1.10.0'
-    api group: 'org.terasology.joml-ext', name: 'joml-geometry', version: '0.1.0'
+    api "org.joml:joml:1.10.0"
+    api "org.terasology.joml-ext:joml-geometry:0.1.0"
 
-    implementation group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.3'
-    api group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
-    implementation group: 'de.matthiasmann.twl', name: 'PNGDecoder', version: '1111'
+    implementation "org.abego.treelayout:org.abego.treelayout.core:1.0.3"
+    api "com.miglayout:miglayout-core:5.0"
+    implementation "de.matthiasmann.twl:PNGDecoder:1111"
 
     // Logging
-    implementation('org.slf4j:slf4j-api:1.7.36') {
-        because('a backend-independent Logger')
+    implementation("org.slf4j:slf4j-api:1.7.36") {
+        because("a backend-independent Logger")
     }
     implementation("ch.qos.logback:logback-classic:1.2.12") {
         because("telemetry implementation uses logback to send to logstash " +
@@ -124,45 +124,45 @@ dependencies {
     }
 
     // audio
-    implementation group: 'com.projectdarkstar.ext.jorbis', name: 'jorbis', version: '0.0.17'
+    implementation "com.projectdarkstar.ext.jorbis:jorbis:0.0.17"
 
-    // Small-time 3rd party libs we've stored in our Artifactory for access
-    implementation group: 'ec.util', name: 'MersenneTwister', version: '20'
+    // Small-time 3rd party libs we"ve stored in our Artifactory for access
+    implementation "ec.util:MersenneTwister:20"
 
     // telemetry
-    implementation(group: 'com.snowplowanalytics', name: 'snowplow-java-tracker', version: '0.12.1') {
-        exclude group: 'org.slf4j', module: 'slf4j-simple'
+    implementation("com.snowplowanalytics:snowplow-java-tracker:0.12.1") {
+        exclude group: "org.slf4j", module: "slf4j-simple"
     }
-    implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
+    implementation "net.logstash.logback:logstash-logback-encoder:7.4"
 
     // Our developed libs
-    api group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '7.2.0-SNAPSHOT'
-    api group: 'org.terasology.gestalt', name: 'gestalt-module', version: '7.2.0-SNAPSHOT'
-    api group: 'org.terasology.gestalt', name: 'gestalt-entity-system', version: '7.2.0-SNAPSHOT'
-    api group: 'org.terasology.gestalt', name: 'gestalt-util', version: '7.2.0-SNAPSHOT'
+    api "org.terasology.gestalt:gestalt-asset-core:7.2.0-SNAPSHOT"
+    api "org.terasology.gestalt:gestalt-module:7.2.0-SNAPSHOT"
+    api "org.terasology.gestalt:gestalt-entity-system:7.2.0-SNAPSHOT"
+    api "org.terasology.gestalt:gestalt-util:7.2.0-SNAPSHOT"
     api "com.github.zafarkhaja:java-semver:0.10.0"  // ASAP: Remove after https://github.com/MovingBlocks/gestalt/pull/110
 
-    api group: 'org.terasology', name: 'TeraMath', version: '1.5.0'
-    api group: 'org.terasology', name: 'splash-screen', version: '1.1.1'
-    api group: 'org.terasology.jnlua', name: 'JNLua', version: '0.1.0-SNAPSHOT'
-    api group: 'org.terasology.jnbullet', name: 'JNBullet', version: '1.0.2'
-    api group: 'org.terasology.nui', name: 'nui', version: '3.0.0'
-    api group: 'org.terasology.nui', name: 'nui-reflect', version: '3.0.0'
-    api group: 'org.terasology.nui', name: 'nui-gestalt7', version: '3.0.0'
+    api "org.terasology:TeraMath:1.5.0"
+    api "org.terasology:splash-screen:1.1.1"
+    api "org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT"
+    api "org.terasology.jnbullet:JNBullet:1.0.2"
+    api "org.terasology.nui:nui:3.0.0"
+    api "org.terasology.nui:nui-reflect:3.0.0"
+    api "org.terasology.nui:nui-gestalt7:3.0.0"
 
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
-    api fileTree(dir: 'libs', include: '*.jar')
+    api fileTree(dir: "libs", include: "*.jar")
 
     // TODO: Consider moving this back to the PC Facade instead of having the engine rely on it?
-    implementation group: 'org.terasology.crashreporter', name: 'cr-terasology', version: '5.0.0'
+    implementation "org.terasology.crashreporter:cr-terasology:5.0.0"
 
     api(project(":subsystems:TypeHandlerLibrary"))
 }
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.17.0'
+        artifact = "com.google.protobuf:protoc:3.17.0"
     }
     plugins {
     }
@@ -187,30 +187,30 @@ jar {
 
 sourceSets {
     jmh {
-        java.srcDirs = ['src/jmh/java']
-        resources.srcDirs = ['src/jmh/resources']
+        java.srcDirs = ["src/jmh/java"]
+        resources.srcDirs = ["src/jmh/resources"]
         compileClasspath += sourceSets.main.runtimeClasspath
         java.destinationDirectory = new File("$buildDir/jmhClasses")
     }
 }
 
 task jmh(type: JavaExec, dependsOn: jmhClasses) {
-    mainClass = 'org.openjdk.jmh.Main'
+    mainClass = "org.openjdk.jmh.Main"
     classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
 }
 
 dependencies {
-    jmhAnnotationProcessor group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.27'
-    jmhImplementation 'org.openjdk.jmh:jmh-core:1.27'
-    jmhImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.27'
+    jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.27"
+    jmhImplementation "org.openjdk.jmh:jmh-core:1.27"
+    jmhImplementation "org.openjdk.jmh:jmh-generator-annprocess:1.27"
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Version file stuff                                                                                                //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// First read the internal version out of the engine's module.txt
-def moduleFile = file('src/main/resources/org/terasology/engine/module.txt')
+// First read the internal version out of the engine"s module.txt
+def moduleFile = file("src/main/resources/org/terasology/engine/module.txt")
 
 if (!moduleFile.exists()) {
     println "Failed to find module.txt for engine"
@@ -225,7 +225,7 @@ def moduleConfig = slurper.parseText(moduleFile.text)
 version = moduleConfig.version
 
 // Jenkins-Artifactory integration catches on to this as part of the Maven-type descriptor
-group = 'org.terasology.engine'
+group = "org.terasology.engine"
 
 println "Version for $project.name loaded as $version for group $group"
 
@@ -282,8 +282,8 @@ idea {
     module {
         // Change around the output a bit
         inheritOutputDirs = false
-        outputDir = file('build/classes')
-        testOutputDir = file('build/testClasses')
+        outputDir = file("build/classes")
+        testOutputDir = file("build/testClasses")
         downloadSources = true
     }
 }

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -4,11 +4,12 @@
 // The PC facade is responsible for the primary distribution - a plain Java application runnable on PCs
 
 import Terasology_dist_gradle.ValidateZipDistribution
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.terasology.gradology.RunTerasology
 import org.terasology.gradology.nativeSubdirectoryName
-import java.text.SimpleDateFormat
-import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
@@ -20,9 +21,6 @@ plugins {
 
 // Grab all the common stuff like plugins to use, artifact repositories, code analysis config
 apply(from = "$rootDir/config/gradle/publish.gradle")
-
-val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
-dateTimeFormat.timeZone = TimeZone.getTimeZone("UTC")
 
 // Default path to store server data if running headless via Gradle
 val localServerDataPath by extra("terasology-server")
@@ -40,7 +38,7 @@ val distsDirectory: DirectoryProperty by project
 val env: MutableMap<String, String> = System.getenv()!!
 
 // Version related
-val startDateTimeString = dateTimeFormat.format(Date())!!
+val startDateTimeString = OffsetDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"))
 val versionFileName = "VERSION"
 val versionBase by lazy { File(templatesDir, "version.txt").readText().trim() }
 val displayVersion = versionBase


### PR DESCRIPTION
gradle groovy allows quite similar syntax for groovy and kotlin, do a first step to switch over to kotlin by replacing quotes, use java date formatting introduced in java-8, and register some tasks so they do not get configured when not executed.
