### PR TITLE
test(network): add a regression test for #1079 (EntityRef.copy on a client)

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/EntityCopyOnClientTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/EntityCopyOnClientTest.java
@@ -1,0 +1,57 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.integrationenvironment;
+
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.context.Context;
+import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
+import org.terasology.engine.network.NetworkComponent;
+import org.terasology.engine.network.NetworkMode;
+import org.terasology.engine.registry.In;
+import org.terasology.unittest.stubs.IntegerComponent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Regression test for #1079: "EntityManager::copy works incorrectly on a remote client" - copying a
+ * networked entity on a client and then modifying the copy's components was reported to also modify
+ * the original, attributed at the time to the copy's {@link EntityRef} "getting directed to the last
+ * registered thing with the given net id".
+ * <p>
+ * That mechanism no longer exists: {@code NetworkEntitySystem#onAddNetworkComponent}, which registers a
+ * {@link NetworkComponent}-bearing entity into the client/server's netId lookup, is gated
+ * {@code @NetFilterEvent(netFilter = RegisterMode.AUTHORITY)} - a client never runs it, including for a
+ * locally-created copy that happens to carry a (copied) {@code NetworkComponent}. This test exercises
+ * the actual copy path on a real client context to confirm component mutation is properly isolated.
+ */
+@IntegrationEnvironment(networkMode = NetworkMode.LISTEN_SERVER)
+public class EntityCopyOnClientTest {
+
+    @In
+    private ModuleTestingHelper helper;
+
+    @Test
+    public void copyingANetworkedEntityOnAClientDoesNotMutateTheOriginal() throws Exception {
+        Context clientContext = helper.createClient();
+        EntityManager clientEntityManager = clientContext.get(EntityManager.class);
+
+        // A NetworkComponent is what distinguishes the entity this issue was about from any other -
+        // its presence is what used to trigger the redirection.
+        NetworkComponent networkComponent = new NetworkComponent();
+        networkComponent.setNetworkId(9001);
+        EntityRef original = clientEntityManager.create(networkComponent, new IntegerComponent(42));
+
+        EntityRef copy = original.copy();
+        assertThat(copy.exists()).isTrue();
+        assertThat(copy.getId()).isNotEqualTo(original.getId());
+
+        IntegerComponent copyValue = copy.getComponent(IntegerComponent.class);
+        copyValue.value = 99;
+        copy.saveComponent(copyValue);
+
+        assertThat(copy.getComponent(IntegerComponent.class).value).isEqualTo(99);
+        assertThat(original.getComponent(IntegerComponent.class).value).isEqualTo(42);
+    }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/soloturn/yggdrasil).

Investigated #1079 ("EntityManager::copy works incorrectly on a remote client" - copying a networked entity and modifying the copy also modified the original, attributed at the time to the copy's `EntityRef` getting redirected via net-id lookup).

Traced the mechanism the original report described: `NetworkEntitySystem#onAddNetworkComponent` is what registers a `NetworkComponent`-bearing entity into the netId→entity lookup (`NetworkSystemImpl#netIdToEntityId`). It's gated `@NetFilterEvent(netFilter = RegisterMode.AUTHORITY)` - a client never runs it, including for a locally-created copy that happens to carry a (copied) `NetworkComponent`. That's the mechanism the 2014 report needed to exist for the redirection to happen, and it doesn't apply client-side.

Confirmed by running an actual test against a real client context via the MTE integration environment (`ModuleTestingHelper#createClient()`): creating a `NetworkComponent`-bearing entity on a client, copying it, and mutating a component on the copy leaves the original untouched.

No production code change - the bug doesn't reproduce against current `develop`. Adding the test as a permanent regression guard and documentation of why, since the entity system has been substantially rewritten since 2014 and nothing currently links back to this issue.

## Test plan

- [x] `EntityCopyOnClientTest` (1/1 pass) via `:engine-tests:integrationTest`.
