### PR TITLE
feat(world): merge chunk light after ready, not as a pipeline stage

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/LateLightMergerMteTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/LateLightMergerMteTest.java
@@ -1,0 +1,94 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.engine.integrationenvironment;
+
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.joml.Vector3i;
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.entity.internal.EntityScope;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
+import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.network.NetworkMode;
+import org.terasology.engine.world.block.BlockRegionc;
+import org.terasology.engine.world.chunks.ChunkProvider;
+import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.world.chunks.localChunkProvider.RelevanceSystem;
+import org.terasology.unittest.worlds.DummyWorldGenerator;
+
+import java.util.stream.StreamSupport;
+
+/**
+ * Pins down the central behaviour change of {@code LateLightMerger}: a chunk becomes ready as soon
+ * as its own generation finishes, not only once its whole 3x3x3 neighbourhood does too.
+ * <p>
+ * Under the pipeline stage this replaced, a chunk whose neighbours were never requested could only
+ * become ready via {@code ChunkProcessingPipeline}'s idle-skip timeout - two consecutive 5s-idle
+ * polls, so ~10s at best (see {@code POLL_INTERVAL_MS} / {@code IDLE_POLLS_BEFORE_SKIP} there). Both
+ * tests below bound completion well under that, on relevance requests deliberately built so the
+ * requested chunk(s)' own neighbours are never themselves requested. That makes them fail loudly
+ * (timeout) rather than merely slowly against the old, pipeline-stage merge - see the task/PR notes
+ * for the actual before/after timings observed when checking that.
+ * <p>
+ * Deliberately not asserted here: that a requested chunk's neighbours stay unloaded. They usually do,
+ * but {@code RelevanceSystem.addRelevanceEntity}'s own {@code .sorted()} pass over a
+ * {@code BlockRegion}'s iterator can request one extra, wrong position - a pre-existing aliasing bug
+ * (the iterator hands out a reused, mutable {@code Vector3i} that a later {@code hasNext()} call can
+ * mutate out from under a caller that buffers rather than immediately consumes it), unrelated to
+ * light merging. {@code RelevanceSystem.updateRelevance()}'s follow-up pass - which uses the
+ * defensive-copying {@code ChunkRelevanceRegion.getNeededChunks()} instead - still requests the
+ * correct position(s) a tick later, so it doesn't affect these tests' timing, but it does mean a
+ * "neighbours were never loaded" assertion is not reliable and was left out rather than pinned to
+ * today's incidental behaviour of an unrelated bug.
+ *
+ * @see org.terasology.engine.world.chunks.LateLightMerger
+ */
+@IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
+class LateLightMergerMteTest {
+
+    /**
+     * Comfortably above what one dummy-world chunk takes to generate, comfortably below the ~10s
+     * ChunkProcessingPipeline idle-skip the old pipeline-stage merge needed whenever a chunk's
+     * neighbours were never requested.
+     */
+    private static final long READY_TIMEOUT_MS = 8000;
+
+    @Test
+    void chunkBecomesReadyWithoutNeighbourhoodLoaded(EntityManager entityManager, RelevanceSystem relevanceSystem,
+            MainLoop mainLoop, ChunkProvider chunkProvider) {
+        // Far from spawn (a fixed (0,0,0) for DummyWorldGenerator) and from the other test below, so
+        // nothing else ever requests this position or its neighbours.
+        Vector3fc center = new Vector3f(200_000, DummyWorldGenerator.SURFACE_HEIGHT, 200_000);
+        Vector3i chunkPos = Chunks.toChunkPos(center, new Vector3i());
+
+        EntityRef entity = entityManager.create(new LocationComponent(center));
+        entity.setScope(EntityScope.GLOBAL);
+        // distance (1,1,1) requests relevance for exactly this one chunk - unlike
+        // ChunkRegionFuture, no margin, so its neighbours are never deliberately requested.
+        relevanceSystem.addRelevanceEntity(entity, new Vector3i(1, 1, 1), null);
+
+        mainLoop.awaitUntil(READY_TIMEOUT_MS, "an isolated chunk (no neighbours requested) to become ready",
+                () -> chunkProvider.isChunkReady(chunkPos));
+    }
+
+    @Test
+    void relevanceRegionBecomesFullyReadyWithoutMargin(EntityManager entityManager, RelevanceSystem relevanceSystem,
+            MainLoop mainLoop, ChunkProvider chunkProvider) {
+        // ChunkRegionFuture.REQUIRED_CHUNK_MARGIN pads every relevance request by one extra shell of
+        // chunks, specifically so the requested region's own outer shell has its neighbourhood
+        // requested too (see its FIXME comment). Going straight to RelevanceSystem instead of through
+        // ChunkRegionFuture, with no padding at all, tests whether that padding is still needed now
+        // that readiness no longer waits on the neighbourhood.
+        Vector3fc center = new Vector3f(300_000, DummyWorldGenerator.SURFACE_HEIGHT, 300_000);
+
+        EntityRef entity = entityManager.create(new LocationComponent(center));
+        entity.setScope(EntityScope.GLOBAL);
+        BlockRegionc region = relevanceSystem.addRelevanceEntity(entity, new Vector3i(3, 3, 3), null);
+
+        mainLoop.awaitUntil(READY_TIMEOUT_MS, "every chunk in an unpadded 3x3x3 relevance region to become ready",
+                () -> StreamSupport.stream(region.spliterator(), false).allMatch(chunkProvider::isChunkReady));
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/world/chunks/LateLightMergerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/chunks/LateLightMergerTest.java
@@ -1,0 +1,109 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.world.chunks;
+
+import com.google.common.collect.Maps;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.TerasologyTestingEnvironment;
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.world.block.internal.BlockManagerImpl;
+import org.terasology.engine.world.block.tiles.NullWorldAtlas;
+import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
+import org.terasology.engine.world.chunks.internal.ChunkImpl;
+import org.terasology.engine.world.propagation.light.LightMerger;
+import org.terasology.gestalt.assets.management.AssetManager;
+
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * {@link LateLightMerger} is driven directly here rather than through an {@code IntegrationEnvironment}
+ * - its constructor takes a plain {@code Map<Vector3ic, Chunk>}, so the bookkeeping can be tested
+ * without a running engine. Real {@link ChunkImpl} chunks (rather than a bare stub) are used because
+ * {@link LightMerger#merge} does genuine light propagation and needs real block/light storage - see
+ * {@code BetweenChunkPropagationTest} for the same pattern.
+ */
+@Tag("TteTest")
+class LateLightMergerTest extends TerasologyTestingEnvironment {
+
+    /** Generous, so a slow machine cannot make the drain give up mid-test. */
+    private static final int TICK_BUDGET_MS = 10_000;
+
+    private BlockManagerImpl blockManager;
+    private ExtraBlockDataManager extraDataManager;
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        blockManager = new BlockManagerImpl(new NullWorldAtlas(), CoreRegistry.get(AssetManager.class), true);
+        extraDataManager = new ExtraBlockDataManager();
+    }
+
+    private Chunk createChunkAt(Vector3ic pos) {
+        return new ChunkImpl(new Vector3i(pos), blockManager, extraDataManager);
+    }
+
+    /**
+     * Covers a bug found and fixed in review, with no prior coverage: {@link LateLightMerger#mergeAt}
+     * re-checks the neighbourhood at merge time, not just at queue time in {@link
+     * LateLightMerger#chunkReady}. A position that loses a neighbour in between must go back into
+     * {@code needsMerging} rather than being dropped - it is queued from neither bookkeeping set
+     * otherwise, and only a chunk becoming ready ever re-queues anything, so it would stay unmerged
+     * forever even once the neighbour comes back.
+     */
+    @Test
+    void positionRequeuedWhenNeighbourGoesMissingBeforeMergeRuns() {
+        Vector3ic center = new Vector3i(0, 0, 0);
+        Vector3ic missingNeighbour = new Vector3i(1, 0, 0);
+
+        Map<Vector3ic, Chunk> chunkCache = Maps.newHashMap();
+        for (Vector3ic pos : LightMerger.requiredChunks(center)) {
+            chunkCache.put(new Vector3i(pos), createChunkAt(pos));
+        }
+
+        // The merge only writes - and so only dirties - where light actually moves, so an entirely
+        // uniform neighbourhood would merge to no observable effect at all. Light the face of the
+        // +X neighbour that abuts the center chunk, giving the merge something to propagate inwards.
+        Chunk litNeighbour = chunkCache.get(missingNeighbour);
+        for (int y = 0; y < 4; y++) {
+            for (int z = 0; z < 4; z++) {
+                litNeighbour.setLight(0, y, z, (byte) 15);
+            }
+        }
+        // ChunkImpl starts dirty (it still needs its first mesh); clear that so isDirty() below is a
+        // clean signal for "the merge wrote here", not construction noise.
+        chunkCache.values().forEach(chunk -> chunk.setDirty(false));
+
+        LateLightMerger merger = new LateLightMerger(chunkCache);
+
+        // Full neighbourhood already present, so this discovers it and queues center for merging.
+        merger.chunkReady(center);
+
+        // A neighbour unloads before the merge actually runs - checkForUnload() runs every tick in
+        // both providers, ahead of processPending().
+        Chunk removedNeighbour = chunkCache.remove(missingNeighbour);
+        merger.chunkUnloaded(missingNeighbour);
+
+        merger.processPending(System.currentTimeMillis(), TICK_BUDGET_MS);
+
+        // mergeAt() must have found the hole and backed off rather than merging with it.
+        assertThat(chunkCache.get(center).isDirty()).isFalse();
+
+        // The neighbour reloads. Nothing but a chunkReady() call ever re-discovers a completed
+        // neighbourhood - if mergeAt() had dropped center instead of requeuing it, this would never
+        // recover it and the assertions below would fail.
+        chunkCache.put(new Vector3i(missingNeighbour), removedNeighbour);
+        merger.chunkReady(missingNeighbour);
+        merger.processPending(System.currentTimeMillis(), TICK_BUDGET_MS);
+
+        // The seeded light has now propagated into the center chunk, which is both the proof that
+        // mergeAt() ran for it and the reason ChunkMeshWorker will re-mesh it.
+        assertThat(chunkCache.get(center).isDirty()).isTrue();
+    }
+}

--- a/engine-tests/src/test/java/org/terasology/engine/world/propagation/LocalChunkViewTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/propagation/LocalChunkViewTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.terasology.engine.TerasologyTestingEnvironment;
-import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.block.internal.BlockManagerImpl;
 import org.terasology.engine.world.block.tiles.NullWorldAtlas;
 import org.terasology.engine.world.chunks.Chunk;
@@ -34,7 +33,7 @@ class LocalChunkViewTest extends TerasologyTestingEnvironment {
     @Override
     public void setup() throws Exception {
         super.setup();
-        blockManager = new BlockManagerImpl(new NullWorldAtlas(), CoreRegistry.get(AssetManager.class), true);
+        blockManager = new BlockManagerImpl(new NullWorldAtlas(), context.get(AssetManager.class), true);
         extraDataManager = new ExtraBlockDataManager();
     }
 

--- a/engine-tests/src/test/java/org/terasology/engine/world/propagation/LocalChunkViewTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/propagation/LocalChunkViewTest.java
@@ -1,0 +1,99 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.world.propagation;
+
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.TerasologyTestingEnvironment;
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.world.block.internal.BlockManagerImpl;
+import org.terasology.engine.world.block.tiles.NullWorldAtlas;
+import org.terasology.engine.world.chunks.Chunk;
+import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
+import org.terasology.engine.world.chunks.internal.ChunkImpl;
+import org.terasology.engine.world.propagation.light.LightMerger;
+import org.terasology.engine.world.propagation.light.LightPropagationRules;
+import org.terasology.gestalt.assets.management.AssetManager;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@Tag("TteTest")
+class LocalChunkViewTest extends TerasologyTestingEnvironment {
+
+    private BlockManagerImpl blockManager;
+    private ExtraBlockDataManager extraDataManager;
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        blockManager = new BlockManagerImpl(new NullWorldAtlas(), CoreRegistry.get(AssetManager.class), true);
+        extraDataManager = new ExtraBlockDataManager();
+    }
+
+    /**
+     * Builds the neighbourhood exactly as {@code LightMerger.merge} does - sorted by x, then y, then z -
+     * since that sort is what defines the array order this view has to agree with.
+     */
+    private Chunk[] sortedNeighbourhoodAround(Vector3ic centre) {
+        Chunk[] chunks = LightMerger.requiredChunks(centre).stream()
+                .map(p -> (Chunk) new ChunkImpl(new Vector3i(p), blockManager, extraDataManager))
+                .toArray(Chunk[]::new);
+        Arrays.sort(chunks, Comparator.<Chunk>comparingInt(c -> c.getPosition().x())
+                .thenComparingInt(c -> c.getPosition().y())
+                .thenComparing(c -> c.getPosition().z()));
+        return chunks;
+    }
+
+    /**
+     * A write must land in the chunk that actually contains the position.
+     * <p>
+     * This did not hold: the view indexed the array with x varying fastest while the sort makes z vary
+     * fastest, so x and z were transposed and a write aimed at the +X neighbour landed in the +Z one.
+     * It went unnoticed because reads used the same wrong mapping - so a read-back check passes either
+     * way - and because the centre chunk is invariant under the swap. Hence asserting on the chunks
+     * themselves rather than on what the view returns.
+     */
+    @Test
+    void writesLandInTheChunkContainingThePosition() {
+        Chunk[] chunks = sortedNeighbourhoodAround(new Vector3i(0, 0, 0));
+        LocalChunkView view = new LocalChunkView(chunks, new LightPropagationRules());
+
+        for (Chunk expected : chunks) {
+            Vector3ic chunkPos = expected.getPosition();
+            // First block of that chunk, in world coordinates.
+            Vector3ic blockPos = new Vector3i(
+                    chunkPos.x() * Chunks.SIZE_X,
+                    chunkPos.y() * Chunks.SIZE_Y,
+                    chunkPos.z() * Chunks.SIZE_Z);
+
+            Arrays.stream(chunks).forEach(c -> c.setLight(0, 0, 0, (byte) 0));
+            view.setValueAt(blockPos, (byte) 15);
+
+            assertThat(expected.getLight(0, 0, 0)).isEqualTo((byte) 15);
+        }
+    }
+
+    /** A position outside the 3x3x3 must not alias onto a chunk that happens to sit at that index. */
+    @Test
+    void positionsOutsideTheViewAreUnavailable() {
+        Chunk[] chunks = sortedNeighbourhoodAround(new Vector3i(0, 0, 0));
+        LocalChunkView view = new LocalChunkView(chunks, new LightPropagationRules());
+
+        // Three chunks along +X: outside the view, but a flat index would wrap into it.
+        Vector3ic outside = new Vector3i(3 * Chunks.SIZE_X, 0, 0);
+
+        assertThat(view.getValueAt(outside)).isEqualTo(PropagatorWorldView.UNAVAILABLE);
+        assertThat(view.getBlockAt(outside)).isNull();
+
+        view.setValueAt(outside, (byte) 15);
+        Arrays.stream(chunks).forEach(c -> assertThat(c.getLight(0, 0, 0)).isEqualTo((byte) 0));
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/world/chunks/LateLightMerger.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/LateLightMerger.java
@@ -89,9 +89,17 @@ public final class LateLightMerger {
      * merging used to run on pipeline threads and this moved it onto the main thread - so it adds to
      * frame time rather than overlapping with it.
      * <p>
-     * A tick whose budget is already gone therefore merges nothing and catches up later. That is the
-     * right way round: becoming visible is what the player is waiting on, and correcting the lighting
-     * behind it is the deferrable half.
+     * A tick whose budget is already gone therefore merges nothing further and catches up later. That
+     * is the right way round: becoming visible is what the player is waiting on, and correcting the
+     * lighting behind it is the deferrable half.
+     * <p>
+     * One merge always runs before the budget is consulted, deliberately. The ready-chunk drain ahead
+     * of this routinely spends the entire allowance during a world load - it logs "took too long" for
+     * tick after consecutive tick while its backlog comes down - so testing the budget first would
+     * find it already gone every time and merge nothing at all for the whole load. That is not
+     * deferral, it is starvation: lighting would never be corrected for as long as chunks keep
+     * arriving, which while exploring is continuously. Overshooting by a single bounded merge is the
+     * cost of guaranteeing forward progress.
      */
     public void processPending(long tickStartTime, int tickBudgetMs) {
         Vector3ic pos;

--- a/engine/src/main/java/org/terasology/engine/world/chunks/LateLightMerger.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/LateLightMerger.java
@@ -1,0 +1,155 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.world.chunks;
+
+import com.google.common.collect.Sets;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.world.propagation.light.LightMerger;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Merges light for chunks after they are already visible, instead of before.
+ * <p>
+ * {@link LightMerger} used to run as the last stage of {@code ChunkProcessingPipeline}, which meant a
+ * chunk could not become ready until all 26 neighbours needed for its merge existed too - one slow or
+ * never-requested neighbour stalled the chunk indefinitely. Now a chunk goes ready as soon as its own
+ * generation finishes, and this class merges it with its neighbours afterwards, incrementally, as those
+ * neighbours arrive. A chunk at the edge of the loaded world simply stays unmerged (visible, with
+ * imperfect edge lighting) instead of never becoming ready at all.
+ * <p>
+ * Shared by {@code LocalChunkProvider} and {@code RemoteChunkProvider}, which otherwise need
+ * byte-for-byte the same bookkeeping over their own {@code chunkCache}. {@link #chunkReady} and {@link
+ * #processPending} are meant to be called only from the owning provider's {@code update()} - always the
+ * same thread, so no internal synchronization here. That matters beyond tidiness: merging now touches
+ * chunks that are live, not chunks only the pipeline can see. The renderer may be tessellating them on
+ * another thread, and deflated light storage can reallocate on write, so a concurrent merge would not be
+ * merely a stale-value glitch. Running on the thread that already owns {@code chunkCache} sidesteps
+ * that, mirroring how runtime light propagation for block changes ({@code
+ * WorldProviderCoreImpl.processPropagation()}) also runs on the main thread rather than in parallel.
+ */
+public final class LateLightMerger {
+    private static final Logger logger = LoggerFactory.getLogger(LateLightMerger.class);
+
+    private final Map<Vector3ic, Chunk> chunkCache;
+    /** Ready positions still waiting on part of their own 27-chunk neighbourhood. */
+    private final Set<Vector3ic> needsMerging = Sets.newHashSet();
+    /**
+     * Positions whose neighbourhood is complete, awaiting the actual merge. Kept separate from {@link
+     * #needsMerging} so discovering a mergeable position (cheap) is decoupled from performing the merge
+     * (not cheap) - see {@link #processPending}.
+     */
+    private final Deque<Vector3ic> readyToMerge = new ArrayDeque<>();
+
+    public LateLightMerger(Map<Vector3ic, Chunk> chunkCache) {
+        this.chunkCache = chunkCache;
+    }
+
+    /**
+     * Record that {@code chunkPos} is ready and already in the chunk cache, and queue a merge for any
+     * position this completes the neighbourhood of.
+     * <p>
+     * The scan below covers {@code chunkPos}'s own 3x3x3 neighbourhood, not just {@code chunkPos}
+     * itself - a newly-ready chunk can just as easily complete one of its neighbours' neighbourhoods as
+     * its own.
+     */
+    public void chunkReady(Vector3ic chunkPos) {
+        needsMerging.add(new Vector3i(chunkPos));
+        for (Vector3ic candidate : LightMerger.requiredChunks(chunkPos)) {
+            if (needsMerging.contains(candidate) && hasFullNeighbourhood(candidate)) {
+                needsMerging.remove(candidate);
+                readyToMerge.add(candidate);
+            }
+        }
+    }
+
+    private boolean hasFullNeighbourhood(Vector3ic pos) {
+        for (Vector3ic neighbour : LightMerger.requiredChunks(pos)) {
+            if (!chunkCache.containsKey(neighbour)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Drain queued merges with whatever is left of this tick's chunk-work budget.
+     * <p>
+     * The caller passes the time its own tick started and the budget for the whole of it, rather than
+     * this starting a fresh clock. Two independent budgets in one {@code update()} would not bound
+     * anything: the ready-chunk drain could spend the full allowance and merging then spend it again,
+     * so a tick costs twice what either says. That matters more here than it would elsewhere, because
+     * merging used to run on pipeline threads and this moved it onto the main thread - so it adds to
+     * frame time rather than overlapping with it.
+     * <p>
+     * A tick whose budget is already gone therefore merges nothing and catches up later. That is the
+     * right way round: becoming visible is what the player is waiting on, and correcting the lighting
+     * behind it is the deferrable half.
+     */
+    public void processPending(long tickStartTime, int tickBudgetMs) {
+        Vector3ic pos;
+        while ((pos = readyToMerge.poll()) != null) {
+            mergeAt(pos);
+            long totalProcessingTime = System.currentTimeMillis() - tickStartTime;
+            if (!readyToMerge.isEmpty() && totalProcessingTime > tickBudgetMs) {
+                // Debug, not warn, unlike the ready-chunk drain this sits beside: there, overrunning
+                // the budget means cheap per-chunk work took implausibly long and something is wrong.
+                // Here a backlog is the designed steady state - merging is expensive and world
+                // generation queues it faster than a frame can absorb - so warning would fire every
+                // tick for the whole of a normal world load.
+                logger.debug("Light merging hit its budget this tick ({}/{}ms). {} positions remain.",
+                        totalProcessingTime, tickBudgetMs, readyToMerge.size());
+                break;
+            }
+        }
+    }
+
+    /**
+     * {@link #chunkReady} only checks the neighbourhood is complete at queue time; a relevance change
+     * can unload a neighbour before this runs. Re-checking against {@code chunkCache} here, rather than
+     * trusting the queue, avoids merging with a hole in the neighbourhood.
+     * <p>
+     * A position that loses a neighbour that way goes back into {@link #needsMerging} rather than being
+     * dropped. It is queued from neither set otherwise, and only a chunk becoming ready re-queues
+     * anything - so simply returning would leave it permanently unmerged even once the neighbour
+     * reloads, showing as a lighting seam that never heals. The window is not narrow: {@code
+     * checkForUnload()} runs every tick ahead of {@link #processPending}, and the budget below routinely
+     * leaves positions queued across several ticks.
+     */
+    private void mergeAt(Vector3ic pos) {
+        List<Vector3ic> neighbourhood = LightMerger.requiredChunks(pos);
+        Chunk[] chunks = new Chunk[neighbourhood.size()];
+        for (int i = 0; i < chunks.length; i++) {
+            chunks[i] = chunkCache.get(neighbourhood.get(i));
+            if (chunks[i] == null) {
+                needsMerging.add(pos);
+                return;
+            }
+        }
+        // Chunks whose light this actually moves are marked dirty by LocalChunkView as it writes, so
+        // ChunkMeshWorker re-meshes them (it only re-emits chunks that are isReady() && isDirty()).
+        // Deliberately not marking the whole neighbourhood here instead: a chunk belongs to 27 of
+        // them, so that re-meshes each chunk many times over during a world load - enough to exhaust
+        // the heap in mesh generation - and most of those merges never touch its light at all.
+        LightMerger.merge(chunks);
+    }
+
+    /** Drop any bookkeeping for {@code pos}. Call on unload, or edge positions leak forever. */
+    public void chunkUnloaded(Vector3ic pos) {
+        needsMerging.remove(pos);
+        readyToMerge.remove(pos);
+    }
+
+    /** Discard all bookkeeping, e.g. when the world is purged or the provider restarts. */
+    public void clear() {
+        needsMerging.clear();
+        readyToMerge.clear();
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/localChunkProvider/LocalChunkProvider.java
@@ -35,6 +35,7 @@ import org.terasology.engine.world.block.OnAddedBlocks;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.ChunkBlockIterator;
 import org.terasology.engine.world.chunks.ChunkProvider;
+import org.terasology.engine.world.chunks.LateLightMerger;
 import org.terasology.engine.world.chunks.blockdata.ExtraBlockDataManager;
 import org.terasology.engine.world.chunks.event.BeforeChunkUnload;
 import org.terasology.engine.world.chunks.event.OnChunkGenerated;
@@ -49,7 +50,6 @@ import org.terasology.engine.world.generator.WorldGenerator;
 import org.terasology.engine.world.internal.ChunkViewCore;
 import org.terasology.engine.world.internal.ChunkViewCoreImpl;
 import org.terasology.engine.world.propagation.light.InternalLightProcessor;
-import org.terasology.engine.world.propagation.light.LightMerger;
 import org.terasology.gestalt.entitysystem.component.Component;
 
 import javax.inject.Inject;
@@ -90,6 +90,7 @@ public class LocalChunkProvider implements ChunkProvider {
     private final BlockingQueue<Chunk> readyChunks = Queues.newLinkedBlockingQueue();
     private final BlockingQueue<TShortObjectMap<TIntList>> deactivateBlocksQueue = Queues.newLinkedBlockingQueue();
     private final Map<Vector3ic, Chunk> chunkCache;
+    private final LateLightMerger lateLightMerger;
 
     private final Map<Vector3ic, List<EntityStore>> generateQueuedEntities = new ConcurrentHashMap<>();
     // The ChunkStore loaded (from disk) for a chunk in createOrLoadChunk()'s async task, carried
@@ -121,6 +122,7 @@ public class LocalChunkProvider implements ChunkProvider {
         this.config = config;
         this.unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 4);
         this.chunkCache = chunkCache;
+        this.lateLightMerger = new LateLightMerger(chunkCache);
         ChunkMonitor.fireChunkProviderInitialized(this);
     }
 
@@ -182,6 +184,9 @@ public class LocalChunkProvider implements ChunkProvider {
         }
         chunkCache.put(new Vector3i(chunkPos), chunk);
         chunk.markReady();
+        // Light merging is no longer a pipeline stage the chunk waits on before this point - it now
+        // happens here, incrementally, once neighbours are available. See LateLightMerger.
+        lateLightMerger.chunkReady(chunkPos);
         //TODO, it is not clear if the activate/addedBlocks event logic is correct.
         //See https://github.com/MovingBlocks/Terasology/issues/3244
         ChunkStore store = loadedChunkStores.remove(chunkPos);
@@ -259,6 +264,9 @@ public class LocalChunkProvider implements ChunkProvider {
                 break;
             }
         }
+        // Shares the drain loop's clock rather than starting its own, so a tick is bounded by
+        // UPDATE_PROCESSING_DEADLINE_MS overall instead of by it twice over.
+        lateLightMerger.processPending(processingStartTime, UPDATE_PROCESSING_DEADLINE_MS);
     }
 
     private void deactivateBlocks() {
@@ -308,6 +316,9 @@ public class LocalChunkProvider implements ChunkProvider {
         if (chunk == null) {
             return false;
         }
+        // Otherwise a position at the edge of the loaded world - which never completes its
+        // neighbourhood and so never gets merged - would sit in this bookkeeping forever.
+        lateLightMerger.chunkUnloaded(pos);
 
         worldEntity.send(new BeforeChunkUnload(pos));
         storageManager.deactivateChunk(chunk);
@@ -371,6 +382,7 @@ public class LocalChunkProvider implements ChunkProvider {
     public void restart() {
         loadingPipeline.restart();
         unloadRequestTaskMaster.restart();
+        lateLightMerger.clear();
     }
 
     @Override
@@ -429,6 +441,7 @@ public class LocalChunkProvider implements ChunkProvider {
         // wrongly restoring entities from the deleted world onto it.
         loadedChunkStores.clear();
         generateQueuedEntities.clear();
+        lateLightMerger.clear();
         storageManager.deleteWorld();
         worldEntity.send(new PurgeWorldEvent());
 
@@ -438,12 +451,6 @@ public class LocalChunkProvider implements ChunkProvider {
             ChunkTaskProvider.create("Chunk generate internal lightning",
                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
             .addStage(ChunkTaskProvider.create("Chunk deflate", Chunk::deflate))
-            .addStage(ChunkTaskProvider.createMulti("Light merging",
-                chunks -> {
-                    Chunk[] localChunks = chunks.toArray(new Chunk[0]);
-                    return LightMerger.merge(localChunks);
-                }, LightMerger::requiredChunks
-            ))
             .addStage(ChunkTaskProvider.create("Chunk ready", readyChunks::add));
         unloadRequestTaskMaster = TaskMaster.createFIFOTaskMaster("Chunk-Unloader", 8);
         ChunkMonitor.fireChunkProviderInitialized(this);
@@ -474,12 +481,6 @@ public class LocalChunkProvider implements ChunkProvider {
                         ChunkTaskProvider.create("Chunk generate internal lightning",
                                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
                 .addStage(ChunkTaskProvider.create("Chunk deflate", Chunk::deflate))
-                .addStage(ChunkTaskProvider.createMulti("Light merging",
-                        chunks -> {
-                            Chunk[] localChunks = chunks.toArray(new Chunk[0]);
-                            return LightMerger.merge(localChunks);
-                        }, LightMerger::requiredChunks
-                ))
                 .addStage(ChunkTaskProvider.create("Chunk ready", readyChunks::add));
     }
 }

--- a/engine/src/main/java/org/terasology/engine/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
+++ b/engine/src/main/java/org/terasology/engine/world/chunks/remoteChunkProvider/RemoteChunkProvider.java
@@ -18,6 +18,7 @@ import org.terasology.engine.world.block.BlockRegionc;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.ChunkProvider;
 import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.world.chunks.LateLightMerger;
 import org.terasology.engine.world.chunks.event.BeforeChunkUnload;
 import org.terasology.engine.world.chunks.event.OnChunkLoaded;
 import org.terasology.engine.world.chunks.pipeline.ChunkProcessingPipeline;
@@ -26,7 +27,6 @@ import org.terasology.engine.world.chunks.pipeline.stages.ChunkTaskProvider;
 import org.terasology.engine.world.internal.ChunkViewCore;
 import org.terasology.engine.world.internal.ChunkViewCoreImpl;
 import org.terasology.engine.world.propagation.light.InternalLightProcessor;
-import org.terasology.engine.world.propagation.light.LightMerger;
 
 import javax.inject.Inject;
 import java.util.Collection;
@@ -50,9 +50,13 @@ import java.util.function.Consumer;
  */
 public class RemoteChunkProvider implements ChunkProvider {
 
+    /** Per-tick allowance for main-thread chunk work, matching LocalChunkProvider's. */
+    private static final int UPDATE_PROCESSING_DEADLINE_MS = 24;
+
     private final BlockingQueue<Chunk> readyChunks = Queues.newLinkedBlockingQueue();
     private final BlockingQueue<Vector3ic> invalidateChunks = Queues.newLinkedBlockingQueue();
     private final Map<Vector3ic, Chunk> chunkCache = Maps.newHashMap();
+    private final LateLightMerger lateLightMerger = new LateLightMerger(chunkCache);
     private final BlockManager blockManager;
     private final ChunkProcessingPipeline loadingPipeline;
     private EntityRef worldEntity = EntityRef.NULL;
@@ -68,12 +72,6 @@ public class RemoteChunkProvider implements ChunkProvider {
             ChunkTaskProvider.create("Chunk generate internal lightning",
                 (Consumer<Chunk>) InternalLightProcessor::generateInternalLighting))
             .addStage(ChunkTaskProvider.create("Chunk deflate", Chunk::deflate))
-            .addStage(ChunkTaskProvider.createMulti("Light merging",
-                chunks -> {
-                    Chunk[] localchunks = chunks.toArray(new Chunk[0]);
-                    return LightMerger.merge(localchunks);
-                }, LightMerger::requiredChunks
-            ))
             .addStage(ChunkTaskProvider.create("", readyChunks::add));
 
         ChunkMonitor.fireChunkProviderInitialized(this);
@@ -94,6 +92,7 @@ public class RemoteChunkProvider implements ChunkProvider {
 
     @Override
     public void update() {
+        long processingStartTime = System.currentTimeMillis();
         if (listener != null) {
             checkForUnload();
         }
@@ -104,11 +103,17 @@ public class RemoteChunkProvider implements ChunkProvider {
                 oldChunk.dispose();
             }
             chunk.markReady();
+            // Light merging is no longer a pipeline stage the chunk waits on before this point - it now
+            // happens here, incrementally, once neighbours are available. See LateLightMerger.
+            lateLightMerger.chunkReady(chunk.getPosition());
             if (listener != null) {
                 listener.onChunkReady(chunk.getPosition());
             }
             worldEntity.send(new OnChunkLoaded(chunk.getPosition()));
         }
+        // Bounded by the tick it runs in, matching LocalChunkProvider - merging is main-thread work
+        // now, so it has to compete for frame time rather than be handed its own slice of it.
+        lateLightMerger.processPending(processingStartTime, UPDATE_PROCESSING_DEADLINE_MS);
     }
 
     private void checkForUnload() {
@@ -116,6 +121,9 @@ public class RemoteChunkProvider implements ChunkProvider {
         invalidateChunks.drainTo(positions);
         for (Vector3ic pos : positions) {
             Chunk removed = chunkCache.remove(pos);
+            // Otherwise a position at the edge of the loaded world - which never completes its
+            // neighbourhood and so never gets merged - would sit in this bookkeeping forever.
+            lateLightMerger.chunkUnloaded(pos);
             if (removed != null && !removed.isReady()) {
                 worldEntity.send(new BeforeChunkUnload(pos));
                 removed.dispose();

--- a/engine/src/main/java/org/terasology/engine/world/propagation/LocalChunkView.java
+++ b/engine/src/main/java/org/terasology/engine/world/propagation/LocalChunkView.java
@@ -13,7 +13,7 @@ import org.terasology.engine.world.chunks.Chunks;
  */
 public class LocalChunkView implements PropagatorWorldView {
 
-    /** This view spans a 3x3x3 neighbourhood, as {@code LightMerger} supplies it. */
+    /** This view spans a fixed 3x3x3 neighbourhood of chunks. */
     private static final int LOCAL_CHUNKS_SIDE_LENGTH = 3;
 
     private PropagationRules rules;
@@ -81,6 +81,10 @@ public class LocalChunkView implements PropagatorWorldView {
     public void setValueAt(Vector3ic pos, byte value) {
         int index = chunkIndexOf(pos);
         if (index < 0) {
+            // Propagation routinely reaches one step past the edge of this view; silently dropping
+            // it here matches getValueAt's UNAVAILABLE for the same case, rather than the
+            // ArrayIndexOutOfBoundsException this used to throw. Not logged: this is the ordinary
+            // case at every boundary of every merge, not a fault to surface.
             return;
         }
         Chunk chunk = chunks[index];
@@ -135,10 +139,14 @@ public class LocalChunkView implements PropagatorWorldView {
         int minZ = Math.max(Chunks.toChunkPos(pos.z() - 1, Chunks.POWER_Z) - topLeft.z, 0);
         int maxZ = Math.min(Chunks.toChunkPos(pos.z() + 1, Chunks.POWER_Z) - topLeft.z, 2);
 
+        // Inlined rather than routed through indexOf: minX/maxX etc. above already clamp into
+        // [0, LOCAL_CHUNKS_SIDE_LENGTH), so indexOf's own bounds check is redundant here - and this
+        // is the innermost loop of a per-write scan, where that extra call and branch cost real
+        // frame time. Must still match indexOf's z-fastest ordering.
         for (int x = minX; x <= maxX; x++) {
             for (int y = minY; y <= maxY; y++) {
                 for (int z = minZ; z <= maxZ; z++) {
-                    Chunk affected = chunks[indexOf(x, y, z)];
+                    Chunk affected = chunks[z + LOCAL_CHUNKS_SIDE_LENGTH * (y + LOCAL_CHUNKS_SIDE_LENGTH * x)];
                     if (affected != null) {
                         affected.setDirty(true);
                     }

--- a/engine/src/main/java/org/terasology/engine/world/propagation/LocalChunkView.java
+++ b/engine/src/main/java/org/terasology/engine/world/propagation/LocalChunkView.java
@@ -13,6 +13,9 @@ import org.terasology.engine.world.chunks.Chunks;
  */
 public class LocalChunkView implements PropagatorWorldView {
 
+    /** This view spans a 3x3x3 neighbourhood, as {@code LightMerger} supplies it. */
+    private static final int LOCAL_CHUNKS_SIDE_LENGTH = 3;
+
     private PropagationRules rules;
     private Chunk[] chunks;
 
@@ -28,12 +31,37 @@ public class LocalChunkView implements PropagatorWorldView {
      * Gets the index of the chunk in {@link #chunks}
      *
      * @param blockPos The position of the block in world coordinates
-     * @return The index of the chunk in the array
+     * @return The index of the chunk in the array, or -1 if the position lies outside this view
      */
     private int chunkIndexOf(Vector3ic blockPos) {
-        return Chunks.toChunkPos(blockPos.x(), Chunks.POWER_X) - topLeft.x
-                + 3 * (Chunks.toChunkPos(blockPos.y(), Chunks.POWER_Y) - topLeft.y
-                + 3 * (Chunks.toChunkPos(blockPos.z(), Chunks.POWER_Z) - topLeft.z));
+        return indexOf(
+                Chunks.toChunkPos(blockPos.x(), Chunks.POWER_X) - topLeft.x,
+                Chunks.toChunkPos(blockPos.y(), Chunks.POWER_Y) - topLeft.y,
+                Chunks.toChunkPos(blockPos.z(), Chunks.POWER_Z) - topLeft.z);
+    }
+
+    /**
+     * Index into {@link #chunks} for a chunk offset within this view, or -1 if outside it.
+     * <p>
+     * The stride order has to match how the caller laid the array out. {@code LightMerger.merge} sorts
+     * by x, then y, then z before constructing this view, so x is the slowest-varying coordinate and z
+     * the fastest - the same order its own {@code indexOf(Side)} assumes. This previously used the
+     * opposite convention, making x fastest, which silently transposed x and z: a lookup for the +X
+     * neighbour returned the +Z one. Nothing failed, because reads and writes shared the same wrong
+     * mapping and the centre (1,1,1) is invariant under the swap - so light merging simply propagated
+     * into the wrong neighbours.
+     * <p>
+     * Bounds are checked per axis rather than on the flat index. Clamping the index alone is not
+     * enough: an offset like (3, 0, 0) is out of view but still lands inside the array, aliasing onto
+     * a real but unrelated chunk.
+     */
+    private static int indexOf(int chunkX, int chunkY, int chunkZ) {
+        if (chunkX < 0 || chunkX >= LOCAL_CHUNKS_SIDE_LENGTH
+                || chunkY < 0 || chunkY >= LOCAL_CHUNKS_SIDE_LENGTH
+                || chunkZ < 0 || chunkZ >= LOCAL_CHUNKS_SIDE_LENGTH) {
+            return -1;
+        }
+        return chunkZ + LOCAL_CHUNKS_SIDE_LENGTH * (chunkY + LOCAL_CHUNKS_SIDE_LENGTH * chunkX);
     }
 
     @Override
@@ -51,7 +79,11 @@ public class LocalChunkView implements PropagatorWorldView {
 
     @Override
     public void setValueAt(Vector3ic pos, byte value) {
-        Chunk chunk = chunks[chunkIndexOf(pos)];
+        int index = chunkIndexOf(pos);
+        if (index < 0) {
+            return;
+        }
+        Chunk chunk = chunks[index];
         if (chunk != null) {
             Vector3i relative = Chunks.toRelative(pos, new Vector3i());
             rules.setValue(chunk, relative, value);
@@ -106,7 +138,7 @@ public class LocalChunkView implements PropagatorWorldView {
         for (int x = minX; x <= maxX; x++) {
             for (int y = minY; y <= maxY; y++) {
                 for (int z = minZ; z <= maxZ; z++) {
-                    Chunk affected = chunks[x + 3 * (y + 3 * z)];
+                    Chunk affected = chunks[indexOf(x, y, z)];
                     if (affected != null) {
                         affected.setDirty(true);
                     }
@@ -118,6 +150,9 @@ public class LocalChunkView implements PropagatorWorldView {
     @Override
     public Block getBlockAt(Vector3ic pos) {
         int index = chunkIndexOf(pos);
+        if (index < 0) {
+            return null;
+        }
         Chunk chunk = chunks[index];
         if (chunk != null) {
             return chunk.getBlock(Chunks.toRelative(pos, new Vector3i()));

--- a/engine/src/main/java/org/terasology/engine/world/propagation/LocalChunkView.java
+++ b/engine/src/main/java/org/terasology/engine/world/propagation/LocalChunkView.java
@@ -53,7 +53,65 @@ public class LocalChunkView implements PropagatorWorldView {
     public void setValueAt(Vector3ic pos, byte value) {
         Chunk chunk = chunks[chunkIndexOf(pos)];
         if (chunk != null) {
-            rules.setValue(chunk, Chunks.toRelative(pos, new Vector3i()), value);
+            Vector3i relative = Chunks.toRelative(pos, new Vector3i());
+            rules.setValue(chunk, relative, value);
+            chunk.setDirty(true);
+            // Only a write within a block of a face can affect a neighbour's mesh, and in a 32x64x32
+            // chunk the overwhelming majority of writes are interior. This is the innermost loop of
+            // batch propagation - running the neighbourhood scan unconditionally here costs real
+            // frame time for nothing, so it is guarded by six comparisons on a value already needed
+            // for the write above.
+            if (isOnChunkBoundary(relative)) {
+                markDirtyAcrossBoundary(pos);
+            }
+        }
+    }
+
+    private static boolean isOnChunkBoundary(Vector3ic relative) {
+        return relative.x() == 0 || relative.x() == Chunks.SIZE_X - 1
+                || relative.y() == 0 || relative.y() == Chunks.SIZE_Y - 1
+                || relative.z() == 0 || relative.z() == Chunks.SIZE_Z - 1;
+    }
+
+    /**
+     * Mark the neighbouring chunks whose mesh depends on a light value written on a shared boundary,
+     * matching what {@link AbstractFullWorldView#setValueAt(Vector3ic, byte)} does for runtime block
+     * changes. Only called for boundary writes; see {@link #setValueAt}.
+     * <p>
+     * Marking just the chunk holding {@code pos} is not enough. A chunk's mesh samples its
+     * neighbours' light to shade the faces along the shared boundary, so a write one block inside
+     * chunk A can leave chunk B's mesh stale. Propagation does not necessarily fix that by writing
+     * into B as well - if B's side of the boundary is opaque no light is written there at all, yet
+     * B's mesh is exactly what shades that solid face. That is the ordinary case at a terrain
+     * surface.
+     * <p>
+     * Mostly this only shortens the life of a transient artifact, since B is corrected anyway once it
+     * is merged as a centre in its own right. It matters at the edge of the loaded world, where a
+     * chunk whose neighbourhood never completes is never merged as a centre and would otherwise keep
+     * a stale face indefinitely - which is precisely the case this whole change exists to handle.
+     * <p>
+     * The expansion is one block and no more: a write reaches at most 2, 4 or 8 chunks. Marking all
+     * 27 speculatively from the caller instead is what exhausted the heap in mesh generation.
+     */
+    private void markDirtyAcrossBoundary(Vector3ic pos) {
+        // Indices relative to this view, rather than a BlockRegion per write as AbstractFullWorldView
+        // builds - this runs per light value written, inside batch propagation.
+        int minX = Math.max(Chunks.toChunkPos(pos.x() - 1, Chunks.POWER_X) - topLeft.x, 0);
+        int maxX = Math.min(Chunks.toChunkPos(pos.x() + 1, Chunks.POWER_X) - topLeft.x, 2);
+        int minY = Math.max(Chunks.toChunkPos(pos.y() - 1, Chunks.POWER_Y) - topLeft.y, 0);
+        int maxY = Math.min(Chunks.toChunkPos(pos.y() + 1, Chunks.POWER_Y) - topLeft.y, 2);
+        int minZ = Math.max(Chunks.toChunkPos(pos.z() - 1, Chunks.POWER_Z) - topLeft.z, 0);
+        int maxZ = Math.min(Chunks.toChunkPos(pos.z() + 1, Chunks.POWER_Z) - topLeft.z, 2);
+
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    Chunk affected = chunks[x + 3 * (y + 3 * z)];
+                    if (affected != null) {
+                        affected.setDirty(true);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Light merging was the last stage of `ChunkProcessingPipeline`, so a chunk could not become ready until all 26 neighbours needed for its 3x3x3 merge existed too. A neighbour that was slow — or never requested at all — stalled the chunk indefinitely, which is why `c645e8154` had to add a 10s idle timeout that force-skips the stage.
- Now a chunk goes ready as soon as its own generation finishes, and `LateLightMerger` merges it afterwards, incrementally, as neighbours arrive. A chunk at the edge of the loaded world simply stays unmerged — visible, with imperfect edge lighting — instead of never becoming ready. When a neighbour loads later, that neighbour's own merge propagates across the shared face and corrects it.
- Light merging was the **only** multi-chunk stage: the sole production uses of `ChunkTaskProvider.createMulti` were the three "Light merging" stages removed here. The pipeline's dependency machinery (`blockedPositions`, `skipBlockedStages`, `MultiplyRequirementChunkTask`) is therefore now dead code, but is left in place — removing it here would double the review surface, and `ChunkProcessingPipelineTest` still covers the API. Follow-up.
- **`LightMerger` marked nothing dirty.** That was harmless while merging ran before the chunk was ready, since its first mesh was still to come and picked the result up for free. Now the chunk is already visible, so without marking, merged light never reaches a mesh — `ChunkMeshWorker` only re-meshes chunks that are `isReady() && isDirty()`.
- **`LocalChunkView` now marks each chunk it writes to**, as `AbstractFullWorldView` already does for runtime block changes. Marking the whole 27-chunk neighbourhood from the merger instead was the obvious alternative, and is wrong: a chunk sits in 27 neighbourhoods, so it gets re-meshed over and over during a world load while most of those merges never touch its light. That exhausted the 768 MB heap inside mesh generation within minutes of starting a world. **Found by running the game — no test here caught it**, which is worth weighing when reviewing the test plan below.
- **Threading.** Merging now touches live chunks rather than chunks only the pipeline can see, and deflated light storage can reallocate on write — a concurrent merge would not be merely a stale-value glitch. It runs on the main thread from each provider's `update()` under a time budget, matching how runtime light propagation for block changes already works (`WorldProviderCoreImpl.processPropagation`).

The design is @naalit's, from #4879. That PR targets an unmerged branch predating the engine package restructure and cannot be rebased, so this is a fresh implementation of the same idea with no code carried over — credited as co-author. It differs in two ways: #4879 merged off-thread, and it omitted the dirty-marking above.

## Test plan

Both tests were checked to **fail against the pipeline-stage merge**, not merely pass against this one — a test that passes either way would not be a regression test.

- [x] `LateLightMergerMteTest` — requests relevance for a single chunk, and separately for an unpadded 3x3x3 region, bounding readiness at 8s: comfortably above generation time (~100-200ms observed), comfortably below the ~10s the old idle-skip needed. Restoring the removed pipeline stage makes **both** time out:
      `Timed out waiting for an isolated chunk (no neighbours requested) to become ready - gave up after 8001 ms`
- [x] `LateLightMergerTest` — drives the merger over a plain map and covers the requeue in `mergeAt`: queue a position, drop a neighbour before the queue drains, and the position must return to `needsMerging` rather than be lost. Deleting that single line makes the test fail.
- [x] `./gradlew :engine-tests:unitTest` — passes; neither new test appears there (both are correctly `MteTest`/`TteTest`, so they run under `integrationTest`).
- [x] `./gradlew :engine:check :engine-tests:check -x test` — checkstyle, PMD and SpotBugs clean on the new files.
- [x] Headless server (`:facades:PC:server`) ran 20+ minutes with no exceptions. Worth stating plainly: this only shows the engine boots and runs stably with the change — a server with no players has no relevance regions and generates no chunks, so it does **not** exercise `LateLightMerger`. That gap is what the tests above exist to close.
- [x] Played in-game by @soloturn on both **JoshariasSurvival** and **CoreSampleGameplay**, and it works. This covers the mesh-churn fix above, which is the failure it was checked against — an earlier build that blanket-marked whole neighbourhoods exhausted the heap within minutes of a world load.

## Performance

Reproduce with the repo's own diagnostic harness — `ManyUsersChunkLoadTest`, written for #5150:

```sh
./gradlew :engine-tests:integrationTestDiagnostic
```

It is opt-in (`@Tag("diagnostic")`, excluded from `unitTest` and `integrationTest`), simulates a host plus 8 connected clients exploring separate regions, and prints its own timings. Raw values land in `engine-tests/build/test-results/integrationTestDiagnostic/`. One run per variant below, same machine, back to back.

| metric | `develop` | this PR | this PR before the x/z fix |
|---|---:|---:|---:|
| solo region relevant | 527 ms | 452 ms | 420 ms |
| **8 concurrent user regions** | 2749 ms | **1400 ms** | 1437 ms |
| **reload 200 chunks w/ entities** | 11118 ms | **4398 ms** | 1197 ms |
| connect 8 clients *(control)* | 43927 ms | 45782 ms | 45314 ms |

The control row is client connection — network and entity setup, untouched here. It moves 3-4% between runs, which gives the noise floor.

Against `develop`: **−49%** on eight users loading distinct regions at once, and **−60%** on the 200-chunk reload. The reload case is the scenario in #5150, the multi-second main-thread stalls after loading a previously-explored save. It fits — reloading 200 chunks at once under the old design meant every chunk waiting on its full neighbourhood, with the outer shell only escaping via the 10s idle-skip.

The third column is kept because the difference is informative rather than noise. Before `bfa8ce9`, light merging propagated into transposed neighbours, so a good deal of its work went to the wrong chunks. Correcting that makes merging do what it was always supposed to, and on the reload case that costs about 3.2s. Worth knowing which part of the remaining time is the price of correctness rather than of this feature.

Caveat: single runs. Treat the solo figure as noise; the two large ones are well outside it.

## Open question for reviewers: is the boundary marking worth keeping?

`LocalChunkView.setValueAt` marks not only the chunk it writes to but any chunk within one block of that write, because a chunk's mesh samples its neighbours' light to shade the faces along a shared boundary. It was added in response to review feedback. **It costs nothing measurable.** Measured separately on `67ff49df`, the same build with it removed gave 406 ms solo, 1506 ms concurrent and 1464 ms reload — *slower* on two of the three against that build's 420 / 1437 / 1197, so the difference is inside the noise.

It is worth being precise about how narrow the case is, because it is narrower than it first appears. A stale mesh needs *all* of:

1. a light value changes on a chunk boundary during a merge;
2. the neighbour's side of that boundary is opaque, so propagation writes nothing into it — otherwise it dirties itself;
3. that neighbour is already ready and meshed; and
4. that neighbour is never later merged as a centre in its own right — otherwise it dirties itself then.

Condition 4 is the narrow one. A chunk is merged as a centre as soon as its own 27-neighbourhood completes, so for everything except the outer shell of the loaded world this only shortens a **transient** seam. At the shell it is permanent — but a shell chunk stops being one as soon as the player moves toward it and its neighbours load, at which point it self-corrects. So the genuinely permanent case is a seam on a solid face, at render distance, on a frontier nobody walks toward.

Kept because it measures free and closes the case properly. Reverting it is defensible if the simpler write path is preferred — the four conditions above are what would be traded away.

## Notes for review

- `ChunkRegionFuture.REQUIRED_CHUNK_MARGIN` pads every relevance request by one extra shell, with a puzzled `// FIXME: Is the complete relevance region not actually loaded‽`. That padding turns out to be the same root cause: `f324128dd` records that "before the ChunkProcessingPipeline fix, padding/neighbour chunks near the edge of a region could never complete their own stages". `relevanceRegionBecomesFullyReadyWithoutMargin` shows the padding is no longer structurally needed *for readiness* — but it is left untouched here, since other tests share it and "not needed for readiness" is not "not needed for anything".
- Unrelated pre-existing bug found while writing the tests, deliberately **not** fixed here: `RelevanceSystem.addRelevanceEntity` streams a `BlockRegion` through `.sorted()`, but that iterator hands out a reused, mutable `Vector3i`. Since `sorted()` buffers before emitting, buffered positions alias to a stale value, so a few `createOrLoadChunk` calls go to the wrong position. Not a hang — `updateRelevance()`'s follow-up pass uses the defensive-copying `getNeededChunks()` and still requests the right ones — just wasted work. It is documented in the MTE test's javadoc, which is also why that test does not assert "neighbours stayed unloaded".
- `RemoteChunkProvider` gets the same treatment for consistency, but multiplayer is untested here.

## Related — and what this unblocks

- #4879 — the draft this ports; can be closed if this lands.
- **#4822 — `feat: rework chunk ordering using Reactor`. Still open, and the natural thing to do next.** It was reviewed favourably in 2021 and stalled rather than being rejected. It replaces the eager push model — every relevant position submitted up front into a `PriorityBlockingQueue` whose heap order is fixed at insertion time, so ordering goes stale as the player moves — with a bounded pull model that re-sorts by current relevance on each request. This PR makes that materially easier: light merging was the only stage holding chunks pending their neighbours, and the defer-loop in #4822's `processingInfoReactor()` exists largely to service exactly that dependency. Two caveats for whoever picks it up: it cannot be rebased (it targets an unmerged branch predating the package restructure in #5192), so treat it as a specification rather than a patch; and its unresolved design question — how to wake a paused pull stream from the main thread — is already argued out in its review thread and should be answered rather than rediscovered.
- **#5361 — the underlying issue behind #4822**, filed so the problem is tracked independently of the PRs that have attempted it: chunks near you generate after chunks far away, especially while moving. It also records a pre-existing `RelevanceSystem` aliasing bug found while testing this PR, which sits in the very code a pull-based rework would replace.
