### PR TITLE
test: add private serialisation cases to type serialiser tests

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/persistence/serializers/TypeSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/serializers/TypeSerializerTest.java
@@ -110,15 +110,19 @@ class TypeSerializerTest extends ModuleEnvironmentTest {
         assertEquals(INSTANCE, deserializedInstance);
     }
 
+    @SuppressWarnings("PMD.UnusedPrivateField")
     public static final class SomeClass<T> {
         @SerializedName("generic-t")
         public T data;
         public List<T> list = Lists.newArrayList();
         public Set<Animal<?>> animals = Sets.newHashSet();
         public Animal<T> singleAnimal;
+        @SerializedName("private-generic-t")
+        private final T privateData;
 
         SomeClass(T data) {
             this.data = data;
+            this.privateData = data;
         }
 
         @Override

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/coreTypes/factories/ObjectFieldMapTypeHandlerFactoryTest.java
@@ -56,6 +56,16 @@ public class ObjectFieldMapTypeHandlerFactoryTest {
     }
 
     @Test
+    @DisplayName("Test that type handler is correctly created via type handler factory")
+    public void testMixedVisibilityTypeClassTypeHandlerCreationViaFactory() {
+        Optional<TypeHandler<PublicPrivateMixedClass<Integer, List<Integer>>>> typeHandler =
+                typeHandlerFactory.create(new TypeInfo<PublicPrivateMixedClass<Integer, List<Integer>>>() { }, context);
+
+        assertTrue(typeHandler.isPresent());
+        assertTrue(typeHandler.get() instanceof ObjectFieldMapTypeHandler);
+    }
+
+    @Test
     @DisplayName("Test implicit type handler loading for plain old java objects (pojo)")
     public void testPojo() {
         typeHandlerFactory.create(new TypeInfo<SingleTypeClass<Integer>>() { }, context);
@@ -92,6 +102,18 @@ public class ObjectFieldMapTypeHandlerFactoryTest {
     }
 
     @Test
+    @DisplayName("Test implicit type handler loading for multiple objects of same type but differing visibility")
+    public void testMixedVisibilityMultipleObjectsOfSameType() {
+        typeHandlerFactory.create(new TypeInfo<PublicPrivateMixedClass<Integer, Integer>>() { }, context);
+
+        // Verify that the Integer TypeHandler loading was called on the TypeHandlerLibrary
+        verify(typeHandlerLibrary, times(1)).getTypeHandler((Type) any());
+        verify(typeHandlerLibrary, times(1)).getTypeHandler(eq(TypeInfo.of(Integer.class).getType()));
+        verify(typeHandlerLibrary, never()).getTypeHandler((Class<Object>) any());
+        verify(typeHandlerLibrary, never()).getTypeHandler((TypeInfo<Object>) any());
+    }
+
+    @Test
     @DisplayName("Test implicit type handler loading for multiple objects of different type")
     public void testMultipleObjectsOfDifferentType() {
         typeHandlerFactory.create(new TypeInfo<MultiTypeClass<Integer, List<Integer>>>() { }, context);
@@ -111,6 +133,11 @@ public class ObjectFieldMapTypeHandlerFactoryTest {
     private static class MultiTypeClass<T, U> {
         public T t;
         public U u;
+    }
+
+    private static class PublicPrivateMixedClass<T, U> {
+        public T t;
+        private U u;
     }
 
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(


### PR DESCRIPTION
### Contains
This adds some tests to verify that private fields are no longer serialised (following on from #5208).

### How to test
The `testMixedVisibilityTypeClassTypeHandlerCreationViaFactory` and `testMixedVisibilityMultipleObjectsOfSameType` tests should succeed.