### PR TITLE
doc: add Homebrew (macOS) install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ If you already have a Java Development Kit (JDK) installed, you may use a direct
 
 ßDirect download stable builds are uploaded to [our release section here on GitHub](https://github.com/MovingBlocks/Terasology/releases) while the cutting-edge develop version can be downloaded direct [here from our Jenkins](https://jenkins.terasology.io/job/Terasology/job/Omega/job/develop/lastSuccessfulBuild/artifact/distros/omega/build/distributions/TerasologyOmega.zip).
 
+#### macOS (Homebrew)
+
+On macOS, Terasology can also be installed via our [Homebrew tap](https://github.com/MovingBlocks/homebrew-terasology):
+
+```sh
+brew tap MovingBlocks/terasology
+brew install terasology            # latest stable release
+brew install terasology-latest-bin # latest develop build (Omega CI)
+```
+
+Both install a launchable `Terasology.app` in `/Applications` (plus a matching terminal command) and can be installed side by side. `openjdk` is pulled in automatically as a dependency.
+
 
 ## Development
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Adds a "macOS (Homebrew)" subsection to the README's Alternative Installation Methods, pointing at the [MovingBlocks/homebrew-terasology](https://github.com/MovingBlocks/homebrew-terasology) tap (transferred from a personal fork in #5351) with `brew tap`/`brew install` commands for both the stable and latest-develop casks.

## Test plan

- [x] Verified both cask names/behavior against the actual tap: `brew tap MovingBlocks/terasology`, `brew install terasology` and `brew install terasology-latest-bin` both install a launchable `.app` plus terminal command, side-by-side capable, `openjdk` pulled in automatically

## Related

- See #5351 (tap ownership transfer this documents)
