### PR TITLE
fix(persistence): resolve EntityRef fields lazily to survive forward references

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/persistence/EntitySerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/EntitySerializerTest.java
@@ -27,6 +27,8 @@ import org.terasology.engine.network.NetworkMode;
 import org.terasology.engine.network.NetworkSystem;
 import org.terasology.engine.persistence.serializers.EntitySerializer;
 import org.terasology.engine.persistence.serializers.PersistenceComponentSerializeCheck;
+import org.terasology.engine.persistence.typeHandling.extensionTypes.EntityRefTypeHandler;
+import org.terasology.engine.persistence.typeHandling.protobuf.ProtobufPersistedDataSerializer;
 import org.terasology.engine.recording.RecordAndReplayCurrentStatus;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.testUtil.ModuleManagerFactory;
@@ -37,6 +39,7 @@ import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
 import org.terasology.gestalt.di.ServiceRegistry;
 import org.terasology.gestalt.entitysystem.component.EmptyComponent;
+import org.terasology.persistence.typeHandling.PersistedData;
 import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
 import org.terasology.protobuf.EntityData;
 import org.terasology.reflection.ModuleTypeRegistry;
@@ -297,6 +300,37 @@ public class EntitySerializerTest {
 
         assertTrue(loadedEntity.exists());
         assertTrue(loadedEntity.hasComponent(MappedTypeComponent.class));
+    }
+
+    /**
+     * Reproduces the forward-reference scenario from a real load: entity A's component references entity B by id
+     * before B itself has been deserialized (e.g. a save file lists an inventory-holding entity before an item
+     * inside it). Goes through {@link org.terasology.engine.persistence.typeHandling.extensionTypes.EntityRefTypeHandler#deserialize}
+     * itself, the way {@code ComponentSerializer} actually calls it, rather than constructing
+     * {@link org.terasology.engine.persistence.typeHandling.extensionTypes.ForwardReferenceEntityRef} by hand - a full
+     * serialize/{@link EngineEntityManager#clear()}/deserialize round trip isn't used here because
+     * {@code clear()} doesn't actually clear the manager's id-to-pool mapping (a pre-existing quirk, unrelated to
+     * this fix) and so can't reproduce "id not yet known" the way a genuinely fresh load does.
+     */
+    @Test
+    public void testForwardReferenceResolvesOnceTargetIsCreated() {
+        long futureId = entityManager.getNextId();
+        PersistedData persistedFutureId = new ProtobufPersistedDataSerializer().serialize(futureId);
+        EntityRef entityRef = new EntityRefTypeHandler(entityManager).deserialize(persistedFutureId)
+                .orElseThrow(() -> new AssertionError("expected a numeric id to deserialize to some EntityRef"));
+
+        // Nothing has been created with this id yet - must not resolve to a dead stub.
+        assertFalse(entityRef.exists());
+
+        // The next entity created is assigned futureId, exactly as if it were deserialized moments later in the
+        // same batch that already handed out a reference to it.
+        EntityRef created = entityManager.create();
+        created.addComponent(new IntegerComponent(42));
+        assertEquals(futureId, created.getId());
+
+        assertTrue(entityRef.exists());
+        assertEquals(futureId, entityRef.getId());
+        assertEquals(42, entityRef.getComponent(IntegerComponent.class).value);
     }
 
     private EntityRef serializeDeserializeEntity(EntityRef entity) {

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/EntityRefTypeHandler.java
@@ -29,7 +29,9 @@ public class EntityRefTypeHandler extends TypeHandler<EntityRef> {
     @Override
     public Optional<EntityRef> deserialize(PersistedData data) {
         if (data.isNumber()) {
-            return Optional.ofNullable(entityManager.getEntity(data.getAsLong()));
+            // Deferred: the referenced id may belong to an entity later in the same batch that hasn't been
+            // deserialized yet. See ForwardReferenceEntityRef for why resolving eagerly here would lose the reference.
+            return Optional.of(new ForwardReferenceEntityRef(entityManager, data.getAsLong()));
         }
         return Optional.ofNullable(EntityRef.NULL);
     }

--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/ForwardReferenceEntityRef.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/extensionTypes/ForwardReferenceEntityRef.java
@@ -1,0 +1,175 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.persistence.typeHandling.extensionTypes;
+
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
+import org.terasology.engine.entitySystem.entity.internal.EntityScope;
+import org.terasology.engine.entitySystem.prefab.Prefab;
+import org.terasology.gestalt.entitysystem.component.Component;
+import org.terasology.gestalt.entitysystem.event.Event;
+
+import java.util.List;
+
+/**
+ * An {@link EntityRef} for an id not registered yet. Retries the lookup on every delegated call until the
+ * target, deserialized later in the same batch, exists.
+ */
+public class ForwardReferenceEntityRef extends EntityRef {
+    private final EngineEntityManager entityManager;
+    private final long id;
+    private EntityRef resolved;
+
+    public ForwardReferenceEntityRef(EngineEntityManager entityManager, long id) {
+        this.entityManager = entityManager;
+        this.id = id;
+    }
+
+    private EntityRef resolve() {
+        if (resolved == null || !resolved.exists()) {
+            EntityRef candidate = entityManager.getEntity(id);
+            if (candidate.exists()) {
+                resolved = candidate;
+            } else {
+                return candidate;
+            }
+        }
+        return resolved;
+    }
+
+    @Override
+    public EntityRef copy() {
+        EntityRef target = resolve();
+        if (target.exists()) {
+            return target.copy();
+        }
+        // Not resolvable yet - the copy has to stay a forward reference too, or it freezes into
+        // "doesn't exist" permanently the moment something copies this ref before its target loads.
+        return new ForwardReferenceEntityRef(entityManager, id);
+    }
+
+    @Override
+    public boolean exists() {
+        return resolve().exists();
+    }
+
+    @Override
+    public boolean isActive() {
+        return resolve().isActive();
+    }
+
+    @Override
+    public void destroy() {
+        resolve().destroy();
+    }
+
+    @Override
+    public <T extends Event> T send(T event) {
+        return resolve().send(event);
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return resolve().isPersistent();
+    }
+
+    @Override
+    public boolean isAlwaysRelevant() {
+        return resolve().isAlwaysRelevant();
+    }
+
+    @Override
+    public void setAlwaysRelevant(boolean alwaysRelevant) {
+        resolve().setAlwaysRelevant(alwaysRelevant);
+    }
+
+    @Override
+    public EntityRef getOwner() {
+        return resolve().getOwner();
+    }
+
+    @Override
+    public void setOwner(EntityRef owner) {
+        resolve().setOwner(owner);
+    }
+
+    @Override
+    public void setScope(EntityScope scope) {
+        resolve().setScope(scope);
+    }
+
+    @Override
+    public void setSectorScope(long maxDelta) {
+        resolve().setSectorScope(maxDelta);
+    }
+
+    @Override
+    public void setSectorScope(long unloadedMaxDelta, long loadedMaxDelta) {
+        resolve().setSectorScope(unloadedMaxDelta, loadedMaxDelta);
+    }
+
+    @Override
+    public EntityScope getScope() {
+        return resolve().getScope();
+    }
+
+    @Override
+    public void invalidate() {
+        resolve().invalidate();
+    }
+
+    @Override
+    public Prefab getParentPrefab() {
+        return resolve().getParentPrefab();
+    }
+
+    @Override
+    public String toFullDescription() {
+        return resolve().toFullDescription();
+    }
+
+    @Override
+    public <T extends Component> T addComponent(T component) {
+        return resolve().addComponent(component);
+    }
+
+    @Override
+    public void removeComponent(Class<? extends Component> componentClass) {
+        resolve().removeComponent(componentClass);
+    }
+
+    @Override
+    public void saveComponent(Component component) {
+        resolve().saveComponent(component);
+    }
+
+    @Override
+    public boolean hasComponent(Class<? extends Component> component) {
+        return resolve().hasComponent(component);
+    }
+
+    @Override
+    public boolean hasAnyComponents(List<Class<? extends Component>> filterComponents) {
+        return resolve().hasAnyComponents(filterComponents);
+    }
+
+    @Override
+    public boolean hasAllComponents(List<Class<? extends Component>> filterComponents) {
+        return resolve().hasAllComponents(filterComponents);
+    }
+
+    @Override
+    public <T extends Component> T getComponent(Class<T> componentClass) {
+        return resolve().getComponent(componentClass);
+    }
+
+    @Override
+    public Iterable<Component> iterateComponents() {
+        return resolve().iterateComponents();
+    }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Fixes inventory items (and any other `EntityRef`-referencing component) silently vanishing on save/reload, depending on load order.
- `EntitySerializer.deserialize()` resolves every `EntityRef` field on an entity before that entity itself is registered with the entity manager, and `EntityRestorer` drives this as one sequential pass over a store's entity list - so if entity A's component references entity B by id, and B happens to sit later than A in that list, the lookup permanently resolved to a dead `EntityRef.NULL` stub with no retry once B actually got created moments later.
- `EntityRefTypeHandler` now hands back a `LazyLoadEntityRef` that defers resolution until something actually uses it - always after the whole store has finished loading, by which point every id is resolvable regardless of order.

## Follow-up (CodeRabbit review)

- `LazyLoadEntityRef.copy()` now stays lazy for an unresolved target instead of copying the dead `EntityRef.NULL` candidate and permanently losing the reference.
- `setScope`/both `setSectorScope` overloads/`getScope`/`invalidate` now delegate through `resolve()` like everything else - `EntityRef` gives these no-op defaults rather than declaring them abstract, so the missing overrides compiled fine but silently no-op'd on an unresolved ref.
- Regression test now goes through `EntityRefTypeHandler.deserialize()` itself rather than constructing `LazyLoadEntityRef` by hand.

## Test plan

- [x] `EntitySerializerTest` (15/15, including `testForwardReferenceResolvesOnceTargetIsCreated`), `PojoEntityManagerTest` (30/30) - all pass.
- [ ] In-game: reproduced originally with a crafted tool and separately with plain gathered items ("Rock", "Stick") each vanishing on reload in different runs - reporter is verifying against a live build.

## Related

- Fixes #5364.
- Related to #5051. That crash is already patched separately (5f605206a made `SkeletonRenderer` recreate a corrupted bone entity instead of NPEing) but the fix explicitly left open why the ref died in the first place - this is that.
