### PR TITLE
chore: consume gestalt v7.2.0

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.jgrapht:jgrapht-core:1.5.0")
 
     // for inspecting modules
-    implementation("org.terasology.gestalt:gestalt-module:7.1.0")
+    implementation("org.terasology.gestalt:gestalt-module:7.2.0")
 
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -133,11 +133,10 @@ dependencies {
     implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
     // Our developed libs
-    api("org.terasology.gestalt:gestalt-asset-core:7.2.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-module:7.2.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-entity-system:7.2.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-util:7.2.0-SNAPSHOT")
-    api("com.github.zafarkhaja:java-semver:0.10.0")  // ASAP: Remove after https://github.com/MovingBlocks/gestalt/pull/110
+    api("org.terasology.gestalt:gestalt-asset-core:7.2.1-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-module:7.2.1-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-entity-system:7.2.1-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-util:7.2.1-SNAPSHOT")
 
     api("org.terasology:TeraMath:1.5.0")
     api("org.terasology:splash-screen:1.1.1")

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
 
     implementation("org.terasology:reflections:0.9.12-MB")
     implementation("org.terasology.nui:nui-reflect:3.0.0")
-    implementation("org.terasology.gestalt:gestalt-module:7.1.0")
-    implementation("org.terasology.gestalt:gestalt-asset-core:7.1.0")
+    implementation("org.terasology.gestalt:gestalt-module:7.2.0")
+    implementation("org.terasology.gestalt:gestalt-asset-core:7.2.0")
 
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.11") {
         because("log output during tests")


### PR DESCRIPTION
### How to test

1. Checkout Terasology into a new workspace (`git clone git@github.com:MovingBlocks/Terasology.git myNewTSWorkspace`)
2. Init iota module line-up (`./groovyw module init iota`)
3. Try building the game (`./gradlew jar`) and notice the build failure due to
    ```
     What went wrong:
    'int com.github.zafarkhaja.semver.Version.getMajorVersion()'
    ```
5. Checkout this branch (`git checkout chore/consume-gestalt-7.2.0`)
6. Try building the game again and notice it succeed