### PR TITLE
fix(rendering): don't crash the game on a failed shader recompile

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphicsManager.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglGraphicsManager.java
@@ -6,6 +6,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.context.Lifetime;
 import org.terasology.engine.core.GameThread;
 import org.terasology.engine.core.subsystem.DisplayDeviceInfo;
@@ -48,6 +50,8 @@ import static org.lwjgl.opengl.GL11.glGenTextures;
 import static org.lwjgl.opengl.GL11.glTexParameterf;
 
 public class LwjglGraphicsManager implements LwjglGraphicsProcessing {
+
+    private static final Logger logger = LoggerFactory.getLogger(LwjglGraphicsManager.class);
 
     private final BlockingDeque<Runnable> displayThreadActions = Queues.newLinkedBlockingDeque();
 
@@ -110,7 +114,17 @@ public class LwjglGraphicsManager implements LwjglGraphicsProcessing {
         if (!displayThreadActions.isEmpty()) {
             List<Runnable> actions = Lists.newArrayListWithExpectedSize(displayThreadActions.size());
             displayThreadActions.drainTo(actions);
-            actions.forEach(Runnable::run);
+            // One action failing must not silently drop the rest of the batch. This queue is shared by
+            // every asynchToDisplayThread caller - ShaderManager.recompileAllShaders() alone queues one
+            // action per loaded shader - so an uncaught exception from any single queued action used to
+            // abort every action queued after it in the same frame, not just the one that failed.
+            for (Runnable action : actions) {
+                try {
+                    action.run();
+                } catch (RuntimeException e) {
+                    logger.warn("Display thread action failed: {}", e.getMessage(), e); //NOPMD
+                }
+            }
         }
     }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLMaterial.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLMaterial.java
@@ -132,10 +132,24 @@ public class GLSLMaterial extends BaseMaterial {
         uniformLocationMap.clear();
         bindMap.clear();
 
-        disposalAction.shaderPrograms.put(0, shader.linkShaderProgram(0));
-        for (Set<ShaderProgramFeature> permutation : Sets.powerSet(shader.getAvailableFeatures())) {
-            int featureMask = ShaderProgramFeature.getBitset(permutation);
-            disposalAction.shaderPrograms.put(featureMask, shader.linkShaderProgram(featureMask));
+        // Existing programs are already gone by this point (above). shader already skips (and logs)
+        // any feature combination that failed to compile for the running driver, most reachable here
+        // since ShaderManager.recompileAllShaders() - the video settings screen's path - is what
+        // first exercises feature combinations a lower preset never used. Mirror that here: linking
+        // a hash the shader never compiled would attach shader object 0, a GL-level failure that
+        // doesn't throw, silently producing a broken program instead of a caught, logged one.
+        try {
+            if (shader.hasCompiledPermutation(0)) {
+                disposalAction.shaderPrograms.put(0, shader.linkShaderProgram(0));
+            }
+            for (Set<ShaderProgramFeature> permutation : Sets.powerSet(shader.getAvailableFeatures())) {
+                int featureMask = ShaderProgramFeature.getBitset(permutation);
+                if (shader.hasCompiledPermutation(featureMask)) {
+                    disposalAction.shaderPrograms.put(featureMask, shader.linkShaderProgram(featureMask));
+                }
+            }
+        } catch (RuntimeException e) {
+            logger.warn("Failed to recompile {}: {}", getUrn(), e.getMessage()); //NOPMD
         }
 
         //resolves #966

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLShader.java
@@ -116,6 +116,18 @@ public class GLSLShader extends Shader {
         return availableFeatures;
     }
 
+    /**
+     * @return true if the given feature combination's fragment/vertex programs actually compiled -
+     * false if {@link #registerAllShaderPermutations} skipped it after a compile failure. Callers
+     * (GLSLMaterial) must check this before {@link #linkShaderProgram} - linking a feature hash that
+     * was never compiled attaches shader object 0, a GL-level failure {@code glLinkProgram} doesn't
+     * surface as a Java exception, so it would otherwise silently produce a broken program instead
+     * of a caught, logged failure.
+     */
+    boolean hasCompiledPermutation(int featureHash) {
+        return disposalAction.fragmentPrograms.containsKey(featureHash);
+    }
+
     // made package-private after CheckStyle suggestion
     int linkShaderProgram(int featureHash) {
         int shaderProgram = GL20.glCreateProgram();
@@ -133,7 +145,16 @@ public class GLSLShader extends Shader {
     @Override
     public void recompile() {
         graphicsProcessing.asynchToDisplayThread(() -> {
-            registerAllShaderPermutations();
+            // registerAllShaderPermutations() already isolates a single bad permutation - this catch
+            // is a generic safety net for anything else going wrong, same as doReload()'s. This entry
+            // point reaches the same compile paths from ShaderManager.recompileAllShaders(), driven by
+            // the video settings screen switching feature presets, which is exactly where a
+            // never-before-compiled combination of features is first exercised.
+            try {
+                registerAllShaderPermutations();
+            } catch (RuntimeException e) {
+                logger.warn("{}", e.getMessage()); //NOPMD
+            }
         });
     }
 
@@ -264,21 +285,30 @@ public class GLSLShader extends Shader {
     private void registerAllShaderPermutations() {
         Set<Set<ShaderProgramFeature>> allPermutations = Sets.powerSet(availableFeatures);
 
+        int compiledCount = 0;
         for (Set<ShaderProgramFeature> permutation : allPermutations) {
-            int featureHash = ShaderProgramFeature.getBitset(permutation);
+            // Caught per-permutation, not around the whole loop: one bad feature combination must
+            // not also skip every later permutation in iteration order - those would otherwise
+            // never get registered at all, not just the one that actually failed to compile.
+            try {
+                int featureHash = ShaderProgramFeature.getBitset(permutation);
 
-            int fragShaderId = compileShader(GL20.GL_FRAGMENT_SHADER, permutation);
-            int vertShaderId = compileShader(GL20.GL_VERTEX_SHADER, permutation);
-            if (shaderProgramBase.getGeometryProgram() != null) {
-                int geomShaderId = compileShader(GL32.GL_GEOMETRY_SHADER, permutation);
-                disposalAction.geometryPrograms.put(featureHash, geomShaderId);
+                int fragShaderId = compileShader(GL20.GL_FRAGMENT_SHADER, permutation);
+                int vertShaderId = compileShader(GL20.GL_VERTEX_SHADER, permutation);
+                if (shaderProgramBase.getGeometryProgram() != null) {
+                    int geomShaderId = compileShader(GL32.GL_GEOMETRY_SHADER, permutation);
+                    disposalAction.geometryPrograms.put(featureHash, geomShaderId);
+                }
+
+                disposalAction.fragmentPrograms.put(featureHash, fragShaderId);
+                disposalAction.vertexPrograms.put(featureHash, vertShaderId);
+                compiledCount++;
+            } catch (RuntimeException e) {
+                logger.warn("Skipping shader permutation {} for {}: {}", permutation, getUrn(), e.getMessage()); //NOPMD
             }
-
-            disposalAction.fragmentPrograms.put(featureHash, fragShaderId);
-            disposalAction.vertexPrograms.put(featureHash, vertShaderId);
         }
 
-        logger.debug("Compiled {} permutations for {}.", allPermutations.size(), getUrn()); //NOPMD
+        logger.debug("Compiled {} of {} permutations for {}.", compiledCount, allPermutations.size(), getUrn()); //NOPMD
     }
 
     private String assembleShader(int type, Set<ShaderProgramFeature> features) {


### PR DESCRIPTION
Fixes #5292 - switching the video preset from High to Ultra crashed with `RuntimeException: Failed to resolve required asset: 'CoreRendering:prePostComposite'`, a material unrelated to any of Ultra's actual new features.

## Trace

Full trace posted on the issue. Short version: `ShaderManager.recompileAllShaders()` (called from the video settings screen's preset apply) recompiles every loaded shader, then every loaded material. Three places on that path throw a plain `RuntimeException` on failure with nothing to catch it:

1. **`GLSLShader.recompile()`** - queues `registerAllShaderPermutations()`, which throws on any `GL_COMPILE_STATUS` failure while compiling the *powerset* of that shader's features. `doReload()` a few dozen lines down in the same file guards the identical call with `try { ... } catch (RuntimeException e) { logger.warn(...); }`. Same operation, only one of its two entry points was safe.
2. **`GLSLMaterial.recompile()`** - unguarded at both of its own call sites, and clears every existing compiled program *before* relinking, so a failure partway through relinking leaves nothing to fall back to.
3. **`LwjglGraphicsManager.processActions()`** - drains the shared display-thread action queue with a plain `forEach(Runnable::run)`. `recompileAllShaders()` alone queues one action per loaded shader onto this queue, so an uncaught exception from any single one used to abort every action queued after it in the same batch - the likely reason an unrelated material (`prePostComposite`) is what actually surfaced in the crash.

## Fix

Each site gets the same shape this codebase already uses in `doReload()`: log and continue instead of propagate. No site here throws on the success path, so this only changes what happens when a shader genuinely fails to compile.

## What I could and couldn't verify

Traced by reading, not reproduced - the actual `GL_COMPILE_STATUS` failure needs the reporter's AMD RX 580 / Mesa stack, which I don't have here, so I can't confirm which specific shader permutation fails on that hardware. What this does confirm and fix: the code path that turns *any* such failure, on *any* driver, into a hard crash rather than the degraded-but-running game the original report asked for.

Compiles clean (`:engine:compileJava`, `:engine-tests:compileTestJava`). No existing unit tests cover these LWJGL/GL-context-bound classes to run.
