### PR TITLE
build(gradle): add build-time validation for prefabs and JSON assets #4986

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,6 +138,22 @@ pipeline {
                             [threshold: 1, type: 'TOTAL_NORMAL', unstable: true]    // mark stage "unstable" on existing normal findings
                         ])
 
+                    // JSON asset validation. Assets the engine genuinely cannot load already fail
+                    // the Build stage, so what reaches here is the other half: files that load
+                    // despite being defective, such as a duplicate key whose earlier value is
+                    // silently discarded. Those must stay visible without blocking anyone.
+                    //
+                    // Gated on NEW only, deliberately. There is an existing backlog, and a gate on
+                    // TOTAL would mark every build unstable until it is cleared — which trains
+                    // people to ignore the signal. New findings mark the stage unstable; the
+                    // backlog is reported and trended without crying wolf.
+                    recordIssues(skipBlames: true, enabledForFailure: true,
+                        tool: checkStyle(id: 'json-assets', name: 'JSON Assets',
+                                         pattern: '**/build/reports/json-assets/*.xml'),
+                        qualityGates: [
+                            [threshold: 1, type: 'NEW_NORMAL', unstable: true]
+                        ])
+
                     recordIssues(skipBlames: true, enabledForFailure: true,
                         tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true))
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -64,15 +64,16 @@ dependencies {
     // for inspecting modules
     implementation("org.terasology.gestalt:gestalt-module:8.0.1-SNAPSHOT")
 
-    // JSON parsing for build-time asset validation
-    implementation("org.json:json:20240303")
+    // JSON parsing for build-time asset validation.
+    // Must match the engine's parser (settings.gradle.kts pins gson 2.8.6) so that validation
+    // accepts exactly what the engine's asset loaders accept - see ValidateJsonAssets.
+    implementation("com.google.code.gson:gson:2.8.6")
 
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:5.0.0.4638")
 
     api(kotlin("test"))
-    testImplementation(gradleTestKit())
 }
 
 group = "org.terasology.gradology"

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:5.0.0.4638")
 
     api(kotlin("test"))
+    testImplementation(gradleTestKit())
 }
 
 group = "org.terasology.gradology"

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
     // for inspecting modules
     implementation("org.terasology.gestalt:gestalt-module:8.0.1-SNAPSHOT")
 
+    // JSON parsing for build-time asset validation
+    implementation("org.json:json:20240303")
+
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:5.0.0.4638")

--- a/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
@@ -3,21 +3,115 @@
 
 package org.terasology.gradology
 
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
-import org.json.JSONException
-import org.json.JSONObject
 import java.io.File
+
+/**
+ * The outcome of inspecting a single JSON asset.
+ *
+ * @property error why the file could not be parsed at all, or null if it parsed cleanly
+ * @property warnings problems that do not stop the engine loading the file, but are still defects
+ */
+data class AssetInspection(val error: String?, val warnings: List<String>)
+
+/**
+ * Parses Terasology JSON assets the same way the engine does.
+ *
+ * Parsing deliberately mirrors the engine's own asset loaders rather than strict RFC 8259:
+ * `UIFormat` and `UISkinFormat` call `JsonReader.setLenient(true)` outright, and the block and
+ * prefab formats go through `Gson.fromJson`, which is lenient by default. Terasology's asset
+ * format therefore permits slash-star licence headers and double-slash inline notes, and a large
+ * share of shipped assets use them - `CoreAssets` alone has dozens. A strict parser here would
+ * reject content the engine loads happily.
+ *
+ * Kept free of Gradle types so it can be tested directly, without standing up a nested build.
+ */
+object JsonAssetInspector {
+
+    fun inspect(file: File): AssetInspection {
+        val warnings = mutableListOf<String>()
+        return try {
+            file.bufferedReader().use { source ->
+                val reader = JsonReader(source)
+                reader.isLenient = true
+
+                if (reader.peek() == JsonToken.END_DOCUMENT) {
+                    return AssetInspection("${file.path}: file is empty", warnings)
+                }
+
+                walk(reader, file, "", warnings)
+
+                if (reader.peek() != JsonToken.END_DOCUMENT) {
+                    return AssetInspection(
+                        "${file.path}: unexpected trailing content after the root value",
+                        warnings
+                    )
+                }
+            }
+            AssetInspection(null, warnings)
+        } catch (e: Exception) {
+            AssetInspection("${file.path}: ${e.message ?: e.javaClass.simpleName}", warnings)
+        }
+    }
+
+    /**
+     * Walk the whole token stream. Reading every token is what proves the document parses;
+     * tracking the names seen per object is what surfaces duplicate keys.
+     *
+     * Duplicate keys are warnings rather than errors: Gson silently keeps the last occurrence, so
+     * a duplicate never breaks loading - but it does mean an earlier value is being discarded
+     * without anyone noticing, which is nearly always a mistake.
+     */
+    private fun walk(reader: JsonReader, file: File, path: String, warnings: MutableList<String>) {
+        when (reader.peek()) {
+            JsonToken.BEGIN_OBJECT -> {
+                reader.beginObject()
+                val seen = mutableSetOf<String>()
+                while (reader.hasNext()) {
+                    val name = reader.nextName()
+                    val childPath = if (path.isEmpty()) name else "$path.$name"
+                    if (!seen.add(name)) {
+                        warnings.add(
+                            "${file.path}: duplicate key \"$name\" at $childPath" +
+                                " - the last occurrence wins, the earlier value is silently discarded"
+                        )
+                    }
+                    walk(reader, file, childPath, warnings)
+                }
+                reader.endObject()
+            }
+
+            JsonToken.BEGIN_ARRAY -> {
+                reader.beginArray()
+                var index = 0
+                while (reader.hasNext()) {
+                    walk(reader, file, "$path[${index++}]", warnings)
+                }
+                reader.endArray()
+            }
+
+            else -> reader.skipValue()
+        }
+    }
+}
 
 /**
  * Gradle task that validates JSON assets (prefabs, blocks, ui, etc.) at build time.
  *
  * Iterates over all configured JSON asset files and attempts to parse each one.
- * If any file contains malformed JSON, the build fails with a descriptive error message.
+ * If any file cannot be parsed, the build fails with a descriptive error message.
+ * See [JsonAssetInspector] for what counts as parseable, and why it is not strict JSON.
  *
  * Example usage in a build script:
  * ```kotlin
@@ -39,7 +133,20 @@ abstract class ValidateJsonAssets : DefaultTask() {
      */
     @get:InputFiles
     @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     val jsonAssets: ConfigurableFileCollection = project.files()
