### PR TITLE
refactor: replace blacklist/whitelist terminology with denylist/allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,9 +94,11 @@ config/metrics/
 API_file.txt
 New_API_file.txt
 
-# Ignore Whitelist and Blacklist files
+# Ignore Whitelist/Allowlist and Blacklist/Denylist files
 whitelist.json
 blacklist.json
+allowlist.json
+denylist.json
 
 # Profiling related
 terasology.jfr

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="3">
@@ -15,5 +14,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -15,5 +15,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" project-jdk-name="temurin-23" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="3">
@@ -14,5 +15,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" project-jdk-name="temurin-23" project-jdk-type="JavaSDK" />
 </project>

--- a/docs/Modding-API.md
+++ b/docs/Modding-API.md
@@ -1,13 +1,13 @@
 Modding API
 =================
 
-Terasology's engine uses a whitelisting approach to expose an API for modules using two primary methods and a rarely needed third one:
+Terasology's engine uses a allowlisting approach to expose an API for modules using two primary methods and a rarely needed third one:
 
 * Classes or packages marked with the `@API` annotation
-* Classes or packages in the basic whitelist defined in `ExternalApiWhitelist.java`
+* Classes or packages in the basic allowlist defined in `ExternalApiWhitelist.java`
 * Rarely blocks of code in the engine may be hit in a way requiring use of `AccessController.doPrivileged(...)` - usually module authors do not need to worry about this but once in a while it could explain something quirky.
 
-This is to both protect the user's system from malicious code (for instance you cannot use `java.io.File` directly) and to better document what is available. If you attempt to use a class not on the whitelist you'll get log message like:
+This is to both protect the user's system from malicious code (for instance you cannot use `java.io.File` directly) and to better document what is available. If you attempt to use a class not on the allowlist you'll get log message like:
 
 `Denied access to class (not allowed with this module's permissions): some.package.and.class`
 

--- a/docs/Playing.md
+++ b/docs/Playing.md
@@ -143,13 +143,13 @@ Alternatively you can run from source and supply parameters for game configurati
 
 This will all become easier as the project and especially the launcher mature further :-)
 
-### Server Whitelist and Blacklist
+### Server Allowlist and Denylist
 
-Hosting a server will create a whitelist and a blacklist that can be used to manage who is able to connect to that server.
+Hosting a server will create a allowlist and a denylist that can be used to manage who is able to connect to that server.
 
-If the whitelist contains at least one client ID, only the ID(s) on the list will be allowed to connect to the server. All IDs not on the whitelist are effectively blacklisted.
+If the allowlist contains at least one client ID, only the ID(s) on the list will be allowed to connect to the server. All IDs not on the allowlist are effectively denylisted.
 
-If the whitelist is empty, any ID not on the blacklist will be able to connect. 
+If the allowlist is empty, any ID not on the denylist will be able to connect. 
 
 Client IDs are added to the lists in JSON format, for example: ["6a5f11f7-4038-4ef0-91ac-86cb957588b1","01264d12-27cf-4699-b8e2-bdc92ac8ef73"]
 

