### PR TITLE
Prerequisites for Artifactory & Jenkins migration/upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,10 +125,10 @@ pipeline {
             }
             post {
                 always {
-                    // the default resolution when omitting `defaultBranch` is to `master`
+                    // the default resolution when omitting `targetBranch` is to `master`
                     // this is wrong in our case, so explicitly set `develop` as default
                     // TODO: does this also work for PRs with different base branch?
-                    discoverGitReferenceBuild(defaultBranch: 'develop')
+                    discoverGitReferenceBuild(targetBranch: 'develop')
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml'),
                         qualityGates: [

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,10 +13,22 @@ buildscript {
         google()
         gradlePluginPortal()
 
+        // required to provide runtime dependencies to build-logic.
         maven {
-            // required to provide runtime dependencies to build-logic.
-            name = "Terasology Artifactory"
-            url = uri("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+            val repoViaEnv = System.getenv()["RESOLUTION_REPO"]
+            if (rootProject.hasProperty("alternativeResolutionRepo")) {
+                // If the user supplies an alternative repo via gradle.properties then use that
+                name = "from alternativeResolutionRepo property"
+                // Fun Gradle/Kotlin-ism: a general import at the top of a class used in a buildscript block won't help
+                url =  java.net.URI(rootProject.properties["alternativeResolutionRepo"] as String)
+            } else if (repoViaEnv != null && repoViaEnv != "") {
+                name = "from \$RESOLUTION_REPO"
+                url = java.net.URI(repoViaEnv)
+            } else {
+                // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
+                name = "Terasology Artifactory"
+                url = java.net.URI("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+            }
         }
 
         // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?

--- a/templates/build.gradle
+++ b/templates/build.gradle
@@ -4,10 +4,22 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+
+        // required to provide runtime dependencies to build-logic.
         maven {
-            // required to provide runtime dependencies to build-logic.
-            name = "Terasology Artifactory"
-            url = "https://artifactory.terasology.io/artifactory/virtual-repo-live"
+            def repoViaEnv = System.getenv()["RESOLUTION_REPO"]
+            if (rootProject.hasProperty("alternativeResolutionRepo")) {
+                // If the user supplies an alternative repo via gradle.properties then use that
+                name = "from alternativeResolutionRepo property"
+                url =  URI(rootProject.properties["alternativeResolutionRepo"] as String)
+            } else if (repoViaEnv != null && repoViaEnv != "") {
+                name = "from \$RESOLUTION_REPO"
+                url = URI(repoViaEnv)
+            } else {
+                // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
+                name = "Terasology Artifactory"
+                url = URI("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+            }
         }
 
         // TODO MYSTERY: As of November 7th 2011 virtual-repo-live could no longer be relied on for latest snapshots - Pro feature?

--- a/templates/facades.gradle
+++ b/templates/facades.gradle
@@ -11,8 +11,19 @@ repositories {
 
     // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
     maven {
-        name "Terasology Artifactory"
-        url "https://artifactory.terasology.io/artifactory/repo"
+        def repoViaEnv = System.getenv()["RESOLUTION_REPO"]
+        if (rootProject.hasProperty("alternativeResolutionRepo")) {
+            // If the user supplies an alternative repo via gradle.properties then use that
+            name = "from alternativeResolutionRepo property"
+            url =  URI(rootProject.properties["alternativeResolutionRepo"] as String)
+        } else if (repoViaEnv != null && repoViaEnv != "") {
+            name = "from \$RESOLUTION_REPO"
+            url = URI(repoViaEnv)
+        } else {
+            // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
+            name = "Terasology Artifactory"
+            url = URI("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+        }
     }
 }
 


### PR DESCRIPTION
This fixes an apparent syntax issue in a newer Jenkinsfile and attempts to refresh the support to test a different Artifactory URL via alternativeResolutionRepo in a gradle.properties copied (manually due to something else that broke) from the templates directory to the project root

Tested over at https://jenkins.nanoware.us/job/repatriation/job/terasologyengine/job/mbdev/ (building Nanoware/Terasology/mbdev) as infra migration / upgrades are sort of tricky to test normally. Plus the Nanoware org job line in the current Jenkins is actually empty, partly because moving from the fancy Cloudbees Jenkins lost us a plugin that let you set easy properties at the folder level - which allowed all Nanoware jobs to automatically swap to a different set of Artifactory registries :-(

Or rather, lol, it would be tested there, but apparently I've run up against an SSD quota within GCP since I have two 200 GB Jenkins disks and some smaller stuff (including the build agent for the current test) and apparently the default limit is 500 GB? Who knew. Submitted a request to increase and will also decrease the Jenkins disk as we haven't needed that much space for a long time at this point.

Odds are this PR will fail testing here, and I may have to merge it on the spot when I get a chance to try swapping DNS over to the new stuff to start validating and rebuilding all the things. I count it a breaking change not to the game but logistics-wise - some stuff is likely to blow up till everything is trickled out to everywhere.

I've largely kept https://github.com/MovingBlocks/Logistics/tree/repatriation updated with new infra config and docs, but there's a bit more to come