### PR TITLE
fix: point terasology-nuigestalt at nui-gestalt8, correct its stale version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,9 +31,17 @@ dependencyResolutionManagement {
             library("slf4j-api", "org.slf4j", "slf4j-api").versionRef(slf4j)
             library("slf4j-jul", "org.slf4j", "jul-to-slf4j").versionRef(slf4j)
             library("slf4j-simple", "org.slf4j", "slf4j-simple").versionRef("slf4j")
-            val nui = version("nui", "4.0.0-SNAPSHOT")
+            // Was pinned to 4.0.0-SNAPSHOT, a version TeraNUI has never actually published (its
+            // real history goes 1.x -> 3.0 -> 3.1.x) - all three artifacts were resolving to
+            // whatever got published under that fictional coordinate years ago, frozen ever since,
+            // regardless of what TeraNUI's current source actually contains. Corrected to match
+            // TeraNUI's real current version (its build.gradle.kts's nuiVersion).
+            val nui = version("nui", "3.1.1-SNAPSHOT")
             library("terasology-nui", "org.terasology.nui", "nui").versionRef(nui)
-            library("terasology-nuigestalt", "org.terasology.nui", "nui-gestalt").versionRef(nui)
+            // Was "nui-gestalt" - orphaned since TeraNUI split it into nui-gestalt5/nui-gestalt7 in
+            // 2021 (MovingBlocks/TeraNUI@0784aad); see #5393. nui-gestalt8 (MovingBlocks/TeraNUI#86)
+            // is the module actually compatible with this project's gestalt 8.0.2-SNAPSHOT.
+            library("terasology-nuigestalt", "org.terasology.nui", "nui-gestalt8").versionRef(nui)
             library("terasology-nuireflect", "org.terasology.nui", "nui-reflect").versionRef(nui)
         }
     }


### PR DESCRIPTION
Fixes #5393.

Two separate problems in the same three catalog lines:

1. The `nui` version was pinned to `4.0.0-SNAPSHOT`, a version TeraNUI has never actually published — its real history goes 1.x → 3.0 → 3.1.x (currently `3.1.1-SNAPSHOT`). All three `org.terasology.nui:*` artifacts (`nui`, `nui-gestalt`, `nui-reflect`) were resolving to whatever got published under that fictional coordinate years ago, frozen ever since, regardless of what TeraNUI's current source actually contains.
2. `terasology-nuigestalt` specifically pointed at `nui-gestalt`, a module TeraNUI hasn't had since it split into `nui-gestalt5`/`nui-gestalt7` in 2021 (`MovingBlocks/TeraNUI@0784aad`) — so even once the version above is fixed, that artifactId still wouldn't correspond to anything TeraNUI could ever publish again.

Repointed at `nui-gestalt8` ([MovingBlocks/TeraNUI#86](https://github.com/MovingBlocks/TeraNUI/pull/86)), the module that's actually compatible with this project's gestalt `8.0.2-SNAPSHOT` — neither `nui-gestalt5` nor `nui-gestalt7` support the `Supplier<ModuleEnvironment>` constructor shape `ComponentLibrary`/`EventLibrary`/`BlockFamilyLibrary`/`DefaultWorldGeneratorPluginLibrary`/`NUIManagerInternal` actually use.

Test plan:
- [x] Wired `nui-gestalt8` into this checkout via composite-build source substitution (`includeBuild`, not part of this diff — TeraNUI#86 isn't published anywhere yet) and confirmed `:engine:compileJava`, `:engine:compileTestJava`, and `:engine-tests:compileTestJava` all compile cleanly against real, current TeraNUI source for the first time
- [x] Confirmed against the real Artifactory (no source substitution) that `org.terasology.nui:nui:3.1.1-SNAPSHOT` and `org.terasology.nui:nui-reflect:3.1.1-SNAPSHOT` **already resolve today** — only `org.terasology.nui:nui-gestalt8:3.1.1-SNAPSHOT` is missing (`:engine:dependencies` fails on exactly that one coordinate, nothing else)

**Don't merge this ahead of TeraNUI#86 actually publishing** — unlike the old dead `nui-gestalt` coordinate (which at least resolved, just to stale content), `nui-gestalt8` doesn't exist at all yet, so merging this now would make `:engine:dependencies`/any build hard-fail for everyone until [MovingBlocks/TeraNUI#86](https://github.com/MovingBlocks/TeraNUI/pull/86) (and the PRs it's stacked on) merge and a CI run publishes it. The `nui`/`nui-reflect` version fix (4.0.0-SNAPSHOT → 3.1.1-SNAPSHOT) is independently safe and already resolves against the real Artifactory today, if it's worth splitting out and merging separately/sooner.
