### PR TITLE
fix: three bugs found by a broad code sweep (claude-fable-5)

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/characters/CharacterSystem.java
@@ -119,9 +119,16 @@ public class CharacterSystem extends BaseComponentSystem implements UpdateSubscr
     public String getInstigatorName(EntityRef instigator) {
         if (instigator.hasComponent(CharacterComponent.class)) {
             EntityRef instigatorClient = instigator.getComponent(CharacterComponent.class).controller;
-            EntityRef instigatorClientInfo = instigatorClient.getComponent(ClientComponent.class).clientInfo;
-            return instigatorClientInfo.getComponent(DisplayNameComponent.class).name;
-        } else if (instigator.getParentPrefab() != null) {
+            ClientComponent clientComponent = instigatorClient.getComponent(ClientComponent.class);
+            if (clientComponent != null) {
+                DisplayNameComponent instigatorDisplayName = clientComponent.clientInfo.getComponent(DisplayNameComponent.class);
+                if (instigatorDisplayName != null) {
+                    return instigatorDisplayName.name;
+                }
+            }
+        }
+
+        if (instigator.getParentPrefab() != null) {
             //A DisplayName can be specified in the entity prefab
             //Otherwise, the game will attempt to generate one from the name of that prefab
             Prefab parentPrefab = instigator.getParentPrefab();

--- a/engine/src/main/java/org/terasology/engine/network/internal/NetClient.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/NetClient.java
@@ -340,8 +340,8 @@ public class NetClient extends AbstractClient implements WorldChangeListener {
                 }
             } else {
                 NetworkComponent networkComponent = target.getComponent(NetworkComponent.class);
-                if (networkComponent != null && netRelevant.contains(networkComponent.getNetworkId())
-                        || netInitial.contains(networkComponent.getNetworkId())) {
+                if (networkComponent != null && (netRelevant.contains(networkComponent.getNetworkId())
+                        || netInitial.contains(networkComponent.getNetworkId()))) {
                     queuedOutgoingEvents.add(NetData.EventMessage.newBuilder()
                         .setTargetId(networkComponent.getNetworkId())
                         .setEvent(eventSerializer.serialize(event)).build());

--- a/engine/src/main/java/org/terasology/engine/recording/RecordAndReplaySerializer.java
+++ b/engine/src/main/java/org/terasology/engine/recording/RecordAndReplaySerializer.java
@@ -105,10 +105,8 @@ public final class RecordAndReplaySerializer {
     }
 
     private void serializeFileAmount(Gson gson, String recordingPath) {
-        try {
-            JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + FILE_AMOUNT));
+        try (JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + FILE_AMOUNT))) {
             gson.toJson(recordAndReplayUtils.getFileAmount(), Integer.class, writer);
-            writer.close();
             logger.info("File Amount Serialization completed!");
         } catch (Exception e) {
             logger.error("Error while serializing file amount:", e);
@@ -129,10 +127,8 @@ public final class RecordAndReplaySerializer {
     }
 
     private void serializeCharacterStateEventPositionMap(Gson gson, String recordingPath) {
-        try {
-            JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + STATE_EVENT_POSITION));
+        try (JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + STATE_EVENT_POSITION))) {
             gson.toJson(characterStateEventPositionMap.getIdToData(), HashMap.class, writer);
-            writer.close();
             characterStateEventPositionMap.reset();
             logger.info("CharacterStateEvent positions Serialization completed!");
         } catch (Exception e) {
@@ -155,10 +151,8 @@ public final class RecordAndReplaySerializer {
     }
 
     private void serializeAttackEventExtraRecorder(Gson gson, String recordingPath) {
-        try {
-            JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + DIRECTION_ORIGIN_LIST));
+        try (JsonWriter writer = new JsonWriter(new FileWriter(recordingPath + DIRECTION_ORIGIN_LIST))) {
             gson.toJson(directionAndOriginPosRecorderList.getList(), ArrayList.class, writer);
-            writer.close();
             directionAndOriginPosRecorderList.reset();
             logger.info("AttackEvent extras serialization completed!");
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
Found by a broad code-quality sweep of `engine/` using `claude-fable-5`, each verified before fixing:

- **`CharacterSystem.getInstigatorName`**: same bug already fixed once in this file's `getPlayerNameFromCharacter` - a non-player character (mob/NPC) death instigator has `controller == EntityRef.NULL`, so `clientComponent` was null and this crashed on any death caused by a monster. Falls through to the existing prefab-name logic instead, matching what the method's own javadoc already documents as the fallback.
- **`NetClient.send(Event, EntityRef)`**: an unparenthesized `&& ... ||` where `&&` binds tighter, so a null `networkComponent` still had `getNetworkId()` dereferenced by the second clause. Not reachable through current call sites (both already guard against it), but inconsistent with the three sibling methods in the same class that already use the correct short-circuit pattern - a landmine for the next caller change.
- **`RecordAndReplaySerializer`**: three `serialize*` methods opened a `JsonWriter`/`FileWriter` outside try-with-resources, closing it only after the potentially-throwing `gson.toJson()` call - leaking the file handle on any serialization failure. Inconsistent with the deserialize counterparts in the same class, which already use try-with-resources correctly.

## Test plan
- [x] `gradle :engine:compileJava` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)