### PR TITLE
fix: move remaining CrashReporter.report() calls off-thread

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateLoading.java
@@ -247,7 +247,7 @@ public class StateLoading implements GameState {
                 String errorMessage = String.format("Failed to load game. There was an error during \"%s\".",
                         current == null ? "the last part" : current.getMessage());
                 gameEngine.changeState(new StateMainMenu(errorMessage));
-                CrashReporter.report(e, LoggingContext.getLoggingPath());
+                new Thread(() -> CrashReporter.report(e, LoggingContext.getLoggingPath()), "CrashReporter").start();
                 return;
             }
         }

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/ExtraMenuScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/ingame/ExtraMenuScreen.java
@@ -32,8 +32,9 @@ public class ExtraMenuScreen extends CoreScreenLayer {
 
         WidgetUtil.trySubscribe(this, "telemetry", button -> triggerForwardAnimation(TelemetryScreen.ASSET_URI));
         WidgetUtil.trySubscribe(this, "devTools", widget -> triggerForwardAnimation(DevToolsMenuScreen.ASSET_URI));
-        WidgetUtil.trySubscribe(this, "crashReporter", widget -> CrashReporter.report(new Throwable("There is no error."),
-                LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER));
+        WidgetUtil.trySubscribe(this, "crashReporter", widget -> new Thread(() ->
+                CrashReporter.report(new Throwable("There is no error."),
+                        LoggingContext.getLoggingPath(), CrashReporter.MODE.ISSUE_REPORTER), "CrashReporter").start());
         WidgetUtil.trySubscribe(this, "close", widget -> triggerBackAnimation());
     }
 

--- a/facades/PC/src/main/java/org/terasology/engine/Terasology.java
+++ b/facades/PC/src/main/java/org/terasology/engine/Terasology.java
@@ -323,7 +323,7 @@ public final class Terasology implements Callable<Integer> {
         Path logPath = LoggingContext.getLoggingPath();
 
         if (!GraphicsEnvironment.isHeadless() && crashReportEnabled) {
-            CrashReporter.report(throwable, logPath);
+            new Thread(() -> CrashReporter.report(throwable, logPath), "CrashReporter").start();
         } else {
             throwable.printStackTrace();
             System.err.println("For more details, see the log files in " + logPath.toAbsolutePath().normalize());


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

On macOS crash reporter causes the GUI to hang.

- `099a1908d` fixed the main-menu Extras screen's crash reporter button (`ExtrasMenuScreen.java`) by moving `CrashReporter.report()` onto a background thread, since it calls a blocking Swing modal dialog (`SwingUtilities.invokeAndWait`) that otherwise freezes the whole game on the calling thread.
- That fix missed three other call sites hitting the exact same problem, confirmed live via `jstack` on a hung process — the main thread was blocked in `EventQueue.invokeAndWait`, called directly from `CrashReporter.report`, not from a background thread:
  - `ExtraMenuScreen.java` (singular "Extra") — the in-game pause menu's near-duplicate Extras screen, easy to miss since it's a separate file from the already-fixed main-menu one (`ExtrasMenuScreen.java`, plural).
  - `StateLoading.java` — reports load-failure exceptions on the main loading thread.
  - `Terasology.java` (facades/PC) — `reportException()`, the actual top-level uncaught-exception handler. This is the most important of the three: any unhandled exception on the main thread would hang instead of showing the crash dialog, defeating the reporter's whole purpose.
- All three are now on the same background `Thread` pattern as the original fix.
- **That alone wasn't enough on macOS.** Backgrounding the call stopped the *whole game* from hanging, but the reporter dialog itself still could never appear: showing it requires AWT to initialize its native AppKit toolkit on the same OS thread GLFW already owns exclusively under `-XstartOnFirstThread` (required for the game window itself), and that initialization blocks forever waiting for a run loop turn GLFW never yields. Confirmed live via a second `jstack` capture — the background `"CrashReporter"` thread was stuck in `sun.lwawt.macosx.LWCToolkit.initAppkit` (native method).
- This is a hard, single-process macOS constraint, not something fixable by rearranging threads within the game's own JVM. As a sanity check, removing `-Djava.awt.headless=true` (the flag that was turning the hang into a clean `HeadlessException` instead of a real deadlock) was tested live and reproduced the exact same native-thread deadlock — confirming that flag is load-bearing, not just masking the underlying problem, and was reverted.
- **The actual isolation fix now lives in the CrashReporter library itself, not here.** An earlier revision of this PR added a Terasology-side `CrashReporterLauncher`/`CrashReporterProcess` that spawned the reporter in a separate JVM subprocess. Per [review feedback](https://github.com/MovingBlocks/Terasology/pull/5338#issuecomment-5089756251), that logic moved into `CrashReporter.report()` directly ([MovingBlocks/CrashReporter#52](https://github.com/MovingBlocks/CrashReporter/pull/52)) instead, so every consumer (Terasology, Destination Sol) gets the fix automatically just by depending on a new version, with no caller-side special-casing. All four call sites here go back to the simple `new Thread(() -> CrashReporter.report(...), "CrashReporter").start()` pattern from the original fix; the Terasology-side subprocess classes were removed as redundant.
  - **Current dependency state**: this PR currently resolves `CrashReporter` via Terasology's composite build against the local source checked out at `libs/CrashReporter` (branch `fix/macos-process-isolation`, not yet merged/released) rather than a published Maven version. Once `MovingBlocks/CrashReporter#52` is merged and released, `engine/build.gradle.kts` and `facades/PC/build.gradle.kts` will need a dependency version bump to pick it up outside of local composite-build dev setups - that's a small follow-up once a release exists, not blocking this PR's review.
- While verifying the log tabs during that work, found and filed a separate, pre-existing bug: the earliest "init"-phase log lines land in a stray `logFileFolder_IS_UNDEFINED` directory instead of the correct per-session log folder, due to a Logback/MDC initialization-ordering race already flagged as a TODO in `LoggingContext.java`. Not macOS-specific, not introduced by this PR — filed separately as #5339 rather than folded in here.

## Test plan

- [ ] In-game pause menu → Extras → Issue Reporter: dialog opens in a separate process without freezing the game, on macOS.
- [ ] Main menu → Extras → Issue Reporter: still works (regression check on the already-fixed path).
- [ ] Force a load failure (e.g. corrupt a save) and confirm the crash dialog appears without hanging `StateLoading`.
- [ ] Throw an uncaught exception from the main loop and confirm the crash dialog appears without hanging the process.
- [ ] Windows/Linux: crash reporter still opens in-process as before (no behavior change expected there).
- [ ] Once `MovingBlocks/CrashReporter#52` is released, bump the dependency version here and confirm the same macOS behavior holds outside the local composite-build setup.

## Related

- Follow-up to `099a1908d` (PR #5337, already merged to `develop`).
- Depends on [MovingBlocks/CrashReporter#52](https://github.com/MovingBlocks/CrashReporter/pull/52) for the actual macOS fix (currently resolved via local composite-build source, not a release).
- Follow-up issue filed for the unrelated logging bug found along the way: #5339.
