### PR TITLE
fix(module): attribute classes to the module that actually provides them

### DIFF
--- a/docs/Engine-Testing-Patterns.md
+++ b/docs/Engine-Testing-Patterns.md
@@ -257,6 +257,77 @@ Distinguish between:
 Some functionality (like chat) requires an ECS system to be registered and
 processing events — just having the service in the context isn't enough.
 
+## Choosing a World Generator
+
+`@IntegrationEnvironment` defaults to `unittest:dummy`, whose
+`FlatSurfaceHeightProvider` produces an `ElevationFacet` and a `SurfacesFacet`.
+Setting up the local player needs one of those (or a `SpawnHeightFacet`) —
+`AbstractSpawner.findSpawnPosition` throws
+`IllegalStateException: No spawn height facet or elevation facet facet found`
+without one, and the engine never finishes loading.
+
+`unittest:empty` produces **no facets at all**. It is only usable for tests
+that never bring up a player, which in practice means almost none of them.
+Unless you specifically need an empty world, leave `worldGenerator` unset.
+
+## Module Attribution Failures
+
+A failure like this during engine startup:
+
+```
+VerifyException: Environment has no module for SomeEvent
+    at EntitySystemSetupUtil.registerEvents
+```
+
+means the environment's *class index* and its *modules* disagree. Something
+indexed the class, but no module's class predicate claims it. Two independent
+mechanisms decide this, and both have to agree:
+
+| Mechanism | Question it answers | Built by |
+|-----------|--------------------|----------|
+| Class index | "what classes exist here?" | `UrlClassIndex`, per classpath entry |
+| Class predicate | "is this class mine?" | `Module.getClassPredicate()` |
+
+Two things make this confusing to diagnose:
+
+**Startup runs against a pre-game environment.** `StateHeadlessSetup.init`
+calls `initEntityAndComponentManagers()` — and therefore `registerEvents` —
+*before* it builds the game manifest and hands off to `StateLoading`. At that
+point the environment holds only `engine` and `unittest`; the modules your
+test declared in `dependencies` are not in it yet. Any class the index turns
+up that does not belong to those two has nothing to attribute it to.
+
+**Only some modules get a real predicate.** `ClasspathCompromisingModuleFactory`
+is used only when `org.terasology.load_classpath_modules` is set (MTE sets it
+in `Engines.createEngine`). Modules built by the plain gestalt `ModuleFactory`
+get `x -> false`, so they never claim anything. The `engine` module gets its
+own lambda from `ModuleManager.loadAndConfigureEngineModule`.
+
+### Diagnosing
+
+The exception message names the class, where it was loaded from, and which
+modules the environment actually contained. That is usually enough: if the
+class came from a module jar that is not in the module list, the index is
+reaching further than the predicates do.
+
+When you need more, note that the class predicate is only consulted for
+modules in the environment — instrumenting `ClassesInModule.test` tells you
+nothing if the module is not there, which reads misleadingly like the
+logging is broken rather than the code path never running. Dump
+`ModuleEnvironment.getModuleIdsOrderedByDependencies()` first.
+
+### A module's code lives in two places
+
+In a development build a module's classes exist both in `build/classes` and
+in the jar packed from it, and gestalt puts *both* on the module's classpath
+list. Which one the JVM serves a class from depends on how the module reached
+the classpath — Gradle gives the module under test its own `build/classes` but
+resolves its module *dependencies* as jar artifacts.
+
+Compare code sources as normalised `Path`s, never as URLs: the same jar is
+`file:...jar` as a code source but `jar:file:...jar!/` as a classpath root, and
+URL equality is exact-string over those spellings.
+
 ## Test Timing Diagnostics
 
 MTE integration tests — especially those creating clients — are prone to

--- a/docs/Engine-Testing-Patterns.md
+++ b/docs/Engine-Testing-Patterns.md
@@ -274,7 +274,7 @@ Unless you specifically need an empty world, leave `worldGenerator` unset.
 
 A failure like this during engine startup:
 
