### PR TITLE
fix: upgrade crash reporter to 5.1.0 to resolve macOS issues

### DIFF
--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -145,7 +145,7 @@ dependencies {
     api(fileTree("libs") { include("*.jar") })
 
     // TODO: Consider moving this back to the PC Facade instead of having the engine rely on it?
-    implementation("org.terasology.crashreporter:cr-terasology:5.0.0")
+    implementation("org.terasology.crashreporter:cr-terasology:5.1.0")
 
     api(project(":subsystems:TypeHandlerLibrary"))
 }

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation("io.projectreactor:reactor-core:3.4.7")
 
     // TODO: Consider whether we can move the CR dependency back here from the engine, where it is referenced from the main menu
-    implementation("org.terasology.crashreporter:cr-terasology:5.0.0")
+    implementation("org.terasology.crashreporter:cr-terasology:5.1.0")
 
     runtimeOnly(libs.logback) {
         because("to configure logging with logback.xml")


### PR DESCRIPTION
### Contains
This pull request upgrades the crash reporter dependency to version 5.1.0, which includes MovingBlocks/CrashReporter#52.

### How to test
- See #5338 for more information (the relevant fixes there were eventually moved in the crash reporter library instead).