### PR TITLE
build: clear Gradle 10 deprecations, bump wrapper to 9.7.1

### DIFF
--- a/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
+++ b/build-logic/src/main/kotlin/org/terasology/gradology/module_build.kt
@@ -16,9 +16,7 @@ import java.io.File
 // or something else from gradle.api.artifacts, but it exposes no concrete implementation
 // of those interfaces.
 data class GradleDependencyInfo(val group: String, val module: String, val version: String) {
-    fun asMap(): Map<String, String> {
-        return mapOf("group" to group, "name" to module, "version" to version)
-    }
+    fun asNotation(): String = "$group:$module:$version"
 }
 
 

--- a/build-logic/src/main/kotlin/terasology-module.gradle.kts
+++ b/build-logic/src/main/kotlin/terasology-module.gradle.kts
@@ -61,12 +61,12 @@ dependencies {
         if (optional) {
             // `optional` module dependencies are ones it does not require for runtime
             // (but will use opportunistically if available)
-            compileOnly(gradleDep.asMap())
+            compileOnly(gradleDep.asNotation())
             // though modules also sometimes use "optional" to describe their test dependencies;
             // they're not required for runtime, but they *are* required for tests.
-            testImplementation(gradleDep.asMap())
+            testImplementation(gradleDep.asNotation())
         } else {
-            implementation(gradleDep.asMap())
+            implementation(gradleDep.asNotation())
         }
     }
 

