### PR TITLE
fix(persistence): stop ProtobufPersistedData.isArray() lying for maps

### DIFF
--- a/engine/src/main/java/org/terasology/engine/persistence/typeHandling/protobuf/ProtobufPersistedData.java
+++ b/engine/src/main/java/org/terasology/engine/persistence/typeHandling/protobuf/ProtobufPersistedData.java
@@ -198,7 +198,13 @@ public class ProtobufPersistedData implements PersistedData, PersistedDataArray 
 
     @Override
     public boolean isArray() {
-        return true;
+        // A single EntityData.Value message doubles as a scalar, an array (repeated scalar/nested-value
+        // fields) and a value map (name-value pairs), so unlike the Gson-backed PersistedData this can't
+        // just check "is this element shaped like a JSON array". Every other kind (including scalars,
+        // which callers already treat as size-1 arrays via getAsArray()/getArrayItem()) genuinely can be
+        // read as an array; only a real value map can't - mirror isValueMap()'s own check instead of
+        // reporting true unconditionally. See #5069.
+        return data.getNameValueCount() == 0;
     }
 
     @Override


### PR DESCRIPTION
Fixes #5069 - `PersistedData.isArray()` can return `true` for data that is actually a value map, forcing callers to add their own `isValueMap()` check to tell the two apart, as `GenericMapTypeHandler` had to when reading save-game data ([#5062](https://github.com/MovingBlocks/Terasology/pull/5062)).

## Root cause

Gson-backed `PersistedData` (JSON config/prefabs) already scopes `isArray()` correctly - `AbstractGsonPersistedData` just delegates to `JsonElement.isJsonArray()`, which is never `true` for a `JsonObject`.

`ProtobufPersistedData` - the class backing **save-game entity serialization** - is different. A single `EntityData.Value` protobuf message doubles as a scalar, an array (repeated scalar/nested-value fields) and a value map (name-value pairs), and `isArray()` ignored all of that:

```java
public boolean isArray() {
    return true;
}
```

So for any save-game field actually shaped as a map, `isArray()` lied, and the only way to tell was the separate `isValueMap()` check `GenericMapTypeHandler` already had to add. Every other `isArray()`/`getAsArray()` caller in the type-handling code has the same latent exposure, just less likely to hit it in practice since `Map` fields are where array/map shape confusion naturally arises.

## Fix

Mirror `isValueMap()`'s own check instead of hardcoding `true`:

```java
public boolean isArray() {
    return data.getNameValueCount() == 0;
}
```

Every other kind this class represents - scalars (already treated as size-1 arrays by `getAsArray()`/`getArrayItem()` elsewhere in this class), genuine repeated-value arrays, and null - keeps reporting `isArray()` as `true` exactly as before; only the one case that was actually wrong (a real value map) now correctly reports `false`. `getAsArray()` is gated on `isArray()`, so this also means it now correctly throws instead of silently succeeding when called on map-shaped data.

`GenericMapTypeHandler`'s existing `isValueMap()` check is now redundant for this case but harmless, so it's left in place rather than touched here.

## Verification

`:engine:compileJava` clean. `engine-tests:unitTest` and `subsystems:TypeHandlerLibrary:test` both pass in full, no failures - notably `EntitySerializerTest` (14 tests), which round-trips components through the real `EntityData.Entity` protobuf path this class backs, and `GenericMapTypeHandlerTest`/`CollectionTypeHandlerTest`/`ArrayTypeHandlerTest`, which cover the array/map-shape-detection callers most exposed to this bug.
