### PR TITLE
fix(network,mte): bind test hosts to an ephemeral port, not 25777

### DIFF
--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/Engines.java
@@ -321,7 +321,8 @@ public class Engines {
         coreContextOverride.put(Config.class, client.getFromEngineContext(Config.class));
         JoinStatus joinStatus = null;
         try {
-            joinStatus = coreContextOverride.get(NetworkSystem.class).join("localhost", 25777);
+            int hostPort = hostContext.get(NetworkSystem.class).getBoundPort();
+            joinStatus = coreContextOverride.get(NetworkSystem.class).join("localhost", hostPort);
         } catch (InterruptedException e) {
             logger.warn("Interrupted while joining: ", e);
         }

--- a/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/TestingStateHeadlessSetup.java
+++ b/engine-tests/src/main/java/org/terasology/engine/integrationenvironment/TestingStateHeadlessSetup.java
@@ -70,6 +70,10 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
         worldGenerationConfig.setDefaultGenerator(worldGeneratorUri);
         worldGenerationConfig.setWorldTitle(WORLD_TITLE);
         worldGenerationConfig.setDefaultSeed(DEFAULT_SEED);
+
+        // 0 = OS picks a free port. Tests run many hosts in parallel; the default.cfg port would
+        // collide across them. See NetworkSystem#getBoundPort().
+        config.getNetwork().setServerPort(0);
     }
 
     @Override

--- a/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
+++ b/engine-tests/src/test/java/org/terasology/engine/integrationenvironment/ClientConnectionTest.java
@@ -10,6 +10,7 @@ import org.terasology.engine.core.TerasologyEngine;
 import org.terasology.engine.core.modes.StateIngame;
 import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.network.NetworkMode;
+import org.terasology.engine.network.NetworkSystem;
 
 import java.io.IOException;
 import java.util.List;
@@ -23,6 +24,12 @@ public class ClientConnectionTest {
         helper.createClient();
         List<TerasologyEngine> engines = helper.getEngines();
         Assertions.assertEquals(2, engines.size());
+
+        // Host binds to an OS-assigned ephemeral port (0), not the fixed default.cfg one - so
+        // parallel test hosts never collide on the same port. See NetworkSystem#getBoundPort().
+        int boundPort = helper.getHostContext().get(NetworkSystem.class).getBoundPort();
+        Assertions.assertTrue(boundPort > 0, "expected an OS-assigned port, got " + boundPort);
+        Assertions.assertNotEquals(25777, boundPort, "host used the fixed default port instead of an ephemeral one");
         logger.info("Engine 0 is {}", engines.get(0));
         logger.info("Engine 1 is {}", engines.get(1));
         Assertions.assertAll(engines

--- a/engine/src/main/java/org/terasology/engine/network/NetworkSystem.java
+++ b/engine/src/main/java/org/terasology/engine/network/NetworkSystem.java
@@ -20,7 +20,15 @@ import org.terasology.engine.world.chunks.remoteChunkProvider.RemoteChunkProvide
 // TODO: Refactor the core gameplay components like the list of players into a separate system.
 public interface NetworkSystem extends BlockRegistrationListener {
 
+    /**
+     * @param port 0 lets the OS pick a free port - see {@link #getBoundPort()}.
+     */
     void host(int port, boolean dedicatedServer) throws HostingFailedException;
+
+    /**
+     * @return the port actually bound by {@link #host}, or -1 if not hosting.
+     */
+    int getBoundPort();
 
     JoinStatus join(String address, int port) throws InterruptedException;
 

--- a/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
+++ b/engine/src/main/java/org/terasology/engine/network/internal/NetworkSystemImpl.java
@@ -184,7 +184,6 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
                 // Start the server.
                 serverChannelFuture = b.bind();
 
-                logger.info("Started server on port {}", port);
                 if (config.getServerMOTD() != null) {
                     logger.info("Server MOTD is \"{}\"", config.getServerMOTD()); //NOPMD
                 } else {
@@ -195,6 +194,9 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
                     logger.info("Server started");
                 }
                 serverChannelFuture.sync();
+                // Local address is only reliably populated once bind() has completed - hence after sync(),
+                // not next to the bind() call above. Matters when port was 0 (see getBoundPort()).
+                logger.info("Started server on port {}", getBoundPort());
                 nextNetworkTick = time.getRealTimeInMs();
             } catch (ChannelException e) {
                 if (e.getCause() instanceof BindException) {
@@ -372,6 +374,14 @@ public class NetworkSystemImpl implements EntityChangeSubscriber, NetworkSystem 
     @Override
     public NetworkMode getMode() {
         return mode;
+    }
+
+    @Override
+    public int getBoundPort() {
+        if (serverChannelFuture == null) {
+            return -1;
+        }
+        return ((InetSocketAddress) serverChannelFuture.channel().localAddress()).getPort();
     }
 
     @Override


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Every MTE integration test host bound `default.cfg`'s hardcoded `serverPort` (25777). Run enough of them in parallel and they race for the same port - `java.net.BindException: Address already in use` - failing tests that have nothing wrong with them.
- `NetworkSystem` gets a new `getBoundPort()`, since asking for port 0 (OS picks a free one) means the caller no longer knows the port up front.
- `TestingStateHeadlessSetup` now requests port 0 for test hosts; `Engines.connectToHost()` reads the host's actual bound port back instead of hardcoding 25777 for the client join.
- Left the shipped `default.cfg` port untouched - real self-hosted servers still want a stable, discoverable port. This only changes the MTE test harness.

## Test plan

- [x] `ClientConnectionTest` - new assertion that the host's bound port is neither 0 nor the fixed 25777.
- [x] `./gradlew :engine-tests:unitTest` - passes.
- [x] `./gradlew :engine-tests:integrationTest` - 45/45 suites pass under real parallelism (previously 5 of them intermittently failed with the port-collision error under the same conditions).
