### PR TITLE
fix: destroy replaced bone entities and keep logging alive on reconfigure failure

### DIFF
--- a/config/groovy/common.groovy
+++ b/config/groovy/common.groovy
@@ -406,7 +406,9 @@ class common {
                 }
                 currentPageUrl = getLink(connection, "next")
                 // TODO: This comparison is vulnerable to a page request size of "100" or anything that starts with a 1, but just using 99 above ..
-                if (currentPageUrl.contains("page=1")) {
+                // Safe-navigated: getLink returns null when there is no "next" link at all,
+                // which is the normal case for a result set that fits on one page (e.g. libs).
+                if (currentPageUrl?.contains("page=1")) {
                     //println "The pagination warped back to page 1, we're done!"
                     currentPageUrl = null
                 }

--- a/engine/src/main/java/org/terasology/engine/core/LoggingContext.java
+++ b/engine/src/main/java/org/terasology/engine/core/LoggingContext.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.core;
 
+import ch.qos.logback.classic.BasicConfigurator;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.joran.spi.JoranException;
@@ -104,6 +105,11 @@ public final class LoggingContext {
                 new ContextInitializer(context).autoConfig();
             } catch (JoranException e) {
                 e.printStackTrace(); //NOPMD
+                // reset() has already cleared the appenders, so without a fallback here a failed
+                // reconfigure leaves logging silently dead for the rest of the run.
+                BasicConfigurator basicConfigurator = new BasicConfigurator();
+                basicConfigurator.setContext(context);
+                basicConfigurator.configure(context);
             }
         }
     }

--- a/engine/src/main/java/org/terasology/engine/rendering/logic/SkeletonRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/logic/SkeletonRenderer.java
@@ -101,6 +101,9 @@ public class SkeletonRenderer extends BaseComponentSystem implements RenderSyste
             if (boneEntity == null || !boneEntity.exists() || !boneEntity.hasComponent(LocationComponent.class)) {
                 if (boneEntity != null && boneEntity.exists()) {
                     logger.warn("Bone entity for \"{}\" exists but has no LocationComponent, recreating", bone.getName());
+                    // Destroy before replacing the map entry, or the old one is orphaned in the
+                    // world - these accumulate on every load of an affected save.
+                    boneEntity.destroy();
                 }
                 boneEntity = entityManager.create(new LocationComponent());
                 skeleton.boneEntities.put(bone.getName(), boneEntity);


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

- `SkeletonRenderer.newSkeleton` replaced a bone entity missing its `LocationComponent` without destroying the old one, orphaning an entity per affected bone on every load of such a save. Raised on #5343 by CodeRabbit, not picked up before merge.
- `LoggingContext.initialize` calls `context.reset()` before `autoConfig()`, so a `JoranException` left the context with no appenders and logging silently dead for the rest of the run. Falls back to `BasicConfigurator` now. Raised on #5343 by Copilot.

## Test plan

- [x] `:engine:compileJava` and `:engine:checkstyleMain` clean.
- [ ] Load a save with a skeleton whose bone entities failed to restore; confirm no entity growth across repeated loads.
- [ ] Not exercised: the `JoranException` path needs a deliberately malformed `logback.xml`.

## Related

- Follow-up to #5343.
