### PR TITLE
Revert "Revert "feat: upgrade to Gestalt 8""

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.jgrapht:jgrapht-core:1.5.0")
 
     // for inspecting modules
-    implementation("org.terasology.gestalt:gestalt-module:7.2.0")
+    implementation("org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT")
 
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")

--- a/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
@@ -66,8 +66,8 @@ class ModuleMetadataForGradle(private val moduleConfig: ModuleMetadata) {
     }
 
     private fun versionStringFromGestaltDependency(gestaltDependency: DependencyInfo): String {
-        val version = if (gestaltDependency.versionPredicate() is VersionRange) {
-            gestaltDependency.versionPredicate().toString()
+        val version = if (gestaltDependency.versionRange() is VersionRange) {
+            gestaltDependency.versionRange().toString()
         } else {
             // TODO: gradle-compatible version expressions for gestalt dependencies
             //     https://github.com/MovingBlocks/gestalt/issues/114

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     implementation(group = "org.terasology.engine", name = "engine", version = moduleMetadata.engineVersion())
     testImplementation(group = "org.terasology.engine", name = "engine-tests", version = moduleMetadata.engineVersion())
 
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+
     for ((gradleDep, optional) in moduleMetadata.moduleDependencies()) {
         if (optional) {
             // `optional` module dependencies are ones it does not require for runtime
@@ -144,8 +146,17 @@ tasks.named("processResources") {
     dependsOn("syncAssets", "syncOverrides", "syncDeltas", "syncModuleInfo")
 }
 
-tasks.named("compileJava") {
+tasks.named<JavaCompile>("compileJava") {
     dependsOn("processResources")
+    // Create an asset list during compilation (needed for Gestalt 8)
+    inputs.files(sourceSets.main.get().resources.srcDirs)
+    options.compilerArgs = arrayListOf("-Aresource=${sourceSets.main.get().resources.srcDirs.joinToString(File.pathSeparator)}")
+}
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn("processResources")
+    // Create an asset list during compilation (needed for Gestalt 8)
+    inputs.files(sourceSets.test.get().resources.srcDirs)
+    options.compilerArgs = arrayListOf("-Aresource=${sourceSets.test.get().resources.srcDirs.joinToString(File.pathSeparator)}")
 }
 
 tasks.named<Test>("test") {

--- a/engine-tests/build.gradle.kts
+++ b/engine-tests/build.gradle.kts
@@ -56,6 +56,11 @@ dependencies {
     implementation("com.google.protobuf:protobuf-java:3.16.1")
     implementation("org.terasology:reflections:0.9.12-MB")
 
+    implementation("com.github.zafarkhaja:java-semver:0.10.2")
+
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+    testAnnotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
 
     testImplementation("ch.qos.logback:logback-classic:1.4.14") {
@@ -91,8 +96,17 @@ tasks.register<Copy>("copyResourcesToClasses") {
     into(sourceSets["main"].output.classesDirs.first())
 }
 
-tasks.named("compileJava") {
+tasks.named<JavaCompile>("compileJava") {
     dependsOn("copyResourcesToClasses")
+    // Create an asset list during compilation (needed for Gestalt 8)
+    inputs.files(sourceSets.main.get().resources.srcDirs)
+    options.compilerArgs = arrayListOf("-Aresource=${sourceSets.main.get().resources.srcDirs.joinToString(File.pathSeparator)}")
+}
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn("copyResourcesToClasses")
+    // Create an asset list during compilation (needed for Gestalt 8)
+    inputs.files(sourceSets.test.get().resources.srcDirs)
+    options.compilerArgs = arrayListOf("-Aresource=${sourceSets.test.get().resources.srcDirs.joinToString(File.pathSeparator)}")
 }
 
 tasks.withType<Jar> {

--- a/engine-tests/src/main/java/org/terasology/unittest/ExampleClass.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/ExampleClass.java
@@ -3,7 +3,7 @@
 
 package org.terasology.unittest;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public class ExampleClass implements ExampleInterface {

--- a/engine-tests/src/main/java/org/terasology/unittest/ExampleInterface.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/ExampleInterface.java
@@ -3,8 +3,10 @@
 
 package org.terasology.unittest;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.IndexInherited;
 
 @API
+@IndexInherited
 public interface ExampleInterface {
 }

--- a/engine-tests/src/main/java/org/terasology/unittest/stubs/package-info.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/stubs/package-info.java
@@ -4,4 +4,4 @@
 @API
 package org.terasology.unittest.stubs;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine-tests/src/main/java/org/terasology/unittest/worlds/package-info.java
+++ b/engine-tests/src/main/java/org/terasology/unittest/worlds/package-info.java
@@ -4,4 +4,4 @@
 @API
 package org.terasology.unittest.worlds;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine-tests/src/test/java/org/terasology/documentation/ApiScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/ApiScraper.java
@@ -10,7 +10,7 @@ import org.terasology.engine.core.module.ExternalApiWhitelist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
 import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.net.URL;
 import java.util.HashMap;

--- a/engine-tests/src/test/java/org/terasology/documentation/apiScraper/CompleteApiScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/apiScraper/CompleteApiScraper.java
@@ -10,7 +10,7 @@ import org.terasology.engine.core.module.ExternalApiWhitelist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
 import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;

--- a/engine-tests/src/test/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleMetadata;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
 import org.terasology.unittest.ExampleClass;
@@ -56,9 +56,13 @@ public class ClasspathCompromisingModuleFactoryTest {
     public void archiveModuleContainsClass() throws IOException {
         Module module = factory.createArchiveModule(new File("FIXME.jar"));
 
-        Class<?> someClassInTheModule = module.getModuleManifest().getTypesAnnotatedWith(API.class).iterator().next();
+        String someClassInTheModule = module.getClassIndex().getTypesAnnotatedWith(API.class.getName()).iterator().next();
 
-        assertTrue(module.getClassPredicate().test(someClassInTheModule));
+        try {
+            assertTrue(module.getClassPredicate().test(Class.forName(someClassInTheModule)));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
         assertFalse(module.getClassPredicate().test(SOME_CLASS_OUTSIDE_THE_MODULE));
     }
 

--- a/engine-tests/src/test/java/org/terasology/engine/core/module/ModuleDownloadListGeneratorTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/module/ModuleDownloadListGeneratorTest.java
@@ -4,8 +4,8 @@ package org.terasology.engine.core.module;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.reflections.Reflections;
 import org.terasology.engine.core.TerasologyConstants;
+import org.terasology.gestalt.di.index.CompoundClassIndex;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleMetadata;
 import org.terasology.gestalt.module.ModuleRegistry;
@@ -86,7 +86,7 @@ public class ModuleDownloadListGeneratorTest {
         if (version != null) {
             metadata.setVersion(new Version(version));
         }
-        return new Module(metadata, new EmptyFileSource(), Collections.emptyList(), new Reflections(), (c) -> false);
+        return new Module(metadata, new EmptyFileSource(), Collections.emptyList(), new CompoundClassIndex(), (c) -> false);
     }
     private Module buildEngineModule(String version) {
         return buildSimpleModule(TerasologyConstants.ENGINE_MODULE.toString(), version);

--- a/engine-tests/src/test/java/org/terasology/engine/core/module/ModuleManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/module/ModuleManagerTest.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.reflections.Reflections;
 import org.terasology.engine.config.flexible.AutoConfig;
 import org.terasology.engine.core.PathManager;
 import org.terasology.engine.core.PathManagerProvider;
 import org.terasology.engine.core.subsystem.EngineSubsystem;
 import org.terasology.engine.logic.permission.PermissionSetComponent;
 import org.terasology.engine.world.block.structure.AttachSupportRequiredComponent;
+import org.terasology.gestalt.di.index.CompoundClassIndex;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleMetadata;
@@ -59,7 +59,7 @@ public class ModuleManagerTest {
                 new ModuleMetadata(new Name("EmptyTestModule"), new Version("0.0.1")),
                 new EmptyFileSource(),
                 Collections.emptyList(),
-                new Reflections(),
+                new CompoundClassIndex(),
                 (clazz) -> false
         );
     }
@@ -127,7 +127,7 @@ public class ModuleManagerTest {
         environment = manager.getEnvironment();
         engineModule = environment.get(ENGINE_MODULE);
 
-        assertThat(engineModule.getModuleManifest().getSubTypesOf(EngineSubsystem.class)).contains(subsystem);
+        assertThat(engineModule.getClassIndex().getSubtypesOf(EngineSubsystem.class.getName())).contains(subsystem.getName());
 
         assertThat(environment.getSubtypesOf(EngineSubsystem.class)).contains(subsystem);
 

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/serializers/TypeSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/serializers/TypeSerializerTest.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import org.joml.Vector3f;
 import org.junit.jupiter.api.Test;
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.ModuleEnvironmentTest;
 import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.core.module.ModuleContext;
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.terasology.engine.testUtil.Assertions.assertNotEmpty;
 
-class TypeSerializerTest extends ModuleEnvironmentTest {
+public class TypeSerializerTest extends ModuleEnvironmentTest {
     private static final SomeClass<Integer> INSTANCE = new SomeClass<>(0xdeadbeef);
     private static final String INSTANCE_JSON = "{\"generic-t\":-559038737,\"list\":[50,51,-52,-53]," +
             "\"animals\":[{\"class\":\"org.terasology.engine.persistence.serializers.TypeSerializerTest$Dog\"," +
@@ -155,6 +156,7 @@ class TypeSerializerTest extends ModuleEnvironmentTest {
     }
 
     @SuppressWarnings("checkstyle:FinalClass")
+    @IndexInherited
     public static class Animal<T> {
         public T data;
 
@@ -177,6 +179,11 @@ class TypeSerializerTest extends ModuleEnvironmentTest {
         @Override
         public int hashCode() {
             return Objects.hash(data);
+        }
+
+        @Override
+        public String toString() {
+            return "Animal(data = " + data.toString() + ")";
         }
     }
 

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -120,19 +120,25 @@ dependencies {
     }
     implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
+    // JSemVer (Semantic Versioning) - A dependency of Gestalt
+    implementation("com.github.zafarkhaja:java-semver:0.10.2")
+
     // Our developed libs
-    api("org.terasology.gestalt:gestalt-asset-core:7.2.1-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-module:7.2.1-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-entity-system:7.2.1-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-util:7.2.1-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-asset-core:8.0.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-entity-system:8.0.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-util:8.0.0-SNAPSHOT")
+    api("org.terasology.gestalt:gestalt-inject:8.0.0-SNAPSHOT")
+
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
 
     api("org.terasology:TeraMath:1.5.0")
     api("org.terasology:splash-screen:1.1.1")
     api("org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT")
     api("org.terasology.jnbullet:JNBullet:1.0.4")
-    api("org.terasology.nui:nui:3.0.0")
-    api("org.terasology.nui:nui-reflect:3.0.0")
-    api("org.terasology.nui:nui-gestalt7:3.0.0")
+    api("org.terasology.nui:nui:4.0.0-SNAPSHOT")
+    api("org.terasology.nui:nui-reflect:4.0.0-SNAPSHOT")
+    api("org.terasology.nui:nui-gestalt:4.0.0-SNAPSHOT")
 
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)
@@ -206,11 +212,23 @@ tasks.register<Copy>("copyResourcesToClasses") {
     into(sourceSets["main"].output.classesDirs.first())
 }
 
-tasks.named("compileJava") {
+tasks.named<JavaCompile>("compileJava") {
     dependsOn(
         tasks.named("copyResourcesToClasses"),
         tasks.named("createVersionInfoFile")
     )
+    // Create an asset list during compilation (needed for Gestalt 8)
+    inputs.files(sourceSets.main.get().resources.srcDirs)
+    options.compilerArgs = arrayListOf("-Aresource=${sourceSets.main.get().resources.srcDirs.joinToString(File.pathSeparator)}")
+}
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn(
+        tasks.named("copyResourcesToClasses"),
+        tasks.named("createVersionInfoFile")
+    )
+    // Create an asset list during compilation (needed for Gestalt 8)
+    inputs.files(sourceSets.test.get().resources.srcDirs)
+    options.compilerArgs = arrayListOf("-Aresource=${sourceSets.test.get().resources.srcDirs.joinToString(File.pathSeparator)}")
 }
 
 // Instructions for packaging a jar file for the engine

--- a/engine/src/main/java/org/terasology/engine/audio/Sound.java
+++ b/engine/src/main/java/org/terasology/engine/audio/Sound.java
@@ -22,7 +22,8 @@ public abstract class Sound<T extends AssetData> extends Asset<T> implements org
      * @param assetType The asset type this asset belongs to.
      */
     protected Sound(ResourceUrn urn, AssetType<?, T> assetType, DisposableResource resource) {
-        super(urn, assetType, resource);
+        super(urn, assetType);
+        setDisposableResource(resource);
     }
 
     /**

--- a/engine/src/main/java/org/terasology/engine/audio/events/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/audio/events/package-info.java
@@ -17,4 +17,4 @@
  */
 @API package org.terasology.engine.audio.events;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/audio/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/audio/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.audio;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/config/Config.java
+++ b/engine/src/main/java/org/terasology/engine/config/Config.java
@@ -23,7 +23,7 @@ import org.terasology.engine.utilities.gson.ResolutionHandler;
 import org.terasology.engine.utilities.gson.SetMultimapTypeAdapter;
 import org.terasology.engine.utilities.gson.UriTypeAdapterFactory;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
 import org.terasology.gestalt.naming.gson.NameTypeAdapter;

--- a/engine/src/main/java/org/terasology/engine/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/engine/config/RenderingConfig.java
@@ -4,7 +4,7 @@
 package org.terasology.engine.config;
 
 import org.terasology.engine.core.subsystem.Resolution;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.rendering.cameras.PerspectiveCameraSettings;
 import org.terasology.engine.rendering.nui.layers.mainMenu.videoSettings.DisplayModeSetting;
 import org.terasology.engine.rendering.nui.layers.mainMenu.videoSettings.ScreenshotSize;

--- a/engine/src/main/java/org/terasology/engine/config/RenderingDebugConfig.java
+++ b/engine/src/main/java/org/terasology/engine/config/RenderingDebugConfig.java
@@ -5,7 +5,7 @@ package org.terasology.engine.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.utilities.subscribables.AbstractSubscribable;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;

--- a/engine/src/main/java/org/terasology/engine/config/facade/TelemetryConfiguration.java
+++ b/engine/src/main/java/org/terasology/engine/config/facade/TelemetryConfiguration.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.config.facade;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * TelemetryConfiguration is a wrapper for {@link org.terasology.engine.config.TelemetryConfig}.

--- a/engine/src/main/java/org/terasology/engine/config/flexible/AutoConfig.java
+++ b/engine/src/main/java/org/terasology/engine/config/flexible/AutoConfig.java
@@ -4,6 +4,7 @@ package org.terasology.engine.config.flexible;
 
 import com.google.common.collect.ImmutableList;
 import org.reflections.ReflectionUtils;
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.config.flexible.internal.SettingBuilder;
 import org.terasology.engine.config.flexible.internal.SettingImplBuilder;
 import org.terasology.engine.core.SimpleUri;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
  * Represents a config class that will be automatically initialized and rendered by the engine.
  * All settings must be contained in {@code public static} fields of type {@link Setting}.
  */
+@IndexInherited
 public abstract class AutoConfig {
     private SimpleUri id;
 

--- a/engine/src/main/java/org/terasology/engine/config/flexible/Setting.java
+++ b/engine/src/main/java/org/terasology/engine/config/flexible/Setting.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.config.flexible;
 
 import org.terasology.engine.config.flexible.constraints.SettingConstraint;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.reflection.TypeInfo;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/config/flexible/constraints/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/config/flexible/constraints/package-info.java
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 @API package org.terasology.engine.config.flexible.constraints;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/config/flexible/ui/ConstraintWidgetFactory.java
+++ b/engine/src/main/java/org/terasology/engine/config/flexible/ui/ConstraintWidgetFactory.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.config.flexible.ui;
 
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.config.flexible.Setting;
 import org.terasology.engine.config.flexible.constraints.SettingConstraint;
 import org.terasology.nui.UIWidget;
@@ -17,6 +18,7 @@ import java.util.Optional;
  * @param <T> type of setting
  * @param <C> concrete type of {@link SettingConstraint}
  */
+@IndexInherited
 public abstract class ConstraintWidgetFactory<T, C extends SettingConstraint<T>> {
     private Setting<T> setting;
 

--- a/engine/src/main/java/org/terasology/engine/context/Context.java
+++ b/engine/src/main/java/org/terasology/engine/context/Context.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.context;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;

--- a/engine/src/main/java/org/terasology/engine/core/ComponentFieldUri.java
+++ b/engine/src/main/java/org/terasology/engine/core/ComponentFieldUri.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 import java.util.Objects;

--- a/engine/src/main/java/org/terasology/engine/core/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/ComponentSystemManager.java
@@ -21,7 +21,7 @@ import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.registry.InjectionHelper;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 import java.util.List;

--- a/engine/src/main/java/org/terasology/engine/core/GameScheduler.java
+++ b/engine/src/main/java/org/terasology/engine/core/GameScheduler.java
@@ -5,7 +5,7 @@ package org.terasology.engine.core;
 
 import org.terasology.engine.monitoring.ThreadActivity;
 import org.terasology.engine.monitoring.ThreadMonitor;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/engine/src/main/java/org/terasology/engine/core/Observer.java
+++ b/engine/src/main/java/org/terasology/engine/core/Observer.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.core;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * A general interface for observers

--- a/engine/src/main/java/org/terasology/engine/core/SimpleUri.java
+++ b/engine/src/main/java/org/terasology/engine/core/SimpleUri.java
@@ -4,7 +4,7 @@ package org.terasology.engine.core;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -487,7 +487,12 @@ public class TerasologyEngine implements GameEngine {
         }
 
         if (assetTypeManager instanceof AutoReloadAssetTypeManager) {
-            ((AutoReloadAssetTypeManager) assetTypeManager).reloadChangedAssets();
+            try {
+                ((AutoReloadAssetTypeManager) assetTypeManager).reloadChangedAssets();
+            } catch (IllegalStateException ignore) {
+                // ignore: This can happen if a module environment switch is happening in a different thread.
+                return true;
+            }
         }
 
         processPendingState();

--- a/engine/src/main/java/org/terasology/engine/core/Time.java
+++ b/engine/src/main/java/org/terasology/engine/core/Time.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * The timer manages all time in the game.

--- a/engine/src/main/java/org/terasology/engine/core/Uri.java
+++ b/engine/src/main/java/org/terasology/engine/core/Uri.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/core/bootstrap/ClassMetaLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/core/bootstrap/ClassMetaLibrary.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.core.bootstrap;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 import java.lang.annotation.Annotation;

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/AwaitedLocalCharacterSpawnEvent.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/AwaitedLocalCharacterSpawnEvent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.core.modes.loadProcesses;
 
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Event which is triggered when LocalPlayer is setup with a character entity. Allows for detection of when LocalPlayer is

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -50,7 +50,7 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
         Module module = super.createDirectoryModule(metadata, directory);
         return new Module(
                 module.getMetadata(), module.getResources(),
-                module.getClasspaths(), module.getModuleManifest(),
+                module.getClasspaths(), module.getClassIndex(),
                 new ClassesInModule(module));
     }
 
@@ -59,7 +59,7 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
         Module module = super.createArchiveModule(metadata, archive);
         return new Module(
                 module.getMetadata(), module.getResources(),
-                module.getClasspaths(), module.getModuleManifest(),
+                module.getClasspaths(), module.getClassIndex(),
                 new ClassesInModule(module));
     }
 
@@ -158,7 +158,6 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
     static class ClassesInModule implements Predicate<Class<?>> {
 
         private final Set<URL> classpaths;
-        private final ClassLoader[] classLoaders;
         private final String name;
 
         ClassesInModule(Module module) {
@@ -174,13 +173,12 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
                     throw new RuntimeException(e);
                 }
             }).collect(ImmutableSet.toImmutableSet());
-            classLoaders = module.getModuleManifest().getConfiguration().getClassLoaders();
             name = module.getId().toString();
         }
 
         @Override
         public boolean test(Class<?> aClass) {
-            URL classUrl = ClasspathHelper.forClass(aClass, classLoaders);
+            URL classUrl = ClasspathHelper.forClass(aClass);
             return classpaths.contains(classUrl);
         }
 

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleInputStream.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleInputStream.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core.module;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleListDownloader.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleListDownloader.java
@@ -6,10 +6,10 @@ package org.terasology.engine.core.module;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.TerasologyConstants;
+import org.terasology.gestalt.di.index.CompoundClassIndex;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleMetadata;
 import org.terasology.gestalt.module.ModuleMetadataJsonAdapter;
@@ -60,7 +60,7 @@ public class ModuleListDownloader implements Callable<ModuleRegistry> {
 
                 ModuleMetadata meta = metaReader.read(new StringReader(json));
                 logger.debug("Read module {} - {}", meta.getId(), meta.getVersion()); //NOPMD
-                modules.add(new Module(meta, new EmptyFileSource(), Collections.emptyList(), new Reflections(),
+                modules.add(new Module(meta, new EmptyFileSource(), Collections.emptyList(), new CompoundClassIndex(),
                         (c) -> false));
             }
 

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -15,6 +15,9 @@ import org.terasology.engine.config.SystemConfig;
 import org.terasology.engine.core.PathManager;
 import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.utilities.Jvm;
+import org.terasology.gestalt.di.DefaultBeanContext;
+import org.terasology.gestalt.di.index.CompoundClassIndex;
+import org.terasology.gestalt.di.index.UrlClassIndex;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
@@ -198,7 +201,10 @@ public class ModuleManager {
         Module packageModule = moduleFactory.createPackageModule("org.terasology.engine");
 
         // We need to add reflections from our subsystems and other classes.
-        Reflections packageReflections = packageModule.getModuleManifest();
+        CompoundClassIndex packageClassIndex = new CompoundClassIndex();
+        packageClassIndex.add(packageModule.getClassIndex());
+
+        Reflections packageReflections = new Reflections();
         ConfigurationBuilder config = reflectionsConfigurationFrom(packageReflections);
 
         Collection<File> classPaths = new HashSet<>(packageModule.getClasspaths());
@@ -206,6 +212,7 @@ public class ModuleManager {
             URL url = ClasspathHelper.forClass(aClass);
             config.addUrls(url);  // include this in reflections scan
             classPaths.add(urlToFile(url));  // also include in Module.moduleClasspaths
+            packageClassIndex.add(UrlClassIndex.byClassLoader(aClass.getClassLoader()));
             logger.debug("Adding path to engine module for class: {} {}", url, aClass);
         }
 
@@ -221,7 +228,7 @@ public class ModuleManager {
                 packageModule.getMetadata(),
                 packageModule.getResources(),
                 classPaths,
-                packageReflections,
+                packageClassIndex,
                 clazz ->
                         packageModule.getClassPredicate().test(clazz)
                                 || config.getUrls().contains(ClasspathHelper.forClass(clazz))
@@ -253,7 +260,9 @@ public class ModuleManager {
         ExternalApiWhitelist.PACKAGES.forEach(permissionSet::addAPIPackage);
 
         APIScanner apiScanner = new APIScanner(permissionProviderFactory);
-        registry.stream().map(Module::getModuleManifest).forEach(apiScanner::scan);
+        for (Module module : registry) {
+            apiScanner.scan(module.getClassIndex());
+        }
 
         permissionSet.grantPermission("com.google.gson", ReflectPermission.class);
         permissionSet.grantPermission("com.google.gson.internal", ReflectPermission.class);
@@ -366,9 +375,9 @@ public class ModuleManager {
         ModuleEnvironment newEnvironment;
         boolean permissiveSecurityEnabled = Boolean.parseBoolean(System.getProperty(SystemConfig.PERMISSIVE_SECURITY_ENABLED_PROPERTY));
         if (permissiveSecurityEnabled) {
-            newEnvironment = new ModuleEnvironment(finalModules, wrappingPermissionProviderFactory);
+            newEnvironment = new ModuleEnvironment(new DefaultBeanContext(), finalModules, wrappingPermissionProviderFactory);
         } else {
-            newEnvironment = new ModuleEnvironment(finalModules, permissionProviderFactory);
+            newEnvironment = new ModuleEnvironment(new DefaultBeanContext(), finalModules, permissionProviderFactory);
         }
         if (asPrimary) {
             environment = newEnvironment;

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleOutputStream.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleOutputStream.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core.module;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/engine/src/main/java/org/terasology/engine/core/module/SandboxFileManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/SandboxFileManager.java
@@ -5,7 +5,7 @@ package org.terasology.engine.core.module;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.PathManager;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;

--- a/engine/src/main/java/org/terasology/engine/core/module/rendering/RenderingModuleRegistry.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/rendering/RenderingModuleRegistry.java
@@ -5,7 +5,7 @@ package org.terasology.engine.core.module.rendering;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.rendering.dag.ModuleRendering;
 import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 import javax.annotation.Nullable;

--- a/engine/src/main/java/org/terasology/engine/core/module/rendering/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/rendering/package-info.java
@@ -4,4 +4,4 @@
 @API
 package org.terasology.engine.core.module.rendering;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/DisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/DisplayDevice.java
@@ -4,7 +4,7 @@ package org.terasology.engine.core.subsystem;
 
 import org.terasology.engine.rendering.nui.layers.mainMenu.videoSettings.DisplayModeSetting;
 import org.terasology.engine.utilities.subscribables.Subscribable;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.List;
 

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/EngineSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/EngineSubsystem.java
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core.subsystem;
 
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.GameEngine;
 import org.terasology.engine.core.modes.GameState;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManager;
 
+@IndexInherited
 public interface EngineSubsystem {
 
     /**

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/common/hibernation/HibernationManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/common/hibernation/HibernationManager.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core.subsystem.common.hibernation;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/entitySystem/entity/internal/EntityScope.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/entity/internal/EntityScope.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.entitySystem.entity.internal;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public enum EntityScope {

--- a/engine/src/main/java/org/terasology/engine/entitySystem/entity/lifecycleEvents/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/entity/lifecycleEvents/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.entitySystem.entity.lifecycleEvents;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/entity/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/entity/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.entitySystem.entity;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/event/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/event/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.entitySystem.event;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/metadata/ComponentLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/metadata/ComponentLibrary.java
@@ -24,7 +24,7 @@ public class ComponentLibrary extends ModuleClassLibrary<Component> {
     private static final Logger logger = LoggerFactory.getLogger(ComponentLibrary.class);
 
     public ComponentLibrary(ModuleEnvironment environment, ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategyLibrary) {
-        super(environment, reflectFactory, copyStrategyLibrary);
+        super(() -> environment, reflectFactory, copyStrategyLibrary);
     }
 
     private ComponentLibrary(ComponentLibrary componentLibrary, CopyStrategyLibrary newCopyStrategies) {

--- a/engine/src/main/java/org/terasology/engine/entitySystem/metadata/EventLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/metadata/EventLibrary.java
@@ -21,7 +21,7 @@ public class EventLibrary extends ModuleClassLibrary<Event> {
     private static final Logger logger = LoggerFactory.getLogger(EventLibrary.class);
 
     public EventLibrary(ModuleEnvironment environment, ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategyLibrary) {
-        super(environment, reflectFactory, copyStrategyLibrary);
+        super(() -> environment, reflectFactory, copyStrategyLibrary);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/entitySystem/metadata/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/metadata/package-info.java
@@ -8,4 +8,4 @@
 @API
 package org.terasology.engine.entitySystem.metadata;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.entitySystem;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/prefab/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/prefab/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.entitySystem.prefab;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/sectors/LoadedSectorUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/sectors/LoadedSectorUpdateEvent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.entitySystem.sectors;
 
 import org.joml.Vector3i;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.Set;
 

--- a/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorRegionComponent.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorRegionComponent.java
@@ -5,7 +5,7 @@ package org.terasology.engine.entitySystem.sectors;
 import org.joml.Vector3i;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorSimulationComponent.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorSimulationComponent.java
@@ -6,7 +6,7 @@ import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.internal.BaseEntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EntityScope;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * The component that allows the {@link SectorSimulationSystem} to send simulation events to a sector-scope entity.

--- a/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorSimulationEvent.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorSimulationEvent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.entitySystem.sectors;
 
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This is the event sent to all sector-level entities by the {@link SectorSimulationSystem}, allowing them to do simulation. It

--- a/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorUtil.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/sectors/SectorUtil.java
@@ -7,7 +7,7 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.location.LocationComponent;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.ChunkProvider;
 import org.terasology.engine.world.chunks.Chunks;

--- a/engine/src/main/java/org/terasology/engine/entitySystem/systems/RegisterSystem.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/systems/RegisterSystem.java
@@ -3,6 +3,8 @@
 
 package org.terasology.engine.entitySystem.systems;
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -22,6 +24,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterSystem {
 
     String[] requiresOptional() default {};

--- a/engine/src/main/java/org/terasology/engine/entitySystem/systems/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/systems/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.entitySystem.systems;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/i18n/TranslationSystem.java
+++ b/engine/src/main/java/org/terasology/engine/i18n/TranslationSystem.java
@@ -4,7 +4,7 @@
 package org.terasology.engine.i18n;
 
 import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.translate.Translator;
 
 import java.util.Locale;

--- a/engine/src/main/java/org/terasology/engine/i18n/assets/Translation.java
+++ b/engine/src/main/java/org/terasology/engine/i18n/assets/Translation.java
@@ -36,7 +36,8 @@ public class Translation extends Asset<TranslationData> {
      * @param data      The actual translation data. Never <code>null</code>.
      */
     public Translation(ResourceUrn urn, AssetType<?, TranslationData> assetType, TranslationData data, Translation.DisposalAction disposalAction) {
-        super(urn, assetType, disposalAction);
+        super(urn, assetType);
+        setDisposableResource(disposalAction);
         this.disposalAction = disposalAction;
         this.disposalAction.setAsset(this);
         reload(data);

--- a/engine/src/main/java/org/terasology/engine/i18n/assets/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/i18n/assets/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.i18n.assets;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/input/RegisterBindAxis.java
+++ b/engine/src/main/java/org/terasology/engine/input/RegisterBindAxis.java
@@ -3,6 +3,8 @@
 
 package org.terasology.engine.input;
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,6 +12,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterBindAxis {
     String id();
 

--- a/engine/src/main/java/org/terasology/engine/input/RegisterBindButton.java
+++ b/engine/src/main/java/org/terasology/engine/input/RegisterBindButton.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.input;
 
+import org.terasology.context.annotation.Index;
 import org.terasology.input.ActivateMode;
 
 import java.lang.annotation.ElementType;
@@ -12,6 +13,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterBindButton {
     String id();
 

--- a/engine/src/main/java/org/terasology/engine/input/RegisterRealBindAxis.java
+++ b/engine/src/main/java/org/terasology/engine/input/RegisterRealBindAxis.java
@@ -3,6 +3,8 @@
 
 package org.terasology.engine.input;
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,6 +12,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterRealBindAxis {
     String id();
 

--- a/engine/src/main/java/org/terasology/engine/input/binds/general/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/input/binds/general/package-info.java
@@ -7,5 +7,5 @@
         displayName = "${engine:menu#category-general}"
         ) package org.terasology.engine.input.binds.general;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.input.InputCategory;

--- a/engine/src/main/java/org/terasology/engine/input/binds/interaction/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/input/binds/interaction/package-info.java
@@ -10,5 +10,5 @@
                 "engine:frob"
         }) package org.terasology.engine.input.binds.interaction;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.input.InputCategory;

--- a/engine/src/main/java/org/terasology/engine/input/binds/inventory/UseItemButton.java
+++ b/engine/src/main/java/org/terasology/engine/input/binds/inventory/UseItemButton.java
@@ -6,7 +6,7 @@ package org.terasology.engine.input.binds.inventory;
 import org.terasology.engine.input.BindButtonEvent;
 import org.terasology.engine.input.DefaultBinding;
 import org.terasology.engine.input.RegisterBindButton;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.input.ControllerId;
 import org.terasology.input.InputType;
 

--- a/engine/src/main/java/org/terasology/engine/input/binds/movement/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/input/binds/movement/package-info.java
@@ -18,5 +18,5 @@
                 "engine:crouch"
         }) package org.terasology.engine.input.binds.movement;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.input.InputCategory;

--- a/engine/src/main/java/org/terasology/engine/input/cameraTarget/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/input/cameraTarget/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.input.cameraTarget;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/input/events/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/input/events/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.input.events;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/input/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/input/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.input;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/actions/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/actions/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.actions;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/autoCreate/AutoCreateComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/autoCreate/AutoCreateComponent.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.logic.autoCreate;
 
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This component is used to mark prefabs that should automatically created when a game begins or is loaded, if one does not already exist.

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/BehaviorAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/BehaviorAction.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.logic.behavior;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/BehaviorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/BehaviorComponent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.behavior;
 
 import org.terasology.engine.logic.behavior.asset.BehaviorTree;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Entities with this component are handled by a behavior tree. Default tree to fetch may be set.

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/CollectiveBehaviorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/CollectiveBehaviorComponent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.behavior;
 
 import org.terasology.engine.logic.behavior.asset.BehaviorTree;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Entities with this component are handled by a behavior tree. Default tree to fetch may be set.

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/CollectiveInterpreter.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/CollectiveInterpreter.java
@@ -6,7 +6,7 @@ import org.terasology.engine.logic.behavior.asset.BehaviorTree;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.CollectiveBehaviorTreeRunner;
 import org.terasology.engine.logic.common.DisplayNameComponent;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.Set;
 

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/Interpreter.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/Interpreter.java
@@ -6,7 +6,7 @@ import org.terasology.engine.logic.behavior.asset.BehaviorTree;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BehaviorTreeRunner;
 import org.terasology.engine.logic.common.DisplayNameComponent;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * An interpreter evaluates a behavior tree. Uses BehaviorTreeRunner to actually evaluate the tree. The runner

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/CounterAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/CounterAction.java
@@ -6,7 +6,7 @@ import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.properties.Range;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/InvertAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/InvertAction.java
@@ -6,7 +6,7 @@ import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Inverts the child's return value. Doesn't change RUNNING.

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/LookupAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/LookupAction.java
@@ -8,7 +8,7 @@ import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorNode;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.properties.OneOf;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/LoopAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/LoopAction.java
@@ -6,7 +6,7 @@ import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Node, that loops its child forever

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/SleepAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/SleepAction.java
@@ -6,7 +6,7 @@ import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.properties.Range;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/TimeoutAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/TimeoutAction.java
@@ -8,7 +8,7 @@ import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.properties.Range;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.behavior.actions;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/asset/BehaviorTree.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/asset/BehaviorTree.java
@@ -6,7 +6,7 @@ import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.logic.behavior.core.BehaviorNode;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Behavior tree asset. Can be loaded and saved into json. Actors should never run the nodes behind a asset directly.

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/asset/GroupBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/asset/GroupBuilder.java
@@ -5,7 +5,7 @@ package org.terasology.engine.logic.behavior.asset;
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.registry.In;
 
 import java.io.InputStream;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/asset/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/asset/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.behavior.asset;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/core/Action.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/core/Action.java
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.logic.behavior.core;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.IndexInherited;
 
 /**
  * The action that is used by an action or decorator node. Every action node of a behavior tree has its own action
@@ -12,6 +13,7 @@ import org.terasology.gestalt.module.sandbox.API;
  * Action instances are shown in the property panel of the behavior editor.
  */
 @API
+@IndexInherited
 public interface Action {
 
     /**

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/core/Actor.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/core/Actor.java
@@ -13,7 +13,7 @@ import org.terasology.engine.entitySystem.metadata.EntitySystemLibrary;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.reflection.metadata.FieldMetadata;
 
 import java.lang.reflect.Field;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/core/BaseAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/core/BaseAction.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.logic.behavior.core;
 
 import org.terasology.engine.logic.behavior.BehaviorAction;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * BaseAction that uses BehaviorAction annotation as its name.

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/core/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/core/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.behavior.core;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/nui/BehaviorNodeComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/nui/BehaviorNodeComponent.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.logic.behavior.nui;
 
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.Color;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/nui/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/nui/package-info.java
@@ -6,5 +6,5 @@
         displayName = "${engine:menu#category-behavior}"
         ) package org.terasology.engine.logic.behavior.nui;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.input.InputCategory;

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.behavior;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/characters/events/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/events/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.characters.events;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionEndPredicted.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionEndPredicted.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.characters.interactions;
 
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  *

--- a/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionScreenComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionScreenComponent.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.logic.characters.interactions;
 
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Entities with this component will show an UI during interactions.

--- a/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionStartPredicted.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionStartPredicted.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.characters.interactions;
 
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Sent to the client by itself at the start of an interaction between a character and a target.

--- a/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionUtil.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/interactions/InteractionUtil.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.characters.CharacterComponent;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Utility class for entities with the {@link CharacterComponent}.

--- a/engine/src/main/java/org/terasology/engine/logic/characters/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.characters;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/chat/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/chat/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.chat;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/clipboard/ClipboardManager.java
+++ b/engine/src/main/java/org/terasology/engine/logic/clipboard/ClipboardManager.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.logic.clipboard;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API // Temporarily in base permission set, until fixed - (permissionSet = "clipboard")
 public interface ClipboardManager {

--- a/engine/src/main/java/org/terasology/engine/logic/common/lifespan/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/common/lifespan/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.common.lifespan;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/common/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/common/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.common;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/config/ModuleConfigManager.java
+++ b/engine/src/main/java/org/terasology/engine/logic/config/ModuleConfigManager.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.logic.config;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public interface ModuleConfigManager {

--- a/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/CommandParameterSuggester.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/CommandParameterSuggester.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.logic.console.commandSystem;
 
 import org.terasology.engine.entitySystem.entity.EntityRef;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.Set;
 

--- a/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/ConsoleCommand.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/ConsoleCommand.java
@@ -7,7 +7,7 @@ import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.console.Console;
 import org.terasology.engine.logic.console.commandSystem.exceptions.CommandExecutionException;
 import org.terasology.engine.logic.console.commandSystem.exceptions.CommandSuggestionException;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 import java.util.Comparator;

--- a/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/adapter/ParameterAdapter.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/adapter/ParameterAdapter.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.logic.console.commandSystem.adapter;
 
 import org.terasology.engine.logic.console.commandSystem.AbstractCommand;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Used for providing parameters to {@code execute} and {@code suggest} methods of {@link AbstractCommand}

--- a/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/adapter/ParameterAdapterManager.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/adapter/ParameterAdapterManager.java
@@ -5,7 +5,7 @@ package org.terasology.engine.logic.console.commandSystem.adapter;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.terasology.engine.entitySystem.prefab.Prefab;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.engine.world.block.family.BlockFamily;
 

--- a/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/annotations/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/commandSystem/annotations/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.console.commandSystem.annotations;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/console/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.console;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/console/suggesters/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/suggesters/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.console.suggesters;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/delay/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/delay/package-info.java
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 @API package org.terasology.engine.logic.delay;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/health/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/health/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.health;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/inventory/events/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/inventory/events/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.inventory.events;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/inventory/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/inventory/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.inventory;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/location/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/location/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.location;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/nameTags/NameTagComponent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/nameTags/NameTagComponent.java
@@ -5,7 +5,7 @@ package org.terasology.engine.logic.nameTags;
 import org.terasology.engine.logic.common.DisplayNameComponent;
 import org.terasology.engine.network.Replicate;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.Color;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/notifications/NotificationMessageEvent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/notifications/NotificationMessageEvent.java
@@ -8,7 +8,7 @@ import org.terasology.engine.logic.console.CoreMessageType;
 import org.terasology.engine.logic.console.Message;
 import org.terasology.engine.logic.console.MessageEvent;
 import org.terasology.engine.logic.players.PlayerUtil;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.network.OwnerEvent;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/logic/permission/PermissionManager.java
+++ b/engine/src/main/java/org/terasology/engine/logic/permission/PermissionManager.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.permission;
 
 import com.google.common.base.Predicate;
 import org.terasology.engine.entitySystem.entity.EntityRef;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public interface PermissionManager {

--- a/engine/src/main/java/org/terasology/engine/logic/players/event/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/event/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.players.event;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/players/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.players;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/logic/selection/ApplyBlockSelectionEvent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/selection/ApplyBlockSelectionEvent.java
@@ -5,7 +5,7 @@ package org.terasology.engine.logic.selection;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This event is fired once a player finished a selection using an item with a BlockSelectionComponent. The item used

--- a/engine/src/main/java/org/terasology/engine/logic/selection/MovableSelectionEndEvent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/selection/MovableSelectionEndEvent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.selection;
 
 import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This event is sent when the player finalizes the position of a moving selection by clicking the left mouse button.

--- a/engine/src/main/java/org/terasology/engine/logic/selection/MovableSelectionStartEvent.java
+++ b/engine/src/main/java/org/terasology/engine/logic/selection/MovableSelectionStartEvent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.logic.selection;
 
 import org.terasology.engine.world.selection.BlockSelectionComponent;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This event should be sent by a system after it receives a {@link ApplyBlockSelectionEvent} which marks the end of a

--- a/engine/src/main/java/org/terasology/engine/logic/spawner/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/logic/spawner/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.logic.spawner;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/math/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/math/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.math;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/monitoring/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/monitoring/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.monitoring;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/network/events/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/network/events/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.network.events;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/network/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/network/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.network;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/particles/ParticleData.java
+++ b/engine/src/main/java/org/terasology/engine/particles/ParticleData.java
@@ -5,7 +5,7 @@ package org.terasology.engine.particles;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
 import org.joml.Vector4f;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Data object to store the data of a single particle.

--- a/engine/src/main/java/org/terasology/engine/particles/ParticleDataMask.java
+++ b/engine/src/main/java/org/terasology/engine/particles/ParticleDataMask.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.particles;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Data mask used internally by the particle system.

--- a/engine/src/main/java/org/terasology/engine/particles/ParticleSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/particles/ParticleSystemManager.java
@@ -4,7 +4,7 @@ package org.terasology.engine.particles;
 
 import org.terasology.engine.particles.rendering.ParticleRenderingData;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.stream.Stream;
 

--- a/engine/src/main/java/org/terasology/engine/particles/ParticleSystemManagerImpl.java
+++ b/engine/src/main/java/org/terasology/engine/particles/ParticleSystemManagerImpl.java
@@ -21,7 +21,7 @@ import org.terasology.engine.registry.In;
 import org.terasology.engine.registry.Share;
 import org.terasology.gestalt.entitysystem.component.Component;
 import org.terasology.gestalt.entitysystem.event.ReceiveEvent;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/engine/src/main/java/org/terasology/engine/particles/components/ParticleDataSpriteComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/ParticleDataSpriteComponent.java
@@ -5,7 +5,7 @@ package org.terasology.engine.particles.components;
 import org.joml.Vector2f;
 import org.terasology.engine.rendering.assets.texture.Texture;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/particles/components/ParticleEmitterComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/ParticleEmitterComponent.java
@@ -8,7 +8,7 @@ import org.terasology.engine.particles.ParticlePool;
 import org.terasology.engine.particles.functions.affectors.AffectorFunction;
 import org.terasology.engine.particles.functions.generators.GeneratorFunction;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/engine/src/main/java/org/terasology/engine/particles/components/affectors/AccelerationAffectorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/affectors/AccelerationAffectorComponent.java
@@ -5,7 +5,7 @@ package org.terasology.engine.particles.components.affectors;
 import org.joml.Vector3f;
 import org.terasology.engine.network.Replicate;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/particles/components/affectors/VelocityAffectorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/affectors/VelocityAffectorComponent.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.particles.components.affectors;
 
 import org.terasology.gestalt.entitysystem.component.EmptyComponent;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public class VelocityAffectorComponent extends EmptyComponent<VelocityAffectorComponent> {

--- a/engine/src/main/java/org/terasology/engine/particles/components/generators/ColorRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/generators/ColorRangeGeneratorComponent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.particles.components.generators;
 
 import org.joml.Vector4f;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/particles/components/generators/EnergyRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/generators/EnergyRangeGeneratorComponent.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.particles.components.generators;
 
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/particles/components/generators/PositionRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/generators/PositionRangeGeneratorComponent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.particles.components.generators;
 
 import org.joml.Vector3f;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/particles/components/generators/ScaleRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/generators/ScaleRangeGeneratorComponent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.particles.components.generators;
 
 import org.joml.Vector3f;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/particles/components/generators/TextureOffsetGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/generators/TextureOffsetGeneratorComponent.java
@@ -6,7 +6,7 @@ import org.joml.Vector2f;
 import org.joml.Vector2i;
 import org.terasology.engine.rendering.assets.texture.Texture;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/engine/particles/components/generators/VelocityRangeGeneratorComponent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/components/generators/VelocityRangeGeneratorComponent.java
@@ -4,7 +4,7 @@ package org.terasology.engine.particles.components.generators;
 
 import org.joml.Vector3f;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Generator for a particle's velocity.

--- a/engine/src/main/java/org/terasology/engine/particles/events/ParticleSystemUpdateEvent.java
+++ b/engine/src/main/java/org/terasology/engine/particles/events/ParticleSystemUpdateEvent.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.particles.events;
 
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Fired to notify the ParticleSystemManager that a system needs to be reconfigured.

--- a/engine/src/main/java/org/terasology/engine/particles/functions/RegisterParticleSystemFunction.java
+++ b/engine/src/main/java/org/terasology/engine/particles/functions/RegisterParticleSystemFunction.java
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.particles.functions;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -16,4 +17,5 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterParticleSystemFunction { }

--- a/engine/src/main/java/org/terasology/engine/particles/functions/affectors/AffectorFunction.java
+++ b/engine/src/main/java/org/terasology/engine/particles/functions/affectors/AffectorFunction.java
@@ -7,7 +7,7 @@ import org.terasology.engine.particles.ParticleDataMask;
 import org.terasology.engine.particles.functions.ParticleSystemFunction;
 import org.terasology.engine.utilities.random.Random;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * A affector function is called on a particle's data when it is updated to set its fields (Ex. Apply a force to a particle).

--- a/engine/src/main/java/org/terasology/engine/particles/functions/generators/GeneratorFunction.java
+++ b/engine/src/main/java/org/terasology/engine/particles/functions/generators/GeneratorFunction.java
@@ -7,7 +7,7 @@ import org.terasology.engine.particles.ParticleDataMask;
 import org.terasology.engine.particles.functions.ParticleSystemFunction;
 import org.terasology.engine.utilities.random.Random;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * A generator function is called on a particle's data when it is created to set its fields.

--- a/engine/src/main/java/org/terasology/engine/particles/rendering/ParticleRenderingData.java
+++ b/engine/src/main/java/org/terasology/engine/particles/rendering/ParticleRenderingData.java
@@ -4,7 +4,7 @@ package org.terasology.engine.particles.rendering;
 
 import org.terasology.engine.particles.ParticlePool;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 
 @API

--- a/engine/src/main/java/org/terasology/engine/persistence/TemplateEngine.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/TemplateEngine.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.persistence;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Transforms the input text that contains markers (e.g. <code>${text}</code> expressions).

--- a/engine/src/main/java/org/terasology/engine/persistence/TemplateEngineImpl.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/TemplateEngineImpl.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * A simple template engine that replaces <code>${text}</code> expressions

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/RegisterTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/RegisterTypeHandler.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.persistence.typeHandling;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/RegisterTypeHandlerFactory.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/RegisterTypeHandlerFactory.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.persistence.typeHandling;
 
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/engine/src/main/java/org/terasology/engine/physics/components/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/physics/components/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.physics.components;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/physics/components/shapes/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/physics/components/shapes/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.physics.components.shapes;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/physics/events/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/physics/events/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.physics.events;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/physics/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/physics/package-info.java
@@ -31,4 +31,4 @@
  */
 @API package org.terasology.engine.physics;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/physics/shapes/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/physics/shapes/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.physics.shapes;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/registry/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/registry/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.registry;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/AABBRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/AABBRenderer.java
@@ -19,7 +19,7 @@ import org.terasology.engine.rendering.assets.mesh.resource.DrawingMode;
 import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.utilities.Assets;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.joml.geom.AABBf;
 import org.terasology.joml.geom.AABBfc;
 import org.terasology.nui.Color;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/animation/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/animation/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.animation;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/font/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/font/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.font;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/material/Material.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/material/Material.java
@@ -21,7 +21,8 @@ import java.nio.FloatBuffer;
 public abstract class Material extends Asset<MaterialData> {
 
     protected Material(ResourceUrn urn, AssetType<?, MaterialData> assetType, DisposableResource resource) {
-        super(urn, assetType, resource);
+        super(urn, assetType);
+        setDisposableResource(resource);
     }
 
     protected Material(ResourceUrn urn, AssetType<?, MaterialData> assetType) {

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/material/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/material/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.material;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/Mesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/Mesh.java
@@ -19,7 +19,8 @@ public abstract class Mesh extends Asset<MeshData> {
     }
 
     protected Mesh(ResourceUrn urn, AssetType<?, MeshData> assetType, DisposableResource resource) {
-        super(urn, assetType, resource);
+        super(urn, assetType);
+        setDisposableResource(resource);
     }
 
     public abstract AABBfc getAABB();

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/MeshBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/MeshBuilder.java
@@ -7,7 +7,7 @@ import org.joml.Vector2fc;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.Colorc;
 import org.terasology.engine.utilities.Assets;
 

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/ScreenQuadMeshProducer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/ScreenQuadMeshProducer.java
@@ -10,7 +10,7 @@ import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.gestalt.assets.AssetDataProducer;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.module.annotations.RegisterAssetDataProducer;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 
 import java.io.IOException;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/mesh/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.mesh;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/shader/Shader.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/shader/Shader.java
@@ -11,7 +11,8 @@ import org.terasology.gestalt.assets.ResourceUrn;
 public abstract class Shader extends Asset<ShaderData> {
 
     protected Shader(ResourceUrn urn, AssetType<?, ShaderData> assetType, DisposableResource resource) {
-        super(urn, assetType, resource);
+        super(urn, assetType);
+        setDisposableResource(resource);
     }
 
     protected Shader(ResourceUrn urn, AssetType<?, ShaderData> assetType) {

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/shader/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/shader/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.shader;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/skeletalmesh/SkeletalMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/skeletalmesh/SkeletalMesh.java
@@ -14,7 +14,8 @@ import java.util.Collection;
 public abstract class SkeletalMesh extends Asset<SkeletalMeshData> {
 
     protected SkeletalMesh(ResourceUrn urn, AssetType<?, SkeletalMeshData> assetType, DisposableResource disposableResource) {
-        super(urn, assetType, disposableResource);
+        super(urn, assetType);
+        setDisposableResource(disposableResource);
     }
 
     protected SkeletalMesh(ResourceUrn urn, AssetType<?, SkeletalMeshData> assetType) {

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/skeletalmesh/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/skeletalmesh/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.skeletalmesh;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/texture/TextureRegionAsset.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/texture/TextureRegionAsset.java
@@ -15,6 +15,7 @@ public abstract class TextureRegionAsset<T extends AssetData> extends Asset<T> i
     }
 
     protected TextureRegionAsset(ResourceUrn urn, AssetType<?, T> assetType, DisposableResource disposableResource) {
-        super(urn, assetType, disposableResource);
+        super(urn, assetType);
+        setDisposableResource(disposableResource);
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/texture/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/texture/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.texture;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/assets/texture/subtexture/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/assets/texture/subtexture/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.assets.texture.subtexture;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/backdrop/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/backdrop/package-info.java
@@ -4,4 +4,4 @@
 @API
 package org.terasology.engine.rendering.backdrop;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/cameras/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/cameras/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.cameras;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/ModuleRendering.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/ModuleRendering.java
@@ -4,6 +4,7 @@ package org.terasology.engine.rendering.dag;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.module.ModuleManager;
@@ -17,6 +18,7 @@ import org.terasology.gestalt.naming.Name;
 import org.terasology.nui.properties.Range;
 
 @RegisterSystem
+@IndexInherited
 public abstract class ModuleRendering {
     protected static final Logger logger = LoggerFactory.getLogger(ModuleRendering.class);
 

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/dependencyConnections/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/dependencyConnections/package-info.java
@@ -3,4 +3,4 @@
 @API
  package org.terasology.engine.rendering.dag.dependencyConnections;
 
- import org.terasology.gestalt.module.sandbox.API;
+ import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/nodes/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/nodes/package-info.java
@@ -3,4 +3,4 @@
 @API
 package org.terasology.engine.rendering.dag.nodes;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/package-info.java
@@ -21,4 +21,4 @@
 @API
 package org.terasology.engine.rendering.dag;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/stateChanges/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/stateChanges/package-info.java
@@ -11,4 +11,4 @@
 @API
 package org.terasology.engine.rendering.dag.stateChanges;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/iconmesh/IconMeshFactory.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/iconmesh/IconMeshFactory.java
@@ -13,7 +13,7 @@ import org.terasology.engine.rendering.assets.texture.TextureRegion;
 import org.terasology.engine.utilities.Assets;
 import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.joml.geom.Rectanglei;
 import org.terasology.nui.Color;

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.logic;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/ScreenLayerClosedEvent.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/ScreenLayerClosedEvent.java
@@ -5,7 +5,7 @@ package org.terasology.engine.rendering.nui;
 import org.terasology.engine.network.OwnerEvent;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.entitysystem.event.Event;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * The event is sent to the UI layer

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/UIScreenLayer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/UIScreenLayer.java
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.nui;
 
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.nui.ControlWidget;
 
+@IndexInherited
 public interface UIScreenLayer extends ControlWidget {
 
     boolean isLowerLayerVisible();

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/contextMenu/ContextMenuUtils.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/contextMenu/ContextMenuUtils.java
@@ -4,7 +4,7 @@ package org.terasology.engine.rendering.nui.contextMenu;
 
 import com.google.common.collect.Lists;
 import org.joml.Vector2i;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.databinding.Binding;
 import org.terasology.nui.databinding.ReadOnlyBinding;
 import org.terasology.nui.widgets.UIList;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/contextMenu/MenuTree.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/contextMenu/MenuTree.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.rendering.nui.contextMenu;
 
 import com.google.common.collect.Lists;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.List;
 import java.util.function.Consumer;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/editor/binds/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/editor/binds/package-info.java
@@ -5,4 +5,4 @@
 package org.terasology.engine.rendering.nui.editor.binds;
 
 import org.terasology.input.InputCategory;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/NUIManagerInternal.java
@@ -189,13 +189,16 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     }
 
     public void refreshWidgetsLibrary() {
-        widgetsLibrary = new WidgetLibrary(context.get(ModuleManager.class).getEnvironment(),
+        widgetsLibrary = new WidgetLibrary(() -> context.get(ModuleManager.class).getEnvironment(),
                 context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
         ModuleEnvironment environment = context.get(ModuleManager.class).getEnvironment();
         for (Class<? extends UIWidget> type : environment.getSubtypesOf(UIWidget.class)) {
             Name module = verifyNotNull(environment.getModuleProviding(type), "No module provides %s", type);
             widgetsLibrary.register(new ResourceUrn(module.toString(), type.getSimpleName()), type);
         }
+        // Interfaces are not instantiatable and so are not usually stored in the widget library.
+        // We make a special exception in this case since all Terasology UI screens inherit from this base interface to use common styles.
+        widgetsLibrary.register(new ResourceUrn("engine", UIScreenLayer.class.getSimpleName()), UIScreenLayer.class);
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/hud/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/hud/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.nui.layers.hud;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/DebugMetricsSystem.java
@@ -5,7 +5,7 @@ package org.terasology.engine.rendering.nui.layers.ingame.metrics;
 import com.google.common.base.Preconditions;
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.registry.Share;
 
 import java.util.ArrayList;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/MetricsMode.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/metrics/MetricsMode.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.nui.layers.ingame.metrics;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * A metrics mode is a named entry in the {@link DebugOverlay}.

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.rendering.nui.layers.ingame;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/MessagePopup.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/MessagePopup.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.rendering.nui.layers.mainMenu;
 
 import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.WidgetUtil;
 import org.terasology.nui.widgets.ActivateEventListener;
 import org.terasology.nui.widgets.UILabel;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/moduleDetailsScreen/ModuleDetailsScreen.java
@@ -306,7 +306,7 @@ public class ModuleDetailsScreen extends CoreScreenLayer {
             public void draw(DependencyInfo value, Canvas canvas) {
                 Module module = moduleManager.getRegistry().getLatestModuleVersion(value.getId());
 
-                if (module == null || !(value.versionPredicate().test(module.getVersion()))) {
+                if (module == null || !value.versionRange().contains(module.getVersion())) {
                     canvas.setMode("invalid");
                 } else {
                     canvas.setMode("available");

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/package-info.java
@@ -16,4 +16,4 @@
  */
 @API package org.terasology.engine.rendering.nui;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/skin/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/skin/package-info.java
@@ -7,4 +7,4 @@
  */
 @API package org.terasology.engine.rendering.nui.skin;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/basic/flow/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/basic/flow/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.data.basic.flow;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/basic/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/basic/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.data.basic;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/html/basic/list/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/html/basic/list/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.data.html.basic.list;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/html/basic/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/html/basic/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.data.html.basic;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/html/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/html/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.data.html;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/data/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.data;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/ui/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/ui/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.ui;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/ui/style/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/browser/ui/style/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets.browser.ui.style;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/package-info.java
@@ -6,4 +6,4 @@
  */
 @API package org.terasology.engine.rendering.nui.widgets;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/fbms/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/fbms/package-info.java
@@ -16,4 +16,4 @@
 @API
 package org.terasology.engine.rendering.opengl.fbms;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/package-info.java
@@ -4,4 +4,4 @@
 @API
 package org.terasology.engine.rendering.opengl;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/BlockMeshGenerator.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.primitives;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.world.ChunkView;
 

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkMesh.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkMesh.java
@@ -14,7 +14,7 @@ import org.terasology.engine.rendering.assets.mesh.resource.VertexByteAttributeB
 import org.terasology.engine.rendering.assets.mesh.resource.VertexFloatAttributeBinding;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResource;
 import org.terasology.engine.rendering.assets.mesh.resource.VertexResourceBuilder;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
 

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkVertexFlag.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/ChunkVertexFlag.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.rendering.primitives;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public enum ChunkVertexFlag {

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/Tessellator.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/Tessellator.java
@@ -9,7 +9,7 @@ import org.joml.Vector3fc;
 import org.joml.Vector4f;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.rendering.assets.mesh.StandardMeshData;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.mesh.MeshData;
 import org.terasology.engine.utilities.Assets;

--- a/engine/src/main/java/org/terasology/engine/rendering/primitives/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/primitives/package-info.java
@@ -3,4 +3,4 @@
 @API
 package org.terasology.engine.rendering.primitives;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRenderer.java
@@ -8,7 +8,7 @@ import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
 import org.terasology.engine.rendering.dag.RenderGraph;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Implementations of this class are responsible for rendering the whole 3D world,

--- a/engine/src/main/java/org/terasology/engine/rendering/world/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/package-info.java
@@ -3,4 +3,4 @@
 @API
 package org.terasology.engine.rendering.world;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/rendering/world/selection/BlockSelectionRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/selection/BlockSelectionRenderer.java
@@ -17,7 +17,7 @@ import org.terasology.engine.rendering.assets.texture.TextureRegionAsset;
 import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.utilities.Assets;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.joml.geom.Rectanglef;
 import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;

--- a/engine/src/main/java/org/terasology/engine/rendering/world/viewDistance/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/viewDistance/package-info.java
@@ -3,4 +3,4 @@
 @API
 package org.terasology.engine.rendering.world.viewDistance;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/telemetry/Metrics.java
+++ b/engine/src/main/java/org/terasology/engine/telemetry/Metrics.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.telemetry.metrics.Metric;
 
 import java.lang.reflect.Constructor;

--- a/engine/src/main/java/org/terasology/engine/telemetry/TelemetryCategory.java
+++ b/engine/src/main/java/org/terasology/engine/telemetry/TelemetryCategory.java
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.telemetry;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -16,6 +17,7 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface TelemetryCategory {
     /**
      * @return The id of the category.

--- a/engine/src/main/java/org/terasology/engine/telemetry/TelemetryField.java
+++ b/engine/src/main/java/org/terasology/engine/telemetry/TelemetryField.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.telemetry;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/engine/src/main/java/org/terasology/engine/telemetry/TelemetryParams.java
+++ b/engine/src/main/java/org/terasology/engine/telemetry/TelemetryParams.java
@@ -5,7 +5,7 @@ package org.terasology.engine.telemetry;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;

--- a/engine/src/main/java/org/terasology/engine/telemetry/TelemetryUtils.java
+++ b/engine/src/main/java/org/terasology/engine/telemetry/TelemetryUtils.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.facade.TelemetryConfiguration;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.subsystem.DisplayDevice;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.telemetry.logstash.TelemetryLogstashAppender;
 import org.terasology.engine.telemetry.metrics.Metric;

--- a/engine/src/main/java/org/terasology/engine/telemetry/metrics/Metric.java
+++ b/engine/src/main/java/org/terasology/engine/telemetry/metrics/Metric.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.facade.TelemetryConfiguration;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.subsystem.DisplayDevice;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.telemetry.Metrics;
 import org.terasology.engine.telemetry.TelemetryCategory;

--- a/engine/src/main/java/org/terasology/engine/utilities/Assets.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/Assets.java
@@ -13,7 +13,7 @@ import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.engine.audio.StaticSound;
 import org.terasology.engine.audio.StreamingSound;
 import org.terasology.engine.entitySystem.prefab.Prefab;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.nui.asset.UIElement;
 import org.terasology.engine.registry.CoreRegistry;

--- a/engine/src/main/java/org/terasology/engine/utilities/collection/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/collection/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.utilities.collection;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/utilities/concurrency/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/concurrency/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.utilities.concurrency;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/utilities/modifiable/ModifiableValue.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/modifiable/ModifiableValue.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.utilities.modifiable;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * A helper type to get and modify the value of a component without changing its actual value.

--- a/engine/src/main/java/org/terasology/engine/utilities/procedural/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/procedural/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.utilities.procedural;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/utilities/random/DiscreteDistribution.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/random/DiscreteDistribution.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.utilities.random;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/engine/utilities/random/FastRandom.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/random/FastRandom.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.utilities.random;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Random number generator based on the Xorshift generator by George Marsaglia.

--- a/engine/src/main/java/org/terasology/engine/utilities/random/MersenneRandom.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/random/MersenneRandom.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.utilities.random;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import ec.util.MersenneTwisterFast;
 

--- a/engine/src/main/java/org/terasology/engine/utilities/random/PDist.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/random/PDist.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.utilities.random;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public class PDist {

--- a/engine/src/main/java/org/terasology/engine/utilities/random/Random.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/random/Random.java
@@ -5,7 +5,7 @@ package org.terasology.engine.utilities.random;
 
 import org.joml.Vector3f;
 import org.terasology.math.TeraMath;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.List;
 

--- a/engine/src/main/java/org/terasology/engine/world/block/Blocks.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/Blocks.java
@@ -6,7 +6,7 @@ package org.terasology.engine.world.block;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.terasology.math.TeraMath;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * Utility class for common block-related operations.

--- a/engine/src/main/java/org/terasology/engine/world/block/entity/damage/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/entity/damage/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.entity.damage;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/entity/neighbourUpdate/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/entity/neighbourUpdate/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.entity.neighbourUpdate;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/entity/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/entity/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.entity;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/entity/placement/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/entity/placement/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.entity.placement;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamily.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamily.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.block.family;
 
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockUri;
@@ -11,6 +12,7 @@ import org.terasology.engine.world.block.BlockUri;
  * This will enable such effects as players picking up a block with one orientation and it grouping
  * with the same block with different orientations, and placing it in different directions.
  */
+@IndexInherited
 public interface BlockFamily {
     ResourceUrn CUBE_SHAPE_URN = new ResourceUrn("engine:cube");
 

--- a/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
@@ -33,7 +33,7 @@ public class BlockFamilyLibrary {
     private ClassLibrary<BlockFamily> library;
 
     public BlockFamilyLibrary(ModuleEnvironment moduleEnvironment, Context context) {
-        library = new DefaultModuleClassLibrary<>(moduleEnvironment, context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
+        library = new DefaultModuleClassLibrary<>(() -> moduleEnvironment, context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
         for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterBlockFamily.class)) {
 
             if (!BlockFamily.class.isAssignableFrom(entry)) {

--- a/engine/src/main/java/org/terasology/engine/world/block/family/RegisterBlockFamily.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/RegisterBlockFamily.java
@@ -3,6 +3,8 @@
 package org.terasology.engine.world.block.family;
 
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -20,6 +22,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterBlockFamily {
     String value();
 }

--- a/engine/src/main/java/org/terasology/engine/world/block/family/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.family;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/items/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/items/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.items;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/loader/BlockFamilyDefinition.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/loader/BlockFamilyDefinition.java
@@ -7,7 +7,7 @@ import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.world.block.shapes.BlockShape;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.world.block.BlockBuilderHelper;
 import org.terasology.engine.world.block.family.BlockFamily;
 import org.terasology.engine.world.block.family.BlockFamilyLibrary;

--- a/engine/src/main/java/org/terasology/engine/world/block/loader/BlockFamilyDefinitionData.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/loader/BlockFamilyDefinitionData.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.terasology.engine.world.block.family.AbstractBlockFamily;
 import org.terasology.gestalt.assets.AssetData;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.List;
 import java.util.Map;

--- a/engine/src/main/java/org/terasology/engine/world/block/loader/EntityData.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/loader/EntityData.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.world.block.loader;
 
 import org.terasology.engine.entitySystem.prefab.Prefab;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public class EntityData {

--- a/engine/src/main/java/org/terasology/engine/world/block/loader/InventoryData.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/loader/InventoryData.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.block.loader;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public class InventoryData {

--- a/engine/src/main/java/org/terasology/engine/world/block/loader/SectionDefinitionData.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/loader/SectionDefinitionData.java
@@ -8,7 +8,7 @@ import org.joml.Vector4f;
 import org.terasology.engine.world.block.DefaultColorSource;
 import org.terasology.engine.world.block.shapes.BlockShape;
 import org.terasology.engine.world.block.sounds.BlockSounds;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.world.block.BlockPart;
 import org.terasology.engine.world.block.tiles.BlockTile;
 

--- a/engine/src/main/java/org/terasology/engine/world/block/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/regions/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/regions/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.regions;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/shapes/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/shapes/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.shapes;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/block/sounds/BlockSounds.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/sounds/BlockSounds.java
@@ -6,7 +6,7 @@ import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.audio.StaticSound;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/engine/src/main/java/org/terasology/engine/world/block/sounds/BlockSoundsData.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/sounds/BlockSoundsData.java
@@ -4,7 +4,7 @@ package org.terasology.engine.world.block.sounds;
 
 import org.terasology.gestalt.assets.AssetData;
 import org.terasology.engine.audio.StaticSound;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/engine/world/block/tiles/BlockTile.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/tiles/BlockTile.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Lists;
 import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.awt.image.BufferedImage;
 import java.util.Collections;

--- a/engine/src/main/java/org/terasology/engine/world/block/tiles/WorldAtlas.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/tiles/WorldAtlas.java
@@ -5,7 +5,7 @@ package org.terasology.engine.world.block.tiles;
 
 import org.joml.Vector2f;
 import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public interface WorldAtlas {

--- a/engine/src/main/java/org/terasology/engine/world/block/typeEntity/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/typeEntity/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.block.typeEntity;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/chunks/Chunk.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/Chunk.java
@@ -7,7 +7,7 @@ import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockRegionc;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.protobuf.EntityData;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/world/chunks/ChunkBlockIterator.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/ChunkBlockIterator.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.world.chunks;
 
 import org.joml.Vector3ic;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.world.block.Block;
 
 @API

--- a/engine/src/main/java/org/terasology/engine/world/chunks/Chunks.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/Chunks.java
@@ -8,7 +8,7 @@ import org.joml.RoundingMode;
 import org.joml.Vector3fc;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.engine.world.block.BlockRegionc;
 

--- a/engine/src/main/java/org/terasology/engine/world/chunks/RenderableChunk.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/RenderableChunk.java
@@ -4,7 +4,7 @@ package org.terasology.engine.world.chunks;
 
 import org.joml.Vector3f;
 import org.terasology.joml.geom.AABBfc;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.rendering.primitives.ChunkMesh;
 
 /**

--- a/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/ExtraBlockDataManager.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/ExtraBlockDataManager.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.gestalt.module.ModuleEnvironment;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;
 

--- a/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/ExtraDataSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/ExtraDataSystem.java
@@ -3,7 +3,8 @@
 
 package org.terasology.engine.world.chunks.blockdata;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -17,5 +18,6 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface ExtraDataSystem {
 }

--- a/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/RegisterExtraData.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/blockdata/RegisterExtraData.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.world.chunks.blockdata;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/engine/src/main/java/org/terasology/engine/world/chunks/event/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/event/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.chunks.event;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/generation/facets/base/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/facets/base/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.generation.facets.base;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/generation/facets/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/facets/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.generation.facets;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/generation/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.generation;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/generator/RegisterWorldGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/RegisterWorldGenerator.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.generator;
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,6 +15,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterWorldGenerator {
     String id();
 

--- a/engine/src/main/java/org/terasology/engine/world/generator/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.generator;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
@@ -19,7 +19,7 @@ public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginL
     private final ClassLibrary<WorldGeneratorPlugin> library;
 
     public DefaultWorldGeneratorPluginLibrary(ModuleEnvironment moduleEnvironment, Context context) {
-        library = new DefaultModuleClassLibrary<>(moduleEnvironment, context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
+        library = new DefaultModuleClassLibrary<>(() -> moduleEnvironment, context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
         for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterPlugin.class)) {
             if (WorldGeneratorPlugin.class.isAssignableFrom(entry)) {
                 ResourceUrn resourceUrn = new ResourceUrn(moduleEnvironment.getModuleProviding(entry).toString(), entry.getSimpleName());

--- a/engine/src/main/java/org/terasology/engine/world/generator/plugin/RegisterPlugin.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/plugin/RegisterPlugin.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.generator.plugin;
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,5 +11,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterPlugin {
 }

--- a/engine/src/main/java/org/terasology/engine/world/generator/plugin/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/plugin/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.generator.plugin;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/selection/BlockSelectionComponent.java
+++ b/engine/src/main/java/org/terasology/engine/world/selection/BlockSelectionComponent.java
@@ -7,7 +7,7 @@ import org.terasology.engine.logic.selection.MovableSelectionStartEvent;
 import org.terasology.engine.rendering.assets.texture.Texture;
 import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.gestalt.entitysystem.component.Component;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  *         <br><br>

--- a/engine/src/main/java/org/terasology/engine/world/selection/event/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/selection/event/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.selection.event;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/sun/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/sun/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.sun;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/time/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/time/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.time;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/viewer/color/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/viewer/color/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.viewer.color;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/viewer/layers/FacetLayer.java
+++ b/engine/src/main/java/org/terasology/engine/world/viewer/layers/FacetLayer.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.world.viewer.layers;
 
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.core.Observer;
 import org.terasology.engine.world.generation.Region;
 import org.terasology.nui.Color;
@@ -12,6 +13,7 @@ import java.awt.image.BufferedImage;
 /**
  * A visual representation of a facet class
  */
+@IndexInherited
 public interface FacetLayer  {
 
     /**

--- a/engine/src/main/java/org/terasology/engine/world/viewer/layers/FacetLayerConfig.java
+++ b/engine/src/main/java/org/terasology/engine/world/viewer/layers/FacetLayerConfig.java
@@ -3,7 +3,7 @@
 
 package org.terasology.engine.world.viewer.layers;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 @API
 public interface FacetLayerConfig {

--- a/engine/src/main/java/org/terasology/engine/world/viewer/layers/engine/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/viewer/layers/engine/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.viewer.layers.engine;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/viewer/layers/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/viewer/layers/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.viewer.layers;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/viewer/picker/package-info.java
+++ b/engine/src/main/java/org/terasology/engine/world/viewer/picker/package-info.java
@@ -3,4 +3,4 @@
 
 @API package org.terasology.engine.world.viewer.picker;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;

--- a/engine/src/main/java/org/terasology/engine/world/zones/ConstantLayerThickness.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/ConstantLayerThickness.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.zones;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This is a {@link LayerThickness} for a layer that has a constant, predetermined thickness at all paints.

--- a/engine/src/main/java/org/terasology/engine/world/zones/LayerThickness.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/LayerThickness.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.zones;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * This function is used to determine the thickness of a {@link LayeredZoneRegionFunction} at each point on the layer.

--- a/engine/src/main/java/org/terasology/engine/world/zones/LayeredZoneRegionFunction.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/LayeredZoneRegionFunction.java
@@ -6,7 +6,7 @@ import org.joml.Vector2i;
 import org.terasology.engine.world.chunks.Chunks;
 import org.terasology.engine.world.generation.Region;
 import org.terasology.engine.world.generation.facets.ElevationFacet;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.Comparator;
 import java.util.List;

--- a/engine/src/main/java/org/terasology/engine/world/zones/MinMaxLayerThickness.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/MinMaxLayerThickness.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.zones;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.utilities.procedural.BrownianNoise;
 import org.terasology.engine.utilities.procedural.SimplexNoise;
 

--- a/engine/src/main/java/org/terasology/engine/world/zones/SeededNoiseLayerThickness.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/SeededNoiseLayerThickness.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.zones;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.utilities.procedural.Noise;
 
 import java.util.function.LongFunction;

--- a/engine/src/main/java/org/terasology/engine/world/zones/SingleBlockRasterizer.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/SingleBlockRasterizer.java
@@ -5,7 +5,7 @@ package org.terasology.engine.world.zones;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.generation.Region;
 import org.terasology.engine.world.generation.WorldRasterizer;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;

--- a/engine/src/main/java/org/terasology/engine/world/zones/Zone.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/Zone.java
@@ -14,7 +14,7 @@ import org.terasology.engine.world.generation.WorldBuilder;
 import org.terasology.engine.world.generation.WorldRasterizer;
 import org.terasology.engine.world.generator.WorldGenerator;
 import org.terasology.engine.world.viewer.layers.FacetLayer;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 import org.terasology.engine.rendering.nui.layers.mainMenu.preview.FacetLayerPreview;
 import org.terasology.engine.rendering.nui.layers.mainMenu.preview.PreviewGenerator;
 import org.terasology.engine.world.block.Block;

--- a/engine/src/main/java/org/terasology/engine/world/zones/ZonePlugin.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/ZonePlugin.java
@@ -5,7 +5,7 @@ package org.terasology.engine.world.zones;
 import org.joml.Vector3ic;
 import org.terasology.engine.world.generation.Region;
 import org.terasology.engine.world.generator.plugin.WorldGeneratorPlugin;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;

--- a/engine/src/main/java/org/terasology/engine/world/zones/ZoneRegionFunction.java
+++ b/engine/src/main/java/org/terasology/engine/world/zones/ZoneRegionFunction.java
@@ -3,7 +3,7 @@
 package org.terasology.engine.world.zones;
 
 import org.terasology.engine.world.generation.Region;
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;
 
 /**
  * The ZoneRegionFunction determines which blocks are part of a given region.

--- a/subsystems/DiscordRPC/build.gradle.kts
+++ b/subsystems/DiscordRPC/build.gradle.kts
@@ -17,6 +17,9 @@ configure<SourceSetContainer> {
 
 dependencies {
     implementation(project(":engine"))
+
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+
     api("com.jagrosh:DiscordIPC:0.4")
 
     constraints {

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -23,9 +23,11 @@ dependencies {
     implementation("net.sf.trove4j:trove4j:3.0.3")
 
     implementation("org.terasology:reflections:0.9.12-MB")
-    implementation("org.terasology.nui:nui-reflect:3.0.0")
-    implementation("org.terasology.gestalt:gestalt-module:7.2.0")
-    implementation("org.terasology.gestalt:gestalt-asset-core:7.2.0")
+    implementation("org.terasology.nui:nui-reflect:4.0.0-SNAPSHOT")
+    implementation("org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT")
+    implementation("org.terasology.gestalt:gestalt-asset-core:8.0.0-SNAPSHOT")
+
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
 
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.11") {
         because("log output during tests")

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/TypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/TypeHandler.java
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.persistence.typeHandling;
 
+import org.terasology.context.annotation.IndexInherited;
+
 import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
  * Serializes objects of type {@link T} to and from a {@link PersistedData}.
  */
+@IndexInherited
 public abstract class TypeHandler<T> {
     /**
      * Serializes a single non-null value.

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerFactory.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/TypeHandlerFactory.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.persistence.typeHandling;
 
+import org.terasology.context.annotation.IndexInherited;
 import org.terasology.reflection.TypeInfo;
 
 import java.util.Optional;
@@ -10,6 +11,7 @@ import java.util.Optional;
  * Creates type handlers for a set of types. Type handler factories are generally used when a set of types
  * are similar in serialization structure.
  */
+@IndexInherited
 public interface TypeHandlerFactory {
     /**
      * Creates a {@link TypeHandler} for the given type {@link T}. If the type is not supported by

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/package-info.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/package-info.java
@@ -9,4 +9,4 @@
 @API
 package org.terasology.persistence.typeHandling;
 
-import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.context.annotation.API;


### PR DESCRIPTION
Reverts MovingBlocks/Terasology#5270
Reapplies #5267 

We currently do not have an explicit dependency of modules on specific engine versions.
Modules implicitly depend on the latest engine build.

Had to revert #5267 to first publish pre-gestalt-8-upgrade module versions.
Inventory v1.5.0, Furnishings v1.2.0 and Behaviors v1.2.0 were published to artifactory.
Gestalt 8 upgrade changes can be re-applied again.
Afterwards the associated module PRs for the gestalt 8 upgrade can be merged according to the module dependency chain (Inventory first, then Behaviors and Furnishings in arbitrary order)
