### PR TITLE
ci: enable PMD checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
                         tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true))
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
-                        tool: pmd(pattern: '**/build/reports/pmd/*.xml', useRankAsPriority: true))
+                        tool: pmdParser(pattern: '**/build/reports/pmd/*.html', useRankAsPriority: true))
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
 
         stage('Analytics') {
             steps {
-                sh './gradlew --console=plain check -x test -x pmdMain -x pmdTest -x pmdJmh' // TODO: Probably more cleanly remove PMD overall if no use?
+                sh './gradlew --console=plain check -x test'
             }
             post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,9 +139,10 @@ pipeline {
                         ])
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
-                        tools: [
-                            spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true)
-                        ])
+                        tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true))
+
+                    recordIssues(skipBlames: true, enabledForFailure: true,
+                        tool: pmd(pattern: '**/build/reports/pmd/*.xml', useRankAsPriority: true))
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
                         tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true))
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
-                        tool: pmdParser(pattern: '**/build/reports/pmd/*.html', useRankAsPriority: true))
+                        tool: pmdParser(pattern: '**/build/reports/pmd/*.xml', useRankAsPriority: true))
 
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', \


### PR DESCRIPTION
- enables PMD checks in "Analytics" stage including recording the findings
- also aligns instructions for consistency
- increases the duration of the "Analytics" stage by roughly 1 minute
- does not (yet) make a finding-free PMD check run mandatory -> will be done in follow-up