### PR TITLE
fix(rendering): actually suppress FBO resize-to-zero on minimize

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/lwjgl/LwjglDisplayDevice.java
@@ -202,11 +202,23 @@ public class LwjglDisplayDevice extends AbstractSubscribable implements DisplayD
 
     protected void updateViewport(int width, int height) {
         glViewport(0, 0, width, height);
-        
-        //If the screen is minimized, resolution change is stopped to avoid the width and height of FBO being set to 0.
+
+        // GLFW reports the framebuffer as 0x0 while the window is minimized, and
+        // DisplayResolutionDependentFbo.propertyChange regenerates every resolution-dependent FBO at
+        // whatever size the display device reports whenever this event fires - it does not look at
+        // the old/new values below, only at whether the event fired at all. So an unconditional fire
+        // here means minimizing regenerates every FBO at 0x0, and restoring the window leaves them
+        // that way until something else triggers a further resize - the black screen on restore this
+        // is meant to prevent (#4980, #5081).
+        //
+        // PropertyChangeSupport.firePropertyChange skips notifying listeners when old equals new, so
+        // that is used here as the on/off switch: while minimized, pass (1, 1) so the compare matches
+        // and nothing fires; otherwise pass (0, 1) so a genuine resize still does. This was previously
+        // inverted - isMinimized picked the value that differs from newValue, the opposite of what
+        // "stop the resolution change" requires - so it suppressed real resizes instead of minimizes.
         boolean isMinimized = GLFW.glfwGetWindowAttrib(GLFW.glfwGetCurrentContext(), GLFW.GLFW_ICONIFIED) == GLFW.GLFW_TRUE;
-        int i = isMinimized ? 0 : 1;       
-        propertyChangeSupport.firePropertyChange(DISPLAY_RESOLUTION_CHANGE, i, 1);
+        int oldValue = isMinimized ? 1 : 0;
+        propertyChangeSupport.firePropertyChange(DISPLAY_RESOLUTION_CHANGE, oldValue, 1);
     }
 
     private GLFWVidMode getFullScreenDisplayMode() {


### PR DESCRIPTION
Fixes #5081 - game screen goes dark after minimizing (via a third-party minimize tool) and restoring.

## This is #4980's fix, with an inverted condition

`LwjglDisplayDevice.updateViewport` already tries to guard against this - added by #4980 for an earlier report of the identical symptom - but the guard never actually worked.

GLFW reports the framebuffer as 0x0 while a window is minimized. `DisplayResolutionDependentFbo.propertyChange` and `PerspectiveCamera`'s own `DISPLAY_RESOLUTION_CHANGE` listener both react to the event firing at all, not to its old/new values - `propertyChange` regenerates every resolution-dependent FBO at whatever size the display device reports at that moment. #4980's intent was to stop that event firing while minimized, using `PropertyChangeSupport.firePropertyChange`'s own behaviour of skipping notification when old equals new as the switch:

```java
boolean isMinimized = GLFW.glfwGetWindowAttrib(...) == GLFW.GLFW_TRUE;
int i = isMinimized ? 0 : 1;
propertyChangeSupport.firePropertyChange(DISPLAY_RESOLUTION_CHANGE, i, 1);
```

This picks the value backwards: while minimized, `i=0` differs from `newValue=1`, so the event still fires - unchanged from before #4980 landed. While *not* minimized, `i=1` matches `newValue=1`, so it's suppressed - a second, unrelated regression, since that's exactly when a resize should propagate.

## Fix

Flip which value goes with which case: `(1, 1)` while minimized so the compare matches and nothing fires, `(0, 1)` otherwise so a genuine resize still does.

## What I could and couldn't verify

Root-caused and fixed by reading, not reproduced - confirming this needs an actual Windows session with a real or synthetic minimize gesture, which I don't have here. The fix follows directly from documented GLFW behaviour (0x0 framebuffer while iconified) and `PropertyChangeSupport`'s own equals-based suppression semantics, not from observing the bug happen.

No existing tests cover this class - `updateViewport` needs a live GLFW window/context, not something headless-testable. `:engine:compileJava` is clean.
