### PR TITLE
fix(module): stop scanning modules APIScanner can never resolve

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleManager.java
@@ -72,6 +72,7 @@ public class ModuleManager {
             new WarnOnlyProviderFactory(permissionProviderFactory);
 
     private final ModuleRegistry registry = new TableModuleRegistry();
+    private final Set<Module> classpathModules = new HashSet<>();
     private ModuleEnvironment environment;
     private final ModuleMetadataJsonAdapter metadataReader = newMetadataReader();
     private final ModuleFactory moduleFactory = newModuleFactory(metadataReader);
@@ -177,6 +178,7 @@ public class ModuleManager {
                     continue;
                 }
                 if (registry.add(module)) {
+                    classpathModules.add(module);
                     logger.info("Loaded {} from {}", module.getId(), path); //NOPMD
                 } else {
                     logger.info("Module {} from {} was a duplicate; not registering this copy.", module.getId(), path); //NOPMD
@@ -260,8 +262,15 @@ public class ModuleManager {
         ExternalApiWhitelist.CLASSES.forEach(permissionSet::addAPIClass);
         ExternalApiWhitelist.PACKAGES.forEach(permissionSet::addAPIPackage);
 
+        // Only the engine module, and (in dev mode) modules explicitly loaded onto the JVM
+        // classpath, have classes resolvable via the system classloader APIScanner uses here.
+        // Modules loaded from the application/module path (the normal case) are only ever
+        // accessible through their own ModuleClassLoader - JavaModuleClassLoader#loadClass
+        // doesn't consult this permission set for inter-module access at all, so scanning
+        // those modules here is both guaranteed to fail and pointless.
         APIScanner apiScanner = new APIScanner(permissionProviderFactory);
-        for (Module module : registry) {
+        apiScanner.scan(engineModule.getClassIndex());
+        for (Module module : classpathModules) {
             apiScanner.scan(module.getClassIndex());
         }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `setupSandbox()` looped over every registered module and scanned each one's
  class index against the system classloader. That's only ever resolvable for
  the engine module (and, in dev mode, modules explicitly loaded onto the JVM
  classpath) — modules loaded from the application/module path live only in
  their own `ModuleClassLoader`, so the scan was guaranteed to fail for them.
  It was also pointless even on success: `JavaModuleClassLoader#loadClass`
  only consults this permission set for classes from a *non*-module
  classloader, so it never gated module-to-module API access anyway.
- Restricted the scan to the engine module plus any dev-mode classpath
  modules, eliminating the routine `ClassNotFoundException` noise at startup
  without changing sandbox behavior for anything that mattered.

## Test plan

- [ ] `gradle :engine:compileJava` passes (verified locally)
- [ ] Launch the game and confirm `APIScanner` no longer logs class-not-found
      for modules loaded from `modules/` at startup

## Related

- See MovingBlocks/gestalt#167, which downgrades the resulting log level but
  doesn't address this underlying scan
