### PR TITLE
review: fix test context chaining and Environment CoreRegistry

### DIFF
--- a/engine-tests/src/main/java/org/terasology/engine/Environment.java
+++ b/engine-tests/src/main/java/org/terasology/engine/Environment.java
@@ -87,6 +87,7 @@ class Environment {
         setupCelestialSystem(serviceRegistry);
 
         this.context = new ContextImpl(serviceRegistry);
+        CoreRegistry.setContext(this.context);
 
         registerBlockTypeHandlers(this.context);
         registerCollisionTypeHandlers(this.context);

--- a/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.mock;
  * A base class for unit test classes to inherit to run in a Terasology environment - with LWJGL set up and so forth
  */
 public abstract class TerasologyTestingEnvironment {
+    private static Context baseContext;
     protected static Context context;
 
     private static final Logger logger = LoggerFactory.getLogger(TerasologyTestingEnvironment.class);
@@ -68,7 +69,8 @@ public abstract class TerasologyTestingEnvironment {
          * (Reusing a headless environment after other tests have modified the core registry isn't really clean)
          */
         env = new HeadlessEnvironment(new Name("engine"), new Name("unittest"));
-        context = env.getContext();
+        baseContext = env.getContext();
+        context = baseContext;
         CoreRegistry.setContext(context);
         moduleManager = context.get(ModuleManager.class);
 
@@ -82,7 +84,9 @@ public abstract class TerasologyTestingEnvironment {
         mockTime = mock(EngineTime.class);
         serviceRegistry.with(Time.class).lifetime(Lifetime.Singleton).use(() -> mockTime);
         NetworkSystemImpl networkSystem = new NetworkSystemImpl(mockTime, context);
-        serviceRegistry.with(Game.class).lifetime(Lifetime.Singleton).use(Game::new);
+        Game game = new Game();
+        game.load(new GameManifest("world1", "world1", 0));
+        serviceRegistry.with(Game.class).lifetime(Lifetime.Singleton).use(() -> game);
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
 
@@ -94,13 +98,12 @@ public abstract class TerasologyTestingEnvironment {
         serviceRegistry.with(DirectionAndOriginPosRecorderList.class).lifetime(Lifetime.Singleton).use(() -> directionAndOriginPosRecorderList);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
 
-        Game game = new Game();
-        game.load(new GameManifest("world1", "world1", 0));
         serviceRegistry.with(StorageManager.class).lifetime(Lifetime.Singleton).use(ReadWriteStorageManager.class);
 
         serviceRegistry.with(ComponentSystemManager.class).lifetime(Lifetime.Singleton).use(ComponentSystemManager.class);
         serviceRegistry.with(Console.class).lifetime(Lifetime.Singleton).use(ConsoleImpl.class);
-        context = new ContextImpl(context, serviceRegistry);
+        context = new ContextImpl(baseContext, serviceRegistry);
+        CoreRegistry.setContext(context);
         engineEntityManager = context.get(EngineEntityManager.class);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),
                 context.get(EntitySystemLibrary.class), moduleManager.getEnvironment(), engineEntityManager);

--- a/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
@@ -83,7 +83,7 @@ public abstract class TerasologyTestingEnvironment {
 
         mockTime = mock(EngineTime.class);
         serviceRegistry.with(Time.class).lifetime(Lifetime.Singleton).use(() -> mockTime);
-        NetworkSystemImpl networkSystem = new NetworkSystemImpl(mockTime, context);
+        NetworkSystemImpl networkSystem = new NetworkSystemImpl(mockTime, baseContext);
         Game game = new Game();
         game.load(new GameManifest("world1", "world1", 0));
         serviceRegistry.with(Game.class).lifetime(Lifetime.Singleton).use(() -> game);

--- a/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
@@ -46,13 +46,13 @@ import static org.mockito.Mockito.mock;
  * A base class for unit test classes to inherit to run in a Terasology environment - with LWJGL set up and so forth
  */
 public abstract class TerasologyTestingEnvironment {
+    protected static Context context;
+
     private static final Logger logger = LoggerFactory.getLogger(TerasologyTestingEnvironment.class);
 
     private static Context baseContext;
     private static ModuleManager moduleManager;
     private static HeadlessEnvironment env;
-
-    protected static Context context;
 
     protected EngineTime mockTime;
 
@@ -70,14 +70,14 @@ public abstract class TerasologyTestingEnvironment {
         env = new HeadlessEnvironment(new Name("engine"), new Name("unittest"));
         baseContext = env.getContext();
         context = baseContext;
-        CoreRegistry.setContext(context);
+        CoreRegistry.setContext(context); // initial setup for @BeforeAll lookups
         moduleManager = context.get(ModuleManager.class);
 
     }
 
     @BeforeEach
     public void setup() throws Exception {
-        CoreRegistry.setContext(baseContext);
+        CoreRegistry.setContext(baseContext); // clear stale per-test context from previous run
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(ModuleManager.class).lifetime(Lifetime.Singleton).use(() -> moduleManager);
 
@@ -103,7 +103,7 @@ public abstract class TerasologyTestingEnvironment {
         serviceRegistry.with(ComponentSystemManager.class).lifetime(Lifetime.Singleton).use(ComponentSystemManager.class);
         serviceRegistry.with(Console.class).lifetime(Lifetime.Singleton).use(ConsoleImpl.class);
         context = new ContextImpl(baseContext, serviceRegistry);
-        CoreRegistry.setContext(context);
+        CoreRegistry.setContext(context); // switch to per-test child context
         engineEntityManager = context.get(EngineEntityManager.class);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),
                 context.get(EntitySystemLibrary.class), moduleManager.getEnvironment(), engineEntityManager);
@@ -116,7 +116,7 @@ public abstract class TerasologyTestingEnvironment {
             complete = prefabLoadStep.step();
         }
         context.get(ComponentSystemManager.class).initialise();
-        CoreRegistry.setContext(context);
+        CoreRegistry.setContext(context); // reassert after prefab loading and system init
     }
 
     @AfterAll

--- a/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
@@ -77,6 +77,7 @@ public abstract class TerasologyTestingEnvironment {
 
     @BeforeEach
     public void setup() throws Exception {
+        CoreRegistry.setContext(baseContext);
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(ModuleManager.class).lifetime(Lifetime.Singleton).use(() -> moduleManager);
 

--- a/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
@@ -46,14 +46,13 @@ import static org.mockito.Mockito.mock;
  * A base class for unit test classes to inherit to run in a Terasology environment - with LWJGL set up and so forth
  */
 public abstract class TerasologyTestingEnvironment {
-    private static Context baseContext;
-    protected static Context context;
-
     private static final Logger logger = LoggerFactory.getLogger(TerasologyTestingEnvironment.class);
 
+    private static Context baseContext;
     private static ModuleManager moduleManager;
-
     private static HeadlessEnvironment env;
+
+    protected static Context context;
 
     protected EngineTime mockTime;
 

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -20,11 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PathManagerTest {
 
     private PathManager pathManager;
+    private PathManager originalInstance;
 
     @BeforeEach
     public void setup(@TempDir Path tempHome) throws IOException {
+        originalInstance = PathManager.getInstance();
         pathManager = PathManager.getInstance();
         pathManager.useOverrideHomePath(tempHome);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PathManager.setInstance(originalInstance);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -22,11 +23,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PathManagerTest {
 
     private PathManager pathManager;
+    private Path originalHomePath;
 
     @BeforeEach
     public void setup(@TempDir Path tempHome) throws IOException {
         pathManager = PathManager.getInstance();
+        originalHomePath = pathManager.getHomePath();
         pathManager.useOverrideHomePath(tempHome);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (originalHomePath != null && Files.isDirectory(originalHomePath)) {
+            pathManager.useOverrideHomePath(originalHomePath);
+        }
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.core;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -23,20 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PathManagerTest {
 
     private PathManager pathManager;
-    private Path originalHomePath;
 
     @BeforeEach
     public void setup(@TempDir Path tempHome) throws IOException {
         pathManager = PathManager.getInstance();
-        originalHomePath = pathManager.getHomePath();
         pathManager.useOverrideHomePath(tempHome);
-    }
-
-    @AfterEach
-    public void tearDown() throws IOException {
-        if (originalHomePath != null) {
-            pathManager.useOverrideHomePath(originalHomePath);
-        }
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -76,5 +78,78 @@ public class PathManagerTest {
     public void savePathIsUnderSavesDirectory() {
         Path savePath = pathManager.getSavePath("MyWorld");
         assertEquals(pathManager.getSavesPath(), savePath.getParent());
+    }
+
+    @Test
+    public void getSavePathEmptyOrSpecialCharactersReturnsRoot() {
+        Path savePath = pathManager.getSavePath("!!!@@@");
+        // All invalid characters are removed, leaving an empty string.
+        // Resolving an empty string against savesPath returns savesPath itself.
+        assertEquals(pathManager.getSavesPath(), savePath);
+    }
+
+    @Test
+    public void getSavePathIgnoresPathTraversal() {
+        Path savePath = pathManager.getSavePath("../../Windows/System32");
+        // Dots and slashes are removed, combining the remaining valid characters.
+        assertEquals("WindowsSystem32", savePath.getFileName().toString());
+        assertEquals(pathManager.getSavesPath(), savePath.getParent());
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    public void useDefaultHomePathMac(@TempDir Path tempHome) throws IOException {
+        String originalHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", tempHome.toString());
+            pathManager.useDefaultHomePath();
+            
+            Path expectedMacPath = tempHome.resolve("Library/Application Support/Terasology");
+            assertEquals(expectedMacPath.toAbsolutePath(), pathManager.getHomePath().toAbsolutePath());
+            assertTrue(Files.isDirectory(pathManager.getHomePath()));
+            assertTrue(Files.isDirectory(pathManager.getSavesPath()));
+        } finally {
+            if (originalHome != null) {
+                System.setProperty("user.home", originalHome);
+            } else {
+                System.clearProperty("user.home");
+            }
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    public void useDefaultHomePathLinux(@TempDir Path tempHome) throws IOException {
+        String originalHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", tempHome.toString());
+            pathManager.useDefaultHomePath();
+            
+            Path expectedLinuxPath = tempHome.resolve(".local/share/terasology");
+            assertEquals(expectedLinuxPath.toAbsolutePath(), pathManager.getHomePath().toAbsolutePath());
+            assertTrue(Files.isDirectory(pathManager.getHomePath()));
+            assertTrue(Files.isDirectory(pathManager.getSavesPath()));
+        } finally {
+            if (originalHome != null) {
+                System.setProperty("user.home", originalHome);
+            } else {
+                System.clearProperty("user.home");
+            }
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void useDefaultHomePathWindows() throws IOException {
+        // Windows relies on JNA (Shell32Util) which directly interrogates the Windows Registry/API.
+        // We cannot easily redirect this to a @TempDir. We only verify that the path resolves to a valid Windows dir.
+        // Note: This will create a 'Terasology' folder in the local user's AppData/Saved Games! 
+        pathManager.useDefaultHomePath();
+        assertNotNull(pathManager.getHomePath());
+        
+        // It should end with Terasology
+        assertTrue(pathManager.getHomePath().toString().endsWith("Terasology"));
+        assertTrue(Files.isDirectory(pathManager.getHomePath()));
+        assertTrue(Files.isDirectory(pathManager.getSavesPath()));
     }
 }

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -32,10 +32,22 @@ public class PathManagerTest {
         pathManager.useOverrideHomePath(tempHome);
     }
 
+    /**
+     * Leave the singleton pointing at a directory that actually exists.
+     * <p>
+     * Restoring the original is only right while it is still there. Simply skipping restoration when
+     * it is not - which is what a bare guard does - is the worse option: it leaves the singleton on
+     * this test's {@link TempDir}, which JUnit deletes the moment this class finishes, so the next
+     * class to read the home path fails and the problem propagates instead of stopping here.
+     */
     @AfterEach
     public void tearDown() throws IOException {
         if (originalHomePath != null && Files.isDirectory(originalHomePath)) {
             pathManager.useOverrideHomePath(originalHomePath);
+        } else {
+            Path fallback = Files.createTempDirectory("terasology-pathmanager");
+            fallback.toFile().deleteOnExit();
+            pathManager.useOverrideHomePath(fallback);
         }
     }
 

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -23,18 +23,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PathManagerTest {
 
     private PathManager pathManager;
-    private PathManager originalInstance;
+    private Path originalHomePath;
 
     @BeforeEach
     public void setup(@TempDir Path tempHome) throws IOException {
-        originalInstance = PathManager.getInstance();
         pathManager = PathManager.getInstance();
+        originalHomePath = pathManager.getHomePath();
         pathManager.useOverrideHomePath(tempHome);
     }
 
     @AfterEach
-    public void tearDown() {
-        PathManager.setInstance(originalInstance);
+    public void tearDown() throws IOException {
+        if (originalHomePath != null) {
+            pathManager.useOverrideHomePath(originalHomePath);
+        }
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -1,0 +1,72 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PathManager} path resolution and directory creation.
+ */
+public class PathManagerTest {
+
+    private PathManager pathManager;
+
+    @BeforeEach
+    public void setup(@TempDir Path tempHome) throws IOException {
+        pathManager = PathManager.getInstance();
+        pathManager.useOverrideHomePath(tempHome);
+    }
+
+    @Test
+    public void overrideHomePathSetsAllDirectories() {
+        assertNotNull(pathManager.getHomePath());
+        assertNotNull(pathManager.getSavesPath());
+        assertNotNull(pathManager.getLogPath());
+        assertNotNull(pathManager.getScreenshotPath());
+        assertNotNull(pathManager.getConfigsPath());
+        assertNotNull(pathManager.getInstallPath());
+    }
+
+    @Test
+    public void overrideHomePathCreatesDirectories() {
+        assertTrue(Files.isDirectory(pathManager.getSavesPath()));
+        assertTrue(Files.isDirectory(pathManager.getLogPath()));
+        assertTrue(Files.isDirectory(pathManager.getScreenshotPath()));
+        assertTrue(Files.isDirectory(pathManager.getConfigsPath()));
+    }
+
+    @Test
+    public void getSavePathSanitizesTitle() {
+        Path savePath = pathManager.getSavePath("My!World@Test");
+        // Only alphanumeric, hyphens, underscores, and spaces are kept
+        assertEquals("MyWorldTest", savePath.getFileName().toString());
+    }
+
+    @Test
+    public void getSavePathPreservesValidTitle() {
+        Path savePath = pathManager.getSavePath("Game 1 - Test_World");
+        assertEquals("Game 1 - Test_World", savePath.getFileName().toString());
+    }
+
+    @Test
+    public void getRecordingPathSanitizesTitle() {
+        Path recordingPath = pathManager.getRecordingPath("recording<>:test");
+        assertEquals("recordingtest", recordingPath.getFileName().toString());
+    }
+
+    @Test
+    public void savePathIsUnderSavesDirectory() {
+        Path savePath = pathManager.getSavePath("MyWorld");
+        assertEquals(pathManager.getSavesPath(), savePath.getParent());
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/BaseEntityRefTest.java
@@ -46,6 +46,7 @@ import static org.terasology.engine.entitySystem.entity.internal.EntityScope.SEC
 
 public class BaseEntityRefTest {
 
+    private static Context baseContext;
     private static Context context;
     private PojoEntityManager entityManager;
     private EntityRef ref;
@@ -62,7 +63,8 @@ public class BaseEntityRefTest {
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
         serviceRegistry.with(AssetManager.class).lifetime(Lifetime.Singleton).use(() -> assetTypeManager.getAssetManager());
         serviceRegistry.with(RecordAndReplayCurrentStatus.class).lifetime(Lifetime.Singleton).use(() -> new RecordAndReplayCurrentStatus());
-        context = new ContextImpl(serviceRegistry);
+        baseContext = new ContextImpl(serviceRegistry);
+        context = baseContext;
         CoreRegistry.setContext(context);
     }
 
@@ -74,7 +76,8 @@ public class BaseEntityRefTest {
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
-        context = new ContextImpl(context, serviceRegistry);
+        context = new ContextImpl(baseContext, serviceRegistry);
+        CoreRegistry.setContext(context);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),
                 context.get(EntitySystemLibrary.class), context.get(ModuleManager.class).getEnvironment(),
                 context.get(EngineEntityManager.class));

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityManagerTest.java
@@ -62,6 +62,7 @@ import static org.terasology.engine.entitySystem.entity.internal.EntityScope.CHU
 
 public class PojoEntityManagerTest {
 
+    private static Context baseContext;
     private static Context context;
     private PojoEntityManager entityManager;
     private Prefab prefab;
@@ -77,7 +78,8 @@ public class PojoEntityManagerTest {
         serviceRegistry.with(AssetManager.class).lifetime(Lifetime.Singleton).use(() -> assetTypeManager.getAssetManager());
         RecordAndReplayCurrentStatus recordAndReplayCurrentStatus = new RecordAndReplayCurrentStatus();
         serviceRegistry.with(RecordAndReplayCurrentStatus.class).lifetime(Lifetime.Singleton).use(() -> recordAndReplayCurrentStatus);
-        context = new ContextImpl(serviceRegistry);
+        baseContext = new ContextImpl(serviceRegistry);
+        context = baseContext;
         CoreRegistry.setContext(context);
     }
 
@@ -86,12 +88,13 @@ public class PojoEntityManagerTest {
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
         ServiceRegistry serviceRegistry = new ServiceRegistry();
-        TypeRegistry typeRegistry = new ModuleTypeRegistry(context.get(ModuleManager.class).getEnvironment());
+        TypeRegistry typeRegistry = new ModuleTypeRegistry(baseContext.get(ModuleManager.class).getEnvironment());
         serviceRegistry.with(TypeRegistry.class).lifetime(Lifetime.Singleton).use(() -> typeRegistry);
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
-        context = new ContextImpl(context, serviceRegistry);
+        context = new ContextImpl(baseContext, serviceRegistry);
+        CoreRegistry.setContext(context);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),
                 context.get(EntitySystemLibrary.class), context.get(ModuleManager.class).getEnvironment(),
                 context.get(EngineEntityManager.class));

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityPoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityPoolTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 public class PojoEntityPoolTest {
 
+    private static Context baseContext;
     private static Context context;
     private PojoEntityPool pool;
     private PojoEntityManager entityManager;
@@ -55,7 +56,8 @@ public class PojoEntityPoolTest {
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
         serviceRegistry.with(AssetManager.class).lifetime(Lifetime.Singleton).use(() -> assetTypeManager.getAssetManager());
         serviceRegistry.with(RecordAndReplayCurrentStatus.class).lifetime(Lifetime.Singleton).use(() -> new RecordAndReplayCurrentStatus());
-        context = new ContextImpl(serviceRegistry);
+        baseContext = new ContextImpl(serviceRegistry);
+        context = baseContext;
         CoreRegistry.setContext(context);
     }
 
@@ -66,8 +68,9 @@ public class PojoEntityPoolTest {
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context, serviceRegistry);
-        context = new ContextImpl(context, serviceRegistry);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(baseContext, serviceRegistry);
+        context = new ContextImpl(baseContext, serviceRegistry);
+        CoreRegistry.setContext(context);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),
                 context.get(EntitySystemLibrary.class), context.get(ModuleManager.class).getEnvironment(),
                 context.get(EngineEntityManager.class));

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityPoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityPoolTest.java
@@ -68,7 +68,7 @@ public class PojoEntityPoolTest {
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(baseContext, serviceRegistry);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(baseContext, serviceRegistry);
         CoreRegistry.setContext(context);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/EntitySerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/EntitySerializerTest.java
@@ -56,6 +56,7 @@ import static org.terasology.engine.entitySystem.entity.internal.EntityScope.GLO
 
 public class EntitySerializerTest {
 
+    private static Context baseContext;
     private static Context context;
     private static ModuleManager moduleManager;
     private ComponentLibrary componentLibrary;
@@ -76,7 +77,8 @@ public class EntitySerializerTest {
         assetTypeManager.createAssetType(Prefab.class, PojoPrefab::new, "prefabs");
         assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
         serviceRegistry.with(AssetManager.class).lifetime(Lifetime.Singleton).use(() -> assetTypeManager.getAssetManager());
-        context = new ContextImpl(serviceRegistry);
+        baseContext = new ContextImpl(serviceRegistry);
+        context = baseContext;
         CoreRegistry.setContext(context);
     }
 
@@ -92,7 +94,8 @@ public class EntitySerializerTest {
         serviceRegistry.with(TypeRegistry.class).lifetime(Lifetime.Singleton).use(() -> typeRegistry);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
-        context = new ContextImpl(context, serviceRegistry);
+        context = new ContextImpl(baseContext, serviceRegistry);
+        CoreRegistry.setContext(context);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(context.get(TypeHandlerLibrary.class),
                 context.get(EntitySystemLibrary.class), context.get(ModuleManager.class).getEnvironment(),
                 context.get(EngineEntityManager.class));

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
@@ -49,13 +49,20 @@ public class TestModuleEnvironmentSandbox {
     /**
      * Put the PathManager singleton back where we found it. Without this the global instance keeps
      * pointing at the {@link TempDir} above, which JUnit deletes once this class finishes - any later
-     * test class reading {@code PathManager.getHomePath()} then hits a directory that is gone. Same
-     * restore (and the same already-deleted guard) as PathManagerTest.
+     * test class reading {@code PathManager.getHomePath()} then hits a directory that is gone.
+     * <p>
+     * If the original is itself already gone, fall back to a fresh directory that outlives this class
+     * rather than skipping the restore: skipping would leave the singleton on the doomed
+     * {@link TempDir} and pass the same breakage on to whatever runs next. Mirrors PathManagerTest.
      */
     @AfterEach
     public void restorePathManager() throws IOException {
         if (originalHomePath != null && Files.isDirectory(originalHomePath)) {
             PathManager.getInstance().useOverrideHomePath(originalHomePath);
+        } else {
+            Path fallback = Files.createTempDirectory("terasology-pathmanager");
+            fallback.toFile().deleteOnExit();
+            PathManager.getInstance().useOverrideHomePath(fallback);
         }
     }
 

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
@@ -3,7 +3,6 @@
 
 package org.terasology.engine.persistence.typeHandling.reflection;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,11 +26,8 @@ public class TestModuleEnvironmentSandbox {
     private TypeRegistry typeRegistry;
     private ModuleManager moduleManager;
     private ModuleEnvironment environment;
-    private Path originalHomePath;
-
     @BeforeEach
     protected void provideSandbox(@TempDir Path tempHome) throws Exception {
-        originalHomePath = PathManager.getInstance().getHomePath();
         PathManager.getInstance().useOverrideHomePath(tempHome);
         moduleManager = ModuleManagerFactory.create();
         environment = moduleManager.getEnvironment();
@@ -42,13 +38,6 @@ public class TestModuleEnvironmentSandbox {
         sandbox = new ModuleEnvironmentSandbox(moduleManager, typeRegistry);
 
         // module = environment.get(new Name("unittest"));
-    }
-
-    @AfterEach
-    protected void restorePathManager() throws Exception {
-        if (originalHomePath != null) {
-            PathManager.getInstance().useOverrideHomePath(originalHomePath);
-        }
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.persistence.typeHandling.reflection;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -15,6 +16,8 @@ import org.terasology.reflection.ModuleTypeRegistry;
 import org.terasology.reflection.TypeRegistry;
 import org.terasology.unittest.ExampleInterface;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.terasology.engine.testUtil.Assertions.assertNotEmpty;
@@ -26,8 +29,11 @@ public class TestModuleEnvironmentSandbox {
     private TypeRegistry typeRegistry;
     private ModuleManager moduleManager;
     private ModuleEnvironment environment;
+    private Path originalHomePath;
+
     @BeforeEach
     protected void provideSandbox(@TempDir Path tempHome) throws Exception {
+        originalHomePath = PathManager.getInstance().getHomePath();
         PathManager.getInstance().useOverrideHomePath(tempHome);
         moduleManager = ModuleManagerFactory.create();
         environment = moduleManager.getEnvironment();
@@ -38,6 +44,19 @@ public class TestModuleEnvironmentSandbox {
         sandbox = new ModuleEnvironmentSandbox(moduleManager, typeRegistry);
 
         // module = environment.get(new Name("unittest"));
+    }
+
+    /**
+     * Put the PathManager singleton back where we found it. Without this the global instance keeps
+     * pointing at the {@link TempDir} above, which JUnit deletes once this class finishes - any later
+     * test class reading {@code PathManager.getHomePath()} then hits a directory that is gone. Same
+     * restore (and the same already-deleted guard) as PathManagerTest.
+     */
+    @AfterEach
+    public void restorePathManager() throws IOException {
+        if (originalHomePath != null && Files.isDirectory(originalHomePath)) {
+            PathManager.getInstance().useOverrideHomePath(originalHomePath);
+        }
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.persistence.typeHandling.reflection;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -26,9 +27,11 @@ public class TestModuleEnvironmentSandbox {
     private TypeRegistry typeRegistry;
     private ModuleManager moduleManager;
     private ModuleEnvironment environment;
+    private Path originalHomePath;
 
     @BeforeEach
     protected void provideSandbox(@TempDir Path tempHome) throws Exception {
+        originalHomePath = PathManager.getInstance().getHomePath();
         PathManager.getInstance().useOverrideHomePath(tempHome);
         moduleManager = ModuleManagerFactory.create();
         environment = moduleManager.getEnvironment();
@@ -39,6 +42,13 @@ public class TestModuleEnvironmentSandbox {
         sandbox = new ModuleEnvironmentSandbox(moduleManager, typeRegistry);
 
         // module = environment.get(new Name("unittest"));
+    }
+
+    @AfterEach
+    protected void restorePathManager() throws Exception {
+        if (originalHomePath != null) {
+            PathManager.getInstance().useOverrideHomePath(originalHomePath);
+        }
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/typeHandling/reflection/TestModuleEnvironmentSandbox.java
@@ -5,10 +5,8 @@ package org.terasology.engine.persistence.typeHandling.reflection;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.terasology.engine.core.PathManager;
-import org.terasology.engine.core.PathManagerProvider;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
 import org.terasology.engine.world.block.family.BlockFamily;
@@ -17,13 +15,10 @@ import org.terasology.reflection.ModuleTypeRegistry;
 import org.terasology.reflection.TypeRegistry;
 import org.terasology.unittest.ExampleInterface;
 
-import java.util.Collections;
+import java.nio.file.Path;
 
-import static org.mockito.Mockito.when;
 import static org.terasology.engine.testUtil.Assertions.assertNotEmpty;
 
-@ExtendWith(PathManagerProvider.class)
-@ExtendWith(MockitoExtension.class)
 @SuppressWarnings("FieldCanBeLocal")
 public class TestModuleEnvironmentSandbox {
 
@@ -33,8 +28,8 @@ public class TestModuleEnvironmentSandbox {
     private ModuleEnvironment environment;
 
     @BeforeEach
-    protected void provideSandbox(PathManager pathManager) throws Exception {
-        when(pathManager.getModulePaths()).thenReturn(Collections.emptyList());
+    protected void provideSandbox(@TempDir Path tempHome) throws Exception {
+        PathManager.getInstance().useOverrideHomePath(tempHome);
         moduleManager = ModuleManagerFactory.create();
         environment = moduleManager.getEnvironment();
 


### PR DESCRIPTION
  > **AI-assisted PR.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

  ## Summary

  Seventh review follow-up to #5299 (gestalt-di migration). Test context isolation, new PathManager tests, and a pre-existing test ordering bug fix.

  ## Changes

  - **Test context chaining (5 files):** Introduced `baseContext` pattern — `@BeforeAll` creates a   stable root, `@BeforeEach` creates child contexts from that root instead of chaining from the previous test's context. Also registers a loaded `Game` instance instead of `Game::new`.        
  - **Environment.reset():** Update CoreRegistry after replacing the context with the serviceRegistry-backed one.
  - **TestModuleEnvironmentSandbox:** Fixed 3 tests that failed locally but passed in Jenkins (see   below).
  - **PojoEntityPoolTest:** Use non-deprecated `addEntityManagementRelatedClasses` overload.      
  - **PathManager test coverage:** New test class with singleton cleanup (see below).

  ### TestModuleEnvironmentSandbox — test ordering bug

  These 3 tests used `PathManagerProvider` to mock the `PathManager` singleton, but the mock didn't stub `getInstallPath()`. The `ModuleManager` constructor calls `Jvm.logClasspath()` which needs that method, so the tests NPE'd — unless they ran after another test class that had initialized the real PathManager singleton, giving the mock a real instance to fall back on.    

  Jenkins happened to run classes in a favorable order. Local Gradle didn't.

  Fixed by replacing the incomplete mock with `@TempDir` + the real `PathManager`, matching the pattern used by other test classes. The test verifies `ModuleEnvironmentSandbox` type resolution, not PathManager behavior.

  ### PathManager tests (new)

  PathManager had zero test coverage. Added tests for:

  - `useOverrideHomePath` — verifies all directory paths are set and created
  - `getSavePath` / `getRecordingPath` — title sanitization (special chars stripped, path traversal neutralized)
  - Edge case: all-special-char title resolves to saves root (documents a latent sanitization gap)  
  - Platform-specific `useDefaultHomePath` gated by `@EnabledOnOs` (Linux, Mac, Windows)

  Note: the Windows `useDefaultHomePath` test creates a real `Terasology` directory under the user's Saved Games folder via JNA. Not destructive but a known side effect — future candidate for a `@Tag("filesystem-side-effects")` group.

  Additional tests contributed via Gemini review.

  ## Test Plan

  - [x] 859 tests, zero failures (was 853 with 3 failures before this PR)
  - [x] Full suite rerun confirms no test ordering dependencies
  - [x] All modified test classes pass individually and as a group

  🤖 Generated with [Claude Code](https://claude.com/claude-code)