--- a/config/gradle/publish.gradle
+++ b/config/gradle/publish.gradle
@@ -14,8 +14,9 @@ publishing {
 
             if (rootProject.hasProperty("publishRepo")) {
                 // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                url = "https://artifactory.terasology.io/artifactory/$publishRepo"
-                logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
+                String explicitPublishRepo = rootProject.property("publishRepo")
+                url = "https://artifactory.terasology.io/artifactory/$explicitPublishRepo"
+                logger.info("Changing PUBLISH repoKey set via Gradle property to {}", explicitPublishRepo)
             } else {
                 // Support override from the environment to use a different target publish org
                 String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
@@ -43,8 +44,8 @@ publishing {
 
             if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {
                 credentials {
-                    username = "$mavenUser"
-                    password = "$mavenPass"
+                    username = rootProject.property("mavenUser")
+                    password = rootProject.property("mavenPass")
                 }
                 authentication {
                     basic(BasicAuthentication)

--- a/engine-tests/build.gradle.kts
+++ b/engine-tests/build.gradle.kts
@@ -29,6 +29,7 @@ val env = System.getenv()
 val moduleFile = layout.projectDirectory.file("src/main/resources/org/terasology/unittest/module.txt").asFile
 
 println("Scanning for version in module.txt for engine-tests")
+@Suppress("UNCHECKED_CAST")
 val moduleConfig = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as Map<String, String>
 
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set differently)
@@ -53,7 +54,7 @@ dependencies {
     // Dependency not provided for modules, but required for module-tests
     implementation(libs.gson)
     implementation("org.codehaus.plexus:plexus-utils:3.0.16")
-    implementation("com.google.protobuf:protobuf-java:${libs.versions.protobuf.get().toString()}")
+    implementation("com.google.protobuf:protobuf-java:${libs.versions.protobuf.get()}")
     implementation("org.terasology:reflections:0.9.12-MB")
 
     implementation("com.github.zafarkhaja:java-semver:0.10.2")

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
     api(libs.gson)
     api("net.sf.trove4j:trove4j:3.0.3")
     implementation("io.netty:netty-all:4.1.77.Final")
-    implementation("com.google.protobuf:protobuf-java:${libs.versions.protobuf.get().toString()}")
+    implementation("com.google.protobuf:protobuf-java:${libs.versions.protobuf.get()}")
     implementation("org.lz4:lz4-java:1.8.0")
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     // Javax for protobuf due to @Generated - needed on Java 9 or newer Javas
@@ -154,7 +154,7 @@ dependencies {
 protobuf {
     protoc {
         // See https://github.com/google/protobuf-gradle-plugin/issues/563
-        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get().toString()}"
+        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
     }
     plugins {
     }
@@ -169,6 +169,7 @@ protobuf {
 val moduleFile = layout.projectDirectory.file("src/main/resources/org/terasology/engine/module.txt").asFile
 
 println("Scanning for version in module.txt for engine")
+@Suppress("UNCHECKED_CAST")
 val moduleConfig = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as Map<String, String>
 
 // Gradle uses the magic version variable when creating the jar name (unless explicitly set differently)

--- a/facades/PC/build.gradle.kts
+++ b/facades/PC/build.gradle.kts
@@ -199,7 +199,8 @@ val distForLauncher = tasks.register<Zip>("distForLauncher") {
             if (this.sourcePath == "Terasology" || this.sourcePath == "Terasology.bat") {
                 // I don't know how the "lib/" makes its way in to the classpath used by CreateStartScripts,
                 // so we're adjusting it after-the-fact.
-                filter(ScriptClasspathRewriter(this, defaultLibraryDirectory, launcherLibraryDirectory) as Transformer<String?, String>)
+                val rewriter = ScriptClasspathRewriter(this, defaultLibraryDirectory, launcherLibraryDirectory)
+                filter { line -> rewriter.rewrite(line) }
             }
         }
     })
@@ -242,10 +243,10 @@ tasks.register<Task>("testDist") {
     dependsOn("testDistForLauncher", "testDistZip")
 }
 
-class ScriptClasspathRewriter(file: FileCopyDetails, val oldDirectory: String, val newDirectory: String) : Transformer<String?, String> {
+class ScriptClasspathRewriter(file: FileCopyDetails, val oldDirectory: String, val newDirectory: String) {
     private val isBatchFile = file.name.endsWith(".bat")
 
-    override fun transform(line: String): String = if (isBatchFile) {
+    fun rewrite(line: String): String = if (isBatchFile) {
             line.replace("$oldDirectory\\", "$newDirectory\\")
         } else {
             line.replace("$oldDirectory/", "$newDirectory/")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -21,8 +21,8 @@ javaPlatform {
 
 dependencies {
     // This platform depends on each of its subprojects.
-    subprojects {
-        api(this)
+    subprojects.forEach {
+        api(project(it.path))
     }
 }
 

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -21,8 +21,8 @@ javaPlatform {
 
 dependencies {
     // This platform depends on each of its subprojects.
-    subprojects.forEach {
-        api(project(it.path))
+    subprojects.forEach { subproject ->
+        api(project(subproject.path))
     }
 }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

**Gradle 10 deprecations — 100 warnings before, 39 after**

- `modules/build.gradle.kts` passed the `Project` object itself to `api()`, once per subproject. Using a `Project` as dependency notation fails with an error in Gradle 10; it now depends on `project(path)`.
- `GradleDependencyInfo.asMap()` produced the `group:`/`name:`/`version:` map form, which `terasology-module.gradle.kts` applies to every module. Multi-string notation also fails in Gradle 10, so it now produces single-string `"group:module:version"`. Version ranges are unaffected — they contain no colons, so the coordinate still splits unambiguously.
- `config/gradle/publish.gradle` read `publishRepo`/`mavenUser`/`mavenPass` as bare names, an implicit lookup in a parent project. These sit inside `hasProperty` guards, so they would have broken publishing rather than building.
- Everything still reported after this change traces into `libs/gestalt` or `libs/TeraNUI`. Those are independent repos reached via `includeBuild` and need their own PRs; nothing here can fix them. The module-attributed warnings were never the module repos' fault either — every `modules/*/build.gradle` is byte-identical to `templates/build.gradle` and only applies `terasology-module`, so those were this repo's build-logic reported once per project.
- Left alone deliberately: the protoc coordinate warning attributed to `:engine` is emitted inside protobuf-gradle-plugin 0.9.4's own `ToolsLocator`, which tokenizes the single-string coordinate we hand it and re-assembles it as a map. `engine/build.gradle.kts:157` is already correct single-string notation; that one needs a plugin upgrade, which belongs in its own change.

**Getting to a Gradle that reports them**

- Seeing those warnings at all means running 9.7.1, which this build could not do. Gradle 9.7.1 ships Kotlin 2.4, which enforces `Transformer`'s declared `OUT : Any` bound. `ContentFilterable.filter` takes `Transformer<String?, String>` — the `OUT` is nullable because returning null there drops the line — so naming that type is a compile error (KTLC-358), and `facades/PC/build.gradle.kts` named it twice: implementing the interface, and casting to it. The net effect is that Gradle's own API is not implementable from the Kotlin that Gradle ships with. Passing a lambda instead lets SAM conversion supply the type argument, so the script never names it; `ScriptClasspathRewriter` keeps its logic and never returned null anyway.
- On 9.6.1 Kotlin only warns ("will become an error in language version 2.5"), so this was a prerequisite for the bump rather than a consequence of it. Anyone already running a system Gradle 9.7.1 currently cannot configure this build at all.
- Only `distributionUrl` moves. The wrapper jar and `gradlew` scripts are left untouched — they are just the bootstrapper, and the existing ones drive 9.7.1 fine (verified), so regenerating them would be pure diff noise. Staying on `-bin` too: the `wrapper` task would have switched it to `-all`, making every CI run additionally download sources and docs.

## Test plan

All run through the repo's existing (unmodified) `gradlew`, which picks up 9.7.1 from the bumped `distributionUrl`, on JDK 21.

- [x] `./gradlew compileJava` — whole build configures and compiles, including `facades/PC` and all 55 modules. This is the step that fails outright before the change under Gradle 9.7.1.
- [x] `./gradlew unitTest` — passes across all modules.
- [x] `./gradlew :engine:check :engine-tests:check :facades:PC:check -x test` — checkstyle, PMD and SpotBugs clean; only the pre-existing findings in test sources, unchanged.
- [x] `./gradlew :facades:PC:testDistForLauncher` — passes. This is the behavioural check for the Kotlin change: it builds the launcher distribution and asserts the rewritten `lib/` → `libs/` paths, which is exactly what `ScriptClasspathRewriter` produces.
- [x] `./gradlew :modules:reportModuleOrder` — all 55 modules still resolve and topologically sort. This is the behavioural check for the `asMap()` → single-string change, since it exercises the dependency graph that change feeds.
- [x] `./gradlew --warning-mode all help` — 100 Gradle deprecation warnings before, 39 after, none of the remainder in files this repo tracks.

## Related

- None.
