### PR TITLE
fix(rendering): make save preview screenshots actually capture the game

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
@@ -112,6 +112,13 @@ public class StateIngame implements GameState {
 
     @Override
     public void dispose(boolean shuttingDown) {
+        boolean save = networkSystem.getMode().isAuthority();
+        if (save && storageManager != null && worldRenderer != null) {
+            // Refreshes the FBO the save-preview screenshot reads (#5321, stale/blank otherwise).
+            // Must run before chunkProvider.dispose() / asset disposal below - too late otherwise.
+            worldRenderer.render(RenderingStage.MONO);
+        }
+
         ChunkProvider chunkProvider = context.get(ChunkProvider.class);
         chunkProvider.dispose();
 
@@ -128,7 +135,6 @@ public class StateIngame implements GameState {
         assetTypeManager.getAssetType(BlockFamilyDefinition.class).ifPresent(AssetType::disposeAll);
         assetTypeManager.getAssetType(Prefab.class).ifPresent(AssetType::disposeAll);
 
-        boolean save = networkSystem.getMode().isAuthority();
         if (save && storageManager != null) {
             storageManager.waitForCompletionOfPreviousSaveAndStartSaving();
         }

--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -22,6 +22,7 @@ import org.terasology.engine.logic.console.commandSystem.annotations.Command;
 import org.terasology.engine.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.engine.logic.permission.PermissionManager;
 import org.terasology.engine.logic.players.LocalPlayerSystem;
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.rendering.ShaderManager;
 import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.backdrop.BackdropProvider;
@@ -137,6 +138,20 @@ public final class WorldRendererImpl implements WorldRenderer {
     public void init() {
         initRenderingSupport();
         initRenderingModules();
+
+        // ScreenGrabber lives only in this.context - the child ContextImpl this class builds over the
+        // constructor's outer context plus its own ServiceRegistry (see the constructor). ContextImpl's
+        // lookup walks child-to-parent, never the other way: a parent context has no path to a child's
+        // exclusive registrations. ReadWriteStorageManager.saveGamePreviewImage() resolves ScreenGrabber
+        // via the static CoreRegistry, which is bound to the outer/parent context - so without this,
+        // that lookup returns null and save preview images come out black (#5321). This was removed once
+        // on the theory that ScreenGrabber "should already be resolvable from CoreRegistry" because it's
+        // in the ServiceRegistry LwjglRenderingSubsystemFactory populates - that ServiceRegistry is this
+        // child context's, not the parent's, so the theory doesn't hold; restored.
+        ScreenGrabber screenGrabber = context.get(ScreenGrabber.class);
+        if (screenGrabber != null) {
+            CoreRegistry.put(ScreenGrabber.class, screenGrabber);
+        }
 
         console = context.get(Console.class);
         MethodCommand.registerAvailable(this, console, context);


### PR DESCRIPTION
Fixes #5321 - save game preview images are always black, from two independent causes.

## Cause 1: ScreenGrabber invisible from CoreRegistry, again

This was already fixed once, then reverted on the theory that `ScreenGrabber` "should already be resolvable from `CoreRegistry`" since `LwjglRenderingSubsystemFactory` registers it in a `ServiceRegistry`. Traced why that theory doesn't hold: `ContextImpl.get()` walks child-to-parent only:

```java
public <T> T get(Class<T> type) {
    ...
    T result = type.cast(map.get(type));
    if (result != null) return result;
    try {
        return beanContext.getBean(type);
    } catch (...) {
        if (parent != null) return parent.get(type);   // fallback UP, never down
        ...
    }
}
```

The `ServiceRegistry` in question is `WorldRendererImpl`'s own child context's - built in its constructor over the outer context passed in (`this.context = new ContextImpl(context, serviceRegistry)`) - not the outer/parent context `CoreRegistry` is bound to. A parent has no path to a child's exclusive registrations, only the reverse. So `CoreRegistry.get(ScreenGrabber.class)` was, and after the revert is again, `null` at save time, and `ReadWriteStorageManager.saveGamePreviewImage()` resolves it that way.

Restored the propagation in `WorldRendererImpl.init()`, with a comment laying out the actual mechanism this time, so the next well-intentioned removal has the concrete fact in front of it instead of re-deriving it (or not).

## Cause 2: the FBO being read predates the last render

`storageManager.startSaving()` (called from `StateIngame.dispose()`) calls `saveGamePreviewImage()` synchronously, which reads whatever the post-processing chain last wrote into the final buffer FBO. By the time `dispose()` runs, at least one frame has passed since the main loop's last `render()` call - normal gameplay keeps that FBO current every frame, but nothing does once the loop stops, so the screenshot captures stale leftover content.

`worldRenderer` is still live in `dispose()` at this point - it isn't disposed until later in the same method - so triggering one more `worldRenderer.render(RenderingStage.MONO)` immediately before the save call populates the FBO with real content right before `ScreenGrabber` reads it. This is the exact call `StateIngame.render()` makes every normal frame; `render()` is self-contained (its own `preRenderUpdate()` re-queues visible chunks and updates the scene), so nothing else needs duplicating here.

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. `GamePreviewImageProviderTest` (path-naming logic only, unrelated to pixel content) still passes, 5/5.

No test exercises the actual pixel-capture path - it needs a live GLFW/GL context through a full save/load round trip, not something headless-testable. This is root-caused and fixed by reading the context hierarchy and the save call sequence, not by reproducing a black screenshot and confirming it's no longer black.
