### PR TITLE
chore(rendering): remove the Clamp Lighting setting

### DIFF
--- a/engine/src/main/java/org/terasology/engine/config/RenderingConfig.java
+++ b/engine/src/main/java/org/terasology/engine/config/RenderingConfig.java
@@ -61,7 +61,6 @@ public class RenderingConfig extends AbstractSubscribable {
     public static final String FRAME_LIMIT = "FrameLimit";
     public static final String FBO_SCALE = "FboScale";
     public static final String UI_SCALE = "UiScale";
-    public static final String CLAMP_LIGHTING = "ClampLighting";
     public static final String SCREENSHOT_SIZE = "screenshotSize";
     public static final String SCREENSHOT_FORMAT = "ScreenshotFormat";
     public static final String DUMP_SHADERS = "DumpShaders";
@@ -110,7 +109,6 @@ public class RenderingConfig extends AbstractSubscribable {
     private boolean inscattering;
     private boolean localReflections;
     private boolean vSync;
-    private boolean clampLighting;
     private int fboScale;
     private int uiScale = 100;
     private boolean dumpShaders;
@@ -628,16 +626,6 @@ public class RenderingConfig extends AbstractSubscribable {
         int oldScale = this.uiScale;
         this.uiScale = uiScale;
         propertyChangeSupport.firePropertyChange(UI_SCALE, oldScale, this.uiScale);
-    }
-
-    public boolean isClampLighting() {
-        return clampLighting;
-    }
-
-    public void setClampLighting(boolean clampLighting) {
-        boolean oldValue = this.clampLighting;
-        this.clampLighting = clampLighting;
-        propertyChangeSupport.firePropertyChange(CLAMP_LIGHTING, oldValue, this.clampLighting);
     }
 
     public ScreenshotSize getScreenshotSize() {

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/layers/mainMenu/videoSettings/VideoSettingsScreen.java
@@ -332,7 +332,6 @@ public class VideoSettingsScreen extends CoreScreenLayer {
         WidgetUtil.tryBindCheckbox(this, "vsync", BindHelper.bindBeanProperty("vSync", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "eyeAdaptation", BindHelper.bindBeanProperty("eyeAdaptation", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "ssao", BindHelper.bindBeanProperty("ssao", config.getRendering(), Boolean.TYPE));
-        WidgetUtil.tryBindCheckbox(this, "clampLighting", BindHelper.bindBeanProperty("clampLighting", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "bloom", BindHelper.bindBeanProperty("bloom", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "lightShafts", BindHelper.bindBeanProperty("lightShafts", config.getRendering(), Boolean.TYPE));
         WidgetUtil.tryBindCheckbox(this, "vignette", BindHelper.bindBeanProperty("vignette", config.getRendering(), Boolean.TYPE));

--- a/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLShader.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/opengl/GLSLShader.java
@@ -228,10 +228,6 @@ public class GLSLShader extends Shader {
         if (renderConfig.isInscattering()) {
             builder.append("#define INSCATTERING \n");
         }
-        // TODO A 3D wizard should take a look at this. Configurable for the moment to make better comparisons possible.
-        if (renderConfig.isClampLighting()) {
-            builder.append("#define CLAMP_LIGHTING \n");
-        }
 
         for (ChunkVertexFlag vertexFlag : ChunkVertexFlag.values()) {
             builder.append("#define ").append(vertexFlag.getDefineName()).append(" int(").append(vertexFlag.getValue()).append(") \n");

--- a/engine/src/main/resources/default.cfg
+++ b/engine/src/main/resources/default.cfg
@@ -43,7 +43,6 @@
     "inscattering": true,
     "localReflections": false,
     "vSync": false,
-    "clampLighting": false,
     "fboScale": 100,
     "dumpShaders": false,
     "screenshotSize": "${engine:menu#screenshot-size-normal}",

--- a/engine/src/main/resources/org/terasology/engine/assets/i18n/menu_en.lang
+++ b/engine/src/main/resources/org/terasology/engine/assets/i18n/menu_en.lang
@@ -88,7 +88,6 @@
     "change-keybind-popup-message": "is already bound to an action. Rebind anyway?",
     "change-keybind-popup-title": "Key already bound",
     "chunk-lods": "Chunk LODs",
-    "clamp-lighting": "Clamp Lighting",
     "cloud-shadows": "Cloud Shadows",
     "config": "Configure",
     "connecting-to": "Connecting to",

--- a/engine/src/main/resources/org/terasology/engine/assets/ui/menu/videoMenuScreen.ui
+++ b/engine/src/main/resources/org/terasology/engine/assets/ui/menu/videoMenuScreen.ui
@@ -379,14 +379,6 @@
                                 },
                                 {
                                     "type": "UILabel",
-                                    "text": "${engine:menu#clamp-lighting}: "
-                                },
-                                {
-                                    "type": "UICheckbox",
-                                    "id": "clampLighting"
-                                },
-                                {
-                                    "type": "UILabel",
                                     "text": "${engine:menu#bloom-effect}: "
                                 },
                                 {


### PR DESCRIPTION
Fixes #5152 (the "Clamp Lighting" part of it - see below for the rest).

## Why removal, not a fix

Clamp Lighting was reported to visibly do nothing. The maintainer who investigated confirmed it and asked for outright removal, not a fix: *"remove clamplightning in both ui and Rendering Config"* / *"remove clamp lightning from UI, rendering config and any related code you can find."* That's a still-open TODO from the issue thread - unimplemented.

It clamps the deferred lighting pass's output color to `[0.0, 1.0]` before it reaches later HDR-aware post-processing (bloom, eye adaptation, tone mapping). Most framebuffer formats already clamp on write regardless, so the setting only has a visible effect in specific HDR configurations - which is why toggling it does nothing for most players. Not a bug, a setting whose effect never showed up where a player looking for it would see it.

## What's removed

- `RenderingConfig`: the `clampLighting` field, `isClampLighting()`/`setClampLighting()`, and the `CLAMP_LIGHTING` property-change constant
- `GLSLShader`: the `#define CLAMP_LIGHTING` emission
- `videoMenuScreen.ui`: the checkbox and its label
- `VideoSettingsScreen`: the checkbox binding
- `default.cfg`: the persisted entry
- `menu_en.lang`: the base i18n string

Other locale `.lang` files keep the now-orphaned key - that's the normal state for a retired translation string; Weblate stops requesting it going forward rather than needing 25 files hand-edited here.

## Companion PR

The shader side (the actual `#if defined(CLAMP_LIGHTING)` branch) lives in a separate repo: Terasology/CoreRendering#85

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. `default.cfg`, `videoMenuScreen.ui`, and `menu_en.lang` still parse as valid JSON after the edits (verified with `python3 -m json.tool`, not just by eye). Couldn't launch the actual settings screen to confirm the UI renders without the removed rows - no display in this environment.

## What's still open on #5152

The issue's other item - separating the flickering-light offset per block instead of per chunk - is explicitly *not* addressed here. The maintainer thread flagged it as performance-sensitive ("we need to be considerate of the performance impact here... we probably don't want to merge that until we improved performance a bunch first") and it needs shader-level profiling I can't do in this environment, so I left it out rather than guess at a fix. Eye-adaptation, bloom, and vignette were already fixed in earlier, already-merged CoreRendering PRs (#77, #78, #80).
