### PR TITLE
fix(core): wait for in-flight save before shutting down systems

### DIFF
--- a/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
@@ -148,12 +148,6 @@ public class StateIngame implements GameState {
             worldRenderer = null;
         }
 
-        // The save started above (waitForCompletionOfPreviousSaveAndStartSaving) runs on a
-        // background scheduler and, as part of serializing entities, sends deactivation events to
-        // ComponentSystems - the same systems componentSystemManager.shutdown() is about to tear
-        // down. Blocking on it here, before any system/entity teardown, keeps that in-flight save
-        // from dispatching events into systems (or entities) that have already been shut down.
-        // See #704.
         if (storageManager != null) {
             storageManager.finishSavingAndShutdown();
         }

--- a/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
+++ b/engine/src/main/java/org/terasology/engine/core/modes/StateIngame.java
@@ -147,15 +147,22 @@ public class StateIngame implements GameState {
             worldRenderer.dispose();
             worldRenderer = null;
         }
+
+        // The save started above (waitForCompletionOfPreviousSaveAndStartSaving) runs on a
+        // background scheduler and, as part of serializing entities, sends deactivation events to
+        // ComponentSystems - the same systems componentSystemManager.shutdown() is about to tear
+        // down. Blocking on it here, before any system/entity teardown, keeps that in-flight save
+        // from dispatching events into systems (or entities) that have already been shut down.
+        // See #704.
+        if (storageManager != null) {
+            storageManager.finishSavingAndShutdown();
+        }
+
         componentSystemManager.shutdown();
 
         context.get(PhysicsEngine.class).dispose();
 
         entityManager.clear();
-
-        if (storageManager != null) {
-            storageManager.finishSavingAndShutdown();
-        }
 
         ModuleEnvironment oldEnvironment = context.get(ModuleManager.class).getEnvironment();
         context.get(ModuleManager.class).loadEnvironment(Collections.<Module>emptySet(), true);


### PR DESCRIPTION
Fixes #704 - events getting sent to `ComponentSystem`s after their `shutdown()` has already run, causing NPEs from internal state the system's own `shutdown()` had already cleared (original report: `SignalSystem.producerRemoved` crashing on a null map during host shutdown).

## Root cause

`StateIngame.dispose()` calls `storageManager.waitForCompletionOfPreviousSaveAndStartSaving()`, which starts a `SaveTransaction` on `GameScheduler.parallel()` - a genuine background thread, per `ReadWriteStorageManager.startSaving()`'s `Mono.fromRunnable(...).subscribeOn(GameScheduler.parallel()).subscribe()`. That transaction's `run()` calls `privateEntityManager.deactivateForStorage(entityRef)` while serializing entities, which sends deactivation events to whatever `ComponentSystem`s are still registered to handle them.

`dispose()` went on to call `componentSystemManager.shutdown()` while that save was still running in the background, and only blocked on it much later via `storageManager.finishSavingAndShutdown()` - after `componentSystemManager.shutdown()`, `PhysicsEngine.dispose()`, and `entityManager.clear()` had already run. Any deactivation event the save dispatched in that window landed on a system whose own `shutdown()` may have already nulled out the state its event handler needed - the exact NPE in #704's stack trace, just relocated from the 2013-era synchronous save path to the current async one.

## Fix

Move the `finishSavingAndShutdown()` blocking call to immediately before `componentSystemManager.shutdown()`, so the save (and every event it dispatches) is guaranteed complete before any system, physics, or entity teardown begins. No new logic - two existing calls reordered.

## Verification

`:engine:compileJava` clean. Ran the full `engine-tests:integrationTest` suite (18 MTE test classes, 34 tests) - `StateIngame.dispose()` is exactly the method every test's teardown goes through, so this is a meaningful regression check for the reordering. All 34 pass.

This is inherently hard to verify beyond that: reproducing #704 needs an actual multiplayer host mid-save at the moment of shutdown, which isn't something I can drive here. The integration suite exercising this exact `dispose()` path on every test teardown, 34/34 green, is the best available signal that the reorder doesn't break normal shutdown.
