### PR TITLE
report bug button makes GUI unsresponsive

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/ExtrasMenuScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/ExtrasMenuScreen.java
@@ -46,8 +46,9 @@ public class ExtrasMenuScreen extends CoreScreenLayer {
         });
         WidgetUtil.trySubscribe(this, "credits", button -> triggerForwardAnimation(CreditsScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
-        WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("There is no error."),
-                LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER));
+        WidgetUtil.trySubscribe(this, "crashReporter", widget -> new Thread(() ->
+                CrashReporter.report(new Throwable("There is no error."),
+                        LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER), "CrashReporter").start());
         WidgetUtil.trySubscribe(this, "close", button -> triggerBackAnimation());
     }
 

--- a/engine/src/main/resources/org/terasology/engine/assets/ui/menu/joinGameScreen.ui
+++ b/engine/src/main/resources/org/terasology/engine/assets/ui/menu/joinGameScreen.ui
@@ -91,7 +91,7 @@
                             {
                                 "type": "CardLayout",
                                 "id": "cards",
-                                "defaultCard": "onlineServerListScrollArea",
+                                "currentlyDisplayedCard": "onlineServerListScrollArea",
                                 "contents": [
                                     {
                                         "type": "RelativeLayout",


### PR DESCRIPTION
two fixes, as clicking report bug made the UI unresponsive

* correct CardLayout field name in joinGameScreen.ui
* run CrashReporter.report off the main thread

CrashReporter.report calls showModalDialog, a blocking Swing modal
dialog. Called directly from the button handler, it ran on the game's
main thread, so the whole game froze for as long as that dialog was
open. If the reporter's own internal logic (e.g. a network call)
hangs, there is no way to recover except killing the process, since
the main thread is stuck waiting for it. Moved to a background thread
so the game itself stays responsive regardless of what the reporter
does.

