### PR TITLE
compilejava should create versioninfo file

### DIFF
--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -191,13 +191,10 @@ tasks.register<WriteProperties>("createVersionInfoFile") {
     if (env["JOB_NAME"] != null) {
         property("dateTime", startDateTimeString)
     }
-    destinationFile = layout.buildDirectory.dir("createrVersionInfoFile").get().file("versionInfo.properties")
+    destinationFile = layout.buildDirectory.dir("classes/org/terasology/engine/version").get().file("versionInfo.properties")
 }
 
 tasks.named<Copy>("processResources") {
-    from("createVersionInfoFile") {
-        into("org/terasology/engine/version/")
-    }
     from("$rootDir/docs") {
         include("Credits.md")
     }
@@ -210,7 +207,10 @@ tasks.register<Copy>("copyResourcesToClasses") {
 }
 
 tasks.named("compileJava") {
-    dependsOn(tasks.named("copyResourcesToClasses"))
+    dependsOn(
+        tasks.named("copyResourcesToClasses"),
+        tasks.named("createVersionInfoFile")
+    )
 }
 
 // Instructions for packaging a jar file for the engine


### PR DESCRIPTION
`versionInfo.properties` was not created, depend on it when doing

```
gradle --console=plain clean extractConfig extractNatives distForLauncher testDist

``` 

not sure yet about `Credits.md`:
```
❯ find . -name Credits.md
./docs-pre-merge/Credits.md
```
which is not "docs" as written in `build.gradle.kts`

another question i'd have, what this TODO means?
```
//TODO: Remove this when gestalt can handle ProtectionDomain without classes (Resources)
```