### PR TITLE
fix(input): stop crash when pressing Ctrl/Tab with no default bind

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/nui/SortOrderSystem.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/SortOrderSystem.java
@@ -98,19 +98,22 @@ public class SortOrderSystem extends BaseComponentSystem {
          if (keys.containsKey(Keyboard.Key.RIGHT_CTRL.getId())) {
              keys.get(Keyboard.Key.RIGHT_CTRL.getId()).subscribe(controlSubscriber);
          } else {
-             keys.put(Keyboard.Key.RIGHT_CTRL.getId(), new BindableButtonImpl(new SimpleUri(TerasologyConstants.ENGINE_MODULE, "ctrlMod"), "Control Modifier", new BindButtonEvent()));
+             keys.put(Keyboard.Key.RIGHT_CTRL.getId(), new BindableButtonImpl(
+                    new SimpleUri(TerasologyConstants.ENGINE_MODULE, "ctrlMod"), "Control Modifier", new BindButtonEvent()));
              keys.get(Keyboard.Key.RIGHT_CTRL.getId()).subscribe(controlSubscriber);
          }
          if (keys.containsKey(Keyboard.Key.LEFT_CTRL.getId())) {
              keys.get(Keyboard.Key.LEFT_CTRL.getId()).subscribe(controlSubscriber);
          } else {
-             keys.put(Keyboard.Key.LEFT_CTRL.getId(), new BindableButtonImpl(new SimpleUri(TerasologyConstants.ENGINE_MODULE, "ctrlMod"), "Control Modifier", new BindButtonEvent()));
+             keys.put(Keyboard.Key.LEFT_CTRL.getId(), new BindableButtonImpl(
+                    new SimpleUri(TerasologyConstants.ENGINE_MODULE, "ctrlMod"), "Control Modifier", new BindButtonEvent()));
              keys.get(Keyboard.Key.LEFT_CTRL.getId()).subscribe(controlSubscriber);
          }
          if (keys.containsKey(Keyboard.Key.TAB.getId())) {
              keys.get(Keyboard.Key.TAB.getId()).subscribe(tabSubscriber);
          } else {
-             keys.put(Keyboard.Key.TAB.getId(), new BindableButtonImpl(new SimpleUri(TerasologyConstants.ENGINE_MODULE, "changeFocus"), "Change Focus", new BindButtonEvent()));
+             keys.put(Keyboard.Key.TAB.getId(), new BindableButtonImpl(
+                    new SimpleUri(TerasologyConstants.ENGINE_MODULE, "changeFocus"), "Change Focus", new BindButtonEvent()));
              keys.get(Keyboard.Key.TAB.getId()).subscribe(tabSubscriber);
          }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/SortOrderSystem.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/SortOrderSystem.java
@@ -5,6 +5,7 @@ package org.terasology.engine.rendering.nui;
 
 import com.google.common.collect.Queues;
 import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.core.TerasologyConstants;
 import org.terasology.engine.core.subsystem.config.BindsManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
@@ -97,19 +98,19 @@ public class SortOrderSystem extends BaseComponentSystem {
          if (keys.containsKey(Keyboard.Key.RIGHT_CTRL.getId())) {
              keys.get(Keyboard.Key.RIGHT_CTRL.getId()).subscribe(controlSubscriber);
          } else {
-             keys.put(Keyboard.Key.RIGHT_CTRL.getId(), new BindableButtonImpl(new SimpleUri("ctrlMod"), "Control Modifier", new BindButtonEvent()));
+             keys.put(Keyboard.Key.RIGHT_CTRL.getId(), new BindableButtonImpl(new SimpleUri(TerasologyConstants.ENGINE_MODULE, "ctrlMod"), "Control Modifier", new BindButtonEvent()));
              keys.get(Keyboard.Key.RIGHT_CTRL.getId()).subscribe(controlSubscriber);
          }
          if (keys.containsKey(Keyboard.Key.LEFT_CTRL.getId())) {
              keys.get(Keyboard.Key.LEFT_CTRL.getId()).subscribe(controlSubscriber);
          } else {
-             keys.put(Keyboard.Key.LEFT_CTRL.getId(), new BindableButtonImpl(new SimpleUri("ctrlMod"), "Control Modifier", new BindButtonEvent()));
+             keys.put(Keyboard.Key.LEFT_CTRL.getId(), new BindableButtonImpl(new SimpleUri(TerasologyConstants.ENGINE_MODULE, "ctrlMod"), "Control Modifier", new BindButtonEvent()));
              keys.get(Keyboard.Key.LEFT_CTRL.getId()).subscribe(controlSubscriber);
          }
          if (keys.containsKey(Keyboard.Key.TAB.getId())) {
              keys.get(Keyboard.Key.TAB.getId()).subscribe(tabSubscriber);
          } else {
-             keys.put(Keyboard.Key.TAB.getId(), new BindableButtonImpl(new SimpleUri("changeFocus"), "Change Focus", new BindButtonEvent()));
+             keys.put(Keyboard.Key.TAB.getId(), new BindableButtonImpl(new SimpleUri(TerasologyConstants.ENGINE_MODULE, "changeFocus"), "Change Focus", new BindButtonEvent()));
              keys.get(Keyboard.Key.TAB.getId()).subscribe(tabSubscriber);
          }
 

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/internal/NUIManagerInternal.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/internal/NUIManagerInternal.java
@@ -773,6 +773,12 @@ public class NUIManagerInternal extends BaseComponentSystem implements NUIManage
     @Priority(EventPriority.PRIORITY_HIGH)
     @ReceiveEvent(components = ClientComponent.class)
     public void bindEvent(BindButtonEvent event, EntityRef entity) {
+        if (!event.getId().isValid()) {
+            // A malformed bind id (e.g. built from the single-arg SimpleUri(String) constructor without a
+            // ":" separator) would otherwise crash the ResourceUrn constructor below on every press. See #5224.
+            logger.warn("Ignoring bind event with invalid id: {}", event.getId());
+            return;
+        }
         NUIBindButtonEvent nuiEvent = new NUIBindButtonEvent(mouse, keyboard,
                 new ResourceUrn(event.getId().getModuleName(), event.getId().getObjectName()).toString(),
                 event.getState());


### PR DESCRIPTION
Fixes #5224 - pressing RIGHT_CTRL (or LEFT_CTRL/TAB once something else already claims the key) crashes with `IllegalArgumentException: moduleName must not be null or empty`.

## Root cause

`SortOrderSystem.postBegin()` creates fallback `BindableButtonImpl` instances for RIGHT_CTRL, LEFT_CTRL and TAB whenever `BindsManager.getKeyBinds()` doesn't already have an entry for that physical key - the common case, since only LEFT_CTRL has a `@DefaultBinding` (`CrouchButton`). Each fallback built its id with the single-arg constructor:

```java
new SimpleUri("ctrlMod")
new SimpleUri("changeFocus")
```

`SimpleUri(String)` only populates `moduleName`/`objectName` when the string contains a `:` separator; without one it silently returns an invalid URI (both names empty) instead of failing fast:

```java
public SimpleUri(String simpleUri) {
    if (simpleUri == null) { return; }
    String[] split = simpleUri.split(MODULE_SEPARATOR, 2);
    if (split.length > 1) {
        moduleName = new Name(split[0]);
        objectName = new Name(split[1]);
    }
}
```

The bind system doesn't notice - `BindableButtonImpl` just carries the id around - until `NUIManagerInternal.bindEvent()` calls `event.getId().getModuleName()`/`getObjectName()` straight into `new ResourceUrn(...)`, which does validate and throws. Matches the stack trace in the issue exactly (`bindEvent`, `BindableButtonImpl.updateBindState`).

## Fix

1. **`SortOrderSystem`** - build the ids with the proper `SimpleUri(Name, String)` constructor and `TerasologyConstants.ENGINE_MODULE`, the same convention the engine's own built-in binds use.
2. **`NUIManagerInternal.bindEvent()`** - added a defensive `event.getId().isValid()` guard that logs and returns instead of constructing the `ResourceUrn`, so any other malformed bind id (module code, not just this call site) degrades to a log line instead of taking down the input pipeline.

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. No existing test exercises `SortOrderSystem` or `NUIManagerInternal.bindEvent` directly - both need a live `BindsManager`/NUI event pipeline, not something unit-testable in isolation.

Root-caused and fixed by tracing the exact `SimpleUri` construction/validation path named in the issue's own stack trace, matching soloturn's comment confirming this still reproduces on current develop.
