### PR TITLE
permit install into windows program files

### DIFF
--- a/facades/PC/src/main/startScripts/windowsStartScript.bat.gsp
+++ b/facades/PC/src/main/startScripts/windowsStartScript.bat.gsp
@@ -63,7 +63,7 @@ goto fail
 <% if ( mainClassName.startsWith('--module ') ) { %>set MODULE_PATH=$modulePath<% } %>
 
 @rem Execute ${applicationName}
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "%MODULE_PATH%" <% } %>-jar lib\\Terasology.jar %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "%MODULE_PATH%" <% } %>-jar "%APP_HOME%\\lib\\Terasology.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
when installing terasology into program files, that dir is not writeable. starting up, terasology tries to create a folder in .local, which then fails.

therefor, permit two things with this change. first, permit calling the windows bat script from a different directory. it then needs to find the library relative to the start script location, not to the location where the script is called from.

second, before starting java, change to home directory. ideally, terasology itself should find a proper path by default. but program files as run directory is in any case wrong, so change.

this is the [same change which was used to upload to chocolatey](https://github.com/soloturn/terasology-choco/commit/3e8092aaa83d13cad493fa2ee65488f1f31b4154#diff-18bb80e9c1ce5aace70047ab93d47fed2ad1e7b2d59feb15f49d2dec05678d26).
