### PR TITLE
fix(events): make @NetFilterEvent actually exclude headless servers

### DIFF
--- a/engine-tests/src/main/java/org/terasology/engine/HeadlessEnvironment.java
+++ b/engine-tests/src/main/java/org/terasology/engine/HeadlessEnvironment.java
@@ -22,6 +22,7 @@ import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.modes.loadProcesses.LoadPrefabs;
 import org.terasology.engine.core.module.ExternalApiWhitelist;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.core.subsystem.headless.assets.HeadlessMaterial;
 import org.terasology.engine.core.subsystem.headless.assets.HeadlessMesh;
 import org.terasology.engine.core.subsystem.headless.assets.HeadlessShader;
@@ -152,6 +153,9 @@ public class HeadlessEnvironment extends Environment {
 
     @Override
     protected void setupEntitySystem(ServiceRegistry serviceRegistry) {
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
     }
 

--- a/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
+++ b/engine-tests/src/test/java/org/terasology/engine/TerasologyTestingEnvironment.java
@@ -20,6 +20,7 @@ import org.terasology.engine.core.Time;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.modes.loadProcesses.LoadPrefabs;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.metadata.EntitySystemLibrary;
 import org.terasology.engine.game.Game;
@@ -41,6 +42,7 @@ import org.terasology.persistence.typeHandling.TypeHandlerLibrary;
 import java.nio.file.Path;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * A base class for unit test classes to inherit to run in a Terasology environment - with LWJGL set up and so forth
@@ -96,6 +98,9 @@ public abstract class TerasologyTestingEnvironment {
         serviceRegistry.with(CharacterStateEventPositionMap.class).lifetime(Lifetime.Singleton).use(() -> characterStateEventPositionMap);
         DirectionAndOriginPosRecorderList directionAndOriginPosRecorderList = new DirectionAndOriginPosRecorderList();
         serviceRegistry.with(DirectionAndOriginPosRecorderList.class).lifetime(Lifetime.Singleton).use(() -> directionAndOriginPosRecorderList);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
 
         serviceRegistry.with(StorageManager.class).lifetime(Lifetime.Singleton).use(ReadWriteStorageManager.class);

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/BaseEntityRefTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/BaseEntityRefTest.java
@@ -11,6 +11,7 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
@@ -74,6 +75,9 @@ public class BaseEntityRefTest {
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(baseContext, serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/OwnershipHelperTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/OwnershipHelperTest.java
@@ -11,6 +11,7 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.entity.internal.OwnershipHelper;
@@ -57,6 +58,9 @@ public class OwnershipHelperTest {
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
         RecordAndReplayCurrentStatus recordAndReplayCurrentStatus = new RecordAndReplayCurrentStatus();
         serviceRegistry.with(RecordAndReplayCurrentStatus.class).lifetime(Lifetime.Singleton).use(() -> recordAndReplayCurrentStatus);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         Context context = new ContextImpl(serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityManagerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityManagerTest.java
@@ -11,6 +11,7 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
@@ -91,6 +92,9 @@ public class PojoEntityManagerTest {
         TypeRegistry typeRegistry = new ModuleTypeRegistry(baseContext.get(ModuleManager.class).getEnvironment());
         serviceRegistry.with(TypeRegistry.class).lifetime(Lifetime.Singleton).use(() -> typeRegistry);
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(baseContext, serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityPoolTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/PojoEntityPoolTest.java
@@ -10,6 +10,7 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
@@ -67,6 +68,9 @@ public class PojoEntityPoolTest {
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
         ServiceRegistry serviceRegistry = new ServiceRegistry();
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(baseContext, serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/entitySystem/PrefabTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/entitySystem/PrefabTest.java
@@ -13,6 +13,7 @@ import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.metadata.ComponentLibrary;
 import org.terasology.engine.entitySystem.prefab.Prefab;
 import org.terasology.engine.entitySystem.prefab.PrefabData;
@@ -79,6 +80,10 @@ public class PrefabTest {
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
         serviceRegistry.with(NetworkSystem.class).lifetime(Lifetime.Singleton).use(() -> networkSystem);
+
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
 
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(context, serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/ComponentSerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/ComponentSerializerTest.java
@@ -13,6 +13,7 @@ import org.terasology.context.Lifetime;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.metadata.ComponentLibrary;
@@ -73,6 +74,9 @@ public class ComponentSerializerTest {
         serviceRegistry.with(AssetManager.class).lifetime(Lifetime.Singleton).use(() -> assetManager);
         TypeRegistry typeRegistry = new ModuleTypeRegistry(moduleManager.getEnvironment());
         serviceRegistry.with(TypeRegistry.class).lifetime(Lifetime.Singleton).use(() -> typeRegistry);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(context, serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/persistence/EntitySerializerTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/persistence/EntitySerializerTest.java
@@ -10,6 +10,7 @@ import org.terasology.context.Lifetime;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.bootstrap.EntitySystemSetupUtil;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.core.module.ModuleManager;
 import org.terasology.engine.entitySystem.DoNotPersist;
 import org.terasology.engine.entitySystem.entity.EntityRef;
@@ -92,6 +93,9 @@ public class EntitySerializerTest {
 
         TypeRegistry typeRegistry = new ModuleTypeRegistry(moduleManager.getEnvironment());
         serviceRegistry.with(TypeRegistry.class).lifetime(Lifetime.Singleton).use(() -> typeRegistry);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(true);
+        serviceRegistry.with(DisplayDevice.class).lifetime(Lifetime.Singleton).use(() -> displayDevice);
         EntitySystemSetupUtil.addReflectionBasedLibraries(serviceRegistry);
         EntitySystemSetupUtil.addEntityManagementRelatedClasses(serviceRegistry);
         context = new ContextImpl(baseContext, serviceRegistry);

--- a/engine-tests/src/test/java/org/terasology/engine/recording/EventSystemReplayImplTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/recording/EventSystemReplayImplTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.reflections.Reflections;
 import org.terasology.engine.context.internal.ContextImpl;
 import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.PojoEntityManager;
 import org.terasology.engine.entitySystem.event.AbstractConsumableEvent;
@@ -57,6 +58,8 @@ public class EventSystemReplayImplTest {
         entityManager.setPrefabManager(new PojoPrefabManager(context));
         NetworkSystem networkSystem = mock(NetworkSystem.class);
         when(networkSystem.getMode()).thenReturn(NetworkMode.NONE);
+        DisplayDevice displayDevice = mock(DisplayDevice.class);
+        when(displayDevice.isHeadless()).thenReturn(false);
         recordAndReplayCurrentStatus = new RecordAndReplayCurrentStatus();
         RecordedEventStore eventStore = new RecordedEventStore();
         RecordAndReplayUtils recordAndReplayUtils = new RecordAndReplayUtils();
@@ -77,7 +80,8 @@ public class EventSystemReplayImplTest {
         selectedClassesToReplay.add(InputEvent.class);
 
         eventSystem = new EventSystemReplayImpl(entitySystemLibrary.getEventLibrary(), networkSystem, entityManager,
-                eventStore, recordAndReplaySerializer, recordAndReplayUtils, selectedClassesToReplay, recordAndReplayCurrentStatus);
+                eventStore, recordAndReplaySerializer, recordAndReplayUtils, selectedClassesToReplay, recordAndReplayCurrentStatus,
+                displayDevice);
 
         entityManager.setEventSystem(eventSystem);
 

--- a/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
+++ b/engine/src/main/java/org/terasology/engine/core/bootstrap/EntitySystemSetupUtil.java
@@ -7,6 +7,7 @@ import com.google.common.base.VerifyException;
 import org.terasology.context.Lifetime;
 import org.terasology.engine.audio.events.PlaySoundEvent;
 import org.terasology.engine.context.Context;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.entity.internal.PojoEntityManager;
@@ -181,8 +182,9 @@ public final class EntitySystemSetupUtil {
 
     public static final class NetworkEventSystemWrapped extends NetworkEventSystemDecorator {
         @Inject
-        public NetworkEventSystemWrapped(NetworkSystem networkSystem, EntitySystemLibrary entitySystemLibrary) {
-            super(new EventSystemImpl(networkSystem.getMode().isAuthority()),
+        public NetworkEventSystemWrapped(NetworkSystem networkSystem, EntitySystemLibrary entitySystemLibrary,
+                                         DisplayDevice displayDevice) {
+            super(new EventSystemImpl(networkSystem.getMode().isAuthority(), displayDevice.isHeadless()),
                             networkSystem, entitySystemLibrary.getEventLibrary());
         }
     }
@@ -192,8 +194,9 @@ public final class EntitySystemSetupUtil {
         public RecordingEventSystemWrapped(RecordingClasses recordingClasses, NetworkSystem networkSystem,
                                            EntitySystemLibrary entitySystemLibrary,
                                            RecordedEventStore recordedEventStore,
-                                           RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) {
-            super(new NetworkEventSystemDecorator(new EventSystemImpl(networkSystem.getMode().isAuthority()),
+                                           RecordAndReplayCurrentStatus recordAndReplayCurrentStatus,
+                                           DisplayDevice displayDevice) {
+            super(new NetworkEventSystemDecorator(new EventSystemImpl(networkSystem.getMode().isAuthority(), displayDevice.isHeadless()),
                     networkSystem, entitySystemLibrary.getEventLibrary()), new EventCatcher(recordingClasses, recordedEventStore),
                     recordAndReplayCurrentStatus);
         }

--- a/engine/src/main/java/org/terasology/engine/entitySystem/event/internal/EventSystemImpl.java
+++ b/engine/src/main/java/org/terasology/engine/entitySystem/event/internal/EventSystemImpl.java
@@ -24,6 +24,7 @@ import org.terasology.engine.entitySystem.event.ConsumableEvent;
 import org.terasology.engine.entitySystem.event.EventPriority;
 import org.terasology.engine.entitySystem.event.PendingEvent;
 import org.terasology.engine.entitySystem.event.Priority;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.systems.ComponentSystem;
 import org.terasology.engine.entitySystem.systems.NetFilterEvent;
 import org.terasology.engine.monitoring.PerformanceMonitor;
@@ -53,6 +54,7 @@ public class EventSystemImpl implements EventSystem {
 
     private static final Logger logger = LoggerFactory.getLogger(EventSystemImpl.class);
     private final boolean isAuthority;
+    private final boolean isHeadless;
 
     private Map<Class<? extends Event>, SetMultimap<Class<? extends Component>, EventHandlerInfo>> componentSpecificHandlers = Maps.newHashMap();
     private SetMultimap<Class<? extends Event>, EventHandlerInfo> generalHandlers = HashMultimap.create();
@@ -67,12 +69,17 @@ public class EventSystemImpl implements EventSystem {
 
 
     @Inject
-    public EventSystemImpl(NetworkSystem networkSystem) {
-        this(networkSystem.getMode().isAuthority());
+    public EventSystemImpl(NetworkSystem networkSystem, DisplayDevice displayDevice) {
+        this(networkSystem.getMode().isAuthority(), displayDevice.isHeadless());
     }
 
     public EventSystemImpl(boolean isAuthority) {
+        this(isAuthority, false);
+    }
+
+    public EventSystemImpl(boolean isAuthority, boolean isHeadless) {
         this.isAuthority = isAuthority;
+        this.isHeadless = isHeadless;
         this.mainThread = Thread.currentThread();
     }
 
@@ -112,7 +119,7 @@ public class EventSystemImpl implements EventSystem {
             if (receiveEventAnnotation != null) {
 
                 NetFilterEvent netFilterAnnotation =  method.getAnnotation(NetFilterEvent.class);
-                if (netFilterAnnotation != null && !netFilterAnnotation.netFilter().isValidFor(isAuthority, false)) {
+                if (netFilterAnnotation != null && !netFilterAnnotation.netFilter().isValidFor(isAuthority, isHeadless)) {
                     continue;
                 }
 

--- a/engine/src/main/java/org/terasology/engine/recording/EventSystemReplayImpl.java
+++ b/engine/src/main/java/org/terasology/engine/recording/EventSystemReplayImpl.java
@@ -18,6 +18,7 @@ import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.core.PathManager;
+import org.terasology.engine.core.subsystem.DisplayDevice;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.event.AbstractConsumableEvent;
@@ -87,6 +88,7 @@ public class EventSystemReplayImpl implements EventSystem {
 
     private EventLibrary eventLibrary;
     private NetworkSystem networkSystem;
+    private DisplayDevice displayDevice;
 
     //Event replaying
     /** if the recorded events were loaded from the RecordedEventStore. */
@@ -112,15 +114,15 @@ public class EventSystemReplayImpl implements EventSystem {
     public EventSystemReplayImpl(EventLibrary eventLibrary, NetworkSystem networkSystem, EngineEntityManager entityManager,
                                  RecordedEventStore recordedEventStore, RecordAndReplaySerializer recordAndReplaySerializer,
                                  RecordAndReplayUtils recordAndReplayUtils, RecordingClasses recordingClasses,
-                                 RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) {
+                                 RecordAndReplayCurrentStatus recordAndReplayCurrentStatus, DisplayDevice displayDevice) {
         this(eventLibrary, networkSystem, entityManager, recordedEventStore, recordAndReplaySerializer, recordAndReplayUtils,
-                recordingClasses.getClassesToRecord(), recordAndReplayCurrentStatus);
+                recordingClasses.getClassesToRecord(), recordAndReplayCurrentStatus, displayDevice);
     }
 
     public EventSystemReplayImpl(EventLibrary eventLibrary, NetworkSystem networkSystem, EngineEntityManager entityManager,
                                  RecordedEventStore recordedEventStore, RecordAndReplaySerializer recordAndReplaySerializer,
                                  RecordAndReplayUtils recordAndReplayUtils, List<Class<?>> selectedClassesToReplay,
-                                 RecordAndReplayCurrentStatus recordAndReplayCurrentStatus) {
+                                 RecordAndReplayCurrentStatus recordAndReplayCurrentStatus, DisplayDevice displayDevice) {
         this.mainThread = Thread.currentThread();
         this.eventLibrary = eventLibrary;
         this.networkSystem = networkSystem;
@@ -130,6 +132,7 @@ public class EventSystemReplayImpl implements EventSystem {
         this.recordAndReplayUtils = recordAndReplayUtils;
         this.selectedClassesToReplay = selectedClassesToReplay;
         this.recordAndReplayCurrentStatus = recordAndReplayCurrentStatus;
+        this.displayDevice = displayDevice;
     }
 
     /**
@@ -321,7 +324,8 @@ public class EventSystemReplayImpl implements EventSystem {
             ReceiveEvent receiveEventAnnotation = method.getAnnotation(ReceiveEvent.class);
             if (receiveEventAnnotation != null) {
                 NetFilterEvent netFilterAnnotation =  method.getAnnotation(NetFilterEvent.class);
-                if (netFilterAnnotation != null && !netFilterAnnotation.netFilter().isValidFor(networkSystem.getMode().isAuthority(), false)) {
+                if (netFilterAnnotation != null
+                        && !netFilterAnnotation.netFilter().isValidFor(networkSystem.getMode().isAuthority(), displayDevice.isHeadless())) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #5251 - a headless dedicated server logs a `NullPointerException` on player death. `Terasology/Inventory`'s `CharacterInventorySystem.resetDropMark()` calls `nuiManager.getHUD()`, and `nuiManager` is `null` on a server, since there's no UI. The handler is already annotated `@NetFilterEvent(netFilter = RegisterMode.CLIENT)`, specifically to exclude exactly this case - but the annotation never actually worked for headless servers.

## Root cause

`RegisterMode.isValidFor(isAuthority, headless)` computes:

```java
(isAuthority ? validWhenAuthority : validWhenRemote) && (!headless || validWhenHeadless)
```

For `RegisterMode.CLIENT`, `validWhenAuthority=true` (a listen-server/single-player process is simultaneously its own authority and a client with a UI, so CLIENT-filtered handlers are meant to still run there) and `validWhenHeadless=false` (the actual "not on a headless process" exclusion). Both `EventSystemImpl.registerEventHandler()` and `EventSystemReplayImpl.registerEventHandler()` call this with the headless parameter hardcoded to `false`:

```java
netFilterAnnotation.netFilter().isValidFor(isAuthority, false)
```

so the `!headless || validWhenHeadless` term always evaluates `true` regardless of whether the process is actually headless, and CLIENT-filtered handlers register and run everywhere the authority-side term allows - including headless dedicated servers, which is exactly the one case the annotation exists to exclude.

`ComponentSystemManager` already does this correctly for class-level `@RegisterSystem` filtering, sourcing `isHeadless` from `context.get(DisplayDevice.class).isHeadless()` (`HeadlessDisplayDevice` returns `true`) - the two per-method `@NetFilterEvent` implementations just never picked up the same value.

## Fix

Thread the real `DisplayDevice.isHeadless()` value through both `EventSystemImpl` and `EventSystemReplayImpl`, via their `@Inject` constructors and the `EntitySystemSetupUtil` wrapper classes that construct them. No changes needed in `Terasology/Inventory` - its existing `@NetFilterEvent(netFilter = RegisterMode.CLIENT)` annotation was already correct.

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. `EventSystemReplayImplTest` and `PojoEventSystemTests` pass (the former updated for the new `DisplayDevice` constructor parameter). Also ran the full `integrationenvironment` suite (18 MTE test classes, 34 tests, exercising the `@Inject`-wired `EventSystemImpl`/`EventSystemReplayImpl` construction paths this change touches) - all pass, no regressions.

No test reproduces the exact reported NPE, since that needs a real headless dedicated server plus the `Inventory` module's UI-dependent handler, not something covered by engine-side unit/integration tests.
