### PR TITLE
chore: remove year from idea copyright template

### DIFF
--- a/.idea/copyright/Terasology_Foundation.xml
+++ b/.idea/copyright/Terasology_Foundation.xml
@@ -2,7 +2,7 @@
   <copyright>
     <option name="allowReplaceRegexp" value="20\d\d" />
     <option name="keyword" value="Copyright.*(Moving\s?Blocks|Terasology)" />
-    <option name="notice" value="Copyright &amp;#36;today.year The Terasology Foundation&#10;SPDX-License-Identifier: Apache-2.0" />
+    <option name="notice" value="Copyright The Terasology Foundation&#10;SPDX-License-Identifier: Apache-2.0" />
     <option name="myName" value="Terasology Foundation" />
   </copyright>
 </component>


### PR DESCRIPTION
Based on our discussion on Discord and the resulting decision to remove the year from our in-file copyright notices (see [link](https://discord.com/channels/270264625419911192/1125013678966710342/1193634866688958534)).

Summary:

There's unclarity on whether the copyright year refers to the date of file creation, last change, or the current year.
Date of creation is hard to track and loses meaning in the light of code changes, moves, or copies.
Current year introduces maintenance overhead, especially for small maintainer groups such as ours.
Many organizations started removing the year from the in-file copyright notices.

Apache License requires us to include a `LICENSE` and a `NOTICE` file and to maintain file-level copyright notices.
It doesn't object to changing file-level copyright notices, for instance, removing the year.
