### PR TITLE
fix(world): skip prefab components with no registered metadata instead of NPEing

### DIFF
--- a/engine/src/main/java/org/terasology/engine/world/block/items/BlockItemFactory.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/items/BlockItemFactory.java
@@ -4,6 +4,8 @@ package org.terasology.engine.world.block.items;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.SignedBytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.ComponentContainer;
 import org.terasology.engine.entitySystem.entity.EntityBuilder;
 import org.terasology.engine.entitySystem.entity.EntityManager;
@@ -37,6 +39,8 @@ import java.util.Set;
  * @see RetainComponentsComponent
  */
 public class BlockItemFactory {
+    private static final Logger logger = LoggerFactory.getLogger(BlockItemFactory.class);
+
     private final EntityManager entityManager;
 
     /**
@@ -186,7 +190,14 @@ public class BlockItemFactory {
 
         for (Component component : components.iterateComponents()) {
             if (keepByAnnotation(component) || retainComponents.contains(component.getClass())) {
-                builder.addComponent(entityManager.getComponentLibrary().copy(component));
+                Component copy = entityManager.getComponentLibrary().copy(component);
+                if (copy == null) {
+                    // No registered ComponentMetadata for component's class, most likely because a
+                    // module it depends on isn't loaded - see BlockPrefabManager.updateBlock().
+                    logger.error("No ComponentMetadata for {} - skipping", component.getClass().getName());
+                    continue;
+                }
+                builder.addComponent(copy);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/engine/world/block/typeEntity/BlockTypeEntityGenerator.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/typeEntity/BlockTypeEntityGenerator.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.engine.world.block.typeEntity;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityBuilder;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
@@ -17,6 +19,8 @@ import org.terasology.gestalt.entitysystem.component.Component;
 import java.util.Optional;
 
 public class BlockTypeEntityGenerator implements BlockRegistrationListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(BlockTypeEntityGenerator.class);
 
     private EntityManager entityManager;
     private PrefabManager prefabManager;
@@ -69,7 +73,17 @@ public class BlockTypeEntityGenerator implements BlockRegistrationListener {
         if (prefab.isPresent()) {
             for (Component comp : prefab.get().iterateComponents()) {
                 if (!(comp instanceof NetworkComponent)) {
-                    builder.addComponent(entityManager.getComponentLibrary().copy(comp));
+                    Component copy = entityManager.getComponentLibrary().copy(comp);
+                    if (copy == null) {
+                        // No registered ComponentMetadata for comp's class, most likely because a
+                        // module it depends on isn't loaded - see the matching guard and explanation
+                        // in BlockPrefabManager.updateBlock(). Skip it rather than NPE and take the
+                        // whole block type entity down.
+                        logger.error("No ComponentMetadata for {}, referenced by block {}'s prefab {} - skipping",
+                                comp.getClass().getName(), block.getURI(), prefab.get().getUrn());
+                        continue;
+                    }
+                    builder.addComponent(copy);
                 }
             }
         }

--- a/engine/src/main/java/org/terasology/engine/world/internal/EntityAwareWorldProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/internal/EntityAwareWorldProvider.java
@@ -474,7 +474,15 @@ public class EntityAwareWorldProvider extends AbstractWorldProviderDecorator
             for (Component comp : prefab.iterateComponents()) {
                 Component currentComp = entity.getComponent(comp.getClass());
                 if (currentComp == null) {
-                    entity.addComponent(entityManager.getComponentLibrary().copy(comp));
+                    Component copy = entityManager.getComponentLibrary().copy(comp);
+                    if (copy == null) {
+                        // No registered ComponentMetadata for comp's class, most likely because a
+                        // module it depends on isn't loaded - see BlockPrefabManager.updateBlock().
+                        logger.error("No ComponentMetadata for {}, referenced by prefab {} - skipping",
+                                comp.getClass().getName(), prefab.getUrn());
+                        continue;
+                    }
+                    entity.addComponent(copy);
                 } else {
                     ComponentMetadata<?> metadata = entityManager.getComponentLibrary().getMetadata(comp.getClass());
                     boolean changed = false;


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Three more call sites shared the NPE-on-missing-ComponentMetadata bug that `BlockPrefabManager.updateBlock()` was already hardened against in #5343; hardened them the same way.

## Test plan

- [x] `:engine:compileJava` succeeds
- [x] Full `engine-tests` regression (`test` + `integrationTest`): 1729 tests, 0 failures, 0 errors
- [ ] Reproduce with a block prefab referencing a component from an unloaded optional-dependency module (e.g. ManualLabor:ShapingTable without `machines`) — confirm it now logs and skips instead of crashing

## Related

- No tracked issue; found live while playtesting a save (`josariassurvival`) with an optional-dependency module (`machines`) not loaded.
