### PR TITLE
fix(nui): force a fresh reload of an inherited skin before copying from it

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinFormat.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinFormat.java
@@ -113,6 +113,14 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
                 Optional<? extends UISkinAsset> skin = Assets.get(inherit, UISkinAsset.class);
                 if (skin.isPresent()) {
                     builder.setBaseSkin(skin.get().getSkin());
+                } else {
+                    // Silently proceeding here is what made #1621 so hard to track down: an unresolved
+                    // "inherit" doesn't fail this skin's load, it just quietly omits every property the
+                    // base skin would have supplied (textures included) - the skin loads "successfully"
+                    // with nothing wrong logged anywhere.
+                    logger.warn("Could not resolve inherited skin '{}' - properties from it (including "
+                            + "textures) will be missing from this skin. The module providing it may not "
+                            + "be available yet in the current module environment.", inherit);
                 }
             }
             if (families != null) {

--- a/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinFormat.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/nui/skin/UISkinFormat.java
@@ -23,6 +23,7 @@ import org.terasology.engine.utilities.gson.CaseInsensitiveEnumTypeAdapterFactor
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.format.AbstractAssetFileFormat;
 import org.terasology.gestalt.assets.format.AssetDataFile;
+import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.gestalt.assets.module.annotations.RegisterAssetFileFormat;
 import org.terasology.nui.Color;
 import org.terasology.nui.UITextureRegion;
@@ -110,6 +111,21 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
         public void apply(UISkinBuilder builder) {
             super.apply(builder);
             if (inherit != null) {
+                // UISkinBuilder.build() below copies the base skin's *current* properties into this
+                // skin at build time - it's a one-time snapshot, not a live reference. Assets.get()
+                // alone only returns whatever's already cached, which during a module environment
+                // switch can be the base skin's pre-switch data if reloadAssets() hasn't reached it
+                // yet (it reloads every already-loaded skin once, in whatever order
+                // getLoadedAssetUrns() returns - no dependency ordering between them). Forcing the
+                // reload here, at the one place this skin actually reads from its base, guarantees a
+                // current copy regardless of where either skin falls in that pass - see #1621.
+                // Resolved the same way Assets.get() below resolves it (full or partial urn), so the
+                // asset reloaded here is exactly the one that lookup will find.
+                Assets.resolveAssetUri(inherit, UISkinAsset.class).forEach(inheritUrn ->
+                        CoreRegistry.get(ModuleAwareAssetTypeManager.class)
+                                .getAssetType(UISkinAsset.class)
+                                .ifPresent(assetType -> assetType.reload(inheritUrn)));
+
                 Optional<? extends UISkinAsset> skin = Assets.get(inherit, UISkinAsset.class);
                 if (skin.isPresent()) {
                     builder.setBaseSkin(skin.get().getSkin());
@@ -120,7 +136,7 @@ public class UISkinFormat extends AbstractAssetFileFormat<UISkinData> {
                     // with nothing wrong logged anywhere.
                     logger.warn("Could not resolve inherited skin '{}' - properties from it (including "
                             + "textures) will be missing from this skin. The module providing it may not "
-                            + "be available yet in the current module environment.", inherit);
+                            + "be available in the current module environment.", inherit);
                 }
             }
             if (families != null) {


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/soloturn/yggdrasil).

Fixes #1621 - skin inheritance breaking specifically across a module environment switch (the loading screen).

## Root cause

`UISkinBuilder.build()` copies the base skin's *current* properties into a derived skin at build time - a one-time snapshot, not a live reference. `UISkinFormat`'s `inherit` resolution used `Assets.get()`, which returns whatever's already cached - during an environment switch that can be the base skin's stale pre-switch data, because `ModuleAwareAssetTypeManagerImpl#reloadAssets()` (gestalt-asset-core) reloads every already-loaded asset once, in whatever order `getLoadedAssetUrns()` returns, with **no dependency ordering** between them. If a derived skin's own reload lands before its base's in that same pass, the snapshot it takes is stale. That's what the original report actually hit: a texture moved to a different module, referenced only through an inherited skin property, missing until the affected skins were reloaded again by hand (`reloadSkin` - since removed from the engine entirely, for what it's worth).

## Fix

At the actual point of the stale read: force the base skin to reload from its data producer right before copying from it, resolved the same way (full or partial urn) the subsequent `Assets.get()` resolves it, so the asset forced fresh here is exactly the one that lookup finds. This guarantees a current copy regardless of where either skin falls in a reload pass.

Deliberately **not** touching the shared reload-ordering mechanism (`gestalt-asset-core`, used by every asset type) or `UISkin`'s inheritance/merge architecture (touches every widget in the game) - both would be the more "complete" fix but are foundational changes I'm not making blind without extensive live visual QA across the whole UI. This fixes it at the actual site of the defect for this specific case.

Also logs when `inherit` can't be resolved *at all* (a genuinely different failure - the module providing it not being available) - previously failed completely silently, which is what made this issue so hard to track down in the first place.

## Test plan

- [x] Compiles clean.
- Traced the mechanism through `UISkinFormat` → `UISkinBuilder.build()` → `UISkin` → `AssetType.loadAsset()`/`reload()` to confirm the fix addresses the actual defect (`Asset.reload()` mutates the cached instance in place, so forcing it before the read guarantees the subsequent snapshot is current).
- No automated regression test added - simulating the actual race (module environment switch, reload-order-dependent staleness) would need a full asset-scanning/module-environment test harness; noting that gap rather than skipping it silently.
