### PR TITLE
fix: fix server crash when executing console commands

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/console/CommandEvent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/CommandEvent.java
@@ -13,7 +13,7 @@ import java.util.List;
  *
  */
 @ServerEvent
-final class CommandEvent implements Event {
+public final class CommandEvent implements Event {
 
     private Name commandName;
     private List<String> parameters;


### PR DESCRIPTION
### Contains
This pull request fixes the following crash when trying to run console commands against a server:
```
10:59:55.318 [main] ERROR o.t.engine.core.TerasologyEngine - Uncaught exception, attempting clean game shutdown
java.lang.IllegalAccessError: failed to access class org.terasology.engine.logic.console.CommandEvent from class org.terasology.engine.logic.console.ConsoleSystemMethodAccess (org.terasology.engine.logic.console.CommandEvent is in unnamed module of loader 'app'; org.terasology.engine.logic.console.ConsoleSystemMethodAccess is in unnamed module of loader com.esotericsoftware.reflectasm.AccessClassLoader @4b336cc8)
        at org.terasology.engine.logic.console.ConsoleSystemMethodAccess.invoke(Unknown Source)
        at org.terasology.engine.entitySystem.event.internal.EventSystemImpl$ByteCodeEventHandlerInfo.invoke(EventSystemImpl.java:399)
        at org.terasology.engine.entitySystem.event.internal.EventSystemImpl.sendStandardEvent(EventSystemImpl.java:264)
        at org.terasology.engine.entitySystem.event.internal.EventSystemImpl.send(EventSystemImpl.java:255)
        at org.terasology.engine.core.bootstrap.eventSystem.AbstractEventSystemDecorator.send(AbstractEventSystemDecorator.java:67)
        at org.terasology.engine.network.NetworkEventSystemDecorator.send(NetworkEventSystemDecorator.java:54)
        at org.terasology.engine.core.bootstrap.eventSystem.AbstractEventSystemDecorator.send(AbstractEventSystemDecorator.java:67)
        at org.terasology.engine.recording.RecordingEventSystemDecorator.send(RecordingEventSystemDecorator.java:32)
        at org.terasology.engine.entitySystem.entity.internal.BaseEntityRef.send(BaseEntityRef.java:188)
        at org.terasology.engine.network.internal.NetClient.processEvents(NetClient.java:526)
        at org.terasology.engine.network.internal.NetClient.processReceivedMessages(NetClient.java:420)
        at org.terasology.engine.network.internal.NetClient.update(NetClient.java:220)
        at org.terasology.engine.network.internal.NetworkSystemImpl.update(NetworkSystemImpl.java:341)
        at org.terasology.engine.core.subsystem.common.NetworkSubsystem.preUpdate(NetworkSubsystem.java:38)
        at org.terasology.engine.core.TerasologyEngine.tick(TerasologyEngine.java:506)
        at org.terasology.engine.core.TerasologyEngine.mainLoop(TerasologyEngine.java:473)
        at org.terasology.engine.core.TerasologyEngine.runMain(TerasologyEngine.java:449)
        at org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:415)
        at org.terasology.engine.Terasology.call(Terasology.java:189)
        at org.terasology.engine.Terasology.call(Terasology.java:69)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
        at picocli.CommandLine.access$1200(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2159)
        at picocli.CommandLine.execute(CommandLine.java:2058)
        at org.terasology.engine.Terasology.main(Terasology.java:138)
```

The `CommandEvent` class was package-private, which seems unintentional since the entire `org.terasology.engine.logic.console` package is exported as an API package. This pull request fixes the crash by making it public.

### How to test
- Start a new server with `gradlew server`.
- Run a client with `gradlew game` in a separate terminal (or from IntelliJ).
- Join the server using the client (`Main Menu->Join`).
- On the client, open the console with <kbd>\`</kbd> and run the `setSpawnLocation` command.
- The server should not crash.