### PR TITLE
use dev.dirs to calculate terasology directories

### DIFF
--- a/engine-tests/build.gradle.kts
+++ b/engine-tests/build.gradle.kts
@@ -66,6 +66,9 @@ dependencies {
     testImplementation(libs.logback) {
         because("implementation: a test directly uses logback.classic classes")
     }
+    testImplementation("dev.dirs:directories:26") {
+        because("PathManagerTest checks default log/module-cache paths against the same OS-standard locations PathManager computes them from")
+    }
 
 
     // Test lib dependencies

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
+import dev.dirs.ProjectDirectories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.terasology.engine.utilities.OS;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -70,6 +71,25 @@ public class PathManagerTest {
         assertTrue(Files.isDirectory(pathManager.getConfigsPath()));
     }
 
+    /**
+     * The engine previously computed log/shader-log/module-cache paths from the OS-standard dev.dirs
+     * locations unconditionally, ignoring whatever homePath was actually set to - so a caller like
+     * TerasologyLauncher's {@code --homedir} override (portable installs, testing multiple clients
+     * against separate home directories) would still see its logs and cached modules land outside the
+     * directory it asked for. They need to nest under homePath like everything else updateDirs()
+     * computes, exactly as they did before dev.dirs was introduced.
+     */
+    @Test
+    public void overrideHomePathIsRespectedByLogAndModuleCachePaths() {
+        Path homePath = pathManager.getHomePath();
+        assertTrue(pathManager.getLogPath().startsWith(homePath),
+                "Expected log path to nest under the overridden home path: " + pathManager.getLogPath());
+        assertTrue(pathManager.getShaderLogPath().startsWith(homePath),
+                "Expected shader log path to nest under the overridden home path: " + pathManager.getShaderLogPath());
+        assertTrue(pathManager.getModulePaths().stream().anyMatch(path -> path.startsWith(homePath)),
+                "Expected the module cache path to nest under the overridden home path, among: " + pathManager.getModulePaths());
+    }
+
     @Test
     public void getSavePathSanitizesTitle() {
         Path savePath = pathManager.getSavePath("My!World@Test");
@@ -112,67 +132,62 @@ public class PathManagerTest {
     }
 
     @Test
-    @EnabledOnOs(OS.MAC)
-    public void useDefaultHomePathMac(@TempDir Path tempHome) throws IOException {
-        String originalHome = System.getProperty("user.home");
-        try {
-            System.setProperty("user.home", tempHome.toString());
-            pathManager.useDefaultHomePath();
-
-            Path expectedMacPath = tempHome.resolve("Library/Application Support/Terasology");
-            assertEquals(expectedMacPath.toAbsolutePath(), pathManager.getHomePath().toAbsolutePath());
-            assertTrue(Files.isDirectory(pathManager.getHomePath()));
-            assertTrue(Files.isDirectory(pathManager.getSavesPath()));
-        } finally {
-            if (originalHome != null) {
-                System.setProperty("user.home", originalHome);
-            } else {
-                System.clearProperty("user.home");
-            }
-        }
-    }
-
-    @Test
-    @EnabledOnOs(OS.LINUX)
-    public void useDefaultHomePathLinux(@TempDir Path tempHome) throws IOException {
-        String originalHome = System.getProperty("user.home");
-        try {
-            System.setProperty("user.home", tempHome.toString());
-            pathManager.useDefaultHomePath();
-
-            Path expectedLinuxPath = tempHome.resolve(".local/share/terasology");
-            assertEquals(expectedLinuxPath.toAbsolutePath(), pathManager.getHomePath().toAbsolutePath());
-            assertTrue(Files.isDirectory(pathManager.getHomePath()));
-            assertTrue(Files.isDirectory(pathManager.getSavesPath()));
-        } finally {
-            if (originalHome != null) {
-                System.setProperty("user.home", originalHome);
-            } else {
-                System.clearProperty("user.home");
-            }
-        }
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
     @Tag("filesystem-side-effects")
-    public void useDefaultHomePathWindows() throws IOException {
-        // Windows relies on JNA (Shell32Util) which directly interrogates the Windows Registry/API.
-        // We cannot easily redirect this to a @TempDir. We only verify that the path resolves to a valid Windows dir.
-        //
-        // This really does create a 'Terasology' folder in the developer's own Saved Games directory,
-        // which is why it is tagged and excluded from `test` and `unitTest`. Run it deliberately with
+    public void useDefaultHomePathResolvesToARealProjectDirectory() throws IOException {
+        // dev.dirs (ProjectDirectories) asks the OS directly (platform APIs on Windows/macOS, XDG env
+        // vars/spec on Linux) rather than going through Java's `user.home` system property, so unlike
+        // the old hand-rolled per-OS logic this replaced, that property can no longer be redirected to
+        // a @TempDir to sandbox this call - every platform now does what only Windows used to: this
+        // really creates a directory in the developer's own OS-standard data location. That's why it's
+        // tagged and excluded from `test`/`unitTest` - run it deliberately with
         // `gradlew :engine-tests:filesystemSideEffectTest`.
-        //
-        // Note the Mac and Linux equivalents above do not need the tag: they redirect `user.home` to a
-        // @TempDir first, which Windows cannot do because the lookup goes through the OS rather than
-        // that property. So this is the one test in the class that escapes its sandbox.
         pathManager.useDefaultHomePath();
-        assertNotNull(pathManager.getHomePath());
 
-        // It should end with Terasology
-        assertTrue(pathManager.getHomePath().toString().endsWith("Terasology"));
-        assertTrue(Files.isDirectory(pathManager.getHomePath()));
+        Path homePath = pathManager.getHomePath();
+        assertNotNull(homePath);
+        assertTrue(homePath.toString().toLowerCase().contains("terasology"),
+                "Expected the default home path to be namespaced under \"terasology\": " + homePath);
+        assertTrue(Files.isDirectory(homePath));
         assertTrue(Files.isDirectory(pathManager.getSavesPath()));
+    }
+
+    /**
+     * Without {@code --homedir} (or a manual pick), logs, the module cache, and configs should each
+     * keep following their own OS-standard location ({@code $XDG_STATE_HOME}/dataLocalDir, cacheDir,
+     * configDir) instead of always nesting under homePath (dataDir) - homePath overriding everything
+     * is only supposed to kick in once something actually overrides homePath. Both need to hold: the
+     * override still relocates everything when used, and leaving it alone still gets the OS-standard
+     * split.
+     */
+    @Test
+    @Tag("filesystem-side-effects")
+    public void defaultHomePathKeepsLogCacheAndConfigsOnTheirOwnOsStandardLocations() throws IOException {
+        pathManager.useDefaultHomePath();
+
+        ProjectDirectories projectDirs = ProjectDirectories.from("org", "terasology", "terasology");
+        Path expectedCacheBase = Paths.get(projectDirs.cacheDir);
+        Path expectedConfigBase = Paths.get(projectDirs.configDir);
+        // Logs are state, not data: on Linux that's $XDG_STATE_HOME, not dataLocalDir - dev.dirs
+        // itself has no state_dir field to compare against, so mirror PathManager's own fallback here.
+        Path expectedLogBase;
+        if (OS.get() == OS.LINUX) {
+            String xdgStateHome = System.getenv("XDG_STATE_HOME");
+            Path stateHome = (xdgStateHome != null && !xdgStateHome.isEmpty())
+                    ? Paths.get(xdgStateHome)
+                    : Paths.get(System.getProperty("user.home"), ".local", "state");
+            expectedLogBase = stateHome.resolve(Paths.get(projectDirs.dataDir).getFileName());
+        } else {
+            expectedLogBase = Paths.get(projectDirs.dataLocalDir);
+        }
+
+        assertTrue(pathManager.getLogPath().startsWith(expectedLogBase),
+                "Expected log path under the OS-standard state dir " + expectedLogBase
+                        + ", got: " + pathManager.getLogPath());
+        assertTrue(pathManager.getModulePaths().stream().anyMatch(path -> path.startsWith(expectedCacheBase)),
+                "Expected the module cache under the OS-standard cache dir " + expectedCacheBase
+                        + ", among: " + pathManager.getModulePaths());
+        assertTrue(pathManager.getConfigsPath().startsWith(expectedConfigBase),
+                "Expected configs under the OS-standard config dir " + expectedConfigBase
+                        + ", got: " + pathManager.getConfigsPath());
     }
 }

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -86,8 +86,19 @@ public class PathManagerTest {
                 "Expected log path to nest under the overridden home path: " + pathManager.getLogPath());
         assertTrue(pathManager.getShaderLogPath().startsWith(homePath),
                 "Expected shader log path to nest under the overridden home path: " + pathManager.getShaderLogPath());
-        assertTrue(pathManager.getModulePaths().stream().anyMatch(path -> path.startsWith(homePath)),
+        Path moduleCachePath = homePath.resolve("cachedModules");
+        assertTrue(pathManager.getModulePaths().contains(moduleCachePath),
                 "Expected the module cache path to nest under the overridden home path, among: " + pathManager.getModulePaths());
+    }
+
+    /**
+     * getHomeModPath() used to return modPaths.get(0) - the cache or install path, never homePath's
+     * own module dir. Callers (install, download, behavior save) want that dir specifically.
+     */
+    @Test
+    public void getHomeModPathReturnsHomeDirectorysOwnModulesFolder() {
+        Path expected = pathManager.getHomePath().resolve("modules");
+        assertEquals(expected, pathManager.getHomeModPath());
     }
 
     @Test
@@ -172,7 +183,7 @@ public class PathManagerTest {
         Path expectedLogBase;
         if (OS.get() == OS.LINUX) {
             String xdgStateHome = System.getenv("XDG_STATE_HOME");
-            Path stateHome = (xdgStateHome != null && !xdgStateHome.isEmpty())
+            Path stateHome = (xdgStateHome != null && !xdgStateHome.isEmpty() && Paths.get(xdgStateHome).isAbsolute())
                     ? Paths.get(xdgStateHome)
                     : Paths.get(System.getProperty("user.home"), ".local", "state");
             expectedLogBase = stateHome.resolve(Paths.get(projectDirs.dataDir).getFileName());

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     api(libs.guava)
     api(libs.gson)
     api("net.sf.trove4j:trove4j:3.0.3")
+    implementation("dev.dirs:directories:26")
     implementation("io.netty:netty-all:4.1.77.Final")
     implementation("com.google.protobuf:protobuf-java:${libs.versions.protobuf.get().toString()}")
     implementation("org.lz4:lz4-java:1.8.0")

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     api(libs.guava)
     api(libs.gson)
     api("net.sf.trove4j:trove4j:3.0.3")
+    implementation("dev.dirs:directories:26")
     implementation("io.netty:netty-all:4.1.77.Final")
     implementation("com.google.protobuf:protobuf-java:${libs.versions.protobuf.get().toString()}")
     implementation("org.lz4:lz4-java:1.8.0")

--- a/engine/src/main/java/org/terasology/engine/core/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/PathManager.java
@@ -418,8 +418,9 @@ public final class PathManager {
         if (OS.get() != OS.LINUX) {
             return Paths.get(PROJECT_DIRS.dataLocalDir);
         }
+        // Spec requires $XDG_STATE_HOME to be absolute. Relative -> invalid -> ignore, use default.
         String xdgStateHome = System.getenv("XDG_STATE_HOME");
-        Path stateHome = (xdgStateHome != null && !xdgStateHome.isEmpty())
+        Path stateHome = (xdgStateHome != null && !xdgStateHome.isEmpty() && Paths.get(xdgStateHome).isAbsolute())
                 ? Paths.get(xdgStateHome)
                 : Paths.get(System.getProperty("user.home"), ".local", "state");
         // Reuse dataDir's project-name segment ("terasology") rather than hardcoding it again.
@@ -442,7 +443,9 @@ public final class PathManager {
     }
 
     public Path getHomeModPath() {
-        return modPaths.get(0);
+        // Not modPaths.get(0) - that's install or cache dir, not homePath's own module dir. Callers
+        // (ModuleInstaller, ClientConnectionHandler, Behavior[/Collective]System) want the latter.
+        return homePath.resolve(MODULE_DIR);
     }
 
     public Path getSavePath(String title) {

--- a/engine/src/main/java/org/terasology/engine/core/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/PathManager.java
@@ -36,10 +36,10 @@ public final class PathManager {
     private static final Path PROJECT_PATH = Paths.get(PROJECT_DIRS.dataDir);
     private static final String SAVED_GAMES_DIR = "saves";
     private static final String RECORDINGS_LIBRARY_DIR = "recordings";
-    private static final String LOG_DIR = PROJECT_DIRS.dataLocalDir + "/logs";
-    private static final String SHADER_LOG_DIR = PROJECT_DIRS.dataLocalDir + "/shaders";
+    private static final String LOG_DIR = "logs";
+    private static final String SHADER_LOG_DIR = "shaders";
     private static final String MODULE_DIR = "modules";
-    private static final String MODULE_CACHE_DIR = PROJECT_DIRS.cacheDir + "/cachedModules";
+    private static final String MODULE_CACHE_DIR = "cachedModules";
     private static final String SCREENSHOT_DIR = "screenshots";
     private static final String NATIVES_DIR = "natives";
     private static final String CONFIGS_DIR = "configs";
@@ -63,9 +63,22 @@ public final class PathManager {
     private Path nativesPath;
     private Path configsPath;
 
+    // Logs and the module cache have a real OS-standard home (dataLocalDir / cacheDir) that's
+    // different from where saves/configs/etc. live (dataDir). That split only makes sense while
+    // homePath is the OS default; once something picks its own homePath (--homedir, or the user
+    // choosing one), there's no separate OS-standard location to defer to anymore, so everything
+    // - logs and module cache included - nests under that chosen homePath instead. See updateDirs().
+    private boolean usingOsStandardDirs = true;
+
     private PathManager() {
         installPath = findInstallPath();
-        homePath = PROJECT_PATH;
+        // Only a fallback for whoever constructs a PathManager without then calling useDefaultHomePath()/
+        // useOverrideHomePath()/chooseHomePathManually() - the normal launch path always calls one of those
+        // before this default is ever read. findInstallPath() already has its own fallback (the current
+        // directory) for when native-library detection fails, e.g. in a dev workspace; keeping homePath in
+        // step with that here means an unconfigured PathManager still behaves the way it always has instead
+        // of silently switching to the OS home directory underneath something that isn't expecting it to.
+        homePath = installPath;
     }
 
     private static Path findInstallPath() {
@@ -160,13 +173,17 @@ public final class PathManager {
      * Uses the given path as the home instead of the default home path. Especially interesting for unit tests, as java>17 does not
      * make it easy to set environment variables. see: https://www.baeldung.com/java-unit-testing-environment-variables .
      *
-     * Currently LOG_DIR and LOG_SHADER_DIR are not affected here, as not based on homePath.
+     * Everything updateDirs() computes - saves, logs, shader logs, the module cache, and the rest -
+     * nests under whatever homePath is set to here, so callers of this method (notably
+     * TerasologyLauncher, via {@code --homedir}) get a fully self-contained tree at the path they
+     * asked for, not just the save data.
      *
      * @param rootPath Path to use as the home path.
      * @throws IOException Thrown when required directories cannot be accessed.
      */
     public void useOverrideHomePath(Path rootPath) throws IOException {
         this.homePath = rootPath.toRealPath();
+        usingOsStandardDirs = false;
         updateDirs();
     }
 
@@ -177,6 +194,7 @@ public final class PathManager {
     public void useDefaultHomePath() throws IOException {
         // use datadir, .local/share for linux e.g.
         homePath = PROJECT_PATH;
+        usingOsStandardDirs = true;
         updateDirs();
     }
 
@@ -195,6 +213,7 @@ public final class PathManager {
             // If the system is headless
             homePath = Paths.get("").toAbsolutePath();
         }
+        usingOsStandardDirs = false;
         updateDirs();
     }
 
@@ -293,11 +312,24 @@ public final class PathManager {
     private void updateDirs() throws IOException {
         savesPath = homePath.resolve(SAVED_GAMES_DIR);
         recordingsPath = homePath.resolve(RECORDINGS_LIBRARY_DIR);
-        logPath = Paths.get(LOG_DIR);
-        shaderLogPath = Paths.get(SHADER_LOG_DIR);
+        // Logs are state, not data - $XDG_STATE_HOME on Linux, not dev.dirs' dataDir/dataLocalDir.
+        // dev.dirs has no state_dir field at all (it predates that part of the spec), so resolveStateDir()
+        // reads $XDG_STATE_HOME itself on Linux. macOS/Windows have no OS-standard state location
+        // either, so dataLocalDir stays the fallback there. Only used while homePath itself is still
+        // the OS default - once homePath is chosen by something else (--homedir, manual pick), logs
+        // move under it too so the whole tree stays self-contained.
+        Path logBase = usingOsStandardDirs ? resolveStateDir() : homePath;
+        logPath = logBase.resolve(LOG_DIR);
+        shaderLogPath = logPath.resolve(SHADER_LOG_DIR);
         screenshotPath = homePath.resolve(SCREENSHOT_DIR);
         nativesPath = installPath.resolve(NATIVES_DIR);
-        configsPath = homePath.resolve(CONFIGS_DIR);
+        // configDir is dev.dirs' own OS-standard location for config (XDG_CONFIG_HOME on Linux,
+        // \config under RoamingAppData on Windows) - genuinely separate from dataDir there. On macOS
+        // dev.dirs has no such split; configDir just points back at the same Application Support
+        // folder as dataDir/homePath, so still appending CONFIGS_DIR keeps config files in their own
+        // subfolder there too, instead of dumping them loose at the tree root.
+        Path configBase = usingOsStandardDirs ? Paths.get(PROJECT_DIRS.configDir) : homePath;
+        configsPath = configBase.resolve(CONFIGS_DIR);
         if (currentWorldPath == null) {
             currentWorldPath = homePath;
         }
@@ -375,9 +407,31 @@ public final class PathManager {
         }
     }
 
+    /**
+     * The OS-standard location for logs (state, not data). Only Linux/XDG defines one -
+     * {@code $XDG_STATE_HOME} (default {@code ~/.local/state}) - dev.dirs has no {@code state_dir}
+     * field for it since it predates that part of the spec, so this reads the environment itself
+     * instead. macOS and Windows have no equivalent OS-standard state location at all, so those fall
+     * back to {@code dataLocalDir}, same as before.
+     */
+    private static Path resolveStateDir() {
+        if (OS.get() != OS.LINUX) {
+            return Paths.get(PROJECT_DIRS.dataLocalDir);
+        }
+        String xdgStateHome = System.getenv("XDG_STATE_HOME");
+        Path stateHome = (xdgStateHome != null && !xdgStateHome.isEmpty())
+                ? Paths.get(xdgStateHome)
+                : Paths.get(System.getProperty("user.home"), ".local", "state");
+        // Reuse dataDir's project-name segment ("terasology") rather than hardcoding it again.
+        return stateHome.resolve(Paths.get(PROJECT_DIRS.dataDir).getFileName());
+    }
+
     protected ImmutableList<Path> defaultModPaths() throws IOException {
         Path homeModPath = homePath.resolve(MODULE_DIR);
-        Path modCachePath = homePath.resolve(MODULE_CACHE_DIR);
+        // Same OS-standard-vs-homePath split as logPath in updateDirs(): the module cache is a
+        // cache (cacheDir, e.g. ~/.cache on Linux) only while homePath is still the OS default.
+        Path modCacheBase = usingOsStandardDirs ? Paths.get(PROJECT_DIRS.cacheDir) : homePath;
+        Path modCachePath = modCacheBase.resolve(MODULE_CACHE_DIR);
 
         if (homePath.equals(installPath)) {
             return ImmutableList.of(modCachePath, homeModPath);

--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -270,6 +270,7 @@ public class TerasologyEngine implements GameEngine {
         logger.info("{}", TerasologyVersion.getInstance());
         logger.info("Home path: {}", PathManager.getInstance().getHomePath());
         logger.info("Install path: {}", PathManager.getInstance().getInstallPath());
+        logger.info("Log path: {}", PathManager.getInstance().getLogPath());
         logger.info("Java: {} in {}", System.getProperty("java.version"), System.getProperty("java.home"));
         logger.info("Java VM: {}, version: {}", System.getProperty("java.vm.name"), System.getProperty("java.vm" +
                 ".version"));

--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -310,6 +310,7 @@ public class TerasologyEngine implements GameEngine {
         logger.info("{}", TerasologyVersion.getInstance());
         logger.info("Home path: {}", PathManager.getInstance().getHomePath());
         logger.info("Install path: {}", PathManager.getInstance().getInstallPath());
+        logger.info("Log path: {}", PathManager.getInstance().getLogPath());
         logger.info("Java: {} in {}", System.getProperty("java.version"), System.getProperty("java.home"));
         logger.info("Java VM: {}, version: {}", System.getProperty("java.vm.name"), System.getProperty("java.vm" +
                 ".version"));

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -274,14 +274,7 @@ public final class Terasology implements Callable<Integer> {
             setMemoryLimit(maxDataSize);
         }
 
-        if (homeDir != null) {
-            logger.info("homeDir is {}", homeDir);
-            PathManager.getInstance().useOverrideHomePath(homeDir);
-            // TODO: what is this?
-            //   PathManager.getInstance().chooseHomePathManually();
-        } else {
-            PathManager.getInstance().useDefaultHomePath();
-        }
+        PathManager.getInstance().useDefaultHomePath();
 
         if (isHeadless) {
             crashReportEnabled = false;

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -274,7 +274,12 @@ public final class Terasology implements Callable<Integer> {
             setMemoryLimit(maxDataSize);
         }
 
-        PathManager.getInstance().useDefaultHomePath();
+        if (homeDir != null) {
+            logger.info("homeDir is {}", homeDir);
+            PathManager.getInstance().useOverrideHomePath(homeDir);
+        } else {
+            PathManager.getInstance().useDefaultHomePath();
+        }
 
         if (isHeadless) {
             crashReportEnabled = false;

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandlerTest.java
@@ -14,26 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StringRepresentationTypeHandlerTest {
 
-    /**
-     * Records whether {@link #getFromString} was reached. The contract under test is not just
-     * "returns empty" but "never forwards null to the subclass" — asserting only on the returned
-     * Optional would still pass if a subclass happened to tolerate null and return null itself.
-     */
-    private static final class RecordingHandler extends StringRepresentationTypeHandler<String> {
-        private boolean getFromStringCalled;
-
-        @Override
-        public String getAsString(String item) {
-            return item;
-        }
-
-        @Override
-        public String getFromString(String representation) {
-            getFromStringCalled = true;
-            return representation;
-        }
-    }
-
     private final RecordingHandler typeHandler = new RecordingHandler();
 
     @Test
@@ -62,5 +42,25 @@ class StringRepresentationTypeHandlerTest {
 
         assertFalse(result.isPresent());
         assertFalse(typeHandler.getFromStringCalled);
+    }
+
+    /**
+     * Records whether {@link #getFromString} was reached. The contract under test is not just
+     * "returns empty" but "never forwards null to the subclass" — asserting only on the returned
+     * Optional would still pass if a subclass happened to tolerate null and return null itself.
+     */
+    private static final class RecordingHandler extends StringRepresentationTypeHandler<String> {
+        private boolean getFromStringCalled;
+
+        @Override
+        public String getAsString(String item) {
+            return item;
+        }
+
+        @Override
+        public String getFromString(String representation) {
+            getFromStringCalled = true;
+            return representation;
+        }
     }
 }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/soloturn/yggdrasil).

Fixes #5281 (installing into `C:\Program Files\terasology` and running without elevation crashes with `AccessDeniedException` trying to create `.local` next to the install - the game shouldn't be writing user data next to its own binaries in the first place).

Uses [dev.dirs](https://codeberg.org/dirs/directories-jvm) (`dev.dirs:directories:26` - the project moved from GitHub to Codeberg, same artifact) to find the OS-standard folder for each kind of data. On Linux that means:

| Folder | XDG variable |
|---|---|
| saves, recordings, screenshots, modules, sandbox | `XDG_DATA_HOME` (dev.dirs `dataDir`) |
| logs | `XDG_STATE_HOME` (dev.dirs has no `state_dir` field - read directly) |
| module cache | `XDG_CACHE_HOME` (dev.dirs `cacheDir`) |
| configs | `XDG_CONFIG_HOME` (dev.dirs `configDir`) |

macOS has no env vars, just fixed folders under `~/Library`:

| Folder | macOS location |
|---|---|
| saves, recordings, screenshots, modules, sandbox, logs, configs | `~/Library/Application Support/<project>` (dev.dirs `dataDir`/`dataLocalDir`/`configDir` - all three the same folder there) |
| module cache | `~/Library/Caches/<project>` (dev.dirs `cacheDir`) |

Windows has no env vars either, just Known Folder IDs:

| Folder | Windows location |
|---|---|
| saves, recordings, screenshots, modules, sandbox | `FOLDERID_RoamingAppData\<project>\data` (dev.dirs `dataDir`) |
| logs | `FOLDERID_LocalAppData\<project>\data` (dev.dirs `dataLocalDir`) |
| module cache | `FOLDERID_LocalAppData\<project>\cache` (dev.dirs `cacheDir`) |
| configs | `FOLDERID_RoamingAppData\<project>\config` (dev.dirs `configDir`) |

`--homedir=<path>` (used by TerasologyLauncher, and by tests via `useOverrideHomePath`) overrides all of that: every folder below then nests under `<path>` instead, so the whole tree is self-contained and relocatable. With no `--homedir`, each folder gets its own real OS-standard location.

## Where each directory ends up

| Folder | Launcher / tests | Linux | macOS | Windows |
|---|---|---|---|---|
| | `--homedir` flag | no flag | no flag | no flag |
| saves | `<homedir>/saves` | `~/.local/share/terasology/saves` | `~/Library/Application Support/org.terasology.terasology/saves` | `%APPDATA%\org\terasology\terasology\data\saves` |
| recordings | `<homedir>/recordings` | `~/.local/share/terasology/recordings` | `~/Library/Application Support/org.terasology.terasology/recordings` | `%APPDATA%\org\terasology\terasology\data\recordings` |
| logs | `<homedir>/logs` | `~/.local/state/terasology/logs` | `~/Library/Application Support/org.terasology.terasology/logs` | `%LOCALAPPDATA%\org\terasology\terasology\data\logs` |
| shader logs | `<homedir>/logs/shaders` | `~/.local/state/terasology/logs/shaders` | `~/Library/Application Support/org.terasology.terasology/logs/shaders` | `%LOCALAPPDATA%\org\terasology\terasology\data\logs\shaders` |
| modules | `<homedir>/modules` | `~/.local/share/terasology/modules` | `~/Library/Application Support/org.terasology.terasology/modules` | `%APPDATA%\org\terasology\terasology\data\modules` |
| module cache | `<homedir>/cachedModules` | `~/.cache/terasology/cachedModules` | `~/Library/Caches/org.terasology.terasology/cachedModules` | `%LOCALAPPDATA%\org\terasology\terasology\cache\cachedModules` |
| screenshots | `<homedir>/screenshots` | `~/.local/share/terasology/screenshots` | `~/Library/Application Support/org.terasology.terasology/screenshots` | `%APPDATA%\org\terasology\terasology\data\screenshots` |
| configs | `<homedir>/configs` | `~/.config/terasology/configs` | `~/Library/Application Support/org.terasology.terasology/configs` | `%APPDATA%\org\terasology\terasology\config\configs` |
| sandbox | `<homedir>/sandbox` | `~/.local/share/terasology/sandbox` | `~/Library/Application Support/org.terasology.terasology/sandbox` | `%APPDATA%\org\terasology\terasology\data\sandbox` |

`<homedir>` = the folder passed to `--homedir` / `useOverrideHomePath`. Different per install, no fixed value. macOS configs land next to saves (not under `Library/Preferences`) because dev.dirs doesn't give macOS a separate config location - `configDir` there is the same folder as `dataDir`.

## Test plan

- [x] `PathManagerTest` (9/9 in `unitTest`, 2/2 in `filesystemSideEffectTest`) - all pass.
- [x] Full `engine-tests:unitTest` suite - no new failures.
- [x] `checkstyleMain` passes on `PathManager.java`.
- [x] On-disk spot check on macOS: `cachedModules` lands under `~/Library/Caches/org.terasology.terasology`, separate from `saves`/`logs`/`configs`/etc. under `~/Library/Application Support/org.terasology.terasology`, when no `--homedir` is set.
