### PR TITLE
chore: update JNBullet to 1.0.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ dependencies {
     natives(group = "org.terasology.jnlua", name = "jnlua_natives", version = "0.1.0-SNAPSHOT", ext = "zip")
 
     // Natives for JNBullet
-    natives(group = "org.terasology.jnbullet", name = "JNBullet", version = "1.0.4-SNAPSHOT", ext = "zip")
+    natives(group = "org.terasology.jnbullet", name = "JNBullet", version = "1.0.4", ext = "zip")
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ dependencies {
     natives(group = "org.terasology.jnlua", name = "jnlua_natives", version = "0.1.0-SNAPSHOT", ext = "zip")
 
     // Natives for JNBullet
-    natives(group = "org.terasology.jnbullet", name = "JNBullet", version = "1.0.2", ext = "zip")
+    natives(group = "org.terasology.jnbullet", name = "JNBullet", version = "1.0.4-SNAPSHOT", ext = "zip")
 
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     api("org.terasology:TeraMath:1.5.0")
     api("org.terasology:splash-screen:1.1.1")
     api("org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT")
-    api("org.terasology.jnbullet:JNBullet:1.0.4-SNAPSHOT")
+    api("org.terasology.jnbullet:JNBullet:1.0.4")
     api("org.terasology.nui:nui:3.0.0")
     api("org.terasology.nui:nui-reflect:3.0.0")
     api("org.terasology.nui:nui-gestalt7:3.0.0")

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     api("org.terasology:TeraMath:1.5.0")
     api("org.terasology:splash-screen:1.1.1")
     api("org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT")
-    api("org.terasology.jnbullet:JNBullet:1.0.2")
+    api("org.terasology.jnbullet:JNBullet:1.0.4-SNAPSHOT")
     api("org.terasology.nui:nui:3.0.0")
     api("org.terasology.nui:nui-reflect:3.0.0")
     api("org.terasology.nui:nui-gestalt7:3.0.0")


### PR DESCRIPTION
### Contains

With JNBullet v1.0.4(-SNAPSHOT) we bundle natives for both Intel and Apple Silicon Macs. 

Nothing should change for Linux and Windows.

Related to MovingBlocks/JNBullet#15.

Contributes to #5055.

### How to test

Just checkout this PR and run the game from source.

- on Mac, at least the game menu should show up (there are more issues with OpenGL on M1, at least)
- on Linux and Windows, the game should run as before

### Outstanding before merging

- [x] relase JNBullet 1.0.4 if the SNAPSHOT version tests out fine
- [x] consume the non-SNAPSHOT version here
