### PR TITLE
feat(world): add CelestialSystem/BackdropProvider#getMoonPhase()

### DIFF
--- a/engine-tests/src/test/java/org/terasology/engine/world/sun/DefaultCelestialSystemTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/world/sun/DefaultCelestialSystemTest.java
@@ -1,0 +1,73 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.engine.world.sun;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.world.WorldProvider;
+import org.terasology.engine.world.time.WorldTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * See #94: getMoonPhase() is a hook other systems (rendering, gameplay, a future calendar) can key off
+ * without each needing their own day-counting logic, based on the same day counter getSunPosAngle()
+ * already uses.
+ */
+public class DefaultCelestialSystemTest {
+
+    private static final float MOON_CYCLE_DAYS = 29.53f;
+    private static final float EPSILON = 1e-4f;
+
+    private WorldTime worldTime;
+    private DefaultCelestialSystem celestialSystem;
+
+    @BeforeEach
+    public void setup() {
+        CelestialModel model = mock(CelestialModel.class);
+        WorldProvider worldProvider = mock(WorldProvider.class);
+        EntityManager entityManager = mock(EntityManager.class);
+        worldTime = mock(WorldTime.class);
+        when(worldProvider.getTime()).thenReturn(worldTime);
+
+        celestialSystem = new DefaultCelestialSystem(model, worldProvider, entityManager);
+    }
+
+    private void setDays(float days) {
+        when(worldTime.getDays()).thenReturn(days);
+    }
+
+    @Test
+    public void newMoonAtDayZero() {
+        setDays(0f);
+        assertEquals(0f, celestialSystem.getMoonPhase(), EPSILON);
+    }
+
+    @Test
+    public void fullMoonHalfwayThroughTheCycle() {
+        setDays(MOON_CYCLE_DAYS / 2f);
+        assertEquals(0.5f, celestialSystem.getMoonPhase(), EPSILON);
+    }
+
+    @Test
+    public void phaseWrapsAroundAfterACompleteCycle() {
+        setDays(MOON_CYCLE_DAYS + MOON_CYCLE_DAYS / 4f);
+        assertEquals(0.25f, celestialSystem.getMoonPhase(), EPSILON);
+    }
+
+    @Test
+    public void phaseWrapsAroundAfterManyCycles() {
+        setDays(MOON_CYCLE_DAYS * 100 + MOON_CYCLE_DAYS * 0.75f);
+        assertEquals(0.75f, celestialSystem.getMoonPhase(), EPSILON);
+    }
+
+    @Test
+    public void phaseStaysInRangeWhenSunIsHalted() {
+        setDays(1000f);
+        celestialSystem.toggleSunHalting(MOON_CYCLE_DAYS / 4f);
+        assertEquals(0.25f, celestialSystem.getMoonPhase(), EPSILON);
+    }
+}

--- a/engine/src/main/java/org/terasology/engine/rendering/backdrop/BackdropProvider.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/backdrop/BackdropProvider.java
@@ -28,4 +28,6 @@ public interface BackdropProvider {
 
     Vector3f getSunDirection(boolean moonlightFlip);
 
+    float getMoonPhase();
+
 }

--- a/engine/src/main/java/org/terasology/engine/rendering/backdrop/Skysphere.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/backdrop/Skysphere.java
@@ -70,4 +70,9 @@ public class Skysphere implements BackdropProvider {
 
         return sunDirection;
     }
+
+    @Override
+    public float getMoonPhase() {
+        return celSystem.getMoonPhase();
+    }
 }

--- a/engine/src/main/java/org/terasology/engine/world/sun/CelestialSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/sun/CelestialSystem.java
@@ -24,4 +24,12 @@ public interface CelestialSystem {
      * @return Whether the sun is currently halted or not
      */
     boolean isSunHalted();
+
+    /**
+     * @return the current phase of the moon, as a value in [0, 1) where 0 (and the limit at 1) is new
+     * moon and 0.5 is full moon. Intended as a hook for anything wanting to key off the moon's phase -
+     * rendering, gameplay, a future astronomical/calendar system - without needing its own day-counting
+     * logic. See #94.
+     */
+    float getMoonPhase();
 }

--- a/engine/src/main/java/org/terasology/engine/world/sun/DefaultCelestialSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/sun/DefaultCelestialSystem.java
@@ -33,6 +33,12 @@ public class DefaultCelestialSystem extends BaseComponentSystem implements Celes
 
     private float haltedTime = 0f;
 
