### PR TITLE
Example Brokk.ai-based fix of a bad logging dir on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,13 @@ blacklist.json
 terasology.jfr
 local.properties
 *.hprof
+
+### BROKK'S CONFIGURATION ###
+.brokk/**
+/.brokk/workspace.properties
+/.brokk/sessions/
+/.brokk/dependencies/
+/.brokk/history.zip
+!AGENTS.md
+!.brokk/style.md
+!.brokk/project.properties

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Terasology Coding Style Guide
+
+This guide captures the specific coding patterns and Gradle conventions found in the Terasology codebase, focusing on modern Gradle Kotlin DSL (KTS) usage and engine-specific architectures.
+
+## 1. Build System & Gradle (KTS)
+
+The project uses Gradle Kotlin DSL with a centralized `build-logic` composite build.
+
+### Dependency Management
+- **Version Catalogs**: Use the `libs` catalog in `settings.gradle.kts` for common dependencies.
+- **Constraints**: Use `constraints { ... }` blocks to force specific transitive dependency versions (e.g., forcing a newer `bytebuddy` for Java 17 compatibility).
+- **Dependency Substitution**: Use `resolutionStrategy.dependencySubstitution` to swap remote module dependencies with local project sources when available.
+- **Platform BOMs**: Use `platform()` for grouping related dependencies (e.g., LWJGL).
+
+### Task Configuration
+- **Lazy Registration**: Favor `tasks.register<Type>("name")` over `tasks.create`.
+- **Property Delegation**: Use `val propertyName by extra("value")` for sharing variables across subprojects.
+- **Inputs/Outputs**: Always define `outputs.dir` or `outputs.file` for custom extraction/copy tasks to support Gradle's up-to-date checks and automatic `clean` task generation.
+- **Duplication Strategy**: Explicitly set `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` when merging resources or classes from multiple source sets.
+
+### Java Toolchains & Compatibility
+- **JVM Toolchain**: Strictly target Java 17 using `jvmToolchain(17)`.
+- **Validation**: Include runtime checks in build scripts to warn users if the `JavaVersion.current()` deviates from the expected version.
+
+## 2. Java & Engine Architecture
+
+### Dependency Injection & Context
+- **The `@In` Annotation**: Use the `@In` annotation for automatic service injection within NUI screens and engine components.
+- **Context Registry**: Use `context.get(Class<T>)` to retrieve engine services and `CoreRegistry.put()` for global accessibility when necessary.
+
+### Resource & Asset Handling
+- **ResourceUrn**: Always use `ResourceUrn` for identifying assets (e.g., `engine:universeSetupScreen`).
+- **Asset Templates**: Store static configuration templates in the `/templates` directory and use custom tasks like `CopyButNeverOverwrite` to initialize them into the project root.
+
+### UI Development (NUI)
+- **Binding Pattern**: Use `Binding<T>` and `ReadOnlyBinding<T>` to link UI widgets (like `UIText` or `UIDropdown`) to underlying configuration data.
+- **Widget Subscription**: Use `WidgetUtil.trySubscribe(this, "widgetId", handler)` for cleaner event handling.
+- **Wait Popups**: Long-running operations (like world preview generation) must be wrapped in a `WaitPopup` using `Callable` operations to keep the UI responsive.
+
+## 3. Automation & CI (Jenkins)
+
+- **Declarative Pipelines**: Use Jenkins Declarative Pipeline syntax with `post { always { ... } }` for test result aggregation.
+- **Static Analysis Integration**: Build stages should explicitly trigger `recordIssues` for Checkstyle, PMD, and SpotBugs.
+- **Flaky Test Management**: Segregate tests using JUnit 5 tags:
+    - `unitTest`: Fast, excludes `MteTest`/`TteTest`.
+    - `integrationTest`: Slow, includes `MteTest`/`TteTest`, excludes `flaky`.
+    - `integrationTestFlaky`: Only runs tests tagged with both integration tags and `flaky`.
+
+## 4. Metadata & Versioning
+
+- **Module Metadata**: Engine and module versions should be mastered in `module.txt` (JSON format) and read into the build system via `JsonSlurper`.
+- **Version Info**: The build must generate a `versionInfo.properties` file containing Git hashes, build numbers, and timestamps to be bundled within the JAR for runtime diagnostics.

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -275,7 +275,8 @@ public final class Terasology implements Callable<Integer> {
         }
 
         if (homeDir != null) {
-            logger.info("homeDir is {}", homeDir);
+            // This is called before logging is initialized, so we use stdout.
+            System.out.println("homeDir is " + homeDir);
             PathManager.getInstance().useOverrideHomePath(homeDir);
             // TODO: what is this?
             //   PathManager.getInstance().chooseHomePathManually();

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -140,7 +140,17 @@ public final class Terasology implements Callable<Integer> {
 
     @Override
     public Integer call() throws IOException {
-        setupLogging();
+        // IMPORTANT: Logging must be initialized BEFORE any class with a static Logger field
+        // is loaded. Classes like PathManager have static loggers that trigger Logback
+        // initialization when the class is loaded. If Logback initializes before
+        // LoggingContext.initialize() sets the logFileFolder system property,
+        // it creates a "logFileFolder_IS_UNDEFINED" directory.
+        //
+        // Therefore: compute log path directly from homeDir, then call setupLogging(),
+        // THEN call handleLaunchArguments() which loads PathManager.
+        Path logPath = (homeDir != null ? homeDir : Paths.get(".")).resolve("logs");
+        setupLogging(logPath);
+
         handleLaunchArguments();
 
         SplashScreen splashScreen;
@@ -257,9 +267,8 @@ public final class Terasology implements Callable<Integer> {
         return (newTitle + " " + fileNumber);
     }
 
-    private static void setupLogging() {
-        Path path = Paths.get("logs");
-        LoggingContext.initialize(path);
+    private static void setupLogging(Path logPath) {
+        LoggingContext.initialize(logPath);
     }
 
     private void handleLaunchArguments() throws IOException {
@@ -271,7 +280,8 @@ public final class Terasology implements Callable<Integer> {
         }
 
         if (homeDir != null) {
-            // This is called before logging is initialized, so we use stdout.
+            // Use stdout here since this is pre-initialization diagnostic output.
+            // Logger is available but using println keeps the initialization sequence clear.
             System.out.println("homeDir is " + homeDir);
             PathManager.getInstance().useOverrideHomePath(homeDir);
             // TODO: what is this?

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -140,8 +140,8 @@ public final class Terasology implements Callable<Integer> {
 
     @Override
     public Integer call() throws IOException {
-        handleLaunchArguments();
         setupLogging();
+        handleLaunchArguments();
 
         SplashScreen splashScreen;
         if (splashEnabled) {
@@ -258,11 +258,7 @@ public final class Terasology implements Callable<Integer> {
     }
 
     private static void setupLogging() {
-        Path path = PathManager.getInstance().getLogPath();
-        if (path == null) {
-            path = Paths.get("logs");
-        }
-
+        Path path = Paths.get("logs");
         LoggingContext.initialize(path);
     }
 


### PR DESCRIPTION
### Contains

I'm playing with brokk.ai and this is solely a test of a simple bug fix - just getting commits off my test system to see them in a different light. 100% AI including commit after each edit as that's how Brokk does it. Need to look at this with less sleepy eyes to see if it makes sense then tidy up further if so :-)

### How to test

When running Terasology from source without this fix you get a badly named logs folder as logging initializes before the folder name is available. Running Terasology _with_ this fix (and that folder from a prior execution deleted) the bad folder should not show up.

### Outstanding before merging

* Is AI work, needs extra shifty eyes and human judgement with extreme prejudice ;-) 
* Brokk tries to generate an AGENTS.md after an initial look at the codebase. It catches a few things but leaves loads of others out.  That's a different effort, really - this PR could be redone with a single commit without the AI extras for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to startup/log initialization ordering plus repo hygiene files; low risk aside from potential differences in early log location resolution when `--homedir` is used.
> 
> **Overview**
> Fixes a startup ordering issue where Logback could initialize before `LoggingContext.initialize()`, creating a `logFileFolder_IS_UNDEFINED` logs directory.
> 
> `Terasology.call()` now computes the log directory directly from `--homedir` (or `.`) and initializes logging *before* `handleLaunchArguments()` loads `PathManager`; `setupLogging()` is updated to accept an explicit `Path`, and early `homeDir` diagnostics switch from SLF4J to `System.out`.
> 
> Also adds Brokk-related ignores under `.brokk/` and checks in an `AGENTS.md` style guide file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e6a3e65f6b20272b69611e31b64d5960299faef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->