### PR TITLE
fix(headless): actually check readiness in pregenerateChunks

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/subsystem/headless/renderer/HeadlessWorldRenderer.java
+++ b/engine/src/main/java/org/terasology/engine/core/subsystem/headless/renderer/HeadlessWorldRenderer.java
@@ -132,8 +132,12 @@ public class HeadlessWorldRenderer implements WorldRenderer {
 
     @Override
     public boolean pregenerateChunks() {
-        // TODO Auto-generated method stub
-        return false;
+        chunkProvider.update();
+        // force=true: updateChunksInProximity's "did the camera move" shortcut never fires here since the
+        // headless camera position never changes, so a forced full rescan is the only way to learn whether
+        // every chunk in view distance has actually loaded (see #5024).
+        updateChunksInProximity(true);
+        return !pendingChunks;
     }
 
     @Override


### PR DESCRIPTION
Fixes #5024 - `PrepareWorld` always waits the full 5 seconds in headless, regardless of how quickly the world is actually ready.

## Root cause

`PrepareWorld.step()` loops until `worldRenderer.pregenerateChunks()` returns `true` or 5 seconds elapse. `HeadlessWorldRenderer.pregenerateChunks()` was an unimplemented stub:

```java
@Override
public boolean pregenerateChunks() {
    // TODO Auto-generated method stub
    return false;
}
```

Always `false` means the loop only ever exits via the timeout, so every headless run - including every MTE integration test - burns the full 5 seconds here no matter how small or fast-generating the test world is.

## Fix

Implemented it using the same chunk-loaded/local-view readiness check `updateChunksInProximity()` already performs for per-frame updates: advance `chunkProvider`, force a full rescan of the current view region, and report done once every chunk in it is loaded (`chunkProvider.getChunk(pos) != null && worldProvider.getLocalView(pos) != null` for each position) - mirroring what the graphical `RenderableWorldImpl.pregenerateChunks()` checks, minus the mesh-generation part that doesn't apply headless.

The rescan has to be **forced**. `updateChunksInProximity`'s own "did the camera move" shortcut is keyed off `chunkPos`, which never changes in headless (`NullCamera` always reports the same position) - an unforced call would never re-examine chunk state and would permanently report "nothing pending" from its zero-value field default. That's a second, more subtle way to land on the same always-`true`-without-checking-anything failure mode as a bare `return true`, which is what @keturn's comment on the issue describes having already tried and found broke a following test.

## Verification

`:engine:compileJava` clean. Ran the full `engine-tests:integrationTest` suite scoped to `org.terasology.engine.integrationenvironment.*` - 18 MTE test classes, 34 tests total, covering both per-class and per-method lifecycles, run back-to-back in the same JVM. This is the exact scenario keturn's earlier attempt broke ("first test fine, next one had problems"). All 34 pass, 0 failures, 0 errors.

No existing test exercises `HeadlessWorldRenderer.pregenerateChunks()` directly, only indirectly through the full MTE bootstrap above.
