### PR TITLE
DI PR post-review follow-up 2 - 4 code quality tweaks

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
@@ -418,7 +418,7 @@ public class StateLoading implements GameState {
             if (!headless) {
                 loadProcesses.add(new RegisterInputSystem(context));
             }
-            loadProcesses.add(new RegisterRemoteWorldSystems(gameManifest, context));
+            loadProcesses.add(new RegisterRemoteWorldSystems(context));
             loadProcesses.add(new RegisterBlockFamilies(context));
             loadProcesses.add(new ProcessBlockPrefabs(context));
             loadProcesses.add(new InitialiseSystems(context));

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/RegisterRemoteWorldSystems.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/RegisterRemoteWorldSystems.java
@@ -7,7 +7,6 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.modes.SingleStepLoadProcess;
 import org.terasology.engine.entitySystem.systems.ComponentSystem;
-import org.terasology.engine.game.GameManifest;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.world.BlockEntityRegistry;
@@ -17,7 +16,7 @@ import org.terasology.engine.world.sun.CelestialSystem;
 public class RegisterRemoteWorldSystems extends SingleStepLoadProcess {
     private final Context context;
 
-    public RegisterRemoteWorldSystems(GameManifest gameManifest, Context context) {
+    public RegisterRemoteWorldSystems(Context context) {
         this.context = context;
     }
 

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/RegisterRemoteWorldSystems.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/RegisterRemoteWorldSystems.java
@@ -7,7 +7,6 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.modes.SingleStepLoadProcess;
 import org.terasology.engine.entitySystem.systems.ComponentSystem;
-import org.terasology.engine.game.GameManifest;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.world.BlockEntityRegistry;
@@ -16,11 +15,9 @@ import org.terasology.engine.world.sun.CelestialSystem;
 
 public class RegisterRemoteWorldSystems extends SingleStepLoadProcess {
     private final Context context;
-    private final GameManifest gameManifest;
 
     public RegisterRemoteWorldSystems(GameManifest gameManifest, Context context) {
         this.context = context;
-        this.gameManifest = gameManifest;
     }
 
     @Override
@@ -30,11 +27,6 @@ public class RegisterRemoteWorldSystems extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-//        WorldGenerator worldGenerator = context.get(WorldGenerator.class);
-//        InjectionHelper.inject(worldGenerator, context);
-//        // setting the world seed will create the world builder
-//        worldGenerator.setWorldSeed(gameManifest.getSeed());
-
         context.get(NetworkSystem.class).setRemoteWorldProvider(context.get(RemoteChunkProvider.class));
 
         ComponentSystemManager componentSystemManager = context.get(ComponentSystemManager.class);

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/RegisterRemoteWorldSystems.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/RegisterRemoteWorldSystems.java
@@ -7,6 +7,7 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.core.modes.SingleStepLoadProcess;
 import org.terasology.engine.entitySystem.systems.ComponentSystem;
+import org.terasology.engine.game.GameManifest;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.world.BlockEntityRegistry;

--- a/engine/src/main/java/org/terasology/engine/logic/console/ConsoleImpl.java
+++ b/engine/src/main/java/org/terasology/engine/logic/console/ConsoleImpl.java
@@ -50,8 +50,8 @@ public class ConsoleImpl implements Console {
     private final Context context;
 
     @Inject
-    public ConsoleImpl(Context context) {
-        this.networkSystem = context.get(NetworkSystem.class);
+    public ConsoleImpl(NetworkSystem networkSystem, Context context) {
+        this.networkSystem = networkSystem;
         this.context = context;
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/NUIManagerInternal.java
@@ -503,14 +503,14 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     }
 
     private <T extends ControlWidget> void initialiseControlWidget(T overlay, ResourceUrn screenUri) {
-        ContextImpl timedContextForModulesWidgets = new ContextImpl(this.context);
+        ContextImpl widgetContext = new ContextImpl(this.context);
 
         Module declaringModule = moduleEnvironment.get(screenUri.getModuleName());
         TypeWidgetLibrary moduleLibrary =
-                new TypeWidgetLibraryImpl(typeWidgetFactoryRegistry, declaringModule, timedContextForModulesWidgets);
-        timedContextForModulesWidgets.put(TypeWidgetLibrary.class, moduleLibrary);
+                new TypeWidgetLibraryImpl(typeWidgetFactoryRegistry, declaringModule, widgetContext);
+        widgetContext.put(TypeWidgetLibrary.class, moduleLibrary);
 
-        InjectionHelper.inject(overlay, timedContextForModulesWidgets);
+        InjectionHelper.inject(overlay, widgetContext);
 
         overlay.initialise();
     }

--- a/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
@@ -4,7 +4,6 @@ package org.terasology.engine.world.block.family;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.context.Context;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.registry.InjectionHelper;
 import org.terasology.engine.world.block.BlockBuilderHelper;
@@ -34,8 +33,8 @@ public class BlockFamilyLibrary {
 
     private ClassLibrary<BlockFamily> library;
 
-    public BlockFamilyLibrary(ModuleEnvironment moduleEnvironment, Context context) {
-        library = new DefaultModuleClassLibrary<>(() -> moduleEnvironment, context.get(ReflectFactory.class), context.get(CopyStrategyLibrary.class));
+    public BlockFamilyLibrary(ModuleEnvironment moduleEnvironment, ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategyLibrary) {
+        library = new DefaultModuleClassLibrary<>(() -> moduleEnvironment, reflectFactory, copyStrategyLibrary);
         for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterBlockFamily.class)) {
 
             if (!BlockFamily.class.isAssignableFrom(entry)) {
@@ -52,8 +51,8 @@ public class BlockFamilyLibrary {
     }
 
     @Inject
-    public BlockFamilyLibrary(ModuleManager moduleManager, Context context) {
-        this(moduleManager.getEnvironment(), context);
+    public BlockFamilyLibrary(ModuleManager moduleManager, ReflectFactory reflectFactory, CopyStrategyLibrary copyStrategyLibrary) {
+        this(moduleManager.getEnvironment(), reflectFactory, copyStrategyLibrary);
     }
 
     /**


### PR DESCRIPTION
## Summary

Phase 2 code quality follow-up to #5313, addressing BSA's review comments on #5299.

## Changes

- **RegisterRemoteWorldSystems:** Remove commented-out world generator code and unused `gameManifest` field
- **NUIManagerInternal:** Rename `timedContextForModulesWidgets` → `widgetContext`
- **ConsoleImpl:** Inject `NetworkSystem` directly instead of pulling from Context. Context retained only for lazy `PermissionManager` lookup (runtime `@Share`, not available at construction)
- **BlockFamilyLibrary:** Replace `Context` parameter with explicit `ReflectFactory` and `CopyStrategyLibrary` in both constructors

## Test Plan

- [x] Engine, engine-tests, and test compilation all pass
- [x] Local single-player game starts, console works, blocks place/break correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
