### PR TITLE
Fix #5330's failing test, and the same ordering bug in updatePriority

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
@@ -110,12 +110,40 @@ public class WorldBuilderTest {
     }
 
     @Test
-    public void testIncorrectProviderOrder() {
+    public void testProviderRegistrationOrderDoesNotMatter() {
+        // Providers reach WorldBuilder in whatever order the module/class scan hands them over, which is
+        // hash-based and varies between JVM runs. Registering a consumer before its producer must therefore
+        // still build a valid world rather than reporting the producer as missing.
+        WorldBuilder consumerFirst = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        consumerFirst.setSeed(12);
+        consumerFirst.addProvider(new Facet1Provider()); // requires Facet2
+        consumerFirst.addProvider(new Facet2Provider()); // produces Facet2
+
+        WorldBuilder producerFirst = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        producerFirst.setSeed(12);
+        producerFirst.addProvider(new Facet2Provider());
+        producerFirst.addProvider(new Facet1Provider());
+
+        BlockRegion regionToGenerate = new BlockRegion(0, 0, 0).expand(1, 1, 1);
+
+        Region consumerFirstData = consumerFirst.build().getWorldData(regionToGenerate);
+        Region producerFirstData = producerFirst.build().getWorldData(regionToGenerate);
+
+        // Both orders must agree, and must agree with the borders asserted by testBorderCalculation.
+        assertEquals(regionToGenerate, consumerFirstData.getFacet(Facet1.class).getWorldRegion());
+        assertEquals(producerFirstData.getFacet(Facet1.class).getWorldRegion(),
+                consumerFirstData.getFacet(Facet1.class).getWorldRegion());
+        assertEquals(producerFirstData.getFacet(Facet2.class).getWorldRegion(),
+                consumerFirstData.getFacet(Facet2.class).getWorldRegion());
+    }
+
+    @Test
+    public void testGenuinelyMissingProviderStillThrows() {
+        // Order independence must not weaken the real check: a required facet that nothing produces
+        // or updates is still a configuration error, whatever order the providers arrived in.
         WorldBuilder worldBuilder = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
         worldBuilder.setSeed(12);
-        // Facet1Provider requires Facet2Provider, add them in incorrect order
-        worldBuilder.addProvider(new Facet1Provider());
-        worldBuilder.addProvider(new Facet2Provider());
+        worldBuilder.addProvider(new Facet1Provider()); // requires Facet2, which nothing here provides
 
         assertThrows(IllegalStateException.class, worldBuilder::build);
     }

--- a/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
@@ -170,7 +170,11 @@ public class WorldBuilderTest {
         BlockRegion density = regionData.getFacet(DensityLike.class).getWorldRegion();
         BlockRegion roughness = regionData.getFacet(RoughnessLike.class).getWorldRegion();
 
-        assertTrue(roughness.getSizeX() >= density.getSizeX() && roughness.getSizeZ() >= density.getSizeZ(),
+        // Containment by world coordinate, not merely a comparison of sizes: the read is
+        // roughness.getWorld(x, z) for each (x, z) of density, so a roughness region that were larger
+        // but offset would still throw. Assert the bounds actually enclose density's.
+        assertTrue(roughness.minX() <= density.minX() && roughness.maxX() >= density.maxX()
+                        && roughness.minZ() <= density.minZ() && roughness.maxZ() >= density.maxZ(),
                 "Roughness " + roughness + " must cover every column of Density " + density
                         + "; DensityUpdater reads one from the other by world coordinate.");
     }

--- a/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/generation/WorldBuilderTest.java
@@ -148,6 +148,96 @@ public class WorldBuilderTest {
         assertThrows(IllegalStateException.class, worldBuilder::build);
     }
 
+    @Test
+    public void testRequiredFacetCoversUpdatedFacet() {
+        // Mirrors the CoreWorlds/Caves arrangement behind Terasology/CoreWorlds#48:
+        //   DensityUpdater  updates Density, requires Roughness with no border of its own
+        //   SurfaceSpreader updates Spread,  requires Density with a sides border
+        // The sides border SurfaceSpreader asks for on Density has to reach Roughness too, otherwise
+        // DensityUpdater iterates a Density region wider than the Roughness it reads per column and
+        // walks off the end of it.
+        WorldBuilder worldBuilder = new WorldBuilder(context.get(WorldGeneratorPluginLibrary.class));
+        worldBuilder.setSeed(12);
+        worldBuilder.addProvider(new RoughnessProvider());
+        worldBuilder.addProvider(new DensityProvider());
+        worldBuilder.addProvider(new DensityUpdater());
+        worldBuilder.addProvider(new SpreadProvider());
+        worldBuilder.addProvider(new SurfaceSpreader());
+
+        BlockRegion regionToGenerate = new BlockRegion(0, 0, 0).expand(1, 1, 1);
+        Region regionData = worldBuilder.build().getWorldData(regionToGenerate);
+
+        BlockRegion density = regionData.getFacet(DensityLike.class).getWorldRegion();
+        BlockRegion roughness = regionData.getFacet(RoughnessLike.class).getWorldRegion();
+
+        assertTrue(roughness.getSizeX() >= density.getSizeX() && roughness.getSizeZ() >= density.getSizeZ(),
+                "Roughness " + roughness + " must cover every column of Density " + density
+                        + "; DensityUpdater reads one from the other by world coordinate.");
+    }
+
+    public static class DensityLike extends BaseFacet3D {
+        public DensityLike(BlockRegion targetRegion, Border3D border) {
+            super(targetRegion, border);
+        }
+    }
+
+    public static class RoughnessLike extends BaseFacet3D {
+        public RoughnessLike(BlockRegion targetRegion, Border3D border) {
+            super(targetRegion, border);
+        }
+    }
+
+    public static class SpreadLike extends BaseFacet3D {
+        public SpreadLike(BlockRegion targetRegion, Border3D border) {
+            super(targetRegion, border);
+        }
+    }
+
+    @Produces(RoughnessLike.class)
+    public static class RoughnessProvider implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+            region.setRegionFacet(RoughnessLike.class,
+                    new RoughnessLike(region.getRegion(), region.getBorderForFacet(RoughnessLike.class)));
+        }
+    }
+
+    @Produces(DensityLike.class)
+    public static class DensityProvider implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+            region.setRegionFacet(DensityLike.class,
+                    new DensityLike(region.getRegion(), region.getBorderForFacet(DensityLike.class)));
+        }
+    }
+
+    @Produces(SpreadLike.class)
+    public static class SpreadProvider implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+            region.setRegionFacet(SpreadLike.class,
+                    new SpreadLike(region.getRegion(), region.getBorderForFacet(SpreadLike.class)));
+        }
+    }
+
+    /** Stands in for CoreWorlds' DensityNoiseProvider. */
+    @Requires(@Facet(RoughnessLike.class))
+    @Updates(@Facet(value = DensityLike.class, border = @FacetBorder(top = 1)))
+    public static class DensityUpdater implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+        }
+    }
+
+    /** Stands in for Caves' CaveToSurfaceProvider. */
+    @Requires(@Facet(value = DensityLike.class, border = @FacetBorder(sides = 3)))
+    @Updates(@Facet(value = SpreadLike.class, border = @FacetBorder(sides = 3)))
+    public static class SurfaceSpreader implements FacetProvider {
+        @Override
+        public void process(GeneratingRegion region) {
+        }
+    }
+
     public static class Facet1 extends BaseFacet3D {
         public boolean updated;
 

--- a/engine/src/main/java/org/terasology/engine/world/generation/WorldBuilder.java
+++ b/engine/src/main/java/org/terasology/engine/world/generation/WorldBuilder.java
@@ -347,18 +347,25 @@ public class WorldBuilder extends ProviderStore {
     private int updatePriority(FacetProvider provider, Class<? extends WorldFacet> facet) {
         Updates updates = provider.getClass().getAnnotation(Updates.class);
         if (updates != null) {
-            return updates.priority();
-        } else {
-            Requires requires = provider.getClass().getAnnotation(Requires.class);
-            if (requires != null) {
-                for (Facet f : requires.value()) {
-                    if (f.value() == facet) {
-                        return UpdatePriority.PRIORITY_REQUIRES;
-                    }
+            // Only the facets this provider actually updates get its update priority. Returning it for
+            // every facet - including ones the provider merely requires - understates how much of the
+            // facet's provider chain that requirement depends on, because addProviderChain then skips
+            // updaters at or below the returned priority.
+            for (Facet f : updates.value()) {
+                if (f.value() == facet) {
+                    return updates.priority();
                 }
             }
-            return UpdatePriority.PRIORITY_PRODUCES;
         }
+        Requires requires = provider.getClass().getAnnotation(Requires.class);
+        if (requires != null) {
+            for (Facet f : requires.value()) {
+                if (f.value() == facet) {
+                    return UpdatePriority.PRIORITY_REQUIRES;
+                }
+            }
+        }
+        return UpdatePriority.PRIORITY_PRODUCES;
     }
 
     // Ensure that rasterizers that must run after others are in the correct order. This ensures that blocks from


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Targets `soloturn-loadgame` rather than `develop`, so merging this into #5330 keeps that PR as the one of record and turns its build green.

## Summary

- **Fixes #5330's red build.** `WorldBuilderTest.testIncorrectProviderOrder` asserted that registering a consumer before its producer must throw `IllegalStateException` — the exact behaviour #5330 removes — so `Tests / Unit Tests` fails. That test encoded the bug as the contract: provider registration order carries no meaning, since it comes from hash-based module and class-index iteration, so a build that succeeds in one order and fails in the other *is* the defect. Replaced with `testProviderRegistrationOrderDoesNotMatter`, which builds both orders and asserts the resulting facet regions agree with each other and with `testBorderCalculation`.
- **Keeps the real check.** Added `testGenuinelyMissingProviderStillThrows` — a required facet that nothing produces or updates must still fail the build. The old test was serving double duty and only the ordering half needed to change.
- **Extends the fix to a second symptom of the same root cause.** `updatePriority` returned the provider's `@Updates` priority for *every* facet as soon as the provider carried an `@Updates` annotation, including facets it merely `@Requires`. Its own Javadoc already specifies the intended behaviour, so this is the implementation catching up with the documented contract.

## Why the `updatePriority` change matters

`addProviderChain` skips updaters whose priority is not greater than the `minPriority` handed to it. Returning `PRIORITY_NORMAL` for a require-only facet therefore drops every normal-priority updater of that facet out of the requirement's chain. Those updaters are then not ordered before the requiring provider, and `determineBorders` — which walks that ordering in a single reverse pass — can apply a border to a facet *after* the provider that needed to propagate it onward has already been visited.

That is the engine-side cause of the out-of-bounds read currently patched at module level in Terasology/CoreWorlds#48:

- Caves' `CaveToSurfaceProvider` requires `DensityFacet` with `sides = 3` while updating `SurfacesFacet` and `CaveFacet`.
- CoreWorlds' `DensityNoiseProvider` updates `DensityFacet` and requires `SurfaceRoughnessFacet` with no border of its own.

With the wrong priority, `DensityNoiseProvider` could be left out of the chain expanded for that requirement and visited before `sides = 3` reached `DensityFacet`, so `SurfaceRoughnessFacet` never grew to match. `DensityNoiseProvider` then iterated a `DensityFacet` region wider in X/Z than the roughness facet it reads per column and walked off the end of it — `BaseFacet2D.getWorldIndex` throws.

Because the ordering derives from hash-based iteration over `Class` keys, and `Class` uses identity hash codes that are re-randomised per JVM start, whether this happened varied between launches rather than between world seeds. That is why the crash looked random and was hard to pin to a repro.

## Test plan

- [x] `testRequiredFacetCoversUpdatedFacet` models the arrangement above with synthetic facets and asserts the required facet still covers every column of the updated one. Verified it **fails without** the `updatePriority` change and **passes with** it.
- [x] Each commit verified green independently, so the test fix can be taken on its own if the `updatePriority` change is preferred as a separate PR.
- [x] Full `engine-tests` suite run locally: 858 tests, the only failures being `TestModuleEnvironmentSandbox`, which passes in isolation and fails only in a full-suite run — pre-existing `PathManager` cross-class pollution, unrelated to this change.

## Not addressed here

CodeRabbit's suggestion on #5330 to filter both passes by `ScalableFacetProvider` is deliberately not applied — reasoning in [this comment](https://github.com/MovingBlocks/Terasology/pull/5330#issuecomment-5079341247). Short version: the non-filtering is pre-existing rather than introduced by #5330, and the proposed diff would turn a silent degradation into a hard `IllegalStateException` at world-generator initialisation. Worth its own issue.

## Related

- Builds on #5330
- Engine-side cause of Terasology/CoreWorlds#48
