### PR TITLE
fix(module): guard getModuleProviding where null throws or fails quietly

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/ComponentSystemManager.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.context.Context;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.systems.ComponentSystem;
@@ -74,6 +75,13 @@ public class ComponentSystemManager {
                 continue;
             }
             Name moduleId = environment.getModuleProviding(type);
+            if (moduleId == null) {
+                // Filing this under a null key would drop it silently: the loop below walks the
+                // environment's modules, so a system with no module is simply never loaded.
+                logger.error("Cannot load {}, no module provides it: {}", type.getSimpleName(), //NOPMD
+                        ModuleAttribution.describeUnattributedClass(type, environment));
+                continue;
+            }
             RegisterSystem registerInfo = type.getAnnotation(RegisterSystem.class);
             if (registerInfo.value().isValidFor(netMode.isAuthority(), isHeadless) && areOptionalRequirementsContained(registerInfo, environment)) {
                 systemsByModule.put(moduleId, type);

--- a/engine/src/main/java/org/terasology/engine/core/ComponentSystemManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/ComponentSystemManager.java
@@ -74,12 +74,10 @@ public class ComponentSystemManager {
                 logger.error("Cannot load {}, must be a subclass of ComponentSystem", type.getSimpleName()); //NOPMD
                 continue;
             }
-            Name moduleId = environment.getModuleProviding(type);
+            Name moduleId = ModuleAttribution.moduleProvidingOrReport(logger, "load", type, environment);
             if (moduleId == null) {
                 // Filing this under a null key would drop it silently: the loop below walks the
                 // environment's modules, so a system with no module is simply never loaded.
-                logger.error("Cannot load {}, no module provides it: {}", type.getSimpleName(), //NOPMD
-                        ModuleAttribution.describeUnattributedClass(type, environment));
                 continue;
             }
             RegisterSystem registerInfo = type.getAnnotation(RegisterSystem.class);

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleAttribution.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleAttribution.java
@@ -3,19 +3,76 @@
 
 package org.terasology.engine.core.module;
 
+import org.slf4j.Logger;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.naming.Name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Helpers for reporting when a {@link ModuleEnvironment} cannot say which module a class came from.
  */
 public final class ModuleAttribution {
 
+    /** How many distinct classes {@link #reportUnattributedOnce} names before it falls quiet. */
+    private static final int DISTINCT_CLASS_REPORT_LIMIT = 20;
+
+    /**
+     * How long the throttle stays quiet before reporting afresh.
+     * <p>
+     * Long enough that one startup's worth of failures counts as a single burst, short enough that
+     * a later unrelated one is still heard.
+     */
+    private static final long REPORT_RESET_MS = 60_000;
+
+    private static final Set<String> reportedClasses = ConcurrentHashMap.newKeySet();
+    private static final AtomicBoolean limitAnnounced = new AtomicBoolean();
+    private static volatile long lastReportMs;
+
     private ModuleAttribution() {
         // static utility class, no instance needed
+    }
+
+    /**
+     * Report a class the environment cannot attribute, at most once per class and not many times.
+     * <p>
+     * For callers on paths hot enough that reporting every occurrence would drown the log - type
+     * handling runs this per type, per serialization - or where a null is usually legitimate and
+     * only occasionally a real fault. Names at most {@value #DISTINCT_CLASS_REPORT_LIMIT} distinct
+     * classes, says so when it stops, and starts over after {@value #REPORT_RESET_MS}ms of quiet.
+     * <p>
+     * The throttle is deliberately crude, and deliberately static: it exists to make a
+     * currently-invisible problem visible without making it unbearable, and should go away once
+     * the underlying attribution failures are fixed rather than becoming permanent furniture.
+     *
+     * @param logger the caller's logger, so the message is attributed to where it happened
+     * @param what a short description of what could not be done, e.g. "build a type URI"
+     * @param type the class that could not be attributed
+     * @param environment the environment that was asked
+     */
+    public static void reportUnattributedOnce(Logger logger, String what, Class<?> type, ModuleEnvironment environment) {
+        long now = System.currentTimeMillis();
+        if (now - lastReportMs > REPORT_RESET_MS) {
+            reportedClasses.clear();
+            limitAnnounced.set(false);
+        }
+        lastReportMs = now;
+
+        if (!reportedClasses.add(type.getName())) {
+            return;
+        }
+        if (reportedClasses.size() > DISTINCT_CLASS_REPORT_LIMIT) {
+            if (limitAnnounced.compareAndSet(false, true)) {
+                logger.warn("More than {} classes could not be attributed to a module. Further reports are"
+                        + " suppressed until this stops happening.", DISTINCT_CLASS_REPORT_LIMIT);
+            }
+            return;
+        }
+        logger.warn("Could not {} - no module provides {}", what, describeUnattributedClass(type, environment));
     }
 
     /**

--- a/engine/src/main/java/org/terasology/engine/core/module/ModuleAttribution.java
+++ b/engine/src/main/java/org/terasology/engine/core/module/ModuleAttribution.java
@@ -9,70 +9,37 @@ import org.terasology.gestalt.naming.Name;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Helpers for reporting when a {@link ModuleEnvironment} cannot say which module a class came from.
  */
 public final class ModuleAttribution {
 
-    /** How many distinct classes {@link #reportUnattributedOnce} names before it falls quiet. */
-    private static final int DISTINCT_CLASS_REPORT_LIMIT = 20;
-
-    /**
-     * How long the throttle stays quiet before reporting afresh.
-     * <p>
-     * Long enough that one startup's worth of failures counts as a single burst, short enough that
-     * a later unrelated one is still heard.
-     */
-    private static final long REPORT_RESET_MS = 60_000;
-
-    private static final Set<String> reportedClasses = ConcurrentHashMap.newKeySet();
-    private static final AtomicBoolean limitAnnounced = new AtomicBoolean();
-    private static volatile long lastReportMs;
-
     private ModuleAttribution() {
         // static utility class, no instance needed
     }
 
     /**
-     * Report a class the environment cannot attribute, at most once per class and not many times.
+     * The module providing {@code type}, or null - having said so - if the environment cannot name one.
      * <p>
-     * For callers on paths hot enough that reporting every occurrence would drown the log - type
-     * handling runs this per type, per serialization - or where a null is usually legitimate and
-     * only occasionally a real fault. Names at most {@value #DISTINCT_CLASS_REPORT_LIMIT} distinct
-     * classes, says so when it stops, and starts over after {@value #REPORT_RESET_MS}ms of quiet.
-     * <p>
-     * The throttle is deliberately crude, and deliberately static: it exists to make a
-     * currently-invisible problem visible without making it unbearable, and should go away once
-     * the underlying attribution failures are fixed rather than becoming permanent furniture.
+     * What a null means is the caller's to decide, and the reason differs per site, so each one keeps
+     * its own comment and its own handling. What they share is the report, which lives here so every
+     * site says the same thing in the same shape.
      *
      * @param logger the caller's logger, so the message is attributed to where it happened
-     * @param what a short description of what could not be done, e.g. "build a type URI"
-     * @param type the class that could not be attributed
-     * @param environment the environment that was asked
+     * @param what a short description of what could not be done, e.g. "load", "register bind"
+     * @param type the class to attribute
+     * @param environment the environment to ask
+     * @return the module providing {@code type}, or null if the environment cannot name one
      */
-    public static void reportUnattributedOnce(Logger logger, String what, Class<?> type, ModuleEnvironment environment) {
-        long now = System.currentTimeMillis();
-        if (now - lastReportMs > REPORT_RESET_MS) {
-            reportedClasses.clear();
-            limitAnnounced.set(false);
+    public static Name moduleProvidingOrReport(Logger logger, String what, Class<?> type,
+                                               ModuleEnvironment environment) {
+        Name moduleId = environment.getModuleProviding(type);
+        if (moduleId == null) {
+            logger.error("Cannot {} {}, no module provides it: {}", what, type.getSimpleName(), //NOPMD
+                    describeUnattributedClass(type, environment));
         }
-        lastReportMs = now;
-
-        if (!reportedClasses.add(type.getName())) {
-            return;
-        }
-        if (reportedClasses.size() > DISTINCT_CLASS_REPORT_LIMIT) {
-            if (limitAnnounced.compareAndSet(false, true)) {
-                logger.warn("More than {} classes could not be attributed to a module. Further reports are"
-                        + " suppressed until this stops happening.", DISTINCT_CLASS_REPORT_LIMIT);
-            }
-            return;
-        }
-        logger.warn("Could not {} - no module provides {}", what, describeUnattributedClass(type, environment));
+        return moduleId;
     }
 
     /**

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/config/BindsSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/config/BindsSubsystem.java
@@ -11,6 +11,7 @@ import org.terasology.engine.config.BindsConfig;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.facade.BindsConfiguration;
 import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.core.subsystem.EngineSubsystem;
 import org.terasology.engine.input.BindAxisEvent;
@@ -229,11 +230,31 @@ public class BindsSubsystem implements EngineSubsystem, BindsManager {
         mouseWheelDownBind = null;
     }
 
+    /**
+     * The module a bind belongs to, or null - having said so - if the environment cannot name one.
+     * <p>
+     * A null module here would otherwise produce a bind URI with no module part, which registers
+     * but never matches anything, so the bind is quietly absent in game.
+     */
+    private Name moduleProvidingBind(ModuleEnvironment environment, Class<?> registerBindClass) {
+        Name moduleId = environment.getModuleProviding(registerBindClass);
+        if (moduleId == null) {
+            logger.error("Cannot register bind {}, no module provides it: {}", //NOPMD
+                    registerBindClass.getSimpleName(),
+                    ModuleAttribution.describeUnattributedClass(registerBindClass, environment));
+        }
+        return moduleId;
+    }
+
     private void registerButtonBinds(ModuleEnvironment environment) {
         Iterable<Class<?>> classes = environment.getTypesAnnotatedWith(RegisterBindButton.class);
         for (Class<?> registerBindClass : classes) {
             RegisterBindButton info = registerBindClass.getAnnotation(RegisterBindButton.class);
-            SimpleUri bindUri = new SimpleUri(environment.getModuleProviding(registerBindClass), info.id());
+            Name moduleId = moduleProvidingBind(environment, registerBindClass);
+            if (moduleId == null) {
+                continue;
+            }
+            SimpleUri bindUri = new SimpleUri(moduleId, info.id());
             if (BindButtonEvent.class.isAssignableFrom(registerBindClass)) {
                 try {
                     BindableButton bindButton = registerBindButton(bindUri, info.description(), (BindButtonEvent) registerBindClass.newInstance());
@@ -258,7 +279,10 @@ public class BindsSubsystem implements EngineSubsystem, BindsManager {
         Iterable<Class<?>> classes = environment.getTypesAnnotatedWith(RegisterBindAxis.class);
         for (Class<?> registerBindClass : classes) {
             RegisterBindAxis info = registerBindClass.getAnnotation(RegisterBindAxis.class);
-            Name moduleId = environment.getModuleProviding(registerBindClass);
+            Name moduleId = moduleProvidingBind(environment, registerBindClass);
+            if (moduleId == null) {
+                continue;
+            }
             SimpleUri id = new SimpleUri(moduleId, info.id());
             if (BindAxisEvent.class.isAssignableFrom(registerBindClass)) {
                 BindableButton positiveButton = getBindButton(new SimpleUri(info.positiveButton()));
@@ -289,7 +313,10 @@ public class BindsSubsystem implements EngineSubsystem, BindsManager {
         Iterable<Class<?>> classes = environment.getTypesAnnotatedWith(RegisterRealBindAxis.class);
         for (Class<?> registerBindClass : classes) {
             RegisterRealBindAxis info = registerBindClass.getAnnotation(RegisterRealBindAxis.class);
-            Name moduleId = environment.getModuleProviding(registerBindClass);
+            Name moduleId = moduleProvidingBind(environment, registerBindClass);
+            if (moduleId == null) {
+                continue;
+            }
             SimpleUri id = new SimpleUri(moduleId, info.id());
             if (BindAxisEvent.class.isAssignableFrom(registerBindClass)) {
                 try {

--- a/engine/src/main/java/org/terasology/engine/core/subsystem/config/BindsSubsystem.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/config/BindsSubsystem.java
@@ -237,13 +237,7 @@ public class BindsSubsystem implements EngineSubsystem, BindsManager {
      * but never matches anything, so the bind is quietly absent in game.
      */
     private Name moduleProvidingBind(ModuleEnvironment environment, Class<?> registerBindClass) {
-        Name moduleId = environment.getModuleProviding(registerBindClass);
-        if (moduleId == null) {
-            logger.error("Cannot register bind {}, no module provides it: {}", //NOPMD
-                    registerBindClass.getSimpleName(),
-                    ModuleAttribution.describeUnattributedClass(registerBindClass, environment));
-        }
-        return moduleId;
+        return ModuleAttribution.moduleProvidingOrReport(logger, "register bind", registerBindClass, environment);
     }
 
     private void registerButtonBinds(ModuleEnvironment environment) {

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/ModuleRendering.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/ModuleRendering.java
@@ -50,12 +50,8 @@ public abstract class ModuleRendering {
      * {@code "null:fbo.something"}, which register happily and then fail to match anything.
      */
     private Name moduleProviding(Class<?> implementingClass) {
-        Name module = moduleManager.getEnvironment().getModuleProviding(implementingClass);
-        if (module == null) {
-            logger.error("No module provides rendering class {}: {}", implementingClass.getSimpleName(), //NOPMD
-                    ModuleAttribution.describeUnattributedClass(implementingClass, moduleManager.getEnvironment()));
-        }
-        return module;
+        return ModuleAttribution.moduleProvidingOrReport(logger, "use rendering class", implementingClass,
+                moduleManager.getEnvironment());
     }
 
     public boolean isEnabled() {

--- a/engine/src/main/java/org/terasology/engine/rendering/dag/ModuleRendering.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/dag/ModuleRendering.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.context.annotation.IndexInherited;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.rendering.dag.dependencyConnections.BufferPair;
@@ -39,7 +40,22 @@ public abstract class ModuleRendering {
     public ModuleRendering(Context context) {
         this.context = context;
         moduleManager = context.get(ModuleManager.class);
-        providingModule = moduleManager.getEnvironment().getModuleProviding(this.getClass());
+        providingModule = moduleProviding(this.getClass());
+    }
+
+    /**
+     * The module providing this rendering class, complaining if the environment cannot name one.
+     * <p>
+     * A null here is not obviously fatal, so it is easy to miss: it goes on to build FBO URIs like
+     * {@code "null:fbo.something"}, which register happily and then fail to match anything.
+     */
+    private Name moduleProviding(Class<?> implementingClass) {
+        Name module = moduleManager.getEnvironment().getModuleProviding(implementingClass);
+        if (module == null) {
+            logger.error("No module provides rendering class {}: {}", implementingClass.getSimpleName(), //NOPMD
+                    ModuleAttribution.describeUnattributedClass(implementingClass, moduleManager.getEnvironment()));
+        }
+        return module;
     }
 
     public boolean isEnabled() {
@@ -80,8 +96,7 @@ public abstract class ModuleRendering {
     }
 
     protected void setProvidingModule(Class implementingClass) {
-        ModuleManager moduleManager = context.get(ModuleManager.class);
-        this.providingModule = moduleManager.getEnvironment().getModuleProviding(implementingClass);
+        this.providingModule = moduleProviding(implementingClass);
     }
 
     protected BufferPair createBufferPair(String primaryBufferName, String secondaryBufferName,

--- a/engine/src/main/java/org/terasology/engine/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/ReflectionUtil.java
@@ -7,7 +7,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.reflections.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.nui.UIWidget;
@@ -35,6 +38,8 @@ import java.util.stream.Stream;
 
 
 public final class ReflectionUtil {
+    private static final Logger logger = LoggerFactory.getLogger(ReflectionUtil.class);
+
     private ReflectionUtil() {
     }
 
@@ -653,6 +658,10 @@ public final class ReflectionUtil {
         Name moduleProvidingType = moduleEnvironment.getModuleProviding(getRawType(type));
 
         if (moduleProvidingType == null) {
+            // Usually legitimate - plenty of non-module classes reach here - but a module class
+            // that fails attribution lands in the same branch and silently loses its module
+            // qualifier, so the URI stops matching. Throttled because this runs per type.
+            ModuleAttribution.reportUnattributedOnce(logger, "build a type URI", getRawType(type), moduleEnvironment);
             return typeSimpleName;
         }
 
@@ -674,6 +683,7 @@ public final class ReflectionUtil {
         Name moduleProviding = environment.getModuleProviding(clazz);
 
         if (moduleProviding == null) {
+            ModuleAttribution.reportUnattributedOnce(logger, "build a simple URI", clazz, environment);
             return null;
         }
 
@@ -695,6 +705,7 @@ public final class ReflectionUtil {
         Name moduleProviding = environment.getModuleProviding(clazz);
 
         if (moduleProviding == null) {
+            ModuleAttribution.reportUnattributedOnce(logger, "build a fully qualified URI", clazz, environment);
             return null;
         }
 

--- a/engine/src/main/java/org/terasology/engine/utilities/ReflectionUtil.java
+++ b/engine/src/main/java/org/terasology/engine/utilities/ReflectionUtil.java
@@ -7,10 +7,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.reflections.ReflectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.nui.UIWidget;
@@ -38,8 +35,6 @@ import java.util.stream.Stream;
 
 
 public final class ReflectionUtil {
-    private static final Logger logger = LoggerFactory.getLogger(ReflectionUtil.class);
-
     private ReflectionUtil() {
     }
 
@@ -658,10 +653,6 @@ public final class ReflectionUtil {
         Name moduleProvidingType = moduleEnvironment.getModuleProviding(getRawType(type));
 
         if (moduleProvidingType == null) {
-            // Usually legitimate - plenty of non-module classes reach here - but a module class
-            // that fails attribution lands in the same branch and silently loses its module
-            // qualifier, so the URI stops matching. Throttled because this runs per type.
-            ModuleAttribution.reportUnattributedOnce(logger, "build a type URI", getRawType(type), moduleEnvironment);
             return typeSimpleName;
         }
 
@@ -683,7 +674,6 @@ public final class ReflectionUtil {
         Name moduleProviding = environment.getModuleProviding(clazz);
 
         if (moduleProviding == null) {
-            ModuleAttribution.reportUnattributedOnce(logger, "build a simple URI", clazz, environment);
             return null;
         }
 
@@ -705,7 +695,6 @@ public final class ReflectionUtil {
         Name moduleProviding = environment.getModuleProviding(clazz);
 
         if (moduleProviding == null) {
-            ModuleAttribution.reportUnattributedOnce(logger, "build a fully qualified URI", clazz, environment);
             return null;
         }
 

--- a/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
@@ -4,6 +4,7 @@ package org.terasology.engine.world.block.family;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.registry.InjectionHelper;
 import org.terasology.engine.world.block.BlockBuilderHelper;
@@ -11,6 +12,7 @@ import org.terasology.engine.world.block.loader.BlockFamilyDefinition;
 import org.terasology.engine.world.block.shapes.BlockShape;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.module.ModuleEnvironment;
+import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.util.reflection.ParameterProvider;
 import org.terasology.gestalt.util.reflection.SimpleClassFactory;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
@@ -41,10 +43,17 @@ public class BlockFamilyLibrary {
                 logger.error("Cannot load {}, must be a subclass of BlockFamily", entry.getSimpleName()); //NOPMD
                 continue;
             }
+            Name moduleProviding = moduleEnvironment.getModuleProviding(entry);
+            if (moduleProviding == null) {
+                // Without this the line below dereferences null and takes the whole library down.
+                logger.error("Cannot load {}, no module provides it: {}", entry.getSimpleName(), //NOPMD
+                        ModuleAttribution.describeUnattributedClass(entry, moduleEnvironment));
+                continue;
+            }
             RegisterBlockFamily registerInfo = entry.getAnnotation(RegisterBlockFamily.class);
             String id = registerInfo.value();
             logger.debug("Registering blockFamily {}", id);
-            library.register(new ResourceUrn(moduleEnvironment.getModuleProviding(entry).toString(), registerInfo.value()).toString(),
+            library.register(new ResourceUrn(moduleProviding.toString(), registerInfo.value()).toString(),
                     (Class<? extends BlockFamily>) entry);
 
         }

--- a/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/block/family/BlockFamilyLibrary.java
@@ -43,11 +43,9 @@ public class BlockFamilyLibrary {
                 logger.error("Cannot load {}, must be a subclass of BlockFamily", entry.getSimpleName()); //NOPMD
                 continue;
             }
-            Name moduleProviding = moduleEnvironment.getModuleProviding(entry);
+            Name moduleProviding = ModuleAttribution.moduleProvidingOrReport(logger, "load", entry, moduleEnvironment);
             if (moduleProviding == null) {
                 // Without this the line below dereferences null and takes the whole library down.
-                logger.error("Cannot load {}, no module provides it: {}", entry.getSimpleName(), //NOPMD
-                        ModuleAttribution.describeUnattributedClass(entry, moduleEnvironment));
                 continue;
             }
             RegisterBlockFamily registerInfo = entry.getAnnotation(RegisterBlockFamily.class);

--- a/engine/src/main/java/org/terasology/engine/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
@@ -3,7 +3,11 @@
 package org.terasology.engine.world.generator.plugin;
 
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.module.ModuleAttribution;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.context.Context;
 import org.terasology.gestalt.module.ModuleEnvironment;
@@ -18,6 +22,8 @@ import java.util.List;
 
 public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginLibrary {
 
+    private static final Logger logger = LoggerFactory.getLogger(DefaultWorldGeneratorPluginLibrary.class);
+
     private final ClassLibrary<WorldGeneratorPlugin> library;
 
     public DefaultWorldGeneratorPluginLibrary(ModuleEnvironment moduleEnvironment, Context context) {
@@ -29,7 +35,14 @@ public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginL
         library = new DefaultModuleClassLibrary<>(() -> moduleEnvironment, reflectFactory, copyStrategyLibrary);
         for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterPlugin.class)) {
             if (WorldGeneratorPlugin.class.isAssignableFrom(entry)) {
-                ResourceUrn resourceUrn = new ResourceUrn(moduleEnvironment.getModuleProviding(entry).toString(), entry.getSimpleName());
+                Name moduleProviding = moduleEnvironment.getModuleProviding(entry);
+                if (moduleProviding == null) {
+                    // Without this the line below dereferences null and takes the whole library down.
+                    logger.error("Cannot register world generator plugin {}, no module provides it: {}", //NOPMD
+                            entry.getSimpleName(), ModuleAttribution.describeUnattributedClass(entry, moduleEnvironment));
+                    continue;
+                }
+                ResourceUrn resourceUrn = new ResourceUrn(moduleProviding.toString(), entry.getSimpleName());
                 library.register(resourceUrn.toString(), entry.asSubclass(WorldGeneratorPlugin.class));
             }
         }

--- a/engine/src/main/java/org/terasology/engine/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
+++ b/engine/src/main/java/org/terasology/engine/world/generator/plugin/DefaultWorldGeneratorPluginLibrary.java
@@ -35,11 +35,10 @@ public class DefaultWorldGeneratorPluginLibrary implements WorldGeneratorPluginL
         library = new DefaultModuleClassLibrary<>(() -> moduleEnvironment, reflectFactory, copyStrategyLibrary);
         for (Class<?> entry : moduleEnvironment.getTypesAnnotatedWith(RegisterPlugin.class)) {
             if (WorldGeneratorPlugin.class.isAssignableFrom(entry)) {
-                Name moduleProviding = moduleEnvironment.getModuleProviding(entry);
+                Name moduleProviding = ModuleAttribution.moduleProvidingOrReport(logger,
+                        "register world generator plugin", entry, moduleEnvironment);
                 if (moduleProviding == null) {
                     // Without this the line below dereferences null and takes the whole library down.
-                    logger.error("Cannot register world generator plugin {}, no module provides it: {}", //NOPMD
-                            entry.getSimpleName(), ModuleAttribution.describeUnattributedClass(entry, moduleEnvironment));
                     continue;
                 }
                 ResourceUrn resourceUrn = new ResourceUrn(moduleProviding.toString(), entry.getSimpleName());


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

Follow-up to #5352, from @BenjaminAmos' review comment there listing other callers of `ModuleEnvironment#getModuleProviding` that fail opaquely when it returns null.

Working through them, the six sites turned out to fail in **three different ways**, which is the part worth reviewing rather than the diff:

| Site | What a null actually did |
|---|---|
| `ComponentSystemManager` | Filed the system under a **null multimap key**. The loop below walks the environment's modules, so the system was **silently never loaded** — no error, no crash, the feature just absent. |
| `BlockFamilyLibrary` | **NPE** on `.toString()`, taking down the whole block family library, naming nothing useful. |
| `DefaultWorldGeneratorPluginLibrary` | **NPE**, same shape. |
| `BindsSubsystem` (×3) | Built a `SimpleUri` with no module part. Registers fine, matches nothing — the bind is quietly missing in game. |
| `ModuleRendering` (×2) | Went on to build FBO URIs like `"null:fbo.something"`. |
| `ReflectionUtil` (×3) | Nothing — null is a **documented, usually legitimate** return value there. Left untouched. |

So the first five are behaviour fixes rather than logging: each now reports what happened and skips, matching the `logger.error(...); continue;` idiom those loops already use for entries of the wrong type. `ModuleRendering` reports but is otherwise unchanged, since a null providing module isn't obviously fatal there. All five share one helper, `ModuleAttribution.moduleProvidingOrReport`, so the report reads the same everywhere and there is a single place to change when the audit below lands.

## What changed after review

The first version of this PR also added a throttled reporter (`reportUnattributedOnce`) and wired it into `ReflectionUtil`'s three sites, on the grounds that a module class failing attribution lands in the same branch as the legitimate nulls and silently loses its module qualifier.

@BenjaminAmos asked whether throttling belongs in the logging framework rather than the call site. Looking into it, the answer is neither:

- Stock `DuplicateMessageFilter` keys on the raw message pattern *before* parameter substitution, so one parameterized call site collapses to a single report no matter how many distinct classes fail. It cannot express "once per distinct class".
- A custom `TurboFilter` keyed on formatted output could, but it still holds process-global state — the same defect CodeRabbit flagged on the original throttle, relocated somewhere harder to find.

CodeRabbit's finding on that static state was correct and worth recording: there is no `forkEvery` or `maxParallelForks` anywhere in the tree, so every test class inside a Gradle test task shares one JVM, and one engine's reports could suppress another's.

So the throttle is gone rather than relocated, and `ReflectionUtil` is back to base with a zero diff. This PR is now just the defensive checks — which @BenjaminAmos asked for regardless — and nothing else.

## Follow-up: the environment-switch audit

@BenjaminAmos proposed a one-time audit at environment switch, and validating it as part of the test suite. That is the right home for the reporting this PR dropped: walk the environment's indexed classes once and report *"N classes cannot be attributed: [first 10]"*, which gives the whole picture at the moment it becomes true, needs no throttle by construction, and is scoped per environment rather than static. `EnvironmentSwitchHandler` already iterates types for component and event registration, so the scan can fold into an existing pass rather than adding one.

Tracked as follow-up work, not in this PR. Related: #4986.

## Verification

- `:engine-tests:unitTest` — full engine unit suite green
- `:engine:checkstyleMain` — green
- `BindsSubsystemTest`, `ReflectionUtilTest` — green (targeted; the three restructured bind sites and the now-reverted `ReflectionUtil`)
- **No reports fire during a healthy engine startup**, checked against `ExampleTest` on the original revision, so these are fault signals rather than background noise.
