### PR TITLE
perf(input): stop sending CharacterMoveInputEvent every idle tick

### DIFF
--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
@@ -118,6 +118,10 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     private boolean sentIdleInput;
     private boolean lastSentRun = run;
     private boolean lastSentCrouch = crouch;
+    // setRotation() (SetDirectionEvent) sets lookPitch/lookYaw directly rather than going through
+    // lookPitchDelta/lookYawDelta, so the delta fields alone can't detect that kind of view change.
+    private float lastSentLookPitch = lookPitch;
+    private float lastSentLookYaw = lookYaw;
 
     @In
     private Time time;
@@ -164,7 +168,12 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
         boolean hasMovementOrLookInput = relativeMovement.x != 0 || relativeMovement.y != 0 || relativeMovement.z != 0
                 || lookYawDelta != 0 || lookPitchDelta != 0 || jump;
         boolean toggleStateChanged = run != lastSentRun || crouch != lastSentCrouch;
-        if (!hasMovementOrLookInput && !toggleStateChanged && sentIdleInput) {
+        // setRotation() can move lookPitch/lookYaw directly between ticks, outside of lookPitchDelta/
+        // lookYawDelta - catch that here too, or a SetDirectionEvent arriving while otherwise idle
+        // would silently never reach the server.
+        boolean absoluteViewChanged = Float.compare(lookPitch, lastSentLookPitch) != 0
+                || Float.compare(lookYaw, lastSentLookYaw) != 0;
+        if (!hasMovementOrLookInput && !toggleStateChanged && !absoluteViewChanged && sentIdleInput) {
             // Nothing changed since the last (already-sent) idle tick. ServerCharacterPredictionSystem's
             // own periodic "repeat last input" fallback (~every 50ms, see MAX_INPUT_UNDERFLOW) keeps
             // gravity and physics ticking for this character from the last sent state without us having
@@ -202,6 +211,8 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
             sentIdleInput = !hasMovementOrLookInput && !toggleStateChanged;
             lastSentRun = run;
             lastSentCrouch = crouch;
+            lastSentLookPitch = lookPitch;
+            lastSentLookYaw = lookYaw;
         }
         jump = false;
     }
@@ -258,6 +269,10 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
             // the correct location.
             lookYaw = 0f;
             lookPitch = 0f;
+            // sentIdleInput may still be true from a previous character entity's idle streak (e.g.
+            // after death and respawn) - reset it so the new entity's first event always sends,
+            // instead of being mistaken for a repeat of an idle tick it never actually had.
+            sentIdleInput = false;
             update(0);
         }
     }

--- a/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
+++ b/engine/src/main/java/org/terasology/engine/logic/players/LocalPlayerSystem.java
@@ -111,6 +111,14 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
     private float lookYaw;
     private double lookYawDelta;
 
+    // Tracks whether the most recently sent CharacterMoveInputEvent already reported "nothing is
+    // happening" (see processInput) - lets us skip re-sending an identical no-op event every single
+    // tick while idle, per #4993, while still sending the one event that marks the transition into
+    // idle so the server's own periodic "repeat last input" fallback has a state to continue from.
+    private boolean sentIdleInput;
+    private boolean lastSentRun = run;
+    private boolean lastSentCrouch = crouch;
+
     @In
     private Time time;
 
@@ -148,6 +156,19 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
             lookPitchDelta = 0;
             lookYawDelta = 0;
             jump = false;
+            // Force the first tick after refocus to send, whatever it finds.
+            sentIdleInput = false;
+            return;
+        }
+
+        boolean hasMovementOrLookInput = relativeMovement.x != 0 || relativeMovement.y != 0 || relativeMovement.z != 0
+                || lookYawDelta != 0 || lookPitchDelta != 0 || jump;
+        boolean toggleStateChanged = run != lastSentRun || crouch != lastSentCrouch;
+        if (!hasMovementOrLookInput && !toggleStateChanged && sentIdleInput) {
+            // Nothing changed since the last (already-sent) idle tick. ServerCharacterPredictionSystem's
+            // own periodic "repeat last input" fallback (~every 50ms, see MAX_INPUT_UNDERFLOW) keeps
+            // gravity and physics ticking for this character from the last sent state without us having
+            // to re-send an identical no-op event every single frame. See #4993.
             return;
         }
 