+
+    /**
+     * Where the findings are written.
+     *
+     * This exists mainly so the task has a declared output. Without one Gradle has no up-to-date
+     * criterion and re-parses every asset on every build - which matters, because the
+     * `terasology-module` plugin wires this into `processResources` for every module. With it,
+     * an unchanged asset tree is skipped outright and the task can be served from the build cache.
+     */
+    @get:OutputFile
+    val report: RegularFileProperty = project.objects.fileProperty()
+        .convention(project.layout.buildDirectory.file("reports/json-assets/validation.txt"))
 
     /**
      * Add files or file trees of JSON assets to validate.
@@ -51,10 +158,25 @@ abstract class ValidateJsonAssets : DefaultTask() {
     @TaskAction
     fun validate() {
         val errors = mutableListOf<String>()
+        val warnings = mutableListOf<String>()
 
         for (file in jsonAssets) {
-            validateFile(file)?.let { errors.add(it) }
+            val inspection = JsonAssetInspector.inspect(file)
+            inspection.error?.let { errors.add(it) }
+            warnings.addAll(inspection.warnings)
         }
+
+        warnings.forEach { logger.warn("  ! $it") }
+
+        val reportFile = report.get().asFile
+        reportFile.parentFile.mkdirs()
+        reportFile.writeText(buildString {
+            appendLine("checked: ${jsonAssets.count()}")
+            appendLine("errors: ${errors.size}")
+            appendLine("warnings: ${warnings.size}")
+            errors.forEach { appendLine("ERROR $it") }
+            warnings.forEach { appendLine("WARN $it") }
+        })
 
         if (errors.isNotEmpty()) {
             val message = buildString {
@@ -65,14 +187,5 @@ abstract class ValidateJsonAssets : DefaultTask() {
         }
 
         logger.lifecycle("All JSON assets are valid.")
-    }
-
-    private fun validateFile(file: File): String? {
-        return try {
-            JSONObject(file.readText())
-            null  // valid
-        } catch (e: JSONException) {
-            "${file.path}: ${e.message}"
-        }
     }
 }

--- a/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
@@ -5,8 +5,9 @@ package org.terasology.gradology
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.json.JSONException
 import org.json.JSONObject
@@ -17,6 +18,13 @@ import java.io.File
  *
  * Iterates over all configured JSON asset files and attempts to parse each one.
  * If any file contains malformed JSON, the build fails with a descriptive error message.
+ *
+ * Example usage in a build script:
+ * ```kotlin
+ * tasks.register<ValidateJsonAssets>("validateJsonAssets") {
+ *     source(fileTree("assets") { include("**&#47;*.prefab", "**&#47;*.json") })
+ * }
+ * ```
  */
 abstract class ValidateJsonAssets : DefaultTask() {
 
@@ -25,24 +33,27 @@ abstract class ValidateJsonAssets : DefaultTask() {
         description = "Validates that all JSON assets (prefabs, blocks, ui, etc.) are well-formed."
     }
 
+    /**
+     * The set of JSON asset files to validate.
+     * Use [source] to add file trees.
+     */
     @get:InputFiles
-    val jsonAssets: MutableList<ConfigurableFileTree> = mutableListOf()
+    @get:SkipWhenEmpty
+    val jsonAssets: ConfigurableFileCollection = project.files()
 
     /**
-     * Add a file tree of JSON assets to validate.
+     * Add files or file trees of JSON assets to validate.
      */
-    fun source(fileTree: ConfigurableFileTree) {
-        jsonAssets.add(fileTree)
+    fun source(vararg paths: Any) {
+        jsonAssets.from(*paths)
     }
 
     @TaskAction
     fun validate() {
         val errors = mutableListOf<String>()
 
-        for (fileTree in jsonAssets) {
-            for (file in fileTree) {
-                validateFile(file)?.let { errors.add(it) }
-            }
+        for (file in jsonAssets) {
+            validateFile(file)?.let { errors.add(it) }
         }
 
         if (errors.isNotEmpty()) {

--- a/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
@@ -54,10 +54,10 @@ object JsonAssetInspector {
                 reader.isLenient = true
 
                 if (reader.peek() == JsonToken.END_DOCUMENT) {
-                    return AssetInspection("${file.path}: file is empty", warnings)
+                    return AssetInspection("file is empty", warnings)
                 }
 
-                walk(reader, file, "", warnings)
+                walk(reader, "", warnings)
 
                 // Content after the root value is a defect, but not a fatal one: the engine's
                 // loaders read a single value and never check what follows, so the file still
@@ -75,14 +75,14 @@ object JsonAssetInspector {
 
                 if (hasTrailingContent) {
                     warnings.add(
-                        "${file.path}: unexpected content after the root value" +
+                        "unexpected content after the root value" +
                             " - the engine reads the first value and silently ignores the rest"
                     )
                 }
             }
             AssetInspection(null, warnings)
         } catch (e: Exception) {
-            AssetInspection("${file.path}: ${e.message ?: e.javaClass.simpleName}", warnings)
+            AssetInspection(e.message ?: e.javaClass.simpleName, warnings)
         }
     }
 
@@ -94,7 +94,7 @@ object JsonAssetInspector {
      * a duplicate never breaks loading - but it does mean an earlier value is being discarded
      * without anyone noticing, which is nearly always a mistake.
      */
-    private fun walk(reader: JsonReader, file: File, path: String, warnings: MutableList<String>) {
+    private fun walk(reader: JsonReader, path: String, warnings: MutableList<String>) {
         when (reader.peek()) {
             JsonToken.BEGIN_OBJECT -> {
                 reader.beginObject()
@@ -104,11 +104,11 @@ object JsonAssetInspector {
                     val childPath = if (path.isEmpty()) name else "$path.$name"
                     if (!seen.add(name)) {
                         warnings.add(
-                            "${file.path}: duplicate key \"$name\" at $childPath" +
+                            "duplicate key \"$name\" at $childPath" +
                                 " - the last occurrence wins, the earlier value is silently discarded"
                         )
                     }
-                    walk(reader, file, childPath, warnings)
+                    walk(reader, childPath, warnings)
                 }
                 reader.endObject()
             }
@@ -117,7 +117,7 @@ object JsonAssetInspector {
                 reader.beginArray()
                 var index = 0
                 while (reader.hasNext()) {
-                    walk(reader, file, "$path[${index++}]", warnings)
+                    walk(reader, "$path[${index++}]", warnings)
                 }
                 reader.endArray()
             }
@@ -158,20 +158,24 @@ abstract class ValidateJsonAssets : DefaultTask() {
     val jsonAssets: ConfigurableFileCollection = project.files()
 
     /**
-     * Where the findings are written.
+     * Where the findings are written, in CheckStyle XML.
      *
-     * This exists mainly so the task has a declared output. Without one Gradle has no up-to-date
-     * criterion and re-parses every asset on every build - which matters, because the
-     * `terasology-module` plugin wires this into `processResources` for every module. With it, an
-     * unchanged asset tree is skipped outright.
+     * Two jobs. It gives the task a declared output, without which Gradle has no up-to-date
+     * criterion and re-parses every asset on every build — that matters because the
+     * `terasology-module` plugin wires this into `processResources` for every module.
      *
-     * Deliberately not `@CacheableTask`: the findings name files by absolute path, so the output is
-     * not relocatable and sharing it between machines would report paths that do not exist there.
-     * Up-to-date checking is the win here; build-cache reuse would need relative paths first.
+     * And it makes the findings *visible*. Warnings that only reach the console are warnings
+     * nobody reads. CheckStyle XML is the format the Jenkinsfile already parses with the Warnings
+     * Next Generation plugin, so recording these alongside checkstyle, PMD and SpotBugs is one
+     * more `recordIssues` block rather than new infrastructure — including the reference-build
+     * comparison that distinguishes a warning you just introduced from the existing backlog.
+     *
+     * Deliberately not `@CacheableTask`: findings name files by absolute path, as every other
+     * analysis report here does, so the output is not relocatable between machines.
      */
     @get:OutputFile
     val report: RegularFileProperty = project.objects.fileProperty()
-        .convention(project.layout.buildDirectory.file("reports/json-assets/validation.txt"))
+        .convention(project.layout.buildDirectory.file("reports/json-assets/json-assets.xml"))
 
     /**
      * Add files or file trees of JSON assets to validate.
@@ -183,25 +187,25 @@ abstract class ValidateJsonAssets : DefaultTask() {
     @TaskAction
     fun validate() {
         val errors = mutableListOf<String>()
-        val warnings = mutableListOf<String>()
+        val findings = LinkedHashMap<File, MutableList<Pair<String, String>>>()
 
         for (file in jsonAssets) {
             val inspection = JsonAssetInspector.inspect(file)
-            inspection.error?.let { errors.add(it) }
-            warnings.addAll(inspection.warnings)
+            val perFile = findings.getOrPut(file) { mutableListOf() }
+            inspection.error?.let {
+                errors.add("${file.path}: $it")
+                perFile.add("error" to it)
+            }
+            inspection.warnings.forEach {
+                logger.warn("  ! ${file.path}: $it")
+                perFile.add("warning" to it)
+            }
+            if (perFile.isEmpty()) {
+                findings.remove(file)
+            }
         }
 
-        warnings.forEach { logger.warn("  ! $it") }
-
-        val reportFile = report.get().asFile
-        reportFile.parentFile.mkdirs()
-        reportFile.writeText(buildString {
-            appendLine("checked: ${jsonAssets.count()}")
-            appendLine("errors: ${errors.size}")
-            appendLine("warnings: ${warnings.size}")
-            errors.forEach { appendLine("ERROR $it") }
-            warnings.forEach { appendLine("WARN $it") }
-        })
+        writeCheckstyleReport(findings)
 
         if (errors.isNotEmpty()) {
             val message = buildString {
@@ -213,4 +217,41 @@ abstract class ValidateJsonAssets : DefaultTask() {
 
         logger.lifecycle("All JSON assets are valid.")
     }
+
+    /**
+     * Emit findings as CheckStyle XML — the schema the Warnings Next Generation plugin already
+     * parses for this project. Severity carries the contract: `error` is something the engine
+     * cannot load, `warning` is something it loads despite the file being defective.
+     *
+     * No line numbers: Gson's reader reports a JSON path rather than a position, so the path is
+     * put in the message instead and the line is left at 0. Grouping and trend still work; only
+     * inline annotation precision is lost.
+     */
+    private fun writeCheckstyleReport(findings: Map<File, List<Pair<String, String>>>) {
+        val reportFile = report.get().asFile
+        reportFile.parentFile.mkdirs()
+        reportFile.writeText(buildString {
+            appendLine("""<?xml version="1.0" encoding="UTF-8"?>""")
+            appendLine("""<checkstyle version="8.0">""")
+            findings.forEach { (file, entries) ->
+                appendLine("""  <file name="${xmlAttr(file.path)}">""")
+                entries.forEach { (severity, message) ->
+                    appendLine(
+                        """    <error line="0" severity="$severity" """ +
+                            """message="${xmlAttr(message)}" source="JsonAssets" />"""
+                    )
+                }
+                appendLine("  </file>")
+            }
+            appendLine("</checkstyle>")
+        })
+    }
+
+    /** Escape the five characters that cannot appear literally in an XML attribute value. */
+    private fun xmlAttr(value: String): String =
+        value.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;")
 }

--- a/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
@@ -1,0 +1,67 @@
+// Copyright 2024 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.gradology
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.TaskAction
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Gradle task that validates JSON assets (prefabs, blocks, ui, etc.) at build time.
+ *
+ * Iterates over all configured JSON asset files and attempts to parse each one.
+ * If any file contains malformed JSON, the build fails with a descriptive error message.
+ */
+abstract class ValidateJsonAssets : DefaultTask() {
+
+    init {
+        group = "Verification"
+        description = "Validates that all JSON assets (prefabs, blocks, ui, etc.) are well-formed."
+    }
+
+    @get:InputFiles
+    val jsonAssets: MutableList<ConfigurableFileTree> = mutableListOf()
+
+    /**
+     * Add a file tree of JSON assets to validate.
+     */
+    fun source(fileTree: ConfigurableFileTree) {
+        jsonAssets.add(fileTree)
+    }
+
+    @TaskAction
+    fun validate() {
+        val errors = mutableListOf<String>()
+
+        for (fileTree in jsonAssets) {
+            for (file in fileTree) {
+                validateFile(file)?.let { errors.add(it) }
+            }
+        }
+
+        if (errors.isNotEmpty()) {
+            val message = buildString {
+                appendLine("Found ${errors.size} invalid JSON asset(s):")
+                errors.forEach { appendLine("  - $it") }
+            }
+            throw GradleException(message)
+        }
+
+        logger.lifecycle("All JSON assets are valid.")
+    }
+
+    private fun validateFile(file: File): String? {
+        return try {
+            JSONObject(file.readText())
+            null  // valid
+        } catch (e: JSONException) {
+            "${file.path}: ${e.message}"
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
@@ -35,6 +35,12 @@ data class AssetInspection(val error: String?, val warnings: List<String>)
  * share of shipped assets use them - `CoreAssets` alone has dozens. A strict parser here would
  * reject content the engine loads happily.
  *
+ * The contract that follows from this: **an error is something the engine genuinely cannot load;
+ * a warning is something it loads despite the file being defective.** Duplicate keys and trailing
+ * content are both warnings for that reason - Gson keeps the last duplicate, and the loaders read
+ * a single root value without checking what comes after it. Anything that fails the parse outright
+ * fails the build, because the engine would fail on it too.
+ *
  * Kept free of Gradle types so it can be tested directly, without standing up a nested build.
  */
 object JsonAssetInspector {
@@ -52,10 +58,21 @@ object JsonAssetInspector {
 
                 walk(reader, file, "", warnings)
 
-                if (reader.peek() != JsonToken.END_DOCUMENT) {
-                    return AssetInspection(
-                        "${file.path}: unexpected trailing content after the root value",
-                        warnings
+                // Content after the root value is a defect, but not a fatal one: the engine's
+                // loaders read a single value and never check what follows, so the file still
+                // loads. Peeking can itself throw when the trailing bytes are not the start of a
+                // value (a stray closing brace, say), so that has to be caught here rather than
+                // by the outer handler - otherwise it would be reported as a parse failure.
+                val hasTrailingContent = try {
+                    reader.peek() != JsonToken.END_DOCUMENT
+                } catch (e: Exception) {
+                    true
+                }
+
+                if (hasTrailingContent) {
+                    warnings.add(
+                        "${file.path}: unexpected content after the root value" +
+                            " - the engine reads the first value and silently ignores the rest"
                     )
                 }
             }

--- a/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/ValidateJsonAssets.kt
@@ -5,6 +5,7 @@ package org.terasology.gradology
 
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
+import com.google.gson.stream.MalformedJsonException
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
@@ -65,7 +66,10 @@ object JsonAssetInspector {
                 // by the outer handler - otherwise it would be reported as a parse failure.
                 val hasTrailingContent = try {
                     reader.peek() != JsonToken.END_DOCUMENT
-                } catch (e: Exception) {
+                } catch (e: MalformedJsonException) {
+                    // Only malformed trailing bytes count as trailing content. A read failure is
+                    // not a verdict about the file, so it falls through to the outer handler and
+                    // is reported as an error rather than being swallowed as a passing warning.
                     true
                 }
 
@@ -158,8 +162,12 @@ abstract class ValidateJsonAssets : DefaultTask() {
      *
      * This exists mainly so the task has a declared output. Without one Gradle has no up-to-date
      * criterion and re-parses every asset on every build - which matters, because the
-     * `terasology-module` plugin wires this into `processResources` for every module. With it,
-     * an unchanged asset tree is skipped outright and the task can be served from the build cache.
+     * `terasology-module` plugin wires this into `processResources` for every module. With it, an
+     * unchanged asset tree is skipped outright.
+     *
+     * Deliberately not `@CacheableTask`: the findings name files by absolute path, so the output is
+     * not relocatable and sharing it between machines would report paths that do not exist there.
+     * Up-to-date checking is the win here; build-cache reuse would need relative paths first.
      */
     @get:OutputFile
     val report: RegularFileProperty = project.objects.fileProperty()

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -6,6 +6,7 @@
 import org.gradle.plugins.ide.eclipse.model.EclipseModel
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.terasology.gradology.ModuleMetadataForGradle
+import org.terasology.gradology.ValidateJsonAssets
 
 plugins {
     `java-library`
@@ -138,9 +139,24 @@ tasks.register<Copy>("syncModuleInfo") {
     into(mainSourceSet.output.classesDirs.first())
 }
 
+// Validate all JSON assets (prefabs, blocks, ui, etc.) at build time
+tasks.register<ValidateJsonAssets>("validateJsonAssets") {
+    val assetsDir = project.file("assets")
+    if (assetsDir.exists()) {
+        listOf("prefabs", "blocks", "blockSounds", "ui", "shapes", "materials", "fonts", "behaviors").forEach { assetType ->
+            val dir = assetsDir.resolve(assetType)
+            if (dir.exists()) {
+                source(project.fileTree(dir) { include("**/*.json", "**/*.prefab", "**/*.block", "**/*.ui") })
+            }
+        }
+        // Also catch any other .json files directly in assets
+        source(project.fileTree(assetsDir) { include("**/*.json") })
+    }
+}
+
 tasks.named("processResources") {
     // Make sure the assets directory is included
-    dependsOn("syncAssets", "syncOverrides", "syncDeltas", "syncModuleInfo")
+    dependsOn("syncAssets", "syncOverrides", "syncDeltas", "syncModuleInfo", "validateJsonAssets")
 }
 
 tasks.named<JavaCompile>("compileJava") {

--- a/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
+++ b/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
@@ -4,14 +4,24 @@
 package org.terasology.gradology
 
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
+/**
+ * Tests exercise [JsonAssetInspector] directly rather than through Gradle TestKit.
+ *
+ * TestKit was tried first and does not work for this task: `withPluginClasspath()` makes the
+ * plugin available to the `plugins {}` DSL, but not to the build script's *compile* classpath, so
+ * a generated script that does `import org.terasology.gradology.ValidateJsonAssets` fails with
+ * "Unresolved reference". That failure is the worst kind - the build under test dies for a reason
+ * unrelated to the assertion, so the tests never exercised the validator at all. Calling the
+ * inspector directly is both honest and considerably faster.
+ */
 class ValidateJsonAssetsTest {
 
     /**
@@ -30,11 +40,7 @@ class ValidateJsonAssetsTest {
      */
     @Test
     fun `valid JSON files pass validation`() {
-        val projectDir = createTempProjectDir()
-
-        // Write a valid prefab
-        val assetsDir = projectDir.resolve("assets/prefabs").also { it.mkdirs() }
-        assetsDir.resolve("player.prefab").writeText("""
+        val file = writeAsset("player.prefab", """
             {
               "persisted": true,
               "Location": {},
@@ -42,79 +48,146 @@ class ValidateJsonAssetsTest {
             }
         """.trimIndent())
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("validateJsonAssets")
-            .withPluginClasspath()
-            .build()
+        val inspection = JsonAssetInspector.inspect(file)
 
-        assertEquals(TaskOutcome.SUCCESS, result.task(":validateJsonAssets")?.outcome)
+        assertNull(inspection.error, "expected a clean parse, got: ${inspection.error}")
+        assertTrue(inspection.warnings.isEmpty())
     }
 
     /**
-     * Verifies that malformed JSON files cause the build to fail with a descriptive message.
+     * Verifies that malformed JSON is reported, naming the offending file.
      */
     @Test
-    fun `malformed JSON file fails the build`() {
-        val projectDir = createTempProjectDir()
-
-        // Write an invalid prefab (missing closing brace)
-        val assetsDir = projectDir.resolve("assets/prefabs").also { it.mkdirs() }
-        assetsDir.resolve("broken.prefab").writeText("""
+    fun `malformed JSON is reported as an error`() {
+        val file = writeAsset("broken.prefab", """
             {
               "persisted": true,
               "Location": {
         """.trimIndent())
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("validateJsonAssets")
-            .withPluginClasspath()
-            .buildAndFail()
+        val inspection = JsonAssetInspector.inspect(file)
 
-        assertEquals(TaskOutcome.FAILED, result.task(":validateJsonAssets")?.outcome)
-        assert(result.output.contains("broken.prefab")) {
-            "Expected error output to mention the broken file, but got:\n${result.output}"
-        }
+        assertNotNull(inspection.error)
+        assertTrue(
+            inspection.error!!.contains("broken.prefab"),
+            "Expected the error to name the file, got: ${inspection.error}"
+        )
     }
 
     /**
-     * Verifies that a project with no assets directory succeeds without errors.
+     * The regression guard for this task's original defect.
+     *
+     * Terasology's asset format is lenient JSON, not RFC 8259. Shipped assets rely on that - a
+     * licence header or an inline note is the norm, not the exception. Validating with a strict
+     * parser (the task originally used org.json) fails the build on content the engine loads
+     * fine: every module sampled failed, `CoreAssets` alone with 56 files.
+     *
+     * The fixture is modelled directly on `CoreAssets/assets/blocks/soil/Snowball.block` and
+     * `CakeLie/assets/blocks/ChocolateBlock.block`.
      */
     @Test
-    fun `project with no assets directory passes validation`() {
-        val projectDir = createTempProjectDir()
-        // No assets dir created intentionally
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("validateJsonAssets")
-            .withPluginClasspath()
-            .build()
-
-        assertEquals(TaskOutcome.SUCCESS, result.task(":validateJsonAssets")?.outcome)
-    }
-
-    private fun createTempProjectDir(): File {
-        val projectDir = Files.createTempDirectory("terasology-test").toFile()
-        projectDir.deleteOnExit()
-        // Minimal build.gradle.kts to register the task
-        projectDir.resolve("build.gradle.kts").writeText("""
-            import org.terasology.gradology.ValidateJsonAssets
-
-            tasks.register<ValidateJsonAssets>("validateJsonAssets") {
-                val assetsDir = project.file("assets")
-                if (assetsDir.exists()) {
-                    listOf("prefabs", "blocks", "ui").forEach { assetType ->
-                        val dir = assetsDir.resolve(assetType)
-                        if (dir.exists()) {
-                            source(project.fileTree(dir) { include("**/*.json", "**/*.prefab", "**/*.block", "**/*.ui") })
-                        }
-                    }
+    fun `assets using engine-style comments pass validation`() {
+        val file = writeAsset("Chocolate.block", """
+            /*
+             * Copyright 2014 MovingBlocks
+             *
+             * Licensed under the Apache License, Version 2.0 (the "License");
+             */
+            {
+                // Graphics
+                "displayName": "Chocolate",
+                "basedOn": "CoreAssets:soil",
+                //no prefab I could find; WIP?
+                "inventory": {
+                    "stackable": true
                 }
             }
         """.trimIndent())
-        projectDir.resolve("settings.gradle.kts").writeText("")
-        return projectDir
+
+        val inspection = JsonAssetInspector.inspect(file)
+
+        assertNull(inspection.error, "comments are valid in Terasology assets, got: ${inspection.error}")
+    }
+
+    /**
+     * Trailing commas are likewise accepted by the engine's lenient parser.
+     * `moduleDetailsScreen.ui` has one.
+     */
+    @Test
+    fun `trailing commas pass validation`() {
+        val file = writeAsset("trailing.ui", """
+            {
+              "contents": [
+                { "type": "UILabel" },
+              ]
+            }
+        """.trimIndent())
+
+        assertNull(JsonAssetInspector.inspect(file).error)
+    }
+
+    /**
+     * Duplicate keys are real defects but do not break loading - Gson keeps the last occurrence -
+     * so they are reported without failing the build. Found in the engine's own
+     * `moduleDetailsScreen.ui`, which declared `layoutInfo` twice on one widget.
+     */
+    @Test
+    fun `duplicate keys warn without failing`() {
+        val file = writeAsset("duplicate.prefab", """
+            {
+              "layoutInfo": { "position-top": { "target": "TOP" } },
+              "other": 1,
+              "layoutInfo": { "position-top": { "target": "BOTTOM" } }
+            }
+        """.trimIndent())
+
+        val inspection = JsonAssetInspector.inspect(file)
+
+        assertNull(inspection.error, "a duplicate key must not fail the build")
+        assertEquals(1, inspection.warnings.size, "expected exactly one warning: ${inspection.warnings}")
+        assertTrue(inspection.warnings.single().contains("duplicate key \"layoutInfo\""))
+    }
+
+    /**
+     * Duplicate keys are detected at any depth, not just at the root.
+     */
+    @Test
+    fun `duplicate keys are detected in nested objects`() {
+        val file = writeAsset("nested.prefab", """
+            {
+              "outer": {
+                "inner": [
+                  { "a": 1, "a": 2 }
+                ]
+              }
+            }
+        """.trimIndent())
+
+        val inspection = JsonAssetInspector.inspect(file)
+
+        assertNull(inspection.error)
+        assertTrue(
+            inspection.warnings.single().contains("outer.inner[0].a"),
+            "Expected the warning to carry the JSON path, got: ${inspection.warnings}"
+        )
+    }
+
+    /**
+     * An empty asset file is a packaging mistake rather than valid content.
+     */
+    @Test
+    fun `empty file is reported as an error`() {
+        val file = writeAsset("empty.prefab", "")
+
+        assertNotNull(JsonAssetInspector.inspect(file).error)
+    }
+
+    private fun writeAsset(name: String, content: String): File {
+        val dir = Files.createTempDirectory("terasology-test").toFile()
+        dir.deleteOnExit()
+        return dir.resolve(name).also {
+            it.writeText(content)
+            it.deleteOnExit()
+        }
     }
 }

--- a/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
+++ b/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
@@ -182,6 +182,61 @@ class ValidateJsonAssetsTest {
         assertNotNull(JsonAssetInspector.inspect(file).error)
     }
 
+    /**
+     * A stray closing brace after the root object warns rather than failing.
+     *
+     * The engine's loaders read one root value and never check what follows, so the file loads
+     * fine - failing the build would punish a defect the engine does not care about. Modelled on
+     * `Apiculture/assets/ui/extractor.ui`, found by the first full Omega sweep.
+     *
+     * Note this shape makes `JsonReader.peek()` itself throw, so it is not enough to compare
+     * against END_DOCUMENT; the regression here is the error/warning classification.
+     */
+    @Test
+    fun `trailing content after the root value warns without failing`() {
+        val file = writeAsset("extractor.ui", """
+            {
+              "type": "UIBox",
+              "contents": []
+            }
+            }
+        """.trimIndent())
+
+        val inspection = JsonAssetInspector.inspect(file)
+
+        assertNull(inspection.error, "the engine loads this, so it must not fail the build")
+        assertTrue(
+            inspection.warnings.single().contains("unexpected content after the root value"),
+            "expected a trailing-content warning, got: ${inspection.warnings}"
+        )
+    }
+
+    /**
+     * A missing separator between object members is a hard failure - no JSON parser accepts it,
+     * lenient or not, so the engine cannot load the file either.
+     *
+     * Modelled on `Cooking/assets/prefabs/CookingRecipes.prefab`, which is broken in the shipped
+     * module: its recipes silently do not load today.
+     */
+    @Test
+    fun `missing comma between members is an error`() {
+        val file = writeAsset("CookingRecipes.prefab", """
+            {
+              "ListRecipes": {
+                "recipes": {
+                  "Cooking:Coconut": { "outputCount": 1 }
+                  "Cooking:BoiledEgg": { "outputCount": 1 }
+                }
+              }
+            }
+        """.trimIndent())
+
+        assertNotNull(
+            JsonAssetInspector.inspect(file).error,
+            "a missing separator must fail - the engine cannot parse it either"
+        )
+    }
+
     private fun writeAsset(name: String, content: String): File {
         val dir = Files.createTempDirectory("terasology-test").toFile()
         dir.deleteOnExit()

--- a/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
+++ b/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
@@ -70,9 +70,11 @@ class ValidateJsonAssetsTest {
         val inspection = JsonAssetInspector.inspect(file)
 
         assertNotNull(inspection.error)
+        // Naming the file is the task's job, not the inspector's — keeping them separate is what
+        // lets the path and the message land in different XML attributes without duplication.
         assertTrue(
-            inspection.error!!.contains("broken.prefab"),
-            "Expected the error to name the file, got: ${inspection.error}"
+            !inspection.error!!.contains("broken.prefab"),
+            "the inspector should describe the fault, not embed the path: ${inspection.error}"
         )
     }
 
@@ -260,7 +262,9 @@ class ValidateJsonAssetsTest {
 
         val report = task.report.get().asFile
         assertTrue(report.exists(), "expected a report at ${report.path}")
-        assertTrue(report.readText().contains("errors: 0"), "report was: ${report.readText()}")
+        val xml = report.readText()
+        assertTrue(xml.contains("<checkstyle"), "report was: $xml")
+        assertTrue(!xml.contains("severity="), "a clean tree must record no findings: $xml")
     }
 
     /**
@@ -280,8 +284,11 @@ class ValidateJsonAssetsTest {
         assertFailsWith<GradleException> { task.validate() }
 
         val report = task.report.get().asFile.readText()
-        assertTrue(report.contains("ERROR"), "expected the error in the report, got: $report")
-        assertTrue(report.contains("duplicate key"), "expected the warning too, got: $report")
+        assertTrue(report.contains("""severity="error""""), "expected the error, got: $report")
+        assertTrue(report.contains("""severity="warning""""), "expected the warning, got: $report")
+        assertTrue(report.contains("duplicate key"), "expected the warning text, got: $report")
+        // The severity split is the contract Jenkins keys on, so both must survive a failing run.
+        assertTrue(report.contains("broken.prefab"), "expected the file named, got: $report")
     }
 
     private fun newProjectDir(): File =

--- a/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
+++ b/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
@@ -1,0 +1,120 @@
+// Copyright 2024 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.gradology
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ValidateJsonAssetsTest {
+
+    /**
+     * Verifies that the task can be registered and configured on a Gradle project.
+     */
+    @Test
+    fun `task can be registered on a project`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("validateJsonAssets", ValidateJsonAssets::class.java).get()
+        assertNotNull(task)
+        assertEquals("Verification", task.group)
+    }
+
+    /**
+     * Verifies that valid JSON files pass validation without errors.
+     */
+    @Test
+    fun `valid JSON files pass validation`() {
+        val projectDir = createTempProjectDir()
+
+        // Write a valid prefab
+        val assetsDir = projectDir.resolve("assets/prefabs").also { it.mkdirs() }
+        assetsDir.resolve("player.prefab").writeText("""
+            {
+              "persisted": true,
+              "Location": {},
+              "Network": { "replicateMode": "ALWAYS" }
+            }
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("validateJsonAssets")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":validateJsonAssets")?.outcome)
+    }
+
+    /**
+     * Verifies that malformed JSON files cause the build to fail with a descriptive message.
+     */
+    @Test
+    fun `malformed JSON file fails the build`() {
+        val projectDir = createTempProjectDir()
+
+        // Write an invalid prefab (missing closing brace)
+        val assetsDir = projectDir.resolve("assets/prefabs").also { it.mkdirs() }
+        assetsDir.resolve("broken.prefab").writeText("""
+            {
+              "persisted": true,
+              "Location": {
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("validateJsonAssets")
+            .withPluginClasspath()
+            .buildAndFail()
+
+        assertEquals(TaskOutcome.FAILED, result.task(":validateJsonAssets")?.outcome)
+        assert(result.output.contains("broken.prefab")) {
+            "Expected error output to mention the broken file, but got:\n${result.output}"
+        }
+    }
+
+    /**
+     * Verifies that a project with no assets directory succeeds without errors.
+     */
+    @Test
+    fun `project with no assets directory passes validation`() {
+        val projectDir = createTempProjectDir()
+        // No assets dir created intentionally
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("validateJsonAssets")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":validateJsonAssets")?.outcome)
+    }
+
+    private fun createTempProjectDir(): File {
+        val projectDir = Files.createTempDirectory("terasology-test").toFile()
+        projectDir.deleteOnExit()
+        // Minimal build.gradle.kts to register the task
+        projectDir.resolve("build.gradle.kts").writeText("""
+            import org.terasology.gradology.ValidateJsonAssets
+
+            tasks.register<ValidateJsonAssets>("validateJsonAssets") {
+                val assetsDir = project.file("assets")
+                if (assetsDir.exists()) {
+                    listOf("prefabs", "blocks", "ui").forEach { assetType ->
+                        val dir = assetsDir.resolve(assetType)
+                        if (dir.exists()) {
+                            source(project.fileTree(dir) { include("**/*.json", "**/*.prefab", "**/*.block", "**/*.ui") })
+                        }
+                    }
+                }
+            }
+        """.trimIndent())
+        projectDir.resolve("settings.gradle.kts").writeText("")
+        return projectDir
+    }
+}

--- a/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
+++ b/build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt
@@ -3,11 +3,13 @@
 
 package org.terasology.gradology
 
+import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -236,6 +238,58 @@ class ValidateJsonAssetsTest {
             "a missing separator must fail - the engine cannot parse it either"
         )
     }
+
+    /**
+     * The tests above cover parsing. This one covers the task: `jsonAssets` wiring, report
+     * creation, and that a clean tree succeeds.
+     *
+     * Worth having on its own terms - a regression in any of that would leave every
+     * inspector test green, which is the same shape of gap that let the original strict parser
+     * ship with a passing suite.
+     */
+    @Test
+    fun `task validates its configured sources and writes a report`() {
+        val projectDir = newProjectDir()
+        val assets = projectDir.resolve("assets").also { it.mkdirs() }
+        assets.resolve("ok.prefab").writeText("""{ "persisted": true }""")
+
+        val task = newTask(projectDir)
+        task.source(task.project.fileTree(assets))
+
+        task.validate()
+
+        val report = task.report.get().asFile
+        assertTrue(report.exists(), "expected a report at ${report.path}")
+        assertTrue(report.readText().contains("errors: 0"), "report was: ${report.readText()}")
+    }
+
+    /**
+     * Failure propagation and warning aggregation, at the task level: an unparseable asset must
+     * fail the build, while a merely defective one is still only recorded.
+     */
+    @Test
+    fun `task fails on unparseable assets and still records warnings`() {
+        val projectDir = newProjectDir()
+        val assets = projectDir.resolve("assets").also { it.mkdirs() }
+        assets.resolve("broken.prefab").writeText("""{ "a": {""")
+        assets.resolve("duplicate.prefab").writeText("""{ "a": 1, "a": 2 }""")
+
+        val task = newTask(projectDir)
+        task.source(task.project.fileTree(assets))
+
+        assertFailsWith<GradleException> { task.validate() }
+
+        val report = task.report.get().asFile.readText()
+        assertTrue(report.contains("ERROR"), "expected the error in the report, got: $report")
+        assertTrue(report.contains("duplicate key"), "expected the warning too, got: $report")
+    }
+
+    private fun newProjectDir(): File =
+        Files.createTempDirectory("terasology-task").toFile().also { it.deleteOnExit() }
+
+    private fun newTask(projectDir: File): ValidateJsonAssets =
+        ProjectBuilder.builder().withProjectDir(projectDir).build()
+            .tasks.register("validateJsonAssets", ValidateJsonAssets::class.java).get()
 
     private fun writeAsset(name: String, content: String): File {
         val dir = Files.createTempDirectory("terasology-test").toFile()

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -5,6 +5,7 @@
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import org.terasology.gradology.ValidateJsonAssets
 
 plugins {
     id("java-library")
@@ -205,6 +206,18 @@ tasks.named<Copy>("processResources") {
     from("$rootDir/docs") {
         include("Credits.md")
     }
+}
+
+// Validate all engine JSON assets (prefabs, etc.) at build time
+tasks.register<ValidateJsonAssets>("validateJsonAssets") {
+    val resourcesDir = project.file("src/main/resources")
+    if (resourcesDir.exists()) {
+        source(project.fileTree(resourcesDir) { include("**/*.prefab", "**/*.block", "**/*.ui", "**/*.json") })
+    }
+}
+
+tasks.named("processResources") {
+    dependsOn("validateJsonAssets")
 }
 
 //TODO: Remove this when gestalt can handle ProtectionDomain without classes (Resources)

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -206,6 +206,7 @@ tasks.named<Copy>("processResources") {
     from("$rootDir/docs") {
         include("Credits.md")
     }
+    dependsOn("validateJsonAssets")
 }
 
 // Validate all engine JSON assets (prefabs, etc.) at build time
@@ -214,10 +215,6 @@ tasks.register<ValidateJsonAssets>("validateJsonAssets") {
     if (resourcesDir.exists()) {
         source(project.fileTree(resourcesDir) { include("**/*.prefab", "**/*.block", "**/*.ui", "**/*.json") })
     }
-}
-
-tasks.named("processResources") {
-    dependsOn("validateJsonAssets")
 }
 
 //TODO: Remove this when gestalt can handle ProtectionDomain without classes (Resources)

--- a/engine/src/main/resources/org/terasology/engine/assets/ui/menu/moduleDetailsScreen.ui
+++ b/engine/src/main/resources/org/terasology/engine/assets/ui/menu/moduleDetailsScreen.ui
@@ -59,11 +59,6 @@
                         "columns": 2,
                         "column-widths": [0.35, 0.65],
                         "horizontalSpacing": 4,
-                        "layoutInfo": {
-                            "position-top": {
-                                "target": "TOP"
-                            }
-                        },
                         "contents": [
                             {
                                 "id": "firstColumn",


### PR DESCRIPTION
This PR implements build-time validation for all JSON-based assets (such as .prefab, .block, .ui, and .json files) in both engine and modules.
It introduces a custom Gradle task that parses each asset and fails the build with a descriptive error if any file contains malformed JSON.

Modified files:

[ValidateJsonAssets.kt](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
New Gradle task that validates JSON assets at build time.
[build.gradle.kts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
Adds the org.json dependency and test dependencies for the new task.
[terasology-module.gradle.kts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
Registers the validation task for all modules and hooks it into the build process.
[build.gradle.kts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
Registers the validation task for engine assets and hooks it into the build process.
build-logic/src/test/kotlin/org/terasology/gradology/ValidateJsonAssetsTest.kt:
Unit tests for the validation task, covering valid, invalid, and missing asset scenarios.
How to test:

Run a build (./gradlew build) with valid and invalid JSON assets to confirm that the build fails on malformed files and succeeds otherwise.
Run the included unit tests for the validation task.
Outstanding before merging:

 Review if additional asset types should be included.
 Documentation update if needed.
 
Closes #4986