### PR TITLE
fix(rendering): stop double-applying daylight to held/thrown block light

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/WorldRendererImpl.java
@@ -378,7 +378,17 @@ public final class WorldRendererImpl implements WorldRenderer {
 
     @Override
     public float getMainLightIntensityAt(Vector3f position) {
-        return backdropProvider.getDaylight() * worldProvider.getSunlight(position) / 15.0f;
+        // Deliberately NOT scaled by backdropProvider.getDaylight() here. This value ends up as the
+        // "sunlight" G-buffer channel for block items, held items and meshes (MeshRenderer,
+        // SkeletonRenderer), consumed by the deferred main-light pass (DeferredMainLightNode /
+        // lightGeometryPass_frag.glsl -> calcSunlightColorDeferred -> calcDayAndNightLightingFactor),
+        // which already multiplies by its own "daylight" uniform - sourced from this same
+        // backdropProvider.getDaylight() - and adds a NIGHT_BRIGHTNESS moonlight term on top. Chunk
+        // terrain feeds that same deferred pass an unscaled raw sunlight value for the same reason.
+        // Pre-multiplying by daylight here double-applied the day/night curve and skipped the
+        // moonlight term entirely, leaving held/thrown blocks and particles far darker than world
+        // blocks at night. See #181.
+        return worldProvider.getSunlight(position) / 15.0f;
     }
 
     @Override


### PR DESCRIPTION
Fixes #181 - physics blocks, carried blocks, and meshes appear much darker at night than world blocks - basically black, per later reports on the issue, while particles by contrast render bright.

## ⚠️ Please verify live before merging

Root-caused and fixed by tracing the rendering pipeline end to end (see below) - **not by rendering and comparing frames**, I don't have a GL context here. Worth a quick visual check by hand at night: hold an item, throw/drop a block, and compare its brightness against nearby world terrain in the same lighting - it should now look roughly the same instead of near-black.

## Root cause

`WorldRendererImpl.getMainLightIntensityAt()` feeds `MeshRenderer`/`SkeletonRenderer`'s `"sunlight"` material uniform (used for block items, held items, and other mesh-rendered entities) with:

```java
backdropProvider.getDaylight() * worldProvider.getSunlight(position) / 15.0f
```

That uniform is written into the deferred G-buffer's sunlight channel (`block_frag.glsl` / `genericMeshMaterial_frag.glsl`: `outLight.rgba = vec4(blockLight, sunlight, 0.0, 0.0)`), consumed by the deferred main-light pass (CoreRendering's `DeferredMainLightNode` driving `lightGeometryPass_frag.glsl`), which reads it as `sunlightIntensity` and calls `calcSunlightColorDeferred()` → `calcDayAndNightLightingFactor()`, which multiplies by its own `"daylight"` uniform - set by `DeferredMainLightNode` from that exact same `backdropProvider.getDaylight()` - and adds a `NIGHT_BRIGHTNESS` moonlight term on top.

Chunk terrain (`chunk_frag.glsl`) writes its raw, unscaled `v_sunlight` value into the same G-buffer channel, so the deferred pass's daylight multiplication and moonlight addition apply once, correctly, to chunks. For block items and meshes, `getMainLightIntensityAt()` already multiplied by daylight before the deferred pass multiplied by it again - squaring the day/night falloff (`0.15 * 0.15 = 0.0225` at minimum daylight) and feeding the moonlight compensation term an already-dimmed input, instead of the raw sky-exposure value it expects.

## Fix

Return the raw sky-exposure fraction, matching what chunk rendering already writes into the same G-buffer channel, and let the shared deferred lighting pass apply the day/night curve (including the moonlight term chunks already receive) exactly once, consistently.

`getRenderingLightIntensityAt()`, a separate method with no current callers in this codebase, is untouched - it has its own unrelated `"+0.05f"` night-floor hack and isn't part of this G-buffer pipeline.

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. No test covers `WorldRendererImpl`/`getMainLightIntensityAt` - it needs a live GL context to observe rendered output, not something unit-testable.
