### PR TITLE
gradle versions catalog, not yet for build-logic

### DIFF
--- a/engine-tests/build.gradle.kts
+++ b/engine-tests/build.gradle.kts
@@ -51,34 +51,31 @@ dependencies {
     implementation(project(":engine"))
 
     // Dependency not provided for modules, but required for module-tests
-    implementation("com.google.code.gson:gson:2.8.6")
+    implementation(libs.gson)
     implementation("org.codehaus.plexus:plexus-utils:3.0.16")
     implementation("com.google.protobuf:protobuf-java:3.16.1")
     implementation("org.terasology:reflections:0.9.12-MB")
 
     implementation("com.github.zafarkhaja:java-semver:0.10.2")
 
-    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
-    testAnnotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+    annotationProcessor(libs.gestalt.injectjava)
+    testAnnotationProcessor(libs.gestalt.injectjava)
 
     implementation("org.terasology.joml-ext:joml-test:0.1.0")
 
-    testImplementation("ch.qos.logback:logback-classic:1.4.14") {
+    testImplementation(libs.logback) {
         because("implementation: a test directly uses logback.classic classes")
     }
 
 
     // Test lib dependencies
-    implementation(platform("org.junit:junit-bom:5.10.1")) {
-        // junit-bom will set version numbers for the other org.junit dependencies.
-    }
-    api("org.junit.jupiter:junit-jupiter-api") {
+    api(libs.junit.api) {
         because("we export jupiter Extensions for module tests")
     }
     api("com.google.truth:truth:1.1.3") {
         because("we provide some helper classes")
     }
-    implementation("org.mockito:mockito-core:5.6.0") {
+    implementation(libs.mockito.core) {
         because("classes like HeadlessEnvironment use mocks")
     }
     constraints {

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -58,8 +58,8 @@ configurations.configureEach {
 // Primary dependencies definition
 dependencies {
     // Storage and networking
-    api("com.google.guava:guava:31.0-jre")
-    api("com.google.code.gson:gson:2.8.6")
+    api(libs.guava)
+    api(libs.gson)
     api("net.sf.trove4j:trove4j:3.0.3")
     implementation("io.netty:netty-all:4.1.77.Final")
     implementation("com.google.protobuf:protobuf-java:3.22.0")
@@ -100,10 +100,10 @@ dependencies {
     implementation("de.matthiasmann.twl:PNGDecoder:1111")
 
     // Logging
-    implementation("org.slf4j:slf4j-api:2.0.11") {
+    implementation(libs.slf4j.api) {
         because("a backend-independent Logger")
     }
-    implementation("ch.qos.logback:logback-classic:1.4.14") {
+    implementation(libs.logback) {
         because("telemetry implementation uses logback to send to logstash " +
                 "and we bundle org.terasology.logback for the regex filter")
     }
@@ -124,21 +124,21 @@ dependencies {
     implementation("com.github.zafarkhaja:java-semver:0.10.2")
 
     // Our developed libs
-    api("org.terasology.gestalt:gestalt-asset-core:8.0.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-entity-system:8.0.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-util:8.0.0-SNAPSHOT")
-    api("org.terasology.gestalt:gestalt-inject:8.0.0-SNAPSHOT")
+    api(libs.gestalt.core)
+    api(libs.gestalt.module)
+    api(libs.gestalt.entitysystem)
+    api(libs.gestalt.util)
+    api(libs.gestalt.inject)
 
-    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+    annotationProcessor(libs.gestalt.injectjava)
 
     api("org.terasology:TeraMath:1.5.0")
     api("org.terasology:splash-screen:1.1.1")
     api("org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT")
     api("org.terasology.jnbullet:JNBullet:1.0.4")
-    api("org.terasology.nui:nui:4.0.0-SNAPSHOT")
-    api("org.terasology.nui:nui-reflect:4.0.0-SNAPSHOT")
-    api("org.terasology.nui:nui-gestalt:4.0.0-SNAPSHOT")
+    api(libs.terasology.nui)
+    api(libs.terasology.nuireflect)
+    api(libs.terasology.nuigestalt)
 
 
     // Wildcard dependency to catch any libs provided with the project (remote repo preferred instead)

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -69,13 +69,13 @@ dependencies {
     // TODO: Consider whether we can move the CR dependency back here from the engine, where it is referenced from the main menu
     implementation(group = "org.terasology.crashreporter", name = "cr-terasology", version = "5.0.0")
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.4.14") {
+    runtimeOnly(libs.logback) {
         because("to configure logging with logback.xml")
     }
     runtimeOnly("org.codehaus.janino:janino:3.1.7") {
         because("allows use of EvaluatorFilter in logback.xml")
     }
-    runtimeOnly("org.slf4j:jul-to-slf4j:2.0.11") {
+    runtimeOnly(libs.slf4j.jul) {
         because("redirects java.util.logging from miscellaneous dependencies through slf4j")
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,39 @@
 rootProject.name = "Terasology"
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            val gestalt = version("gestalt", "8.0.0-SNAPSHOT")
+            library("gestalt-core", "org.terasology.gestalt", "gestalt-asset-core" ).versionRef(gestalt)
+            library("gestalt-entitysystem", "org.terasology.gestalt", "gestalt-entity-system" ).versionRef(gestalt)
+            library("gestalt-inject", "org.terasology.gestalt", "gestalt-inject" ).versionRef(gestalt)
+            library("gestalt-injectjava", "org.terasology.gestalt", "gestalt-inject-java" ).versionRef(gestalt)
+            library("gestalt-java", "org.terasology.gestalt", "gestalt-java" ).versionRef(gestalt)
+            library("gestalt-module", "org.terasology.gestalt", "gestalt-module" ).versionRef(gestalt)
+            library("gestalt-util", "org.terasology.gestalt", "gestalt-util" ).versionRef(gestalt)
+            library("gson", "com.google.code.gson:gson:2.8.6")
+            library("guava", "com.google.guava:guava:31.1-jre")
+            val junit5 = version("junit5", "5.10.1")
+            library("junit-api", "org.junit.jupiter", "junit-jupiter-api").versionRef(junit5)
+            library("junit-engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef(junit5)
+            library("junit-params", "org.junit.jupiter", "junit-jupiter-params").versionRef(junit5)
+            library("logback", "ch.qos.logback:logback-classic:1.4.14")
+            val mockito = version("mockito", "5.6.0")
+            library("mockito-core", "org.mockito", "mockito-core").versionRef(mockito)
+            library("mockito-inline", "org.mockito:mockito-inline:3.12.4")
+            library("mockito-junit", "org.mockito", "mockito-junit-jupiter").versionRef(mockito)
+            val slf4j = version("slf4j", "2.0.11")
+            library("slf4j-api", "org.slf4j", "slf4j-api").versionRef(slf4j)
+            library("slf4j-jul", "org.slf4j", "jul-to-slf4j").versionRef(slf4j)
+            library("slf4j-simple", "org.slf4j", "slf4j-simple").versionRef("slf4j")
+            val nui = version("nui", "4.0.0-SNAPSHOT")
+            library("terasology-nui", "org.terasology.nui", "nui").versionRef(nui)
+            library("terasology-nuigestalt", "org.terasology.nui", "nui-gestalt").versionRef(nui)
+            library("terasology-nuireflect", "org.terasology.nui", "nui-reflect").versionRef(nui)
+        }
+    }
+}
+
 includeBuild("build-logic")
 include("engine", "engine-tests", "facades", "metas", "libs", "modules")
 

--- a/subsystems/DiscordRPC/build.gradle.kts
+++ b/subsystems/DiscordRPC/build.gradle.kts
@@ -18,7 +18,7 @@ configure<SourceSetContainer> {
 dependencies {
     implementation(project(":engine"))
 
-    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+    annotationProcessor(libs.gestalt.injectjava)
 
     api("com.jagrosh:DiscordIPC:0.4")
 

--- a/subsystems/TypeHandlerLibrary/build.gradle.kts
+++ b/subsystems/TypeHandlerLibrary/build.gradle.kts
@@ -19,28 +19,24 @@ configure<SourceSetContainer> {
 }
 
 dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.11")
+    implementation(libs.slf4j.api)
     implementation("net.sf.trove4j:trove4j:3.0.3")
 
     implementation("org.terasology:reflections:0.9.12-MB")
     implementation("org.terasology.nui:nui-reflect:4.0.0-SNAPSHOT")
-    implementation("org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT")
-    implementation("org.terasology.gestalt:gestalt-asset-core:8.0.0-SNAPSHOT")
+    implementation(libs.gestalt.module)
+    implementation(libs.gestalt.core)
 
-    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+    annotationProcessor(libs.gestalt.injectjava)
 
-    testRuntimeOnly("org.slf4j:slf4j-simple:2.0.11") {
+    testRuntimeOnly(libs.slf4j.simple) {
         because("log output during tests")
     }
-    testImplementation(platform("org.junit:junit-bom:5.10.1")) {
-        // junit-bom will set version numbers for the other org.junit dependencies.
-    }
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.mockito:mockito-inline:3.12.4")
-
-    testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
+    testImplementation(libs.junit.api)
+    testImplementation(libs.junit.params)
+    testRuntimeOnly(libs.junit.engine)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockito.junit)
 }
 
 tasks.register<Test>("unitTest") {


### PR DESCRIPTION
introduce a gradle versions catalog to share dependency versions accross multiple promects, this helps centralize the gestalt version, amongst others. description here:
https://docs.gradle.org/current/userguide/platforms.html.

this does not yet work for build-logic, unfortunately, see ticket: https://github.com/gradle/gradle/issues/15383.
