### PR TITLE
Windowedfullscreen fix

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -98,8 +98,8 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
                             vidMode.width(),
                             vidMode.height(),
                             GLFW.GLFW_DONT_CARE);
+                    GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
                 }
-                GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
                 config.setDisplayModeSetting(displayModeSetting);
                 config.setWindowedFullscreen(true);
                 break;

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -78,7 +78,6 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
         setDisplayModeSetting(displayModeSetting, true);
     }
 
-    @SuppressWarnings({"checkstyle:WhitespaceAround", "checkstyle:WhitespaceAfter"})
     public void setDisplayModeSetting(DisplayModeSetting displayModeSetting, boolean resize) {
         long window = GLFW.glfwGetCurrentContext();
         switch (displayModeSetting) {

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -88,7 +88,9 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
                 break;
             case WINDOWED_FULLSCREEN:
                 GLFWVidMode vidMode = desktopResolution.get();
-                for(int i=0;i<2;i++){
+                // Attempt to go into fullscreen twice to fix the taskbar showing on-top of the game on Windows.
+                // See also: https://github.com/MovingBlocks/Terasology/issues/5228.
+                for (int i = 0; i < 2; i++) {
                     GLFW.glfwSetWindowMonitor(window,
                             MemoryUtil.NULL,
                             0,

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -78,6 +78,7 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
         setDisplayModeSetting(displayModeSetting, true);
     }
 
+    @SuppressWarnings({"checkstyle:WhitespaceAround", "checkstyle:WhitespaceAfter"})
     public void setDisplayModeSetting(DisplayModeSetting displayModeSetting, boolean resize) {
         long window = GLFW.glfwGetCurrentContext();
         switch (displayModeSetting) {
@@ -88,25 +89,15 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
                 break;
             case WINDOWED_FULLSCREEN:
                 GLFWVidMode vidMode = desktopResolution.get();
-                GLFW.glfwSetWindowMonitor(window,
-                        MemoryUtil.NULL,
-                        0,
-                        0,
-                        vidMode.width(),
-                        vidMode.height(),
-                        GLFW.GLFW_DONT_CARE);
-                GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
-                config.setDisplayModeSetting(displayModeSetting);
-                config.setWindowedFullscreen(true);
-                /////////////////////////////////////////////
-                 vidMode = desktopResolution.get();
-                GLFW.glfwSetWindowMonitor(window,
-                        MemoryUtil.NULL,
-                        0,
-                        0,
-                        vidMode.width(),
-                        vidMode.height(),
-                        GLFW.GLFW_DONT_CARE);
+                for(int i=0;i<2;i++){
+                    GLFW.glfwSetWindowMonitor(window,
+                            MemoryUtil.NULL,
+                            0,
+                            0,
+                            vidMode.width(),
+                            vidMode.height(),
+                            GLFW.GLFW_DONT_CARE);
+                }
                 GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
                 config.setDisplayModeSetting(displayModeSetting);
                 config.setWindowedFullscreen(true);

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -98,6 +98,18 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
                 GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
                 config.setDisplayModeSetting(displayModeSetting);
                 config.setWindowedFullscreen(true);
+                /////////////////////////////////////////////
+                 vidMode = desktopResolution.get();
+                GLFW.glfwSetWindowMonitor(window,
+                        MemoryUtil.NULL,
+                        0,
+                        0,
+                        vidMode.width(),
+                        vidMode.height(),
+                        GLFW.GLFW_DONT_CARE);
+                GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
+                config.setDisplayModeSetting(displayModeSetting);
+                config.setWindowedFullscreen(true);
                 break;
             case WINDOWED:
                 GLFW.glfwSetWindowAttrib(window, GLFW.GLFW_DECORATED, GLFW.GLFW_TRUE);


### PR DESCRIPTION
this PR fixes #5228 when windowed full screen is pressed it will still show the task bar i fix that buy making it double click the windowed full screen so it will change its state twice (i used for loop for that)

How to test
go to setting go to video change to windowed then change to windowed full screen
because previously when you press windowed then press windowed fullscreen it will keep the task bar

Outstanding before merging
If anything. You can use neat checkboxes! Feel free to delete if not needed

[no ] Need to consider use case x
[no ] Still have to adjust the wiki doc
[no ] Will need translation work
