### PR TITLE
gradle-8.9 permit java-22

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
gradle wrapper jar not upgraded this time, as it just blows up the repository history and repo size. older one is just fine.

gradle bin distribution instead of all distribution un used, as src will be downloaded in case of kotlin build anyway, by intellij, in case build scripts are edited. in all other cases, bin distribution always was favorable.
