### PR TITLE
feat: add tracy profiler integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,8 @@ dependencies {
     // Natives for JNBullet
     natives(group = "org.terasology.jnbullet", name = "JNBullet", version = "1.0.4", ext = "zip")
 
+    // Natives for Tracy bindings (embedded in JAR)
+    natives("io.github.benjaminamos.TracyJavaBindings:TracyJavaBindings:1.0.0-SNAPSHOT")
 }
 
 tasks.register<Copy>("extractWindowsNatives") {
@@ -135,6 +137,13 @@ tasks.register<Copy>("extractNativeBulletNatives") {
     into("$dirNatives")
 }
 
+tasks.register<Copy>("extractTracyJNINatives") {
+    description = "Extracts the Tracy JNI natives from the module jar"
+    from(configurations["natives"].filter { it.name.contains("TracyJavaBindings") }.map { zipTree(it) })
+    into(dirNatives)
+    exclude("io/**", "META-INF/**")
+}
+
 tasks.register("extractNatives") {
     description = "Extracts all the native lwjgl libraries from the downloaded zip"
     dependsOn(
@@ -142,7 +151,8 @@ tasks.register("extractNatives") {
         "extractLinuxNatives",
         "extractMacOSXNatives",
         "extractJNLuaNatives",
-        "extractNativeBulletNatives"
+        "extractNativeBulletNatives",
+        "extractTracyJNINatives"
     )
     // specifying the outputs directory lets gradle have an up-to-date check, and automatic clean task
     outputs.dir("$dirNatives")

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -142,6 +142,8 @@ dependencies {
     implementation("org.terasology.crashreporter:cr-terasology:5.0.0")
 
     api(project(":subsystems:TypeHandlerLibrary"))
+
+    implementation("io.github.benjaminamos.TracyJavaBindings:TracyJavaBindings:1.0.0-SNAPSHOT")
 }
 
 protobuf {

--- a/engine/src/main/java/org/terasology/engine/config/SystemConfig.java
+++ b/engine/src/main/java/org/terasology/engine/config/SystemConfig.java
@@ -68,6 +68,12 @@ public class SystemConfig extends AutoConfig {
             name("${engine:menu#settings-monitoring-enabled}")
     );
 
+    public final Setting<Boolean> tracyProfilerEnabled = setting(
+            type(Boolean.class),
+            defaultValue(false),
+            name("${engine:menu#settings-tracy-profiler-enabled}")
+    );
+
     public final Setting<Boolean> writeSaveGamesEnabled = setting(
             type(Boolean.class),
             defaultValue(true),

--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -468,12 +468,10 @@ public class TerasologyEngine implements GameEngine {
      */
     @SuppressWarnings("checkstyle:EmptyBlock")
     private void mainLoop() {
-        PerformanceMonitor.startActivity("Other");
         // MAIN GAME LOOP
         while (tick()) {
             /* do nothing */
         }
-        PerformanceMonitor.endActivity();
     }
 
     /**
@@ -482,6 +480,7 @@ public class TerasologyEngine implements GameEngine {
      * @return true if the loop requesting a tick should continue running
      */
     public boolean tick() {
+        PerformanceMonitor.startActivity("Tick");
         if (shutdownRequested) {
             return false;
         }
@@ -524,8 +523,8 @@ public class TerasologyEngine implements GameEngine {
         }
         assetTypeManager.disposedUnusedAssets();
 
+        PerformanceMonitor.endActivity();
         PerformanceMonitor.rollCycle();
-        PerformanceMonitor.startActivity("Other");
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/monitoring/PerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/PerformanceMonitor.java
@@ -19,6 +19,7 @@ import org.terasology.engine.monitoring.impl.PerformanceMonitorInternal;
  */
 public final class PerformanceMonitor {
     private static PerformanceMonitorInternal instance;
+    private static boolean tracyEnabled;
 
     static {
         instance = new NullPerformanceMonitor();
@@ -127,6 +128,10 @@ public final class PerformanceMonitor {
         return instance.getAllocationMean();
     }
 
+    public static void setTracyEnabled(boolean enabled) {
+        tracyEnabled = enabled;
+    }
+
     /**
      * Enables or disables the Performance Monitoring system.
      * <br><br>
@@ -139,7 +144,7 @@ public final class PerformanceMonitor {
             if (instance != null) {
                 instance.shutdown();
             }
-            instance = new PerformanceMonitorImpl();
+            instance = new PerformanceMonitorImpl(tracyEnabled);
         } else if (!enabled && !(instance instanceof NullPerformanceMonitor)) {
             if (instance != null) {
                 instance.shutdown();

--- a/engine/src/main/java/org/terasology/engine/monitoring/PerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/PerformanceMonitor.java
@@ -136,8 +136,14 @@ public final class PerformanceMonitor {
      */
     public static void setEnabled(boolean enabled) {
         if (enabled && !(instance instanceof PerformanceMonitorImpl)) {
+            if (instance != null) {
+                instance.shutdown();
+            }
             instance = new PerformanceMonitorImpl();
         } else if (!enabled && !(instance instanceof NullPerformanceMonitor)) {
+            if (instance != null) {
+                instance.shutdown();
+            }
             instance = new NullPerformanceMonitor();
         }
     }

--- a/engine/src/main/java/org/terasology/engine/monitoring/impl/NullPerformanceMonitor.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/impl/NullPerformanceMonitor.java
@@ -38,4 +38,7 @@ public class NullPerformanceMonitor implements PerformanceMonitorInternal {
         return metrics;
     }
 
+    @Override
+    public void shutdown() {
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/monitoring/impl/PerformanceMonitorImpl.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/impl/PerformanceMonitorImpl.java
@@ -59,7 +59,7 @@ public class PerformanceMonitorImpl implements PerformanceMonitorInternal {
     private final Thread mainThread;
     private final EngineTime timer;
 
-    public PerformanceMonitorImpl() {
+    public PerformanceMonitorImpl(boolean enableTracy) {
         activityStack  = Queues.newArrayDeque();
         executionData  = Lists.newLinkedList();
         allocationData = Lists.newLinkedList();
@@ -81,7 +81,7 @@ public class PerformanceMonitorImpl implements PerformanceMonitorInternal {
         timer = (EngineTime) CoreRegistry.get(Time.class);
         mainThread = Thread.currentThread();
 
-        if (!tracyEnabled) {
+        if (enableTracy && !tracyEnabled) {
             Tracy.startupProfiler();
             tracyEnabled = true;
         }

--- a/engine/src/main/java/org/terasology/engine/monitoring/impl/PerformanceMonitorInternal.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/impl/PerformanceMonitorInternal.java
@@ -21,4 +21,6 @@ public interface PerformanceMonitorInternal {
     TObjectDoubleMap<String> getDecayingSpikes();
 
     TObjectDoubleMap<String> getAllocationMean();
+
+    void shutdown();
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/DebugOverlay.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/DebugOverlay.java
@@ -271,6 +271,7 @@ public class DebugOverlay extends CoreScreenLayer {
      */
     public void toggleMetricsMode() {
         MetricsMode mode = debugMetricsSystem.toggle();
+        PerformanceMonitor.setTracyEnabled(systemConfig.tracyProfilerEnabled.get());
         PerformanceMonitor.setEnabled(mode.isPerformanceManagerMode());
     }
 }

--- a/engine/src/main/resources/org/terasology/engine/assets/i18n/menu.lang
+++ b/engine/src/main/resources/org/terasology/engine/assets/i18n/menu.lang
@@ -340,6 +340,7 @@
     "settings-debug-mode": "settings-debug-mode",
     "settings-language": "settings-language",
     "settings-monitoring-enabled": "settings-monitoring-enabled",
+    "settings-tracy-profiler-enabled": "settings-tracy-profiler-enabled",
     "settings-saves-enabled": "settings-saves-enabled",
     "settings-seconds-between-saves": "settings-seconds-between-saves",
     "settings-title": "settings-title",

--- a/engine/src/main/resources/org/terasology/engine/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/org/terasology/engine/assets/i18n/menu_en.lang
@@ -350,6 +350,7 @@
     "settings-debug-mode": "Debug mode",
     "settings-language": "Language",
     "settings-monitoring-enabled": "Monitoring",
+    "settings-tracy-profiler-enabled": "Tracy Profiler",
     "settings-saves-enabled": "Game saves",
     "settings-seconds-between-saves": "Seconds between saves",
     "settings-title": "Settings",


### PR DESCRIPTION
### Contains
This pull request integrates Terasology's `PerformanceMonitor` with the [Tracy Profiler](https://github.com/wolfpld/tracy). This allows for better visualising performance traces and should help with diagnosing performance bottlenecks.

![image](https://github.com/MovingBlocks/Terasology/assets/24301287/6ec5336f-910f-45a6-8c16-89f0529daeff)

### How to test
- Clone a local copy of the Tracy bindings with https://github.com/MovingBlocks/TracyJavaBindings
- Enable the Tracy profiler integration in `Settings->Autoconfig`
- Start a new game
- Open the debugging overlay with <kbd>F3</kbd>
- Enable profiling by pressing <kbd>F4</kbd> once

### Outstanding before merging
- [X] Decide on a permanent home for the Tracy bindings library (should it stay under my namespace or be moved into the `MovingBlocks` organisation?)
- [ ] Decide how to distribute the Tracy bindings library