### PR TITLE
fix(TypeHandlerLibrary): move StringRepresentationTypeHandlerTest's inner class to the end

### DIFF
--- a/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandlerTest.java
+++ b/subsystems/TypeHandlerLibrary/src/test/java/org/terasology/persistence/typeHandling/StringRepresentationTypeHandlerTest.java
@@ -14,26 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StringRepresentationTypeHandlerTest {
 
-    /**
-     * Records whether {@link #getFromString} was reached. The contract under test is not just
-     * "returns empty" but "never forwards null to the subclass" — asserting only on the returned
-     * Optional would still pass if a subclass happened to tolerate null and return null itself.
-     */
-    private static final class RecordingHandler extends StringRepresentationTypeHandler<String> {
-        private boolean getFromStringCalled;
-
-        @Override
-        public String getAsString(String item) {
-            return item;
-        }
-
-        @Override
-        public String getFromString(String representation) {
-            getFromStringCalled = true;
-            return representation;
-        }
-    }
-
     private final RecordingHandler typeHandler = new RecordingHandler();
 
     @Test
@@ -62,5 +42,25 @@ class StringRepresentationTypeHandlerTest {
 
         assertFalse(result.isPresent());
         assertFalse(typeHandler.getFromStringCalled);
+    }
+
+    /**
+     * Records whether {@link #getFromString} was reached. The contract under test is not just
+     * "returns empty" but "never forwards null to the subclass" — asserting only on the returned
+     * Optional would still pass if a subclass happened to tolerate null and return null itself.
+     */
+    private static final class RecordingHandler extends StringRepresentationTypeHandler<String> {
+        private boolean getFromStringCalled;
+
+        @Override
+        public String getAsString(String item) {
+            return item;
+        }
+
+        @Override
+        public String getFromString(String representation) {
+            getFromStringCalled = true;
+            return representation;
+        }
     }
 }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/soloturn/yggdrasil).

Found while checking why several other open PRs' checkstyle jobs were failing: `StringRepresentationTypeHandlerTest.java` (added in 962df32fb, already on `develop`) has an `InnerTypeLast` violation - `RecordingHandler` is declared before the field/methods that use it, and checkstyle wants inner types last. Since checkstyle scans the whole module, this fails the gate for every subsequent PR regardless of what they actually touch - confirmed the identical violation in at least #5374, #5376, #5387's build logs.

No behavior change, just reordered so `RecordingHandler` comes after the field and `@Test` methods.

## Test plan

- [x] `:subsystems:TypeHandlerLibrary:checkstyleTest` passes clean (was failing with this violation before).
