### PR TITLE
review: safeguard implicit type casts and fail-fast on null singletons

### DIFF
--- a/engine/src/main/java/org/terasology/engine/config/flexible/AutoConfigManager.java
+++ b/engine/src/main/java/org/terasology/engine/config/flexible/AutoConfigManager.java
@@ -78,8 +78,9 @@ public class AutoConfigManager {
                         logger.error("Error while loading config {} from disk", config.getId(), e); //NOPMD
                     }
                     return configClass.cast(config);
-                } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException ignore) {
-                    return null;
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                    logger.error("Failed to instantiate AutoConfig {}", configClass.getSimpleName(), e);
+                    throw new RuntimeException("Failed to instantiate AutoConfig " + configClass.getSimpleName(), e);
                 }
             });
         }

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseBlocks.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseBlocks.java
@@ -25,7 +25,12 @@ public class InitialiseBlocks extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        ((BlockManagerImpl) context.get(BlockManager.class)).initialise(gameManifest.getRegisteredBlockFamilies(), gameManifest.getBlockIdMap());
+        BlockManager blockManager = context.get(BlockManager.class);
+        if (blockManager instanceof BlockManagerImpl impl) {
+            impl.initialise(gameManifest.getRegisteredBlockFamilies(), gameManifest.getBlockIdMap());
+        } else {
+            throw new IllegalStateException("Expected BlockManagerImpl but got " + blockManager.getClass().getName());
+        }
         return true;
     }
 

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseBlocks.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseBlocks.java
@@ -29,7 +29,8 @@ public class InitialiseBlocks extends SingleStepLoadProcess {
         if (blockManager instanceof BlockManagerImpl impl) {
             impl.initialise(gameManifest.getRegisteredBlockFamilies(), gameManifest.getBlockIdMap());
         } else {
-            throw new IllegalStateException("Expected BlockManagerImpl but got " + blockManager.getClass().getName());
+            throw new IllegalStateException("Expected BlockManagerImpl but got "
+                    + (blockManager == null ? "null" : blockManager.getClass().getName()));
         }
         return true;
     }

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -382,15 +382,29 @@ public class ModuleManager {
         return loadEnvironment(new ContextImpl(), modules, asPrimary);
     }
 
+    /**
+     * Load a module environment backed by the given context's BeanContext.
+     *
+     * @param context must be a {@link ContextImpl} — the BeanContext is extracted for module
+     *                dependency injection. Use {@link #loadEnvironment(Set, boolean)} if no
+     *                specific context is needed.
+     * @param modules the modules to include in the environment
+     * @param asPrimary if true, sets this as the primary environment
+     * @return the loaded module environment
+     * @throws IllegalStateException if context is not a ContextImpl
+     */
     public ModuleEnvironment loadEnvironment(Context context, Set<Module> modules, boolean asPrimary) {
+        if (!(context instanceof ContextImpl contextImpl)) {
+            throw new IllegalStateException("loadEnvironment requires a ContextImpl but got " + context.getClass().getName());
+        }
         Set<Module> finalModules = Sets.newLinkedHashSet(modules);
         finalModules.add(engineModule);
         ModuleEnvironment newEnvironment;
         boolean permissiveSecurityEnabled = Boolean.parseBoolean(System.getProperty(SystemConfig.PERMISSIVE_SECURITY_ENABLED_PROPERTY));
         if (permissiveSecurityEnabled) {
-            newEnvironment = new ModuleEnvironment(((ContextImpl) context).getBeanContext(), finalModules, wrappingPermissionProviderFactory);
+            newEnvironment = new ModuleEnvironment(contextImpl.getBeanContext(), finalModules, wrappingPermissionProviderFactory);
         } else {
-            newEnvironment = new ModuleEnvironment(((ContextImpl) context).getBeanContext(), finalModules, permissionProviderFactory);
+            newEnvironment = new ModuleEnvironment(contextImpl.getBeanContext(), finalModules, permissionProviderFactory);
         }
         if (asPrimary) {
             environment = newEnvironment;

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -395,7 +395,8 @@ public class ModuleManager {
      */
     public ModuleEnvironment loadEnvironment(Context context, Set<Module> modules, boolean asPrimary) {
         if (!(context instanceof ContextImpl contextImpl)) {
-            throw new IllegalStateException("loadEnvironment requires a ContextImpl but got " + context.getClass().getName());
+            throw new IllegalStateException("loadEnvironment requires a ContextImpl but got "
+                    + (context == null ? "null" : context.getClass().getName()));
         }
         Set<Module> finalModules = Sets.newLinkedHashSet(modules);
         finalModules.add(engineModule);


### PR DESCRIPTION
> **AI-assisted PR.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Third review follow-up to #5299 (gestalt-di migration), focused on making implicit type assumptions explicit with safe casts, documentation, and fail-fast error handling.

## Changes

- **InitialiseBlocks:** Replace blind `BlockManager` → `BlockManagerImpl` cast with `instanceof` check and clear error message
- **ModuleManager.loadEnvironment:** Add Javadoc documenting the `ContextImpl` requirement and replace blind cast with `instanceof` + error message
- **AutoConfigManager:** Replace silent `return null` on construction failure with logged error + `RuntimeException` to prevent publishing null singletons

## Test Plan

- [x] Engine compilation passes
- [x] Single-player game starts (exercises all three code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
