### PR TITLE
Ctrl crash

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -538,52 +538,57 @@ public class TerasologyEngine implements GameEngine {
             return false;
         }
 
-        if (assetTypeManager instanceof AutoReloadAssetTypeManager) {
-            try {
-                ((AutoReloadAssetTypeManager) assetTypeManager).reloadChangedAssets();
-            } catch (IllegalStateException ignore) {
-                // ignore: This can happen if a module environment switch is happening in a different thread.
-                return true;
+        try {
+            if (assetTypeManager instanceof AutoReloadAssetTypeManager) {
+                try {
+                    ((AutoReloadAssetTypeManager) assetTypeManager).reloadChangedAssets();
+                } catch (IllegalStateException ignore) {
+                    // ignore: This can happen if a module environment switch is happening in a different thread.
+                    return true;
+                }
             }
-        }
 
-        processPendingState();
+            processPendingState();
 
-        if (currentState == null) {
-            shutdown();
-            return false;
-        }
-
-        Iterator<Float> updateCycles = timeSubsystem.getEngineTime().tick();
-        CoreRegistry.setContext(currentState.getContext());
-        gameContext.get(NetworkSystem.class).setContext(currentState.getContext());
-
-        for (EngineSubsystem subsystem : allSubsystems) {
-            try (Activity ignored = PerformanceMonitor.startActivity(subsystem.getName() + " PreUpdate")) {
-                subsystem.preUpdate(currentState, timeSubsystem.getEngineTime().getRealDelta());
+            if (currentState == null) {
+                shutdown();
+                return false;
             }
-        }
 
-        while (updateCycles.hasNext()) {
-            float updateDelta = updateCycles.next(); // gameTime gets updated here!
-            try (Activity ignored = PerformanceMonitor.startActivity("Main Update")) {
-                currentState.update(updateDelta);
+            Iterator<Float> updateCycles = timeSubsystem.getEngineTime().tick();
+            CoreRegistry.setContext(currentState.getContext());
+            gameContext.get(NetworkSystem.class).setContext(currentState.getContext());
+
+            for (EngineSubsystem subsystem : allSubsystems) {
+                try (Activity ignored = PerformanceMonitor.startActivity(subsystem.getName() + " PreUpdate")) {
+                    subsystem.preUpdate(currentState, timeSubsystem.getEngineTime().getRealDelta());
+                }
             }
-        }
 
-        // Waiting processes are set by modules via GameThread.a/synch() methods.
-        GameThread.processWaitingProcesses();
-
-        for (EngineSubsystem subsystem : getSubsystems()) {
-            try (Activity ignored = PerformanceMonitor.startActivity(subsystem.getName() + " Subsystem postUpdate")) {
-                subsystem.postUpdate(currentState, timeSubsystem.getEngineTime().getRealDelta());
+            while (updateCycles.hasNext()) {
+                float updateDelta = updateCycles.next(); // gameTime gets updated here!
+                try (Activity ignored = PerformanceMonitor.startActivity("Main Update")) {
+                    currentState.update(updateDelta);
+                }
             }
-        }
-        assetTypeManager.disposedUnusedAssets();
 
-        PerformanceMonitor.rollCycle();
-        PerformanceMonitor.startActivity("Other");
-        return true;
+            // Waiting processes are set by modules via GameThread.a/synch() methods.
+            GameThread.processWaitingProcesses();
+
+            for (EngineSubsystem subsystem : getSubsystems()) {
+                try (Activity ignored = PerformanceMonitor.startActivity(subsystem.getName() + " Subsystem postUpdate")) {
+                    subsystem.postUpdate(currentState, timeSubsystem.getEngineTime().getRealDelta());
+                }
+            }
+            assetTypeManager.disposedUnusedAssets();
+
+            PerformanceMonitor.rollCycle();
+            PerformanceMonitor.startActivity("Other");
+            return true;
+        } catch (Exception ignore) {
+            ignore.printStackTrace();
+            return true;
+        }
     }
 
     public void cleanup() {


### PR DESCRIPTION
to better find the cause of  #5224 , crash on right ctrl, it catches all exceptions. the error on right-ctrl is then when debugging in intellij:
```
Caused by: java.lang.NullPointerException: Cannot load from byte/boolean array because "this.deflated" is null

```

when running with `gradle game` : 
```
java.lang.IllegalArgumentException: moduleName must not be null or empty
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
        at org.terasology.gestalt.assets.ResourceUrn.<init>(ResourceUrn.java:185)
        at org.terasology.gestalt.assets.ResourceUrn.<init>(ResourceUrn.java:128)
        at org.terasology.engine.rendering.nui.internal.NUIManagerInternal.bindEvent(NUIManagerInternal.java:770)
        at org.terasology.engine.rendering.nui.internal.NUIManagerInternalMethodAccess.invoke(Unknown Source)
        at org.terasology.engine.entitySystem.event.internal.EventSystemImpl$ByteCodeEventHandlerInfo.invoke(EventSystemImpl.java:399)
        at org.terasology.engine.entitySystem.event.internal.EventSystemImpl.sendConsumableEvent(EventSystemImpl.java:274)
        at org.terasology.engine.entitySystem.event.internal.EventSystemImpl.send(EventSystemImpl.java:253)
        at org.terasology.engine.core.bootstrap.eventSystem.AbstractEventSystemDecorator.send(AbstractEventSystemDecorator.java:67)
        at org.terasology.engine.network.NetworkEventSystemDecorator.send(NetworkEventSystemDecorator.java:54)
        at org.terasology.engine.core.bootstrap.eventSystem.AbstractEventSystemDecorator.send(AbstractEventSystemDecorator.java:67)
        at org.terasology.engine.recording.RecordingEventSystemDecorator.send(RecordingEventSystemDecorator.java:32)
        at org.terasology.engine.entitySystem.entity.internal.BaseEntityRef.send(BaseEntityRef.java:188)
        at org.terasology.engine.input.internal.BindableButtonImpl.updateBindState(BindableButtonImpl.java:153)
        at org.terasology.engine.input.InputSystem.updateBindState(InputSystem.java:314)
        at org.terasology.engine.input.InputSystem.processKeyboardInput(InputSystem.java:389)
        at org.terasology.engine.input.InputSystem.update(InputSystem.java:132)
```
but it stays alive.
