### PR TITLE
review: safe JoinServer handoff, ScreenGrabber visibility, deprecate CoreRegistry constructor

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseWorld.java
@@ -83,6 +83,8 @@ public class InitialiseWorld extends SingleStepLoadProcess {
         WorldInfo worldInfo = verifyNotNull(gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD),
                 "Game manifest does not contain a MAIN_WORLD");
         verify(worldInfo.getWorldGenerator().isValid(), "Game manifest did not specify world type.");
+        // Seed is carried by the GameManifest from the UI (GameManifestProvider).
+        // Generate a random fallback if the manifest doesn't specify one.
         if (worldInfo.getSeed() == null || worldInfo.getSeed().isEmpty()) {
             FastRandom random = new FastRandom();
             worldInfo.setSeed(random.nextString(16));

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/JoinServer.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/JoinServer.java
@@ -31,6 +31,8 @@ import org.terasology.gestalt.naming.NameVersion;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 
 //TODO document this!
 public class JoinServer extends VariableStepLoadProcess {
@@ -41,7 +43,7 @@ public class JoinServer extends VariableStepLoadProcess {
     private GameManifest gameManifest;
     private JoinStatus joinStatus;
 
-    private Thread applyModuleThread;
+    private FutureTask<Context> applyModuleTask;
     private ModuleEnvironment oldEnvironment;
 
     public JoinServer(Context context, GameManifest gameManifest, JoinStatus joinStatus) {
@@ -53,7 +55,7 @@ public class JoinServer extends VariableStepLoadProcess {
 
     @Override
     public String getMessage() {
-        if (applyModuleThread != null) {
+        if (applyModuleTask != null) {
             return "${engine:menu#scanning-for-assets}";
         } else {
             return joinStatus.getCurrentActivity();
@@ -62,8 +64,21 @@ public class JoinServer extends VariableStepLoadProcess {
 
     @Override
     public boolean step() {
-        if (applyModuleThread != null) {
-            if (!applyModuleThread.isAlive()) {
+        if (applyModuleTask != null) {
+            if (applyModuleTask.isDone()) {
+                try {
+                    Context gameContext = applyModuleTask.get();
+                    CoreRegistry.setContext(gameContext);
+                } catch (ExecutionException e) {
+                    logger.error("Failed to apply game environment", e.getCause());
+                    StateMainMenu mainMenu = new StateMainMenu("Failed to apply game environment: " + e.getCause().getMessage());
+                    context.get(GameEngine.class).changeState(mainMenu);
+                    networkSystem.shutdown();
+                    return false;
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
                 if (oldEnvironment != null) {
                     oldEnvironment.close();
                 }
@@ -120,15 +135,17 @@ public class JoinServer extends VariableStepLoadProcess {
             context.get(Game.class).load(gameManifest);
 
             EnvironmentSwitchHandler environmentSwitchHandler = context.get(EnvironmentSwitchHandler.class);
-            ContextImpl modulesContext = new ContextImpl(context,
-                    moduleManager.getEnvironment().getBeans(BeanContext.class).stream().findFirst().get());
+            BeanContext moduleBeanContext = moduleManager.getEnvironment().getBeans(BeanContext.class).stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Loaded module environment did not expose a BeanContext"));
+            ContextImpl modulesContext = new ContextImpl(context, moduleBeanContext);
             ServiceRegistry gameContextRegistry = new ServiceRegistry();
-            applyModuleThread = new Thread(() -> {
+            applyModuleTask = new FutureTask<>(() -> {
                 environmentSwitchHandler.handleSwitchToGameEnvironment(modulesContext, gameContextRegistry);
-                Context gameContext = new ContextImpl(modulesContext, gameContextRegistry);
-                CoreRegistry.setContext(gameContext);
+                return new ContextImpl(modulesContext, gameContextRegistry);
             });
-            applyModuleThread.start();
+            new Thread(applyModuleTask, "apply-module-environment").start();
 
             return false;
         } else if (joinStatus.getStatus() == JoinStatus.Status.FAILED) {

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/JoinServer.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/JoinServer.java
@@ -74,7 +74,7 @@ public class JoinServer extends VariableStepLoadProcess {
                     StateMainMenu mainMenu = new StateMainMenu("Failed to apply game environment: " + e.getCause().getMessage());
                     context.get(GameEngine.class).changeState(mainMenu);
                     networkSystem.shutdown();
-                    return false;
+                    return true;
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return false;

--- a/engine/src/main/java/org/terasology/engine/persistence/internal/ReadWriteStorageManager.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/internal/ReadWriteStorageManager.java
@@ -116,6 +116,11 @@ public final class ReadWriteStorageManager extends AbstractStorageManager
     private final Game game;
     private final BlockManager blockManager;
 
+    /**
+     * @deprecated Use the @Inject constructor instead. This constructor relies on CoreRegistry
+     *             for implicit dependencies which conflicts with the DI migration.
+     */
+    @Deprecated
     public ReadWriteStorageManager(Path savePath, ModuleEnvironment environment, EngineEntityManager entityManager, BlockManager blockManager,
                                    ExtraBlockDataManager extraDataManager, RecordAndReplaySerializer recordAndReplaySerializer,
                                    RecordAndReplayUtils recordAndReplayUtils, RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) {

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -12,7 +12,6 @@ import org.terasology.engine.config.RenderingConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.GameEngine;
-import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.core.modes.StateMainMenu;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.module.rendering.RenderingModuleRegistry;
@@ -138,13 +137,6 @@ public final class WorldRendererImpl implements WorldRenderer {
     public void init() {
         initRenderingSupport();
         initRenderingModules();
-
-        // Make ScreenGrabber visible from the shared game context so that
-        // ReadWriteStorageManager.saveGamePreviewImage() can resolve it via CoreRegistry.
-        ScreenGrabber screenGrabber = context.get(ScreenGrabber.class);
-        if (screenGrabber != null) {
-            CoreRegistry.put(ScreenGrabber.class, screenGrabber);
-        }
 
         console = context.get(Console.class);
         MethodCommand.registerAvailable(this, console, context);

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -12,6 +12,7 @@ import org.terasology.engine.config.RenderingConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.GameEngine;
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.core.modes.StateMainMenu;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.module.rendering.RenderingModuleRegistry;
@@ -137,6 +138,13 @@ public final class WorldRendererImpl implements WorldRenderer {
     public void init() {
         initRenderingSupport();
         initRenderingModules();
+
+        // Make ScreenGrabber visible from the shared game context so that
+        // ReadWriteStorageManager.saveGamePreviewImage() can resolve it via CoreRegistry.
+        ScreenGrabber screenGrabber = context.get(ScreenGrabber.class);
+        if (screenGrabber != null) {
+            CoreRegistry.put(ScreenGrabber.class, screenGrabber);
+        }
 
         console = context.get(Console.class);
         MethodCommand.registerAvailable(this, console, context);


### PR DESCRIPTION
> **AI-assisted PR.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Sixth review follow-up to #5299 (gestalt-di migration). The last critical fix, plus cleanup and a partial fix for save previews.

## Changes

- **JoinServer:** Replace bare Thread with FutureTask for safe thread handoff. Exceptions are now surfaced instead of silently treated as success. Unsafe `.stream().findFirst().get()` replaced with `orElseThrow()`. CoreRegistry is now set from the main thread after the task completes, not from the worker.
- **InitialiseWorld:** Clarify seed origin with a comment — seed is carried by the GameManifest from the UI, with a random fallback.
- **ReadWriteStorageManager:** Deprecate the old constructor that relies on CoreRegistry for implicit dependencies.
- **WorldRendererImpl:** Propagate ScreenGrabber to CoreRegistry so save preview image capture can find it. This fixed one part of #5321 — the screenshot is now taken and saved to disk, but the framebuffer is empty at capture time (render loop has stopped). The remaining timing issue is tracked in #5321.

## Related

- #5321 (black save preview images — framebuffer timing)
- #5316 (overlapping NUIManagers)

## Test Plan

- [x] Engine compilation passes
- [x] Screenshot IS saved to disk (confirmed in logs)
- [x] Single-player game starts, multiplayer join works
- [x] Save preview still black due to framebuffer timing (#5321)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
