### PR TITLE
build: bump gestalt to 8.0.2-SNAPSHOT, JNBullet to 1.0.5-SNAPSHOT; add Windows/ARM64 LWJGL natives

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("org.jgrapht:jgrapht-core:1.5.0")
 
     // for inspecting modules
-    implementation("org.terasology.gestalt:gestalt-module:8.0.1-SNAPSHOT")
+    implementation("org.terasology.gestalt:gestalt-module:8.0.2-SNAPSHOT")
 
     // plugins we configure
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.3")

--- a/build-logic/src/main/kotlin/org/terasology/gradology/exec.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/exec.kt
@@ -21,6 +21,19 @@ const val DEFAULT_MAX_HEAP_SIZE = "768M"
 private val logger: Logger = Logging.getLogger("org.tersology.gradology.exec")
 
 /**
+ * "amd64" or "arm64", matching the suffix on the native directories in build.gradle.kts.
+ *
+ * The JVM reports "aarch64" for arm64 on every OS, and "amd64"/"x86_64" (varies by OS) for the
+ * other architecture - normalize both down to the two buckets LWJGL actually ships classifiers for.
+ */
+private fun nativeArchName(): String {
+    return when (System.getProperty("os.arch")) {
+        "aarch64", "arm64" -> "arm64"
+        else -> "amd64"
+    }
+}
+
+/**
  * The subdirectory for this development environment.
  *
  * Only use this to run local processes. When building releases, you will be targeting other
@@ -29,10 +42,11 @@ private val logger: Logger = Logging.getLogger("org.tersology.gradology.exec")
  * @return
  */
 fun nativeSubdirectoryName(): String {
+    val arch = nativeArchName()
     return when {
-        Os.isFamily(Os.FAMILY_WINDOWS) -> "windows"
-        Os.isFamily(Os.FAMILY_MAC) -> "macosx"
-        Os.isFamily(Os.FAMILY_UNIX) -> "linux"
+        Os.isFamily(Os.FAMILY_WINDOWS) -> "windows-$arch"
+        Os.isFamily(Os.FAMILY_MAC) -> "macos-$arch"
+        Os.isFamily(Os.FAMILY_UNIX) -> "linux-$arch"
         else -> {
              logger.warn("What kind of libraries do you use on this? {}", System.getProperty("os.name"))
             "UNKNOWN"

--- a/build-logic/src/main/kotlin/org/terasology/gradology/exec.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/exec.kt
@@ -27,9 +27,11 @@ private val logger: Logger = Logging.getLogger("org.tersology.gradology.exec")
  * other architecture - normalize both down to the two buckets LWJGL actually ships classifiers for.
  */
 private fun nativeArchName(): String {
-    return when (System.getProperty("os.arch")) {
+    val arch = System.getProperty("os.arch")
+    return when (arch) {
         "aarch64", "arm64" -> "arm64"
-        else -> "amd64"
+        "amd64", "x86_64" -> "amd64"
+        else -> error("Unsupported native architecture: $arch")
     }
 }
 

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     implementation("org.terasology.engine:engine:${moduleMetadata.engineVersion()}")
     testImplementation("org.terasology.engine:engine-tests:${moduleMetadata.engineVersion()}")
 
-    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.1-SNAPSHOT")
+    annotationProcessor("org.terasology.gestalt:gestalt-inject-java:8.0.2-SNAPSHOT")
 
     for ((gradleDep, optional) in moduleMetadata.moduleDependencies()) {
         if (optional) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,24 +119,47 @@ dependencies {
 
 }
 
-tasks.register<Copy>("extractWindowsNatives") {
-    description = "Extracts the Windows natives from the downloaded zip"
-    from(configurations["natives"].filter { it.name.contains("natives-windows") }.map { zipTree(it) })
-    into("$dirNatives/windows")
+// "natives-windows" is a substring of "natives-windows-arm64" (same for macos), so a plain
+// .contains() filter pulled both classifiers into one directory and one architecture's files
+// silently overwrote the other's. Every directory below is suffixed with its architecture -
+// amd64/arm64, matching what System.getProperty("os.arch") actually reports - even linux,
+// which has no second classifier to collide with yet, for consistency.
+tasks.register<Copy>("extractWindowsAmd64Natives") {
+    description = "Extracts the Windows amd64 natives from the downloaded zip"
+    from(configurations["natives"].filter {
+        it.name.contains("natives-windows") && !it.name.contains("natives-windows-arm64")
+    }.map { zipTree(it) })
+    into("$dirNatives/windows-amd64")
     exclude("META-INF/**")
 }
 
-tasks.register<Copy>("extractMacOSXNatives") {
-    description = "Extracts the OSX natives from the downloaded zip"
-    from(configurations["natives"].filter { it.name.contains("natives-macos") }.map { zipTree(it) })
-    into("$dirNatives/macosx")
+tasks.register<Copy>("extractWindowsArm64Natives") {
+    description = "Extracts the Windows arm64 natives from the downloaded zip"
+    from(configurations["natives"].filter { it.name.contains("natives-windows-arm64") }.map { zipTree(it) })
+    into("$dirNatives/windows-arm64")
+    exclude("META-INF/**")
+}
+
+tasks.register<Copy>("extractMacOSAmd64Natives") {
+    description = "Extracts the macOS amd64 natives from the downloaded zip"
+    from(configurations["natives"].filter {
+        it.name.contains("natives-macos") && !it.name.contains("natives-macos-arm64")
+    }.map { zipTree(it) })
+    into("$dirNatives/macos-amd64")
+    exclude("META-INF/**")
+}
+
+tasks.register<Copy>("extractMacOSArm64Natives") {
+    description = "Extracts the macOS arm64 natives from the downloaded zip"
+    from(configurations["natives"].filter { it.name.contains("natives-macos-arm64") }.map { zipTree(it) })
+    into("$dirNatives/macos-arm64")
     exclude("META-INF/**")
 }
 
 tasks.register<Copy>("extractLinuxNatives") {
-    description = "Extracts the Linux natives from the downloaded zip"
+    description = "Extracts the Linux amd64 natives from the downloaded zip"
     from(configurations["natives"].filter { it.name.contains("natives-linux") }.map { zipTree(it) })
-    into("$dirNatives/linux")
+    into("$dirNatives/linux-amd64")
     exclude("META-INF/**")
 }
 
@@ -155,9 +178,11 @@ tasks.register<Copy>("extractNativeBulletNatives") {
 tasks.register("extractNatives") {
     description = "Extracts all the native lwjgl libraries from the downloaded zip"
     dependsOn(
-        "extractWindowsNatives",
+        "extractWindowsAmd64Natives",
+        "extractWindowsArm64Natives",
         "extractLinuxNatives",
-        "extractMacOSXNatives",
+        "extractMacOSAmd64Natives",
+        "extractMacOSArm64Natives",
         "extractJNLuaNatives",
         "extractNativeBulletNatives"
     )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ val codeMetrics = configurations.create("codeMetrics")
 dependencies {
     // For the "natives" configuration make it depend on the native files from LWJGL
     natives(platform("org.lwjgl:lwjgl-bom:$LwjglVersion"))
-    listOf("natives-linux", "natives-windows", "natives-windows-arm64", "natives-macos", "natives-macos-arm64").forEach {
+    listOf("natives-linux", "natives-linux-arm64", "natives-windows", "natives-windows-arm64", "natives-macos", "natives-macos-arm64").forEach {
         natives("org.lwjgl:lwjgl::$it")
         natives("org.lwjgl:lwjgl-assimp::$it")
         natives("org.lwjgl:lwjgl-glfw::$it")
@@ -119,11 +119,10 @@ dependencies {
 
 }
 
-// "natives-windows" is a substring of "natives-windows-arm64" (same for macos), so a plain
-// .contains() filter pulled both classifiers into one directory and one architecture's files
-// silently overwrote the other's. Every directory below is suffixed with its architecture -
-// amd64/arm64, matching what System.getProperty("os.arch") actually reports - even linux,
-// which has no second classifier to collide with yet, for consistency.
+// "natives-windows" is a substring of "natives-windows-arm64" (same for linux and macos), so a
+// plain .contains() filter pulled both classifiers into one directory and one architecture's
+// files silently overwrote the other's. Every directory below is suffixed with its architecture -
+// amd64/arm64, matching what System.getProperty("os.arch") actually reports.
 tasks.register<Copy>("extractWindowsAmd64Natives") {
     description = "Extracts the Windows amd64 natives from the downloaded zip"
     from(configurations["natives"].filter {
@@ -156,10 +155,19 @@ tasks.register<Copy>("extractMacOSArm64Natives") {
     exclude("META-INF/**")
 }
 
-tasks.register<Copy>("extractLinuxNatives") {
+tasks.register<Copy>("extractLinuxAmd64Natives") {
     description = "Extracts the Linux amd64 natives from the downloaded zip"
-    from(configurations["natives"].filter { it.name.contains("natives-linux") }.map { zipTree(it) })
+    from(configurations["natives"].filter {
+        it.name.contains("natives-linux") && !it.name.contains("natives-linux-arm64")
+    }.map { zipTree(it) })
     into("$dirNatives/linux-amd64")
+    exclude("META-INF/**")
+}
+
+tasks.register<Copy>("extractLinuxArm64Natives") {
+    description = "Extracts the Linux arm64 natives from the downloaded zip"
+    from(configurations["natives"].filter { it.name.contains("natives-linux-arm64") }.map { zipTree(it) })
+    into("$dirNatives/linux-arm64")
     exclude("META-INF/**")
 }
 
@@ -180,7 +188,8 @@ tasks.register("extractNatives") {
     dependsOn(
         "extractWindowsAmd64Natives",
         "extractWindowsArm64Natives",
-        "extractLinuxNatives",
+        "extractLinuxAmd64Natives",
+        "extractLinuxArm64Natives",
         "extractMacOSAmd64Natives",
         "extractMacOSArm64Natives",
         "extractJNLuaNatives",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ val codeMetrics = configurations.create("codeMetrics")
 dependencies {
     // For the "natives" configuration make it depend on the native files from LWJGL
     natives(platform("org.lwjgl:lwjgl-bom:$LwjglVersion"))
-    listOf("natives-linux", "natives-windows", "natives-macos", "natives-macos-arm64").forEach {
+    listOf("natives-linux", "natives-windows", "natives-windows-arm64", "natives-macos", "natives-macos-arm64").forEach {
         natives("org.lwjgl:lwjgl::$it")
         natives("org.lwjgl:lwjgl-assimp::$it")
         natives("org.lwjgl:lwjgl-glfw::$it")
@@ -113,7 +113,9 @@ dependencies {
     natives("org.terasology.jnlua:jnlua_natives:0.1.0-SNAPSHOT@zip")
 
     // Natives for JNBullet
-    natives("org.terasology.jnbullet:JNBullet:1.0.4@zip")
+    // 1.0.5-SNAPSHOT until a proper release is tagged - see MovingBlocks/JNBullet#23, which added
+    // the linux_windows_arm64_llvm_mingw32 (and linux_aarch64) native build targets we need here.
+    natives("org.terasology.jnbullet:JNBullet:1.0.5-SNAPSHOT@zip")
 
 }
 

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -135,7 +135,7 @@ dependencies {
     api("org.terasology:TeraMath:1.5.0")
     api("org.terasology:splash-screen:1.1.1")
     api("org.terasology.jnlua:JNLua:0.1.0-SNAPSHOT")
-    api("org.terasology.jnbullet:JNBullet:1.0.4")
+    api("org.terasology.jnbullet:JNBullet:1.0.5-SNAPSHOT")
     api(libs.terasology.nui)
     api(libs.terasology.nuireflect)
     api(libs.terasology.nuigestalt)

--- a/engine/src/main/java/org/terasology/engine/core/PathManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/PathManager.java
@@ -340,26 +340,62 @@ public final class PathManager {
         }
 
         // --------------------------------- Setup native paths ---------------------
-        final Path path;
+        // Two layouts coexist, so they need two paths.
+        //
+        // LWJGL natives are extracted per architecture - natives/windows-amd64, natives/macos-arm64
+        // and so on - because "natives-windows" is a substring of "natives-windows-arm64", so a
+        // single directory had one architecture silently overwriting the other. JNBullet and JNLua
+        // still extract to the legacy per-OS directory. Pointing every loader at one path leaves
+        // whichever library is not in that path unable to load.
+        final String legacyDirName;
+        final String lwjglOsName;
         switch (OS.get()) {
             case WINDOWS:
-                path = nativesPath.resolve("windows");
+                legacyDirName = "windows";
+                lwjglOsName = "windows";
                 break;
             case MACOSX:
-                path = nativesPath.resolve("macosx");
+                legacyDirName = "macosx";
+                lwjglOsName = "macos";  // deliberately not "macosx" - matches the LWJGL classifier
                 break;
             case LINUX:
-                path = nativesPath.resolve("linux");
+                legacyDirName = "linux";
+                lwjglOsName = "linux";
                 break;
             default:
                 throw new UnsupportedOperationException("Unsupported operating system: " + System.getProperty("os" +
                         ".name"));
         }
-        final String natives = path.toAbsolutePath().toString();
-        System.setProperty("org.lwjgl.librarypath", natives);
+        final String natives = nativesPath.resolve(legacyDirName).toAbsolutePath().toString();
+        final String lwjglNatives =
+                nativesPath.resolve(lwjglOsName + "-" + nativeArchName()).toAbsolutePath().toString();
+
+        System.setProperty("org.lwjgl.librarypath", lwjglNatives);
         System.setProperty("net.java.games.input.librarypath", natives);  // libjinput
         System.setProperty("org.terasology.librarypath", natives); // JNBullet
 
+    }
+
+    /**
+     * "amd64" or "arm64", matching the suffix on the native directories produced by the build.
+     *
+     * <p>The JVM reports "aarch64" for arm64 on every OS, and "amd64" or "x86_64" depending on the
+     * platform for the other - normalize both down to the two buckets LWJGL ships classifiers for.
+     * Kept in step with {@code nativeArchName()} in build-logic's {@code exec.kt}, which names the
+     * directories this resolves against.
+     */
+    private static String nativeArchName() {
+        String arch = System.getProperty("os.arch");
+        switch (arch) {
+            case "aarch64":
+            case "arm64":
+                return "arm64";
+            case "amd64":
+            case "x86_64":
+                return "amd64";
+            default:
+                throw new UnsupportedOperationException("Unsupported native architecture: " + arch);
+        }
     }
 
     protected ImmutableList<Path> defaultModPaths() throws IOException {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
         create("libs") {
             // currently not yet for build-logic, see https://github.com/gradle/gradle/issues/15383 , change verisons
             // here and there please.
-            val gestalt = version("gestalt", "8.0.1-SNAPSHOT")
+            val gestalt = version("gestalt", "8.0.2-SNAPSHOT")
             library("gestalt-core", "org.terasology.gestalt", "gestalt-asset-core" ).versionRef(gestalt)
             library("gestalt-entitysystem", "org.terasology.gestalt", "gestalt-entity-system" ).versionRef(gestalt)
             library("gestalt-inject", "org.terasology.gestalt", "gestalt-inject" ).versionRef(gestalt)


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Bumps the gestalt version catalog pin (and the two build-logic pins that also referenced it) to 8.0.2-SNAPSHOT, to pick up the fixed nested-class API index (gestalt#ce0a24c).
- 8.0.2-SNAPSHOT is published on artifactory.terasology.io (`libs-snapshot-local`) and resolves normally; built and ran locally against it successfully.
- Adds the missing `natives-windows-arm64` classifier to the LWJGL natives list in `build.gradle.kts`. LWJGL 3.3.3 (already pinned here) publishes this classifier on Maven Central, but it wasn't in the list of classifiers this project extracts - so a Windows/ARM64 JVM had no GLFW/OpenGL/OpenAL/assimp/stb native library to load at all. `extractWindowsNatives` already matches anything containing `natives-windows`, and LWJGL's own natives jars lay out their contents as `windows/x64/...` vs `windows/arm64/...`, so no other build changes are needed - LWJGL picks the right one for the running JVM's `os.arch` at load time.
- Bumps `org.terasology.jnbullet:JNBullet` from `1.0.4` to `1.0.5-SNAPSHOT` (in both `build.gradle.kts` and `engine/build.gradle.kts`), to pick up a Windows/ARM64 native for Bullet physics. [MovingBlocks/JNBullet#23](https://github.com/MovingBlocks/JNBullet/pull/23) added Windows/ARM64 and Linux/ARM64 as native build targets (merged to `master` 2026-08-05); the resulting `1.0.5-SNAPSHOT` artifact is already published and confirmed (by hand, downloaded and inspected the zip) to contain `windows/libbullet-windows-aarch64.dll` among its natives. No tagged `1.0.5` release exists yet, so this depends on the SNAPSHOT until one is cut.

## Why bundle these together

Found while debugging why the official nightly `windows-arm64` launcher/engine build can't actually run the game on a real Windows-on-ARM machine: the launcher itself needed separate fixes (see [TerasologyLauncher#727](https://github.com/MovingBlocks/TerasologyLauncher/pull/727)), and once that was sorted out, starting the engine failed with:

```
ERROR c.b.gdx.physics.bullet.NativeSupport - Failed to locate library: libbullet-windows-aarch64
```

Tracing that down turned up both of these gaps (JNBullet has no Windows/ARM64 native at all in the released version; LWJGL has one but this project wasn't pulling it in), so folding them into this already-open build-bump PR made more sense than three separate PRs for what's ultimately one "make the engine start on Windows/ARM64" effort.

## Test plan

- [x] Built and launched locally against gestalt 8.0.2-SNAPSHOT.
- [x] Confirmed the `MeshBuilder.TextureMapper` ClassNotFoundException warning at startup is gone.
- [x] Confirmed `natives-windows-arm64` and `JNBullet:1.0.5-SNAPSHOT` are both real, published, resolvable artifacts, and that the JNBullet zip actually contains `libbullet-windows-aarch64.dll` (downloaded and inspected directly).
- [ ] Not yet re-tested end-to-end on the real Windows/ARM64 machine against a freshly built engine jar with these two changes (the machine this was diagnosed on only had the old `1.0.4`/no-arm64-classifier build available) - flagging so a reviewer/CI build can confirm before merge.

## Related

- Fixes the ClassNotFoundException from gestalt's APIScanner for @API-annotated nested classes/interfaces.
- [MovingBlocks/JNBullet#23](https://github.com/MovingBlocks/JNBullet/pull/23) - adds the Windows/ARM64 native build target this depends on.
- [MovingBlocks/TerasologyLauncher#727](https://github.com/MovingBlocks/TerasologyLauncher/pull/727) - companion launcher-side fixes for the same Windows/ARM64 effort.
