### PR TITLE
load a saved game failed to initialise WorldGenerator

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
@@ -110,12 +110,40 @@ public class WorldBuilderTest {
     }
 
     @Test
-    public void testIncorrectProviderOrder() {
+    public void testProviderRegistrationOrderDoesNotMatter() {
+        // Providers reach WorldBuilder in whatever order the module/class scan hands them over, which is
+        // hash-based and varies between JVM runs. Registering a consumer before its producer must therefore
+        // still build a valid world rather than reporting the producer as missing.
+        WorldBuilder consumerFirst = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        consumerFirst.setSeed(12);
+        consumerFirst.addProvider(new Facet1Provider()); // requires Facet2
+        consumerFirst.addProvider(new Facet2Provider()); // produces Facet2
+
+        WorldBuilder producerFirst = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        producerFirst.setSeed(12);
+        producerFirst.addProvider(new Facet2Provider());
+        producerFirst.addProvider(new Facet1Provider());
+
+        BlockRegion regionToGenerate = new BlockRegion(0, 0, 0).expand(1, 1, 1);
+
+        Region consumerFirstData = consumerFirst.build().getWorldData(regionToGenerate);
+        Region producerFirstData = producerFirst.build().getWorldData(regionToGenerate);
+
+        // Both orders must agree, and must agree with the borders asserted by testBorderCalculation.
+        assertEquals(regionToGenerate, consumerFirstData.getFacet(Facet1.class).getWorldRegion());
+        assertEquals(producerFirstData.getFacet(Facet1.class).getWorldRegion(),
+                consumerFirstData.getFacet(Facet1.class).getWorldRegion());
+        assertEquals(producerFirstData.getFacet(Facet2.class).getWorldRegion(),
+                consumerFirstData.getFacet(Facet2.class).getWorldRegion());
+    }
+
+    @Test
+    public void testGenuinelyMissingProviderStillThrows() {
+        // Order independence must not weaken the real check: a required facet that nothing produces
+        // or updates is still a configuration error, whatever order the providers arrived in.
         WorldBuilder worldBuilder = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
         worldBuilder.setSeed(12);
-        // Facet1Provider requires Facet2Provider, add them in incorrect order
-        worldBuilder.addProvider(new Facet1Provider());
-        worldBuilder.addProvider(new Facet2Provider());
+        worldBuilder.addProvider(new Facet1Provider()); // requires Facet2, which nothing here provides
 
         assertThrows(IllegalStateException.class, worldBuilder::build);
     }

--- a/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
@@ -170,7 +170,11 @@ public class WorldBuilderTest {
         BlockRegion density = regionData.getFacet(DensityLike.class).getWorldRegion();
         BlockRegion roughness = regionData.getFacet(RoughnessLike.class).getWorldRegion();
 
-        assertTrue(roughness.getSizeX() >= density.getSizeX() && roughness.getSizeZ() >= density.getSizeZ(),
+        // Containment by world coordinate, not merely a comparison of sizes: the read is
+        // roughness.getWorld(x, z) for each (x, z) of density, so a roughness region that were larger
+        // but offset would still throw. Assert the bounds actually enclose density's.
+        assertTrue(roughness.minX() <= density.minX() && roughness.maxX() >= density.maxX()
+                        && roughness.minZ() <= density.minZ() && roughness.maxZ() >= density.maxZ(),
                 "Roughness " + roughness + " must cover every column of Density " + density
                         + "; DensityUpdater reads one from the other by world coordinate.");
     }

--- a/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
@@ -148,6 +148,96 @@ public class WorldBuilderTest {
         assertThrows(IllegalStateException.class, worldBuilder::build);
     }
 
+    @Test
+    public void testRequiredFacetCoversUpdatedFacet() {
+        // Mirrors the CoreWorlds/Caves arrangement behind Terasology/CoreWorlds#48:
+        //   DensityUpdater  updates Density, requires Roughness with no border of its own
+        //   SurfaceSpreader updates Spread,  requires Density with a sides border
+        // The sides border SurfaceSpreader asks for on Density has to reach Roughness too, otherwise
+        // DensityUpdater iterates a Density region wider than the Roughness it reads per column and
+        // walks off the end of it.
+        WorldBuilder worldBuilder = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        worldBuilder.setSeed(12);
+        worldBuilder.addProvider(new RoughnessProvider());
+        worldBuilder.addProvider(new DensityProvider());
+        worldBuilder.addProvider(new DensityUpdater());
+        worldBuilder.addProvider(new SpreadProvider());
+        worldBuilder.addProvider(new SurfaceSpreader());
+
+        BlockRegion regionToGenerate = new BlockRegion(0, 0, 0).expand(1, 1, 1);
+        Region regionData = worldBuilder.build().getWorldData(regionToGenerate);
+
+        BlockRegion density = regionData.getFacet(DensityLike.class).getWorldRegion();
+        BlockRegion roughness = regionData.getFacet(RoughnessLike.class).getWorldRegion();
+
+        assertTrue(roughness.getSizeX() >= density.getSizeX() && roughness.getSizeZ() >= density.getSizeZ(),
+                "Roughness " + roughness + " must cover every column of Density " + density
+                        + "; DensityUpdater reads one from the other by world coordinate.");
+    }
+
+    public static class DensityLike extends BaseFacet3D {
+        public DensityLike(BlockRegion targetRegion, Border3D border) {
+            super(targetRegion, border);
+        }
+    }
+
+    public static class RoughnessLike extends BaseFacet3D {
+        public RoughnessLike(BlockRegion targetRegion, Border3D border) {
+            super(targetRegion, border);
+        }
+    }
+
+    public static class SpreadLike extends BaseFacet3D {
+        public SpreadLike(BlockRegion targetRegion, Border3D border) {
+            super(targetRegion, border);
+        }
+    }
+
+    @Produces(RoughnessLike.class)
+    public static class RoughnessProvider implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+            region.setRegionFacet(RoughnessLike.class,
+                    new RoughnessLike(region.getRegion(), region.getBorderForFacet(RoughnessLike.class)));
+        }
+    }
+
+    @Produces(DensityLike.class)
+    public static class DensityProvider implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+            region.setRegionFacet(DensityLike.class,
+                    new DensityLike(region.getRegion(), region.getBorderForFacet(DensityLike.class)));
+        }
+    }
+
+    @Produces(SpreadLike.class)
+    public static class SpreadProvider implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+            region.setRegionFacet(SpreadLike.class,
+                    new SpreadLike(region.getRegion(), region.getBorderForFacet(SpreadLike.class)));
+        }
+    }
+
+    /** Stands in for CoreWorlds' DensityNoiseProvider. */
+    @Requires(@Facet(RoughnessLike.class))
+    @Updates(@Facet(value = DensityLike.class, border = @FacetBorder(top = 1)))
+    public static class DensityUpdater implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+        }
+    }
+
+    /** Stands in for Caves' CaveToSurfaceProvider. */
+    @Requires(@Facet(value = DensityLike.class, border = @FacetBorder(sides = 3)))
+    @Updates(@Facet(value = SpreadLike.class, border = @FacetBorder(sides = 3)))
+    public static class SurfaceSpreader implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+        }
+    }
+
     public static class Facet1 extends BaseFacet3D {
         public boolean updated;
 

--- a/engine/src/main/java/org/terasology/engine/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/WorldBuilder.java
@@ -347,18 +347,25 @@ public class WorldBuilder extends ProviderStore {
     private int updatePriority(FacetProvider provider, Class<? extends WorldFacet> facet) {
         Updates updates = provider.getClass().getAnnotation(Updates.class);
         if (updates != null) {
-            return updates.priority();
-        } else {
-            Requires requires = provider.getClass().getAnnotation(Requires.class);
-            if (requires != null) {
-                for (Facet f : requires.value()) {
-                    if (f.value() == facet) {
-                        return UpdatePriority.PRIORITY_REQUIRES;
-                    }
+            // Only the facets this provider actually updates get its update priority. Returning it for
+            // every facet - including ones the provider merely requires - understates how much of the
+            // facet's provider chain that requirement depends on, because addProviderChain then skips
+            // updaters at or below the returned priority.
+            for (Facet f : updates.value()) {
+                if (f.value() == facet) {
+                    return updates.priority();
                 }
             }
-            return UpdatePriority.PRIORITY_PRODUCES;
         }
+        Requires requires = provider.getClass().getAnnotation(Requires.class);
+        if (requires != null) {
+            for (Facet f : requires.value()) {
+                if (f.value() == facet) {
+                    return UpdatePriority.PRIORITY_REQUIRES;
+                }
+            }
+        }
+        return UpdatePriority.PRIORITY_PRODUCES;
     }
 
     // Ensure that rasterizers that must run after others are in the correct order. This ensures that blocks from

--- a/engine/src/main/java/org/terasology/engine/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/WorldBuilder.java
@@ -174,6 +174,11 @@ public class WorldBuilder extends ProviderStore {
     private ListMultimap<Class<? extends WorldFacet>, FacetProvider> determineProviderChains(boolean scalable) {
         ListMultimap<Class<? extends WorldFacet>, FacetProvider> result = ArrayListMultimap.create();
         Set<Class<? extends WorldFacet>> facets = new LinkedHashSet<>();
+
+        // Collect every facet produced or updated by any provider before checking requirements
+        // below. providersList's order comes from hash-based module/class-index iteration, so a
+        // provider's position gives no guarantee that its own producer already ran - checking
+        // requirements in the same pass would make this check order-dependent.
         for (FacetProvider provider : providersList) {
             Class<? extends FacetProvider> providerClass = provider.getClass();
             Produces produces = providerClass.getAnnotation(Produces.class);
@@ -181,6 +186,16 @@ public class WorldBuilder extends ProviderStore {
                 facets.addAll(Arrays.asList(produces.value()));
             }
 
+            Updates updates = providerClass.getAnnotation(Updates.class);
+            if (updates != null) {
+                for (Facet facet : updates.value()) {
+                    facets.add(facet.value());
+                }
+            }
+        }
+
+        for (FacetProvider provider : providersList) {
+            Class<? extends FacetProvider> providerClass = provider.getClass();
             Requires requires = providerClass.getAnnotation(Requires.class);
             if (requires != null) {
                 for (Facet facet : requires.value()) {
@@ -189,13 +204,6 @@ public class WorldBuilder extends ProviderStore {
                         logger.error("Facet provider for {} is missing. It is required by {}", facetValue, providerClass);
                         throw new IllegalStateException("Missing facet provider");
                     }
-                }
-            }
-
-            Updates updates = providerClass.getAnnotation(Updates.class);
-            if (updates != null) {
-                for (Facet facet : updates.value()) {
-                    facets.add(facet.value());
                 }
             }
         }


### PR DESCRIPTION
WorldBuilder.determineProviderChains() (engine/.../WorldBuilder.java:174-201) does a single linear pass over providersList: it builds up the set of "known-produced facets" incrementally while simultaneously checking each provider's @Requires against that same still-growing set. providersList's order comes from DefaultWorldGeneratorPluginLibrary
 → Gestalt's ModuleEnvironment.getTypesAnnotatedWith()
 → a HashSet/HashMap chain keyed by Class hashcode — not any stable or dependency-aware order.

So whenever a consumer (CaveLocationProvider) happens to land in providersList before its producer (CaveFacetProvider) due to hash-bucket layout, the check fires a false "missing" error even though both are present and correctly annotated.

```
  16:17:15.608 [main] ERROR o.t.e.world.generation.WorldBuilder - Facet provider for class org.terasology.caves.CaveFacet is missing. It is required by class org.terasology.caves.CaveLocationProvider
  16:17:15.608 [main] ERROR o.t.engine.core.modes.StateLoading - Error while loading org.terasology.engine.core.modes.loadProcesses.InitialiseWorldGenerator@4a093ec3
  java.lang.IllegalStateException: Missing facet provider
          at org.terasology.engine.world.generation.WorldBuilder.determineProviderChains(WorldBuilder.java:190)
          at org.terasology.engine.world.generation.WorldBuilder.build(WorldBuilder.java:95)
          at org.terasology.engine.world.generation.BaseFacetedWorldGenerator.getWorld(BaseFacetedWorldGenerator.java:83)
          at org.terasology.engine.world.generation.BaseFacetedWorldGenerator.initialize(BaseFacetedWorldGenerator.java:58)
          at org.terasology.engine.core.modes.loadProcesses.InitialiseWorldGenerator.step(InitialiseWorldGenerator.java:34)
          at org.terasology.engine.core.modes.StateLoading.update(StateLoading.java:242)
          at org.terasology.engine.core.TerasologyEngine.tick(TerasologyEngine.java:570)
          at org.terasology.engine.core.TerasologyEngine.mainLoop(TerasologyEngine.java:525)
          at org.terasology.engine.core.TerasologyEngine.runMain(TerasologyEngine.java:501)
          at org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:468)
          at org.terasology.engine.Terasology.call(Terasology.java:189)
          at org.terasology.engine.Terasology.call(Terasology.java:69)
          at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
          at picocli.CommandLine.access$1200(CommandLine.java:145)
          at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
          at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
          at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
          at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2159)
          at picocli.CommandLine.execute(CommandLine.java:2058)
          at org.terasology.engine.Terasology.main(Terasology.java:138)

```
