### PR TITLE
DI PR post-review follow-up 1

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation("org.jgrapht:jgrapht-core:1.5.0")
 
     // for inspecting modules
-    implementation("org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT")
+    implementation("org.terasology.gestalt:gestalt-module:8.0.1-SNAPSHOT")
 
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     implementation(group = "org.terasology.engine", name = "engine", version = moduleMetadata.engineVersion())
     testImplementation(group = "org.terasology.engine", name = "engine-tests", version = moduleMetadata.engineVersion())
 
-    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT")
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.1-SNAPSHOT")
 
     for ((gradleDep, optional) in moduleMetadata.moduleDependencies()) {
         if (optional) {

--- a/engine-tests/src/test/java/org/terasology/engine/context/internal/ContextImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/context/internal/ContextImplTest.java
@@ -1,0 +1,102 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.context.internal;
+
+import org.junit.jupiter.api.Test;
+import org.terasology.context.Lifetime;
+import org.terasology.engine.context.Context;
+import org.terasology.gestalt.di.ServiceRegistry;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@link ContextImpl}, focusing on parent-child bean resolution.
+ */
+public class ContextImplTest {
+
+    /**
+     * A child ContextImpl created with a Context-typed parent should still
+     * be able to resolve beans registered in the parent via the BeanContext.
+     * <p>
+     * Before the fix, the ContextImpl(Context) constructor created a standalone
+     * DefaultBeanContext with no parent, so @Inject resolution could not see
+     * parent beans. Only context.get() worked (via the fallback to parent.get()).
+     */
+    @Test
+    public void childContextResolvesParentBeansViaGet() {
+        // Register a bean in the parent context
+        ServiceRegistry parentRegistry = new ServiceRegistry();
+        parentRegistry.with(TestService.class).lifetime(Lifetime.Singleton).use(() -> new TestService("from-parent"));
+        ContextImpl parent = new ContextImpl(parentRegistry);
+
+        // Create child using the Context-typed constructor (the one that was broken)
+        Context parentAsContext = parent; // upcast to Context to use the problematic constructor
+        ContextImpl child = new ContextImpl(parentAsContext);
+
+        // context.get() should resolve from parent (this always worked via fallback)
+        TestService viaGet = child.get(TestService.class);
+        assertNotNull(viaGet, "child.get() should resolve parent bean");
+        assertEquals("from-parent", viaGet.name);
+    }
+
+    @Test
+    public void childContextResolvesParentBeansViaInject() {
+        // Register a bean in the parent context
+        ServiceRegistry parentRegistry = new ServiceRegistry();
+        parentRegistry.with(TestService.class).lifetime(Lifetime.Singleton).use(() -> new TestService("from-parent"));
+        ContextImpl parent = new ContextImpl(parentRegistry);
+
+        // Create child using the Context-typed constructor
+        Context parentAsContext = parent;
+        ContextImpl child = new ContextImpl(parentAsContext);
+
+        // inject() should resolve @Inject fields from the parent BeanContext
+        // Before the fix, this would leave the field null because the child's
+        // DefaultBeanContext had no parent to search.
+        TestConsumer consumer = new TestConsumer();
+        child.inject(consumer);
+        assertNotNull(consumer.service, "inject() should resolve parent bean via BeanContext hierarchy");
+        assertEquals("from-parent", consumer.service.name);
+    }
+
+    @Test
+    public void childContextOverridesParentBean() {
+        ServiceRegistry parentRegistry = new ServiceRegistry();
+        parentRegistry.with(TestService.class).lifetime(Lifetime.Singleton).use(() -> new TestService("from-parent"));
+        ContextImpl parent = new ContextImpl(parentRegistry);
+
+        ServiceRegistry childRegistry = new ServiceRegistry();
+        childRegistry.with(TestService.class).lifetime(Lifetime.Singleton).use(() -> new TestService("from-child"));
+        ContextImpl child = new ContextImpl((Context) parent, childRegistry);
+
+        // Child's own bean should take priority
+        TestService viaGet = child.get(TestService.class);
+        assertNotNull(viaGet);
+        assertEquals("from-child", viaGet.name);
+    }
+
+    @Test
+    public void childContextWithNullParentDoesNotFail() {
+        ContextImpl child = new ContextImpl((Context) null);
+
+        // Should return null, not throw
+        assertNull(child.get(TestService.class));
+    }
+
+    public static class TestService {
+        public final String name;
+
+        public TestService(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class TestConsumer {
+        @Inject
+        public TestService service;
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/context/internal/ContextImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/context/internal/ContextImplTest.java
@@ -1,4 +1,4 @@
-// Copyright 2022 The Terasology Foundation
+// Copyright 2026 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.context.internal;
 
@@ -19,44 +19,34 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class ContextImplTest {
 
     /**
-     * A child ContextImpl created with a Context-typed parent should still
-     * be able to resolve beans registered in the parent via the BeanContext.
-     * <p>
-     * Before the fix, the ContextImpl(Context) constructor created a standalone
-     * DefaultBeanContext with no parent, so @Inject resolution could not see
-     * parent beans. Only context.get() worked (via the fallback to parent.get()).
+     * A child ContextImpl created with a Context-typed parent should resolve
+     * beans registered in the parent via context.get().
      */
     @Test
     public void childContextResolvesParentBeansViaGet() {
-        // Register a bean in the parent context
         ServiceRegistry parentRegistry = new ServiceRegistry();
         parentRegistry.with(TestService.class).lifetime(Lifetime.Singleton).use(() -> new TestService("from-parent"));
         ContextImpl parent = new ContextImpl(parentRegistry);
 
-        // Create child using the Context-typed constructor (the one that was broken)
-        Context parentAsContext = parent; // upcast to Context to use the problematic constructor
-        ContextImpl child = new ContextImpl(parentAsContext);
+        ContextImpl child = new ContextImpl((Context) parent);
 
-        // context.get() should resolve from parent (this always worked via fallback)
         TestService viaGet = child.get(TestService.class);
         assertNotNull(viaGet, "child.get() should resolve parent bean");
         assertEquals("from-parent", viaGet.name);
     }
 
+    /**
+     * A child ContextImpl created with a Context-typed parent should resolve
+     * @Inject dependencies from the parent's BeanContext hierarchy.
+     */
     @Test
     public void childContextResolvesParentBeansViaInject() {
-        // Register a bean in the parent context
         ServiceRegistry parentRegistry = new ServiceRegistry();
         parentRegistry.with(TestService.class).lifetime(Lifetime.Singleton).use(() -> new TestService("from-parent"));
         ContextImpl parent = new ContextImpl(parentRegistry);
 
-        // Create child using the Context-typed constructor
-        Context parentAsContext = parent;
-        ContextImpl child = new ContextImpl(parentAsContext);
+        ContextImpl child = new ContextImpl((Context) parent);
 
-        // inject() should resolve @Inject fields from the parent BeanContext
-        // Before the fix, this would leave the field null because the child's
-        // DefaultBeanContext had no parent to search.
         TestConsumer consumer = new TestConsumer();
         child.inject(consumer);
         assertNotNull(consumer.service, "inject() should resolve parent bean via BeanContext hierarchy");

--- a/engine-tests/src/test/java/org/terasology/engine/context/internal/ContextImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/context/internal/ContextImplTest.java
@@ -9,9 +9,12 @@ import org.terasology.gestalt.di.ServiceRegistry;
 
 import javax.inject.Inject;
 
+import org.terasology.gestalt.di.exceptions.DependencyResolutionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link ContextImpl}, focusing on parent-child bean resolution.
@@ -67,6 +70,43 @@ public class ContextImplTest {
         TestService viaGet = child.get(TestService.class);
         assertNotNull(viaGet);
         assertEquals("from-child", viaGet.name);
+    }
+
+    /**
+     * When the parent is not a ContextImpl, the child cannot inherit the parent's
+     * BeanContext (instanceof check). context.get() should still resolve via the
+     * parent fallback, but @Inject resolution should not see parent beans.
+     */
+    @Test
+    public void childContextWithNonContextImplParentFallsBackToGetOnly() {
+        Context plainParent = new Context() {
+            private final TestService service = new TestService("from-plain-parent");
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T get(Class<T> type) {
+                if (type == TestService.class) {
+                    return (T) service;
+                }
+                return null;
+            }
+
+            @Override
+            public <T, U extends T> void put(Class<T> type, U object) {
+            }
+        };
+
+        ContextImpl child = new ContextImpl(plainParent);
+
+        // get() works via parent fallback
+        TestService viaGet = child.get(TestService.class);
+        assertNotNull(viaGet, "child.get() should resolve from non-ContextImpl parent via fallback");
+        assertEquals("from-plain-parent", viaGet.name);
+
+        // @Inject fails because there is no parent BeanContext to search
+        TestConsumer consumer = new TestConsumer();
+        assertThrows(DependencyResolutionException.class, () -> child.inject(consumer),
+                "inject() should fail for non-ContextImpl parent with no BeanContext hierarchy");
     }
 
     @Test

--- a/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
+++ b/engine/src/main/java/org/terasology/engine/context/internal/ContextImpl.java
@@ -74,7 +74,8 @@ public class ContextImpl implements Context {
         ServiceRegistry thisServiceRegistry = new ServiceRegistry();
         thisServiceRegistry.with(Context.class).lifetime(Lifetime.Singleton).use(() -> this);
         thisServiceRegistry.with(ContextImpl.class).lifetime(Lifetime.Singleton).use(() -> this);
-        this.beanContext = new DefaultBeanContext(thisServiceRegistry);
+        this.beanContext = new DefaultBeanContext(
+                parent instanceof ContextImpl ? ((ContextImpl) parent).beanContext : null, thisServiceRegistry);
         this.parent = parent;
     }
 

--- a/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
@@ -145,10 +145,6 @@ public class StateLoading implements GameState {
         }
 
         progress = 0;
-        maxProgress = 0;
-        for (LoadProcess process : loadProcesses) {
-            maxProgress += process.getExpectedCost();
-        }
 
         popStep();
         if (nuiManager != null) {
@@ -159,54 +155,54 @@ public class StateLoading implements GameState {
     }
 
     private void initClient(GameEngine engine, ServiceRegistry serviceRegistry) {
-        loadProcesses.add(new JoinServer(context, gameManifest, joinStatus));
+        addAndTrack(new JoinServer(context, gameManifest, joinStatus));
         if (!headless) {
-            loadProcesses.add(new InitialiseRendering(serviceRegistry));
+            addAndTrack(new InitialiseRendering(serviceRegistry));
         }
-        loadProcesses.add(new InitialiseEntitySystem(context, serviceRegistry));
-        loadProcesses.add(new RegisterBlocks(context, serviceRegistry));
+        addAndTrack(new InitialiseEntitySystem(context, serviceRegistry));
+        addAndTrack(new RegisterBlocks(context, serviceRegistry));
         if (!headless) {
-            loadProcesses.add(new InitialiseGraphics(context));
+            addAndTrack(new InitialiseGraphics(context));
         }
-//        loadProcesses.add(new LoadPrefabs(context));
-//        loadProcesses.add(new ProcessBlockPrefabs(context));
-        loadProcesses.add(new LoadExtraBlockData(serviceRegistry));
-        loadProcesses.add(new InitialiseComponentSystemManager(serviceRegistry));
-//        loadProcesses.add(new RegisterSystems(context, netMode));
-//        loadProcesses.add(new RegisterWorldSystems(gameManifest, context));
-        loadProcesses.add(new InitialiseCommandSystem(serviceRegistry));
-        loadProcesses.add(new InitialiseRemoteWorld(context, serviceRegistry, gameManifest));
-        loadProcesses.add(new InitialisePhysics(context, serviceRegistry));
-//        loadProcesses.add(new InitialiseSystems(context));
-//        loadProcesses.add(new PreBeginSystems(context));
-//        loadProcesses.add(new CreateRemoteWorldEntity(context));
-//        loadProcesses.add(new PostBeginSystems(context));
-//        loadProcesses.add(new SetupRemotePlayer(context));
-//        loadProcesses.add(new AwaitCharacterSpawn(context));
-//        loadProcesses.add(new RegisterBlockFamilies(context));
-//        loadProcesses.add(new PrepareWorld(context));
-        loadProcesses.add(new SwitchToContextStep(engine));
-        loadProcesses.add(new AddClientPostLoadProcessesStep());
+//        addAndTrack(new LoadPrefabs(context));
+//        addAndTrack(new ProcessBlockPrefabs(context));
+        addAndTrack(new LoadExtraBlockData(serviceRegistry));
+        addAndTrack(new InitialiseComponentSystemManager(serviceRegistry));
+//        addAndTrack(new RegisterSystems(context, netMode));
+//        addAndTrack(new RegisterWorldSystems(gameManifest, context));
+        addAndTrack(new InitialiseCommandSystem(serviceRegistry));
+        addAndTrack(new InitialiseRemoteWorld(context, serviceRegistry, gameManifest));
+        addAndTrack(new InitialisePhysics(context, serviceRegistry));
+//        addAndTrack(new InitialiseSystems(context));
+//        addAndTrack(new PreBeginSystems(context));
+//        addAndTrack(new CreateRemoteWorldEntity(context));
+//        addAndTrack(new PostBeginSystems(context));
+//        addAndTrack(new SetupRemotePlayer(context));
+//        addAndTrack(new AwaitCharacterSpawn(context));
+//        addAndTrack(new RegisterBlockFamilies(context));
+//        addAndTrack(new PrepareWorld(context));
+        addAndTrack(new SwitchToContextStep(engine));
+        addAndTrack(new AddClientPostLoadProcessesStep());
     }
 
     private void initHost(GameEngine engine, ServiceRegistry serviceRegistry) {
-        loadProcesses.add(new RegisterMods(context, serviceRegistry, gameManifest));
+        addAndTrack(new RegisterMods(context, serviceRegistry, gameManifest));
         if (!headless) {
-            loadProcesses.add(new InitialiseRendering(serviceRegistry));
+            addAndTrack(new InitialiseRendering(serviceRegistry));
         }
-        loadProcesses.add(new InitialiseEntitySystem(context, serviceRegistry));
-        loadProcesses.add(new RegisterBlocks(context, serviceRegistry));
+        addAndTrack(new InitialiseEntitySystem(context, serviceRegistry));
+        addAndTrack(new RegisterBlocks(context, serviceRegistry));
         if (!headless) {
-            loadProcesses.add(new InitialiseGraphics(context));
+            addAndTrack(new InitialiseGraphics(context));
         }
-        loadProcesses.add(new InitialiseComponentSystemManager(serviceRegistry));
-        loadProcesses.add(new InitialiseCommandSystem(serviceRegistry));
-        loadProcesses.add(new LoadExtraBlockData(serviceRegistry));
-        loadProcesses.add(new InitialiseWorld(gameManifest, context, serviceRegistry));
-        loadProcesses.add(new InitialisePhysics(context, serviceRegistry));
-        loadProcesses.add(new SwitchToContextStep(engine));
+        addAndTrack(new InitialiseComponentSystemManager(serviceRegistry));
+        addAndTrack(new InitialiseCommandSystem(serviceRegistry));
+        addAndTrack(new LoadExtraBlockData(serviceRegistry));
+        addAndTrack(new InitialiseWorld(gameManifest, context, serviceRegistry));
+        addAndTrack(new InitialisePhysics(context, serviceRegistry));
+        addAndTrack(new SwitchToContextStep(engine));
         // Post-Init processes
-        loadProcesses.add(new AddHostPostLoadProcessesStep());
+        addAndTrack(new AddHostPostLoadProcessesStep());
     }
 
     private void addAndTrack(LoadProcess process) {

--- a/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
@@ -325,6 +325,12 @@ public class StateLoading implements GameState {
             context = engine.createChildContext(serviceRegistry);
             CoreRegistry.setContext(context);
             nuiManager = context.get(NUIManager.class);
+            // Re-push the loading screen onto the new NUI manager so it stays
+            // visible after the context swap. The old manager that created it
+            // is no longer being rendered.
+            if (nuiManager != null && loadingScreen != null) {
+                loadingScreen = nuiManager.pushScreen("engine:loadingScreen", LoadingScreen.class);
+            }
             return true;
         }
 
@@ -385,6 +391,9 @@ public class StateLoading implements GameState {
                 loadProcesses.add(new AwaitCharacterSpawn(context));
             }
             loadProcesses.add(new PrepareWorld(context));
+            for (LoadProcess process : loadProcesses) {
+                maxProgress += process.getExpectedCost();
+            }
             return true;
         }
 
@@ -441,6 +450,9 @@ public class StateLoading implements GameState {
             loadProcesses.add(new SetupRemotePlayer(context));
             loadProcesses.add(new AwaitCharacterSpawn(context));
             loadProcesses.add(new PrepareWorld(context));
+            for (LoadProcess process : loadProcesses) {
+                maxProgress += process.getExpectedCost();
+            }
             return true;
         }
 

--- a/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
@@ -209,6 +209,11 @@ public class StateLoading implements GameState {
         loadProcesses.add(new AddHostPostLoadProcessesStep());
     }
 
+    private void addAndTrack(LoadProcess process) {
+        loadProcesses.add(process);
+        maxProgress += process.getExpectedCost();
+    }
+
     private void popStep() {
         if (current != null) {
             progress += current.getExpectedCost();
@@ -357,23 +362,23 @@ public class StateLoading implements GameState {
 
         @Override
         public boolean step() {
-            loadProcesses.add(new ConfigureEntitySystem(context));
-            loadProcesses.add(new InitialiseBlocks(gameManifest, context));
-            loadProcesses.add(new LoadPrefabs(context));
-            loadProcesses.add(new RegisterSystems(context, netMode));
+            addAndTrack(new ConfigureEntitySystem(context));
+            addAndTrack(new InitialiseBlocks(gameManifest, context));
+            addAndTrack(new LoadPrefabs(context));
+            addAndTrack(new RegisterSystems(context, netMode));
             if (!headless) {
-                loadProcesses.add(new RegisterInputSystem(context));
+                addAndTrack(new RegisterInputSystem(context));
             }
-            loadProcesses.add(new RegisterWorldSystems(gameManifest, context));
-            loadProcesses.add(new RegisterBlockFamilies(context));
-            loadProcesses.add(new ProcessBlockPrefabs(context));
-            loadProcesses.add(new InitialiseSystems(context));
-            loadProcesses.add(new PreBeginSystems(context));
-            loadProcesses.add(new LoadEntities(context));
-            loadProcesses.add(new InitialiseBlockTypeEntities(context));
-            loadProcesses.add(new CreateWorldEntity(context, gameManifest));
-            loadProcesses.add(new InitialiseWorldGenerator(context));
-            loadProcesses.add(new InitialiseRecordAndReplay(context));
+            addAndTrack(new RegisterWorldSystems(gameManifest, context));
+            addAndTrack(new RegisterBlockFamilies(context));
+            addAndTrack(new ProcessBlockPrefabs(context));
+            addAndTrack(new InitialiseSystems(context));
+            addAndTrack(new PreBeginSystems(context));
+            addAndTrack(new LoadEntities(context));
+            addAndTrack(new InitialiseBlockTypeEntities(context));
+            addAndTrack(new CreateWorldEntity(context, gameManifest));
+            addAndTrack(new InitialiseWorldGenerator(context));
+            addAndTrack(new InitialiseRecordAndReplay(context));
             if (netMode.isServer()) {
                 boolean dedicated;
                 if (netMode == NetworkMode.DEDICATED_SERVER) {
@@ -383,17 +388,14 @@ public class StateLoading implements GameState {
                 } else {
                     throw new IllegalStateException("Invalid server mode: " + netMode);
                 }
-                loadProcesses.add(new StartServer(context, dedicated));
+                addAndTrack(new StartServer(context, dedicated));
             }
-            loadProcesses.add(new PostBeginSystems(context));
+            addAndTrack(new PostBeginSystems(context));
             if (netMode.hasLocalClient()) {
-                loadProcesses.add(new SetupLocalPlayer(context));
-                loadProcesses.add(new AwaitCharacterSpawn(context));
+                addAndTrack(new SetupLocalPlayer(context));
+                addAndTrack(new AwaitCharacterSpawn(context));
             }
-            loadProcesses.add(new PrepareWorld(context));
-            for (LoadProcess process : loadProcesses) {
-                maxProgress += process.getExpectedCost();
-            }
+            addAndTrack(new PrepareWorld(context));
             return true;
         }
 
@@ -420,21 +422,21 @@ public class StateLoading implements GameState {
 
         @Override
         public boolean step() {
-            loadProcesses.add(new ConfigureEntitySystem(context));
-            loadProcesses.add(new InitialiseBlocks(gameManifest, context));
-            loadProcesses.add(new LoadPrefabs(context));
-            loadProcesses.add(new RegisterSystems(context, netMode));
+            addAndTrack(new ConfigureEntitySystem(context));
+            addAndTrack(new InitialiseBlocks(gameManifest, context));
+            addAndTrack(new LoadPrefabs(context));
+            addAndTrack(new RegisterSystems(context, netMode));
             if (!headless) {
-                loadProcesses.add(new RegisterInputSystem(context));
+                addAndTrack(new RegisterInputSystem(context));
             }
-            loadProcesses.add(new RegisterRemoteWorldSystems(context));
-            loadProcesses.add(new RegisterBlockFamilies(context));
-            loadProcesses.add(new ProcessBlockPrefabs(context));
-            loadProcesses.add(new InitialiseSystems(context));
-            loadProcesses.add(new PreBeginSystems(context));
-            loadProcesses.add(new CreateRemoteWorldEntity(context));
-            loadProcesses.add(new InitialiseBlockTypeEntities(context));
-            loadProcesses.add(new InitialiseRecordAndReplay(context));
+            addAndTrack(new RegisterRemoteWorldSystems(context));
+            addAndTrack(new RegisterBlockFamilies(context));
+            addAndTrack(new ProcessBlockPrefabs(context));
+            addAndTrack(new InitialiseSystems(context));
+            addAndTrack(new PreBeginSystems(context));
+            addAndTrack(new CreateRemoteWorldEntity(context));
+            addAndTrack(new InitialiseBlockTypeEntities(context));
+            addAndTrack(new InitialiseRecordAndReplay(context));
             if (netMode.isServer()) {
                 boolean dedicated;
                 if (netMode == NetworkMode.DEDICATED_SERVER) {
@@ -444,15 +446,12 @@ public class StateLoading implements GameState {
                 } else {
                     throw new IllegalStateException("Invalid server mode: " + netMode);
                 }
-                loadProcesses.add(new StartServer(context, dedicated));
+                addAndTrack(new StartServer(context, dedicated));
             }
-            loadProcesses.add(new PostBeginSystems(context));
-            loadProcesses.add(new SetupRemotePlayer(context));
-            loadProcesses.add(new AwaitCharacterSpawn(context));
-            loadProcesses.add(new PrepareWorld(context));
-            for (LoadProcess process : loadProcesses) {
-                maxProgress += process.getExpectedCost();
-            }
+            addAndTrack(new PostBeginSystems(context));
+            addAndTrack(new SetupRemotePlayer(context));
+            addAndTrack(new AwaitCharacterSpawn(context));
+            addAndTrack(new PrepareWorld(context));
             return true;
         }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/UniverseSetupScreen.java
@@ -383,6 +383,7 @@ public class UniverseSetupScreen extends CoreScreenLayer implements UISliderOnCh
      * needed for successful game creation.
      */
     public void setEnvironment(UniverseWrapper universeWrapper) {
+        this.universeWrapper = universeWrapper;
         prepareContext();
 
         DependencyResolver resolver = new DependencyResolver(moduleManager.getRegistry());

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
         create("libs") {
             // currently not yet for build-logic, see https://github.com/gradle/gradle/issues/15383 , change verisons
             // here and there please.
-            val gestalt = version("gestalt", "8.0.0-SNAPSHOT")
+            val gestalt = version("gestalt", "8.0.1-SNAPSHOT")
             library("gestalt-core", "org.terasology.gestalt", "gestalt-asset-core" ).versionRef(gestalt)
             library("gestalt-entitysystem", "org.terasology.gestalt", "gestalt-entity-system" ).versionRef(gestalt)
             library("gestalt-inject", "org.terasology.gestalt", "gestalt-inject" ).versionRef(gestalt)


### PR DESCRIPTION
## Summary

First pass addressing review findings from #5299 (gestalt-di migration). This PR contains only the review-fix delta — not the full 137-file migration.

This is as much a workflow demonstration as a fix PR. We're using a structured review triage process ([GDD framework](https://siliconsaga.net/guardian-driven-development/)) to systematically work through findings from BSA, Copilot, and CodeRabbit across the massive DI migration PR, phased to avoid another multi-year review cycle.

## Approach

We triaged all review findings into two phases:
- **Phase 1 (this PR):** Runtime correctness fixes
- **Phase 2 (future PR):** Code quality, pattern enforcement, Context injection cleanup

Review threads on #5299 are intentionally NOT resolved — kept for future reference.

## Changes

| Finding | Result |
|---------|--------|
| P1-1: Gestalt version bump | **Fixed** — `8.0.0-SNAPSHOT` → `8.0.1-SNAPSHOT` across settings.gradle.kts and build-logic |
| P1-2: StateLoading.java (BSA+CodeRabbit) | **Fixed** — loading screen re-pushed after NUI manager swap (fixes flicker); progress bar overflow fixed by recalculating maxProgress when post-context-switch steps are injected |
| P1-3: PhysicsEngineManager binding (Copilot) | **False positive** — Gestalt auto-maps all interfaces when `target==root` in `bindExpression()`. Adding explicit `.with(Interface).use(Impl)` creates duplicate bean keys and breaks resolution. |
| P1-4: UniverseSetupScreen wrapper (Copilot+CodeRabbit) | **Fixed** — `setEnvironment()` received a `UniverseWrapper` but never assigned it to the instance field. One-line fix. |
| P1-5: AdvancedGameSetupScreen NPE (Copilot) | **Not reachable** — `NewGameScreen` always calls `setEnvironment()` before showing the screen. Deferred to Phase 2 as defensive hardening. |
| P1-6: AutoConfigManager check (BSA) | **Already resolved** — BSA reinstated the check before merge. |
| P1-7: CodeRabbit triage (17 comments) | **Complete** — 5 already resolved, 2 merged into other P1 items, 10 deferred to Phase 2 |
| P1-8: ContextImpl parent BeanContext (CodeRabbit) | **Fixed** — the `ContextImpl(Context)` constructor created a standalone `DefaultBeanContext` with no parent, so `@Inject` resolution in child contexts could not see parent beans. Affects network handlers, NUI manager, and other child-context callers. |

### ContextImpl fix — test-driven validation

The ContextImpl bug was subtle: `context.get()` still worked (via fallback to `parent.get()`), but `@Inject` resolution through the `BeanContext` hierarchy was broken. No `BeanResolutionException` appeared in logs because the exception was caught and silently fell back to the parent `Context` lookup.

To prove the fix was real, we wrote a unit test (`ContextImplTest.childContextResolvesParentBeansViaInject`) that:
- **Fails without the fix** — `DependencyResolutionException` when injecting a bean registered in the parent
- **Passes with the fix** — child BeanContext correctly walks up to the parent

It remains uncertain whether this bug was actively breaking anything at runtime, since `context.get()` (the common lookup path) worked fine via the fallback. The `@Inject` path through `BeanContext` is used by constructor injection during DI container resolution, which would only surface as issues in code paths that rely on the DI container creating objects with injected parent-context dependencies. The network connection handlers (`ClientConnectionHandler`, `ServerConnectionHandler`) are the most likely candidates, but we have not yet been able to attribute a specific runtime bug to this fix.

## DI Patterns Harvested

While reviewing we discovered and documented several Gestalt DI conventions:

- **Gestalt auto-registers interfaces:** `.with(Impl.class).lifetime(Singleton)` auto-maps all implemented interfaces via `interfaceMapping` in `DefaultBeanContext.bindExpression()`. Do NOT add explicit interface bindings — it breaks resolution.
- **Constructor injection preferred**, `@javax.inject.Inject` on protected members as compromise, `@In` is legacy
- **Never inject `Context` directly** — inject specific dependencies
- **`ServiceRegistry`** for registration phase; **`ImmutableContextImpl`** after init — catches rogue writes
- **`CoreRegistry` is being eliminated** — no new uses

## Remaining Work

Phase 2 items tracked in our workspace for a follow-up PR:
- Direct `Context` injection cleanup (ConsoleImpl, BlockFamilyLibrary, WorldRendererImpl, ReadWriteStorageManager)
- `UniverseSetupScreen` — migrate `Context.put()` to ServiceRegistry
- Test environment fixes (Environment.java context swap, static context leak, uninitialized Game binding)
- EntitySystemSetupUtil replay status, EnvironmentSwitchHandler stale type handlers
- WorldRendererImpl ScreenGrabber visibility (explains black save screenshots)
- ExternalApiWhitelist sandbox surface hardening

## Test Plan

- [x] Gradle resolves gestalt 8.0.1-SNAPSHOT correctly
- [x] Single-player game creation works (new game flow, physics, spawning)
- [x] Universe Setup screen receives seed/settings from Advanced Game Setup
- [x] Loading screen no longer flickers during context swap
- [x] Unit test proves ContextImpl parent BeanContext propagation
- [x] Progress bar stays within bounds during loading
- [ ] Multiplayer connectivity (known issues predate this PR — chest inventory not visible to second client)

## Sample Transcript

As an example of human-agent interaction while working this PR see Gist https://gist.github.com/Cervator/4ef1537704e225c60f66c206ba4f0246

## Sample Thalamus Snippet

This is a gitignored "midterm memory" storage document in a GDD user's workspace named `Thalamus.md` for noting down temporary but at times multi-session topics, both from the human and the agent

### DI Migration Review

Design spec: `docs/plans/2026-03-28-di-migration-review-design.md`
PR under review: MovingBlocks/Terasology#5299 | Branch: `review/post-di`

### Phase 1 — Runtime Correctness (current)

- [x] P1-1: Gestalt version bump to 8.0.1-SNAPSHOT
- [x] P1-2: StateLoading.java — loading screen orphan fixed, progress bar overflow fixed
- [x] P1-3: PhysicsEngineManager — FALSE POSITIVE. Gestalt auto-maps interfaces when target==root
- [x] P1-4: UniverseSetupScreen — wrapper handoff broken (Copilot) — fixed
- [x] P1-5: AdvancedGameSetupScreen — NPE not reachable (NewGameScreen always calls setEnvironment before showing). Defensive guard deferred to Phase 2
- [x] P1-6: AutoConfigManager — check already present (BSA reinstated before merge). Null singleton issue (CodeRabbit) deferred to Phase 2
- [x] P1-7: CodeRabbit triage — 17 comments triaged. 5 already resolved, 1 merged into P1-2, 10 Phase 2, 1 investigated (InitialiseWorld storage path — Phase 2)
- [x] P1-8: ContextImpl.java:79 — fixed. Parent BeanContext now propagated. Unit test proves the fix (DependencyResolutionException before, passes after)

### Phase 2 — Code Quality (parked for later PR)

- ConsoleImpl: inject deps not Context
- BlockFamilyLibrary: unnecessary Context injection
- WorldRendererImpl: replace context param with explicit deps
- ReadWriteStorageManager: deprecate CoreRegistry-dependent constructor
- UniverseSetupScreen: migrate Context.put() to ServiceRegistry
- NUIManagerInternal: rename `timedContextForModulesWidgets`
- RegisterRemoteWorldSystems: remove dead commented-out code
- ModuleManager: document implementation requirement
- InitialiseBlocks: verify downcast safety
- InitialiseWorld: clarify where seed is set
- AutoConfigManager:83: null singleton from failed construction (CodeRabbit)
- Environment.java:55: context swap in test reset() loses setup hooks (CodeRabbit)
- HeadlessEnvironment.java:142: BlockFamilyLibrary mismatch with BlockManagerImpl (CodeRabbit)
- TerasologyTestingEnvironment: static context leaks between tests + uninitialized Game (CodeRabbit)
- EntitySystemSetupUtil:88: replay status always NOT_ACTIVATED from fresh construction (CodeRabbit)
- EnvironmentSwitchHandler:105: stale type handlers across env switches (CodeRabbit)
- ExternalApiWhitelist:62: overly broad `engine.persistence.internal` whitelist (CodeRabbit)
- WorldRendererImpl:153: ScreenGrabber only in private context, explains black save screenshots (CodeRabbit)
- PojoEntityManager:88: Optional deps are bootstrap compromise, tighten later (CodeRabbit)

### DI Patterns (living reference — harvest as we go)

- **Constructor injection preferred**, `@javax.inject.Inject` on protected members as compromise, `@In` is legacy
- **Never inject `Context` directly** — inject specific deps
- **`ServiceRegistry`** for registration phase; **`ImmutableContextImpl`** after — catches rogue writes
- **Gestalt auto-registers interfaces:** `.with(Impl.class).lifetime(Singleton)` auto-maps all interfaces via `interfaceMapping`. Do NOT add explicit `.with(Interface.class).use(Impl.class)` — it creates duplicate bean keys and breaks resolution. Only use explicit interface mapping when target != impl (e.g., `.with(Interface.class).use(() -> specificInstance)`).
- **`Context.put()` should not be called** — migrate to ServiceRegistry-based init
- **`CoreRegistry` is being eliminated** — no new uses (test env is reluctant exception)
- Example: [ComponentSerializerTest L59-79](https://github.com/MovingBlocks/Terasology/blob/ce52b17/engine-tests/src/test/java/org/terasology/engine/persistence/ComponentSerializerTest.java#L59-L79)
- Example: [TerasologyEngine L260](https://github.com/MovingBlocks/Terasology/blob/ce52b17/engine/src/main/java/org/terasology/engine/core/TerasologyEngine.java#L260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Or it would have been, but apparently GitHub fine-grained tokens cannot auto-create PRs in a repo it doesn't have write access to? Weak. May have to set @agent-refr as a collaborator. But first: sleep!)