### PR TITLE
fix: register ComponentClassTypeHandlerFactory in module-environment TypeHandlerLibrary

### DIFF
--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/TypeHandlerLibraryImpl.java
@@ -96,6 +96,7 @@ public class TypeHandlerLibraryImpl extends TypeHandlerLibrary {
     @Inject
     public TypeHandlerLibraryImpl(ModuleManager moduleManager, TypeRegistry typeRegistry) {
         super(new ModuleEnvironmentSandbox(moduleManager, typeRegistry));
+        addTypeHandlerFactory(new ComponentClassTypeHandlerFactory());
 
         // TODO: This used to be done in TypeHandlerLibraryImpl.forModuleEnvironment().
         populateWithDefaultHandlers(this);


### PR DESCRIPTION
## Summary
- `TypeHandlerLibraryImpl`'s `@Inject` constructor (the one actually used by the running game via `forModuleEnvironment()`) never called `addTypeHandlerFactory(new ComponentClassTypeHandlerFactory())`, unlike its two sibling constructors.
- Without it, any `Class<? extends Component>` field (e.g. `RetainComponentsComponent.components`, which rides along on block-item entities) fell through to the generic reflection-based deserializer, which tries to `Unsafe`-allocate a `java.lang.Class` instance and fails:
  ```
  java.lang.RuntimeException: Unable to create an instance of java.lang.Class<? extends org.terasology.gestalt.entitysystem.component.Component>. Register an InstanceCreator for this type to fix this problem.
      at org.terasology.reflection.reflect.ConstructorLibrary$1.construct(ConstructorLibrary.java:65)
      at org.terasology.persistence.typeHandling.coreTypes.ObjectFieldMapTypeHandler.deserialize(ObjectFieldMapTypeHandler.java:107)
      ...
      at org.terasology.engine.persistence.internal.PlayerStoreInternal.restoreEntities(PlayerStoreInternal.java:48)
  ```
- Effect in practice: inventory restoration on load-game breaks partway through the item list as soon as it hits a block-item entity carrying this component.
- Traced to a gap introduced during the gestalt-di migration (~April 2025, commit 9537e27db) - the constructor gained DI wiring but dropped this one factory registration that its predecessors had.

## Test plan
- [x] `gradle :engine:compileJava` succeeds
- [ ] Load a save with block items in inventory and confirm all items restore, not just the last one

🤖 Generated with [Claude Code](https://claude.com/claude-code)