### PR TITLE
feat: make WorldConfigurator subscribable

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/generation/FacetedWorldConfigurator.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/FacetedWorldConfigurator.java
@@ -24,7 +24,7 @@ public class FacetedWorldConfigurator implements WorldConfigurator {
     private final Map<String, Component> properties = Maps.newHashMap();
 
     private final List<ConfigurableFacetProvider> providers;
-    private HashMap<String, Set<PropertyChangeListener>> listeners = new HashMap<>();
+    private HashMap<String, Set<PropertyChangeListener>> listeners = new HashMap<>(); // OK
 
     public FacetedWorldConfigurator(List<ConfigurableFacetProvider> providersList) {
         for (ConfigurableFacetProvider provider : providersList) {

--- a/engine/src/main/java/org/terasology/engine/world/generation/FacetedWorldConfigurator.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/FacetedWorldConfigurator.java
@@ -24,7 +24,7 @@ public class FacetedWorldConfigurator implements WorldConfigurator {
     private final Map<String, Component> properties = Maps.newHashMap();
 
     private final List<ConfigurableFacetProvider> providers;
-    private HashMap<String, Set<PropertyChangeListener>> listeners = new HashMap<>(); // OK
+    private Map<String, Set<PropertyChangeListener>> listeners = new HashMap<>();
 
     public FacetedWorldConfigurator(List<ConfigurableFacetProvider> providersList) {
         for (ConfigurableFacetProvider provider : providersList) {

--- a/engine/src/main/java/org/terasology/engine/world/generation/FacetedWorldConfigurator.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/FacetedWorldConfigurator.java
@@ -8,9 +8,14 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.world.generator.WorldConfigurator;
 import org.terasology.gestalt.entitysystem.component.Component;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class FacetedWorldConfigurator implements WorldConfigurator {
 
@@ -19,6 +24,7 @@ public class FacetedWorldConfigurator implements WorldConfigurator {
     private final Map<String, Component> properties = Maps.newHashMap();
 
     private final List<ConfigurableFacetProvider> providers;
+    private HashMap<String, Set<PropertyChangeListener>> listeners = new HashMap<>();
 
     public FacetedWorldConfigurator(List<ConfigurableFacetProvider> providersList) {
         for (ConfigurableFacetProvider provider : providersList) {
@@ -40,11 +46,79 @@ public class FacetedWorldConfigurator implements WorldConfigurator {
         for (ConfigurableFacetProvider facetProvider : providers) {
             if (key.equals(facetProvider.getConfigurationName())) {
                 facetProvider.setConfiguration(comp);
+                Component oldComp = properties.get(key);
                 properties.put(key, comp);
+
+                PropertyChangeEvent event = new PropertyChangeEvent(this, key, oldComp, comp);
+                Set<PropertyChangeListener> allPropListeners = listeners.get("*");
+                if (allPropListeners != null) {
+                    allPropListeners.forEach(listener -> {
+                        listener.propertyChange(event);
+                    });
+                }
+                Set<PropertyChangeListener> specPropListeners = listeners.get(key);
+                if (specPropListeners != null) {
+                    specPropListeners.forEach(listener -> {
+                        listener.propertyChange(event);
+                    });
+                }
+
                 return;
             }
         }
 
         logger.warn("No property {} found", key);
+    }
+
+    /**
+     * Subscribes a new listener to receive change notifications for all properties.
+     * @param changeListener
+     */
+    @Override
+    public void subscribe(PropertyChangeListener changeListener) {
+        Set<PropertyChangeListener> ls = listeners.computeIfAbsent("*", k -> new HashSet<>());
+        ls.add(changeListener);
+    }
+
+    /**
+     * Unsubscribes an existing listener from receiving change notifications for all properties.
+     * If the listener was subscribed to a specific property separately
+     * via {@link FacetedWorldConfigurator#unsubscribe(String, PropertyChangeListener)},
+     * it will continue to receive change notifications for that property.
+     * @param changeListener
+     */
+    @Override
+    public void unsubscribe(PropertyChangeListener changeListener) {
+        listeners.computeIfPresent("*", (k, v) -> {
+            v.remove(changeListener);
+            return v;
+        });
+    }
+
+    /**
+     * Subscribes a new listener to receive change notifications for the specified property.
+     * @param propertyName
+     * @param changeListener
+     */
+    @Override
+    public void subscribe(String propertyName, PropertyChangeListener changeListener) {
+        Set<PropertyChangeListener> ls = listeners.computeIfAbsent(propertyName, k -> new HashSet<>());
+        ls.add(changeListener);
+    }
+
+    /**
+     * Unsubscribes an existing listener from receiving change notifications for the specified property.
+     * If the listener was subscribed to all properties separately
+     * via {@link FacetedWorldConfigurator#unsubscribe(PropertyChangeListener)},
+     * it will continue to receive change notifications for all properties including the one it is being unsubscribed from now.
+     * @param propertyName
+     * @param changeListener
+     */
+    @Override
+    public void unsubscribe(String propertyName, PropertyChangeListener changeListener) {
+        listeners.computeIfPresent(propertyName, (k, v) -> {
+            v.remove(changeListener);
+            return v;
+        });
     }
 }

--- a/engine/src/main/java/org/terasology/engine/world/generator/WorldConfigurator.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/WorldConfigurator.java
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.generator;
 
+import org.terasology.engine.utilities.subscribables.Subscribable;
 import org.terasology.gestalt.entitysystem.component.Component;
 
 import java.util.Map;
 
 /**
  * Allows for configuration of world generators.
+ * Interested parties can subscribe to all or only specific properties and receive change notifications.
  */
-public interface WorldConfigurator  {
+public interface WorldConfigurator extends Subscribable {
 
     /**
      * The values are supposed to be annotated with {@link org.terasology.nui.properties.Property}

--- a/engine/src/main/java/org/terasology/engine/world/generator/WorldConfiguratorAdapter.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/WorldConfiguratorAdapter.java
@@ -4,6 +4,7 @@ package org.terasology.engine.world.generator;
 
 import org.terasology.gestalt.entitysystem.component.Component;
 
+import java.beans.PropertyChangeListener;
 import java.util.Collections;
 import java.util.Map;
 
@@ -19,6 +20,26 @@ public class WorldConfiguratorAdapter implements WorldConfigurator {
 
     @Override
     public void setProperty(String key, Component comp) {
+        // simply ignore
+    }
+
+    @Override
+    public void subscribe(PropertyChangeListener changeListener) {
+        // simply ignore
+    }
+
+    @Override
+    public void unsubscribe(PropertyChangeListener changeListener) {
+        // simply ignore
+    }
+
+    @Override
+    public void subscribe(String propertyName, PropertyChangeListener changeListener) {
+        // simply ignore
+    }
+
+    @Override
+    public void unsubscribe(String propertyName, PropertyChangeListener changeListener) {
         // simply ignore
     }
 }


### PR DESCRIPTION
### Contains

* interested parties can subscribe to receive change notifications for all or specific properties available
* change notifications include information about the changed property as well as the old and new values
* no longer interested parties can subscribe from all or specific properties
* subscriptions to all properties will remain intact in case a no longer interested party cancels their subscription for specific properties

### How to test

Can be tested using #5226