--- a/engine-tests/src/test/java/org/terasology/engine/network/ServerConnectListManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/network/ServerConnectListManagerTest.java
@@ -4,6 +4,7 @@
 package org.terasology.engine.network;
 
 import com.google.gson.Gson;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -29,9 +30,11 @@ class ServerConnectListManagerTest {
     Path tempDir;
 
     private Context context;
+    private Path originalHomePath;
 
     @BeforeEach
     void setUp() throws IOException {
+        originalHomePath = PathManager.getInstance().getHomePath();
         PathManager.getInstance().useOverrideHomePath(tempDir);
 
         DisplayDevice display = mock(DisplayDevice.class);
@@ -39,6 +42,11 @@ class ServerConnectListManagerTest {
 
         context = mock(Context.class);
         when(context.get(DisplayDevice.class)).thenReturn(display);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        PathManager.getInstance().useOverrideHomePath(originalHomePath);
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/network/ServerConnectListManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/network/ServerConnectListManagerTest.java
@@ -1,0 +1,92 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.network;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.terasology.engine.context.Context;
+import org.terasology.engine.core.PathManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
+import org.terasology.engine.network.internal.ServerConnectListManager;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ServerConnectListManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Context context;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PathManager.getInstance().useOverrideHomePath(tempDir);
+
+        DisplayDevice display = mock(DisplayDevice.class);
+        when(display.isHeadless()).thenReturn(true);
+
+        context = mock(Context.class);
+        when(context.get(DisplayDevice.class)).thenReturn(display);
+    }
+
+    @Test
+    void blacklistJsonIsMigratedToDenylistOnStartup() throws IOException {
+        writeJson(tempDir.resolve("blacklist.json"), Set.of("banned-client"));
+
+        ServerConnectListManager manager = new ServerConnectListManager(context);
+
+        assertTrue(manager.getDenylist().contains("banned-client"),
+                "Entry from blacklist.json should be loaded into the denylist after migration");
+        assertFalse(Files.exists(tempDir.resolve("blacklist.json")),
+                "blacklist.json should be removed after migration");
+        assertTrue(Files.exists(tempDir.resolve("denylist.json")),
+                "denylist.json should exist after migration");
+    }
+
+    @Test
+    void whitelistJsonIsMigratedToAllowlistOnStartup() throws IOException {
+        writeJson(tempDir.resolve("whitelist.json"), Set.of("trusted-client"));
+
+        ServerConnectListManager manager = new ServerConnectListManager(context);
+
+        assertTrue(manager.getAllowlist().contains("trusted-client"),
+                "Entry from whitelist.json should be loaded into the allowlist after migration");
+        assertFalse(Files.exists(tempDir.resolve("whitelist.json")),
+                "whitelist.json should be removed after migration");
+        assertTrue(Files.exists(tempDir.resolve("allowlist.json")),
+                "allowlist.json should exist after migration");
+    }
+
+    @Test
+    void existingDenylistIsNotOverwrittenByLegacyBlacklist() throws IOException {
+        writeJson(tempDir.resolve("blacklist.json"), Set.of("legacy-client"));
+        writeJson(tempDir.resolve("denylist.json"), Set.of("current-client"));
+
+        ServerConnectListManager manager = new ServerConnectListManager(context);
+
+        assertTrue(manager.getDenylist().contains("current-client"),
+                "Existing denylist.json entries should be preserved");
+        assertFalse(manager.getDenylist().contains("legacy-client"),
+                "blacklist.json should not overwrite an existing denylist.json");
+        assertTrue(Files.exists(tempDir.resolve("blacklist.json")),
+                "blacklist.json should be left untouched when denylist.json already exists");
+    }
+
+    private void writeJson(Path path, Set<String> entries) throws IOException {
+        try (Writer writer = Files.newBufferedWriter(path)) {
+            writer.write(new Gson().toJson(entries));
+        }
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/network/ServerConnectListManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/network/ServerConnectListManagerTest.java
@@ -24,10 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class ServerConnectListManagerTest {
+/**
+ * Tests for {@link org.terasology.engine.network.internal.ServerConnectListManager}.
+ * Verifies that legacy {@code blacklist.json} and {@code whitelist.json} files are
+ * automatically migrated to {@code denylist.json} and {@code allowlist.json} on startup,
+ * and that existing new-format files are never overwritten by legacy ones.
+ */
+public class ServerConnectListManagerTest {
 
     @TempDir
-    Path tempDir;
+    private Path tempDir;
 
     private Context context;
     private Path originalHomePath;

--- a/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
@@ -21,6 +21,8 @@ import java.util.Set;
 /**
  * This class provides the methods needed to determine if a client is allowed to connect or not,
  * based on the denylist and allowlist files.
+ *
+ * To account for legacy blacklist and whitelist files on old servers, migrateLegacyFiles() will migrate these files to denylist and allowlist respectively.
  */
 
 public class ServerConnectListManager {
@@ -45,6 +47,7 @@ public class ServerConnectListManager {
     @SuppressWarnings("unchecked")
     private void loadLists() {
         try {
+            migrateLegacyFiles();
             if (createFiles()) {
                 denylistedIDs = GSON.fromJson(Files.newBufferedReader(denylistPath), Set.class);
                 allowlistedIDs = GSON.fromJson(Files.newBufferedReader(allowlistPath), Set.class);
@@ -138,5 +141,24 @@ public class ServerConnectListManager {
 
     private boolean isClientAllowlisted(String clientID) {
         return allowlistedIDs == null || allowlistedIDs.isEmpty() || allowlistedIDs.contains(clientID);
+    }
+
+    private void migrateLegacyFiles(){
+        Path homePath = PathManager.getInstance().getHomePath();
+        Path legacyDenylist = homePath.resolve("blacklist.json");
+        Path legacyAllowlist = homePath.resolve("whitelist.json");
+
+        try{
+            if (Files.exists(legacyDenylist) && !Files.exists(denylistPath)){
+                Files.move(legacyDenylist, denylistPath);
+                logger.info("Migrated blacklist.json -> denylist.json");
+            }
+            if (Files.exists(legacyAllowlist) && !Files.exists(allowlistPath)) {
+                Files.move(legacyAllowlist, allowlistPath);
+                logger.info("Migrated whitelist.json -> allowlist.json");
+            }
+        } catch (IOException e){
+            logger.error("Failed to migrate legacy connect list files: ", e);
+        }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 /**
  * This class provides the methods needed to determine if a client is allowed to connect or not,
- * based on the blacklist and whitelist files.
+ * based on the denylist and allowlist files.
  */
 
 public class ServerConnectListManager {
@@ -29,15 +29,15 @@ public class ServerConnectListManager {
     private static final Gson GSON = new Gson();
 
     private Context context;
-    private Set<String> blacklistedIDs;
-    private Set<String> whitelistedIDs;
-    private final Path blacklistPath;
-    private final Path whitelistPath;
+    private Set<String> denylistedIDs;
+    private Set<String> allowlistedIDs;
+    private final Path denylistPath;
+    private final Path allowlistPath;
 
     @Inject
     public ServerConnectListManager(Context context) {
-        blacklistPath = PathManager.getInstance().getHomePath().resolve("blacklist.json");
-        whitelistPath = PathManager.getInstance().getHomePath().resolve("whitelist.json");
+        denylistPath = PathManager.getInstance().getHomePath().resolve("denylist.json");
+        allowlistPath = PathManager.getInstance().getHomePath().resolve("allowlist.json");
         this.context = context;
         loadLists();
     }
@@ -46,29 +46,29 @@ public class ServerConnectListManager {
     private void loadLists() {
         try {
             if (createFiles()) {
-                blacklistedIDs = GSON.fromJson(Files.newBufferedReader(blacklistPath), Set.class);
-                whitelistedIDs = GSON.fromJson(Files.newBufferedReader(whitelistPath), Set.class);
-                if (blacklistedIDs == null) {
-                    blacklistedIDs = new HashSet<>();
+                denylistedIDs = GSON.fromJson(Files.newBufferedReader(denylistPath), Set.class);
+                allowlistedIDs = GSON.fromJson(Files.newBufferedReader(allowlistPath), Set.class);
+                if (denylistedIDs == null) {
+                    denylistedIDs = new HashSet<>();
                 }
-                if (whitelistedIDs == null) {
-                    whitelistedIDs = new HashSet<>();
+                if (allowlistedIDs == null) {
+                    allowlistedIDs = new HashSet<>();
                 }
             }
         } catch (IOException e) {
-            logger.error("Whitelist or blacklist files not found:", e);
+            logger.error("Allowlist or denylist files not found:", e);
         }
     }
 
     private void saveLists() {
         try {
             if (createFiles()) {
-                Writer blacklistWriter = Files.newBufferedWriter(blacklistPath);
-                Writer whitelistWriter = Files.newBufferedWriter(whitelistPath);
-                blacklistWriter.write(GSON.toJson(blacklistedIDs));
-                whitelistWriter.write(GSON.toJson(whitelistedIDs));
-                blacklistWriter.close();
-                whitelistWriter.close();
+                Writer denylistWriter = Files.newBufferedWriter(denylistPath);
+                Writer allowlistWriter = Files.newBufferedWriter(allowlistPath);
+                denylistWriter.write(GSON.toJson(denylistedIDs));
+                allowlistWriter.write(GSON.toJson(allowlistedIDs));
+                denylistWriter.close();
+                allowlistWriter.close();
             }
         } catch (IOException e) {
             logger.error("Couldn't save lists: ", e);
@@ -80,63 +80,63 @@ public class ServerConnectListManager {
         if (display == null || !display.isHeadless()) {
             return false;
         }
-        if (!Files.exists(blacklistPath)) {
-            Files.createFile(blacklistPath);
+        if (!Files.exists(denylistPath)) {
+            Files.createFile(denylistPath);
         }
-        if (!Files.exists(whitelistPath)) {
-            Files.createFile(whitelistPath);
+        if (!Files.exists(allowlistPath)) {
+            Files.createFile(allowlistPath);
         }
         return true;
     }
 
     public String getErrorMessage(String clientID) {
-        if (isClientBlacklisted(clientID)) {
-            return "client on blacklist";
+        if (isClientDenylisted(clientID)) {
+            return "client on denylist";
         }
-        if (!isClientWhitelisted(clientID)) {
-            return "client not on whitelist";
+        if (!isClientAllowlisted(clientID)) {
+            return "client not on allowlist";
         }
         return null;
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isClientAllowedToConnect(String clientID) {
-        return !isClientBlacklisted(clientID) && isClientWhitelisted(clientID);
+        return !isClientDenylisted(clientID) && isClientAllowlisted(clientID);
     }
 
-    public void addToWhitelist(String clientID) {
-        whitelistedIDs.add(clientID);
+    public void addToAllowlist(String clientID) {
+        allowlistedIDs.add(clientID);
         saveLists();
     }
 
-    public void removeFromWhitelist(String clientID) {
-        whitelistedIDs.remove(clientID);
+    public void removeFromAllowlist(String clientID) {
+        allowlistedIDs.remove(clientID);
         saveLists();
     }
 
-    public Set getWhitelist() {
-        return Collections.unmodifiableSet(whitelistedIDs);
+    public Set getAllowlist() {
+        return Collections.unmodifiableSet(allowlistedIDs);
     }
 
-    public void addToBlacklist(String clientID) {
-        blacklistedIDs.add(clientID);
+    public void addToDenylist(String clientID) {
+        denylistedIDs.add(clientID);
         saveLists();
     }
 
-    public void removeFromBlacklist(String clientID) {
-        blacklistedIDs.remove(clientID);
+    public void removeFromDenylist(String clientID) {
+        denylistedIDs.remove(clientID);
         saveLists();
     }
 
-    public Set getBlacklist() {
-        return Collections.unmodifiableSet(blacklistedIDs);
+    public Set getDenylist() {
+        return Collections.unmodifiableSet(denylistedIDs);
     }
 
-    private boolean isClientBlacklisted(String clientID) {
-        return blacklistedIDs != null && blacklistedIDs.contains(clientID);
+    private boolean isClientDenylisted(String clientID) {
+        return denylistedIDs != null && denylistedIDs.contains(clientID);
     }
 
-    private boolean isClientWhitelisted(String clientID) {
-        return whitelistedIDs == null || whitelistedIDs.isEmpty() || whitelistedIDs.contains(clientID);
+    private boolean isClientAllowlisted(String clientID) {
+        return allowlistedIDs == null || allowlistedIDs.isEmpty() || allowlistedIDs.contains(clientID);
     }
 }

--- a/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
@@ -22,7 +22,8 @@ import java.util.Set;
  * This class provides the methods needed to determine if a client is allowed to connect or not,
  * based on the denylist and allowlist files.
  *
- * To account for legacy blacklist and whitelist files on old servers, migrateLegacyFiles() will migrate these files to denylist and allowlist respectively.
+ * To account for legacy blacklist and whitelist files on old servers,
+ * migrateLegacyFiles() will migrate these files to denylist and allowlist respectively.
  */
 
 public class ServerConnectListManager {
@@ -143,22 +144,27 @@ public class ServerConnectListManager {
         return allowlistedIDs == null || allowlistedIDs.isEmpty() || allowlistedIDs.contains(clientID);
     }
 
-    private void migrateLegacyFiles(){
+    private void migrateLegacyFiles() {
         Path homePath = PathManager.getInstance().getHomePath();
-        Path legacyDenylist = homePath.resolve("blacklist.json");
-        Path legacyAllowlist = homePath.resolve("whitelist.json");
 
-        try{
-            if (Files.exists(legacyDenylist) && !Files.exists(denylistPath)){
+        try {
+            Path legacyDenylist = homePath.resolve("blacklist.json");
+            if (Files.exists(legacyDenylist) && !Files.exists(denylistPath)) {
                 Files.move(legacyDenylist, denylistPath);
                 logger.info("Migrated blacklist.json -> denylist.json");
             }
+        } catch (IOException e) {
+            logger.error("Failed to migrate blacklist.json to denylist.json: ", e);
+        }
+
+        try {
+            Path legacyAllowlist = homePath.resolve("whitelist.json");
             if (Files.exists(legacyAllowlist) && !Files.exists(allowlistPath)) {
                 Files.move(legacyAllowlist, allowlistPath);
                 logger.info("Migrated whitelist.json -> allowlist.json");
             }
-        } catch (IOException e){
-            logger.error("Failed to migrate legacy connect list files: ", e);
+        } catch (IOException e) {
+            logger.error("Failed to migrate whitelist.json to allowlist.json: ", e);
         }
     }
 }

--- a/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/ServerConnectListManager.java
@@ -50,8 +50,11 @@ public class ServerConnectListManager {
         try {
             migrateLegacyFiles();
             if (createFiles()) {
-                denylistedIDs = GSON.fromJson(Files.newBufferedReader(denylistPath), Set.class);
-                allowlistedIDs = GSON.fromJson(Files.newBufferedReader(allowlistPath), Set.class);
+                try (var denylistReader = Files.newBufferedReader(denylistPath);
+                     var allowlistReader = Files.newBufferedReader(allowlistPath)) {
+                    denylistedIDs = GSON.fromJson(denylistReader, Set.class);
+                    allowlistedIDs = GSON.fromJson(allowlistReader, Set.class);
+                }
                 if (denylistedIDs == null) {
                     denylistedIDs = new HashSet<>();
                 }
@@ -67,12 +70,11 @@ public class ServerConnectListManager {
     private void saveLists() {
         try {
             if (createFiles()) {
-                Writer denylistWriter = Files.newBufferedWriter(denylistPath);
-                Writer allowlistWriter = Files.newBufferedWriter(allowlistPath);
-                denylistWriter.write(GSON.toJson(denylistedIDs));
-                allowlistWriter.write(GSON.toJson(allowlistedIDs));
-                denylistWriter.close();
-                allowlistWriter.close();
+                try (Writer denylistWriter = Files.newBufferedWriter(denylistPath);
+                     Writer allowlistWriter = Files.newBufferedWriter(allowlistPath)) {
+                    denylistWriter.write(GSON.toJson(denylistedIDs));
+                    allowlistWriter.write(GSON.toJson(allowlistedIDs));
+                }
             }
         } catch (IOException e) {
             logger.error("Couldn't save lists: ", e);

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -149,20 +149,20 @@ public class SelectGameScreen extends SelectionScreen {
 
     private void loadGame(GameInfo item) {
         if (isLoadingAsServer()) {
-            Path blacklistPath = PathManager.getInstance().getHomePath().resolve("blacklist.json");
-            Path whitelistPath = PathManager.getInstance().getHomePath().resolve("whitelist.json");
-            if (!Files.exists(blacklistPath)) {
+            Path denylistPath = PathManager.getInstance().getHomePath().resolve("denylist.json");
+            Path allowlistPath = PathManager.getInstance().getHomePath().resolve("allowlist.json");
+            if (!Files.exists(denylistPath)) {
                 try {
-                    Files.createFile(blacklistPath);
+                    Files.createFile(denylistPath);
                 } catch (IOException e) {
-                    logger.error("IO Exception on blacklist generation", e);
+                    logger.error("IO Exception on denylist generation", e);
                 }
             }
-            if (!Files.exists(whitelistPath)) {
+            if (!Files.exists(allowlistPath)) {
                 try {
-                    Files.createFile(whitelistPath);
+                    Files.createFile(allowlistPath);
                 } catch (IOException e) {
-                    logger.error("IO Exception on whitelist generation", e);
+                    logger.error("IO Exception on allowlist generation", e);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -149,8 +149,23 @@ public class SelectGameScreen extends SelectionScreen {
 
     private void loadGame(GameInfo item) {
         if (isLoadingAsServer()) {
-            Path denylistPath = PathManager.getInstance().getHomePath().resolve("denylist.json");
-            Path allowlistPath = PathManager.getInstance().getHomePath().resolve("allowlist.json");
+            Path homePath = PathManager.getInstance().getHomePath();
+            Path denylistPath = homePath.resolve("denylist.json");
+            Path allowlistPath = homePath.resolve("allowlist.json");
+            // Migrate legacy files before creating new empty ones, so existing
+            // banned/allowed client IDs are not silently discarded on upgrade.
+            try {
+                Path legacyDenylist = homePath.resolve("blacklist.json");
+                if (Files.exists(legacyDenylist) && !Files.exists(denylistPath)) {
+                    Files.move(legacyDenylist, denylistPath);
+                }
+                Path legacyAllowlist = homePath.resolve("whitelist.json");
+                if (Files.exists(legacyAllowlist) && !Files.exists(allowlistPath)) {
+                    Files.move(legacyAllowlist, allowlistPath);
+                }
+            } catch (IOException e) {
+                logger.error("Failed to migrate legacy connect list files", e);
+            }
             if (!Files.exists(denylistPath)) {
                 try {
                     Files.createFile(denylistPath);

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/SelectGameScreen.java
@@ -152,19 +152,23 @@ public class SelectGameScreen extends SelectionScreen {
             Path homePath = PathManager.getInstance().getHomePath();
             Path denylistPath = homePath.resolve("denylist.json");
             Path allowlistPath = homePath.resolve("allowlist.json");
-            // Migrate legacy files before creating new empty ones, so existing
-            // banned/allowed client IDs are not silently discarded on upgrade.
+            // Migrate each legacy file independently before creating new empty ones,
+            // so existing banned/allowed client IDs are not silently discarded on upgrade.
             try {
                 Path legacyDenylist = homePath.resolve("blacklist.json");
                 if (Files.exists(legacyDenylist) && !Files.exists(denylistPath)) {
                     Files.move(legacyDenylist, denylistPath);
                 }
+            } catch (IOException e) {
+                logger.error("Failed to migrate blacklist.json to denylist.json", e);
+            }
+            try {
                 Path legacyAllowlist = homePath.resolve("whitelist.json");
                 if (Files.exists(legacyAllowlist) && !Files.exists(allowlistPath)) {
                     Files.move(legacyAllowlist, allowlistPath);
                 }
             } catch (IOException e) {
-                logger.error("Failed to migrate legacy connect list files", e);
+                logger.error("Failed to migrate whitelist.json to allowlist.json", e);
             }
             if (!Files.exists(denylistPath)) {
                 try {


### PR DESCRIPTION
### Note

I understand that this might be a non-issue now, but I figured that this might be a good first issue for me to attempt after learning Java in school for the past 12 weeks.

I have included a simple unit-test to prove that the code changes work and below of this PR is a screenshot of the run on my local machine.

Do let me know if you require further code changes! 

### Contains

Replaces blacklist/whitelist terminology with denylist/allowlist in the server connection list system.
 - Renames variables, method names, and log messages in ServerConnectListManager (#refactor)
 - Updates SelectGameScreen to create denylist.json/allowlist.json 
 - Adds migrateLegacyFiles() in both ServerConnectListManager and SelectGameScreen to automatically rename existing blacklist.json/whitelist.json on startup, so existing servers don't lose their access control entries on upgrade  
 - Updates .gitignore to also ignore the new denylist.json/allowlist.json filenames   
 - Updates docs/Playing.md: renames the "Server Whitelist and Blacklist" section to "Server Allowlist and Denylist" and updates all prose references
 - Updates docs/Modding-API.md: replaces "whitelisting approach" and "not on the whitelist" with allowlist equivalents
 - Adds ServerConnectListManagerTest covering the migration logic 

Note: ExternalApiWhitelist.java (module security API) is intentionally not renamed as it is a separate concept and out of scope for this PR.

### How to test

Run the unit tests:
./gradlew :engine-tests:test --tests "org.terasology.engine.network.ServerConnectListManagerTest"

The 3 test cases cover:
- blacklistJsonIsMigratedToDenylistOnStartup —> verifies a legacy blacklist.json is renamed to denylist.json and its entries are loaded 
- whitelistJsonIsMigratedToAllowlistOnStartup —> same for whitelist.json → allowlist.json 
- existingDenylistIsNotOverwrittenByLegacyBlacklist —> verifies that if denylist.json already exists, the legacy blacklist.json is left untouched and does not overwrite the new file 

To manually verify migration: create a blacklist.json or whitelist.json in the Terasology home directory with some client IDs, then start a headless server. The files should be renamed to denylist.json/allowlist.json with entries preserved.

### Outstanding before merging
- Confirm ExternalApiWhitelist.java rename is tracked as a separate issue  


### Unit Test Screenshot
![telegram-cloud-photo-size-5-6253809430994554106-y](https://github.com/user-attachments/assets/da056119-bf98-4d57-9f46-ef4bafaceece)


