### PR TITLE
Fix: Windowed fullscreen showing the taskbar

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.20" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -98,6 +98,18 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
                 GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
                 config.setDisplayModeSetting(displayModeSetting);
                 config.setWindowedFullscreen(true);
+                ////////////////////////////////////////////////:
+                 vidMode = desktopResolution.get();
+                GLFW.glfwSetWindowMonitor(window,
+                        MemoryUtil.NULL,
+                        0,
+                        0,
+                        vidMode.width(),
+                        vidMode.height(),
+                        GLFW.GLFW_DONT_CARE);
+                GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
+                config.setDisplayModeSetting(displayModeSetting);
+                config.setWindowedFullscreen(true);
                 break;
             case WINDOWED:
                 GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_TRUE);


### PR DESCRIPTION
### Contains
this PR fixes #5228 when windowed fullscreen is pressed ir will still show the task bar i fix that buy making it double click the windowed full  screen so wit will change its state twice 
### How to test
go to setting go to video change to windowed then change to windowed fullscreen 
because previously when you press windowed then press windowed fullscreen it will keep the task bar 
### Outstanding before merging

If anything. You can use neat checkboxes! Feel free to delete if not needed

- [no ] Need to consider use case x
- [no ] Still have to adjust the wiki doc
- [no ] Will need translation work