@@ -178,6 +199,9 @@ public class LocalPlayerSystem extends BaseComponentSystem implements UpdateSubs
         if (relMove.isFinite()) {
             entity.send(new CharacterMoveInputEvent(inputSequenceNumber++, lookPitch, lookYaw, relMove, run, crouch,
                     jump, time.getGameDeltaInMs()));
+            sentIdleInput = !hasMovementOrLookInput && !toggleStateChanged;
+            lastSentRun = run;
+            lastSentCrouch = crouch;
         }
         jump = false;
     }


### PR DESCRIPTION
Fixes #4993 - `LocalPlayerSystem.processInput()` sent a `CharacterMoveInputEvent` every single tick regardless of whether the player was providing any input, creating a lot of unnecessary events and debug-log noise.

## ⚠️ Please verify live before merging

This is reasoned from tracing the gravity/replication code paths (see below), **not from observing a running game** - I don't have a GL context available here. The one behavior actually worth double-checking by hand: stand a local-player character still (no keys, no mouse movement) somewhere it should fall - e.g. dig out the block underneath, or spawn over a pit - and confirm it still falls promptly instead of hovering. My reading says `ServerCharacterPredictionSystem`'s existing ~100-150ms "repeat last input" fallback covers this, but that fallback was written for network-jitter tolerance, not for this case, and I can't rule out some interaction I haven't seen. If it turns out to hover, the fix needs to go back to decoupling gravity from `CharacterMoveInputEvent` directly rather than leaning on that fallback.

## Why the obvious fix wasn't safe

`KinematicCharacterMover` only applies gravity (`GRAVITY * movementComp.mode.scaleGravity`) inside `step()`, which only runs when a `CharacterMoveInputEvent` is processed - so a naive "return early if nothing changed" (as originally proposed on the issue) would leave an idle local player floating in place instead of falling, e.g. if a block were removed underfoot. This dependency is exactly what skaldarnar's comment on the issue guessed at.

## Why it's safe anyway

`ServerCharacterPredictionSystem.update()` (`@RegisterSystem(AUTHORITY)`, so this runs for single-player and any host, which is what #4993's own report exercises) already has a "haven't received input in a while, repeat last input" fallback: every `TIME_BETWEEN_STATE_REPLICATE` (50ms), it checks whether the buffered state has fallen more than `MAX_INPUT_UNDERFLOW` (100ms) behind game time, and if so synthesizes a continuation `CharacterMoveInputEvent` from the last real input (with an updated `deltaMs`) and re-steps physics with it. This was almost certainly built for network-jitter tolerance, but it equally covers "the local player stopped sending input" - gravity keeps ticking at a worst-case ~100-150ms cadence regardless, well below the threshold of being noticeable, and self-corrects every replication cycle either way.

Also checked: `CharacterMoveInputEvent.sequenceNumber` has no contiguity requirement (`ClientCharacterPredictionSystem` only compares it with `<=`, to drop already-acknowledged inputs), and the server reconstructs elapsed idle time from its own wall clock rather than from anything the client sends, so skipped sends don't create a "lost time" gap when input resumes.

## Fix

`processInput()` now tracks whether the last sent event was itself a "nothing happening" tick (`sentIdleInput`) and skips sending again while that stays true - i.e. it always sends the *first* idle tick (giving the server's fallback a state to continue from) and any tick with real movement/look/jump input or a run/crouch toggle change, but suppresses the identical repeats in between. Losing window focus still resets the idle marker, so the very next focused tick always sends, regardless of what it finds.

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. `LocalPlayerSystem` has no existing test coverage (needs a live input pipeline, display and camera, not something unit-testable in isolation), so this is root-caused and fixed by tracing the actual gravity/replication code paths, not by observing a running game.
