### PR TITLE
fix(world): avoid double-loading ChunkStore in LocalChunkProvider

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -92,6 +92,11 @@ public class LocalChunkProvider implements ChunkProvider {
     private final Map<Vector3ic, Chunk> chunkCache;
 
     private final Map<Vector3ic, List<EntityStore>> generateQueuedEntities = new ConcurrentHashMap<>();
+    // The ChunkStore loaded (from disk) for a chunk in createOrLoadChunk()'s async task, carried
+    // through to processReadyChunk() so it isn't read from disk, decompressed, and re-parsed a
+    // second time there just to reach restoreEntities() - mirrors how generateQueuedEntities
+    // above already carries a freshly *generated* chunk's entities across the same handoff.
+    private final Map<Vector3ic, ChunkStore> loadedChunkStores = new ConcurrentHashMap<>();
 
     private final StorageManager storageManager;
     private final WorldGenerator generator;
@@ -140,6 +145,7 @@ public class LocalChunkProvider implements ChunkProvider {
                     generateQueuedEntities.put(chunk.getPosition(), buffer.getAll());
                 } else {
                     chunk = chunkStore.getChunk();
+                    loadedChunkStores.put(chunk.getPosition(), chunkStore);
                 }
                 return chunk;
             });
@@ -177,7 +183,7 @@ public class LocalChunkProvider implements ChunkProvider {
         chunk.markReady();
         //TODO, it is not clear if the activate/addedBlocks event logic is correct.
         //See https://github.com/MovingBlocks/Terasology/issues/3244
-        ChunkStore store = this.storageManager.loadChunkStore(chunkPos);
+        ChunkStore store = loadedChunkStores.remove(chunkPos);
         TShortObjectMap<TIntList> mappings = createBatchBlockEventMappings(chunk);
         if (store != null) {
             store.restoreEntities();

--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -177,6 +177,7 @@ public class LocalChunkProvider implements ChunkProvider {
     private void processReadyChunk(final Chunk chunk) {
         Vector3ic chunkPos = chunk.getPosition();
         if (chunkCache.get(chunkPos) != null) {
+            loadedChunkStores.remove(chunkPos);
             return; // TODO move it in pipeline;
         }
         chunkCache.put(new Vector3i(chunkPos), chunk);
@@ -387,6 +388,8 @@ public class LocalChunkProvider implements ChunkProvider {
             chunk.dispose();
         }
         chunkCache.clear();
+        loadedChunkStores.clear();
+        generateQueuedEntities.clear();
         /*
          * The chunk monitor needs to clear chunk references, so it's important
          * that no new chunk get created
@@ -420,6 +423,12 @@ public class LocalChunkProvider implements ChunkProvider {
             chunk.dispose();
         });
         chunkCache.clear();
+        // Positions in-flight or orphaned (early-returned/canceled) in these maps may have been
+        // populated from the world we're about to delete; a stale entry surviving here could
+        // later be matched to a freshly-generated chunk at the same position after the purge,
+        // wrongly restoring entities from the deleted world onto it.
+        loadedChunkStores.clear();
+        generateQueuedEntities.clear();
         storageManager.deleteWorld();
         worldEntity.send(new PurgeWorldEvent());
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

- `LocalChunkProvider` loaded each saved chunk's `ChunkStore` from disk twice: once (discarded) in `createOrLoadChunk()`'s async pipeline task, again synchronously on the main thread in `processReadyChunk()` just to call `restoreEntities()`.
- Carry the already-loaded `ChunkStore` through via a new `loadedChunkStores` map instead of reloading — mirrors the existing `generateQueuedEntities` handoff used for freshly generated chunks. `restoreEntities()` still runs on the main thread as before; only the redundant load is removed.
- Follow-up (per review): unlike `generateQueuedEntities`, which is always overwritten by its own branch before it's read again, `loadedChunkStores` is only written on the "loaded from disk" branch. A position loaded before `purgeWorld()` that's never consumed (early-return in `processReadyChunk()`, or a canceled load) could leave a stale entry; after the purge deletes the world, that position re-enters via the "generate fresh" branch instead, which never touches the map — so the stale `ChunkStore` would survive and get wrongly matched to the new chunk, restoring entities from the deleted world. Fixed by removing the entry on the early-return path and clearing both maps in `purgeWorld()`/`dispose()` before new loads are scheduled.

## Test plan

- [x] `gradle :engine:compileJava` succeeds.
- [ ] In-game: load a saved world, confirm chunks load and entities restore correctly (no regressions in `OnAddedBlocks`/`OnActivatedBlocks`/`OnChunkLoaded` behavior).

## Related

- Refs #5150 — addresses the duplicate-load finding from that issue's profiling data. The issue's broader "move `restoreEntities()` off the main thread" idea is intentionally left for a follow-up, since ECS thread-safety for that hasn't been verified. Not closing the issue since that part is still open.
