### PR TITLE
Reuse ChunkMeshWorker update scratch storage

### DIFF
--- a/engine/src/main/java/org/terasology/engine/rendering/world/ChunkMeshWorker.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/ChunkMeshWorker.java
@@ -25,6 +25,7 @@ import reactor.function.TupleUtils;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -116,12 +117,22 @@ public final class ChunkMeshWorker {
 
     /**
      * Queue all dirty items in our collection, in priority order.
+     * <p>
+     * Only the chunks actually being queued are sorted. Sorting the whole proximity list first and
+     * filtering while walking it - as this used to - orders thousands of chunks to decide the order of
+     * the handful that are dirty this frame, and the two give the same sequence either way. At the
+     * MEGA view distance (33x7x33 = 7623 chunks) that measured ~200us per frame against ~27us, on a
+     * list already near-sorted from last frame; the cost did not vary with how many chunks were dirty,
+     * which is the tell that it was all in touching the list rather than in the queueing.
+     * <p>
+     * The comparator is not cheap per call either - it re-reads the camera through a Provider and
+     * allocates two Vector3f per comparison, via {@code Chunk.getRenderPosition()} - so the win is in
+     * calling it O(dirty log dirty) times instead of O(n log n).
      *
      * @return the number of dirty chunks added to the queue
      */
     public int update() {
-        int statDirtyChunks = 0;
-        chunksInProximityOfCamera.sort(frontToBackComparator);
+        List<Chunk> toQueue = new ArrayList<>();
         for (Chunk chunk : chunksInProximityOfCamera) {
             if (!chunk.isReady()) {
                 // Chunk was added as part of some region, but not yet ready.
@@ -131,6 +142,20 @@ public final class ChunkMeshWorker {
             if (!chunk.isDirty()) {
                 // Chunk is in proximity list, but is no longer dirty. Probably already processed.
                 // Will poll it again next tick to see if it got dirty since then.
+                continue;
+            }
+            toQueue.add(chunk);
+        }
+
+        toQueue.sort(frontToBackComparator);
+
+        int statDirtyChunks = 0;
+        for (Chunk chunk : toQueue) {
+            // Re-checked here, not just when the list was built: emitting can drive mesh generation
+            // synchronously, and that clears the flag. A chunk sitting in the proximity list more than
+            // once - add() does not deduplicate - would otherwise be queued again for a mesh the
+            // emission before it has already produced.
+            if (!chunk.isDirty()) {
                 continue;
             }
             statDirtyChunks++;

--- a/engine/src/main/java/org/terasology/engine/rendering/world/ChunkMeshWorker.java
+++ b/engine/src/main/java/org/terasology/engine/rendering/world/ChunkMeshWorker.java
@@ -57,6 +57,12 @@ public final class ChunkMeshWorker {
 
     private final Sinks.Many<Chunk> chunkMeshPublisher = Sinks.many().unicast().onBackpressureBuffer();
     private final List<Chunk> chunksInProximityOfCamera = Lists.newArrayListWithCapacity(MAX_LOADABLE_CHUNKS);
+    // Scratch buffer for update(): update() is only ever invoked once per frame, from the single
+    // rendering/main thread that owns this worker (see RenderableWorldImpl.queueVisibleChunks /
+    // WorldRendererImpl.preRenderUpdate), so it is never accessed concurrently or re-entrantly.
+    // Reusing it avoids reallocating a new ArrayList every frame; it is cleared on every exit from
+    // update() so it never retains contents or is observable between calls.
+    private final List<Chunk> toQueueScratch = new ArrayList<>();
     private final Flux<Tuple2<Chunk, ChunkMesh>> chunksAndNewMeshes;
     private final Flux<Chunk> completedChunks;
 
@@ -132,39 +138,43 @@ public final class ChunkMeshWorker {
      * @return the number of dirty chunks added to the queue
      */
     public int update() {
-        List<Chunk> toQueue = new ArrayList<>();
-        for (Chunk chunk : chunksInProximityOfCamera) {
-            if (!chunk.isReady()) {
-                // Chunk was added as part of some region, but not yet ready.
-                // Leave it here with the expectation that it will be ready later.
-                continue;
+        List<Chunk> toQueue = toQueueScratch;
+        try {
+            for (Chunk chunk : chunksInProximityOfCamera) {
+                if (!chunk.isReady()) {
+                    // Chunk was added as part of some region, but not yet ready.
+                    // Leave it here with the expectation that it will be ready later.
+                    continue;
+                }
+                if (!chunk.isDirty()) {
+                    // Chunk is in proximity list, but is no longer dirty. Probably already processed.
+                    // Will poll it again next tick to see if it got dirty since then.
+                    continue;
+                }
+                toQueue.add(chunk);
             }
-            if (!chunk.isDirty()) {
-                // Chunk is in proximity list, but is no longer dirty. Probably already processed.
-                // Will poll it again next tick to see if it got dirty since then.
-                continue;
-            }
-            toQueue.add(chunk);
-        }
 
-        toQueue.sort(frontToBackComparator);
+            toQueue.sort(frontToBackComparator);
 
-        int statDirtyChunks = 0;
-        for (Chunk chunk : toQueue) {
-            // Re-checked here, not just when the list was built: emitting can drive mesh generation
-            // synchronously, and that clears the flag. A chunk sitting in the proximity list more than
-            // once - add() does not deduplicate - would otherwise be queued again for a mesh the
-            // emission before it has already produced.
-            if (!chunk.isDirty()) {
-                continue;
+            int statDirtyChunks = 0;
+            for (Chunk chunk : toQueue) {
+                // Re-checked here, not just when the list was built: emitting can drive mesh generation
+                // synchronously, and that clears the flag. A chunk sitting in the proximity list more than
+                // once - add() does not deduplicate - would otherwise be queued again for a mesh the
+                // emission before it has already produced.
+                if (!chunk.isDirty()) {
+                    continue;
+                }
+                statDirtyChunks++;
+                Sinks.EmitResult result = chunkMeshPublisher.tryEmitNext(chunk);
+                if (result.isFailure()) {
+                    logger.error("failed to process chunk {} : {}", chunk, result);
+                }
             }
-            statDirtyChunks++;
-            Sinks.EmitResult result = chunkMeshPublisher.tryEmitNext(chunk);
-            if (result.isFailure()) {
-                logger.error("failed to process chunk {} : {}", chunk, result);
-            }
+            return statDirtyChunks;
+        } finally {
+            toQueue.clear();
         }
-        return statDirtyChunks;
     }
 
     public int numberChunkMeshProcessing() {


### PR DESCRIPTION
This is a one-commit JAIPilot Cloud follow-up on the exact current head of [MovingBlocks/Terasology#5367](https://github.com/MovingBlocks/Terasology/pull/5367). It targets that PR branch directly.

### Change

Reuse a private per-worker ArrayList for the ready-and-dirty chunk set instead of allocating a new list every rendered frame. A finally block clears the scratch list on both normal and exceptional exits.

### Proof

- Exact parent: a7a9c634b1aef78e04e9b61697d2ba61485046b4, the current #5367 head.
- The sole update call path is owned by the render/main thread; filtering, order, dirty re-checks, emission, and return count are unchanged.
- The same eight focused ChunkMeshWorker tests passed before and after.
- At MEGA view distance with 7,623 chunks and about 5 percent dirty, five fixed allocation observations moved from 9,863.97 to 3,127.97 bytes per update, about 68 percent lower.
- The affected engine build, Checkstyle, PMD, and SpotBugs completed with no new findings.

### Boundary and disclosure

The session did not complete the entire engine-tests suite, so this claims only the focused tests and affected-module gates. The unchanged comparator remains the dominant allocator. The measurement uses synthetic DummyChunks and is an allocation-count proof, not an end-to-end frame-rate claim.

JAIPilot Cloud generated and validated the patch in [skrcode/Terasology#2](https://github.com/skrcode/Terasology/pull/2). I reviewed the exact ancestry, complete one-file diff, call-path ownership evidence, and verification boundary before offering it here.