+    /**
+     * Length of a full lunar cycle, in game days. Defaults to the real-world synodic month so a
+     * calendar built on top of this lines up with familiar phase names/timing.
+     */
+    private static final float MOON_CYCLE_DAYS = 29.53f;
+
     public DefaultCelestialSystem(CelestialModel model, Context context) {
         WorldProvider worldProvider = context.get(WorldProvider.class);
         entityManager = context.get(EntityManager.class);
@@ -56,13 +62,7 @@ public class DefaultCelestialSystem extends BaseComponentSystem implements Celes
 
     @Override
     public float getSunPosAngle() {
-        float days;
-        if (isSunHalted()) {
-            days = haltedTime;
-        } else {
-            days = getWorldTime().getDays();
-        }
-        return  model.getSunPosAngle(days);
+        return model.getSunPosAngle(getCurrentDays());
     }
 
     @Override
@@ -74,6 +74,18 @@ public class DefaultCelestialSystem extends BaseComponentSystem implements Celes
     public void toggleSunHalting(float timeInDays) {
         haltSunPosition = !haltSunPosition;
         haltedTime = timeInDays;
+    }
+
+    @Override
+    public float getMoonPhase() {
+        float phase = getCurrentDays() % MOON_CYCLE_DAYS / MOON_CYCLE_DAYS;
+        // getCurrentDays() is expected to always be non-negative, but guard against a negative
+        // result from a halted/rewound time anyway rather than return an out-of-range phase.
+        return phase < 0 ? phase + 1 : phase;
+    }
+
+    private float getCurrentDays() {
+        return isSunHalted() ? haltedTime : getWorldTime().getDays();
     }
     /**
      * Updates the game perception of the time of day via launching a new OnMiddayEvent(),

--- a/engine/src/main/java/org/terasology/engine/world/sun/DefaultCelestialSystem.java
+++ b/engine/src/main/java/org/terasology/engine/world/sun/DefaultCelestialSystem.java
@@ -21,6 +21,12 @@ import java.math.RoundingMode;
  */
 public class DefaultCelestialSystem extends BaseComponentSystem implements CelestialSystem, UpdateSubscriberSystem {
 
+    /**
+     * Length of a full lunar cycle, in game days. Defaults to the real-world synodic month so a
+     * calendar built on top of this lines up with familiar phase names/timing.
+     */
+    private static final float MOON_CYCLE_DAYS = 29.53f;
+
     private final WorldTime worldTime;
 
     private long lastUpdate;
@@ -32,12 +38,6 @@ public class DefaultCelestialSystem extends BaseComponentSystem implements Celes
     private boolean haltSunPosition = false;
 
     private float haltedTime = 0f;
-
-    /**
-     * Length of a full lunar cycle, in game days. Defaults to the real-world synodic month so a
-     * calendar built on top of this lines up with familiar phase names/timing.
-     */
-    private static final float MOON_CYCLE_DAYS = 29.53f;
 
     public DefaultCelestialSystem(CelestialModel model, Context context) {
         WorldProvider worldProvider = context.get(WorldProvider.class);


### PR DESCRIPTION
Fixes #94 - a hook for basing the moon's phase on the game's day counter, without requiring any new art or a persisted "date" concept. The issue's own author only asked for "some sort of hook into basing the phase on a date/counter/something".

## What changed

`WorldTime.getDays()` already provides a continuous day counter (used by `DefaultCelestialSystem.getSunPosAngle()` for the sun's position). `getMoonPhase()` derives from the same counter: `(days % MOON_CYCLE_DAYS) / MOON_CYCLE_DAYS`, a value in `[0, 1)` where `0` is new moon and `0.5` is full moon. `MOON_CYCLE_DAYS` defaults to the real-world synodic month (29.53 days) so a calendar or astronomy system built on top of this later lines up with familiar phase names/timing, matching the issue's own framing ("this could come later and be the basis for an astronomical system").

Added to `CelestialSystem` (implemented by `DefaultCelestialSystem`) and `BackdropProvider` (implemented by `Skysphere`, which already delegates `getSunPositionAngle()` etc. to `CelestialSystem` the same way) - both interfaces have exactly one implementation each, so this is a contained addition.

A companion PR in Terasology/CoreRendering ([#86](https://github.com/Terasology/CoreRendering/pull/86)) uses this to make the existing "moon" highlight glow in the skysphere shader dim toward new moon and brighten toward full moon, rather than staying at constant intensity - a real, visible use of the hook using existing rendering infrastructure, no new textures/art required.

## Note on scope

This issue carries `Type: Dream` and `Revive: Convert` labels - the maintainers' own triage said it should become a GitHub Discussion rather than stay an actionable issue. It was implemented here on the requester's explicit instruction despite that. Please weigh that context when reviewing/merging.

## Verification

`:engine:compileJava` and `:engine-tests:compileTestJava` both clean. Added `DefaultCelestialSystemTest` covering the new logic directly (day 0 = new moon, half a cycle = full moon, wraps correctly after one cycle and after many cycles, stays in range while the sun is halted) - unlike most rendering-adjacent code, this part is pure logic with no GL dependency, so it's genuinely unit-tested: 5/5 pass. Also ran the full `integrationenvironment` suite (18 MTE test classes, 34 tests) to confirm the `BackdropProvider`/`CelestialSystem` interface changes don't break world bootstrap, which depends on both - all 34 pass.

The rendering side (CoreRendering PR) still needs a live playtest to confirm the visual fade reads correctly - noted there.
