### PR TITLE
fix: switch typo in ConditionAction

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/behavior/actions/conditions/ConditionAction.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/actions/conditions/ConditionAction.java
@@ -127,7 +127,7 @@ public class ConditionAction extends BaseAction {
                                     break;
                                 case "!":
                                 case "!=":
-                                    passing = (Double) fieldValue == Double.parseDouble(secondValue);
+                                    passing = (Double) fieldValue != Double.parseDouble(secondValue);
                                     break;
                                 case "<=":
                                     passing = ((Number) fieldValue).doubleValue() <= Double.parseDouble(secondValue);


### PR DESCRIPTION
Found this issue by chance today, seems like we had a bug for the past 7 years in there but never noticed.
Some AI bugginess may have been caused by this, but not sure if it every truly caused big noticeable problems.
Anyway, easy to fix and shouldn't make things worse.