### PR TITLE
MTE follow-ups: review leftovers, awaitClients, and safety-timeout diagnostics

### DIFF
--- a/engine-tests/build.gradle.kts
+++ b/engine-tests/build.gradle.kts
@@ -114,10 +114,16 @@ tasks.withType<Jar> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
+// Tests that touch real user directories rather than a @TempDir. Opt in with
+// `gradlew :engine-tests:filesystemSideEffectTest` - see that task below.
+val filesystemSideEffects = "filesystem-side-effects"
+
 tasks.named<Test>("test") {
     dependsOn(tasks.getByPath(":extractNatives"))
     description = "Runs all tests (slow)"
-    useJUnitPlatform ()
+    useJUnitPlatform {
+        excludeTags(filesystemSideEffects)
+    }
     systemProperty("junit.jupiter.execution.timeout.default", "4m")
 }
 
@@ -126,7 +132,17 @@ tasks.register<Test>("unitTest") {
     group =  "Verification"
     description = "Runs unit tests (fast)"
     useJUnitPlatform {
-        excludeTags("MteTest", "TteTest")
+        excludeTags("MteTest", "TteTest", filesystemSideEffects)
+    }
+    systemProperty("junit.jupiter.execution.timeout.default", "1m")
+}
+
+tasks.register<Test>("filesystemSideEffectTest") {
+    dependsOn(tasks.getByPath(":extractNatives"))
+    group = "Verification"
+    description = "Runs tests that write outside a @TempDir, into real user directories. Opt-in."
+    useJUnitPlatform {
+        includeTags(filesystemSideEffects)
     }
     systemProperty("junit.jupiter.execution.timeout.default", "1m")
 }

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -289,11 +289,14 @@ public class Engines {
     }
 
     /**
+     * Joins {@code client} to the local host and runs the engines until it reaches
+     * {@link StateIngame in-game}.
      *
      * @param client the client engine to connect to the local host
-     * @param mainLoop
-     *
-     * return true if the connection to the host was successful and the client is in state <i>in-game</i>.
+     * @param mainLoop used to tick the engines while the join completes
+     * @throws RuntimeException if the client does not reach in-game before the wait times out. The
+     *         message reports the client's state at that point and the {@link JoinStatus}, which
+     *         distinguishes a join the host refused from one that was merely slow.
      */
     void connectToHost(TerasologyEngine client, MainLoop mainLoop) {
         Context coreContextOverride = client.createChildContext();

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -5,6 +5,7 @@ package org.terasology.engine.integrationenvironment;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -317,7 +318,12 @@ public class Engines {
         try {
             mainLoop.awaitUntil("client to finish joining and reach the in-game state",
                     () -> client.getState() instanceof StateIngame);
-        } catch (AssertionError e) {
+        } catch (AssertionError | UncheckedTimeoutException e) {
+            // Both timeouts have to be caught here. awaitUntil throws AssertionError when the game-time
+            // limit is reached, but MainLoop throws UncheckedTimeoutException when the real-time safety
+            // timeout is hit first - and for a stuck join that is the likelier of the two, since an
+            // engine that is not progressing may not advance game time at all. Letting that one through
+            // would lose the diagnostics in exactly the case they are most needed.
             throw new RuntimeException(describeJoinFailure(client, joinStatus), e);
         }
     }
@@ -332,9 +338,12 @@ public class Engines {
      * where re-running to watch it is not an option.
      */
     private static String describeJoinFailure(TerasologyEngine client, JoinStatus joinStatus) {
+        // Read the state once: the engine is still running while we build this message, so calling
+        // getState() twice could report one state and describe another, or NPE on the second call.
+        GameState state = client.getState();
         StringBuilder message = new StringBuilder("Could not connect client ").append(client)
                 .append(" to local host. Client state when we gave up: ")
-                .append(client.getState() == null ? "none" : client.getState().getClass().getSimpleName());
+                .append(state == null ? "none" : state.getClass().getSimpleName());
 
         if (joinStatus == null) {
             message.append("; the join was interrupted before it reported any status");

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingEnvironment.java
@@ -48,9 +48,17 @@ public interface ModuleTestingEnvironment {
      * <p>
      * Prefer this over {@link #runUntil(Supplier)} in tests: a timeout throws with the description
      * instead of returning a status that is easy to drop.
+     * <p>
+     * Two timeouts can end the wait. The game-time one below throws {@link AssertionError}. The
+     * real-time safety timeout is enforced further down in the main loop and throws
+     * {@link com.google.common.util.concurrent.UncheckedTimeoutException} instead - and for a
+     * condition that never becomes true because the engine has stopped progressing, that is the
+     * likelier of the two, since game time only advances while the engine ticks.
      *
      * @param description what is being waited for, phrased to read after "timed out waiting for"
      * @throws AssertionError if the condition does not hold within DEFAULT_GAME_TIME_TIMEOUT of game time
+     * @throws com.google.common.util.concurrent.UncheckedTimeoutException if the real-time safety
+     *         timeout is exceeded first; see {@link #setSafetyTimeoutMs(long)}
      */
     void awaitUntil(String description, Supplier<Boolean> condition);
 
@@ -60,6 +68,9 @@ public interface ModuleTestingEnvironment {
      * @param gameTimeTimeoutMs how long to wait, in game time
      * @param description what is being waited for, phrased to read after "timed out waiting for"
      * @throws AssertionError if the condition does not hold within {@code gameTimeTimeoutMs} of game time
+     * @throws com.google.common.util.concurrent.UncheckedTimeoutException if the real-time safety
+     *         timeout is exceeded first; see {@link #setSafetyTimeoutMs(long)}
+     * @see #awaitUntil(String, Supplier)
      */
     void awaitUntil(long gameTimeTimeoutMs, String description, Supplier<Boolean> condition);
 
@@ -107,8 +118,12 @@ public interface ModuleTestingEnvironment {
      * {@code NetworkSystem.getPlayers()} can see fewer than it created. Waiting for the host's own view
      * is the fix, and doing it by hand is easy to get subtly wrong.
      *
-     * @param expectedClients how many clients the host should know about
+     * @param expectedClients how many clients the host should know about; zero returns immediately
+     * @throws IllegalArgumentException if {@code expectedClients} is negative, which no wait could satisfy
+     *         meaningfully and which would otherwise pass silently
      * @throws AssertionError if that many never register within the default game-time timeout
+     * @throws com.google.common.util.concurrent.UncheckedTimeoutException if the real-time safety
+     *         timeout is exceeded first; see {@link #awaitUntil(String, Supplier)}
      */
     void awaitClients(int expectedClients);
 

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingEnvironment.java
@@ -100,6 +100,19 @@ public interface ModuleTestingEnvironment {
     Context createClient() throws IOException;
 
     /**
+     * Runs the engines until at least {@code expectedClients} clients are registered with the host.
+     * <p>
+     * {@link #createClient()} returns once that client itself is in-game, which is not the same as the
+     * host having finished registering it - so a test that creates clients and immediately inspects
+     * {@code NetworkSystem.getPlayers()} can see fewer than it created. Waiting for the host's own view
+     * is the fix, and doing it by hand is easy to get subtly wrong.
+     *
+     * @param expectedClients how many clients the host should know about
+     * @throws AssertionError if that many never register within the default game-time timeout
+     */
+    void awaitClients(int expectedClients);
+
+    /**
      * The engines active in this instance of the module testing environment.
      * <p>
      * Engines are created for the host and connecting clients.

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingHelper.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingHelper.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.integrationenvironment;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.joml.Vector3fc;
@@ -100,6 +101,10 @@ public class ModuleTestingHelper implements ModuleTestingEnvironment {
 
     @Override
     public void awaitClients(int expectedClients) {
+        // Without this a negative count is silently satisfied by the >= below before the engine ticks
+        // even once, so a test that computed its expectation wrong would pass rather than say so.
+        Preconditions.checkArgument(expectedClients >= 0, "expectedClients must not be negative, was %s",
+                expectedClients);
         NetworkSystem networkSystem = getHostContext().get(NetworkSystem.class);
         mainLoop.awaitUntil(
                 String.format("%d client(s) to register with the host", expectedClients),

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingHelper.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/ModuleTestingHelper.java
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.integrationenvironment;
 
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.joml.Vector3fc;
 import org.joml.Vector3ic;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.TerasologyEngine;
 import org.terasology.engine.core.modes.StateIngame;
+import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.engine.world.block.BlockRegionc;
 
@@ -94,6 +96,14 @@ public class ModuleTestingHelper implements ModuleTestingEnvironment {
     @Override
     public Context createClient() throws IOException {
         return engines.createClient(mainLoop);
+    }
+
+    @Override
+    public void awaitClients(int expectedClients) {
+        NetworkSystem networkSystem = getHostContext().get(NetworkSystem.class);
+        mainLoop.awaitUntil(
+                String.format("%d client(s) to register with the host", expectedClients),
+                () -> Iterables.size(networkSystem.getPlayers()) >= expectedClients);
     }
 
     @Override

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -118,7 +118,7 @@ public class PathManagerTest {
         try {
             System.setProperty("user.home", tempHome.toString());
             pathManager.useDefaultHomePath();
-            
+
             Path expectedMacPath = tempHome.resolve("Library/Application Support/Terasology");
             assertEquals(expectedMacPath.toAbsolutePath(), pathManager.getHomePath().toAbsolutePath());
             assertTrue(Files.isDirectory(pathManager.getHomePath()));
@@ -139,7 +139,7 @@ public class PathManagerTest {
         try {
             System.setProperty("user.home", tempHome.toString());
             pathManager.useDefaultHomePath();
-            
+
             Path expectedLinuxPath = tempHome.resolve(".local/share/terasology");
             assertEquals(expectedLinuxPath.toAbsolutePath(), pathManager.getHomePath().toAbsolutePath());
             assertTrue(Files.isDirectory(pathManager.getHomePath()));
@@ -169,7 +169,7 @@ public class PathManagerTest {
         // that property. So this is the one test in the class that escapes its sandbox.
         pathManager.useDefaultHomePath();
         assertNotNull(pathManager.getHomePath());
-        
+
         // It should end with Terasology
         assertTrue(pathManager.getHomePath().toString().endsWith("Terasology"));
         assertTrue(Files.isDirectory(pathManager.getHomePath()));

--- a/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/PathManagerTest.java
@@ -4,6 +4,7 @@ package org.terasology.engine.core;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -154,10 +155,18 @@ public class PathManagerTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
+    @Tag("filesystem-side-effects")
     public void useDefaultHomePathWindows() throws IOException {
         // Windows relies on JNA (Shell32Util) which directly interrogates the Windows Registry/API.
         // We cannot easily redirect this to a @TempDir. We only verify that the path resolves to a valid Windows dir.
-        // Note: This will create a 'Terasology' folder in the local user's AppData/Saved Games! 
+        //
+        // This really does create a 'Terasology' folder in the developer's own Saved Games directory,
+        // which is why it is tagged and excluded from `test` and `unitTest`. Run it deliberately with
+        // `gradlew :engine-tests:filesystemSideEffectTest`.
+        //
+        // Note the Mac and Linux equivalents above do not need the tag: they redirect `user.home` to a
+        // @TempDir first, which Windows cannot do because the lookup goes through the OS rather than
+        // that property. So this is the one test in the class that escapes its sandbox.
         pathManager.useDefaultHomePath();
         assertNotNull(pathManager.getHomePath());
         

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ExampleTest.java
@@ -7,6 +7,7 @@ import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
@@ -40,26 +41,34 @@ public class ExampleTest {
 
     @Test
     @Tag("flaky")
-    public void testClientCreation() {
+    public void testClientCreation(TestReporter reporter) {
         logger.info("Starting test 'testClientCreation'");
+        long start = System.currentTimeMillis();
         Assertions.assertDoesNotThrow(helper::createClient);
+        reporter.publishEntry("client_connect_ms", String.valueOf(System.currentTimeMillis() - start));
         logger.info("Done with test 'testClientCreation'");
     }
 
     @Test
     @Tag("flaky")
-    public void testClientConnection() throws IOException {
+    public void testClientConnection(TestReporter reporter) throws IOException {
+        long start = System.currentTimeMillis();
         int currentClients = Lists.newArrayList(entityManager.getEntitiesWith(ClientComponent.class)).size();
 
         // create some clients (the library connects them automatically)
         Context clientContext1 = helper.createClient();
+        reporter.publishEntry("client1_connect_ms", String.valueOf(System.currentTimeMillis() - start));
+
+        long client2Start = System.currentTimeMillis();
         Context clientContext2 = helper.createClient();
+        reporter.publishEntry("client2_connect_ms", String.valueOf(System.currentTimeMillis() - client2Start));
 
         int expectedClients = currentClients + 2;
 
         // wait for both clients to be known to the server
         helper.awaitUntil("both clients to be known to the server",
                 () -> Lists.newArrayList(entityManager.getEntitiesWith(ClientComponent.class)).size() >= expectedClients);
+        reporter.publishEntry("both_known_ms", String.valueOf(System.currentTimeMillis() - start));
         Assertions.assertEquals(expectedClients,
                 Lists.newArrayList(entityManager.getEntitiesWith(ClientComponent.class)).size());
     }
@@ -76,11 +85,14 @@ public class ExampleTest {
 
     @Test
     @Tag("flaky")
-    public void testSendEvent() throws IOException {
+    public void testSendEvent(TestReporter reporter) throws IOException {
+        long start = System.currentTimeMillis();
         Context clientContext = helper.createClient();
+        reporter.publishEntry("client_connect_ms", String.valueOf(System.currentTimeMillis() - start));
 
         // send an event to a client's local player just for fun
         clientContext.get(LocalPlayer.class).getClientEntity().send(new DummyEvent());
+        reporter.publishEntry("total_ms", String.valueOf(System.currentTimeMillis() - start));
     }
 
     @Test

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/TwoClientChatTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/TwoClientChatTest.java
@@ -53,19 +53,13 @@ public class TwoClientChatTest {
         Context client2Ctx = helper.createClient();
         assertNotNull(client2Ctx, "Client 2 context should be created");
         long client2Ms = System.currentTimeMillis() - client2Start;
+        long client2TotalMs = System.currentTimeMillis() - startTime;
         reporter.publishEntry("client2_connect_ms", String.valueOf(client2Ms));
-        logger.info("Client 2 connected in {}ms (total: {}ms)",
-                client2Ms, System.currentTimeMillis() - startTime);
+        logger.info("Client 2 connected in {}ms (total: {}ms)", client2Ms, client2TotalMs);
 
         // Wait for both clients to register on the host
         NetworkSystem hostNetwork = helper.getHostContext().get(NetworkSystem.class);
-        helper.awaitUntil("both clients to register on the host", () -> {
-            int count = 0;
-            for (Client ignored : hostNetwork.getPlayers()) {
-                count++;
-            }
-            return count >= 2;
-        });
+        helper.awaitClients(2);
         assertThat(hostNetwork.getPlayers()).hasSize(2);
         long registeredMs = System.currentTimeMillis() - startTime;
         reporter.publishEntry("both_registered_ms", String.valueOf(registeredMs));
@@ -84,8 +78,9 @@ public class TwoClientChatTest {
         for (Client client : hostNetwork.getPlayers()) {
             client.getEntity().send(new ChatMessageEvent(testMessage, senderInfo));
         }
-        reporter.publishEntry("messages_sent_ms", String.valueOf(System.currentTimeMillis() - startTime));
-        logger.info("Chat messages sent at {}ms", System.currentTimeMillis() - startTime);
+        long messagesSentMs = System.currentTimeMillis() - startTime;
+        reporter.publishEntry("messages_sent_ms", String.valueOf(messagesSentMs));
+        logger.info("Chat messages sent at {}ms", messagesSentMs);
 
         // Wait for client 2's probe to receive the message
         helper.awaitUntil("client 2 to receive the chat message", () -> probe.received);

--- a/engine-tests/src/test/java/org/terasology/engine/network/internal/NetworkOwnershipTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/network/internal/NetworkOwnershipTest.java
@@ -49,7 +49,7 @@ public class NetworkOwnershipTest extends TerasologyTestingEnvironment {
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(ServerConnectListManager.class).lifetime(Lifetime.Singleton).use(ServerConnectListManager.class);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context, serviceRegistry);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(context, serviceRegistry);
         EntitySystemSetupUtil.configureEntityManagementRelatedClasses(
                 context.get(TypeHandlerLibrary.class), context.get(EntitySystemLibrary.class),

--- a/engine/src/main/java/org/terasology/engine/core/modes/AbstractState.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/AbstractState.java
@@ -37,7 +37,7 @@ public abstract class AbstractState implements GameState {
         CoreRegistry.setContext(context);
 
         // let's get the entity event system running
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context, serviceRegistry);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
 
         serviceRegistry.with(Console.class).lifetime(Lifetime.Singleton).use(ConsoleImpl.class);
         if (!isHeadless) {

--- a/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseEntitySystem.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/loadProcesses/InitialiseEntitySystem.java
@@ -25,7 +25,7 @@ public class InitialiseEntitySystem extends SingleStepLoadProcess {
 
     @Override
     public boolean step() {
-        EntitySystemSetupUtil.addEntityManagementRelatedClasses(context, serviceRegistry);
+        EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         return true;
     }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Follow-ups to #5323 and #5325: review comments that were not worth another cycle on those PRs, plus a few small MTE items that were being tracked separately and are cheaper together than apart.

## Summary

**Review leftovers**

- **`connectToHost` javadoc** (Copilot, #5325) — promised a boolean after the method became void. It was stale before that too: a bare `@param mainLoop` with no text, and a `return` line that was never a `@return` tag, so javadoc was not rendering it at all.
- **PMD `GuardLogStatement`** in `TwoClientChatTest` — two `logger.info` calls computed `System.currentTimeMillis() - startTime` inside the argument list. Hoisted, matching what the rest of the method already does. This also fixes a small inconsistency: `messages_sent_ms` was published from one clock call and logged from a second, so the metric and the log line could disagree.
- **The one test that writes outside a `@TempDir`.** `useDefaultHomePathWindows` creates a real `Terasology` folder in the developer's own Saved Games directory — the Windows home lookup goes through the OS, so it cannot be redirected the way the Mac and Linux cases are. Now tagged `filesystem-side-effects`, excluded from `test` and `unitTest`, with an opt-in `filesystemSideEffectTest` task.

  Worth noting the effect is the opposite of what a tag usually buys. The test is `@EnabledOnOs(WINDOWS)`, so it is skipped wherever the CI agent is not Windows, and in practice only ever ran on developer machines — the people it inconveniences. Opt-in is the right default rather than a CI-only group. Verified both directions on Windows: `unitTest` no longer lists the test at all (the tag filter drops it before `@EnabledOnOs` is evaluated), and `filesystemSideEffectTest` runs exactly that one test.

**`awaitClients(int)`**

`createClient()` returns once that client is in-game, which is not the same as the host having finished registering it — so a test that creates clients and immediately reads `NetworkSystem.getPlayers()` can see fewer than it created. The fix was being written by hand, six lines to count an `Iterable`, in whichever test needed it first. Any multi-client test needs this before it can assert anything about the host's view.

**Safety timeout and client state** (found by review on the ported copy, Terasology/ModuleTestingEnvironment#80)

`awaitUntil` throws `AssertionError` on the game-time timeout, but `MainLoop.runWhile` throws `UncheckedTimeoutException` on the real-time safety timeout. Only the first was caught, so a safety timeout bypassed `describeJoinFailure` and reported a bare "MTE Safety timeout exceeded" — losing the client state and `JoinStatus` that flow exists to surface.

That is not a corner case. For a join that is genuinely stuck, the safety timeout is the *likelier* of the two to fire: game time only advances while the engine is ticking, and an engine that has stopped progressing may not advance it at all. The wall clock tends to win the race in exactly the situation where the diagnostics are wanted.

Also `describeJoinFailure` read `client.getState()` twice while the engine was still running, so it could report one state and describe another, or pass the null check and then NPE while building the failure message.

**Small grouped items**

- **Deprecated `addEntityManagementRelatedClasses(Context, ServiceRegistry)`** — the overload ignores the context it is given and delegates to the single-argument form, so passing one implies a relationship that does not exist. Copilot raised this on #5323 against the call site that PR touched; the same shape was left in three others. All three migrated. The deprecated method itself stays — it is public and modules may call it — but it now has no in-tree callers, which is the state it should be in before anyone proposes deleting it.
- **`TestReporter` timings on `ExampleTest`.** #5325 added `publishEntry` to the tests it introduced, but the pre-existing `@Tag("flaky")` tests never got it, which is backwards — those are the ones whose timing anyone wants when they fail. All three flake in the same place, waiting for a client to reach in-game, and `testSendEvent` failed exactly that way on #5323's Jenkins run with no timing recorded.

## Test plan

- [x] `:engine-tests:compileJava`, `:engine-tests:compileTestJava` clean.
- [x] `:engine-tests:checkstyleMain` clean.
- [x] Tag exclusion verified in both directions on Windows, as described above.
- [x] `NetworkModeServerTest` passes in isolation.
- [ ] **No clean full-suite run to report, and I would rather say so than imply one.** Local `:engine-tests:test` runs on this branch failed intermittently with `Game could not be started, server attempted to return to main menu: [World generation timed out]` across whichever MTE tests happened to be running. The failure set moved between runs — six tests, then two, different ones each time — and one run took 39 minutes against a normal 8–9, so the machine was clearly struggling. `develop` passed cleanly at one point, but a single comparison between runs under different load is not evidence of causation, and I am not treating it as such.

  This is the same family as the `ExampleTest.testSendEvent` flake on #5323's Jenkins run. Nothing in this branch obviously touches world generation, but I cannot rule it out from here, and Jenkins is a better-controlled environment than my machine right now. If CI reproduces it, the first thing I would isolate is the `test`-task tag exclusion, since it is the one change that alters test *selection* and MTE tests are order-sensitive.

## Related

- Follows #5323 and #5325.
- Terasology/ModuleTestingEnvironment#80 carries the same `awaitUntil` and connection-diagnostics work for the separate module-side copy of this harness, including the two review fixes above. The two copies are fully duplicated; deduplicating them is a larger question, and these changes only keep them from drifting further.
