### PR TITLE
fix(behavior): re-inject shared Action fields when a tree is copied

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/behavior/core/ActionNode.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/core/ActionNode.java
@@ -8,6 +8,7 @@ import org.terasology.nui.properties.OneOfProviderFactory;
 import org.terasology.nui.properties.PropertyProvider;
 import org.terasology.reflection.reflect.ReflectFactory;
 import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.registry.InjectionHelper;
 
 /**
  * An action node uses a associated Action to control the result state.
@@ -85,7 +86,26 @@ public class ActionNode implements BehaviorNode {
 
     @Override
     public BehaviorNode deepCopy() {
+        reinjectAction();
         return new ActionNode(action);
+    }
+
+    /**
+     * Re-runs {@code @In} field injection on the shared {@link #action} instance.
+     * <p>
+     * {@link BehaviorTreeBuilder} already injects {@link #action} once, when the tree's JSON is first
+     * deserialized - but that can happen as early as {@code LoadPrefabs}, which runs before
+     * {@code RegisterSystems} has shared anything into {@link CoreRegistry} yet, leaving {@code @In}
+     * fields silently null (see #5004). {@code deepCopy()} instead runs once an {@link Actor} actually
+     * exists to attach the tree to, which is always well after the engine has finished loading, so
+     * re-injecting here is a safe, cheap way to guarantee valid values without reordering the load
+     * sequence itself. {@link InjectionHelper#inject(Object)} only overwrites a field when it finds a
+     * non-null value, so repeating this on every copy is idempotent.
+     */
+    protected void reinjectAction() {
+        if (action != null) {
+            InjectionHelper.inject(action);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/terasology/engine/logic/behavior/core/DecoratorNode.java
+++ b/engine/src/main/java/org/terasology/engine/logic/behavior/core/DecoratorNode.java
@@ -36,6 +36,7 @@ public class DecoratorNode extends ActionNode {
 
     @Override
     public BehaviorNode deepCopy() {
+        reinjectAction();
         DecoratorNode node = new DecoratorNode();
         node.setAction(action);
         node.child = child;


### PR DESCRIPTION
Fixes #5004 - `@In`-annotated fields on behavior tree `Action`s sometimes stay null, causing NPEs. The workaround in [Terasology/Behaviors#102](https://github.com/Terasology/Behaviors/pull/102) routes around it by fetching from `CoreRegistry` manually inside each action instead of relying on `@In`.

## Root cause

`Action`'s own javadoc already says it: "There is only one action instance for all actors that run a behavior tree" - `BehaviorTreeBuilder.addAction()` injects `@In` fields into that single shared `Action` once, when the tree's JSON is first deserialized. `ActionNode.deepCopy()`/`DecoratorNode.deepCopy()` (used per-`Actor` by `DefaultBehaviorTreeRunner`) reuse that same instance rather than constructing a fresh one, matching the "one instance for all actors" design - so the single injection is *meant* to be enough.

The problem is **when** it runs. BehaviorTree assets are only loaded on demand, and `StateLoading`'s load sequence resolves every prefab's assets in `LoadPrefabs` before `RegisterSystems` has shared anything into `CoreRegistry`:

```java
addAndTrack(new LoadPrefabs(context));
addAndTrack(new RegisterSystems(context, netMode));
...
addAndTrack(new InitialiseSystems(context));
```

Any prefab that references a `BehaviorTree` component triggers `BehaviorTreeFormat.load()` during `LoadPrefabs`, which is exactly where `addAction()`'s `InjectionHelper.inject(action)` call runs - `CoreRegistry.get(fieldType)` returns `null` for every system at that point, so every `@In` field is silently skipped and stays `null`, and never gets a second chance since the tree is only ever built once per asset.

## Fix

Re-run `InjectionHelper.inject()` on the shared action in `ActionNode`/`DecoratorNode.deepCopy()`, which only runs once an `Actor` actually exists to attach the tree to - always well after the engine has finished loading and `RegisterSystems`/`InitialiseSystems` have run. This fixes the fields without touching the `LoadPrefabs`/`RegisterSystems` ordering itself, which has a much bigger blast radius than I can verify from reading alone. `InjectionHelper.inject()` only overwrites a field when it finds a non-null value, so repeating it on every copy is idempotent - no risk to entities whose fields were already valid.

`Action#setup()`, which the interface's own javadoc says runs "right after all fields are injected", is **not** re-invoked here - it already ran once, at the same premature `LoadPrefabs`-time point, and re-running arbitrary subclass `setup()` logic on every per-actor copy risks duplicating side effects for any action whose `setup()` isn't idempotent. No action in the engine itself overrides `setup()` with anything beyond `BaseAction`'s no-op, so this is a narrower gap than the field-injection one, but worth flagging as a possible follow-up for modules whose actions do rely on it.

## Verification

`:engine:compileJava` clean. `engine-tests:unitTest` scoped to `org.terasology.engine.logic.behavior.*` (`SequenceTest`, `SelectorTest`, `ParallelTest`, `DynamicSelectorTest`, `CounterTest`, `CountCallsTest`) all pass - 4 of those 5 executing suites exercise `deepCopy()` directly.

No test reproduces the actual `LoadPrefabs`-before-`RegisterSystems` race, since that needs a full module environment with a `BehaviorTree`-referencing prefab and an injectable system, not something covered by the existing behavior-tree unit tests (which build trees directly in Java, bypassing asset loading entirely).
