### PR TITLE
fix: stop sending movement input when the window is unfocused

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
@@ -143,6 +143,11 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
 
     private void processInput(EntityRef entity, CharacterMovementComponent characterMovementComponent) {
         if (!display.hasFocus()) {
+            // Otherwise stale pre-focus-loss deltas get sent as the next command once focus returns.
+            relativeMovement.set(0, 0, 0);
+            lookPitchDelta = 0;
+            lookYawDelta = 0;
+            jump = false;
             return;
         }
 

--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
@@ -10,6 +10,7 @@ import org.terasology.engine.config.Config;
 import org.terasology.engine.config.PlayerConfig;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.Time;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.core.subsystem.config.BindsManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
@@ -87,6 +88,9 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     @In
     private BindsManager bindsManager;
 
+    @In
+    private DisplayDevice display;
+
     private Camera playerCamera;
     private boolean localPlayerInitialized = false;
 
@@ -138,6 +142,10 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     }
 
     private void processInput(EntityRef entity, CharacterMovementComponent characterMovementComponent) {
+        if (!display.hasFocus()) {
+            return;
+        }
+
         lookYaw = (float) ((lookYaw - lookYawDelta) % 360);
         lookYawDelta = 0f;
         lookPitch = (float) Math.clamp(-89, 89, lookPitch + lookPitchDelta);


### PR DESCRIPTION
## Summary
- `LocalPlayerSystem.processInput()` sent a `CharacterMoveInputEvent` every frame unconditionally, even with zero keys held and no window focus - a per-frame heartbeat, not edge-triggered on actual input.
- Under a normal frame rate the resulting client/server clock skew is small enough to pass `ServerCharacterPredictionSystem`'s overflow check. When macOS throttles a backgrounded window's render loop to a much lower rate (e.g. after Cmd+Tab), the network-queue delivery granularity no longer scales with it, so a small residual skew leaks past the check every single frame - spamming the "dropping input" warning continuously for as long as the window stays unfocused.
- Fixed by gating `processInput()` on `DisplayDevice.hasFocus()`, the same check `InputSystem.isCapturingMouse()` already uses for raw device polling - no movement input gets generated at all while unfocused.

## Test plan
- [x] `gradle :engine:compileJava` succeeds
- [ ] Cmd+Tab away from the game window and confirm no more "dropping input" spam in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)