### PR TITLE
fix: guard against null in SimpleUri(String) and StringRepresentationTypeHandler

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/core/SimpleUriTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/core/SimpleUriTest.java
@@ -1,0 +1,38 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.core;
+
+import org.junit.jupiter.api.Test;
+import org.terasology.gestalt.naming.Name;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleUriTest {
+
+    @Test
+    void parsesModuleAndObject() {
+        SimpleUri uri = new SimpleUri("engine:something");
+
+        assertTrue(uri.isValid());
+        assertEquals(new Name("engine"), uri.getModuleName());
+        assertEquals(new Name("something"), uri.getObjectName());
+    }
+
+    @Test
+    void stringWithoutSeparatorIsInvalid() {
+        assertFalse(new SimpleUri("engine").isValid());
+    }
+
+    @Test
+    void nullStringIsInvalid() {
+        // Regression: null reached this constructor when deserializing a stale reference and
+        // threw on split(). It must land in the same empty/invalid state as the no-arg form.
+        SimpleUri uri = new SimpleUri((String) null);
+
+        assertFalse(uri.isValid());
+        assertTrue(uri.getModuleName().isEmpty());
+        assertTrue(uri.getObjectName().isEmpty());
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/core/SimpleUri.java
+++ b/engine/src/main/java/org/terasology/engine/core/SimpleUri.java
@@ -58,11 +58,15 @@ public class SimpleUri implements Uri, Comparable<SimpleUri> {
     }
 
     /**
-     * Creates a SimpleUri from a string in the format "module:object". If the string does not match this format, it will be marked invalid
+     * Creates a SimpleUri from a string in the format "module:object". If the string does not match this format
+     * (including {@code null}), it will be marked invalid.
      *
      * @param simpleUri
      */
     public SimpleUri(String simpleUri) {
+        if (simpleUri == null) {
+            return;
+        }
         String[] split = simpleUri.split(MODULE_SEPARATOR, 2);
         if (split.length > 1) {
             moduleName = new Name(split[0]);

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
@@ -19,7 +19,15 @@ public abstract class StringRepresentationTypeHandler<T> extends TypeHandler<T> 
     @Override
     public Optional<T> deserialize(PersistedData data) {
         if (data.isString()) {
-            return Optional.ofNullable(getFromString(data.getAsString()));
+            String value = data.getAsString();
+            if (value == null) {
+                // A PersistedData can report isString() true while still holding no actual
+                // content (e.g. a stale/renamed reference in older save data) - treat that the
+                // same as "absent" instead of forwarding null into getFromString(), which for
+                // handlers like ComponentClassTypeHandler ends up constructing a SimpleUri(null).
+                return Optional.empty();
+            }
+            return Optional.ofNullable(getFromString(value));
         }
         return Optional.empty();
     }

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
@@ -2,9 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.persistence.typeHandling;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class StringRepresentationTypeHandler<T> extends TypeHandler<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(StringRepresentationTypeHandler.class);
+
+    /**
+     * Per-instance rather than static: a single damaged reference can appear on thousands of
+     * entities, so this reports once and then goes quiet - but MTE builds a fresh handler library
+     * per environment, and a static flag would silence every test after the first.
+     */
+    private final AtomicBoolean warnedNullContent = new AtomicBoolean();
 
     public abstract String getAsString(T item);
 
@@ -23,6 +36,13 @@ public abstract class StringRepresentationTypeHandler<T> extends TypeHandler<T> 
             if (value == null) {
                 // PersistedString reports isString() unconditionally, so stale save data can
                 // arrive with null content - treat as absent rather than call getFromString(null).
+                if (warnedNullContent.compareAndSet(false, true)) {
+                    logger.warn("{}: persisted data reported isString() but held null content -"
+                                    + " treating it as absent. Further occurrences from this handler"
+                                    + " are silent. Usually a stale or renamed reference in older"
+                                    + " save data.",
+                            getClass().getSimpleName());
+                }
                 return Optional.empty();
             }
             return Optional.ofNullable(getFromString(value));

--- a/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
+++ b/subsystems/TypeHandlerLibrary/src/main/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandler.java
@@ -21,10 +21,8 @@ public abstract class StringRepresentationTypeHandler<T> extends TypeHandler<T> 
         if (data.isString()) {
             String value = data.getAsString();
             if (value == null) {
-                // A PersistedData can report isString() true while still holding no actual
-                // content (e.g. a stale/renamed reference in older save data) - treat that the
-                // same as "absent" instead of forwarding null into getFromString(), which for
-                // handlers like ComponentClassTypeHandler ends up constructing a SimpleUri(null).
+                // PersistedString reports isString() unconditionally, so stale save data can
+                // arrive with null content - treat as absent rather than call getFromString(null).
                 return Optional.empty();
             }
             return Optional.ofNullable(getFromString(value));

--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandlerTest.java
@@ -1,0 +1,66 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.persistence.typeHandling;
+
+import org.junit.jupiter.api.Test;
+import org.terasology.persistence.typeHandling.inMemory.PersistedInteger;
+import org.terasology.persistence.typeHandling.inMemory.PersistedString;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StringRepresentationTypeHandlerTest {
+
+    /**
+     * Records whether {@link #getFromString} was reached. The contract under test is not just
+     * "returns empty" but "never forwards null to the subclass" — asserting only on the returned
+     * Optional would still pass if a subclass happened to tolerate null and return null itself.
+     */
+    private static final class RecordingHandler extends StringRepresentationTypeHandler<String> {
+        private boolean getFromStringCalled;
+
+        @Override
+        public String getAsString(String item) {
+            return item;
+        }
+
+        @Override
+        public String getFromString(String representation) {
+            getFromStringCalled = true;
+            return representation;
+        }
+    }
+
+    private final RecordingHandler typeHandler = new RecordingHandler();
+
+    @Test
+    void deserializesStringContent() {
+        Optional<String> result = typeHandler.deserialize(new PersistedString("engine:something"));
+
+        assertTrue(result.isPresent());
+        assertEquals("engine:something", result.get());
+        assertTrue(typeHandler.getFromStringCalled);
+    }
+
+    @Test
+    void treatsNullStringContentAsAbsent() {
+        // PersistedString returns true from isString() unconditionally, so a null payload reaches
+        // deserialize() with isString() == true. That is the shape that produced the NPE: null was
+        // forwarded to getFromString(), and ComponentClassTypeHandler built a SimpleUri from it.
+        Optional<String> result = typeHandler.deserialize(new PersistedString(null));
+
+        assertFalse(result.isPresent());
+        assertFalse(typeHandler.getFromStringCalled, "null content must not reach getFromString()");
+    }
+
+    @Test
+    void ignoresNonStringData() {
+        Optional<String> result = typeHandler.deserialize(new PersistedInteger(42));
+
+        assertFalse(result.isPresent());
+        assertFalse(typeHandler.getFromStringCalled);
+    }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Spawning a character (loading player entity data) can crash the whole game with:

```
java.lang.NullPointerException: Cannot invoke "String.split(String, int)" because "simpleUri" is null
	at org.terasology.engine.core.SimpleUri.<init>(SimpleUri.java:66)
	at org.terasology.engine.persistence.typeHandling.reflection.ModuleEnvironmentSandbox.doesSubclassMatch(ModuleEnvironmentSandbox.java:69)
	at org.terasology.engine.persistence.typeHandling.reflection.ModuleEnvironmentSandbox.lambda$findSubTypeOf$1(ModuleEnvironmentSandbox.java:46)
	...
	at org.terasology.engine.persistence.typeHandling.extensionTypes.ComponentClassTypeHandler.getFromString(ComponentClassTypeHandler.java:24)
	at org.terasology.persistence.typeHandling.StringRepresentationTypeHandler.deserialize(StringRepresentationTypeHandler.java:22)
	at org.terasology.persistence.typeHandling.coreTypes.CollectionTypeHandler.deserialize(CollectionTypeHandler.java:45)
	...
	at org.terasology.engine.persistence.internal.PlayerStoreInternal.restoreEntities(PlayerStoreInternal.java:48)
	at org.terasology.engine.logic.players.PlayerSystem.update(PlayerSystem.java:80)
	at org.terasology.engine.core.modes.loadProcesses.AwaitCharacterSpawn.step(AwaitCharacterSpawn.java:37)
```

Root cause: `CollectionTypeHandler.deserialize` is walking a persisted list of component-class references attached to the player entity. One entry no longer resolves to a real class (e.g. a component that existed in an older engine/module build was renamed or removed since the save was written). `PersistedData.isString()` can report `true` for that entry while `getAsString()` still yields `null`, and `StringRepresentationTypeHandler.deserialize` forwards that `null` straight into `getFromString()` without checking - which for `ComponentClassTypeHandler` ends up calling `new SimpleUri(null)`, and `SimpleUri`'s String constructor calls `.split()` on it unconditionally.

Confirmed reproducible on a genuinely fresh world (new seed, not just a stale save) - the corrupt reference lives in the player's global profile data, not the per-world save.

## Changes

- `SimpleUri(String)`: treat a `null` input the same as a malformed one - mark the URI invalid instead of throwing. `SimpleUri` already has this "invalid but not exceptional" behavior for non-null malformed input (see its own javadoc: *"If the string does not match this format, it will be marked invalid"*) - this just extends that same contract to `null`.
- `StringRepresentationTypeHandler.deserialize()`: also guard at the actual entry point where the null appears, so any subclass of it (not just `ComponentClassTypeHandler`) gets `Optional.empty()` for a null-valued string entry instead of forwarding `null` into its own `getFromString()`.

Neither change alters behavior for well-formed input; both are purely defensive against data that no longer round-trips cleanly.

## Test plan

- [x] Compiled both changed files cleanly.
- [x] Patched the compiled classes into a running `engine-5.4.0-SNAPSHOT.jar` / `TypeHandlerLibrary-5.4.0-SNAPSHOT.jar` locally and confirmed the malformed component-class reference is now skipped (`Optional.empty()`) instead of throwing, letting character spawn proceed past the point that previously crashed the whole engine.
- [ ] Not covered by an automated unit test yet - `SimpleUri` and `StringRepresentationTypeHandler` don't currently have a test file I found in this pass; happy to add a `new SimpleUri(null).isValid() == false` regression test if a reviewer wants one before merge.

## Related

- Found while diagnosing Windows/ARM64 launcher and engine startup issues: [TerasologyLauncher#727](https://github.com/MovingBlocks/TerasologyLauncher/pull/727), [Terasology#5359](https://github.com/MovingBlocks/Terasology/pull/5359). This bug itself is architecture-independent (pure reflection/deserialization code, no native code involved) and would reproduce identically on any platform.
