### PR TITLE
fix: character prediction freeze and toggle-inventory NPE

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
@@ -292,6 +292,9 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
         EntityRef controller = characterComponent.controller;
 
         ClientComponent clientComponent = controller.getComponent(ClientComponent.class);
+        if (clientComponent == null) {
+            return "?";
+        }
         EntityRef clientInfo = clientComponent.clientInfo;
 
         DisplayNameComponent displayNameComponent = clientInfo.getComponent(DisplayNameComponent.class);

--- a/engine/src/main/java/org/terasology/engine/logic/characters/ServerCharacterPredictionSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/ServerCharacterPredictionSystem.java
@@ -44,6 +44,11 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
     public static final int MAX_INPUT_OVERFLOW = 100;
     public static final int MAX_INPUT_UNDERFLOW = 100;
     private static final int MAX_INPUT_OVERFLOW_REPLAY_INCREASE = 120;
+    // A server-side stall (e.g. a GC pause) can desync lastState's recorded time from the game
+    // clock by far more than any legitimate single input could. A rejected input never advances
+    // lastState, so that gap only grows every subsequent frame - permanently freezing movement
+    // unless it's beyond this bound treated as a stall and resynced instead.
+    private static final float STALL_RESYNC_THRESHOLD_MS = 1000;
 
     private static final Logger logger = LoggerFactory.getLogger(ServerCharacterPredictionSystem.class);
 
@@ -147,6 +152,13 @@ public class ServerCharacterPredictionSystem extends BaseComponentSystem impleme
             lastInputEvent.put(entity, input);
         } else {
             logger.warn("Received too much input from {}, dropping input. Delta difference: {}", entity, delta);
+            if (delta > STALL_RESYNC_THRESHOLD_MS) {
+                CharacterStateEvent resyncedState = new CharacterStateEvent(lastState);
+                resyncedState.setTime(time.getGameTimeInMs());
+                stateBuffer.add(resyncedState);
+                characterMovementSystemUtility.setToState(entity, resyncedState);
+                logger.warn("Resyncing time for {} after an apparent stall (delta {} ms)", entity, delta);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- **ServerCharacterPredictionSystem**: rejected input never advances `lastState`. Once a stall (e.g. a GC pause during autosave) pushes the gap between `lastState`'s time and the game clock past the overflow threshold, it only grows every following frame and never recovers - the player freezes permanently, requiring a forced quit. Fix: once the overflow exceeds 1000ms, resync `lastState`'s time to the game clock (position/velocity untouched) instead of dropping input forever.
- **CharacterSystem.getPlayerNameFromCharacter**: `characterComponent` and `displayNameComponent` were already null-checked, `clientComponent` was not. When the character's controller has no `ClientComponent`, this threw an NPE - hit via ManualLabor's toggle-inventory action, crashing the game. Fixed with the same null-check pattern already used around it.

## Test plan
- [x] `gradle :engine:compileJava` succeeds
- [ ] Trigger an autosave-adjacent stall and confirm the game recovers instead of freezing
- [ ] Use ManualLabor's toggle-inventory action without a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)