-```
+```text
 VerifyException: Environment has no module for SomeEvent
     at EntitySystemSetupUtil.registerEvents
 ```
@@ -324,9 +324,14 @@ list. Which one the JVM serves a class from depends on how the module reached
 the classpath — Gradle gives the module under test its own `build/classes` but
 resolves its module *dependencies* as jar artifacts.
 
-Compare code sources as normalised `Path`s, never as URLs: the same jar is
+Compare code sources as normalised `Path`s, never as `URL`s: the same jar is
 `file:...jar` as a code source but `jar:file:...jar!/` as a classpath root, and
-URL equality is exact-string over those spellings.
+those differ in both protocol and file component, so they never compare equal.
+
+`URL.equals` is the wrong tool for this regardless — it compares URL components
+and resolves host names to do it, which makes it a blocking call. Where a URL
+comparison really is wanted, use `java.net.URI`; for classpath locations, a
+normalised `Path` is better still.
 
 ## Test Timing Diagnostics
 

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -84,6 +84,9 @@ public class Engines {
     TerasologyEngine host;
     private final NetworkMode networkMode;
 
+    /** The CoreRegistry context from before {@link #setup()}, restored by {@link #tearDown()}. */
+    private Context contextBeforeSetup;
+
     public Engines(List<String> dependencies, String worldGeneratorUri, NetworkMode networkMode,
                    List<Class<? extends EngineSubsystem>> subsystems) {
         this.networkMode = networkMode;
@@ -101,6 +104,9 @@ public class Engines {
      * Every instance should be shut down properly by calling {@link #tearDown()}.
      */
     public void setup() {
+        // Captured before anything starts an engine: bringing up the host installs its own context
+        // into CoreRegistry, and this needs the one from before this environment existed.
+        contextBeforeSetup = CoreRegistry.get(Context.class);
         mockPathManager();
         try {
             host = createHost(networkMode);
@@ -123,6 +129,11 @@ public class Engines {
         engines.forEach(TerasologyEngine::shutdown);
         engines.forEach(TerasologyEngine::cleanup);
         engines.clear();
+        // CoreRegistry is process-global. Leaving this environment's context installed means the
+        // next one wraps it as a parent, so a chain of contexts belonging to shut-down engines
+        // accumulates across a test class and lookups can still resolve to them.
+        CoreRegistry.setContext(contextBeforeSetup);
+        contextBeforeSetup = null;
         try {
             pathManagerCleaner.close();
         } catch (RuntimeException e) {

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -84,8 +84,8 @@ public class Engines {
     TerasologyEngine host;
     private final NetworkMode networkMode;
 
-    /** The CoreRegistry context from before {@link #setup()}, restored by {@link #tearDown()}. */
-    private Context contextBeforeSetup;
+    /** What {@link CoreRegistry} held before {@link #setup()}, restored by {@link #tearDown()}. */
+    private Context coreRegistryBeforeSetup;
 
     public Engines(List<String> dependencies, String worldGeneratorUri, NetworkMode networkMode,
                    List<Class<? extends EngineSubsystem>> subsystems) {
@@ -106,7 +106,7 @@ public class Engines {
     public void setup() {
         // Captured before anything starts an engine: bringing up the host installs its own context
         // into CoreRegistry, and this needs the one from before this environment existed.
-        contextBeforeSetup = CoreRegistry.get(Context.class);
+        coreRegistryBeforeSetup = CoreRegistry.get(Context.class);
         mockPathManager();
         try {
             host = createHost(networkMode);
@@ -126,14 +126,19 @@ public class Engines {
      * Used to properly shut down and clean up a testing environment set up and started with {@link #setup()}.
      */
     public void tearDown() {
-        engines.forEach(TerasologyEngine::shutdown);
-        engines.forEach(TerasologyEngine::cleanup);
-        engines.clear();
-        // CoreRegistry is process-global. Leaving this environment's context installed means the
-        // next one wraps it as a parent, so a chain of contexts belonging to shut-down engines
-        // accumulates across a test class and lookups can still resolve to them.
-        CoreRegistry.setContext(contextBeforeSetup);
-        contextBeforeSetup = null;
+        try {
+            engines.forEach(TerasologyEngine::shutdown);
+            engines.forEach(TerasologyEngine::cleanup);
+            engines.clear();
+        } finally {
+            // CoreRegistry is process-global, so this has to happen even if shutdown throws:
+            // leaving this environment's context installed means the next one wraps it as a
+            // parent, and a chain of contexts belonging to shut-down engines accumulates across a
+            // test class. (CoreRegistry is deprecated and on its way out; until it is gone,
+            // anything read from it may be stale.)
+            CoreRegistry.setContext(coreRegistryBeforeSetup);
+            coreRegistryBeforeSetup = null;
+        }
         try {
             pathManagerCleaner.close();
         } catch (RuntimeException e) {

--- a/engine-tests/src/test/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactoryTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactoryTest.java
@@ -6,21 +6,33 @@ package org.terasology.engine.core.module;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleMetadata;
 import org.terasology.context.annotation.API;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
 import org.terasology.unittest.ExampleClass;
+import org.terasology.unittest.ExampleInterface;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth8.assertThat;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,13 +78,57 @@ public class ClasspathCompromisingModuleFactoryTest {
         assertFalse(module.getClassPredicate().test(SOME_CLASS_OUTSIDE_THE_MODULE));
     }
 
+    /**
+     * A module's code is present at more than one location in a development build: the compiled
+     * classes directory and the jar packed from it. Gradle puts the classes directory on the
+     * classpath for the module under test but resolves its module <em>dependencies</em> as jars,
+     * so a class may well be served from the jar while the module is loaded from its directory.
+     * Both have to count as belonging to the module.
+     */
     @Test
-    @Disabled("TODO: need a jar module alongside a classes directory")
-    public void directoryModuleContainsClassLoadedFromJar() {
+    public void directoryModuleContainsClassLoadedFromJar(@TempDir Path moduleDirectory) throws Exception {
         // Example:
         //   - m/build/classes/org/t/Foo.class
         //   - m/build/libs/foo.jar
         // load m as directory module while foo.jar is on classpath
+        String className = ExampleClass.class.getName();
+        // The interface comes along so the isolated class loader below can resolve it without
+        // delegating to a parent (which would hand back the original class, not the jar's copy).
+        List<String> classResources = Stream.of(ExampleClass.class, ExampleInterface.class)
+                .map(c -> c.getName().replace('.', '/') + ".class")
+                .collect(Collectors.toList());
+
+        Path classesDirectory = moduleDirectory.resolve(Paths.get("build", "classes"));
+        for (String classResource : classResources) {
+            Files.createDirectories(classesDirectory.resolve(classResource).getParent());
+            try (InputStream in = requireNonNull(getClass().getClassLoader().getResourceAsStream(classResource))) {
+                Files.copy(in, classesDirectory.resolve(classResource));
+            }
+        }
+
+        Path jar = moduleDirectory.resolve(Paths.get("build", "libs", "example.jar"));
+        Files.createDirectories(jar.getParent());
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            for (String classResource : classResources) {
+                out.putNextEntry(new JarEntry(classResource));
+                Files.copy(classesDirectory.resolve(classResource), out);
+                out.closeEntry();
+            }
+        }
+
+        ModuleMetadata metadata = new ModuleMetadata(new Name("example"), new Version("1.0.0"));
+        Module module = factory.createDirectoryModule(metadata, moduleDirectory.toFile());
+
+        // Load the class from the jar so that its code source is the jar, not the classes
+        // directory - the situation a module dependency is in when resolved as an artifact.
+        try (URLClassLoader jarLoader = new URLClassLoader(new URL[]{jar.toUri().toURL()}, null)) {
+            Class<?> fromJar = jarLoader.loadClass(className);
+            assertEquals(jar.toUri().toURL(), fromJar.getProtectionDomain().getCodeSource().getLocation());
+
+            assertTrue(module.getClassPredicate().test(fromJar));
+        }
+
+        assertFalse(module.getClassPredicate().test(SOME_CLASS_OUTSIDE_THE_MODULE));
     }
 
     @Test

--- a/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
@@ -3,6 +3,7 @@
 
 package org.terasology.engine.core.bootstrap;
 
+import com.google.common.base.VerifyException;
 import org.terasology.context.Lifetime;
 import org.terasology.engine.audio.events.PlaySoundEvent;
 import org.terasology.engine.context.Context;
@@ -154,8 +155,13 @@ public final class EntitySystemSetupUtil {
     public static void registerEvents(EventSystem eventSystem, ModuleEnvironment environment) {
         for (Class<? extends Event> type : environment.getSubtypesOf(Event.class)) {
             if (type.getAnnotation(DoNotAutoRegister.class) == null) {
-                Name module = verifyNotNull(environment.getModuleProviding(type),
-                        "Environment has no module for %s", unattributedClassReport(type, environment));
+                Name module = environment.getModuleProviding(type);
+                if (module == null) {
+                    // Built here rather than passed to verifyNotNull, whose arguments are
+                    // evaluated for every event whether or not it fails.
+                    throw new VerifyException("Environment has no module for "
+                            + unattributedClassReport(type, environment));
+                }
                 eventSystem.registerEvent(new ResourceUrn(module.toString(), type.getSimpleName()), type);
             }
         }

--- a/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
@@ -33,6 +33,7 @@ import org.terasology.engine.recording.RecordAndReplaySerializer;
 import org.terasology.engine.recording.RecordAndReplayStatus;
 import org.terasology.engine.recording.RecordedEventStore;
 import org.terasology.engine.recording.RecordingClasses;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.engine.recording.RecordingEventSystemDecorator;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.di.ServiceRegistry;
@@ -160,32 +161,11 @@ public final class EntitySystemSetupUtil {
                     // Built here rather than passed to verifyNotNull, whose arguments are
                     // evaluated for every event whether or not it fails.
                     throw new VerifyException("Environment has no module for "
-                            + unattributedClassReport(type, environment));
+                            + ModuleAttribution.describeUnattributedClass(type, environment));
                 }
                 eventSystem.registerEvent(new ResourceUrn(module.toString(), type.getSimpleName()), type);
             }
         }
-    }
-
-    /**
-     * Describe a class the environment turned up but cannot attribute to any of its modules.
-     * <p>
-     * This means the environment's class index and its modules disagree: something indexed the
-     * class, but no module's class predicate claims it. The two facts needed to tell those apart -
-     * where the class was loaded from, and which modules were actually asked - are otherwise
-     * invisible at the point of failure, and reconstructing them costs hours.
-     */
-    private static String unattributedClassReport(Class<?> type, ModuleEnvironment environment) {
-        String codeSource;
-        try {
-            codeSource = String.valueOf(type.getProtectionDomain().getCodeSource().getLocation());
-        } catch (NullPointerException | SecurityException e) {
-            codeSource = "unknown";
-        }
-        List<String> moduleIds = new ArrayList<>();
-        environment.getModuleIdsOrderedByDependencies().forEach(id -> moduleIds.add(id.toString()));
-        return String.format("%s (loaded from %s; environment modules: %s)",
-                type.getName(), codeSource, moduleIds);
     }
 
     private static List<Class<?>> createSelectedClassesToRecordList() {

--- a/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
@@ -155,10 +155,31 @@ public final class EntitySystemSetupUtil {
         for (Class<? extends Event> type : environment.getSubtypesOf(Event.class)) {
             if (type.getAnnotation(DoNotAutoRegister.class) == null) {
                 Name module = verifyNotNull(environment.getModuleProviding(type),
-                        "Environment has no module for %s", type.getSimpleName());
+                        "Environment has no module for %s", unattributedClassReport(type, environment));
                 eventSystem.registerEvent(new ResourceUrn(module.toString(), type.getSimpleName()), type);
             }
         }
+    }
+
+    /**
+     * Describe a class the environment turned up but cannot attribute to any of its modules.
+     * <p>
+     * This means the environment's class index and its modules disagree: something indexed the
+     * class, but no module's class predicate claims it. The two facts needed to tell those apart -
+     * where the class was loaded from, and which modules were actually asked - are otherwise
+     * invisible at the point of failure, and reconstructing them costs hours.
+     */
+    private static String unattributedClassReport(Class<?> type, ModuleEnvironment environment) {
+        String codeSource;
+        try {
+            codeSource = String.valueOf(type.getProtectionDomain().getCodeSource().getLocation());
+        } catch (NullPointerException | SecurityException e) {
+            codeSource = "unknown";
+        }
+        List<String> moduleIds = new ArrayList<>();
+        environment.getModuleIdsOrderedByDependencies().forEach(id -> moduleIds.add(id.toString()));
+        return String.format("%s (loaded from %s; environment modules: %s)",
+                type.getName(), codeSource, moduleIds);
     }
 
     private static List<Class<?>> createSelectedClassesToRecordList() {

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -160,11 +160,13 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
         private final String name;
 
         ClassesInModule(Module module) {
-            // Compare resolved filesystem paths rather than URLs. The same location has several
-            // valid URL spellings - a jar is `file:...jar` as a code source but `jar:file:...jar!/`
-            // when addressed as a classpath root - and URL equality is exact-string over those
-            // forms, so a class served from a module's own jar never matched its module. A
-            // development build has both spellings in play: the module directory contributes
+            // Compare resolved filesystem paths rather than URLs. One location has several valid
+            // URL spellings - a jar is `file:...jar` as a code source but `jar:file:...jar!/` when
+            // addressed as a classpath root - and URL equality compares protocol and file
+            // components, which differ between those two forms, so a class served from a module's
+            // own jar never matched its module. (URL.equals also resolves host names, making it a
+            // blocking call; java.net.URI is the safe choice when a URL comparison is wanted.)
+            // A development build has both spellings in play: the module directory contributes
             // `build/classes` and the jar built from it, and which one a class is served from
             // depends on how the module reached the classpath.
             classpaths = module.getClasspaths().stream()

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.ProtectionDomain;
@@ -160,15 +161,9 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
         private final String name;
 
         ClassesInModule(Module module) {
-            // Compare resolved filesystem paths rather than URLs. One location has several valid
-            // URL spellings - a jar is `file:...jar` as a code source but `jar:file:...jar!/` when
-            // addressed as a classpath root - and URL equality compares protocol and file
-            // components, which differ between those two forms, so a class served from a module's
-            // own jar never matched its module. (URL.equals also resolves host names, making it a
-            // blocking call; java.net.URI is the safe choice when a URL comparison is wanted.)
-            // A development build has both spellings in play: the module directory contributes
-            // `build/classes` and the jar built from it, and which one a class is served from
-            // depends on how the module reached the classpath.
+            // Normalise to filesystem paths so a classpath entry and a loaded class's code source
+            // are comparable: the same jar is `file:...jar` as a code source but `jar:file:...jar!/`
+            // as a classpath root, which are not equal as URLs.
             classpaths = module.getClasspaths().stream()
                     .map(f -> f.toPath().toAbsolutePath().normalize())
                     .collect(ImmutableSet.toImmutableSet());
@@ -188,8 +183,9 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
             }
             try {
                 return Paths.get(domain.getCodeSource().getLocation().toURI()).toAbsolutePath().normalize();
-            } catch (URISyntaxException | IllegalArgumentException e) {
-                // Not a filesystem location (e.g. a jrt: or bundle: URL) - not ours either way.
+            } catch (URISyntaxException | IllegalArgumentException | FileSystemNotFoundException e) {
+                // Not a filesystem location (e.g. a jrt: or bundle: URL, or a scheme with no
+                // installed provider) - not ours either way.
                 return null;
             }
         }

--- a/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ClasspathCompromisingModuleFactory.java
@@ -5,7 +5,6 @@ package org.terasology.engine.core.module;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
-import org.reflections.util.ClasspathHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.module.Module;
@@ -16,11 +15,11 @@ import org.terasology.gestalt.module.ModuleMetadata;
 import java.io.File;
 import java.io.IOException;
 import java.net.JarURLConnection;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.ProtectionDomain;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -157,29 +156,40 @@ class ClasspathCompromisingModuleFactory extends ModuleFactory {
 
     static class ClassesInModule implements Predicate<Class<?>> {
 
-        private final Set<URL> classpaths;
+        private final Set<Path> classpaths;
         private final String name;
 
         ClassesInModule(Module module) {
-            classpaths = module.getClasspaths().stream().map(f -> {
-                try {
-                    URL url = f.toURI().toURL();
-                    if (f.getName().endsWith(".jar")) {
-                        // Code from jars has a `jar:` URL.
-                        return new URL("jar", null, url.toString() + "!/");
-                    }
-                    return url;
-                } catch (MalformedURLException e) {
-                    throw new RuntimeException(e);
-                }
-            }).collect(ImmutableSet.toImmutableSet());
+            // Compare resolved filesystem paths rather than URLs. The same location has several
+            // valid URL spellings - a jar is `file:...jar` as a code source but `jar:file:...jar!/`
+            // when addressed as a classpath root - and URL equality is exact-string over those
+            // forms, so a class served from a module's own jar never matched its module. A
+            // development build has both spellings in play: the module directory contributes
+            // `build/classes` and the jar built from it, and which one a class is served from
+            // depends on how the module reached the classpath.
+            classpaths = module.getClasspaths().stream()
+                    .map(f -> f.toPath().toAbsolutePath().normalize())
+                    .collect(ImmutableSet.toImmutableSet());
             name = module.getId().toString();
         }
 
         @Override
         public boolean test(Class<?> aClass) {
-            URL classUrl = ClasspathHelper.forClass(aClass);
-            return classpaths.contains(classUrl);
+            Path codeSource = codeSourceOf(aClass);
+            return codeSource != null && classpaths.contains(codeSource);
+        }
+
+        private static Path codeSourceOf(Class<?> aClass) {
+            ProtectionDomain domain = aClass.getProtectionDomain();
+            if (domain == null || domain.getCodeSource() == null || domain.getCodeSource().getLocation() == null) {
+                return null;
+            }
+            try {
+                return Paths.get(domain.getCodeSource().getLocation().toURI()).toAbsolutePath().normalize();
+            } catch (URISyntaxException | IllegalArgumentException e) {
+                // Not a filesystem location (e.g. a jrt: or bundle: URL) - not ours either way.
+                return null;
+            }
         }
 
         @Override

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleAttribution.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleAttribution.java
@@ -1,0 +1,49 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.core.module;
+
+import org.terasology.gestalt.module.ModuleEnvironment;
+import org.terasology.gestalt.naming.Name;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helpers for reporting when a {@link ModuleEnvironment} cannot say which module a class came from.
+ */
+public final class ModuleAttribution {
+
+    private ModuleAttribution() {
+        // static utility class, no instance needed
+    }
+
+    /**
+     * Describe a class the environment turned up but cannot attribute to any of its modules.
+     * <p>
+     * That means the environment's class index and its modules disagree: something indexed the
+     * class, but no module's class predicate claims it. The two facts needed to tell those apart -
+     * where the class was loaded from, and which modules were actually asked - are otherwise
+     * invisible at the point of failure, and reconstructing them costs hours.
+     * <p>
+     * Callers should build this only on the failure path; it is not free.
+     *
+     * @param type the class that could not be attributed
+     * @param environment the environment that was asked
+     * @return a description naming the class, its code source, and the environment's modules
+     */
+    public static String describeUnattributedClass(Class<?> type, ModuleEnvironment environment) {
+        String codeSource;
+        try {
+            codeSource = String.valueOf(type.getProtectionDomain().getCodeSource().getLocation());
+        } catch (NullPointerException | SecurityException e) {
+            codeSource = "unknown";
+        }
+        List<String> moduleIds = new ArrayList<>();
+        for (Name id : environment.getModuleIdsOrderedByDependencies()) {
+            moduleIds.add(id.toString());
+        }
+        return String.format("%s (loaded from %s; environment modules: %s)",
+                type.getName(), codeSource, moduleIds);
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -211,9 +211,17 @@ public class ModuleManager {
         Collection<File> classPaths = new HashSet<>(packageModule.getClasspaths());
         for (Class<?> aClass : classesOnClasspathsToAddToEngine) {
             URL url = ClasspathHelper.forClass(aClass);
+            File classPath = urlToFile(url);
             config.addUrls(url);  // include this in reflections scan
-            classPaths.add(urlToFile(url));  // also include in Module.moduleClasspaths
-            packageClassIndex.add(UrlClassIndex.byClassLoader(aClass.getClassLoader()));
+            classPaths.add(classPath);  // also include in Module.moduleClasspaths
+            // Index only the classpath entry this class came from. Indexing the whole
+            // classloader pulls in every entry on the classpath - which in a development or test
+            // run includes the modules' own build outputs - while the class predicate below still
+            // (correctly) refuses to own those classes. Anything in that gap is discovered by
+            // getSubtypesOf but has no module to attribute it to, so registering it fails.
+            packageClassIndex.add(classPath.isDirectory()
+                    ? UrlClassIndex.byDirectory(classPath)
+                    : UrlClassIndex.byArchive(classPath));
             logger.debug("Adding path to engine module for class: {} {}", url, aClass);
         }
 

--- a/engine/src/main/java/org/terasology/engine/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/engine/world/internal/WorldProviderCoreImpl.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
@@ -55,12 +56,17 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     private static final Logger logger = LoggerFactory.getLogger(WorldProviderCoreImpl.class);
 
     /** How many example positions to report per chunk before falling silent about that chunk. */
-    private static final int DROPPED_WRITE_SAMPLES_PER_CHUNK = 3;
+    private static final int DROPPED_WRITE_SAMPLES_PER_CHUNK = 5;
 
-    /** Caps the memory a long session can spend remembering which chunks it has already complained about. */
-    private static final int DROPPED_WRITE_CHUNK_REPORT_LIMIT = 256;
+    /** How many distinct chunks to report at all. Past this it is one bug, not N. */
+    private static final int DROPPED_WRITE_CHUNK_REPORT_LIMIT = 10;
+
+    private static final String DROPPED_WRITE_LIMIT_NOTE =
+            " Reporting limit reached - further discarded writes are silent. "
+                    + "Fix the underlying cause until this message stops appearing.";
 
     private final Map<Vector3ic, AtomicInteger> droppedWritesPerChunk = new ConcurrentHashMap<>();
+    private final AtomicBoolean droppedWriteLimitAnnounced = new AtomicBoolean();
 
     private String title;
     private String seed = "";
@@ -221,15 +227,20 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
      * <p>
      * Logged at {@code warn}, because dropping a write is a caller bug rather than routine: the
      * position should have been made relevant first. A caller writing a region into missing chunks
-     * loses thousands of blocks at a time, so this reports only the first
-     * {@value #DROPPED_WRITE_SAMPLES_PER_CHUNK} positions per chunk - enough to see concrete
-     * coordinates without the log becoming the failure.
+     * loses thousands of blocks across hundreds of chunks at a time, and that is one bug rather
+     * than hundreds - so this reports at most {@value #DROPPED_WRITE_SAMPLES_PER_CHUNK} positions
+     * each from at most {@value #DROPPED_WRITE_CHUNK_REPORT_LIMIT} chunks. Reaching either limit
+     * says so, so that a silent log is never mistaken for a solved problem.
      */
     private void logDroppedWrite(Vector3ic worldPos, Block type) {
         Vector3i chunkPos = Chunks.toChunkPos(worldPos, new Vector3i());
         AtomicInteger dropped = droppedWritesPerChunk.get(chunkPos);
         if (dropped == null) {
             if (droppedWritesPerChunk.size() >= DROPPED_WRITE_CHUNK_REPORT_LIMIT) {
+                if (droppedWriteLimitAnnounced.compareAndSet(false, true)) {
+                    logger.warn("Discarded block writes across more than {} chunks.{}",
+                            DROPPED_WRITE_CHUNK_REPORT_LIMIT, DROPPED_WRITE_LIMIT_NOTE);
+                }
                 return;
             }
             dropped = droppedWritesPerChunk.computeIfAbsent(chunkPos, unused -> new AtomicInteger());
@@ -243,7 +254,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 type != null ? type.getURI() : null,
                 worldPos.x(), worldPos.y(), worldPos.z(),
                 chunkPos.x(), chunkPos.y(), chunkPos.z(),
-                seen == DROPPED_WRITE_SAMPLES_PER_CHUNK ? " Further discards for this chunk are not reported." : "");
+                seen == DROPPED_WRITE_SAMPLES_PER_CHUNK ? DROPPED_WRITE_LIMIT_NOTE : "");
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/engine/world/internal/WorldProviderCoreImpl.java
@@ -61,12 +61,12 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
     /** How many distinct chunks to report at all. Past this it is one bug, not N. */
     private static final int DROPPED_WRITE_CHUNK_REPORT_LIMIT = 10;
 
-    private static final String DROPPED_WRITE_LIMIT_NOTE =
-            " Reporting limit reached - further discarded writes are silent. "
-                    + "Fix the underlying cause until this message stops appearing.";
+    /** Quiet period after which discarded writes are reported afresh. */
+    private static final long DROPPED_WRITE_REPORT_RESET_MS = 30_000;
 
     private final Map<Vector3ic, AtomicInteger> droppedWritesPerChunk = new ConcurrentHashMap<>();
     private final AtomicBoolean droppedWriteLimitAnnounced = new AtomicBoolean();
+    private volatile long lastDroppedWriteReportMs;
 
     private String title;
     private String seed = "";
@@ -231,15 +231,29 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
      * than hundreds - so this reports at most {@value #DROPPED_WRITE_SAMPLES_PER_CHUNK} positions
      * each from at most {@value #DROPPED_WRITE_CHUNK_REPORT_LIMIT} chunks. Reaching either limit
      * says so, so that a silent log is never mistaken for a solved problem.
+     * <p>
+     * A world provider lives for the whole session, so those limits are not spent permanently:
+     * after {@value #DROPPED_WRITE_REPORT_RESET_MS}ms without a discarded write, reporting starts
+     * over. A later, unrelated burst is worth hearing about even if an earlier one used up the
+     * budget.
      */
     private void logDroppedWrite(Vector3ic worldPos, Block type) {
+        long now = System.currentTimeMillis();
+        if (now - lastDroppedWriteReportMs > DROPPED_WRITE_REPORT_RESET_MS) {
+            droppedWritesPerChunk.clear();
+            droppedWriteLimitAnnounced.set(false);
+        }
+        lastDroppedWriteReportMs = now;
+
         Vector3i chunkPos = Chunks.toChunkPos(worldPos, new Vector3i());
         AtomicInteger dropped = droppedWritesPerChunk.get(chunkPos);
         if (dropped == null) {
             if (droppedWritesPerChunk.size() >= DROPPED_WRITE_CHUNK_REPORT_LIMIT) {
                 if (droppedWriteLimitAnnounced.compareAndSet(false, true)) {
-                    logger.warn("Discarded block writes across more than {} chunks.{}",
-                            DROPPED_WRITE_CHUNK_REPORT_LIMIT, DROPPED_WRITE_LIMIT_NOTE);
+                    logger.warn("Discarded block writes across more than {} chunks."
+                                    + " Reporting limit reached - further discarded writes are silent."
+                                    + " Fix the underlying cause until this message stops appearing.",
+                            DROPPED_WRITE_CHUNK_REPORT_LIMIT);
                 }
                 return;
             }
@@ -254,7 +268,9 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 type != null ? type.getURI() : null,
                 worldPos.x(), worldPos.y(), worldPos.z(),
                 chunkPos.x(), chunkPos.y(), chunkPos.z(),
-                seen == DROPPED_WRITE_SAMPLES_PER_CHUNK ? DROPPED_WRITE_LIMIT_NOTE : "");
+                seen == DROPPED_WRITE_SAMPLES_PER_CHUNK
+                        ? " Reporting limit reached for this chunk - further discards are silent."
+                        : "");
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/world/internal/WorldProviderCoreImpl.java
+++ b/engine/src/main/java/org/terasology/engine/world/internal/WorldProviderCoreImpl.java
@@ -9,6 +9,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
@@ -44,9 +46,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class WorldProviderCoreImpl implements WorldProviderCore {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorldProviderCoreImpl.class);
+
+    /** How many example positions to report per chunk before falling silent about that chunk. */
+    private static final int DROPPED_WRITE_SAMPLES_PER_CHUNK = 3;
+
+    /** Caps the memory a long session can spend remembering which chunks it has already complained about. */
+    private static final int DROPPED_WRITE_CHUNK_REPORT_LIMIT = 256;
+
+    private final Map<Vector3ic, AtomicInteger> droppedWritesPerChunk = new ConcurrentHashMap<>();
 
     private String title;
     private String seed = "";
@@ -193,7 +207,43 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
             return oldBlockType;
 
         }
+        logDroppedWrite(worldPos, type);
         return null;
+    }
+
+    /**
+     * Report a block write that was thrown away because its chunk was not loaded.
+     * <p>
+     * {@link #setBlock} returning {@code null} is the documented signal for this, but callers
+     * routinely ignore the return value - so the world silently does not change, later reads come
+     * back as {@code engine:unloaded}, and the failure surfaces somewhere else entirely. Saying so
+     * at the point of loss turns that into an ordinary log line.
+     * <p>
+     * Logged at {@code warn}, because dropping a write is a caller bug rather than routine: the
+     * position should have been made relevant first. A caller writing a region into missing chunks
+     * loses thousands of blocks at a time, so this reports only the first
+     * {@value #DROPPED_WRITE_SAMPLES_PER_CHUNK} positions per chunk - enough to see concrete
+     * coordinates without the log becoming the failure.
+     */
+    private void logDroppedWrite(Vector3ic worldPos, Block type) {
+        Vector3i chunkPos = Chunks.toChunkPos(worldPos, new Vector3i());
+        AtomicInteger dropped = droppedWritesPerChunk.get(chunkPos);
+        if (dropped == null) {
+            if (droppedWritesPerChunk.size() >= DROPPED_WRITE_CHUNK_REPORT_LIMIT) {
+                return;
+            }
+            dropped = droppedWritesPerChunk.computeIfAbsent(chunkPos, unused -> new AtomicInteger());
+        }
+        int seen = dropped.incrementAndGet();
+        if (seen > DROPPED_WRITE_SAMPLES_PER_CHUNK) {
+            return;
+        }
+        logger.warn("Discarding block change to {} at ({}, {}, {}) - its chunk ({}, {}, {}) is not loaded. "
+                        + "Make the position relevant before writing to it.{}",
+                type != null ? type.getURI() : null,
+                worldPos.x(), worldPos.y(), worldPos.z(),
+                chunkPos.x(), chunkPos.y(), chunkPos.z(),
+                seen == DROPPED_WRITE_SAMPLES_PER_CHUNK ? " Further discards for this chunk are not reported." : "");
     }
 
     @Override
@@ -228,6 +278,7 @@ public class WorldProviderCoreImpl implements WorldProviderCore {
                 }
                 result.put(worldPos, oldBlockType);
             } else {
+                logDroppedWrite(worldPos, entry.getValue());
                 result.put(worldPos, null);
             }
         }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

Module integration tests have been failing for any module whose dependencies carry Java code, with `VerifyException: Environment has no module for <X>` thrown from `EntitySystemSetupUtil.registerEvents` during `Engines.createHost` — before any test body runs. `SimpleFarming` was 7/7 failing, `BlockPicker` identically; `Health`, whose only dependency is code-free, passed throughout.

There are two independent defects here, three years apart.

## The regression

`ModuleManager.loadAndConfigureEngineModule` built the engine module's class index with:

```java
packageClassIndex.add(UrlClassIndex.byClassLoader(aClass.getClassLoader()));
```

That is the app class loader, so the index claimed every `META-INF/subtypes` entry on the entire classpath — including every module jar. The engine module's class *predicate*, a few lines further down, still correctly refused to own those classes. Anything falling in that gap gets discovered by `getSubtypesOf` and then has no module to attribute it to.

It surfaces in module-land specifically because that is where module jars sit on the classpath while `StateHeadlessSetup.init` runs `initEntityAndComponentManagers()` — which happens *before* the game manifest and the handoff to `StateLoading`, against a pre-game environment containing only `engine` and `unittest`.

Fixed by indexing only the classpath entry each class actually came from, which is what the predicate already matches on.

Introduced by the Gestalt 8 upgrade (#5267).

## The latent bug

`ClasspathCompromisingModuleFactory.ClassesInModule` compared `URL`s. The same jar has two valid spellings — `file:...jar` as a code source, `jar:file:...jar!/` as a classpath root — and those differ in both protocol and file component, so a class served from a module's own jar never matched its own module. (`URL.equals` is worth avoiding here regardless: it compares components and resolves host names to do it, making it a blocking call.)

Fixed by comparing normalised `Path`s.

This has been latent since 8aef6cc3e (2021-04-16), whose title is *"allow code from either class or jars of module directories"* and which left `@Disabled("TODO: need a jar module alongside a classes directory")` on the test that would have caught it — in the same commit. **That test is now implemented.** It builds the `build/classes` + `build/libs/foo.jar` layout, loads the class through an isolated `URLClassLoader`, and asserts attribution. It fails against the 2021 code, verified by reverting the file and re-running.

Fixing the predicate alone does not fix the regression; that was tested in isolation. Both changes are needed.

## Diagnostics

`Environment has no module for GetItemTooltip` named neither where the class was loaded from nor which modules were actually asked, and both are invisible at the point of failure. Reconstructing them by hand took most of a debugging session. The message now carries them, on the failure path only.

`docs/Engine-Testing-Patterns.md` gains a **Module Attribution Failures** section covering the index-vs-predicate split, the pre-game environment, and the trap that instrumenting the class predicate tells you nothing when the module isn't in the environment — which reads like broken logging rather than a code path that never ran. It also documents why `unittest:empty` is unusable for any test that spawns a player.

## Also here

Two things found while chasing this, both small and both in the same area:

**`setBlock` says when it discards a write.** It returns `null` when the target chunk is not loaded — documented, and universally ignored. The write silently does not happen, later reads come back as `engine:unloaded`, and the failure surfaces somewhere unrelated. Found via ItemPipes, which was losing 756 writes per test run with nothing in the log about it. Warns at the point of loss, capped at five positions each from ten chunks, and says so when it reaches either cap.

**MTE restores the `CoreRegistry` context on teardown.** `Engines.setup()` replaces the process-global context with a wrapper parented on the previous one and never puts it back, so a test class accumulates a chain of contexts belonging to shut-down engines. This is hygiene rather than a fix for anything observed — it was written to test a hypothesis about chunk generation stalling, which it disproved — but symmetric teardown of global state is worth having.

## Verification

| Suite | Result |
|---|---|
| `SimpleFarming:integrationTest` | 7/7 pass (was 0/7) |
| `BlockPicker:integrationTest` | 2/2 pass |
| `Health:integrationTest` | 16 pass, 1 pre-existing skip |
| `engine-tests` `integrationenvironment.*` | 44 pass |
| `engine-tests` `core.module.*` | 15 pass, 1 pre-existing skip |

Module-side PRs for `SimpleFarming` and `ItemPipes` (both requesting the facet-free `unittest:empty` world generator) are held until this merges, since their tests cannot pass without it.
