### PR TITLE
Replace whitelist/blacklist with allowlist/denylist (fixes #5275)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,9 +94,9 @@ config/metrics/
 API_file.txt
 New_API_file.txt
 
-# Ignore Whitelist and Blacklist files
-whitelist.json
-blacklist.json
+# Ignore Allowlist and Denylist files
+allowlist.json
+denylist.json
 
 # Profiling related
 terasology.jfr

--- a/docs/Modding-API.md
+++ b/docs/Modding-API.md
@@ -1,13 +1,13 @@
 Modding API
 =================
 
-Terasology's engine uses a whitelisting approach to expose an API for modules using two primary methods and a rarely needed third one:
+Terasology's engine uses an allowlisting approach to expose an API for modules using two primary methods and a rarely needed third one:
 
 * Classes or packages marked with the `@API` annotation
-* Classes or packages in the basic whitelist defined in `ExternalApiWhitelist.java`
+* Classes or packages in the basic allowlist defined in `ExternalApiAllowlist.java`
 * Rarely blocks of code in the engine may be hit in a way requiring use of `AccessController.doPrivileged(...)` - usually module authors do not need to worry about this but once in a while it could explain something quirky.
 
-This is to both protect the user's system from malicious code (for instance you cannot use `java.io.File` directly) and to better document what is available. If you attempt to use a class not on the whitelist you'll get log message like:
+This is to both protect the user's system from malicious code (for instance you cannot use `java.io.File` directly) and to better document what is available. If you attempt to use a class not on the allowlist you'll get log message like:
 
 `Denied access to class (not allowed with this module's permissions): some.package.and.class`
 

--- a/docs/Module-Security.md
+++ b/docs/Module-Security.md
@@ -44,7 +44,7 @@ The game creates new objects and executes methods on them in response to network
 
 Terasology relies on [Gestalt Module Sandboxing](https://github.com/MovingBlocks/gestalt/wiki/Module%20Sandboxing) to protect from these risks of running untrusted JVM code. However, it's up to the application to make sure the sandbox is configured and applied correctly.
 
-* [o.t.engine.core.module.ExternalApiWhitelist](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/engine/core/module/ExternalApiWhitelist.java) defines a hardcoded list of allowable packages and classes.
+* [o.t.engine.core.module.ExternalApiAllowlist](https://github.com/MovingBlocks/Terasology/blob/develop/engine/src/main/java/org/terasology/engine/core/module/ExternalApiAllowlist.java) defines a hardcoded list of allowable packages and classes.
 
 ## ClassLoaders
 

--- a/docs/Playing.md
+++ b/docs/Playing.md
@@ -143,13 +143,13 @@ Alternatively you can run from source and supply parameters for game configurati
 
 This will all become easier as the project and especially the launcher mature further :-)
 
-### Server Whitelist and Blacklist
+### Server Allowlist and Denylist
 
-Hosting a server will create a whitelist and a blacklist that can be used to manage who is able to connect to that server.
+Hosting a server will create an allowlist and a denylist that can be used to manage who is able to connect to that server.
 
-If the whitelist contains at least one client ID, only the ID(s) on the list will be allowed to connect to the server. All IDs not on the whitelist are effectively blacklisted.
+If the allowlist contains at least one client ID, only the ID(s) on the list will be allowed to connect to the server. All IDs not on the allowlist are effectively denied.
 
-If the whitelist is empty, any ID not on the blacklist will be able to connect. 
+If the allowlist is empty, any ID not on the denylist will be able to connect.
 
 Client IDs are added to the lists in JSON format, for example: ["6a5f11f7-4038-4ef0-91ac-86cb957588b1","01264d12-27cf-4699-b8e2-bdc92ac8ef73"]
 

--- a/engine-tests/src/main/java/org/terasology/engine/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/engine/HeadlessEnvironment.java
@@ -19,7 +19,7 @@ import org.terasology.engine.core.PathManager;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.modes.loadProcesses.LoadPrefabs;
-import org.terasology.engine.core.module.ExternalApiWhitelist;
+import org.terasology.engine.core.module.ExternalApiAllowlist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.subsystem.headless.assets.HeadlessMaterial;
 import org.terasology.engine.core.subsystem.headless.assets.HeadlessMesh;
@@ -264,7 +264,7 @@ public class HeadlessEnvironment extends Environment {
 
     @Override
     protected void setupModuleManager(Set<Name> moduleNames) throws RuntimeException {
-        TypeRegistry.WHITELISTED_CLASSES = ExternalApiWhitelist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
+        TypeRegistry.WHITELISTED_CLASSES = ExternalApiAllowlist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
 
         ModuleManager moduleManager = ModuleManagerFactory.create();
         ModuleTypeRegistry typeRegistry = new ModuleTypeRegistry(moduleManager.getEnvironment());

--- a/engine-tests/src/main/java/org/terasology/engine/ModuleEnvironmentTest.java
+++ b/engine-tests/src/main/java/org/terasology/engine/ModuleEnvironmentTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 import org.terasology.engine.core.PathManager;
-import org.terasology.engine.core.module.ExternalApiWhitelist;
+import org.terasology.engine.core.module.ExternalApiAllowlist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
 import org.terasology.reflection.ModuleTypeRegistry;
@@ -26,8 +26,8 @@ public abstract class ModuleEnvironmentTest {
         PathManager.getInstance().useOverrideHomePath(tempHome);
 
         moduleManager = ModuleManagerFactory.create();
-        TypeRegistry.WHITELISTED_CLASSES = ExternalApiWhitelist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
-        TypeRegistry.WHITELISTED_PACKAGES = ExternalApiWhitelist.PACKAGES;
+        TypeRegistry.WHITELISTED_CLASSES = ExternalApiAllowlist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
+        TypeRegistry.WHITELISTED_PACKAGES = ExternalApiAllowlist.PACKAGES;
         typeRegistry = new ModuleTypeRegistry(moduleManager.getEnvironment());
 
         setup();

--- a/engine-tests/src/test/java/org/terasology/documentation/ApiScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/ApiScraper.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.SortedSetMultimap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.core.module.ExternalApiWhitelist;
+import org.terasology.engine.core.module.ExternalApiAllowlist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
 import org.terasology.gestalt.module.ModuleEnvironment;
@@ -99,9 +99,9 @@ public final class ApiScraper {
                     LOGGER.info("Unknown protocol for: {}, came from {}", apiClass, location);
             }
         }
-        sortedApi.putAll("external", ExternalApiWhitelist.CLASSES.stream()
+        sortedApi.putAll("external", ExternalApiAllowlist.CLASSES.stream()
                 .map(clazz -> clazz.getName() + " (CLASS)").collect(Collectors.toSet()));
-        sortedApi.putAll("external", ExternalApiWhitelist.PACKAGES.stream()
+        sortedApi.putAll("external", ExternalApiAllowlist.PACKAGES.stream()
                 .map(packagee -> packagee + " (PACKAGE)").collect(Collectors.toSet()));
 
         System.out.println("# Modding API:\n");

--- a/engine-tests/src/test/java/org/terasology/documentation/apiScraper/CompleteApiScraper.java
+++ b/engine-tests/src/test/java/org/terasology/documentation/apiScraper/CompleteApiScraper.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.core.module.ExternalApiWhitelist;
+import org.terasology.engine.core.module.ExternalApiAllowlist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
 import org.terasology.gestalt.module.ModuleEnvironment;
@@ -100,9 +100,9 @@ final class CompleteApiScraper {
                     logger.error("Unknown protocol for: {} , came from {}", apiClass, location);
             }
         }
-        api.putAll(EXTERNAL, ExternalApiWhitelist.CLASSES.stream()
+        api.putAll(EXTERNAL, ExternalApiAllowlist.CLASSES.stream()
                 .map(clazz -> clazz.getName() + " (CLASS)").collect(Collectors.toSet()));
-        api.putAll(EXTERNAL, ExternalApiWhitelist.PACKAGES.stream()
+        api.putAll(EXTERNAL, ExternalApiAllowlist.PACKAGES.stream()
                 .map(packagee -> packagee + " (PACKAGE)").collect(Collectors.toSet()));
 
         //Puts the information in the StringBuffer

--- a/engine-tests/src/test/java/org/terasology/reflection/TypeRegistryTest.java
+++ b/engine-tests/src/test/java/org/terasology/reflection/TypeRegistryTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.reflections.Reflections;
 import org.terasology.engine.ModuleEnvironmentTest;
-import org.terasology.engine.core.module.ExternalApiWhitelist;
+import org.terasology.engine.core.module.ExternalApiAllowlist;
 import org.terasology.gestalt.entitysystem.component.Component;
 import org.terasology.gestalt.naming.Name;
 
@@ -49,10 +49,10 @@ public class TypeRegistryTest extends ModuleEnvironmentTest {
     // TODO: Re-enable as gradlew check seems to still stall even with the Ignore in place?
     @Disabled("Seems to intermittently stall, at least on Win10")
     @Test
-    public void testWhitelistedTypes() {
+    public void testAllowlistedTypes() {
         Set<Class<?>> allTypes = typeRegistry.getSubtypesOf(Object.class);
-        for (Class<?> whitelisted : ExternalApiWhitelist.CLASSES) {
-            assumeTrue(allTypes.contains(whitelisted), () -> allTypes.toString() + " should contain " + whitelisted.getName());
+        for (Class<?> allowlisted : ExternalApiAllowlist.CLASSES) {
+            assumeTrue(allTypes.contains(allowlisted), () -> allTypes.toString() + " should contain " + allowlisted.getName());
         }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
+++ b/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java
@@ -14,7 +14,7 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EnvironmentSwitchHandler;
 import org.terasology.engine.core.modes.GameState;
-import org.terasology.engine.core.module.ExternalApiWhitelist;
+import org.terasology.engine.core.module.ExternalApiAllowlist;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.core.subsystem.EngineSubsystem;
@@ -327,8 +327,8 @@ public class TerasologyEngine implements GameEngine {
 
         changeStatus(TerasologyEngineStatus.INITIALIZING_MODULE_MANAGER);
         TypeRegistry.WHITELISTED_CLASSES =
-                ExternalApiWhitelist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
-        TypeRegistry.WHITELISTED_PACKAGES = ExternalApiWhitelist.PACKAGES;
+                ExternalApiAllowlist.CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
+        TypeRegistry.WHITELISTED_PACKAGES = ExternalApiAllowlist.PACKAGES;
 
         ModuleManager moduleManager = new ModuleManager(rootContext.get(Config.class),
                 classesOnClasspathsToAddToEngine);

--- a/engine/src/main/java/org/terasology/engine/core/module/ExternalApiAllowlist.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ExternalApiAllowlist.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 
-public final class ExternalApiWhitelist {
+public final class ExternalApiAllowlist {
     private static final Set<String> NUI_PACKAGES = new ImmutableSet.Builder<String>()
             .add("org.terasology.input")
             .add("org.terasology.input.device")
@@ -188,6 +188,6 @@ public final class ExternalApiWhitelist {
             .add(org.terasology.reflection.metadata.FieldMetadata.class)
             .build();
 
-    private ExternalApiWhitelist() {
+    private ExternalApiAllowlist() {
     }
 }

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -256,8 +256,8 @@ public class ModuleManager {
 
     private void setupSandbox() {
         PermissionSet permissionSet = permissionProviderFactory.getBasePermissionSet();
-        ExternalApiWhitelist.CLASSES.forEach(permissionSet::addAPIClass);
-        ExternalApiWhitelist.PACKAGES.forEach(permissionSet::addAPIPackage);
+        ExternalApiAllowlist.CLASSES.forEach(permissionSet::addAPIClass);
+        ExternalApiAllowlist.PACKAGES.forEach(permissionSet::addAPIPackage);
 
         APIScanner apiScanner = new APIScanner(permissionProviderFactory);
         for (Module module : registry) {

--- a/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 /**
  * This class provides the methods needed to determine if a client is allowed to connect or not,
- * based on the blacklist and whitelist files.
+ * based on the denylist and allowlist files.
  */
 
 public class ServerConnectListManager {
@@ -28,14 +28,14 @@ public class ServerConnectListManager {
     private static final Gson GSON = new Gson();
 
     private Context context;
-    private Set<String> blacklistedIDs;
-    private Set<String> whitelistedIDs;
-    private final Path blacklistPath;
-    private final Path whitelistPath;
+    private Set<String> deniedIDs;
+    private Set<String> allowedIDs;
+    private final Path denylistPath;
+    private final Path allowlistPath;
 
     public ServerConnectListManager(Context context) {
-        blacklistPath = PathManager.getInstance().getHomePath().resolve("blacklist.json");
-        whitelistPath = PathManager.getInstance().getHomePath().resolve("whitelist.json");
+        denylistPath = PathManager.getInstance().getHomePath().resolve("denylist.json");
+        allowlistPath = PathManager.getInstance().getHomePath().resolve("allowlist.json");
         this.context = context;
         loadLists();
     }
@@ -44,29 +44,29 @@ public class ServerConnectListManager {
     private void loadLists() {
         try {
             if (createFiles()) {
-                blacklistedIDs = GSON.fromJson(Files.newBufferedReader(blacklistPath), Set.class);
-                whitelistedIDs = GSON.fromJson(Files.newBufferedReader(whitelistPath), Set.class);
-                if (blacklistedIDs == null) {
-                    blacklistedIDs = new HashSet<>();
+                deniedIDs = GSON.fromJson(Files.newBufferedReader(denylistPath), Set.class);
+                allowedIDs = GSON.fromJson(Files.newBufferedReader(allowlistPath), Set.class);
+                if (deniedIDs == null) {
+                    deniedIDs = new HashSet<>();
                 }
-                if (whitelistedIDs == null) {
-                    whitelistedIDs = new HashSet<>();
+                if (allowedIDs == null) {
+                    allowedIDs = new HashSet<>();
                 }
             }
         } catch (IOException e) {
-            logger.error("Whitelist or blacklist files not found:", e);
+            logger.error("Allowlist or denylist files not found:", e);
         }
     }
 
     private void saveLists() {
         try {
             if (createFiles()) {
-                Writer blacklistWriter = Files.newBufferedWriter(blacklistPath);
-                Writer whitelistWriter = Files.newBufferedWriter(whitelistPath);
-                blacklistWriter.write(GSON.toJson(blacklistedIDs));
-                whitelistWriter.write(GSON.toJson(whitelistedIDs));
-                blacklistWriter.close();
-                whitelistWriter.close();
+                Writer denylistWriter = Files.newBufferedWriter(denylistPath);
+                Writer allowlistWriter = Files.newBufferedWriter(allowlistPath);
+                denylistWriter.write(GSON.toJson(deniedIDs));
+                allowlistWriter.write(GSON.toJson(allowedIDs));
+                denylistWriter.close();
+                allowlistWriter.close();
             }
         } catch (IOException e) {
             logger.error("Couldn't save lists: ", e);
@@ -78,63 +78,63 @@ public class ServerConnectListManager {
         if (display == null || !display.isHeadless()) {
             return false;
         }
-        if (!Files.exists(blacklistPath)) {
-            Files.createFile(blacklistPath);
+        if (!Files.exists(denylistPath)) {
+            Files.createFile(denylistPath);
         }
-        if (!Files.exists(whitelistPath)) {
-            Files.createFile(whitelistPath);
+        if (!Files.exists(allowlistPath)) {
+            Files.createFile(allowlistPath);
         }
         return true;
     }
 
     public String getErrorMessage(String clientID) {
-        if (isClientBlacklisted(clientID)) {
-            return "client on blacklist";
+        if (isClientDenied(clientID)) {
+            return "client on denylist";
         }
-        if (!isClientWhitelisted(clientID)) {
-            return "client not on whitelist";
+        if (!isClientAllowed(clientID)) {
+            return "client not on allowlist";
         }
         return null;
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isClientAllowedToConnect(String clientID) {
-        return !isClientBlacklisted(clientID) && isClientWhitelisted(clientID);
+        return !isClientDenied(clientID) && isClientAllowed(clientID);
     }
 
-    public void addToWhitelist(String clientID) {
-        whitelistedIDs.add(clientID);
+    public void addToAllowlist(String clientID) {
+        allowedIDs.add(clientID);
         saveLists();
     }
 
-    public void removeFromWhitelist(String clientID) {
-        whitelistedIDs.remove(clientID);
+    public void removeFromAllowlist(String clientID) {
+        allowedIDs.remove(clientID);
         saveLists();
     }
 
-    public Set getWhitelist() {
-        return Collections.unmodifiableSet(whitelistedIDs);
+    public Set getAllowlist() {
+        return Collections.unmodifiableSet(allowedIDs);
     }
 
-    public void addToBlacklist(String clientID) {
-        blacklistedIDs.add(clientID);
+    public void addToDenylist(String clientID) {
+        deniedIDs.add(clientID);
         saveLists();
     }
 
-    public void removeFromBlacklist(String clientID) {
-        blacklistedIDs.remove(clientID);
+    public void removeFromDenylist(String clientID) {
+        deniedIDs.remove(clientID);
         saveLists();
     }
 
-    public Set getBlacklist() {
-        return Collections.unmodifiableSet(blacklistedIDs);
+    public Set getDenylist() {
+        return Collections.unmodifiableSet(deniedIDs);
     }
 
-    private boolean isClientBlacklisted(String clientID) {
-        return blacklistedIDs != null && blacklistedIDs.contains(clientID);
+    private boolean isClientDenied(String clientID) {
+        return deniedIDs != null && deniedIDs.contains(clientID);
     }
 
-    private boolean isClientWhitelisted(String clientID) {
-        return whitelistedIDs == null || whitelistedIDs.isEmpty() || whitelistedIDs.contains(clientID);
+    private boolean isClientAllowed(String clientID) {
+        return allowedIDs == null || allowedIDs.isEmpty() || allowedIDs.contains(clientID);
     }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -149,20 +149,20 @@ public class SelectGameScreen extends SelectionScreen {
 
     private void loadGame(GameInfo item) {
         if (isLoadingAsServer()) {
-            Path blacklistPath = PathManager.getInstance().getHomePath().resolve("blacklist.json");
-            Path whitelistPath = PathManager.getInstance().getHomePath().resolve("whitelist.json");
-            if (!Files.exists(blacklistPath)) {
+            Path denylistPath = PathManager.getInstance().getHomePath().resolve("denylist.json");
+            Path allowlistPath = PathManager.getInstance().getHomePath().resolve("allowlist.json");
+            if (!Files.exists(denylistPath)) {
                 try {
-                    Files.createFile(blacklistPath);
+                    Files.createFile(denylistPath);
                 } catch (IOException e) {
-                    logger.error("IO Exception on blacklist generation", e);
+                    logger.error("IO Exception on denylist generation", e);
                 }
             }
-            if (!Files.exists(whitelistPath)) {
+            if (!Files.exists(allowlistPath)) {
                 try {
-                    Files.createFile(whitelistPath);
+                    Files.createFile(allowlistPath);
                 } catch (IOException e) {
-                    logger.error("IO Exception on whitelist generation", e);
+                    logger.error("IO Exception on allowlist generation", e);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/types/object/SubtypeLayoutBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/widgets/types/object/SubtypeLayoutBuilder.java
@@ -65,7 +65,7 @@ public class SubtypeLayoutBuilder<T> extends ExpandableLayoutBuilder<T> {
         List<Class<? extends T>> allowedSubclasses =
                 typeRegistry.getSubtypesOf(baseType.getRawType())
                         .stream()
-                        // Type must come from an allowed module or be in the whitelist
+                        // Type must come from an allowed module or be in the allowlist
                         .filter(clazz -> allowedProvidingModules.contains(getModuleProviding(clazz))
                                 || permissionProvider.isPermitted(clazz))
                         // Filter public, instantiable types


### PR DESCRIPTION
## Summary

Addresses #5275 by replacing usages of "whitelist" and "blacklist" with the more inclusive terms "allowlist" and "denylist" throughout the codebase.

### Changes

- **Renamed `ExternalApiWhitelist` -> `ExternalApiAllowlist`** (class, file, and all references across engine and tests)
- **Refactored `ServerConnectListManager`**: renamed fields (`blacklistedIDs` -> `deniedIDs`, `whitelistedIDs` -> `allowedIDs`), methods (`addToWhitelist` -> `addToAllowlist`, `addToBlacklist` -> `addToDenylist`, etc.), error messages, and file paths (`blacklist.json` -> `denylist.json`, `whitelist.json` -> `allowlist.json`)
- **Updated `SelectGameScreen`**: file path references and log messages
- **Updated all import statements** in `TerasologyEngine`, `ModuleManager`, `HeadlessEnvironment`, `ModuleEnvironmentTest`, `TypeRegistryTest`, `ApiScraper`, `CompleteApiScraper`
- **Renamed test method** `testWhitelistedTypes` -> `testAllowlistedTypes` in `TypeRegistryTest`
- **Updated `.gitignore`** entries for renamed JSON files
- **Updated documentation** in `Playing.md`, `Modding-API.md`, `Module-Security.md`
- **Updated code comment** in `SubtypeLayoutBuilder`

### Not changed

- `TypeRegistry.WHITELISTED_CLASSES` and `TypeRegistry.WHITELISTED_PACKAGES` are left as-is because they are part of the external gestalt library API (`org.terasology.reflection.TypeRegistry`), not Terasology's own code.

### Note on backward compatibility

The server connect list file names change from `blacklist.json`/`whitelist.json` to `denylist.json`/`allowlist.json`. Existing server operators would need to rename their files accordingly.

## Test plan

- [ ] Verify the project compiles successfully
- [ ] Verify no remaining instances of "whitelist" or "blacklist" in Terasology-owned code (external library references excluded)
- [ ] Test server allowlist/denylist functionality with the renamed JSON files