### PR TITLE
feat: make number of chunk processing threads configurable

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.terasology.engine.config.Config;
+import org.terasology.engine.config.RenderingConfig;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.world.BlockEntityRegistry;
@@ -44,6 +45,7 @@ import java.util.concurrent.TimeoutException;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class LocalChunkProviderTest {
 
@@ -74,6 +76,9 @@ class LocalChunkProviderTest {
         worldEntity = mock(EntityRef.class);
         chunkCache = Maps.newConcurrentMap();
         config = mock(Config.class);
+        RenderingConfig renderConfig = mock(RenderingConfig.class);
+        when(renderConfig.getChunkThreads()).thenReturn(0);
+        when(config.getRendering()).thenReturn(renderConfig);
         storageManager = new TestStorageManager();
         generator = new TestWorldGenerator(blockManager);
         chunkProvider = new LocalChunkProvider(storageManager,

--- a/engine-tests/src/test/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProviderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProviderTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.terasology.engine.config.Config;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.world.BlockEntityRegistry;
@@ -54,6 +55,7 @@ class LocalChunkProviderTest {
     private ExtraBlockDataManager extraDataManager;
     private BlockEntityRegistry blockEntityRegistry;
     private EntityRef worldEntity;
+    private Config config;
     private Map<Vector3ic, Chunk> chunkCache;
     private Block blockAtBlockManager;
     private TestStorageManager storageManager;
@@ -71,6 +73,7 @@ class LocalChunkProviderTest {
         blockEntityRegistry = mock(BlockEntityRegistry.class);
         worldEntity = mock(EntityRef.class);
         chunkCache = Maps.newConcurrentMap();
+        config = mock(Config.class);
         storageManager = new TestStorageManager();
         generator = new TestWorldGenerator(blockManager);
         chunkProvider = new LocalChunkProvider(storageManager,
@@ -78,6 +81,7 @@ class LocalChunkProviderTest {
                 generator,
                 blockManager,
                 extraDataManager,
+                config,
                 chunkCache);
         chunkProvider.setBlockEntityRegistry(blockEntityRegistry);
         chunkProvider.setWorldEntity(worldEntity);

--- a/engine-tests/src/test/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipelineTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipelineTest.java
@@ -51,7 +51,7 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
 
     @Test
     void simpleProcessingSuccess() throws ExecutionException, InterruptedException, TimeoutException {
-        pipeline = new ChunkProcessingPipeline((p) -> null, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline(0, (p) -> null, (o1, o2) -> 0);
 
         Vector3i chunkPos = new Vector3i(0, 0, 0);
         Chunk chunk = createChunkAt(chunkPos);
@@ -67,7 +67,7 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
 
     @Test
     void simpleStopProcessingSuccess() {
-        pipeline = new ChunkProcessingPipeline((p) -> null, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline(0, (p) -> null, (o1, o2) -> 0);
 
         Vector3i position = new Vector3i(0, 0, 0);
         Chunk chunk = createChunkAt(position);
@@ -106,7 +106,7 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
                                 Function.identity()
                         ));
 
-        pipeline = new ChunkProcessingPipeline(chunkCache::get, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline(0, chunkCache::get, (o1, o2) -> 0);
         pipeline.addStage(ChunkTaskProvider.createMulti(
                 "flat merging task",
                 (chunks) -> chunks.stream()
@@ -140,7 +140,7 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
                                 Function.identity()
                         ));
 
-        pipeline = new ChunkProcessingPipeline((p) -> null, (o1, o2) -> 0);
+        pipeline = new ChunkProcessingPipeline(0, (p) -> null, (o1, o2) -> 0);
         pipeline.addStage(ChunkTaskProvider.createMulti(
                 "flat merging task",
                 (chunks) -> chunks.stream()
@@ -169,7 +169,7 @@ class ChunkProcessingPipelineTest extends TerasologyTestingEnvironment {
         final AtomicReference<Vector3ic> position = new AtomicReference<>();
         Map<Vector3ic, Future<Chunk>> futures = Maps.newHashMap();
         Map<Vector3ic, Chunk> chunkCache = Maps.newConcurrentMap();
-        pipeline = new ChunkProcessingPipeline(chunkCache::get, (o1, o2) -> {
+        pipeline = new ChunkProcessingPipeline(0, chunkCache::get, (o1, o2) -> {
             if (position.get() != null) {
                 Vector3ic entityPos = position.get();
                 return (int) (entityPos.distance(((PositionFuture<?>) o1).getPosition())

--- a/engine/src/main/java/org/terasology/engine/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/engine/config/RenderingConfig.java
@@ -26,6 +26,7 @@ public class RenderingConfig extends AbstractSubscribable {
     public static final String ANIMATED_MENU = "AnimatedMenu";
     public static final String VIEW_DISTANCE = "viewDistance";
     public static final String CHUNK_LODS = "chunkLods";
+    public static final String CHUNK_THREADS = "chunkThreads";
     public static final String BILLBOARD_LIMIT = "billboardLimit";
     public static final String FLICKERING_LIGHT = "FlickeringLight";
     public static final String ANIMATE_GRASS = "AnimateGrass";
@@ -76,6 +77,7 @@ public class RenderingConfig extends AbstractSubscribable {
     private boolean animatedMenu;
     private ViewDistance viewDistance;
     private float chunkLods;
+    private int chunkThreads;
     private float billboardLimit;
     private boolean flickeringLight;
     private boolean animateGrass;
@@ -268,6 +270,16 @@ public class RenderingConfig extends AbstractSubscribable {
         float oldLods = this.chunkLods;
         this.chunkLods = chunkLods;
         propertyChangeSupport.firePropertyChange(CHUNK_LODS, oldLods, chunkLods);
+    }
+
+    public int getChunkThreads() {
+        return chunkThreads;
+    }
+
+    public void setChunkThreads(int chunkThreads) {
+        float oldChunkThreads = this.chunkThreads;
+        this.chunkThreads = chunkThreads;
+        propertyChangeSupport.firePropertyChange(CHUNK_THREADS, oldChunkThreads, chunkThreads);
     }
 
     public float getBillboardLimit() {

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseRemoteWorld.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseRemoteWorld.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.core.modes.loadProcesses;
 
+import org.terasology.engine.config.Config;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.TerasologyConstants;
@@ -54,7 +55,7 @@ public class InitialiseRemoteWorld extends SingleStepLoadProcess {
         BlockManager blockManager = context.get(BlockManager.class);
         ExtraBlockDataManager extraDataManager = context.get(ExtraBlockDataManager.class);
 
-        RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager, localPlayer);
+        RemoteChunkProvider chunkProvider = new RemoteChunkProvider(blockManager, localPlayer, context.get(Config.class));
 
         WorldProviderCoreImpl worldProviderCore = new WorldProviderCoreImpl(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD), chunkProvider,
                 blockManager.getBlock(BlockManager.UNLOADED_ID), context);

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
@@ -6,6 +6,7 @@ package org.terasology.engine.core.modes.loadProcesses;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.config.Config;
 import org.terasology.engine.config.SystemConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
@@ -136,6 +137,7 @@ public class InitialiseWorld extends SingleStepLoadProcess {
                 worldGenerator,
                 blockManager,
                 extraDataManager,
+                context.get(Config.class),
                 Maps.newConcurrentMap());
         RelevanceSystem relevanceSystem = new RelevanceSystem(chunkProvider);
         context.put(RelevanceSystem.class, relevanceSystem);

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -75,6 +75,33 @@ public class VideoSettingsScreen extends CoreScreenLayer {
             viewDistance.bindSelection(BindHelper.bindBeanProperty("viewDistance", config.getRendering(), ViewDistance.class));
         }
 
+        UISlider chunkThreads = find("chunkThreads", UISlider.class);
+        if (chunkThreads != null) {
+            chunkThreads.setIncrement(1.0f);
+            chunkThreads.setPrecision(0);
+            chunkThreads.setMinimum(0);
+            chunkThreads.setRange(Runtime.getRuntime().availableProcessors());
+            chunkThreads.setLabelFunction(input -> {
+                if (input == 0) {
+                    return "Auto";
+                } else {
+                    return String.valueOf(input.intValue());
+                }
+            });
+            chunkThreads.bindValue(new Binding<Float>() {
+                @Override
+                public Float get() {
+                    return (float) config.getRendering().getChunkThreads();
+                }
+
+                @Override
+                public void set(Float value) {
+                    int chunkThreads = value.intValue();
+                    config.getRendering().setChunkThreads(chunkThreads);
+                }
+            });
+        }
+
         UIDropdown<WaterReflection> waterReflection = find("reflections", UIDropdown.class);
         if (waterReflection != null) {
             waterReflection.setOptionRenderer(new ToStringTextRenderer<>(translationSystem));

--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -14,6 +14,7 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.config.Config;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.EntityStore;
@@ -94,6 +95,7 @@ public class LocalChunkProvider implements ChunkProvider {
     private final WorldGenerator generator;
     private final BlockManager blockManager;
     private final ExtraBlockDataManager extraDataManager;
+    private final Config config;
     private ChunkProcessingPipeline loadingPipeline;
     private TaskMaster<ChunkUnloadRequest> unloadRequestTaskMaster;
     private EntityRef worldEntity = EntityRef.NULL;
@@ -102,13 +104,14 @@ public class LocalChunkProvider implements ChunkProvider {
     private RelevanceSystem relevanceSystem;
 
     public LocalChunkProvider(StorageManager storageManager, EntityManager entityManager, WorldGenerator generator,
-                              BlockManager blockManager, ExtraBlockDataManager extraDataManager,
+                              BlockManager blockManager, ExtraBlockDataManager extraDataManager, Config config,
                               Map<Vector3ic, Chunk> chunkCache) {
         this.storageManager = storageManager;
         this.entityManager = entityManager;
         this.generator = generator;
         this.blockManager = blockManager;
         this.extraDataManager = extraDataManager;
+        this.config = config;
         this.unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 4);
         this.chunkCache = chunkCache;
         ChunkMonitor.fireChunkProviderInitialized(this);
@@ -406,7 +409,7 @@ public class LocalChunkProvider implements ChunkProvider {
         storageManager.deleteWorld();
         worldEntity.send(new PurgeWorldEvent());
 
-        loadingPipeline = new ChunkProcessingPipeline(this::getChunk, relevanceSystem.createChunkTaskComporator());
+        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk, relevanceSystem.createChunkTaskComporator());
         loadingPipeline.addStage(
             ChunkTaskProvider.create("Chunk generate internal lightning",
                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
@@ -441,7 +444,7 @@ public class LocalChunkProvider implements ChunkProvider {
     // TODO: move loadingPipeline initialization into constructor.
     public void setRelevanceSystem(RelevanceSystem relevanceSystem) {
         this.relevanceSystem = relevanceSystem;
-        loadingPipeline = new ChunkProcessingPipeline(this::getChunk, relevanceSystem.createChunkTaskComporator());
+        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk, relevanceSystem.createChunkTaskComporator());
         loadingPipeline.addStage(
                         ChunkTaskProvider.create("Chunk generate internal lightning",
                                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))

--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -409,7 +409,8 @@ public class LocalChunkProvider implements ChunkProvider {
         storageManager.deleteWorld();
         worldEntity.send(new PurgeWorldEvent());
 
-        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk, relevanceSystem.createChunkTaskComporator());
+        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk,
+                relevanceSystem.createChunkTaskComporator());
         loadingPipeline.addStage(
             ChunkTaskProvider.create("Chunk generate internal lightning",
                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
@@ -444,7 +445,8 @@ public class LocalChunkProvider implements ChunkProvider {
     // TODO: move loadingPipeline initialization into constructor.
     public void setRelevanceSystem(RelevanceSystem relevanceSystem) {
         this.relevanceSystem = relevanceSystem;
-        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk, relevanceSystem.createChunkTaskComporator());
+        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk,
+                relevanceSystem.createChunkTaskComporator());
         loadingPipeline.addStage(
                         ChunkTaskProvider.create("Chunk generate internal lightning",
                                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))

--- a/engine/src/main/java/org/terasology/engine/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Queues;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
+import org.terasology.engine.config.Config;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.players.LocalPlayer;
 import org.terasology.engine.monitoring.chunk.ChunkMonitor;
@@ -56,9 +57,9 @@ public class RemoteChunkProvider implements ChunkProvider {
     private EntityRef worldEntity = EntityRef.NULL;
     private ChunkReadyListener listener;
 
-    public RemoteChunkProvider(BlockManager blockManager, LocalPlayer localPlayer) {
+    public RemoteChunkProvider(BlockManager blockManager, LocalPlayer localPlayer, Config config) {
         this.blockManager = blockManager;
-        loadingPipeline = new ChunkProcessingPipeline(this::getChunk,
+        loadingPipeline = new ChunkProcessingPipeline(config.getRendering().getChunkThreads(), this::getChunk,
                 new LocalPlayerRelativeChunkComparator(localPlayer));
 
         loadingPipeline.addStage(

--- a/engine/src/main/resources/org/terasology/engine/assets/i18n/menu.lang
+++ b/engine/src/main/resources/org/terasology/engine/assets/i18n/menu.lang
@@ -426,6 +426,7 @@
     "view-distance-moderate": "view-distance-moderate",
     "view-distance-near": "view-distance-near",
     "view-distance-ultra": "view-distance-ultra",
+    "chunk-threads": "chunk-threads",
     "vignette": "vignette",
     "volumetric-fog": "volumetric-fog",
     "warn-modules": "warn-modules",

--- a/engine/src/main/resources/org/terasology/engine/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/org/terasology/engine/assets/i18n/menu_en.lang
@@ -443,6 +443,7 @@
     "view-distance-moderate": "Moderate",
     "view-distance-near": "Near",
     "view-distance-ultra": "Ultra",
+    "chunk-threads": "Chunk Threads",
     "vignette": "Vignette",
     "volumetric-fog": "Volumetric Fog",
     "warn-modules": "WARNING: Enabling extra modules, especially all or those not in the stable lineup can cause game crashes or broken worlds.\nPlease handle with care.",

--- a/engine/src/main/resources/org/terasology/engine/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/org/terasology/engine/assets/ui/menu/videoMenuScreen.ui
@@ -214,6 +214,14 @@
                                     "id": "viewDistance"
                                 },
                                 {
+                                    "type": "UILabel",
+                                    "text": "${engine:menu#chunk-threads}: "
+                                },
+                                {
+                                    "type": "UISlider",
+                                    "id": "chunkThreads"
+                                },
+                                {
                                     "type": "UISpace",
                                     "size": [1, 13]
                                 },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains
This pull request adds a setting to control the maximum number of available worker threads for chunk processing. More precisely, it controls the number of pooled threads available to [`ChunkProcessingPipeline`](https://github.com/MovingBlocks/Terasology/blob/84dd22eeb751473b73cc13425804fc5dabf0e632/engine/src/main/java/org/terasology/engine/world/chunks/pipeline/ChunkProcessingPipeline.java#L60-L66).

From testing, I have found that reducing the number of chunk threads can noticeably reduce overall CPU utilisation. Although modern operating systems are very good at multitasking, I have noticed detrimental system-wide effects when the game occupies too much processor time at once. The ideal quantity will vary from player to player and so I think this may be a useful option to have configurable.

### How to test
- From the main menu, enter the `Video Settings` screen via `Settings->Video`.
- Scroll down until you see the `Chunk Threads` setting on the left.
- Move the slider around to different values. When the slider is 0, it should say `Auto`.
- For each possible slider value, start a new game. You should still see chunks being generated around you. With fewer chunk threads new chunks may appear more slowly but the overall CPU utilisation should be lower (this may vary depending on your machine).
- Quit the game and re-open it. Verify that the setting you chose before is still visible on the `Settings->Video` screen.
