### PR TITLE
fix: skip project-autoadd workflow for fork PRs

### DIFF
--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   add_opened_to_inbox_board:
     name: Add New Issue/PR to Terasology Inbox Board
-    if: github.event.action == 'opened'
+    if: >-
+      github.event.action == 'opened' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Add to inbox board
@@ -19,9 +21,10 @@ jobs:
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_bug_labeled_to_bug_board:
     name: Assign bug report issues and pull requests to bug board backlog
-    if: |
-      contains(github.event.issue.labels.*.name, 'Type: Bug') ||
-      contains(github.event.pull_request.labels.*.name, 'Type: Bug')
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      (contains(github.event.issue.labels.*.name, 'Type: Bug') ||
+      contains(github.event.pull_request.labels.*.name, 'Type: Bug'))
     runs-on: ubuntu-latest
     steps:
       - name: Add to bug board
@@ -31,14 +34,15 @@ jobs:
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_maintenance_to_stabilization_board:
     name: Assign stabilization / refactoring / chore issues and pull requests to stabilization board backlog
-    if: |
-      github.event.action != 'opened' && 
-      ( contains(github.event.issue.labels.*.name, 'Type: Refactoring') ||
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.event.action != 'opened' &&
+      (contains(github.event.issue.labels.*.name, 'Type: Refactoring') ||
       contains(github.event.pull_request.labels.*.name, 'Type: Refactoring') ||
       contains(github.event.issue.labels.*.name, 'Type: Chore') ||
       contains(github.event.pull_request.labels.*.name, 'Type: Chore') ||
       contains(github.event.issue.labels.*.name, 'Topic: Stabilization') && !contains(github.event.issue.labels.*.name, 'Type: Bug') ||
-      contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization') && !contains(github.event.pull_request.labels.*.name, 'Type: Bug') )
+      contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization') && !contains(github.event.pull_request.labels.*.name, 'Type: Bug'))
     runs-on: ubuntu-latest
     steps:
       - name: Add to stabilization board
@@ -48,10 +52,11 @@ jobs:
           github-token: ${{ secrets.PROJECT_GITHUB_TOKEN }}
   add_features_to_feature_board:
     name: Assign improvement issues and pull requests to feature board backlog
-    if: |
-      github.event.action != 'opened' && 
-      contains(github.event.issue.labels.*.name, 'Type: Improvement') && !contains(github.event.issue.labels.*.name, 'Topic: Stabilization') ||
-      contains(github.event.pull_request.labels.*.name, 'Type: Improvement') && !contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization')
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.event.action != 'opened' &&
+      (contains(github.event.issue.labels.*.name, 'Type: Improvement') && !contains(github.event.issue.labels.*.name, 'Topic: Stabilization') ||
+      contains(github.event.pull_request.labels.*.name, 'Type: Improvement') && !contains(github.event.pull_request.labels.*.name, 'Topic: Stabilization'))
     runs-on: ubuntu-latest
     steps:
       - name: Add to feature board


### PR DESCRIPTION
## Summary

Skip the `project-autoadd.yml` workflow for PRs originating from forks. Fork PRs cannot access repository secrets, causing the workflow to fail with "Input required and not supplied: github-token" on every fork-submitted PR.

## Changes

Added a fork check to each job's `if` condition:
```yaml
github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

This means:
- **Issues:** Always run (unaffected)
- **PRs from the same repo:** Always run (secrets available)
- **PRs from forks:** Skip gracefully (secrets unavailable)

## Test Plan

- [ ] Fork PR no longer shows failed check for project-autoadd
- [ ] Internal PRs still get added to project boards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(But still submitted manually as I keep trying to make minimal access work for machine account @agent-refr)