### PR TITLE
Part fix for M1 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ val codeMetrics = configurations.create("codeMetrics")
 dependencies {
     // For the "natives" configuration make it depend on the native files from LWJGL
     natives(platform("org.lwjgl:lwjgl-bom:$LwjglVersion"))
-    listOf("natives-linux", "natives-windows", "natives-macos").forEach {
+    listOf("natives-linux", "natives-windows", "natives-macos", "natives-macos-arm64").forEach {
         natives("org.lwjgl:lwjgl::$it")
         natives("org.lwjgl:lwjgl-assimp::$it")
         natives("org.lwjgl:lwjgl-glfw::$it")

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -158,7 +158,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.17.0"
+        artifact = "com.google.protobuf:protoc:3.18.0"
     }
     plugins {
     }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     api("com.google.code.gson:gson:2.8.6")
     api("net.sf.trove4j:trove4j:3.0.3")
     implementation("io.netty:netty-all:4.1.77.Final")
-    implementation("com.google.protobuf:protobuf-java:3.16.1")
+    implementation("com.google.protobuf:protobuf-java:3.22.0")
     implementation("org.lz4:lz4-java:1.8.0")
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     // Javax for protobuf due to @Generated - needed on Java 9 or newer Javas
@@ -158,7 +158,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.17.0"
+        artifact = "com.google.protobuf:protoc:3.22.0"
     }
     plugins {
     }


### PR DESCRIPTION
Partly fixes #5055 . Adds support for lwjgl for macOS-arm64, and updates protoc version from 3.17.0 to 3.18.0 (3.17.0 has no arm64 support).

Still doesnt resolve the build issue due to JNBullet as follows

<img width="1339" alt="Screenshot 2024-02-09 at 7 21 28 pm" src="https://github.com/MovingBlocks/Terasology/assets/44602816/2f571575-ebcc-429f-a910-d84a31e20161">

EDIT: Updated protobuf and protoc to 3.22.0 instead of 3.18.0, as protobuf 3.18.0 has vulnerabilities.
