### PR TITLE
feat: add rotated texture drawing support to CanvasUtility

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/headless/renderer/HeadlessCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/headless/renderer/HeadlessCanvasRenderer.java
@@ -86,4 +86,10 @@ public class HeadlessCanvasRenderer implements TerasologyCanvasRenderer {
     public void setUiScale(float uiScale) {
         // Do nothing
     }
+
+    @Override
+    public Mesh getBillboardMesh() {
+        // Headless renderer - return null
+        return null;
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/CanvasUtility.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/CanvasUtility.java
@@ -6,13 +6,19 @@ import org.joml.Quaternionfc;
 import org.joml.Vector2ic;
 import org.joml.Vector3fc;
 import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.engine.rendering.assets.font.Font;
 import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.texture.Texture;
 import org.terasology.engine.rendering.nui.internal.TerasologyCanvasImpl;
 import org.terasology.joml.geom.Rectanglei;
 import org.terasology.nui.Canvas;
+import org.terasology.nui.Colorc;
+import org.terasology.nui.HorizontalAlign;
+import org.terasology.nui.ScaleMode;
 import org.terasology.nui.SubRegion;
+import org.terasology.nui.UITextureRegion;
+import org.terasology.nui.VerticalAlign;
 
 // HACK: This whole class was created in order to provide access to internal, implementation specific methods.
 
@@ -21,6 +27,45 @@ import org.terasology.nui.SubRegion;
  */
 public final class CanvasUtility {
     private CanvasUtility() {
+    }
+
+    /**
+     * Draws a texture with rotation support.
+     * This is a convenience method that wraps drawMesh with rotation using a billboard mesh.
+     *
+     * @param canvas the canvas to draw on
+     * @param texture the texture to draw
+     * @param region the region to draw in
+     * @param rotation the rotation to apply (as quaternion)
+     * @param offset the offset from the center of the region
+     * @param scale the scale factor
+     */
+    public static void drawTexture(Canvas canvas, UITextureRegion texture, Rectanglei region, Quaternionfc rotation,
+                                   Vector3fc offset, float scale) {
+        drawTexture(canvas, texture, region, rotation, offset, scale, 1.0f);
+    }
+
+    /**
+     * Draws a texture with rotation and alpha support.
+     * This is a convenience method that wraps drawMesh with rotation using a billboard mesh.
+     *
+     * @param canvas the canvas to draw on
+     * @param texture the texture to draw
+     * @param region the region to draw in
+     * @param rotation the rotation to apply (as quaternion)
+     * @param offset the offset from the center of the region
+     * @param scale the scale factor
+     * @param alpha the alpha value (0-1)
+     */
+    public static void drawTexture(Canvas canvas, UITextureRegion texture, Rectanglei region, Quaternionfc rotation,
+                                   Vector3fc offset, float scale, float alpha) {
+        // TODO: Find a way to abstractly implement drawTexture with rotation in NUI
+
+        if (!(canvas instanceof TerasologyCanvasImpl)) {
+            throw new UnsupportedOperationException("Drawing rotated textures is only supported using Terasology's internal renderer.");
+        }
+
+        ((TerasologyCanvasImpl) canvas).drawTexture(texture, region, rotation, offset, scale, alpha);
     }
 
     public static void drawMesh(Canvas canvas, Mesh mesh, Texture texture, Rectanglei region, Quaternionfc rotation,

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/LwjglCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/LwjglCanvasRenderer.java
@@ -653,4 +653,9 @@ public class LwjglCanvasRenderer implements TerasologyCanvasRenderer, PropertyCh
             return Objects.hash(textureSize, areaSize, border, tiled);
         }
     }
+
+    @Override
+    public Mesh getBillboardMesh() {
+        return billboard;
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/TerasologyCanvasImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/TerasologyCanvasImpl.java
@@ -115,6 +115,38 @@ public class TerasologyCanvasImpl extends CanvasImpl implements PropertyChangeLi
         drawMesh(mesh, meshMat, region, rotation, offset, scale);
     }
 
+    /**
+     * Draws a texture with rotation support.
+     * This method draws a texture using the billboard mesh with the given rotation.
+     *
+     * @param texture the texture region to draw
+     * @param region the region to draw in (in UI coordinates)
+     * @param rotation the rotation to apply (as quaternion)
+     * @param offset the offset from the center of the region
+     * @param scale the scale factor
+     * @param alpha the alpha value (0-1)
+     */
+    public void drawTexture(UITextureRegion texture, Rectanglei region, Quaternionfc rotation, Vector3fc offset, float scale, float alpha) {
+        Rectanglei drawRegion = relativeToAbsolute(region);
+        if (!state.cropRegion.intersectsRectangle(drawRegion)) {
+            return;
+        }
+
+        // Use the billboard mesh from the renderer
+        Mesh billboard = ((TerasologyCanvasRenderer) renderer).getBillboardMesh();
+        meshMat.setTexture("tex", ((TextureRegion) texture).getTexture());
+
+        // Store and restore alpha
+        float previousAlpha = state.getAlpha();
+        state.setAlpha(state.getAlpha() * alpha);
+
+        ((TerasologyCanvasRenderer) renderer).drawMesh(
+                billboard, meshMat, drawRegion, drawRegion.intersection(state.cropRegion),
+                rotation, offset, scale, state.getAlpha());
+
+        state.setAlpha(previousAlpha);
+    }
+
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(RenderingConfig.UI_SCALE)) {

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/TerasologyCanvasRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/TerasologyCanvasRenderer.java
@@ -19,4 +19,10 @@ public interface TerasologyCanvasRenderer extends CanvasRenderer {
                   Quaternionfc rotation, Vector3fc offset, float scale, float alpha);
 
     void drawMaterialAt(Material material, Rectanglei drawRegion);
+
+    /**
+     * Returns the billboard mesh used for texture rendering.
+     * @return the billboard mesh
+     */
+    Mesh getBillboardMesh();
 }


### PR DESCRIPTION
## Summary

Add support for drawing rotated textures through CanvasUtility, addressing issue #1926.

## Changes

This PR adds the ability to draw textures with rotation (e.g., player cursor aligned with view direction) without requiring workarounds.

### Modified Files:

1. **CanvasUtility.java** - Added `drawTexture` methods with rotation support
2. **TerasologyCanvasRenderer.java** - Added `getBillboardMesh()` method
3. **LwjglCanvasRenderer.java** - Implemented `getBillboardMesh()`
4. **HeadlessCanvasRenderer.java** - Implemented `getBillboardMesh()` (returns null)
5. **TerasologyCanvasImpl.java** - Added `drawTexture` implementation with rotation

## Usage Example

```java
Quaternionfc rotation = new Quaternionf().rotateZ((float) Math.toRadians(45));
Vector3fc offset = new Vector3f(0, 0, 0);
CanvasUtility.drawTexture(canvas, texture, region, rotation, offset, 1.0f);
```
